### PR TITLE
refactor(engine): migrate mana-ability and costs.rs cost movers onto zone_pipeline

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11,10 +11,11 @@ use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    ActivationResidual, CastOfferKind, CastPaymentMode, CastingVariant, CastingVariantChoiceOption,
-    ConvokeMode, CostResume, GameState, NextSpellModifier, PayCostKind, PendingCast,
-    PendingCostMoveResume, SneakPlacement, SpellCastRecord, SpellCostSource, StackEntry,
-    StackEntryKind, TargetSelectionSlot, WaitingFor,
+    ActivationResidual, ActivationTargetSelection, CastOfferKind, CastPaymentMode, CastingVariant,
+    CastingVariantChoiceOption, ConvokeMode, CostResume, GameState, ManaAbilityCostParent,
+    ManaAbilityResume, NextSpellModifier, PayCostKind, PendingCast, PendingCostMoveResume,
+    SneakPlacement, SpellCastRecord, SpellCostSource, StackEntry, StackEntryKind,
+    TargetSelectionSlot, WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
 use crate::types::keywords::{FlashbackCost, Keyword, KeywordKind};
@@ -326,12 +327,14 @@ pub(crate) fn begin_variable_speed_payment(
     resolved: ResolvedAbility,
     cost: AbilityCost,
     ability_index: usize,
+    target_selection: ActivationTargetSelection,
 ) -> WaitingFor {
     let max_speed = effective_speed(state, player);
     let (min, max) = variable_speed_payment_range(&cost, max_speed).unwrap_or((0, max_speed));
     let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
     pending.activation_cost = Some(cost);
     pending.activation_ability_index = Some(ability_index);
+    pending.activation_target_selection = target_selection;
     state.pending_cast = Some(Box::new(pending));
     WaitingFor::NamedChoice {
         player,
@@ -12371,6 +12374,14 @@ fn can_pay_mana_cost_after_auto_tap_with_context_and_cache(
         options.source_cache,
     );
 
+    // CR 601.2g + CR 605.3b + CR 616.1: A costed mana source may stop the
+    // preview at a replacement choice. That is an in-progress, payable mana
+    // payment, not evidence that the source is unavailable. The live flow
+    // serializes the cursor and resumes it after the choice.
+    if mana_ability_cost_payment_is_paused(&simulated) {
+        return true;
+    }
+
     // CR 605.4a: A `TapsForMana` triggered mana ability (Leyline of Abundance /
     // Fertile Ground / Wild Growth / Utopia Sprawl class) resolves inline,
     // adding bonus mana to the pool, when a source is tapped for mana. The
@@ -12983,6 +12994,12 @@ pub(super) fn can_pay_effect_mana_cost_after_auto_tap(
         Some(source_id),
         Some(&effect_ctx),
     );
+    // CR 118.12 + CR 605.3b + CR 616.1: A replacement choice during an
+    // auto-tapped mana ability is an in-progress payment, not an affordability
+    // failure. The live payment will surface that exact choice before spending.
+    if mana_ability_cost_payment_is_paused(&simulated) {
+        return true;
+    }
     // CR 605.4a: Resolve coupled `TapsForMana` triggered mana abilities inline
     // so the bonus mana is in the simulated pool — same authority the real
     // payment path uses, keeping preview and execution in lockstep.
@@ -13038,13 +13055,9 @@ pub(super) fn ability_mana_payment_excluded_sources(
     }
 }
 
-/// Pay a mana cost by auto-tapping lands and deducting from the player's mana pool.
-///
-/// Used by spell casting (`pay_and_push`). Builds a `PaymentContext::Spell` from
-/// the cast object's types so CR 106.6 spell-side restrictions (`allows_spell`)
-/// gate which restricted mana is eligible. For ability activation, use
-/// `pay_ability_mana_cost` instead so restrictions are evaluated against the
-/// source permanent's types via `allows_activation`.
+/// Test-only shorthand for a spell payment with automatic Phyrexian choices.
+/// Production call sites retain the resume-aware entry point below.
+#[cfg(test)]
 pub(super) fn pay_mana_cost(
     state: &mut GameState,
     player: PlayerId,
@@ -13066,6 +13079,29 @@ pub(super) fn pay_mana_cost_with_choices(
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
+    pay_mana_cost_with_choices_and_resume(
+        state,
+        player,
+        source_id,
+        cost,
+        phyrexian_choices,
+        None,
+        events,
+    )
+}
+
+/// CR 107.4f + CR 601.2f-h + CR 605.3b + CR 616.1: A submitted Phyrexian
+/// payment can be interrupted by a costed auto-tapped mana source. Preserve
+/// the finalization root rather than deriving a generic priority resume.
+pub(super) fn pay_mana_cost_with_choices_and_resume(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &crate::types::mana::ManaCost,
+    phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
+    resume: Option<&ManaAbilityResume>,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     super::layers::flush_layers(state);
 
     let spell_meta = build_spell_meta(state, player, source_id);
@@ -13079,6 +13115,7 @@ pub(super) fn pay_mana_cost_with_choices(
         spell_ctx.as_ref(),
         phyrexian_choices,
         events,
+        resume,
     )?;
 
     let spent_convoke_sources = spent_units
@@ -13368,7 +13405,34 @@ pub(super) fn pay_ability_mana_cost_excluding(
     // non-demanded mana. `None` for ordinary top-level ability activations.
     sub_cost_demand: Option<&mana_payment::ColorDemand>,
 ) -> Result<(), EngineError> {
-    pay_ability_mana_cost_with_choices_excluding(
+    pay_ability_mana_cost_excluding_with_parent(
+        state,
+        player,
+        source_id,
+        cost,
+        ability_tag,
+        events,
+        excluded_sources,
+        sub_cost_demand,
+        None,
+    )
+}
+
+/// CR 605.3b + CR 605.3c: The nested mana-source path carries the exact
+/// suspended parent cursor to any child source that pauses on a cost move.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn pay_ability_mana_cost_excluding_with_parent(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &crate::types::mana::ManaCost,
+    ability_tag: Option<crate::types::ability::AbilityTag>,
+    events: &mut Vec<GameEvent>,
+    excluded_sources: &HashSet<ObjectId>,
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
+    parent: Option<&ManaAbilityCostParent>,
+) -> Result<(), EngineError> {
+    pay_ability_mana_cost_with_choices_excluding_and_parent(
         state,
         player,
         source_id,
@@ -13378,11 +13442,15 @@ pub(super) fn pay_ability_mana_cost_excluding(
         events,
         excluded_sources,
         sub_cost_demand,
+        None,
+        parent,
     )
 }
 
+/// CR 107.4f + CR 601.2f-h + CR 605.3b + CR 616.1: Preserve submitted
+/// Phyrexian choices while an activated ability's auto-tapped source pauses.
 #[allow(clippy::too_many_arguments)]
-pub(super) fn pay_ability_mana_cost_with_choices_excluding(
+pub(super) fn pay_ability_mana_cost_with_choices_excluding_and_resume(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
@@ -13392,6 +13460,36 @@ pub(super) fn pay_ability_mana_cost_with_choices_excluding(
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
     sub_cost_demand: Option<&mana_payment::ColorDemand>,
+    resume: &ManaAbilityResume,
+) -> Result<(), EngineError> {
+    pay_ability_mana_cost_with_choices_excluding_and_parent(
+        state,
+        player,
+        source_id,
+        cost,
+        ability_tag,
+        phyrexian_choices,
+        events,
+        excluded_sources,
+        sub_cost_demand,
+        Some(resume),
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pay_ability_mana_cost_with_choices_excluding_and_parent(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &crate::types::mana::ManaCost,
+    ability_tag: Option<crate::types::ability::AbilityTag>,
+    phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
+    events: &mut Vec<GameEvent>,
+    excluded_sources: &HashSet<ObjectId>,
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
+    resume: Option<&ManaAbilityResume>,
+    parent: Option<&ManaAbilityCostParent>,
 ) -> Result<(), EngineError> {
     super::layers::flush_layers(state);
 
@@ -13412,6 +13510,8 @@ pub(super) fn pay_ability_mana_cost_with_choices_excluding(
         events,
         excluded_sources,
         sub_cost_demand,
+        resume,
+        parent,
     )?;
 
     Ok(())
@@ -13427,12 +13527,27 @@ pub(super) fn pay_effect_mana_cost(
     cost: &crate::types::mana::ManaCost,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
+    pay_effect_mana_cost_with_resume(state, player, source_id, cost, None, events)
+}
+
+/// CR 118.12 + CR 605.3b + CR 616.1: Resolution-time cost payment may
+/// auto-activate a mana source whose own cost pauses. Carry the caller-owned
+/// typed payment root into that activation rather than falling back to priority.
+pub(super) fn pay_effect_mana_cost_with_resume(
+    state: &mut GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &crate::types::mana::ManaCost,
+    resume: Option<&ManaAbilityResume>,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EngineError> {
     pay_non_cast_mana_cost(
         state,
         player,
         Some(source_id),
         cost,
         PaymentContext::Effect,
+        resume,
         events,
     )
 }
@@ -13456,6 +13571,7 @@ pub(crate) fn pay_special_action_mana_cost(
         source_id,
         cost,
         PaymentContext::SpecialAction(action),
+        None,
         events,
     )
 }
@@ -13488,19 +13604,29 @@ fn pay_non_cast_mana_cost(
     source_id: Option<ObjectId>,
     cost: &crate::types::mana::ManaCost,
     ctx: PaymentContext<'_>,
+    resume: Option<&ManaAbilityResume>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
     super::layers::flush_layers(state);
 
     let events_before = events.len();
-    super::casting_costs::auto_tap_mana_sources_with_context(
+    super::casting_costs::auto_tap_mana_sources_with_context_and_resume(
         state,
         player,
         cost,
         events,
         source_id,
         Some(&ctx),
+        resume,
     );
+    // CR 118.12 + CR 605.3b + CR 616.1: Do not spend an outer effect-time
+    // payment while an auto-tapped mana ability's replacement-aware cost move
+    // is unresolved. Its cursor retains the exact enclosing continuation.
+    if mana_ability_cost_payment_is_paused(state) {
+        return Err(EngineError::InvalidAction(
+            "Mana payment is awaiting a replacement choice".to_string(),
+        ));
+    }
     // CR 605.4a: Resolve coupled `TapsForMana` triggered mana abilities inline
     // so their bonus mana is in the pool before the affordability check.
     super::triggers::resolve_tap_mana_triggers_inline(state, events, events_before);
@@ -13563,6 +13689,7 @@ fn pay_non_cast_mana_cost(
 /// executes the spend with the given payment context, and processes any
 /// Phyrexian life payments. Returns the spent units so spell-specific callers
 /// can apply grants / bookkeeping. Single authority for restriction gating.
+#[allow(clippy::too_many_arguments)]
 fn auto_tap_and_pay_cost(
     state: &mut GameState,
     player: PlayerId,
@@ -13571,6 +13698,7 @@ fn auto_tap_and_pay_cost(
     ctx: Option<&PaymentContext<'_>>,
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
+    resume: Option<&ManaAbilityResume>,
 ) -> Result<Vec<crate::types::mana::ManaUnit>, EngineError> {
     auto_tap_and_pay_cost_excluding(
         state,
@@ -13581,6 +13709,8 @@ fn auto_tap_and_pay_cost(
         phyrexian_choices,
         events,
         &HashSet::new(),
+        None,
+        resume,
         None,
     )
 }
@@ -13596,9 +13726,11 @@ fn auto_tap_and_pay_cost_excluding(
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
     sub_cost_demand: Option<&mana_payment::ColorDemand>,
+    resume: Option<&ManaAbilityResume>,
+    parent: Option<&ManaAbilityCostParent>,
 ) -> Result<Vec<crate::types::mana::ManaUnit>, EngineError> {
     let events_before = events.len();
-    super::casting_costs::auto_tap_mana_sources_with_context_excluding(
+    super::casting_costs::auto_tap_mana_sources_with_context_excluding_and_resume(
         state,
         player,
         cost,
@@ -13606,7 +13738,14 @@ fn auto_tap_and_pay_cost_excluding(
         Some(source_id),
         ctx,
         excluded_sources,
+        resume,
+        parent,
     );
+    if mana_ability_cost_payment_is_paused(state) {
+        return Err(EngineError::InvalidAction(
+            "Mana payment is awaiting a replacement choice".to_string(),
+        ));
+    }
     // CR 605.4a: Resolve coupled `TapsForMana` triggered mana abilities inline
     // so their bonus mana is in the pool before the affordability check (and
     // before the spend). The post-action trigger scan skips what is resolved
@@ -13698,6 +13837,17 @@ fn auto_tap_and_pay_cost_excluding(
     }
 
     Ok(spent_units)
+}
+
+/// CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: A mana ability's serialized
+/// cost cursor has paused for a replacement choice or that choice's
+/// post-effect. Callers must return that prompt, not treat it as a failed or
+/// completed outer payment.
+pub(super) fn mana_ability_cost_payment_is_paused(state: &GameState) -> bool {
+    matches!(
+        state.pending_cost_move_resume.as_ref(),
+        Some(crate::types::game_state::PendingCostMoveResume::ManaAbilityPayment { .. })
+    )
 }
 
 /// CR 106.6: Build (core-types, subtypes) slices for a `PaymentContext::Activation`
@@ -14048,6 +14198,91 @@ pub(super) fn find_non_self_exile(
     }
 }
 
+/// Removes the one non-self exile leg paid by the interactive activation-cost
+/// handler. Later exile legs remain in the residual for their own choice.
+pub(super) fn remove_selected_non_self_exile_cost(cost: AbilityCost) -> Option<AbilityCost> {
+    match cost {
+        AbilityCost::Exile {
+            filter: Some(TargetFilter::SelfRef),
+            ..
+        } => Some(cost),
+        AbilityCost::Exile { .. } => None,
+        AbilityCost::Composite { costs } => {
+            let mut removed = false;
+            let remaining = costs
+                .into_iter()
+                .filter_map(|cost| {
+                    if !removed
+                        && (find_non_self_exile(&cost).is_some()
+                            || find_battlefield_exile_cost(&cost).is_some())
+                    {
+                        removed = true;
+                        remove_selected_non_self_exile_cost(cost)
+                    } else {
+                        Some(cost)
+                    }
+                })
+                .collect();
+            combine_cost_legs(remaining)
+        }
+        other => Some(other),
+    }
+}
+
+/// Removes the one discard leg paid by the interactive activation cost handler.
+/// This keeps a later mana-leg pause from replaying either a chosen hand discard
+/// or the source-card discard that already left its activation zone.
+pub(super) fn remove_selected_discard_cost(cost: AbilityCost) -> Option<AbilityCost> {
+    match cost {
+        AbilityCost::Discard { .. } => None,
+        AbilityCost::Composite { costs } => {
+            let mut removed = false;
+            let remaining = costs
+                .into_iter()
+                .filter_map(|cost| {
+                    if !removed && matches!(cost, AbilityCost::Discard { .. }) {
+                        removed = true;
+                        remove_selected_discard_cost(cost)
+                    } else {
+                        Some(cost)
+                    }
+                })
+                .collect();
+            combine_cost_legs(remaining)
+        }
+        other => Some(other),
+    }
+}
+
+/// Removes the one non-self sacrifice leg paid by the interactive activation
+/// cost handler. Later sacrifice legs stay in the residual for later choices.
+pub(super) fn remove_selected_non_self_sacrifice_cost(cost: AbilityCost) -> Option<AbilityCost> {
+    match cost {
+        AbilityCost::Sacrifice(sacrifice)
+            if !matches!(sacrifice.target, TargetFilter::SelfRef)
+                && sacrifice.requirement.fixed_count().is_some() =>
+        {
+            None
+        }
+        AbilityCost::Composite { costs } => {
+            let mut removed = false;
+            let remaining = costs
+                .into_iter()
+                .filter_map(|cost| {
+                    if !removed && find_non_self_sacrifice_cost(&cost).is_some() {
+                        removed = true;
+                        remove_selected_non_self_sacrifice_cost(cost)
+                    } else {
+                        Some(cost)
+                    }
+                })
+                .collect();
+            combine_cost_legs(remaining)
+        }
+        other => Some(other),
+    }
+}
+
 /// CR 701.3d + CR 608.2k: Detect a non-self `UnattachFrom` activation cost
 /// (Captain America's Throw) requiring an interactive "unattach a matching
 /// attachment from the source" selection. Returns `(count, filter)`. The
@@ -14059,6 +14294,31 @@ pub(super) fn find_unattach_from_cost(cost: &AbilityCost) -> Option<(u32, &Targe
         AbilityCost::UnattachFrom { filter, count } => Some((*count, filter)),
         AbilityCost::Composite { costs } => costs.iter().find_map(find_unattach_from_cost),
         _ => None,
+    }
+}
+
+/// Removes the one `UnattachFrom` leg paid by its interactive cost handler.
+/// Later unattach legs stay in the residual so each one can acquire its own
+/// selection before the activation reaches the stack.
+pub(super) fn remove_selected_unattach_from_cost(cost: AbilityCost) -> Option<AbilityCost> {
+    match cost {
+        AbilityCost::UnattachFrom { .. } => None,
+        AbilityCost::Composite { costs } => {
+            let mut removed = false;
+            let remaining = costs
+                .into_iter()
+                .filter_map(|cost| {
+                    if !removed && find_unattach_from_cost(&cost).is_some() {
+                        removed = true;
+                        remove_selected_unattach_from_cost(cost)
+                    } else {
+                        Some(cost)
+                    }
+                })
+                .collect();
+            combine_cost_legs(remaining)
+        }
+        other => Some(other),
     }
 }
 
@@ -14443,19 +14703,6 @@ pub(super) fn split_return_to_hand_cost_legs(
     }
 }
 
-/// True only for a residual composed entirely of return-to-hand legs. A full
-/// activation cost may still contain a return leg after another chooser paid a
-/// different component; that legacy path continues through the cost authority.
-pub(super) fn has_only_return_to_hand_cost_legs(cost: &AbilityCost) -> bool {
-    match cost {
-        AbilityCost::ReturnToHand { .. } => true,
-        AbilityCost::Composite { costs } => {
-            !costs.is_empty() && costs.iter().all(has_only_return_to_hand_cost_legs)
-        }
-        _ => false,
-    }
-}
-
 fn combine_cost_legs(costs: Vec<AbilityCost>) -> Option<AbilityCost> {
     match costs.len() {
         0 => None,
@@ -14771,7 +15018,6 @@ pub(crate) fn can_pay_ability_cost_now(
         &super::costs::PaymentScope::Activation {
             excluded_sources: &excluded_sources,
             ability_tag,
-            cost_move_handling: super::costs::ActivationCostMoveHandling::OutcomeAware,
         },
     )
 }
@@ -15075,35 +15321,116 @@ fn quantity_ref_is_board_state_relative(qty: &QuantityRef) -> bool {
     }
 }
 
-/// CR 107.4f + GH #600: Pause for K'rrik/Phyrexian per-shard consent when an
-/// activated ability's mana leg would otherwise be paid inline (e.g. `{B},{T}: …`)
-/// without routing through `enter_payment_step`. Removal-first and `{X}` detours
-/// already hoist mana through `finalize_mana_payment`, which shares this pause
-/// helper — this path covers bare mana + non-removal residual tails only.
-pub(super) fn try_pause_activation_phyrexian_payment(
+/// CR 602.2b + CR 605.3b + CR 616.1: Start a bare activated ability's mana-leg
+/// payment from its exact serialized root. A source cost can pause before either
+/// ordinary spending or Phyrexian selection, so both paths must use the same
+/// automatic finalizer rather than the unrooted direct cost-payment helper.
+/// Removal-first and `{X}` detours already establish this root through
+/// `enter_payment_step`; this path covers bare mana + non-removal residual tails.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn try_finalize_activation_mana_payment(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
     ability_index: usize,
     resolved: &ResolvedAbility,
     cost: &AbilityCost,
+    target_selection: ActivationTargetSelection,
     events: &mut Vec<GameEvent>,
-) -> Option<WaitingFor> {
-    if find_non_self_battlefield_removal_cost(cost).is_some() {
-        return None;
+) -> Result<Option<WaitingFor>, EngineError> {
+    let mut pending = PendingCast::new(source_id, CardId(0), resolved.clone(), ManaCost::NoCost);
+    pending.activation_target_selection = target_selection;
+    try_finalize_activation_mana_payment_from_root(
+        state,
+        player,
+        pending,
+        ability_index,
+        resolved,
+        cost,
+        events,
+    )
+}
+
+/// CR 602.2b + CR 605.3b + CR 616.1: Establish a serialized activation root
+/// for one unpaid, nonzero mana leg. Callers supply the exact root at their
+/// payment boundary, so target-first activations retain chosen targets and only
+/// the non-mana suffix remains after the mana payment settles.
+pub(super) fn try_finalize_pending_activation_mana_leg(
+    state: &mut GameState,
+    player: PlayerId,
+    mut pending: PendingCast,
+    ability_index: usize,
+    cost: &AbilityCost,
+    events: &mut Vec<GameEvent>,
+) -> Result<Option<WaitingFor>, EngineError> {
+    let Some((mana_cost, remaining)) = casting_costs::extract_mana_leg(cost) else {
+        return Ok(None);
+    };
+    if mana_cost.is_without_paying_mana() {
+        return Ok(None);
     }
-    let (mana_cost, remaining) = casting_costs::extract_mana_leg(cost)?;
     let excluded_sources = remaining
         .as_ref()
-        .map(|tail| ability_mana_payment_excluded_sources(tail, source_id))
+        .map(|tail| ability_mana_payment_excluded_sources(tail, pending.object_id))
         .unwrap_or_default();
-    let (source_types, source_subtypes) = activation_source_types(state, source_id);
+    let (source_types, source_subtypes) = activation_source_types(state, pending.object_id);
     let activation_ctx = PaymentContext::Activation {
         source_types: &source_types,
         source_subtypes: &source_subtypes,
-        ability_tag: activation_ability_tag(state, source_id, ability_index),
+        ability_tag: activation_ability_tag(state, pending.object_id, ability_index),
     };
+    pending.cost = mana_cost.clone();
+    pending.activation_cost = remaining;
+    pending.activation_ability_index = Some(ability_index);
+    pending.activation_residual = ActivationResidual::ManaLeg;
+    let pending_source_id = pending.object_id;
+    state.pending_cast = Some(Box::new(pending));
     let waiting = casting_costs::maybe_pause_for_phyrexian_choice(
+        state,
+        player,
+        pending_source_id,
+        &mana_cost,
+        events,
+        Some(&activation_ctx),
+        &excluded_sources,
+        Some(&ManaAbilityResume::FinalizePendingManaPayment { player }),
+    );
+    if let Some(waiting) = waiting {
+        return Ok(Some(waiting));
+    }
+    casting_costs::finalize_automatic_mana_payment(state, player, events).map(Some)
+}
+
+/// CR 602.2b + CR 605.3b + CR 616.1: Finalize an activation mana cost that
+/// was already locked on its serialized root (notably chosen-X before target
+/// selection). The root's residual marker belongs to the caller and must not
+/// be replaced while an automatic mana source can pause on a cost move.
+pub(super) fn finalize_pending_activation_mana_payment(
+    state: &mut GameState,
+    player: PlayerId,
+    pending: PendingCast,
+    ability_index: usize,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let mana_cost = pending.cost.clone();
+    debug_assert!(
+        !mana_cost.is_without_paying_mana(),
+        "only a genuine locked mana cost reaches automatic activation finalization"
+    );
+    let excluded_sources = pending
+        .activation_cost
+        .as_ref()
+        .map(|tail| ability_mana_payment_excluded_sources(tail, pending.object_id))
+        .unwrap_or_default();
+    let (source_types, source_subtypes) = activation_source_types(state, pending.object_id);
+    let activation_ctx = PaymentContext::Activation {
+        source_types: &source_types,
+        source_subtypes: &source_subtypes,
+        ability_tag: activation_ability_tag(state, pending.object_id, ability_index),
+    };
+    let source_id = pending.object_id;
+    state.pending_cast = Some(Box::new(pending));
+    if let Some(waiting) = casting_costs::maybe_pause_for_phyrexian_choice(
         state,
         player,
         source_id,
@@ -15111,15 +15438,31 @@ pub(super) fn try_pause_activation_phyrexian_payment(
         events,
         Some(&activation_ctx),
         &excluded_sources,
-    )?;
-    let mut pending = PendingCast::new(source_id, CardId(0), resolved.clone(), mana_cost);
-    pending.activation_cost = remaining;
-    pending.activation_ability_index = Some(ability_index);
-    if pending.activation_cost.is_some() {
-        pending.activation_residual = ActivationResidual::ManaLeg;
+        Some(&ManaAbilityResume::FinalizePendingManaPayment { player }),
+    ) {
+        return Ok(waiting);
     }
-    state.pending_cast = Some(Box::new(pending));
-    Some(waiting)
+    casting_costs::finalize_automatic_mana_payment(state, player, events)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn try_finalize_activation_mana_payment_from_root(
+    state: &mut GameState,
+    player: PlayerId,
+    mut pending: PendingCast,
+    ability_index: usize,
+    resolved: &ResolvedAbility,
+    cost: &AbilityCost,
+    events: &mut Vec<GameEvent>,
+) -> Result<Option<WaitingFor>, EngineError> {
+    // Preserve the established left-to-right self-discard path: the source-card
+    // discard can pause before the later mana leg, whose continuation then
+    // establishes this same serialized root.
+    if find_non_self_battlefield_removal_cost(cost).is_some() || has_self_ref_discard_cost(cost) {
+        return Ok(None);
+    }
+    pending.ability = resolved.clone();
+    try_finalize_pending_activation_mana_leg(state, player, pending, ability_index, cost, events)
 }
 
 /// CR 602.2: To activate an ability is to put it onto the stack and pay its costs.
@@ -15841,6 +16184,27 @@ pub fn handle_activate_ability(
             });
         }
 
+        // CR 601.2c + CR 601.2h + CR 602.2b: For no-target activations, use
+        // the serialized residual dispatcher for interactive cost kinds not
+        // covered by the earlier specialized detours. Its selected-cost
+        // handlers remove exactly one leg before re-entering the payment
+        // boundary, including repeated and chosen-OneOf costs.
+        if build_target_slots(state, &resolved)?.is_empty() {
+            let mut pending_interactive =
+                PendingCast::new(source_id, CardId(0), resolved.clone(), ManaCost::NoCost);
+            pending_interactive.activation_cost = Some(cost.clone());
+            pending_interactive.activation_ability_index = Some(ability_index);
+            if let Some(waiting_for) =
+                casting_costs::surface_next_unpaid_interactive_activation_cost(
+                    state,
+                    player,
+                    &pending_interactive,
+                )?
+            {
+                return Ok(waiting_for);
+            }
+        }
+
         // Waterbend cost: detour to ManaPayment with Waterbend mode.
         if let Some(wb_cost) = find_waterbend_cost(cost) {
             let mut pending_wb = PendingCast::new(source_id, CardId(0), resolved, wb_cost.clone());
@@ -15874,18 +16238,20 @@ pub fn handle_activate_ability(
                         resolved,
                         cost.clone(),
                         ability_index,
+                        ActivationTargetSelection::Settled,
                     ));
                 }
                 stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
-                if let Some(waiting) = try_pause_activation_phyrexian_payment(
+                if let Some(waiting) = try_finalize_activation_mana_payment(
                     state,
                     player,
                     source_id,
                     ability_index,
                     &resolved,
                     cost,
+                    ActivationTargetSelection::Settled,
                     events,
-                ) {
+                )? {
                     return Ok(waiting);
                 }
                 if let PaymentOutcome::Paused { remaining_cost } = pay_ability_cost_for_activation(
@@ -16001,18 +16367,20 @@ pub fn handle_activate_ability(
                 resolved,
                 cost.clone(),
                 ability_index,
+                ActivationTargetSelection::Pending,
             ));
         }
         stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
-        if let Some(waiting) = try_pause_activation_phyrexian_payment(
+        if let Some(waiting) = try_finalize_activation_mana_payment(
             state,
             player,
             source_id,
             ability_index,
             &resolved,
             cost,
+            ActivationTargetSelection::Pending,
             events,
-        ) {
+        )? {
             return Ok(waiting);
         }
         if let PaymentOutcome::Paused { remaining_cost } = pay_ability_cost_for_activation(

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -13,11 +13,11 @@ use crate::types::ability::{
 use crate::types::card_type::CoreType;
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
-    ActivationResidual, AssistState, CastPaymentMode, CastingVariant, ConvokeMode, CostResume,
-    CounterCostChoice, CounterRemoveChoice, DeferredSacrificeSelection, DistributionUnit,
-    GameState, PayCostKind, PendingCast, PendingCostMoveCompletion, PendingCostMoveResume,
-    PendingDiscardForCostResume, SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot,
-    WaitingFor,
+    ActivationResidual, ActivationTargetSelection, AssistState, CastPaymentMode, CastingVariant,
+    ConvokeMode, CostResume, CounterCostChoice, CounterRemoveChoice, DeferredSacrificeSelection,
+    DistributionUnit, GameState, ManaAbilityCostParent, ManaAbilityResume, PayCostKind,
+    PendingCast, PendingCostMoveCompletion, PendingCostMoveResume, PendingDiscardForCostResume,
+    SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot, WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::Keyword;
@@ -1119,18 +1119,9 @@ fn finish_pending_cost_or_cast(
         return enter_payment_step(state, player, None, events);
     }
 
-    if let Some(ability_index) = pending.activation_ability_index {
-        let waiting_for = push_activated_ability_to_stack(
-            state,
-            player,
-            pending.object_id,
-            ability_index,
-            pending.ability,
-            pending.activation_cost.as_ref(),
-            pending.activation_residual,
-            pending.pending_loyalty_activation_player,
-            events,
-        )?;
+    if pending.activation_ability_index.is_some() {
+        let waiting_for =
+            finish_activated_ability_at_payment_boundary(state, player, pending, events)?;
         return Ok(drain_deferred_triggers_after_stack_object_announcement(
             state,
             events,
@@ -1508,6 +1499,13 @@ pub(crate) fn handle_discard_for_cost(
     }
     let cost_event_end = events.len();
 
+    if pending.activation_ability_index.is_some() {
+        pending.activation_cost = pending
+            .activation_cost
+            .take()
+            .and_then(super::casting::remove_selected_discard_cost);
+    }
+
     let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
 
     // CR 603.2 + CR 603.3b: When `finish_pending_cost_or_cast` lands on `Priority`
@@ -1674,6 +1672,7 @@ fn finish_cost_object_moves(
                 pending.cast_timing_permission,
                 pending.origin_zone,
                 phyrexian_choices.as_deref(),
+                None,
                 Some(FinalizePrePaymentChecks {
                     early_waiting_for: None,
                     cascade_cast_transformed,
@@ -1832,7 +1831,7 @@ pub(crate) fn resume_interrupted_cost_payment(
 
     if let Some(resume) = state.pending_discard_for_cost.take() {
         let player = resume.player;
-        let pending = resume.pending;
+        let mut pending = resume.pending;
         let cost_event_start = replacement_action_cost_event_start.unwrap_or(events.len());
         for &card_id in resume.chosen.iter().skip(resume.paused_at_index + 1) {
             match super::effects::discard::discard_as_cost(state, card_id, player, events) {
@@ -1866,6 +1865,12 @@ pub(crate) fn resume_interrupted_cost_payment(
                 }
             }
         }
+        if pending.activation_ability_index.is_some() {
+            pending.activation_cost = pending
+                .activation_cost
+                .take()
+                .and_then(super::casting::remove_selected_discard_cost);
+        }
         let cost_event_end = events.len();
         let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
         park_cost_payment_triggers_if_paused(
@@ -1889,18 +1894,8 @@ pub(crate) fn resume_interrupted_cost_payment(
         .get(&pending.object_id)
         .map(|o| o.controller)
         .unwrap_or(state.active_player);
-    if let Some(activation_ability_index) = pending.activation_ability_index {
-        return push_activated_ability_to_stack(
-            state,
-            player,
-            pending.object_id,
-            activation_ability_index,
-            pending.ability,
-            pending.activation_cost.as_ref(),
-            pending.activation_residual,
-            pending.pending_loyalty_activation_player,
-            events,
-        );
+    if pending.activation_ability_index.is_some() {
+        return finish_activated_ability_at_payment_boundary(state, player, pending, events);
     }
     finish_pending_cost_or_cast(state, player, pending, events)
 }
@@ -1962,35 +1957,10 @@ pub(crate) fn handle_activation_cost_one_of_choice(
         ));
     }
 
-    // CR 118.12a: `handle_activate_ability` routes bare discard legs through
-    // `WaitingFor::PayCost` before the OneOf gate; mirror that detour here after
-    // the branch is chosen so discard payment is not a silent activation no-op.
-    if let Some(ref cost) = pending.activation_cost {
-        if let Some((count, filter)) = super::casting::find_non_self_discard(cost) {
-            let count = super::quantity::resolve_quantity(state, count, player, pending.object_id)
-                .max(0) as usize;
-            let eligible = super::casting::find_eligible_discard_targets(
-                state,
-                player,
-                pending.object_id,
-                filter,
-            );
-            if eligible.len() < count {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough cards in hand to discard".into(),
-                ));
-            }
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::Discard,
-                choices: eligible,
-                count,
-                min_count: 0,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending),
-                },
-            });
-        }
+    if let Some(waiting_for) =
+        surface_next_unpaid_interactive_activation_cost(state, player, &pending)?
+    {
+        return Ok(waiting_for);
     }
 
     finish_pending_cost_or_cast(state, player, pending, events)
@@ -2058,6 +2028,7 @@ fn auto_activate_spell_mana_abilities_before_deferred_sacrifice(
     state: &mut GameState,
     player: PlayerId,
     pending: &PendingCast,
+    resume: Option<&ManaAbilityResume>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
     let previous_pending = state.pending_cast.clone();
@@ -2083,14 +2054,25 @@ fn auto_activate_spell_mana_abilities_before_deferred_sacrifice(
     let events_before = simulated_events.len();
     let spell_meta = super::casting::build_spell_meta(&simulated, player, pending.object_id);
     let spell_ctx = spell_meta.as_ref().map(PaymentContext::Spell);
-    auto_tap_mana_sources_with_context(
+    auto_tap_mana_sources_with_context_and_resume(
         &mut simulated,
         player,
         &pending.cost,
         &mut simulated_events,
         Some(pending.object_id),
         spell_ctx.as_ref(),
+        resume,
     );
+    // CR 601.2g + CR 605.3b + CR 616.1: The replacement choice belongs to
+    // the caller-owned typed payment root. Do not continue into the pool
+    // spend or deferred sacrifice while that source activation is suspended.
+    if super::casting::mana_ability_cost_payment_is_paused(&simulated) {
+        *state = simulated;
+        *events = simulated_events;
+        return Err(EngineError::InvalidAction(
+            "Mana payment is awaiting a replacement choice".to_string(),
+        ));
+    }
     // CR 605.4a: triggered mana abilities from those taps resolve immediately.
     super::triggers::resolve_tap_mana_triggers_inline(
         &mut simulated,
@@ -2146,6 +2128,7 @@ fn pay_spell_mana_before_deferred_sacrifice(
     player: PlayerId,
     pending: &PendingCast,
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
+    resume: Option<&ManaAbilityResume>,
     events: &mut Vec<GameEvent>,
 ) -> Result<Option<u32>, EngineError> {
     if pending.deferred_sacrificed_permanents.is_empty() {
@@ -2153,7 +2136,9 @@ fn pay_spell_mana_before_deferred_sacrifice(
     }
 
     validate_deferred_spell_sacrifices_at_commit(state, player, pending)?;
-    auto_activate_spell_mana_abilities_before_deferred_sacrifice(state, player, pending, events)?;
+    auto_activate_spell_mana_abilities_before_deferred_sacrifice(
+        state, player, pending, resume, events,
+    )?;
     stamp_convoked_creatures(state, pending.object_id, &pending.convoked_creatures);
     let actual_mana_spent = super::casting::pay_mana_cost_from_pool_with_choices(
         state,
@@ -2399,6 +2384,13 @@ pub(crate) fn handle_sacrifice_for_cost(
     );
     let cost_event_end = events.len();
 
+    if pending.activation_ability_index.is_some() {
+        pending.activation_cost = pending
+            .activation_cost
+            .take()
+            .and_then(super::casting::remove_selected_non_self_sacrifice_cost);
+    }
+
     let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
 
     // CR 603.6c + CR 603.10a + CR 603.3b: When `finish_pending_cost_or_cast`
@@ -2517,6 +2509,14 @@ pub(crate) fn handle_unattach_for_cost(
             });
         }
     }
+
+    // CR 601.2h: This handler paid exactly one interactive `UnattachFrom` leg.
+    // Keep only the unpaid suffix so a later mana-leg root cannot replay the
+    // detached attachment while completing the activation.
+    pending.activation_cost = pending
+        .activation_cost
+        .take()
+        .and_then(super::casting::remove_selected_unattach_from_cost);
 
     // CR 601.2d + CR 608.2k: if this ability divides an effect among targets
     // (Captain America's Throw), the divided total (the unattached Equipment's
@@ -3383,6 +3383,13 @@ fn finish_exile_selection_for_cost(
         }
     }
 
+    if pending.activation_ability_index.is_some() {
+        pending.activation_cost = pending
+            .activation_cost
+            .take()
+            .and_then(super::casting::remove_selected_non_self_exile_cost);
+    }
+
     finish_cost_object_moves(
         state,
         player,
@@ -3547,6 +3554,252 @@ pub(crate) fn handle_exile_materials_for_cost(
     Ok(result)
 }
 
+/// Complete an activation at a cost-payment boundary.
+///
+/// The caller owns the exact `PendingCast` that accumulated targets, mode labels,
+/// distributions, and already-paid interactive cost legs. Preserve that root if
+/// its remaining cost contains a real mana leg: a mana-source cost move can pause
+/// before the activation reaches the stack.
+pub(crate) fn finish_activated_ability_at_payment_boundary(
+    state: &mut GameState,
+    player: PlayerId,
+    pending: PendingCast,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let ability_index = pending.activation_ability_index.ok_or_else(|| {
+        EngineError::InvalidAction(
+            "activation payment boundary missing an ability index".to_string(),
+        )
+    })?;
+
+    if !pending.cost.is_without_paying_mana() {
+        return super::casting::finalize_pending_activation_mana_payment(
+            state,
+            player,
+            pending,
+            ability_index,
+            events,
+        );
+    }
+
+    let should_finalize_mana_leg = !matches!(
+        pending.activation_residual,
+        ActivationResidual::ManaLeg | ActivationResidual::XMana
+    ) && pending
+        .activation_cost
+        .as_ref()
+        .and_then(super::casting_costs::extract_mana_leg)
+        .is_some_and(|(mana_cost, _)| !mana_cost.is_without_paying_mana());
+
+    if should_finalize_mana_leg {
+        let cost = pending
+            .activation_cost
+            .clone()
+            .expect("checked activation cost contains a payable mana leg");
+        return Ok(super::casting::try_finalize_pending_activation_mana_leg(
+            state,
+            player,
+            pending,
+            ability_index,
+            &cost,
+            events,
+        )?
+        .expect("payable activation mana leg enters its finalization flow"));
+    }
+
+    push_activated_ability_to_stack(
+        state,
+        player,
+        pending.object_id,
+        ability_index,
+        pending.ability,
+        pending.activation_cost.as_ref(),
+        pending.activation_residual,
+        pending.activation_target_selection,
+        pending.pending_loyalty_activation_player,
+        events,
+    )
+}
+
+/// CR 601.2c + CR 601.2h + CR 602.2b: Complete a target-first activation
+/// after its target selection has settled.
+///
+/// Marks the target-declaration lifecycle on the serialized root, then uses the
+/// common payment authority. This keeps the full X/counter/disjunctive resolver
+/// intact while preventing an explicitly declined optional target from reopening.
+pub(crate) fn finish_target_selected_activated_ability_at_payment_boundary(
+    state: &mut GameState,
+    player: PlayerId,
+    mut pending: PendingCast,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    pending.activation_target_selection =
+        crate::types::game_state::ActivationTargetSelection::Settled;
+    finish_activated_ability_at_payment_boundary(state, player, pending, events)
+}
+
+/// CR 118.3 + CR 601.2h + CR 602.2b: Surface exactly the next unpaid
+/// interactive activation-cost component from the serialized residual. Every
+/// completed handler removes one matching leg, so repeated components and a
+/// chosen `OneOf` branch naturally re-enter here until no selection remains.
+pub(crate) fn surface_next_unpaid_interactive_activation_cost(
+    state: &GameState,
+    player: PlayerId,
+    pending: &PendingCast,
+) -> Result<Option<WaitingFor>, EngineError> {
+    let Some(cost) = pending.activation_cost.as_ref() else {
+        return Ok(None);
+    };
+    let source_id = pending.object_id;
+
+    if let Some((count, filter)) = super::casting::find_non_self_discard(cost) {
+        let count =
+            super::quantity::resolve_quantity(state, count, player, source_id).max(0) as usize;
+        let eligible =
+            super::casting::find_eligible_discard_targets(state, player, source_id, filter);
+        if eligible.len() < count {
+            return Err(EngineError::ActionNotAllowed(
+                "Not enough cards in hand to discard".into(),
+            ));
+        }
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::Discard,
+            choices: eligible,
+            count,
+            min_count: 0,
+            resume: CostResume::Spell {
+                spell: Box::new(pending.clone()),
+            },
+        }));
+    }
+
+    if let Some((count, sacrifice_filter)) = super::casting::find_non_self_sacrifice_cost(cost) {
+        let eligible = super::casting::find_eligible_sacrifice_targets(
+            state,
+            player,
+            source_id,
+            sacrifice_filter,
+        );
+        let (min_count, max_count) = super::casting::sacrifice_cost_bounds(count, eligible.len());
+        if eligible.len() < min_count {
+            return Err(EngineError::ActionNotAllowed(
+                "Not enough eligible permanents to sacrifice".into(),
+            ));
+        }
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::Sacrifice,
+            choices: eligible,
+            count: max_count,
+            min_count,
+            resume: CostResume::Spell {
+                spell: Box::new(pending.clone()),
+            },
+        }));
+    }
+
+    if let Some((count, zone, filter)) = super::casting::find_non_self_exile(cost) {
+        let zone = ExileCostSourceZone::try_from_zone(zone)
+            .expect("non-self activation exile costs use hand or graveyard");
+        let eligible = super::casting::find_eligible_exile_for_cost_targets(
+            state, player, source_id, zone, filter,
+        );
+        if eligible.len() < count as usize {
+            return Err(EngineError::ActionNotAllowed(
+                "Not enough eligible cards to exile".into(),
+            ));
+        }
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::ExileFromZone { zone },
+            choices: eligible,
+            count: count as usize,
+            min_count: 0,
+            resume: CostResume::Spell {
+                spell: Box::new(pending.clone()),
+            },
+        }));
+    }
+
+    if let Some((count, exile_filter)) = super::casting::find_battlefield_exile_cost(cost) {
+        let effective_filter =
+            super::cost_payability::exile_cost_effective_filter(Some(exile_filter));
+        let eligible = super::cost_payability::eligible_exile_cost_objects(
+            state,
+            player,
+            source_id,
+            Zone::Battlefield,
+            effective_filter.as_ref(),
+            count,
+        );
+        if eligible.len() < count as usize {
+            return Err(EngineError::ActionNotAllowed(
+                "Not enough eligible permanents to exile".into(),
+            ));
+        }
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::ExilePermanent {
+                filter: Some(exile_filter.clone()),
+            },
+            choices: eligible,
+            count: count as usize,
+            min_count: count as usize,
+            resume: CostResume::Spell {
+                spell: Box::new(pending.clone()),
+            },
+        }));
+    }
+
+    if let Some((count, filter)) = super::casting::find_unattach_from_cost(cost) {
+        let eligible = super::casting::find_eligible_unattach_for_cost_targets(
+            state, player, source_id, filter, 0,
+        );
+        if eligible.len() < count as usize {
+            return Err(EngineError::ActionNotAllowed(
+                "Not enough attachments to unattach".into(),
+            ));
+        }
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::UnattachFrom {
+                filter: filter.clone(),
+            },
+            choices: eligible,
+            count: count as usize,
+            min_count: count as usize,
+            resume: CostResume::Spell {
+                spell: Box::new(pending.clone()),
+            },
+        }));
+    }
+
+    if let Some((count, filter)) = super::casting::find_return_to_hand_cost(cost)
+        .filter(|(_, filter)| !matches!(filter, Some(TargetFilter::SelfRef)))
+    {
+        let eligible =
+            super::casting::find_eligible_return_to_hand_targets(state, player, source_id, filter);
+        if eligible.len() < count as usize {
+            return Err(EngineError::ActionNotAllowed(
+                "No eligible permanents to return".into(),
+            ));
+        }
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::ReturnToHand,
+            choices: eligible,
+            count: count as usize,
+            min_count: 0,
+            resume: CostResume::Spell {
+                spell: Box::new(pending.clone()),
+            },
+        }));
+    }
+
+    Ok(None)
+}
+
 /// Push an activated ability to the stack after costs are paid.
 /// Shared by: direct path in `handle_activate_ability`, sacrifice detour, and
 /// waterbend/ManaPayment finalization in the PassPriority handler.
@@ -3558,244 +3811,44 @@ pub(super) fn push_activated_ability_to_stack(
     ability_index: usize,
     mut resolved: ResolvedAbility,
     remaining_cost: Option<&crate::types::ability::AbilityCost>,
-    // CR 601.2g + CR 601.2h + CR 602.2b: POSITIVE signal of which mana-first
-    // detour the caller took, so `remaining_cost` is the unpaid residual non-mana
-    // tail. Threaded from `PendingCast::activation_residual` — set ONLY by the
-    // `{X}`-mana detour (`XMana` → re-surface the residual non-self DISCARD) and
-    // the non-X mana-leg detour (`ManaLeg` → re-surface the residual non-self
-    // battlefield-removal: Sacrifice / battlefield Exile / ReturnToHand).
+    // CR 118.3 + CR 601.2h: The X-mana detour has a deliberately narrow
+    // residual contract. A non-self sacrifice or exile must still fail loudly
+    // rather than be silently accepted through the generic cost dispatcher.
     activation_residual: ActivationResidual,
+    target_selection: ActivationTargetSelection,
     mut pending_loyalty_activation_player: Option<PlayerId>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    // CR 702.170b: Plot is a special action that never uses the stack. A Moved
-    // replacement can now pause its self-exile cost, so resume it here rather
-    // than falling through to the activated-ability stack path.
-    if super::casting::effect_is_plot_grant(&resolved.effect) {
-        super::effects::grant_permission::resolve(state, &resolved, events).map_err(|error| {
-            EngineError::ActionNotAllowed(format!("plot special action failed: {error}"))
-        })?;
-        priority::clear_priority_passes(state);
-        return Ok(WaitingFor::Priority { player });
-    }
-
-    // Pay any activation-cost tail still outstanding. Cost-selection flows may
-    // pass the original full cost; choice-based sub-costs already paid by a
-    // WaitingFor handler are no-ops here.
+    // Pay the exact activation-cost suffix still outstanding. Interactive cost
+    // handlers remove the leg they paid before this boundary, so a parked mana
+    // root never replays an earlier selection.
     if let Some(cost) = remaining_cost {
-        // A residual return-to-hand leg is not auto-payable: it needs the same
-        // card-selection round-trip as the first leg. This also covers a second
-        // return in a composite after `handle_return_to_hand_for_cost` paid the
-        // first one.
-        if super::casting::has_only_return_to_hand_cost_legs(cost) {
-            if let Some((count, filter)) = super::casting::find_return_to_hand_cost(cost) {
-                let eligible = super::casting::find_eligible_return_to_hand_targets(
-                    state, player, source_id, filter,
-                );
-                if eligible.len() < count as usize {
-                    return Err(EngineError::ActionNotAllowed(
-                        "No eligible permanents to return".into(),
-                    ));
-                }
-                let mut pending_return =
-                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-                pending_return.activation_cost = Some(cost.clone());
-                pending_return.activation_ability_index = Some(ability_index);
-                return Ok(WaitingFor::PayCost {
-                    player,
-                    kind: PayCostKind::ReturnToHand,
-                    choices: eligible,
-                    count: count as usize,
-                    min_count: 0,
-                    resume: CostResume::Spell {
-                        spell: Box::new(pending_return),
-                    },
-                });
-            }
-        }
-
-        // CR 601.2f + CR 601.2h + CR 701.9a: When the X-mana detour ran first
-        // (e.g. the Momir Basic emblem's `{X}, Discard a card` cost), the non-self
-        // "discard a card" sub-cost is still OUTSTANDING here AFTER mana payment,
-        // signalled by `ActivationResidual::XMana`. In contrast, the discard-FIRST
-        // pre-check detour in `handle_activate_ability` already paid the discard
-        // and resumes with `None` and the ORIGINAL cost — its discard sub-cost is
-        // correctly no-op'd by `pay_ability_cost_for_activation` below. Gating on
-        // the positive `XMana` signal (not the cost shape) avoids double-charging
-        // the discard on that pre-check path even when the cost is a BARE `Discard`
-        // (which would otherwise fail with an empty hand). Discard is a hand cost,
-        // never a battlefield removal, so the `ManaLeg` detour never produces it.
-        if let Some((count, filter)) = super::casting::find_non_self_discard(cost)
-            .filter(|_| matches!(activation_residual, ActivationResidual::XMana))
-        {
-            let count =
-                super::quantity::resolve_quantity(state, count, player, source_id).max(0) as usize;
-            let eligible =
-                super::casting::find_eligible_discard_targets(state, player, source_id, filter);
-            if eligible.len() < count {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough cards in hand to discard".into(),
-                ));
-            }
-            let mut pending_discard =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_discard.activation_ability_index = Some(ability_index);
-            pending_discard.pending_loyalty_activation_player = pending_loyalty_activation_player;
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::Discard,
-                choices: eligible,
-                count,
-                min_count: 0,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_discard),
-                },
-            });
-        }
-
-        // CR 601.2g + CR 601.2h + CR 602.2b: When the non-X mana-leg detour ran
-        // first (`ActivationResidual::ManaLeg`), the mana leg was already paid on
-        // the INTACT board (the CR 601.2g window), so the residual tail here is a
-        // non-self battlefield-removal cost still OUTSTANDING. Each arm re-surfaces
-        // the interactive removal exactly as the Discard arm above, storing the
-        // residual in the resumed `PendingCast` so its handler completes payment.
-        // These MUST be hand-rolled rather than left to the
-        // `pay_ability_cost_for_activation` fall-through below: that fall-through
-        // pays a `Tap` leg but is a SILENT `Paid` no-op for a non-self Sacrifice or
-        // Exile (it relies on the pre-payment interception the mana-first hoist
-        // bypassed — see the XMana seam comment below). Mirrors the
-        // Sacrifice/Exile/ReturnToHand pre-payment detours in
-        // `handle_activate_ability`, but triggered AFTER mana payment.
-        if matches!(activation_residual, ActivationResidual::ManaLeg) {
-            if let Some((count, sac_filter)) = super::casting::find_non_self_sacrifice_cost(cost) {
-                let eligible = super::casting::find_eligible_sacrifice_targets(
-                    state, player, source_id, sac_filter,
-                );
-                let (min_count, max_count) =
-                    super::casting::sacrifice_cost_bounds(count, eligible.len());
-                if eligible.len() < min_count {
-                    return Err(EngineError::ActionNotAllowed(
-                        "Not enough eligible permanents to sacrifice".into(),
-                    ));
-                }
-                let mut pending_sac =
-                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-                pending_sac.activation_cost = Some(cost.clone());
-                pending_sac.activation_ability_index = Some(ability_index);
-                pending_sac.pending_loyalty_activation_player = pending_loyalty_activation_player;
-                return Ok(WaitingFor::PayCost {
-                    player,
-                    kind: PayCostKind::Sacrifice,
-                    choices: eligible,
-                    count: max_count,
-                    min_count,
-                    resume: CostResume::Spell {
-                        spell: Box::new(pending_sac),
-                    },
-                });
-            }
-
-            // CR 701.13a: battlefield exile-as-cost. `ExilePermanent` (NOT
-            // `ExileFromZone`, whose `ExileCostSourceZone` is Hand|Graveyard-only).
-            // Mirrors the battlefield exile additional-cost arm in
-            // `pay_additional_cost`.
-            if let Some((count, exile_filter)) = super::casting::find_battlefield_exile_cost(cost) {
-                let effective_filter =
-                    super::cost_payability::exile_cost_effective_filter(Some(exile_filter));
-                let eligible = super::cost_payability::eligible_exile_cost_objects(
-                    state,
-                    player,
-                    source_id,
-                    Zone::Battlefield,
-                    effective_filter.as_ref(),
-                    count,
-                );
-                if eligible.len() < count as usize {
-                    return Err(EngineError::ActionNotAllowed(
-                        "Not enough eligible permanents to exile".into(),
-                    ));
-                }
-                let mut pending_exile =
-                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-                pending_exile.activation_cost = Some(cost.clone());
-                pending_exile.activation_ability_index = Some(ability_index);
-                pending_exile.pending_loyalty_activation_player = pending_loyalty_activation_player;
-                return Ok(WaitingFor::PayCost {
-                    player,
-                    kind: PayCostKind::ExilePermanent {
-                        filter: Some(exile_filter.clone()),
-                    },
-                    choices: eligible,
-                    count: count as usize,
-                    min_count: count as usize,
-                    resume: CostResume::Spell {
-                        spell: Box::new(pending_exile),
-                    },
-                });
-            }
-
-            // Plain battlefield bounce (Master Transmuter `{U}, {T}, Return ...`).
-            // The residual stored here is `Composite[Tap, ReturnToHand]`; the
-            // trailing Tap is paid by `handle_return_to_hand_for_cost` (which pays
-            // the stored `activation_cost`), and ReturnToHand is a no-op there
-            // because the handler performs the chosen return itself.
-            if let Some((count, rth_filter)) = super::casting::find_return_to_hand_cost(cost) {
-                let eligible = super::casting::find_eligible_return_to_hand_targets(
-                    state, player, source_id, rth_filter,
-                );
-                if eligible.len() < count as usize {
-                    return Err(EngineError::ActionNotAllowed(
-                        "No eligible permanents to return".into(),
-                    ));
-                }
-                let mut pending_return =
-                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-                pending_return.activation_cost = Some(cost.clone());
-                pending_return.activation_ability_index = Some(ability_index);
-                pending_return.pending_loyalty_activation_player =
-                    pending_loyalty_activation_player;
-                return Ok(WaitingFor::PayCost {
-                    player,
-                    kind: PayCostKind::ReturnToHand,
-                    choices: eligible,
-                    count: count as usize,
-                    min_count: 0,
-                    resume: CostResume::Spell {
-                        spell: Box::new(pending_return),
-                    },
-                });
-            }
-        }
-
-        // CR 118.3 + CR 601.2h: The `{X}`-mana detour (`extract_x_mana_cost` in
-        // `handle_activate_ability`) hoists X-first and leaves the residual tail
-        // here, but ONLY the non-self `Discard` arm above re-surfaces an
-        // interactive cost for the XMana path. A residual non-self SACRIFICE or
-        // non-self EXILE would otherwise fall through to
-        // `pay_ability_cost_for_activation`, where both are silent `Paid` no-ops
-        // (they rely on the pre-payment SacrificeForCost / ExileForCost WaitingFor
-        // interception that the X-first hoist bypassed) — silently SKIPPING the
-        // cost. No current card has an `{X} + non-self-sacrifice/exile` activated
-        // ability (corpus scan = zero), and this was already broken pre-hoist
-        // (X→0), so this is not a regression — but a silent cost-swallow must not
-        // ship. Fail LOUDLY here. This gate is XMana-only: the ManaLeg path's
-        // non-self sacrifice/exile is already handled by the arms above (it never
-        // reaches here), and the two residual variants are mutually exclusive.
+        let has_non_self_sacrifice_or_exile = super::casting::find_non_self_sacrifice_cost(cost)
+            .is_some()
+            || super::casting::find_non_self_exile(cost).is_some()
+            || super::casting::find_battlefield_exile_cost(cost).is_some();
         if matches!(activation_residual, ActivationResidual::XMana)
-            && (super::casting::find_non_self_sacrifice_cost(cost).is_some()
-                || super::casting::find_non_self_exile(cost).is_some())
+            && has_non_self_sacrifice_or_exile
         {
             debug_assert!(
-                false,
-                "X-residual activation left a non-self sacrifice/exile cost unhandled \
-                 (cost: {cost:?}); extend the residual detour in \
-                 push_activated_ability_to_stack"
+                !has_non_self_sacrifice_or_exile,
+                "non-self sacrifice/exile cost unhandled"
             );
             return Err(EngineError::ActionNotAllowed(
-                "Unsupported activated-ability cost: {X} combined with a non-self \
-                 sacrifice/exile is not yet implemented"
-                    .into(),
+                "non-self sacrifice/exile cost unhandled".to_string(),
             ));
+        }
+
+        let mut pending_interactive =
+            PendingCast::new(source_id, CardId(0), resolved.clone(), ManaCost::NoCost);
+        pending_interactive.activation_cost = Some(cost.clone());
+        pending_interactive.activation_ability_index = Some(ability_index);
+        pending_interactive.pending_loyalty_activation_player = pending_loyalty_activation_player;
+        pending_interactive.activation_target_selection = target_selection;
+        if let Some(waiting_for) =
+            surface_next_unpaid_interactive_activation_cost(state, player, &pending_interactive)?
+        {
+            return Ok(waiting_for);
         }
 
         // CR 606.3 + CR 606.5: Capture the symbolic `[−X]` loyalty shape before
@@ -3824,6 +3877,7 @@ pub(super) fn push_activated_ability_to_stack(
                 resolved,
                 cost.clone(),
                 ability_index,
+                target_selection,
             ));
         }
         // CR 606.3: A `[−X]` loyalty ability is modeled as a chosen-X removal of
@@ -3860,12 +3914,14 @@ pub(super) fn push_activated_ability_to_stack(
                 events,
             )?
         {
-            let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+            let mut pending =
+                PendingCast::new(source_id, CardId(0), resolved.clone(), ManaCost::NoCost);
             pending.activation_cost = remaining_cost;
             pending.activation_ability_index = Some(ability_index);
             pending.pending_loyalty_activation_player = should_record_loyalty
                 .then_some(player)
                 .or(pending_loyalty_activation_player);
+            pending.activation_target_selection = target_selection;
             if let Some(pending) = attach_pending_cast_to_cost_move(state, Box::new(pending)) {
                 state.pending_cast = Some(pending);
             }
@@ -3875,6 +3931,31 @@ pub(super) fn push_activated_ability_to_stack(
             super::planeswalker::record_loyalty_activation(state, source_id, player);
             pending_loyalty_activation_player = None;
         }
+    }
+
+    // CR 702.170b: Plot is a special action that never uses the stack. Its
+    // self-exile is still an activation cost, so it must be paid above before
+    // resolving the grant; a Moved replacement can pause that cost move.
+    if super::casting::effect_is_plot_grant(&resolved.effect) {
+        super::effects::grant_permission::resolve(state, &resolved, events).map_err(|error| {
+            EngineError::ActionNotAllowed(format!("plot special action failed: {error}"))
+        })?;
+        priority::clear_priority_passes(state);
+        return Ok(WaitingFor::Priority { player });
+    }
+
+    if matches!(target_selection, ActivationTargetSelection::Settled) {
+        let assigned_targets = flatten_targets_in_chain(&resolved);
+        emit_targeting_events(state, &assigned_targets, source_id, player, events);
+        return push_ability_entry(
+            state,
+            player,
+            source_id,
+            ability_index,
+            resolved,
+            pending_loyalty_activation_player,
+            events,
+        );
     }
 
     // CR 602.2b: Check if the ability has targets that need selection.
@@ -4035,7 +4116,7 @@ fn concretize_chosen_x_cost(cost: &AbilityCost, chosen_x: u32) -> AbilityCost {
 }
 
 /// Final step: create stack entry and record activation.
-fn push_ability_entry(
+pub(super) fn push_ability_entry(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
@@ -6912,6 +6993,19 @@ pub(super) fn pay_and_push_adventure(
         return enter_payment_step(state, player, convoke_mode, events);
     }
 
+    // CR 601.2h + CR 605.3b + CR 616.1: The automatic path must establish its
+    // authoritative payment root before probing mana sources. A source-cost
+    // replacement can suspend either ordinary payment or Phyrexian selection;
+    // retaining this `PendingCast` lets its typed mana resume finish the original
+    // operation rather than falling through to priority.
+    let mut pending = PendingCast::new(object_id, card_id, ability, cost.clone());
+    pending.base_cost = base_cost;
+    pending.casting_variant = casting_variant;
+    pending.cast_timing_permission = cast_timing_permission;
+    pending.distribute = distribute;
+    pending.origin_zone = origin_zone;
+    pending.payment_mode = payment_mode;
+
     // CR 702.132a: Assist — the cost is now fully locked (no X / convoke / manual
     // step pending), so before finalizing, a spell with assist and a generic
     // component lets the caster choose another player to help pay it. Stash the
@@ -6923,13 +7017,6 @@ pub(super) fn pay_and_push_adventure(
         cost,
         casting_variant == CastingVariant::Fuse,
     ) {
-        let mut pending = PendingCast::new(object_id, card_id, ability, cost.clone());
-        pending.base_cost = base_cost.clone();
-        pending.casting_variant = casting_variant;
-        pending.cast_timing_permission = cast_timing_permission;
-        pending.distribute = distribute;
-        pending.origin_zone = origin_zone;
-        pending.payment_mode = payment_mode;
         pending.assist_state = AssistState::Offered;
         state.pending_cast = Some(Box::new(pending));
         return Ok(WaitingFor::AssistChoosePlayer {
@@ -6940,41 +7027,8 @@ pub(super) fn pay_and_push_adventure(
         });
     }
 
-    // CR 107.4f + CR 601.2f: Pause before any Phyrexian shard would deduct life,
-    // whether life is optional or the only legal route. The resume handler calls
-    // `finalize_mana_payment_with_phyrexian_choices` which finishes the cast.
-    if let Some(waiting) = maybe_pause_for_phyrexian_choice(
-        state,
-        player,
-        object_id,
-        cost,
-        events,
-        None,
-        &HashSet::new(),
-    ) {
-        let mut pending = PendingCast::new(object_id, card_id, ability, cost.clone());
-        pending.base_cost = base_cost.clone();
-        pending.casting_variant = casting_variant;
-        pending.cast_timing_permission = cast_timing_permission;
-        pending.distribute = distribute;
-        pending.origin_zone = origin_zone;
-        pending.payment_mode = payment_mode;
-        state.pending_cast = Some(Box::new(pending));
-        return Ok(waiting);
-    }
-
-    finalize_cast(
-        state,
-        player,
-        object_id,
-        card_id,
-        ability,
-        cost,
-        casting_variant,
-        cast_timing_permission,
-        origin_zone,
-        events,
-    )
+    state.pending_cast = Some(Box::new(pending));
+    finalize_automatic_mana_payment(state, player, events)
 }
 
 /// CR 601.2i: Finalize a spell cast.
@@ -7122,37 +7176,10 @@ fn finalize_cast_pre_payment_checks(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(super) fn finalize_cast(
-    state: &mut GameState,
-    player: PlayerId,
-    object_id: ObjectId,
-    card_id: CardId,
-    ability: ResolvedAbility,
-    cost: &crate::types::mana::ManaCost,
-    casting_variant: CastingVariant,
-    cast_timing_permission: Option<CastTimingPermission>,
-    origin_zone: Zone,
-    events: &mut Vec<GameEvent>,
-) -> Result<WaitingFor, EngineError> {
-    finalize_cast_with_phyrexian_choices(
-        state,
-        player,
-        object_id,
-        card_id,
-        ability,
-        cost,
-        casting_variant,
-        cast_timing_permission,
-        origin_zone,
-        None,
-        events,
-    )
-}
-
 /// CR 107.4f + CR 601.2f: Variant of `finalize_cast` that threads explicit per-shard
 /// Phyrexian choices through `pay_mana_cost_with_choices`. `None` preserves
 /// auto-decide behavior.
+#[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn finalize_cast_with_phyrexian_choices(
     state: &mut GameState,
@@ -7178,6 +7205,7 @@ pub(super) fn finalize_cast_with_phyrexian_choices(
         cast_timing_permission,
         origin_zone,
         phyrexian_choices,
+        None,
         None,
         None,
         ReturnedCreatureCostMove::Pending,
@@ -7218,6 +7246,7 @@ fn finalize_cast_with_phyrexian_choices_inner(
     cast_timing_permission: Option<CastTimingPermission>,
     origin_zone: Zone,
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
+    mana_resume: Option<&ManaAbilityResume>,
     pre_payment_checks: Option<FinalizePrePaymentChecks>,
     prepaid_actual_mana_spent: Option<u32>,
     returned_creature_move: ReturnedCreatureCostMove,
@@ -7289,12 +7318,13 @@ fn finalize_cast_with_phyrexian_choices_inner(
     }
 
     if prepaid_actual_mana_spent.is_none() {
-        super::casting::pay_mana_cost_with_choices(
+        super::casting::pay_mana_cost_with_choices_and_resume(
             state,
             player,
             object_id,
             cost,
             phyrexian_choices,
+            mana_resume,
             events,
         )?;
     }
@@ -8414,6 +8444,8 @@ pub(super) fn auto_tap_mana_sources_excluding(
         None,
         None,
         None,
+        None,
+        None,
     );
 }
 
@@ -8436,6 +8468,59 @@ pub(super) fn auto_tap_mana_sources_with_context(
     );
 }
 
+/// Auto-tap mana sources for a resolution-time payment while retaining the
+/// caller's typed continuation if a mana-source cost move is replaced.
+pub(super) fn auto_tap_mana_sources_with_context_and_resume(
+    state: &mut GameState,
+    player: PlayerId,
+    cost: &crate::types::mana::ManaCost,
+    events: &mut Vec<GameEvent>,
+    deprioritize_source: Option<ObjectId>,
+    payment_context: Option<&PaymentContext<'_>>,
+    resume: Option<&crate::types::game_state::ManaAbilityResume>,
+) {
+    auto_tap_mana_sources_with_context_excluding_and_resume(
+        state,
+        player,
+        cost,
+        events,
+        deprioritize_source,
+        payment_context,
+        &HashSet::new(),
+        resume,
+        None,
+    );
+}
+
+/// CR 605.3b + CR 605.3c: Keep both the outer payment root and an optional
+/// suspended parent mana cursor attached to a source selected by auto-tap.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn auto_tap_mana_sources_with_context_excluding_and_resume(
+    state: &mut GameState,
+    player: PlayerId,
+    cost: &crate::types::mana::ManaCost,
+    events: &mut Vec<GameEvent>,
+    deprioritize_source: Option<ObjectId>,
+    payment_context: Option<&PaymentContext<'_>>,
+    excluded_sources: &HashSet<ObjectId>,
+    resume: Option<&ManaAbilityResume>,
+    parent: Option<&ManaAbilityCostParent>,
+) {
+    auto_tap_mana_sources_inner(
+        state,
+        player,
+        cost,
+        events,
+        deprioritize_source,
+        excluded_sources,
+        payment_context,
+        None,
+        None,
+        resume,
+        parent,
+    );
+}
+
 pub(super) fn auto_tap_mana_sources_with_context_excluding(
     state: &mut GameState,
     player: PlayerId,
@@ -8453,6 +8538,8 @@ pub(super) fn auto_tap_mana_sources_with_context_excluding(
         deprioritize_source,
         excluded_sources,
         payment_context,
+        None,
+        None,
         None,
         None,
     );
@@ -8512,6 +8599,8 @@ pub(super) fn auto_tap_mana_sources_with_context_excluding_cached(
         payment_context,
         None,
         source_cache,
+        None,
+        None,
     );
 }
 
@@ -8671,6 +8760,8 @@ fn auto_tap_mana_sources_inner(
     payment_context: Option<&PaymentContext<'_>>,
     sub_cost_demand: Option<&crate::game::mana_payment::ColorDemand>,
     source_cache: Option<&AutoTapSourceCache>,
+    resume: Option<&crate::types::game_state::ManaAbilityResume>,
+    parent: Option<&ManaAbilityCostParent>,
 ) {
     use crate::types::mana::ManaCost;
 
@@ -9069,7 +9160,12 @@ fn auto_tap_mana_sources_inner(
                         Some(&activation_ctx),
                         demand.as_ref(),
                         None,
+                        resume,
+                        parent,
                     );
+                    if super::casting::mana_ability_cost_payment_is_paused(state) {
+                        return;
+                    }
                 }
                 // color_override tells resolve_mana_ability how to resolve the
                 // ability's choice dimension. `SingleColor` replays a per-color
@@ -9094,7 +9190,12 @@ fn auto_tap_mana_sources_inner(
                     override_value,
                     excluded,
                     demand.as_ref(),
+                    resume,
+                    parent,
                 );
+                if super::casting::mana_ability_cost_payment_is_paused(state) {
+                    return;
+                }
             }
         } else {
             // Basic-land-subtype fallback — no explicit ability, just tap + produce.
@@ -9775,7 +9876,7 @@ pub fn enter_payment_step(
                     &pending.cost,
                 )
             {
-                return finalize_mana_payment(state, player, events);
+                return finalize_automatic_mana_payment(state, player, events);
             }
         }
     }
@@ -9797,29 +9898,47 @@ pub fn enter_payment_step(
 /// Called both from the `(ManaPayment, PassPriority)` branch in the main engine
 /// dispatcher and from `enter_payment_step` when classification skips the modal.
 /// This is the single authority for completing a mana payment.
-/// CR 702.132a: At the non-cancellable commit point (just before `finalize_cast`),
-/// spend a committed Assist contribution by tapping the helper's mana sources for
-/// the agreed generic amount. This is deferred to here — rather than performed at
-/// `CommitAssistPayment` — so a `CancelCast` at any intervening (still-cancellable)
-/// payment step never leaves the helper's lands tapped or their mana spent. The
-/// caster's owed cost was already reduced by `generic` at commit time. A no-op for
-/// non-assist casts and for declined/uncommitted assists.
+/// CR 702.132a + CR 601.2h: Start and complete a committed Assist contribution
+/// only at the final payment step. `Committed` is still selected intent, so a
+/// cancellation before this function leaves helper resources untouched. The typed
+/// `PaymentStarted` checkpoint begins exactly before helper auto-tap, preserving
+/// the irreversible boundary if a source-cost replacement pauses the payment.
+/// A no-op for non-assist casts and declined/uncommitted assists.
 pub(super) fn apply_committed_assist(
     state: &mut GameState,
-    pending: &PendingCast,
+    pending: &mut PendingCast,
+    resume: Option<&ManaAbilityResume>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
-    let AssistState::Committed { helper, generic } = pending.assist_state else {
-        return Ok(());
+    let (helper, generic) = match pending.assist_state {
+        AssistState::Committed { helper, generic } => {
+            pending.assist_state = AssistState::PaymentStarted { helper, generic };
+            (helper, generic)
+        }
+        AssistState::PaymentStarted { helper, generic } => (helper, generic),
+        _ => return Ok(()),
     };
     if generic == 0 {
+        pending.assist_state = AssistState::Paid { helper, generic };
         return Ok(());
     }
     let probe = ManaCost::Cost {
         shards: Vec::new(),
         generic,
     };
-    auto_tap_mana_sources(state, helper, &probe, events, None);
+    // CR 702.132a + CR 605.3b + CR 616.1: `PaymentStarted` marks the
+    // irreversible boundary, not a completed source plan. A replacement can
+    // pause after only one selected helper source; retry auto-tap against the
+    // residual pool payment so the still-untapped sources cover the deficit.
+    auto_tap_mana_sources_with_context_and_resume(
+        state, helper, &probe, events, None, None, resume,
+    );
+    if super::casting::mana_ability_cost_payment_is_paused(state) {
+        state.pending_cast = Some(Box::new(pending.clone()));
+        return Err(EngineError::InvalidAction(
+            "Assist mana payment is awaiting a replacement choice".to_string(),
+        ));
+    }
     if let Some(p) = state.players.iter_mut().find(|p| p.id == helper) {
         mana_payment::pay_from_pool(&mut p.mana_pool, &probe).map_err(|e| {
             EngineError::ActionNotAllowed(format!(
@@ -9830,12 +9949,49 @@ pub(super) fn apply_committed_assist(
             state.layers_dirty.mark_full();
         }
     }
+    // CR 702.132a + CR 118.10: A committed Assist contribution pays this
+    // cast's generic portion once. Persist that fact before any later caster
+    // source can pause, so retrying finalization cannot charge the helper twice.
+    pending.assist_state = AssistState::Paid { helper, generic };
     Ok(())
 }
 
 pub fn finalize_mana_payment(
     state: &mut GameState,
     player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let mana_resume = ManaAbilityResume::ManaPayment {
+        outer_player: Some(player),
+        convoke_mode: match &state.waiting_for {
+            WaitingFor::ManaPayment { convoke_mode, .. } => *convoke_mode,
+            _ => None,
+        },
+    };
+    finalize_mana_payment_with_resume(state, player, mana_resume, events)
+}
+
+/// CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: Complete an automatic spell
+/// cast or mana-leg activation from its already-established `PendingCast` root.
+/// A costed auto-tapped source can pause before payment completes; its cursor
+/// retries this exact finalizer rather than returning a player to priority.
+pub(super) fn finalize_automatic_mana_payment(
+    state: &mut GameState,
+    player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    finalize_mana_payment_with_resume(
+        state,
+        player,
+        ManaAbilityResume::FinalizePendingManaPayment { player },
+        events,
+    )
+}
+
+fn finalize_mana_payment_with_resume(
+    state: &mut GameState,
+    player: PlayerId,
+    mana_resume: ManaAbilityResume,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     // CR 107.4f + CR 601.2f: Pause for per-shard Phyrexian choice if the cost contains
@@ -9875,6 +10031,7 @@ pub fn finalize_mana_payment(
                 events,
                 Some(&activation_ctx),
                 &excluded_sources,
+                Some(&mana_resume),
             ) {
                 return Ok(waiting);
             }
@@ -9886,16 +10043,17 @@ pub fn finalize_mana_payment(
             events,
             None,
             &HashSet::new(),
+            Some(&mana_resume),
         ) {
             return Ok(waiting);
         }
     }
 
-    let pending = state
+    let mut pending = state
         .pending_cast
         .take()
         .ok_or_else(|| EngineError::InvalidAction("No pending cast to finalize".to_string()))?;
-    let pending_for_restore = pending.clone();
+    let mut pending_for_restore = pending.clone();
 
     // CR 118.3a: `pending_cast` is now gone, but the caster's pin hints must
     // still reach the spend. Carry them on the transient `active_payment_pins`
@@ -9907,9 +10065,10 @@ pub fn finalize_mana_payment(
     // a later spend.)
     state.active_payment_pins = pending.pinned_pool_units.clone();
     let finalize_result = (|| -> Result<WaitingFor, EngineError> {
-        // CR 702.132a: commit point reached — apply any committed Assist contribution
-        // (tap the helper's sources) now that the cast can no longer be cancelled.
-        apply_committed_assist(state, &pending, events)?;
+        // CR 702.132a + CR 601.2h: payment has reached the Assist contribution;
+        // helper resources begin changing only inside this final payment step.
+        apply_committed_assist(state, &mut pending, Some(&mana_resume), events)?;
+        pending_for_restore = pending.clone();
 
         if let Some(ability_index) = pending.activation_ability_index {
             let excluded_sources = pending
@@ -9919,27 +10078,22 @@ pub fn finalize_mana_payment(
                     super::casting::ability_mana_payment_excluded_sources(cost, pending.object_id)
                 })
                 .unwrap_or_default();
-            super::casting::pay_ability_mana_cost_excluding(
+            super::casting::pay_ability_mana_cost_with_choices_excluding_and_resume(
                 state,
                 player,
                 pending.object_id,
                 &pending.cost,
                 super::casting::activation_ability_tag(state, pending.object_id, ability_index),
+                None,
                 events,
                 &excluded_sources,
                 // Interactive activation resume: top-level, no outer cost on the stack.
                 None,
+                &mana_resume,
             )?;
-            return push_activated_ability_to_stack(
-                state,
-                player,
-                pending.object_id,
-                ability_index,
-                pending.ability,
-                pending.activation_cost.as_ref(),
-                pending.activation_residual,
-                pending.pending_loyalty_activation_player,
-                events,
+            pending.cost = ManaCost::NoCost;
+            return super::casting_targets::finish_activation_after_automatic_mana_payment(
+                state, player, *pending, events,
             );
         }
 
@@ -9981,8 +10135,14 @@ pub fn finalize_mana_payment(
                 .map(|pl| pl.mana_pool.total())
                 .unwrap_or(0)
         });
-        let prepaid_actual_mana_spent =
-            pay_spell_mana_before_deferred_sacrifice(state, player, &pending, None, events)?;
+        let prepaid_actual_mana_spent = pay_spell_mana_before_deferred_sacrifice(
+            state,
+            player,
+            &pending,
+            None,
+            Some(&mana_resume),
+            events,
+        )?;
         let deferred_sacrifice_events =
             pay_deferred_spell_sacrifices_at_commit(state, player, &pending, events)?;
         let final_cast_cost = if prepaid_actual_mana_spent.is_some() {
@@ -10005,7 +10165,14 @@ pub fn finalize_mana_payment(
         // cost recompute this branch currently skips (see
         // `casting::apply_target_dependent_cost_modifiers`) before assuming this
         // code path is exercised by existing coverage.
-        if let Some(unit) = pending.distribute {
+        // CR 601.2d: A distribution committed before payment is already part
+        // of the resolved ability. Automatic finalization still owns the mana
+        // root, but must not open a second distribution prompt or discard the
+        // announced allocation.
+        if let Some(unit) = pending
+            .distribute
+            .filter(|_| pending.ability.distribution.is_none())
+        {
             // CR 601.2d: X-spell distribution — pay mana first to determine X, then
             // trigger DistributeAmong with total = X.
             let pool_before = pool_before_for_distribution.unwrap_or_else(|| {
@@ -10018,11 +10185,13 @@ pub fn finalize_mana_payment(
             });
 
             if prepaid_actual_mana_spent.is_none() {
-                super::casting::pay_mana_cost(
+                super::casting::pay_mana_cost_with_choices_and_resume(
                     state,
                     player,
                     pending.object_id,
                     &pending.cost,
+                    None,
+                    Some(&mana_resume),
                     events,
                 )?;
             }
@@ -10081,6 +10250,7 @@ pub fn finalize_mana_payment(
                     pending.cast_timing_permission,
                     pending.origin_zone,
                     None,
+                    Some(&mana_resume),
                     pre_payment_checks.clone(),
                     prepaid_actual_mana_spent,
                     ReturnedCreatureCostMove::Pending,
@@ -10121,6 +10291,7 @@ pub fn finalize_mana_payment(
             pending.cast_timing_permission,
             pending.origin_zone,
             None,
+            Some(&mana_resume),
             pre_payment_checks,
             prepaid_actual_mana_spent,
             ReturnedCreatureCostMove::Pending,
@@ -10140,6 +10311,16 @@ pub fn finalize_mana_payment(
     state.active_payment_pins.clear();
     match finalize_result {
         Ok(waiting_for) => Ok(waiting_for),
+        // CR 601.2h + CR 605.3b + CR 616.1: An auto-tapped mana ability may
+        // pause on a replacement-aware cost move. Its serialized cursor owns
+        // the source activation; retain the outer cast for the exact
+        // ManaPayment resume rather than reporting a failed payment.
+        Err(_) if super::casting::mana_ability_cost_payment_is_paused(state) => {
+            if state.pending_cast.is_none() {
+                state.pending_cast = Some(pending_for_restore);
+            }
+            Ok(state.waiting_for.clone())
+        }
         Err(err) => {
             if matches!(
                 &err,
@@ -10185,11 +10366,15 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
     phyrexian_choices: &[crate::types::game_state::ShardChoice],
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    let pending = state
+    let mut pending = state
         .pending_cast
         .take()
         .ok_or_else(|| EngineError::InvalidAction("No pending cast to finalize".to_string()))?;
-    let pending_for_restore = pending.clone();
+    let mut pending_for_restore = pending.clone();
+    let mana_resume = ManaAbilityResume::PhyrexianCastPayment {
+        caster: player,
+        choices: phyrexian_choices.to_vec(),
+    };
 
     // CR 118.3a: `pending_cast` is now gone, but the caster's pin hints must
     // still reach the spend. Carry them on the transient `active_payment_pins`
@@ -10199,9 +10384,10 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
     // empty outside an in-progress finalize spend".
     state.active_payment_pins = pending.pinned_pool_units.clone();
     let finalize_result = (|| -> Result<WaitingFor, EngineError> {
-        // CR 702.132a: commit point reached — apply any committed Assist contribution
-        // (tap the helper's sources) now that the cast can no longer be cancelled.
-        apply_committed_assist(state, &pending, events)?;
+        // CR 702.132a + CR 601.2h: payment has reached the Assist contribution;
+        // helper resources begin changing only inside this final payment step.
+        apply_committed_assist(state, &mut pending, Some(&mana_resume), events)?;
+        pending_for_restore = pending.clone();
 
         if let Some(ability_index) = pending.activation_ability_index {
             let excluded_sources = pending
@@ -10211,7 +10397,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                     super::casting::ability_mana_payment_excluded_sources(cost, pending.object_id)
                 })
                 .unwrap_or_default();
-            super::casting::pay_ability_mana_cost_with_choices_excluding(
+            super::casting::pay_ability_mana_cost_with_choices_excluding_and_resume(
                 state,
                 player,
                 pending.object_id,
@@ -10222,15 +10408,17 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                 &excluded_sources,
                 // Interactive Phyrexian-choice resume: top-level activation, no outer cost.
                 None,
+                &mana_resume,
             )?;
             return push_activated_ability_to_stack(
                 state,
                 player,
                 pending.object_id,
                 ability_index,
-                pending.ability,
+                pending.ability.clone(),
                 pending.activation_cost.as_ref(),
                 pending.activation_residual,
+                pending.activation_target_selection,
                 pending.pending_loyalty_activation_player,
                 events,
             );
@@ -10279,6 +10467,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
             player,
             &pending,
             Some(phyrexian_choices),
+            Some(&mana_resume),
             events,
         )?;
         let deferred_sacrifice_events =
@@ -10303,7 +10492,13 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
         // cost recompute this branch currently skips (see
         // `casting::apply_target_dependent_cost_modifiers`) before assuming this
         // code path is exercised by existing coverage.
-        if let Some(unit) = pending.distribute {
+        // CR 601.2d: See the ordinary payment branch above. Submitted
+        // Phyrexian choices do not make an already-announced allocation pending
+        // again.
+        if let Some(unit) = pending
+            .distribute
+            .filter(|_| pending.ability.distribution.is_none())
+        {
             // CR 601.2d: X + distribution + Phyrexian is extremely rare (no known current cards).
             // Fall through to the auto-decision distribution path for safety — the Phyrexian
             // choices were already consumed via pay_mana_cost_with_choices above (the X-spell
@@ -10374,6 +10569,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                     pending.cast_timing_permission,
                     pending.origin_zone,
                     Some(phyrexian_choices),
+                    Some(&mana_resume),
                     pre_payment_checks.clone(),
                     prepaid_actual_mana_spent,
                     ReturnedCreatureCostMove::Pending,
@@ -10415,12 +10611,13 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
             player,
             pending.object_id,
             pending.card_id,
-            pending.ability,
+            pending.ability.clone(),
             &final_cast_cost,
             pending.casting_variant,
             pending.cast_timing_permission,
             pending.origin_zone,
             Some(phyrexian_choices),
+            Some(&mana_resume),
             pre_payment_checks,
             prepaid_actual_mana_spent,
             ReturnedCreatureCostMove::Pending,
@@ -10440,6 +10637,14 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
     state.active_payment_pins.clear();
     match finalize_result {
         Ok(waiting_for) => Ok(waiting_for),
+        // CR 601.2h + CR 605.3b + CR 616.1: See the ordinary payment resume
+        // above. A Phyrexian choice does not change the cursor ownership.
+        Err(_) if super::casting::mana_ability_cost_payment_is_paused(state) => {
+            if state.pending_cast.is_none() {
+                state.pending_cast = Some(pending_for_restore);
+            }
+            Ok(state.waiting_for.clone())
+        }
         Err(err) => {
             if matches!(
                 &err,
@@ -10468,6 +10673,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
 /// Returns `Some(WaitingFor::PhyrexianPayment {...})` when at least one Phyrexian shard
 /// can deduct life; otherwise returns `None` so the caller proceeds with the existing
 /// auto-decision path.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn maybe_pause_for_phyrexian_choice(
     state: &mut GameState,
     player: PlayerId,
@@ -10476,6 +10682,7 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
     events: &mut Vec<GameEvent>,
     payment_context: Option<&PaymentContext<'_>>,
     excluded_sources: &HashSet<ObjectId>,
+    resume: Option<&ManaAbilityResume>,
 ) -> Option<WaitingFor> {
     // CR 107.4f: Fast reject — pause only when cost has intrinsic Phyrexian
     // shards OR the player has a K'rrik-style grant whose color appears in the
@@ -10519,9 +10726,17 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
     // the simulation reflects the actual post-tap pool.
     let events_before = events.len();
     if payment_context.is_none() && excluded_sources.is_empty() {
-        auto_tap_mana_sources(state, player, cost, events, Some(source_id));
+        auto_tap_mana_sources_with_context_and_resume(
+            state,
+            player,
+            cost,
+            events,
+            Some(source_id),
+            None,
+            resume,
+        );
     } else {
-        auto_tap_mana_sources_with_context_excluding(
+        auto_tap_mana_sources_with_context_excluding_and_resume(
             state,
             player,
             cost,
@@ -10529,7 +10744,15 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
             Some(source_id),
             payment_context,
             excluded_sources,
+            resume,
+            None,
         );
+    }
+    // CR 605.3b + CR 616.1: A costed mana source can suspend auto-tap on a
+    // replacement choice. Preserve that live choice; computing Phyrexian
+    // shards here would overwrite its typed payment root.
+    if super::casting::mana_ability_cost_payment_is_paused(state) {
+        return Some(state.waiting_for.clone());
     }
     // CR 605.4a: Resolve coupled `TapsForMana` triggered mana abilities inline so
     // the bonus mana is in the pool before Phyrexian shard options are computed.
@@ -11203,6 +11426,7 @@ mod tests {
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
+            activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         }
     }
@@ -16194,6 +16418,7 @@ mod tests {
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
+            activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         };
 
@@ -16326,6 +16551,7 @@ mod tests {
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
+            activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         };
 
@@ -16427,6 +16653,7 @@ mod tests {
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
+            activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         };
 
@@ -16517,6 +16744,7 @@ mod tests {
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
+            activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         };
 
@@ -16640,6 +16868,7 @@ mod tests {
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
+            activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         };
 
@@ -19631,6 +19860,7 @@ its replicate cost was paid.)\nDraw a card.";
             resolved,
             Some(&residual),
             ActivationResidual::XMana,
+            ActivationTargetSelection::Pending,
             None,
             &mut events,
         );

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -4,7 +4,7 @@ use crate::types::ability::{
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    CostResume, GameState, PayCostKind, PendingCast, StackEntry, StackEntryKind, WaitingFor,
+    ActivationTargetSelection, CostResume, GameState, PayCostKind, PendingCast, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -16,19 +16,16 @@ use super::ability_utils::{
     ability_target_legality_needs_chosen_x, assign_selected_slots_in_chain,
     assign_targets_in_chain, auto_select_targets_for_ability, begin_target_selection_for_ability,
     build_chained_resolved, build_target_slots_labelled, choose_target_for_ability,
-    distribution_targets, flatten_targets_in_chain, ordered_selected_mode_indices,
-    random_select_targets_for_ability, selected_mode_labels, validate_modal_indices,
-    validate_selected_targets_for_ability, TargetSelectionAdvance,
+    distribution_targets, ordered_selected_mode_indices, random_select_targets_for_ability,
+    selected_mode_labels, validate_modal_indices, validate_selected_targets_for_ability,
+    TargetSelectionAdvance,
 };
-use super::casting::{emit_targeting_events, pay_ability_cost_for_activation};
 use super::casting_costs::{
     cost_has_x, drain_deferred_triggers_after_stack_object_announcement, enter_payment_step,
     finish_pending_cast_cost_or_pay,
 };
 use super::engine::EngineError;
-use super::priority;
 use super::restrictions;
-use super::stack;
 
 /// Handle mode selection for a modal spell.
 ///
@@ -222,6 +219,11 @@ pub(crate) fn handle_select_modes(
             .first()
             .and_then(|slot| slot.chooser)
             .unwrap_or(controller);
+        pending_sel.activation_cost = pending.activation_cost;
+        pending_sel.activation_ability_index = pending.activation_ability_index;
+        pending_sel.pending_loyalty_activation_player = pending.pending_loyalty_activation_player;
+        pending_sel.activation_residual = pending.activation_residual;
+        pending_sel.activation_target_selection = pending.activation_target_selection;
         return Ok(WaitingFor::TargetSelection {
             player: initial_player,
             pending_cast: Box::new(pending_sel),
@@ -312,67 +314,22 @@ pub(crate) fn handle_select_targets(
         return Ok(waiting_for);
     }
 
-    if let Some(ability_index) = pending.activation_ability_index {
+    if pending.activation_ability_index.is_some() {
+        let mut pending = pending;
+        pending.ability = ability;
+        pending.activation_target_selection = ActivationTargetSelection::Settled;
         if let Some(waiting_for) = pay_activation_costs_after_target_selection(
             state,
             player,
             &pending,
-            ability.clone(),
-            ability_index,
-            events,
+            pending.ability.clone(),
         )? {
             return Ok(waiting_for);
         }
 
-        let assigned_targets = flatten_targets_in_chain(&ability);
-        emit_targeting_events(state, &assigned_targets, pending.object_id, player, events);
-
-        let entry_id = ObjectId(state.next_object_id);
-        state.next_object_id += 1;
-        // CR 603.4: Stamp the printed-ability index for per-turn resolution tracking.
-        let mut ability = ability;
-        ability.ability_index = Some(ability_index);
-        stack::push_to_stack(
-            state,
-            StackEntry {
-                id: entry_id,
-                source_id: pending.object_id,
-                controller: player,
-                kind: StackEntryKind::ActivatedAbility {
-                    source_id: pending.object_id,
-                    ability,
-                },
-            },
-            events,
+        return super::casting_costs::finish_target_selected_activated_ability_at_payment_boundary(
+            state, player, pending, events,
         );
-
-        restrictions::record_ability_activation(state, pending.object_id, ability_index);
-        // CR 117.1b: Priority permits unbounded activation. `pending_activations`
-        // is a per-priority-window AI-guard — see `GameState::pending_activations`.
-        state
-            .pending_activations
-            .push((pending.object_id, ability_index));
-        events.push(GameEvent::AbilityActivated {
-            player_id: player,
-            source_id: pending.object_id,
-            // CR 606.2: Compute from the source ability's cost; this path covers
-            // boast and other non-targeted activations, so it is normally `Normal`.
-            kind: super::planeswalker::activated_ability_kind(
-                state,
-                pending.object_id,
-                ability_index,
-            ),
-        });
-        // CR 702.142b: Emit additional event when a boast ability is activated.
-        emit_keyword_ability_event_if_tagged(
-            state,
-            pending.object_id,
-            ability_index,
-            player,
-            events,
-        );
-        priority::clear_priority_passes(state);
-        return Ok(WaitingFor::Priority { player });
     }
 
     let cost = pending.cost.clone();
@@ -453,84 +410,27 @@ pub(crate) fn handle_choose_target(
                 return Ok(waiting_for);
             }
 
-            if let Some(ability_index) = pending.activation_ability_index {
+            if pending.activation_ability_index.is_some() {
+                let mut pending = pending;
+                pending.ability = ability;
+                pending.activation_target_selection = ActivationTargetSelection::Settled;
                 if let Some(waiting_for) = pay_activation_costs_after_target_selection(
                     state,
                     controller,
                     &pending,
-                    ability.clone(),
-                    ability_index,
-                    events,
+                    pending.ability.clone(),
                 )? {
                     return Ok(waiting_for);
                 }
 
-                let assigned_targets = flatten_targets_in_chain(&ability);
-                emit_targeting_events(
-                    state,
-                    &assigned_targets,
-                    pending.object_id,
-                    controller,
-                    events,
-                );
-
-                let entry_id = ObjectId(state.next_object_id);
-                state.next_object_id += 1;
-                // CR 603.4: Stamp the printed-ability index for per-turn resolution tracking.
-                let mut ability = ability;
-                ability.ability_index = Some(ability_index);
-                stack::push_to_stack(
-                    state,
-                    StackEntry {
-                        id: entry_id,
-                        source_id: pending.object_id,
-                        controller,
-                        kind: StackEntryKind::ActivatedAbility {
-                            source_id: pending.object_id,
-                            ability,
-                        },
-                    },
-                    events,
-                );
-
-                restrictions::record_ability_activation(state, pending.object_id, ability_index);
-                // CR 117.1b: Priority permits unbounded activation.
-                // `pending_activations` is a per-priority-window AI-guard — see
-                // `GameState::pending_activations`.
-                state
-                    .pending_activations
-                    .push((pending.object_id, ability_index));
-                events.push(GameEvent::AbilityActivated {
-                    player_id: controller,
-                    source_id: pending.object_id,
-                    // CR 606.2: Targeted activations (most loyalty abilities) finalize
-                    // here. Classify from the source ability's printed cost via
-                    // `activated_ability_kind` rather than `pending.activation_cost`:
-                    // the X-cost path clears `pending.activation_cost` before target
-                    // selection (casting_costs.rs), so a targeted `[-X]` loyalty
-                    // ability would otherwise lose its loyalty kind. The printed cost
-                    // is stable, mirroring the non-targeted path in `planeswalker.rs`.
-                    kind: super::planeswalker::activated_ability_kind(
-                        state,
-                        pending.object_id,
-                        ability_index,
-                    ),
-                });
-                // CR 702.142b: Emit additional event when a boast ability is activated.
-                emit_keyword_ability_event_if_tagged(
-                    state,
-                    pending.object_id,
-                    ability_index,
-                    controller,
-                    events,
-                );
-                priority::clear_priority_passes(state);
-                // CR 117.3c + CR 115.1: priority returns to the controller after the
-                // ability is announced, not to a slot's opponent announcer.
+                let waiting_for =
+                    super::casting_costs::finish_target_selected_activated_ability_at_payment_boundary(
+                        state, controller, pending, events,
+                    )?;
                 return Ok(drain_deferred_triggers_after_stack_object_announcement(
                     state,
                     events,
-                    WaitingFor::Priority { player: controller },
+                    waiting_for,
                 ));
             }
 
@@ -544,47 +444,9 @@ fn pay_activation_costs_after_target_selection(
     state: &mut GameState,
     player: PlayerId,
     pending: &PendingCast,
-    mut assigned_ability: ResolvedAbility,
-    ability_index: usize,
-    events: &mut Vec<GameEvent>,
+    assigned_ability: ResolvedAbility,
 ) -> Result<Option<WaitingFor>, EngineError> {
-    if !matches!(pending.cost, ManaCost::NoCost) {
-        let excluded_sources = pending
-            .activation_cost
-            .as_ref()
-            .map(|cost| {
-                super::casting::ability_mana_payment_excluded_sources(cost, pending.object_id)
-            })
-            .unwrap_or_default();
-        super::casting::pay_ability_mana_cost_excluding(
-            state,
-            player,
-            pending.object_id,
-            &pending.cost,
-            super::casting::activation_ability_tag(state, pending.object_id, ability_index),
-            events,
-            &excluded_sources,
-            // Top-level ability activation: no outer cost on the stack.
-            None,
-        )?;
-    }
-
     if let Some(ref activation_cost) = pending.activation_cost {
-        // CR 107.4f + GH #600: Target-first activations store the full cost in
-        // `activation_cost` with `pending.cost = NoCost`; route through the same
-        // Phyrexian pause helper as the no-target activation path.
-        if let Some(waiting) = super::casting::try_pause_activation_phyrexian_payment(
-            state,
-            player,
-            pending.object_id,
-            ability_index,
-            &assigned_ability,
-            activation_cost,
-            events,
-        ) {
-            return Ok(Some(waiting));
-        }
-
         if let Some((count, zone, filter)) = super::casting::find_non_self_exile(activation_cost) {
             let narrow_zone = ExileCostSourceZone::try_from_zone(zone)
                 .expect("find_non_self_exile restricts zone to Hand or Graveyard");
@@ -653,47 +515,41 @@ fn pay_activation_costs_after_target_selection(
                 },
             }));
         }
-
-        let should_record_loyalty = crate::types::ability::is_loyalty_ability_cost(activation_cost)
-            && super::planeswalker::can_activate_loyalty_ability(
-                state,
-                pending.object_id,
-                player,
-                ability_index,
-            );
-        super::casting::stamp_self_ref_discard_cost_paid_object(
-            state,
-            pending.object_id,
-            &mut assigned_ability,
-            activation_cost,
-        );
-        if let super::casting::PaymentOutcome::Paused { remaining_cost } =
-            pay_ability_cost_for_activation(
-                state,
-                player,
-                pending.object_id,
-                activation_cost,
-                super::casting::activation_ability_tag(state, pending.object_id, ability_index),
-                events,
-            )?
-        {
-            let mut pending = pending.clone();
-            pending.ability = assigned_ability;
-            pending.activation_cost = remaining_cost;
-            pending.pending_loyalty_activation_player = should_record_loyalty.then_some(player);
-            if let Some(pending) =
-                super::casting_costs::attach_pending_cast_to_cost_move(state, Box::new(pending))
-            {
-                state.pending_cast = Some(pending);
-            }
-            return Ok(Some(state.waiting_for.clone()));
-        }
-        if should_record_loyalty {
-            super::planeswalker::record_loyalty_activation(state, pending.object_id, player);
-        }
     }
 
     Ok(None)
+}
+
+/// CR 602.2b + CR 605.3b + CR 616.1: Resume an automatic activation mana leg
+/// through the same target-first cost suffix that owns chosen targets,
+/// distribution, and interactive non-mana costs. The mana payment is already
+/// settled, so its root is marked `NoCost` before the suffix is continued.
+pub(crate) fn finish_activation_after_automatic_mana_payment(
+    state: &mut GameState,
+    player: PlayerId,
+    pending: PendingCast,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    if pending.activation_ability_index.is_none() {
+        return Err(EngineError::InvalidAction(
+            "automatic activation mana finalization missing an ability index".to_string(),
+        ));
+    }
+    if matches!(
+        pending.activation_target_selection,
+        ActivationTargetSelection::Settled
+    ) {
+        let ability = pending.ability.clone();
+        if let Some(waiting) =
+            pay_activation_costs_after_target_selection(state, player, &pending, ability)?
+        {
+            return Ok(waiting);
+        }
+    }
+
+    super::casting_costs::finish_activated_ability_at_payment_boundary(
+        state, player, pending, events,
+    )
 }
 
 /// CR 702.172a + CR 601.2f + CR 702.42a: Compose a modal spell's total cost.

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -14920,18 +14920,16 @@ fn assist_commit_rejects_over_max_generic() {
 }
 
 #[test]
-fn assist_cancel_after_commit_does_not_spend_helper_mana() {
-    // CR 601.2i: the helper's mana must not be spent if the caster cancels.
-    // The helper's tap/spend is deferred to finalize_cast, so a CancelCast at
-    // the (manual ⇒ cancellable) post-assist ManaPayment leaves them untouched.
-    use super::super::engine::apply_as_current;
+fn assist_cancel_after_commit_is_allowed_before_helper_payment_starts() {
+    // CR 601.2h + CR 702.132a: committing an Assist contribution selects a
+    // future helper payment but does not pay it. The caster may still reverse
+    // the cast while the helper's resources remain untouched.
     let mut state = setup_game_at_main_phase();
     let obj_id = make_assist_spell(&mut state);
     add_mana(&mut state, PlayerId(0), ManaType::Colorless, 3);
     add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
     add_mana(&mut state, PlayerId(1), ManaType::Colorless, 2);
 
-    // Manual payment keeps the post-assist ManaPayment cancellable.
     let result = handle_cast_spell_with_payment_mode(
         &mut state,
         PlayerId(0),
@@ -14959,7 +14957,8 @@ fn assist_cancel_after_commit_does_not_spend_helper_mana() {
         .unwrap()
         .mana_pool
         .total();
-    apply_as_current(&mut state, GameAction::CancelCast).expect("the caster may cancel");
+    let cancelled = apply_as_current(&mut state, GameAction::CancelCast)
+        .expect("an unspent Assist commitment remains cancellable");
     let p1_after = state
         .players
         .iter()
@@ -14971,8 +14970,15 @@ fn assist_cancel_after_commit_does_not_spend_helper_mana() {
     assert_eq!(
         (p1_before, p1_after),
         (2, 2),
-        "cancelling the cast must not spend the assisting player's mana"
+        "cancelling an unspent Assist commitment cannot spend helper mana"
     );
+    assert!(matches!(
+        cancelled.waiting_for,
+        WaitingFor::Priority {
+            player: PlayerId(0)
+        }
+    ));
+    assert!(state.pending_cast.is_none());
 }
 
 // --- Delve (CR 702.66a) ---

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -47,7 +47,7 @@ use crate::types::ability::{
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    GameState, PendingCostMoveCompletion, PendingCostMoveResume, WaitingFor,
+    GameState, ManaAbilityResume, PendingCostMoveCompletion, PendingCostMoveResume, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
@@ -56,8 +56,8 @@ use crate::types::zones::Zone;
 
 use super::casting::{
     ability_mana_payment_excluded_sources, can_pay_effect_mana_cost_after_auto_tap,
-    find_eligible_discard_targets, pay_ability_mana_cost, pay_ability_mana_cost_excluding,
-    pay_effect_mana_cost,
+    find_eligible_discard_targets, mana_ability_cost_payment_is_paused, pay_ability_mana_cost,
+    pay_ability_mana_cost_excluding, pay_effect_mana_cost_with_resume,
 };
 use super::engine::EngineError;
 use super::filter::FilterContext;
@@ -184,7 +184,6 @@ pub(crate) enum PaymentScope<'a> {
         /// spend restrictions (Quinjet → power-up) gate eligible mana. Resolution
         /// scope never carries a tag (resolution-time costs aren't activations).
         ability_tag: Option<crate::types::ability::AbilityTag>,
-        cost_move_handling: ActivationCostMoveHandling,
     },
     /// `ability` is normally the PAYER-ADJUSTED `ResolvedAbility` clone
     /// (controller swapped to the resolved payer, per `effects/pay.rs`). All
@@ -202,15 +201,6 @@ pub(crate) enum PaymentScope<'a> {
         ability: &'a ResolvedAbility,
         cost_move_root: ResolutionCostMoveRoot,
     },
-}
-
-/// Whether an activation root retains the typed continuation for a self-move
-/// cost replacement. Only mana abilities use the synchronous path because they
-/// have no stack-root continuation until the dedicated ManaAbilityPayment unit.
-#[derive(Clone, Copy)]
-pub(crate) enum ActivationCostMoveHandling {
-    OutcomeAware,
-    ManaAbilitySynchronous,
 }
 
 /// The owner of a resolution-time non-self cost move. Only an accepted
@@ -275,6 +265,87 @@ fn combine_remaining_costs(
     }
 }
 
+/// CR 118.12 + CR 605.3b + CR 616.1: A paused mana-source cost must retain
+/// the *whole* concrete suffix that remains unpaid.  In particular, a dynamic
+/// mana leaf is resolved before it becomes the leading component of the
+/// serialized `EffectPayCost` root.
+fn resume_cost_with_concrete_mana(
+    resume_cost: Option<&AbilityCost>,
+    mana_cost: crate::types::mana::ManaCost,
+) -> AbilityCost {
+    let concrete = AbilityCost::Mana { cost: mana_cost };
+    let Some(resume_cost) = resume_cost else {
+        return concrete;
+    };
+    let mut flattened = Vec::new();
+    flatten_cost_components(resume_cost, &mut flattened);
+    let first = flattened
+        .first_mut()
+        .expect("a mana payment suffix is never empty");
+    if !matches!(
+        first,
+        AbilityCost::Mana { .. } | AbilityCost::ManaDynamic { .. }
+    ) {
+        unreachable!("a mana payment root must begin with mana");
+    }
+    *first = concrete;
+    combine_remaining_costs(None, &flattened).expect("a concrete mana suffix is never empty")
+}
+
+/// Flatten nested Composite nodes only while constructing a serialized payment
+/// suffix. The runtime payment order is unchanged; this makes every later leaf
+/// explicit so an interrupted nested Composite cannot drop an outer sibling.
+fn flatten_cost_components(cost: &AbilityCost, components: &mut Vec<AbilityCost>) {
+    match cost {
+        AbilityCost::Composite { costs } => {
+            for cost in costs {
+                flatten_cost_components(cost, components);
+            }
+        }
+        cost => components.push(cost.clone()),
+    }
+}
+
+/// CR 118.12 + CR 605.3b + CR 616.1: A nested composite carries the unpaid
+/// suffix of each enclosing composite into a paused mana-payment root. The
+/// root begins with `active_cost`; anything after that prefix belongs to an
+/// enclosing composite and remains unpaid when a child component pauses.
+fn enclosing_composite_suffix(
+    active_cost: &AbilityCost,
+    resume_cost: Option<&AbilityCost>,
+) -> Vec<AbilityCost> {
+    let Some(resume_cost) = resume_cost else {
+        return Vec::new();
+    };
+
+    let mut active_components = Vec::new();
+    flatten_cost_components(active_cost, &mut active_components);
+    let mut resume_components = Vec::new();
+    flatten_cost_components(resume_cost, &mut resume_components);
+    resume_components
+        .strip_prefix(active_components.as_slice())
+        .expect("an enclosing resume cost begins with its active composite")
+        .to_vec()
+}
+
+/// CR 118.12 + CR 605.3b + CR 616.1: Builds the concrete unpaid suffix for a
+/// composite component, including every enclosing composite's later leaves.
+fn composite_cost_suffix(
+    leading: Option<&AbilityCost>,
+    following: &[AbilityCost],
+    enclosing_suffix: &[AbilityCost],
+) -> Option<AbilityCost> {
+    let mut components = Vec::new();
+    if let Some(leading) = leading {
+        flatten_cost_components(leading, &mut components);
+    }
+    for cost in following {
+        flatten_cost_components(cost, &mut components);
+    }
+    components.extend(enclosing_suffix.iter().cloned());
+    combine_remaining_costs(None, &components)
+}
+
 /// Resolve a cost's dynamic amount in the active scope (plan §2): activation
 /// uses `resolve_quantity` (player + source); resolution uses
 /// `resolve_quantity_with_targets` against the payer-adjusted ability so
@@ -294,6 +365,70 @@ fn resolve_cost_quantity(
     }
 }
 
+/// CR 118.12 + CR 605.3b: A generic `Effect::PayCost` owns the exact
+/// payer-adjusted resolved ability and concrete mana cost while an auto-tapped
+/// mana source is paused by a replacement effect. Other resolution roots (in
+/// particular `UnlessPayment`) retain their own typed outer context.
+fn effect_pay_cost_mana_resume(
+    state: &GameState,
+    payer: PlayerId,
+    scope: &PaymentScope,
+    cost: AbilityCost,
+) -> Option<ManaAbilityResume> {
+    // CR 601.2h + CR 605.3b + CR 616.1: A manual mana-payment window is
+    // likewise already an authoritative root.  Preserve it verbatim while a
+    // source selected from that window pauses, so replacement resolution
+    // returns the player to the same payment flow rather than to priority.
+    if let WaitingFor::ManaPayment {
+        player,
+        convoke_mode,
+    } = &state.waiting_for
+    {
+        return Some(ManaAbilityResume::ManaPayment {
+            outer_player: Some(*player),
+            convoke_mode: *convoke_mode,
+        });
+    }
+    // CR 118.12 + CR 605.3b + CR 616.1: `UnlessPayment` is already the
+    // authoritative outer payment root.  A mana source paused while funding
+    // it must return to that exact prompt, not manufacture an Effect::PayCost
+    // retry that would bypass the player's submitted unless-payment flow.
+    if let WaitingFor::UnlessPayment {
+        player,
+        cost,
+        pending_effect,
+        trigger_event,
+        effect_description,
+        remaining,
+    } = &state.waiting_for
+    {
+        return Some(ManaAbilityResume::UnlessPayment {
+            outer_player: Some(*player),
+            cost: Box::new(cost.clone()),
+            pending_effect: pending_effect.clone(),
+            trigger_event: trigger_event.clone(),
+            effect_description: effect_description.clone(),
+            remaining: remaining.clone(),
+        });
+    }
+    let PaymentScope::Resolution {
+        ability,
+        cost_move_root: ResolutionCostMoveRoot::EffectPayCost,
+    } = scope
+    else {
+        return None;
+    };
+    let WaitingFor::Priority { player: return_to } = &state.waiting_for else {
+        return None;
+    };
+    Some(ManaAbilityResume::EffectPayCost {
+        payer,
+        return_to: *return_to,
+        ability: Box::new((*ability).clone()),
+        cost: Box::new(cost),
+    })
+}
+
 /// CR 601.2h + CR 616.1: Pause cost payment for a competing replacement effect.
 pub(crate) fn pause_cost_payment_for_replacement_choice(
     state: &mut GameState,
@@ -303,8 +438,9 @@ pub(crate) fn pause_cost_payment_for_replacement_choice(
 }
 
 /// CR 601.2h + CR 602.2b + CR 616.1: Move a self-referential activation cost
-/// through the zone-change pipeline. The continuation has no `PendingCast`
-/// until the activation caller attaches it after this payment function returns.
+/// through the zone-change pipeline. The activation caller replaces the
+/// provisional continuation with its typed root after this payment function
+/// returns.
 fn move_self_activation_cost(
     state: &mut GameState,
     player: PlayerId,
@@ -327,7 +463,13 @@ fn move_self_activation_cost(
                 destination,
                 completion: PendingCostMoveCompletion::FinishPending,
             });
-            pause_cost_payment_for_replacement_choice(state, choice_player);
+            // A mandatory replacement may have delivered this cost move and
+            // surfaced its own post-effect prompt. Only a still-pending CR
+            // 616.1 ordering choice is synthesized here; never clobber the
+            // live delivery-tail prompt.
+            if state.pending_replacement.is_some() {
+                pause_cost_payment_for_replacement_choice(state, choice_player);
+            }
             Some(PaymentOutcome::Paused {
                 remaining_cost: None,
             })
@@ -404,28 +546,6 @@ pub(crate) fn resume_replacement_may_cost_move(
     super::engine_replacement::handle_replacement_choice(state, 0, events)
 }
 
-/// Pays a mana ability's synchronous auto-payable cost components. This is the
-/// only activation root that may bypass the zone-move pipeline until it owns a
-/// dedicated typed continuation.
-pub(crate) fn pay_mana_ability_cost_synchronously(
-    state: &mut GameState,
-    player: PlayerId,
-    source_id: ObjectId,
-    cost: &AbilityCost,
-    events: &mut Vec<GameEvent>,
-) -> Result<(), EngineError> {
-    pay_ability_cost_for_activation_with_cost_move_replacement(
-        state,
-        player,
-        source_id,
-        cost,
-        None,
-        ActivationCostMoveHandling::ManaAbilitySynchronous,
-        events,
-    )
-    .map(|_| ())
-}
-
 pub fn pay_ability_cost_for_activation(
     state: &mut GameState,
     player: PlayerId,
@@ -440,7 +560,6 @@ pub fn pay_ability_cost_for_activation(
         source_id,
         cost,
         ability_tag,
-        ActivationCostMoveHandling::OutcomeAware,
         events,
     )
 }
@@ -451,7 +570,6 @@ fn pay_ability_cost_for_activation_with_cost_move_replacement(
     source_id: ObjectId,
     cost: &AbilityCost,
     ability_tag: Option<crate::types::ability::AbilityTag>,
-    cost_move_handling: ActivationCostMoveHandling,
     events: &mut Vec<GameEvent>,
 ) -> Result<PaymentOutcome, EngineError> {
     let excluded_sources = ability_mana_payment_excluded_sources(cost, source_id);
@@ -464,8 +582,8 @@ fn pay_ability_cost_for_activation_with_cost_move_replacement(
         &PaymentScope::Activation {
             excluded_sources: &excluded_sources,
             ability_tag,
-            cost_move_handling,
         },
+        None,
     )?;
     // CR 601.2h: "Unpayable costs can't be paid." Activation scope maps a
     // payment failure to an illegal action — the authority's `Failed` is the
@@ -534,6 +652,7 @@ fn pay_ability_cost_for_resolution_with_cost_move_root(
             ability,
             cost_move_root,
         },
+        Some(cost),
     )
 }
 
@@ -544,6 +663,7 @@ fn pay_ability_cost_inner(
     cost: &AbilityCost,
     events: &mut Vec<GameEvent>,
     scope: &PaymentScope,
+    resume_cost: Option<&AbilityCost>,
 ) -> Result<PaymentOutcome, EngineError> {
     // CR 118.3 / CR 601.2h: at resolution there is no interactive interceptor or
     // activation-window mana detour, so any shape outside the resolution-payable
@@ -635,9 +755,33 @@ fn pay_ability_cost_inner(
             // auto-tap path. Pre-flight then pay; either step failing is a
             // payment failure (not an engine error).
             PaymentScope::Resolution { .. } => {
-                if !can_pay_effect_mana_cost_after_auto_tap(state, player, source_id, cost)
-                    || pay_effect_mana_cost(state, player, source_id, cost, events).is_err()
+                if !can_pay_effect_mana_cost_after_auto_tap(state, player, source_id, cost) {
+                    return Ok(payment_failed("insufficient mana"));
+                }
+                let resume = effect_pay_cost_mana_resume(
+                    state,
+                    player,
+                    scope,
+                    resume_cost_with_concrete_mana(resume_cost, cost.clone()),
+                );
+                if pay_effect_mana_cost_with_resume(
+                    state,
+                    player,
+                    source_id,
+                    cost,
+                    resume.as_ref(),
+                    events,
+                )
+                .is_err()
                 {
+                    // CR 118.12 + CR 605.3b + CR 616.1: The mana ability
+                    // cursor, rather than the unless-payment handler, owns
+                    // the replacement choice and exact resume state.
+                    if mana_ability_cost_payment_is_paused(state) {
+                        return Ok(PaymentOutcome::Paused {
+                            remaining_cost: None,
+                        });
+                    }
                     return Ok(payment_failed("insufficient mana"));
                 }
             }
@@ -655,18 +799,56 @@ fn pay_ability_cost_inner(
             PaymentScope::Resolution { .. } => {
                 let amount = resolve_cost_quantity(state, quantity, player, source_id, scope);
                 let mana_cost = crate::types::mana::ManaCost::generic(amount.max(0) as u32);
-                if !can_pay_effect_mana_cost_after_auto_tap(state, player, source_id, &mana_cost)
-                    || pay_effect_mana_cost(state, player, source_id, &mana_cost, events).is_err()
+                if !can_pay_effect_mana_cost_after_auto_tap(state, player, source_id, &mana_cost) {
+                    return Ok(payment_failed("insufficient mana"));
+                }
+                let resume = effect_pay_cost_mana_resume(
+                    state,
+                    player,
+                    scope,
+                    resume_cost_with_concrete_mana(resume_cost, mana_cost.clone()),
+                );
+                if pay_effect_mana_cost_with_resume(
+                    state,
+                    player,
+                    source_id,
+                    &mana_cost,
+                    resume.as_ref(),
+                    events,
+                )
+                .is_err()
                 {
+                    // CR 118.12 + CR 605.3b + CR 616.1: See the concrete
+                    // mana-cost arm above; the replacement-aware cursor owns
+                    // this pause as well.
+                    if mana_ability_cost_payment_is_paused(state) {
+                        return Ok(PaymentOutcome::Paused {
+                            remaining_cost: None,
+                        });
+                    }
                     return Ok(payment_failed("insufficient mana"));
                 }
             }
         },
         AbilityCost::Composite { costs } => {
+            let enclosing_suffix = enclosing_composite_suffix(cost, resume_cost);
             for (index, sub_cost) in costs.iter().enumerate() {
                 let prior_waiting_for = state.waiting_for.clone();
-                let outcome =
-                    pay_ability_cost_inner(state, player, source_id, sub_cost, events, scope)?;
+                let sub_resume_cost = composite_cost_suffix(
+                    Some(sub_cost),
+                    &costs[index + 1..],
+                    &enclosing_suffix,
+                )
+                .expect("a composite component always has an unpaid suffix");
+                let outcome = pay_ability_cost_inner(
+                    state,
+                    player,
+                    source_id,
+                    sub_cost,
+                    events,
+                    scope,
+                    matches!(scope, PaymentScope::Resolution { .. }).then_some(&sub_resume_cost),
+                )?;
                 match outcome {
                     PaymentOutcome::Paid => {
                         // CR 118.12: Some resolution-time sub-costs acquire a
@@ -678,15 +860,32 @@ fn pay_ability_cost_inner(
                             && state.waiting_for != prior_waiting_for
                         {
                             return Ok(PaymentOutcome::Paused {
-                                remaining_cost: combine_remaining_costs(None, &costs[index + 1..]),
+                                remaining_cost: composite_cost_suffix(
+                                    None,
+                                    &costs[index + 1..],
+                                    &enclosing_suffix,
+                                ),
                             });
                         }
                     }
                     PaymentOutcome::Paused { remaining_cost } => {
+                        // CR 118.12 + CR 605.3b + CR 616.1: A typed mana root
+                        // already owns this component and every later component.
+                        // Never copy that suffix into the generic effect
+                        // continuation: it would retry a paid prefix or let the
+                        // rider run before the unpaid cost is settled.
+                        if matches!(scope, PaymentScope::Resolution { .. })
+                            && mana_ability_cost_payment_is_paused(state)
+                        {
+                            return Ok(PaymentOutcome::Paused {
+                                remaining_cost: None,
+                            });
+                        }
                         return Ok(PaymentOutcome::Paused {
-                            remaining_cost: combine_remaining_costs(
-                                remaining_cost,
+                            remaining_cost: composite_cost_suffix(
+                                remaining_cost.as_ref(),
                                 &costs[index + 1..],
+                                &enclosing_suffix,
                             ),
                         });
                     }
@@ -840,28 +1039,14 @@ fn pay_ability_cost_inner(
                     )));
                 }
             }
-            let PaymentScope::Activation {
-                cost_move_handling,
-                ..
-            } = scope
+            let PaymentScope::Activation { .. } = scope
             else {
                 unreachable!("self-referential exile costs are not payable at resolution")
             };
-            match cost_move_handling {
-                ActivationCostMoveHandling::OutcomeAware => {
-                    if let Some(outcome) = move_self_activation_cost(
-                        state,
-                        player,
-                        source_id,
-                        Zone::Exile,
-                        events,
-                    ) {
-                        return Ok(outcome);
-                    }
-                }
-                ActivationCostMoveHandling::ManaAbilitySynchronous => {
-                    super::zones::move_to_zone(state, source_id, Zone::Exile, events);
-                }
+            if let Some(outcome) =
+                move_self_activation_cost(state, player, source_id, Zone::Exile, events)
+            {
+                return Ok(outcome);
             }
         }
         // CR 406.6: Non-self exile cost at resolution time (e.g., The Mimeoplasm's
@@ -1246,28 +1431,14 @@ fn pay_ability_cost_inner(
                     "cannot return source to hand: source is not in the required zone",
                 ));
             }
-            let PaymentScope::Activation {
-                cost_move_handling,
-                ..
-            } = scope
+            let PaymentScope::Activation { .. } = scope
             else {
                 unreachable!("self-referential return costs are not payable at resolution")
             };
-            match cost_move_handling {
-                ActivationCostMoveHandling::OutcomeAware => {
-                    if let Some(outcome) = move_self_activation_cost(
-                        state,
-                        player,
-                        source_id,
-                        Zone::Hand,
-                        events,
-                    ) {
-                        return Ok(outcome);
-                    }
-                }
-                ActivationCostMoveHandling::ManaAbilitySynchronous => {
-                    super::zones::move_to_zone(state, source_id, Zone::Hand, events);
-                }
+            if let Some(outcome) =
+                move_self_activation_cost(state, player, source_id, Zone::Hand, events)
+            {
+                return Ok(outcome);
             }
         }
         // Other cost types require interactive resolution and are intercepted
@@ -1390,7 +1561,8 @@ pub(crate) fn can_pay(
                     source_id,
                     cost,
                     &mut Vec::new(),
-                    scope
+                    scope,
+                    None,
                 ),
                 Ok(PaymentOutcome::Paid | PaymentOutcome::Paused { .. })
             );
@@ -1939,7 +2111,6 @@ mod tests {
             let scope = PaymentScope::Activation {
                 excluded_sources: &excluded,
                 ability_tag: None,
-                cost_move_handling: ActivationCostMoveHandling::OutcomeAware,
             };
             assert!(
                 can_pay(&scenario.state, P0, src, &cost, &scope),
@@ -1949,7 +2120,8 @@ mod tests {
             // must mean the authority does not report Failed.
             let mut sim = scenario.state.clone();
             let outcome =
-                pay_ability_cost_inner(&mut sim, P0, src, &cost, &mut Vec::new(), &scope).unwrap();
+                pay_ability_cost_inner(&mut sim, P0, src, &cost, &mut Vec::new(), &scope, None)
+                    .unwrap();
             assert!(
                 !matches!(outcome, PaymentOutcome::Failed { .. }),
                 "can_pay==true but pay_cost returned Failed for {cost:?}"
@@ -1968,12 +2140,18 @@ mod tests {
         let scope = PaymentScope::Activation {
             excluded_sources: &excluded,
             ability_tag: None,
-            cost_move_handling: ActivationCostMoveHandling::OutcomeAware,
         };
         let mut events = Vec::new();
-        let outcome =
-            pay_ability_cost_inner(&mut scenario.state, P0, src, &cost, &mut events, &scope)
-                .unwrap();
+        let outcome = pay_ability_cost_inner(
+            &mut scenario.state,
+            P0,
+            src,
+            &cost,
+            &mut events,
+            &scope,
+            None,
+        )
+        .unwrap();
         assert!(matches!(outcome, PaymentOutcome::Paid));
         assert!(!scenario.state.objects.get(&src).unwrap().tapped);
         assert!(events.iter().any(
@@ -1982,8 +2160,15 @@ mod tests {
 
         // CR 107.6: a permanent that's already untapped can't be untapped again
         // to pay the cost — the second payment must FAIL, not silently no-op.
-        let result =
-            pay_ability_cost_inner(&mut scenario.state, P0, src, &cost, &mut events, &scope);
+        let result = pay_ability_cost_inner(
+            &mut scenario.state,
+            P0,
+            src,
+            &cost,
+            &mut events,
+            &scope,
+            None,
+        );
         assert!(
             result.is_err(),
             "paying {{Q}} on an already-untapped permanent must be rejected (CR 107.6)"
@@ -2041,7 +2226,6 @@ mod tests {
             &PaymentScope::Activation {
                 excluded_sources: &excluded,
                 ability_tag: None,
-                cost_move_handling: ActivationCostMoveHandling::OutcomeAware,
             },
         )
     }
@@ -2634,6 +2818,7 @@ mod tests {
             &waterbend,
             &mut Vec::new(),
             &scope,
+            None,
         )
         .unwrap();
         assert!(
@@ -2650,6 +2835,7 @@ mod tests {
             &AbilityCost::Tap,
             &mut Vec::new(),
             &scope,
+            None,
         )
         .unwrap();
         assert!(

--- a/crates/engine/src/game/effects/collect_evidence.rs
+++ b/crates/engine/src/game/effects/collect_evidence.rs
@@ -219,17 +219,9 @@ pub(crate) fn handle_choice(
             // there — and pushes the ability. Detected by the activation index
             // carried on the pending; spell casts (bestow Detective's Phoenix)
             // have `None` and fall through to `pay_and_push`.
-            if let Some(ability_index) = pending.activation_ability_index {
-                return super::super::casting_costs::push_activated_ability_to_stack(
-                    state,
-                    player,
-                    pending.object_id,
-                    ability_index,
-                    pending.ability,
-                    pending.activation_cost.as_ref(),
-                    pending.activation_residual,
-                    pending.pending_loyalty_activation_player,
-                    events,
+            if pending.activation_ability_index.is_some() {
+                return super::super::casting_costs::finish_activated_ability_at_payment_boundary(
+                    state, player, pending, events,
                 );
             }
             let base_cost = pending.base_cost.clone();
@@ -549,6 +541,7 @@ mod tests {
             ability_snapshot: None,
             color_override: None,
             resume: crate::types::game_state::ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -21,9 +21,10 @@ use crate::types::ability::{AttackScope, AttackSubject};
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
     AutoMayChoice, CastOfferKind, ClauseMinimumSnapshot, DayNight, GameState, LKISnapshot,
-    MayTriggerAutoChoiceKey, PendingContinuation, PendingCopyTokenBatch,
-    PendingPlayerScopeSacrificeChoice, PendingPlayerScopeSacrificeCompletion,
-    PendingRepeatedOptionalPayment, WaitingFor, ZoneChangeRecord,
+    ManaAbilityResume, MayTriggerAutoChoiceKey, PendingContinuation, PendingCopyTokenBatch,
+    PendingCostMoveResume, PendingPlayerScopeSacrificeChoice,
+    PendingPlayerScopeSacrificeCompletion, PendingRepeatedOptionalPayment, WaitingFor,
+    ZoneChangeRecord,
 };
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::mana::ManaCost;
@@ -1253,6 +1254,26 @@ fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbil
     } else {
         state.pending_continuation = Some(PendingContinuation::new(Box::new(head), state));
     }
+}
+
+/// CR 118.12 + CR 608.2c: Complete the original rider of a paused
+/// `Effect::PayCost` only after its typed cost root has settled. The root owns
+/// the parent effect while a mana-source cost move is paused, so this replays
+/// the same child hand-off the ordinary chain walker would have performed.
+pub(crate) fn resolve_effect_pay_cost_rider(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let Some(sub) = ability.sub_ability.as_ref() else {
+        return Ok(());
+    };
+    let mut rider = sub.as_ref().clone();
+    if rider.targets.is_empty() && !ability.targets.is_empty() {
+        rider.targets = ability.targets.clone();
+    }
+    apply_parent_chain_context(&mut rider, ability, None, state);
+    resolve_ability_chain(state, &rider, events, 1)
 }
 
 pub(crate) fn prepend_remaining_pay_cost_continuation(
@@ -8444,6 +8465,22 @@ fn resolve_chain_body(
                 state,
             );
             append_to_pending_continuation(state, Some(Box::new(sub_clone)));
+            return Ok(());
+        }
+        // CR 118.12 + CR 605.3b + CR 616.1: A paused resolution-time PayCost
+        // keeps its original rider on the typed mana root. A replacement
+        // post-effect may itself pause, but its continuation is the only work
+        // allowed to drain before that root resumes; parking the outer rider in
+        // the global continuation queue would run it before the source and cost.
+        let typed_effect_pay_cost_root = matches!(
+            state.pending_cost_move_resume.as_ref(),
+            Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. })
+                if matches!(&pending.resume, ManaAbilityResume::EffectPayCost { .. })
+        );
+        if matches!(ability.effect, Effect::PayCost { .. })
+            && typed_effect_pay_cost_root
+            && waits_for_resolution_choice(&state.waiting_for)
+        {
             return Ok(());
         }
         // If resolve_effect just entered a player-choice state (Scry/Dig/Surveil),

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -250,13 +250,19 @@ fn resolve_ability_cost_payment(
         // `DiscardChoice` — interrupted payment. `state.waiting_for` is already
         // set by the authority; the resolution chain resumes from there.
         Ok(PaymentOutcome::Paused { remaining_cost }) => {
-            if let Some(remaining_cost) = remaining_cost.clone() {
-                super::prepend_remaining_pay_cost_continuation(
-                    state,
-                    ability,
-                    payer,
-                    remaining_cost,
-                );
+            // CR 118.12 + CR 605.3b + CR 616.1: A paused mana-source payment
+            // owns its complete unpaid suffix in `ManaAbilityResume`, never in
+            // the effect continuation queue.  The queue remains only for
+            // ordinary non-mana cost choices such as discard selection.
+            if !crate::game::casting::mana_ability_cost_payment_is_paused(state) {
+                if let Some(remaining_cost) = remaining_cost.clone() {
+                    super::prepend_remaining_pay_cost_continuation(
+                        state,
+                        ability,
+                        payer,
+                        remaining_cost,
+                    );
+                }
             }
             Ok(PaymentOutcome::Paused { remaining_cost })
         }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -76,6 +76,24 @@ pub enum PublicFinalizeMode {
     DeferredDisplay,
 }
 
+/// CR 601.2h + CR 702.132a: Assist remains cancellable while it is only a
+/// selected contribution. Once helper payment has started or completed, its
+/// resources may have changed and cancellation cannot roll that prefix back.
+fn ensure_assist_cancellation_is_allowed(state: &GameState) -> Result<(), EngineError> {
+    if matches!(
+        state
+            .pending_cast
+            .as_deref()
+            .map(|pending| pending.assist_state),
+        Some(AssistState::PaymentStarted { .. } | AssistState::Paid { .. })
+    ) {
+        return Err(EngineError::ActionNotAllowed(
+            "Cannot cancel a cast after an Assist contribution is committed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn handle_unlock_room_door(
     state: &mut GameState,
     player: PlayerId,
@@ -2160,6 +2178,18 @@ pub(super) fn resume_pending_continuation_if_priority(
 ) -> Result<(), EngineError> {
     if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
         effects::drain_pending_continuation(state, events);
+        // CR 605.3b + CR 616.1: Any interactive replacement post-effect may
+        // finish at this common prompt boundary. Once ordinary effect
+        // continuations have drained, resume a parked mana-cost cursor exactly
+        // once; do not depend on a particular choice handler or effect shape.
+        if matches!(state.waiting_for, WaitingFor::Priority { .. })
+            && matches!(
+                state.pending_cost_move_resume,
+                Some(crate::types::game_state::PendingCostMoveResume::ManaAbilityPayment { .. })
+            )
+        {
+            state.waiting_for = mana_abilities::resume_mana_ability_cost_move(state, events)?;
+        }
     }
     Ok(())
 }
@@ -2267,9 +2297,7 @@ fn pass_priority_once_with_pipeline(
     // this drain, a continuation queued after a no-choice effect would sit
     // until an unrelated action, by which point referenced stack objects may
     // have left the stack.
-    if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-        effects::drain_pending_continuation(state, events);
-    }
+    resume_pending_continuation_if_priority(state, events)?;
 
     let skip_triggers =
         stack_was_empty && !state.stack.is_empty() && state.phase == Phase::CombatDamage;
@@ -2717,7 +2745,7 @@ fn finalize_copy_retarget(
         }
         state.waiting_for = wf;
         state.priority_player = player;
-        effects::drain_pending_continuation(state, events);
+        resume_pending_continuation_if_priority(state, events)?;
         return Ok(());
     }
     state.waiting_for = if let Some(remaining) = paradigm_remaining_offers {
@@ -2726,7 +2754,7 @@ fn finalize_copy_retarget(
         WaitingFor::Priority { player }
     };
     state.priority_player = player;
-    effects::drain_pending_continuation(state, events);
+    resume_pending_continuation_if_priority(state, events)?;
     Ok(())
 }
 
@@ -4292,7 +4320,7 @@ fn apply_action(
             subject: None,});
             state.waiting_for = WaitingFor::Priority { player: *player };
             state.priority_player = *player;
-            effects::drain_pending_continuation(state, &mut events);
+            resume_pending_continuation_if_priority(state, &mut events)?;
             state.waiting_for.clone()
         }
         (
@@ -4487,6 +4515,7 @@ fn apply_action(
             // CR 601.2i: Cancelling at mana payment rolls back the cast — pop
             // the stack entry placed at announcement and return the object to
             // its origin zone via `cancel_pending_cast`.
+            ensure_assist_cancellation_is_allowed(state)?;
             let player = *player;
             match state.pending_cast.take() {
                 Some(pending) => {
@@ -4674,11 +4703,11 @@ fn apply_action(
                     .to_string(),
             ));
         }
-        // CR 702.132a: Assist — the chosen player commits how much generic mana to
-        // pay. The caster's owed generic is reduced now, and the commitment is
-        // recorded on the pending cast; the helper's sources are tapped only at
-        // `finalize_cast` (the non-cancellable commit), so a later CancelCast can
-        // never leak the helper's lands or spent mana.
+        // CR 702.132a + CR 601.2h: Assist records the selected generic
+        // contribution and reduces the caster's owed generic now, but helper
+        // resources stay untouched until final payment begins. The typed
+        // PaymentStarted boundary, not this deferred intent, makes cancellation
+        // unavailable once a helper source can have changed state.
         (
             WaitingFor::AssistPayment {
                 caster,
@@ -4709,11 +4738,12 @@ fn apply_action(
                 let mut sim = state.clone();
                 let mut sink = Vec::new();
                 casting_costs::auto_tap_mana_sources(&mut sim, chosen, &probe, &mut sink, None);
-                let feasible = sim
-                    .players
-                    .iter()
-                    .find(|p| p.id == chosen)
-                    .is_some_and(|p| mana_payment::can_pay(&p.mana_pool, &probe));
+                let feasible = casting::mana_ability_cost_payment_is_paused(&sim)
+                    || sim
+                        .players
+                        .iter()
+                        .find(|p| p.id == chosen)
+                        .is_some_and(|p| mana_payment::can_pay(&p.mana_pool, &probe));
                 if !feasible {
                     return Err(EngineError::InvalidAction(format!(
                         "Assisting player cannot produce {generic} generic mana"
@@ -4863,6 +4893,7 @@ fn apply_action(
         // CR 601.2i: CancelCast during Phyrexian payment rolls back the cast —
         // mirrors the ManaPayment CancelCast path.
         (WaitingFor::PhyrexianPayment { player, .. }, GameAction::CancelCast) => {
+            ensure_assist_cancellation_is_allowed(state)?;
             let player = *player;
             match state.pending_cast.take() {
                 Some(pending) => {
@@ -4899,13 +4930,20 @@ fn apply_action(
                     &ability_def,
                     &mut events,
                     crate::types::game_state::ManaAbilityResume::ManaPayment {
+                        outer_player: Some(*player),
                         convoke_mode: *convoke_mode,
                     },
                     None,
                 )?;
                 // CR 605.1b: Process TapsForMana triggers inline during mana payment
                 // (same rationale as the TapLandForMana arm below).
-                if events.len() > events_before {
+                // CR 605.3b + CR 616.1 + CR 603.3b: A paused costed mana
+                // ability serializes its unscanned events in its typed cursor.
+                // The cursor is their single settlement authority, so do not
+                // scan them here and again when the replacement choice resumes.
+                if events.len() > events_before
+                    && !casting::mana_ability_cost_payment_is_paused(state)
+                {
                     let mana_events: Vec<_> = events[events_before..].to_vec();
                     super::triggers::process_triggers(state, &mana_events);
                 }
@@ -5502,7 +5540,7 @@ fn apply_action(
                     if state.pending_batch_deliveries.is_some() {
                         super::zone_pipeline::drain_pending_batch_deliveries(state, &mut events);
                     }
-                    effects::drain_pending_continuation(state, &mut events);
+                    resume_pending_continuation_if_priority(state, &mut events)?;
                     return Ok(ActionResult {
                         events,
                         waiting_for: state.waiting_for.clone(),
@@ -5540,7 +5578,7 @@ fn apply_action(
             if state.pending_batch_deliveries.is_some() {
                 super::zone_pipeline::drain_pending_batch_deliveries(state, &mut events);
             }
-            effects::drain_pending_continuation(state, &mut events);
+            resume_pending_continuation_if_priority(state, &mut events)?;
             state.waiting_for.clone()
         }
         (
@@ -6365,7 +6403,7 @@ fn apply_action(
             subject: None,});
             state.waiting_for = WaitingFor::Priority { player: p };
             state.priority_player = p;
-            effects::drain_pending_continuation(state, &mut events);
+            resume_pending_continuation_if_priority(state, &mut events)?;
             state.waiting_for.clone()
         }
         // CR 701.56a: Time travel — player selected objects for the current phase
@@ -6413,7 +6451,7 @@ fn apply_action(
                     subject: None,});
                     state.waiting_for = WaitingFor::Priority { player: p };
                     state.priority_player = p;
-                    effects::drain_pending_continuation(state, &mut events);
+                    resume_pending_continuation_if_priority(state, &mut events)?;
                     state.waiting_for.clone()
                 }
             } else {
@@ -6423,7 +6461,7 @@ fn apply_action(
                 subject: None,});
                 state.waiting_for = WaitingFor::Priority { player: p };
                 state.priority_player = p;
-                effects::drain_pending_continuation(state, &mut events);
+                resume_pending_continuation_if_priority(state, &mut events)?;
                 state.waiting_for.clone()
             }
         }
@@ -6482,7 +6520,7 @@ fn apply_action(
             let previous_trigger_match_count = state.current_trigger_match_count;
             state.current_trigger_event = pending_event;
             state.current_trigger_match_count = state.pending_optional_trigger_match_count.take();
-            effects::drain_pending_continuation(state, &mut events);
+            resume_pending_continuation_if_priority(state, &mut events)?;
             state.current_trigger_event = previous_trigger_event;
             state.current_trigger_match_count = previous_trigger_match_count;
             state.waiting_for.clone()
@@ -6700,25 +6738,20 @@ fn apply_action(
             // CR 601.2d: Resume casting pipeline after distribution.
             if state.pending_cast.is_some() {
                 let pending = state.pending_cast.take().unwrap();
-                if let Some(ability_index) = pending.activation_ability_index {
+                if pending.activation_ability_index.is_some() {
                     // CR 602.2b + CR 601.2d: an activated ability that divides
                     // damage among targets goes on the stack as an ActivatedAbility
                     // after the division is announced — not as a spell (Captain
-                    // America's Throw). `push_activated_ability_to_stack` pays the
-                    // residual mana leg and no-ops the already-paid UnattachFrom.
+                    // America's Throw). The payment boundary retains the original
+                    // target-first root while it pays the residual mana leg.
                     // The spell-only cost-determination authority used in the `else`
                     // branch (`finish_pending_cast_cost_or_pay`) must NOT be reached
                     // here: it routes into `finalize_cast`, which would commit the
                     // source permanent to the stack as a spell.
-                    casting_costs::push_activated_ability_to_stack(
+                    casting_costs::finish_target_selected_activated_ability_at_payment_boundary(
                         state,
                         p,
-                        pending.object_id,
-                        ability_index,
-                        pending.ability,
-                        pending.activation_cost.as_ref(),
-                        pending.activation_residual,
-                        pending.pending_loyalty_activation_player,
+                        *pending,
                         &mut events,
                     )?
                 } else {
@@ -6802,7 +6835,7 @@ fn apply_action(
                 // Resolution-time distribution continuation path.
                 state.waiting_for = WaitingFor::Priority { player: p };
                 state.priority_player = p;
-                effects::drain_pending_continuation(state, &mut events);
+                resume_pending_continuation_if_priority(state, &mut events)?;
                 state.waiting_for.clone()
             }
         }
@@ -6830,9 +6863,7 @@ fn apply_action(
             state.waiting_for = WaitingFor::Priority { player: p };
             state.priority_player = p;
             effects::counters::drain_pending_counter_moves(state, &mut events);
-            if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                effects::drain_pending_continuation(state, &mut events);
-            }
+            resume_pending_continuation_if_priority(state, &mut events)?;
             state.waiting_for.clone()
         }
         // CR 107.1c + CR 608.2d: Submit the "remove any number of counters"
@@ -6861,9 +6892,7 @@ fn apply_action(
             state.waiting_for = WaitingFor::Priority { player: p };
             state.priority_player = p;
             effects::counters::drain_pending_counter_removals(state, &mut events);
-            if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                effects::drain_pending_continuation(state, &mut events);
-            }
+            resume_pending_continuation_if_priority(state, &mut events)?;
             state.waiting_for.clone()
         }
         // CR 115.7: Retarget a spell or ability on the stack via the dialog
@@ -7071,7 +7100,7 @@ fn apply_retarget(
     });
     state.waiting_for = WaitingFor::Priority { player };
     state.priority_player = player;
-    effects::drain_pending_continuation(state, events);
+    resume_pending_continuation_if_priority(state, events)?;
     Ok(state.waiting_for.clone())
 }
 

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -6,13 +6,12 @@ use crate::types::mana::ManaCost;
 use super::ability_utils::{
     ability_target_legality_needs_chosen_x, assign_targets_in_chain,
     auto_select_targets_for_ability, begin_target_selection_for_ability, build_chained_resolved,
-    build_target_slots_labelled, cap_distribution_target_slots, flatten_targets_in_chain,
-    random_select_targets_for_ability, record_modal_mode_choices, selected_mode_labels,
-    target_constraints_from_modal, validate_modal_indices,
+    build_target_slots_labelled, cap_distribution_target_slots, random_select_targets_for_ability,
+    record_modal_mode_choices, selected_mode_labels, target_constraints_from_modal,
+    validate_modal_indices,
 };
 use super::engine::EngineError;
 use super::engine_stack;
-use super::restrictions;
 use super::triggers;
 use super::{casting, casting_costs, priority};
 
@@ -240,71 +239,14 @@ fn handle_activated_mode_choice(
         if let Some(targets) = resolved_targets {
             let mut resolved = resolved;
             assign_targets_in_chain(state, &mut resolved, &targets)?;
-
-            if let Some(cost) = &ability_cost {
-                let ability_tag = ability_index
-                    .and_then(|index| casting::activation_ability_tag(state, source_id, index));
-                match casting::pay_ability_cost_for_activation(
-                    state,
-                    player,
-                    source_id,
-                    cost,
-                    ability_tag,
-                    events,
-                )? {
-                    casting::PaymentOutcome::Paid => {}
-                    casting::PaymentOutcome::Paused { remaining_cost } => {
-                        let mut pending =
-                            PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-                        pending.activation_cost = remaining_cost;
-                        pending.activation_ability_index = ability_index;
-                        if let Some(pending) = casting_costs::attach_pending_cast_to_cost_move(
-                            state,
-                            Box::new(pending),
-                        ) {
-                            state.pending_cast = Some(pending);
-                        }
-                        return Ok(state.waiting_for.clone());
-                    }
-                    casting::PaymentOutcome::Failed { reason } => {
-                        return Err(EngineError::ActionNotAllowed(reason.reason));
-                    }
-                }
-            }
-            casting::emit_targeting_events(
-                state,
-                &flatten_targets_in_chain(&resolved),
-                source_id,
-                player,
-                events,
-            );
-
-            let entry_id = ObjectId(state.next_object_id);
-            state.next_object_id += 1;
-            // CR 603.4: Stamp the printed-ability index for per-turn resolution
-            // tracking (`AbilityCondition::NthResolutionThisTurn`) before push.
-            let mut resolved_with_idx = resolved;
-            resolved_with_idx.ability_index = ability_index;
-            super::stack::push_to_stack(
-                state,
-                crate::types::game_state::StackEntry {
-                    id: entry_id,
-                    source_id,
-                    controller: player,
-                    kind: crate::types::game_state::StackEntryKind::ActivatedAbility {
-                        source_id,
-                        ability: resolved_with_idx,
-                    },
-                },
-                events,
-            );
-            if let Some(index) = ability_index {
-                restrictions::record_ability_activation(state, source_id, index);
-                // CR 117.1b: Priority permits unbounded activation.
-                // `pending_activations` is a per-priority-window AI-guard —
-                // see `GameState::pending_activations`.
-                state.pending_activations.push((source_id, index));
-            }
+            let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+            pending.activation_cost = ability_cost.clone();
+            pending.activation_ability_index = ability_index;
+            pending.target_constraints = target_constraints;
+            pending.distribute = mode_distribute;
+            casting_costs::finish_target_selected_activated_ability_at_payment_boundary(
+                state, player, pending, events,
+            )
         } else {
             let selection = begin_target_selection_for_ability(
                 state,
@@ -316,96 +258,29 @@ fn handle_activated_mode_choice(
             pending.activation_cost = ability_cost;
             pending.activation_ability_index = ability_index;
             pending.target_constraints = target_constraints;
+            pending.distribute = mode_distribute;
             // CR 601.2c + CR 602.2b: first slot's announcer (controller unless the
             // slot is "of an opponent's choice").
             let initial_player = target_slots
                 .first()
                 .and_then(|slot| slot.chooser)
                 .unwrap_or(player);
-            return Ok(WaitingFor::TargetSelection {
+            Ok(WaitingFor::TargetSelection {
                 player: initial_player,
                 pending_cast: Box::new(pending),
                 target_slots,
                 mode_labels,
                 selection,
-            });
+            })
         }
     } else {
-        if let Some(cost) = &ability_cost {
-            let ability_tag = ability_index
-                .and_then(|index| casting::activation_ability_tag(state, source_id, index));
-            match casting::pay_ability_cost_for_activation(
-                state,
-                player,
-                source_id,
-                cost,
-                ability_tag,
-                events,
-            )? {
-                casting::PaymentOutcome::Paid => {}
-                casting::PaymentOutcome::Paused { remaining_cost } => {
-                    let mut pending =
-                        PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-                    pending.activation_cost = remaining_cost;
-                    pending.activation_ability_index = ability_index;
-                    if let Some(pending) =
-                        casting_costs::attach_pending_cast_to_cost_move(state, Box::new(pending))
-                    {
-                        state.pending_cast = Some(pending);
-                    }
-                    return Ok(state.waiting_for.clone());
-                }
-                casting::PaymentOutcome::Failed { reason } => {
-                    return Err(EngineError::ActionNotAllowed(reason.reason));
-                }
-            }
-        }
-        let entry_id = ObjectId(state.next_object_id);
-        state.next_object_id += 1;
-        // CR 603.4: Stamp the printed-ability index for per-turn resolution tracking.
-        let mut resolved_with_idx = resolved;
-        resolved_with_idx.ability_index = ability_index;
-        super::stack::push_to_stack(
-            state,
-            crate::types::game_state::StackEntry {
-                id: entry_id,
-                source_id,
-                controller: player,
-                kind: crate::types::game_state::StackEntryKind::ActivatedAbility {
-                    source_id,
-                    ability: resolved_with_idx,
-                },
-            },
-            events,
-        );
-        if let Some(index) = ability_index {
-            restrictions::record_ability_activation(state, source_id, index);
-            // CR 117.1b: Priority permits unbounded activation.
-            // `pending_activations` is a per-priority-window AI-guard —
-            // see `GameState::pending_activations`.
-            state.pending_activations.push((source_id, index));
-        }
+        let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+        pending.activation_cost = ability_cost;
+        pending.activation_ability_index = ability_index;
+        pending.target_constraints = target_constraints;
+        pending.distribute = mode_distribute;
+        casting_costs::finish_activated_ability_at_payment_boundary(state, player, pending, events)
     }
-
-    events.push(GameEvent::AbilityActivated {
-        player_id: player,
-        source_id,
-        // CR 606.2: `ability_index` is `Option<usize>` here; classify via the
-        // source ability cost when an index is present, else `Normal`. Using the
-        // index guard avoids the partial-move of `ability_cost` consumed above.
-        kind: ability_index.map_or(
-            crate::types::events::ActivatedAbilityKind::Normal,
-            |index| super::planeswalker::activated_ability_kind(state, source_id, index),
-        ),
-    });
-    // CR 702.142b: Emit additional event when a boast ability is activated.
-    if let Some(index) = ability_index {
-        super::casting_targets::emit_keyword_ability_event_if_tagged(
-            state, source_id, index, player, events,
-        );
-    }
-    priority::clear_priority_passes(state);
-    Ok(WaitingFor::Priority { player })
 }
 
 struct TriggeredModeChoice {

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -621,10 +621,13 @@ pub(super) fn handle_unless_payment(
                 )? {
                     PaymentOutcome::Paid => {}
                     PaymentOutcome::Failed { .. } => payment_failed = true,
-                    // CR 616.1: an atomic Mana cost cannot surface a
-                    // replacement pause; the authority never returns `Paused`
-                    // for it. Treat any pause defensively as not-paid.
-                    PaymentOutcome::Paused { .. } => payment_failed = true,
+                    // CR 118.12 + CR 605.3b + CR 616.1: An auto-tapped mana
+                    // ability can pause on a replacement-aware zone cost.
+                    // Its cursor owns the exact UnlessPayment continuation;
+                    // preserve that choice instead of resolving the effect.
+                    PaymentOutcome::Paused { .. } => {
+                        return Ok(action_result(events, state.waiting_for.clone()));
+                    }
                 }
             }
             // CR 118.4 + CR 107.3c: A dynamic generic cost should have been
@@ -938,8 +941,12 @@ pub(super) fn handle_unless_payment(
                     events,
                 )? {
                     PaymentOutcome::Paid => {}
-                    PaymentOutcome::Failed { .. } | PaymentOutcome::Paused { .. } => {
-                        payment_failed = true;
+                    PaymentOutcome::Failed { .. } => payment_failed = true,
+                    // CR 118.12 + CR 605.3b + CR 616.1: The paused mana
+                    // source owns the original `UnlessPayment` root. Do not
+                    // treat a live replacement choice as declining payment.
+                    PaymentOutcome::Paused { .. } => {
+                        return Ok(action_result(events, state.waiting_for.clone()));
                     }
                 }
             }
@@ -1453,6 +1460,7 @@ pub(super) fn handle_unless_payment_activate_ability(
         &ability_def,
         events,
         crate::types::game_state::ManaAbilityResume::UnlessPayment {
+            outer_player: Some(player),
             cost: Box::new(cost),
             pending_effect,
             trigger_event,

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -933,6 +933,13 @@ pub(super) fn handle_replacement_choice(
             if matches!(waiting_for, WaitingFor::Priority { .. })
                 && (state.pending_continuation.is_some()
                     || state.pending_change_zone_iteration.is_some())
+                // CR 118.12 + CR 605.3b + CR 616.1: A mana-source cost pause
+                // owns the unpaid cost suffix.  Do not drain the ordinary
+                // effect rider before that typed root has settled it.
+                && !matches!(
+                    state.pending_cost_move_resume,
+                    Some(PendingCostMoveResume::ManaAbilityPayment { .. })
+                )
             {
                 // CR 614.12b + CR 614.1c + CR 614.13: drain BOTH the chained
                 // continuation and the multi-target ChangeZone iteration that
@@ -1032,6 +1039,32 @@ pub(super) fn handle_replacement_choice(
                 )
             {
                 waiting_for = super::casting::resume_foretell_cost_move(state, events);
+            }
+
+            // CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: The selected
+            // replacement has delivered the interrupted mana-ability cost move.
+            // Resume only its unpaid cursor suffix; it owns production and the
+            // inline subchain after every cost component has settled.
+            if matches!(waiting_for, WaitingFor::Priority { .. })
+                && matches!(
+                    state.pending_cost_move_resume,
+                    Some(PendingCostMoveResume::ManaAbilityPayment { .. })
+                )
+            {
+                waiting_for = super::mana_abilities::resume_mana_ability_cost_move(state, events)?;
+            }
+
+            // CR 118.12 + CR 605.3b + CR 616.1: The ordinary effect rider may
+            // resume only after the whole typed mana-cost root has either paid
+            // or failed its suffix.  This mirrors the prevention path below.
+            if matches!(waiting_for, WaitingFor::Priority { .. })
+                && (state.pending_continuation.is_some()
+                    || state.pending_change_zone_iteration.is_some())
+            {
+                effects::drain_pending_continuation(state, events);
+                if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                    waiting_for = state.waiting_for.clone();
+                }
             }
 
             // CR 601.2h + CR 602.2b + CR 616.1: Resume a non-move cast or
@@ -1233,6 +1266,27 @@ pub(super) fn handle_replacement_choice(
                 Some(PendingCostMoveResume::Foretell { .. })
             ) {
                 return Ok(super::casting::resume_foretell_cost_move(state, events));
+            }
+            // CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: A fully
+            // prevented or substituted mana-ability cost move still pays that
+            // component, so drain the exact unpaid cursor suffix.
+            if matches!(
+                state.pending_cost_move_resume,
+                Some(PendingCostMoveResume::ManaAbilityPayment { .. })
+            ) {
+                let waiting_for =
+                    super::mana_abilities::resume_mana_ability_cost_move(state, events)?;
+                state.waiting_for = waiting_for.clone();
+                // CR 118.12 + CR 605.3b + CR 616.1: A prevented or substituted
+                // cost move has the same sequencing as a delivered move: settle
+                // the typed cost root first, then exactly once drain its rider.
+                if matches!(waiting_for, WaitingFor::Priority { .. })
+                    && (state.pending_continuation.is_some()
+                        || state.pending_change_zone_iteration.is_some())
+                {
+                    effects::drain_pending_continuation(state, events);
+                }
+                return Ok(state.waiting_for.clone());
             }
             // CR 608.3e: If the ETB was prevented during spell resolution,
             // the permanent goes to the graveyard instead.

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -271,7 +271,9 @@ fn finish_search_found_batch(
                 events,
             );
             set_priority(state, player);
-            effects::drain_pending_continuation(state, events);
+            // CR 605.3b + CR 616.1: resume-aware — a parked mana-cost cursor
+            // settles before (and instead of stranding) the ordinary rider.
+            super::engine::resume_pending_continuation_if_priority(state, events)?;
             return Ok(state.waiting_for.clone());
         }
     }
@@ -669,7 +671,10 @@ fn finalize_standard_search_selection(
         propagate_targets_through_search_shuffle(&mut continuation.chain, &targets);
         state.pending_continuation = Some(continuation);
     }
-    effects::drain_pending_continuation(state, events);
+    // CR 605.3b + CR 616.1: resume-aware — a parked mana-cost cursor settles
+    // before (and instead of stranding) the ordinary rider.
+    super::engine::resume_pending_continuation_if_priority(state, events)
+        .expect("a settled search choice must resume its continuation");
     park_search_observer_triggers(state, events, events_before_drain)
 }
 
@@ -1890,7 +1895,8 @@ pub(super) fn handle_resolution_choice(
             // sub_ability here and hand priority back to the clashing player.
             if !matches!(state.waiting_for, WaitingFor::ClashCardPlacement { .. }) {
                 set_priority(state, player);
-                effects::drain_pending_continuation(state, events);
+                super::engine::resume_pending_continuation_if_priority(state, events)
+                    .expect("a settled clash choice must resume its continuation");
             }
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
@@ -2514,7 +2520,8 @@ pub(super) fn handle_resolution_choice(
                 state.private_look_player = None;
                 set_priority(state, player);
                 if decline_runs_continuation {
-                    effects::drain_pending_continuation(state, events);
+                    super::engine::resume_pending_continuation_if_priority(state, events)
+                        .expect("a settled reveal choice must resume its continuation");
                 } else {
                     state.pending_continuation = None;
                 }
@@ -2567,7 +2574,8 @@ pub(super) fn handle_resolution_choice(
                     cont.chain.context.optional_effect_performed = true;
                 }
             }
-            effects::drain_pending_continuation(state, events);
+            super::engine::resume_pending_continuation_if_priority(state, events)
+                .expect("a settled reveal choice must resume its continuation");
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -2688,7 +2696,8 @@ pub(super) fn handle_resolution_choice(
                 let events_before_drain = events.len();
                 apply_search_partition(state, &chosen, &[], &split, source_id, player, events)?;
                 set_priority(state, player);
-                effects::drain_pending_continuation(state, events);
+                super::engine::resume_pending_continuation_if_priority(state, events)
+                    .expect("a settled search choice must resume its continuation");
                 return Ok(park_search_observer_triggers(
                     state,
                     events,
@@ -2751,7 +2760,8 @@ pub(super) fn handle_resolution_choice(
                 events,
             )?;
             set_priority(state, player);
-            effects::drain_pending_continuation(state, events);
+            super::engine::resume_pending_continuation_if_priority(state, events)
+                .expect("a settled search choice must resume its continuation");
             park_search_observer_triggers(state, events, events_before_partition)
         }
         (
@@ -2968,7 +2978,8 @@ pub(super) fn handle_resolution_choice(
                 // Only after every player has been prompted (the drain leaves no
                 // pending iteration and is no longer waiting on a choice) does
                 // the parked continuation run.
-                effects::drain_pending_continuation(state, events);
+                super::engine::resume_pending_continuation_if_priority(state, events)
+                    .expect("a settled zone choice must resume its continuation");
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
                     state.waiting_for.clone(),
                 ));
@@ -2982,7 +2993,8 @@ pub(super) fn handle_resolution_choice(
                 effects::choose_from_zone::drain_pending_per_category_zone_choice(
                     state, &chosen, events,
                 );
-                effects::drain_pending_continuation(state, events);
+                super::engine::resume_pending_continuation_if_priority(state, events)
+                    .expect("a settled zone choice must resume its continuation");
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
                     state.waiting_for.clone(),
                 ));
@@ -3047,7 +3059,8 @@ pub(super) fn handle_resolution_choice(
                 state.current_trigger_match_count = ctx.match_count;
                 state.die_result_this_resolution = ctx.die_result;
             }
-            effects::drain_pending_continuation(state, events);
+            super::engine::resume_pending_continuation_if_priority(state, events)
+                .expect("a settled zone choice must resume its continuation");
             state.current_trigger_event = prev_trigger_event;
             state.current_trigger_match_count = prev_trigger_match_count;
             state.die_result_this_resolution = prev_die_result;
@@ -3118,7 +3131,8 @@ pub(super) fn handle_resolution_choice(
             // slots). Required so a `repeat_for: DistinctCounterKindsAmong` loop
             // paused on `ChooseOneOfBranch` advances past the first counter kind to
             // prompt for each remaining kind (Bribe Taker).
-            effects::drain_pending_continuation(state, events);
+            super::engine::resume_pending_continuation_if_priority(state, events)
+                .expect("a settled branch choice must resume its continuation");
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
         (
@@ -4298,20 +4312,17 @@ pub(super) fn handle_resolution_choice(
                 }
             }
 
-            set_priority(state, player);
+            let waiting_for = finish_with_continuation(state, player, events);
+            if !matches!(waiting_for, WaitingFor::Priority { .. }) {
+                state.last_named_choice = None;
+                return Ok(ResolutionChoiceOutcome::WaitingFor(waiting_for));
+            }
             if let Some(pending) = state.pending_cast.take() {
-                if let Some(ability_index) = pending.activation_ability_index {
-                    state.waiting_for = casting_costs::push_activated_ability_to_stack(
-                        state,
-                        player,
-                        pending.object_id,
-                        ability_index,
-                        pending.ability,
-                        pending.activation_cost.as_ref(),
-                        pending.activation_residual,
-                        pending.pending_loyalty_activation_player,
-                        events,
-                    )?;
+                if pending.activation_ability_index.is_some() {
+                    state.waiting_for =
+                        casting_costs::finish_activated_ability_at_payment_boundary(
+                            state, player, *pending, events,
+                        )?;
                 } else {
                     // CR 601.2c + CR 601.2f (mirrors the identical fix for
                     // GameAction::DistributeAmong in engine.rs): a NamedChoice
@@ -4377,8 +4388,6 @@ pub(super) fn handle_resolution_choice(
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
                     state.waiting_for.clone(),
                 ));
-            } else {
-                effects::drain_pending_continuation(state, events);
             }
             state.last_named_choice = None;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
@@ -4452,7 +4461,8 @@ pub(super) fn handle_resolution_choice(
                 .map(|o| o.controller)
                 .unwrap_or(state.active_player);
             set_priority(state, controller);
-            effects::drain_pending_continuation(state, events);
+            super::engine::resume_pending_continuation_if_priority(state, events)
+                .expect("a settled guess choice must resume its continuation");
             // Cleared ONLY after the synchronous drain (mirrors NamedChoice), so
             // the wrong/right branch's "number they guessed" read sees it.
             state.last_named_choice = None;
@@ -4502,7 +4512,8 @@ pub(super) fn handle_resolution_choice(
                 source_filter,
             });
             set_priority(state, player);
-            effects::drain_pending_continuation(state, events);
+            super::engine::resume_pending_continuation_if_priority(state, events)
+                .expect("a settled damage-source choice must resume its continuation");
             state.last_chosen_damage_source = None;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
@@ -5312,7 +5323,8 @@ fn finish_with_continuation(
     events: &mut Vec<GameEvent>,
 ) -> WaitingFor {
     set_priority(state, player);
-    effects::drain_pending_continuation(state, events);
+    super::engine::resume_pending_continuation_if_priority(state, events)
+        .expect("a settled resolution choice must resume its continuation");
     state.waiting_for.clone()
 }
 

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -6785,6 +6785,7 @@ fn test_mana_ability_during_mana_payment_stays_in_mana_payment() {
         payment_mode: crate::types::game_state::CastPaymentMode::Auto,
         assist_state: AssistState::NotOffered,
         activation_residual: crate::types::game_state::ActivationResidual::None,
+        activation_target_selection: crate::types::game_state::ActivationTargetSelection::Pending,
         alt_cost_grant_source: None,
     }));
     state.waiting_for = WaitingFor::ManaPayment {
@@ -7177,6 +7178,7 @@ fn taps_for_mana_multiplier_fires_once_on_color_choice_mana_payment_resume() {
         payment_mode: crate::types::game_state::CastPaymentMode::Auto,
         assist_state: AssistState::NotOffered,
         activation_residual: crate::types::game_state::ActivationResidual::None,
+        activation_target_selection: crate::types::game_state::ActivationTargetSelection::Pending,
         alt_cost_grant_source: None,
     }));
     state.waiting_for = WaitingFor::ManaPayment {

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -8,8 +8,10 @@ use crate::types::ability::{
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
-    CostResume, GameState, ManaAbilityResume, ManaChoice, ManaChoiceContext, ManaChoicePrompt,
-    PayCostKind, PayableResource, PendingManaAbility, ProductionOverride, WaitingFor,
+    CostResume, GameState, ManaAbilityCostCursor, ManaAbilityCostParent,
+    ManaAbilityCostParentLifecycle, ManaAbilityCostResolutionMode, ManaAbilityResume, ManaChoice,
+    ManaChoiceContext, ManaChoicePrompt, PayCostKind, PayableResource, PendingCostMoveResume,
+    PendingManaAbility, ProductionOverride, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{ManaColor, ManaCost, ManaPool, ManaType, PaymentContext};
@@ -29,6 +31,7 @@ use super::mana_payment;
 use super::mana_sources;
 use super::mana_sources::{mana_color_to_type, mana_type_to_color};
 use super::sacrifice;
+use super::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 
 /// Check if a typed ability definition represents a mana ability (CR 605).
 /// CR 605.3: Mana abilities produce mana and resolve immediately without using the stack.
@@ -262,6 +265,8 @@ pub fn resolve_mana_ability(
         color_override,
         &HashSet::new(),
         None,
+        None,
+        None,
     )
 }
 
@@ -287,35 +292,67 @@ pub(super) fn resolve_mana_ability_excluding(
     // non-demanded mana, never a floated color the outer cost still needs. `None`
     // at the top-level entry — there is no outer cost on the stack.
     sub_cost_demand: Option<&mana_payment::ColorDemand>,
+    resume: Option<&ManaAbilityResume>,
+    parent: Option<&ManaAbilityCostParent>,
 ) -> Result<(), EngineError> {
-    // Pay the full ability cost (tap, sacrifice, etc.)
-    let waiting_before_cost = state.waiting_for.clone();
-    pay_mana_ability_cost(
-        state,
-        source_id,
+    let waiting_before = state.waiting_for.clone();
+    let ability_index = state
+        .objects
+        .get(&source_id)
+        .and_then(|object| {
+            object
+                .abilities
+                .iter()
+                .position(|ability| ability == ability_def)
+        })
+        .unwrap_or(usize::MAX);
+    let pending = PendingManaAbility {
         player,
-        &ability_def.cost,
-        events,
-        excluded_sources,
-        sub_cost_demand,
-    )?;
-    if state.waiting_for != waiting_before_cost {
-        return Ok(());
-    }
-
-    // CR 117.1 + CR 202.3: This non-interactive entry point is reachable only
-    // when no cost-paid-object snapshot is needed (no battlefield exile
-    // selection); pass `None`. The interactive Food Chain path threads its
-    // captured value through `produce_mana_from_ability` directly.
-    produce_mana_from_ability(
-        state,
         source_id,
-        player,
-        ability_def,
-        events,
+        ability_index,
+        ability_snapshot: Some(ability_def.clone()),
         color_override,
-        None,
-    );
+        // The direct resolver normally leaves its caller's waiting root
+        // untouched.  Its ordinary completion must therefore return to
+        // priority; the outer typed payment root lives exclusively in
+        // `cost_move_resume` and is promoted only when a replaceable cost
+        // move actually pauses.  Reusing that root here would make a
+        // synchronous auto-tap recursively retry its still-live caller.
+        resume: ManaAbilityResume::Priority,
+        cost_move_resume: resume.cloned(),
+        chosen_tappers: Vec::new(),
+        chosen_discards: Vec::new(),
+        chosen_mana_payment: None,
+        chosen_counter_count: None,
+        chosen_x: None,
+        collected_evidence: Vec::new(),
+        chosen_exiled: Vec::new(),
+        chosen_sacrificed_battlefield: Vec::new(),
+        cost_paid_object: None,
+        batch_siblings: Vec::new(),
+    };
+    // CR 605.3b + CR 616.1: This direct path is used by auto-tap and retains
+    // its historical default-output semantics even when a cost move pauses.
+    // The cursor serializes that resolution mode with the exact outer resume.
+    let cost_event_start = events.len();
+    let waiting_for = continue_mana_ability_cost_payment(
+        state,
+        pending,
+        mana_ability_cost_cursor(
+            &ability_def.cost,
+            excluded_sources,
+            sub_cost_demand,
+            ManaAbilityCostResolutionMode::AutoResolved,
+            parent,
+        ),
+        events,
+        cost_event_start,
+    )?;
+    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+        state.waiting_for = waiting_for;
+    } else {
+        state.waiting_for = waiting_before;
+    }
     Ok(())
 }
 
@@ -326,6 +363,7 @@ pub(super) fn resolve_mana_ability_excluding(
 /// `cost_paid_object` carries the captured public characteristics of any
 /// object exiled or sacrificed as part of cost payment so production counts can
 /// resolve cost-paid-object refs (Food Chain / Burnt Offering class).
+#[allow(clippy::too_many_arguments)]
 fn produce_mana_from_ability(
     state: &mut GameState,
     source_id: ObjectId,
@@ -333,6 +371,7 @@ fn produce_mana_from_ability(
     ability_def: &AbilityDefinition,
     events: &mut Vec<GameEvent>,
     color_override: Option<ProductionOverride>,
+    chosen_x: Option<u32>,
     cost_paid_object: Option<CostPaidObjectSnapshot>,
 ) {
     // CR 117.1 + CR 202.3: Build a transient `ResolvedAbility` carrying the
@@ -344,11 +383,7 @@ fn produce_mana_from_ability(
         source_id,
         player,
         ability_def,
-        // CR 107.3c: X is irrelevant here — `ProductionOverride::Combination`
-        // short-circuits `AnyCombination` count resolution (the produced
-        // sequence was pre-chosen by the player), and the produced count X is
-        // enforced via the prompt path's `AnyCombination { count: X }`.
-        None,
+        chosen_x,
         cost_paid_object,
     );
 
@@ -592,6 +627,7 @@ pub fn activate_mana_ability(
             ability_snapshot: Some(ability_def.clone()),
             color_override,
             resume,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -860,6 +896,7 @@ pub fn handle_choose_mana_color(
         &ability_def,
         events,
         Some(override_value),
+        pending.chosen_x,
         pending.cost_paid_object.clone(),
     );
     complete_mana_ability_activation(
@@ -1379,15 +1416,10 @@ fn pay_speed_x_cost(cost: &AbilityCost) -> bool {
 
 pub(super) fn advance_mana_ability_activation(
     state: &mut GameState,
-    mut pending: PendingManaAbility,
+    pending: PendingManaAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
-    let ability_def = state
-        .objects
-        .get(&pending.source_id)
-        .and_then(|obj| obj.abilities.get(pending.ability_index))
-        .cloned()
-        .ok_or_else(|| EngineError::InvalidAction("Mana ability no longer exists".to_string()))?;
+    let ability_def = mana_ability_definition(state, &pending)?;
 
     // CR 107.3a + CR 601.2b + CR 702.179f: A `Pay X speed` mana-ability cost
     // (Chicago Loop's `Pay X speed: Add X mana in any combination of colors`)
@@ -1616,7 +1648,513 @@ pub(super) fn advance_mana_ability_activation(
         }
     }
 
-    if pending.color_override.is_none() {
+    // CR 601.2h + CR 602.2b + CR 616.1: The activation owns a serialized
+    // component cursor while any replaceable cost move is paused. It never
+    // re-enters this choice-discovery prefix after the player answers a
+    // replacement choice, so paid components and selected objects stay paid.
+    let cost_event_start = events.len();
+    continue_mana_ability_cost_payment(
+        state,
+        pending,
+        mana_ability_cost_cursor(
+            &ability_def.cost,
+            &HashSet::new(),
+            None,
+            ManaAbilityCostResolutionMode::Interactive,
+            None,
+        ),
+        events,
+        cost_event_start,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ManaAbilityPaymentProgress {
+    Complete,
+    Paused,
+}
+
+fn mana_ability_definition(
+    state: &GameState,
+    pending: &PendingManaAbility,
+) -> Result<AbilityDefinition, EngineError> {
+    state
+        .objects
+        .get(&pending.source_id)
+        .and_then(|obj| obj.abilities.get(pending.ability_index))
+        .cloned()
+        .or_else(|| pending.ability_snapshot.clone())
+        .ok_or_else(|| EngineError::InvalidAction("Mana ability no longer exists".to_string()))
+}
+
+fn mana_ability_cost_cursor(
+    cost: &Option<AbilityCost>,
+    excluded_sources: &HashSet<ObjectId>,
+    sub_cost_demand: Option<&mana_payment::ColorDemand>,
+    resolution_mode: ManaAbilityCostResolutionMode,
+    parent: Option<&ManaAbilityCostParent>,
+) -> ManaAbilityCostCursor {
+    let mut remaining = Vec::new();
+    if let Some(cost) = cost {
+        append_mana_ability_cost_components(cost, &mut remaining);
+    }
+    let mut excluded_sources: Vec<_> = excluded_sources.iter().copied().collect();
+    excluded_sources.sort_unstable_by_key(|source_id| source_id.0);
+    ManaAbilityCostCursor {
+        remaining,
+        resolution_mode,
+        excluded_sources,
+        sub_cost_demand: sub_cost_demand.copied(),
+        next_tapper: 0,
+        next_discard: 0,
+        next_exiled: 0,
+        next_sacrificed: 0,
+        selected_exile_remaining: None,
+        // CR 603.2 + CR 603.3b: A nested child takes over every unscanned
+        // event already owned by its suspended parent.  It appends only newly
+        // emitted events if it pauses, then hands the one batch back on
+        // completion; no ancestor batch is copied twice.
+        deferred_cost_events: parent.map_or_else(Vec::new, |parent| {
+            parent.cursor.deferred_cost_events.clone()
+        }),
+        current_action_deferred_start: 0,
+        parent: parent.cloned().map(Box::new),
+    }
+}
+
+fn append_mana_ability_cost_components(cost: &AbilityCost, remaining: &mut Vec<AbilityCost>) {
+    match cost {
+        AbilityCost::Composite { costs } => {
+            for cost in costs {
+                append_mana_ability_cost_components(cost, remaining);
+            }
+        }
+        cost => remaining.push(cost.clone()),
+    }
+}
+
+fn promote_cost_move_resume(pending: &mut PendingManaAbility) {
+    if let Some(resume) = pending.cost_move_resume.take() {
+        pending.resume = resume;
+    }
+}
+
+fn promote_cost_move_resume_chain(
+    pending: &mut PendingManaAbility,
+    parent: Option<&mut ManaAbilityCostParent>,
+) {
+    promote_cost_move_resume(pending);
+    if let Some(parent) = parent {
+        promote_cost_move_resume_chain(&mut parent.pending, parent.cursor.parent.as_deref_mut());
+    }
+}
+
+fn suspend_mana_ability_parent_chain(parent: Option<&mut ManaAbilityCostParent>) {
+    if let Some(parent) = parent {
+        parent.lifecycle = ManaAbilityCostParentLifecycle::Suspended;
+        suspend_mana_ability_parent_chain(parent.cursor.parent.as_deref_mut());
+    }
+}
+
+fn pause_mana_ability_cost_payment(
+    state: &mut GameState,
+    pre_delivery_choice_player: Option<PlayerId>,
+    mut pending: PendingManaAbility,
+    mut cursor: ManaAbilityCostCursor,
+    events: &[GameEvent],
+    cost_event_start: usize,
+) {
+    // CR 605.3b + CR 616.1: Promote the typed root only on the paused path.
+    // In particular, a synchronously completed auto-tap must return normally
+    // so its caller can spend the mana rather than recursively retrying.
+    promote_cost_move_resume_chain(&mut pending, cursor.parent.as_deref_mut());
+    // CR 605.3b + CR 605.3c: Only a pause unwinds the parent's synchronous
+    // call frame. Mark the complete parent chain so the resumed child, and no
+    // synchronously completed child, takes ownership of continuing it.
+    suspend_mana_ability_parent_chain(cursor.parent.as_deref_mut());
+    cursor.current_action_deferred_start = cursor.deferred_cost_events.len();
+    cursor
+        .deferred_cost_events
+        .extend_from_slice(&events[cost_event_start..]);
+    state.pending_cost_move_resume = Some(PendingCostMoveResume::ManaAbilityPayment {
+        pending: Box::new(pending),
+        cursor,
+    });
+    // `NeedsChoice` also reports a post-delivery replacement continuation.
+    // That continuation has already consumed `pending_replacement` and installed
+    // its own live prompt, which must remain visible while the typed cursor is
+    // parked. Pre-delivery CR 616.1 ordering is the only case that needs a
+    // synthesized ReplacementChoice.
+    if state.pending_replacement.is_some() {
+        super::costs::pause_cost_payment_for_replacement_choice(
+            state,
+            pre_delivery_choice_player.expect(
+                "a pending replacement must identify the player ordering the interrupted mana cost",
+            ),
+        );
+    }
+}
+
+fn mana_ability_cursor_after_current_component(
+    cursor: &ManaAbilityCostCursor,
+) -> ManaAbilityCostCursor {
+    let mut resumed = cursor.clone();
+    resumed.remaining.remove(0);
+    resumed
+}
+
+fn ensure_mana_ability_selection_cursor_consumed(
+    pending: &PendingManaAbility,
+    cursor: &ManaAbilityCostCursor,
+) -> Result<(), EngineError> {
+    if cursor.next_tapper != pending.chosen_tappers.len() {
+        return Err(EngineError::InvalidAction(
+            "Too many creatures selected for mana ability cost".to_string(),
+        ));
+    }
+    if cursor.next_exiled != pending.chosen_exiled.len() {
+        return Err(EngineError::InvalidAction(
+            "Too many cards selected for mana ability exile cost".to_string(),
+        ));
+    }
+    if cursor.next_discard != pending.chosen_discards.len() {
+        return Err(EngineError::InvalidAction(
+            "Too many cards selected for mana ability cost".to_string(),
+        ));
+    }
+    if cursor.next_sacrificed != pending.chosen_sacrificed_battlefield.len() {
+        return Err(EngineError::InvalidAction(
+            "Too many permanents selected for mana ability sacrifice cost".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn advance_mana_ability_selection_cursor(
+    cursor: &mut ManaAbilityCostCursor,
+    cost: &AbilityCost,
+    paid_discard_count: Option<usize>,
+) -> Result<(), EngineError> {
+    match cost {
+        AbilityCost::TapCreatures { requirement, .. } => {
+            cursor.next_tapper += requirement.fixed_count().ok_or_else(|| {
+                EngineError::InvalidAction(
+                    "Aggregate-power tap cost is not valid for a mana ability".to_string(),
+                )
+            })? as usize;
+        }
+        AbilityCost::Discard { self_scope, .. } if !self_scope.is_source_card() => {
+            cursor.next_discard += paid_discard_count.expect(
+                "mana ability discard count must be captured before moving the selected cards",
+            );
+        }
+        AbilityCost::Sacrifice(cost) if !matches!(cost.target, TargetFilter::SelfRef) => {
+            let crate::types::ability::SacrificeRequirement::Count { count } = cost.requirement
+            else {
+                return Err(EngineError::InvalidAction(
+                    "Unsupported sacrifice cost requirement for mana ability".to_string(),
+                ));
+            };
+            cursor.next_sacrificed += count as usize;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pay_selected_mana_ability_exile_cost(
+    state: &mut GameState,
+    pending: PendingManaAbility,
+    cursor: &mut ManaAbilityCostCursor,
+    count: u32,
+    zone: Option<Zone>,
+    filter: Option<&TargetFilter>,
+    events: &mut Vec<GameEvent>,
+    cost_event_start: usize,
+) -> Result<ManaAbilityPaymentProgress, EngineError> {
+    let effective_zone = exile_cost_effective_zone(zone, filter);
+    if effective_zone == Zone::Library && filter.is_some() {
+        return Err(EngineError::InvalidAction(
+            "Unsupported filtered library exile cost for mana ability".to_string(),
+        ));
+    }
+    if cursor.selected_exile_remaining.is_none() {
+        let end = cursor.next_exiled + count as usize;
+        let selected = pending
+            .chosen_exiled
+            .get(cursor.next_exiled..end)
+            .ok_or_else(|| {
+                EngineError::InvalidAction(
+                    "Missing exiled card selection for mana ability".to_string(),
+                )
+            })?;
+        if contains_duplicate_object_id(selected) {
+            return Err(EngineError::InvalidAction(
+                "Cannot exile the same card more than once for a mana ability cost".to_string(),
+            ));
+        }
+        let legal = eligible_exile_cost_objects(
+            state,
+            pending.player,
+            pending.source_id,
+            effective_zone,
+            filter,
+            count,
+        );
+        if effective_zone == Zone::Library {
+            if selected != legal {
+                return Err(EngineError::ActionNotAllowed(
+                    "Selected cards are no longer on top of your library".to_string(),
+                ));
+            }
+        } else if selected.iter().any(|object_id| {
+            deferred_spell_sacrifice_reserved(state, *object_id) || !legal.contains(object_id)
+        }) {
+            return Err(EngineError::ActionNotAllowed(
+                "Selected card does not match the exile cost".to_string(),
+            ));
+        }
+        cursor.next_exiled = end;
+        cursor.selected_exile_remaining = Some(selected.to_vec());
+    }
+
+    while let Some(object_id) = cursor
+        .selected_exile_remaining
+        .as_ref()
+        .and_then(|remaining| remaining.first())
+        .copied()
+    {
+        if object_id == pending.source_id {
+            return Err(EngineError::ActionNotAllowed(
+                "Source cannot satisfy its own exile cost".to_string(),
+            ));
+        }
+        cursor
+            .selected_exile_remaining
+            .as_mut()
+            .expect("selected exile cursor was checked above")
+            .remove(0);
+        match zone_pipeline::move_object(
+            state,
+            ZoneMoveRequest::cost(object_id, Zone::Exile, pending.source_id),
+            events,
+        ) {
+            ZoneMoveResult::Done => {}
+            ZoneMoveResult::NeedsChoice(choice_player) => {
+                pause_mana_ability_cost_payment(
+                    state,
+                    Some(choice_player),
+                    pending,
+                    cursor.clone(),
+                    events,
+                    cost_event_start,
+                );
+                return Ok(ManaAbilityPaymentProgress::Paused);
+            }
+            ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                unreachable!("a cost move to Exile cannot require Aura attachment")
+            }
+        }
+    }
+    cursor.selected_exile_remaining = None;
+    Ok(ManaAbilityPaymentProgress::Complete)
+}
+
+fn pay_mana_ability_cost_component(
+    state: &mut GameState,
+    pending: PendingManaAbility,
+    cursor: &mut ManaAbilityCostCursor,
+    cost: &AbilityCost,
+    events: &mut Vec<GameEvent>,
+    cost_event_start: usize,
+) -> Result<ManaAbilityPaymentProgress, EngineError> {
+    match cost {
+        AbilityCost::Exile {
+            filter: Some(TargetFilter::SelfRef),
+            zone,
+            count: 1,
+        } => {
+            let required_zone = zone.unwrap_or(Zone::Battlefield);
+            let source = state.objects.get(&pending.source_id).ok_or_else(|| {
+                EngineError::InvalidAction("Source object not found for exile cost".to_string())
+            })?;
+            if source.zone != required_zone {
+                return Err(EngineError::ActionNotAllowed(format!(
+                    "Cannot exile from {:?}: source is not in that zone",
+                    required_zone
+                )));
+            }
+            match zone_pipeline::move_object(
+                state,
+                ZoneMoveRequest::cost(pending.source_id, Zone::Exile, pending.source_id),
+                events,
+            ) {
+                ZoneMoveResult::Done => Ok(ManaAbilityPaymentProgress::Complete),
+                ZoneMoveResult::NeedsChoice(choice_player) => {
+                    pause_mana_ability_cost_payment(
+                        state,
+                        Some(choice_player),
+                        pending,
+                        mana_ability_cursor_after_current_component(cursor),
+                        events,
+                        cost_event_start,
+                    );
+                    Ok(ManaAbilityPaymentProgress::Paused)
+                }
+                ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                    unreachable!("a cost move to Exile cannot require Aura attachment")
+                }
+            }
+        }
+        AbilityCost::Exile {
+            count,
+            zone,
+            filter,
+        } if !matches!(filter, Some(TargetFilter::SelfRef)) => {
+            pay_selected_mana_ability_exile_cost(
+                state,
+                pending,
+                cursor,
+                *count,
+                *zone,
+                filter.as_ref(),
+                events,
+                cost_event_start,
+            )
+        }
+        cost if is_self_contained_mana_subcost(cost) => {
+            match super::costs::pay_ability_cost_for_activation(
+                state,
+                pending.player,
+                pending.source_id,
+                cost,
+                None,
+                events,
+            )? {
+                super::costs::PaymentOutcome::Paid => Ok(ManaAbilityPaymentProgress::Complete),
+                super::costs::PaymentOutcome::Paused { .. } => {
+                    let Some(PendingCostMoveResume::Cast { .. }) =
+                        state.pending_cost_move_resume.take()
+                    else {
+                        unreachable!(
+                            "a paused delegated mana-ability cost must retain the activation cost move"
+                        );
+                    };
+                    let pre_delivery_choice_player = state
+                        .pending_replacement
+                        .is_some()
+                        .then(|| state.waiting_for.acting_player())
+                        .flatten();
+                    pause_mana_ability_cost_payment(
+                        state,
+                        pre_delivery_choice_player,
+                        pending,
+                        mana_ability_cursor_after_current_component(cursor),
+                        events,
+                        cost_event_start,
+                    );
+                    Ok(ManaAbilityPaymentProgress::Paused)
+                }
+                super::costs::PaymentOutcome::Failed { reason } => {
+                    Err(EngineError::ActionNotAllowed(reason.reason))
+                }
+            }
+        }
+        cost => {
+            // CR 601.2h: A dynamic discard cost is measured before its cards
+            // leave the hand, so retain that paid count for the cursor.
+            let paid_discard_count = match cost {
+                AbilityCost::Discard {
+                    count, self_scope, ..
+                } if !self_scope.is_source_card() => Some(
+                    super::quantity::resolve_quantity(
+                        state,
+                        count,
+                        pending.player,
+                        pending.source_id,
+                    )
+                    .max(0) as usize,
+                ),
+                _ => None,
+            };
+            let excluded_sources = cursor.excluded_sources.iter().copied().collect();
+            let mut tappers = pending
+                .chosen_tappers
+                .iter()
+                .copied()
+                .skip(cursor.next_tapper);
+            let mut discards = pending
+                .chosen_discards
+                .iter()
+                .copied()
+                .skip(cursor.next_discard);
+            let mut sacrificed = pending
+                .chosen_sacrificed_battlefield
+                .iter()
+                .copied()
+                .skip(cursor.next_sacrificed);
+            // CR 605.3b + CR 605.3c: A nested source that pauses while
+            // funding this Mana component must retain this exact parent cursor.
+            // The child cursor inherits the parent's existing deferred batch
+            // when it is constructed.  Do not also copy this action's events
+            // into the parent: if the child pauses, its own cursor appends them
+            // exactly once and becomes the temporary settlement authority.
+            let parent_cursor = cursor.clone();
+            let parent = ManaAbilityCostParent {
+                pending: Box::new(pending.clone()),
+                cursor: Box::new(parent_cursor),
+                lifecycle: ManaAbilityCostParentLifecycle::Synchronous,
+            };
+            if let Err(error) = pay_mana_ability_cost_with_choices(
+                state,
+                pending.source_id,
+                pending.player,
+                &Some(cost.clone()),
+                events,
+                &mut tappers,
+                &mut discards,
+                &mut sacrificed,
+                pending.chosen_mana_payment.as_deref(),
+                pending.chosen_counter_count,
+                pending.chosen_x,
+                &excluded_sources,
+                cursor.sub_cost_demand.as_ref(),
+                Some(&parent),
+            ) {
+                // CR 605.3b + CR 605.3c + CR 616.1: A nested mana source
+                // paused on a replacement-aware cost. Its serialized cursor
+                // owns this exact parent; do not turn that valid suspension
+                // into a failed parent mana payment.
+                if super::casting::mana_ability_cost_payment_is_paused(state) {
+                    return Ok(ManaAbilityPaymentProgress::Paused);
+                }
+                return Err(error);
+            }
+            advance_mana_ability_selection_cursor(cursor, cost, paid_discard_count)?;
+            Ok(ManaAbilityPaymentProgress::Complete)
+        }
+    }
+}
+
+fn finish_mana_ability_cost_payment(
+    state: &mut GameState,
+    mut pending: PendingManaAbility,
+    cursor: ManaAbilityCostCursor,
+    events: &mut Vec<GameEvent>,
+    cost_event_start: usize,
+) -> Result<WaitingFor, EngineError> {
+    let resolves_automatically = matches!(
+        cursor.resolution_mode,
+        ManaAbilityCostResolutionMode::AutoResolved
+    );
+    let has_deferred_cost_events = !cursor.deferred_cost_events.is_empty();
+    let parent = cursor
+        .parent
+        .clone()
+        .filter(|parent| matches!(parent.lifecycle, ManaAbilityCostParentLifecycle::Suspended));
+    let ability_def = mana_ability_definition(state, &pending)?;
+    if !resolves_automatically && pending.color_override.is_none() {
         let resolved_for_prompt = resolved_mana_ability_for_current_state(
             state,
             pending.source_id,
@@ -1631,275 +2169,271 @@ pub(super) fn advance_mana_ability_activation(
             pending.source_id,
             Some(&resolved_for_prompt),
         ) {
-            let events_before = events.len();
-            let waiting_before_cost = state.waiting_for.clone();
-            pay_mana_ability_cost_with_choices(
-                state,
-                pending.source_id,
-                pending.player,
-                &ability_def.cost,
-                events,
-                &mut pending.chosen_tappers.iter().copied(),
-                &mut pending.chosen_discards.iter().copied(),
-                &mut pending.chosen_exiled.iter().copied(),
-                &mut pending.chosen_sacrificed_battlefield.iter().copied(),
-                pending.chosen_mana_payment.as_deref(),
-                pending.chosen_counter_count,
-                pending.chosen_x,
-                // CR 605.3c: The interactive resume path is a fresh activation
-                // root, not a link in a suspended in-flight chain. Synchronous
-                // casting auto-tap recursion never crosses an interactive
-                // `WaitingFor` node: the instant a sub-cost needs a prompt the
-                // activation unwinds the Rust stack and serializes to
-                // `PendingManaAbility`. At resume there is therefore no ancestor
-                // activation on the call stack to exclude, so the chain is
-                // empty here.
-                &HashSet::new(),
-                // CR 107.4b + CR 118.10: The interactive resume path is a
-                // top-level activation with no outer cost on the stack, so there
-                // is no colored demand to honor — `None`.
-                None,
-            )?;
-            if state.waiting_for != waiting_before_cost {
-                return Ok(state.waiting_for.clone());
-            }
-            // CR 603.2a + CR 603.2g + CR 605.3b: Cost-payment events (Tap,
-            // Sacrifice, etc.) generated during a mana ability's cost step
-            // trigger external abilities normally — CR 603.2a allows triggers
-            // to fire even when cost payment is in flight, and CR 603.2g
-            // demands that any event that actually occurs trigger its
-            // observers. Mana abilities (CR 605.3b) resolve in two halves
-            // around an interactive `WaitingFor::ChooseManaColor` prompt:
-            // this branch pays the cost and returns the prompt without
-            // flowing back through `run_post_action_pipeline`, which is the
-            // engine's normal trigger scan site. Scan inline here so
-            // cost-payment triggers register before the prompt; otherwise
-            // the events are stranded and never fire any observers (Crime
-            // Novelist, Mayhem Devil, Cruel Celebrant, Korvold, Syr Ginger,
-            // …).
-            if events.len() > events_before {
-                let cost_events: Vec<_> = events[events_before..].to_vec();
-                super::triggers::process_triggers(state, &cost_events);
-            }
-            // CR 605.3a: When the prompt is a single shared color choice and the
-            // cost resolves with no further player input, surface this source's
-            // identical activatable twins so `GameAction::ChooseManaColor` can
-            // bulk-activate them with the chosen color in one round-trip
-            // (the player's 20 Treasures, etc.).
             if matches!(choice, ManaChoicePrompt::SingleColor { .. })
                 && cost_resolves_without_choice(&ability_def.cost)
             {
                 pending.batch_siblings =
                     batch_eligible_siblings(state, pending.player, pending.source_id, &ability_def);
             }
-            return Ok(WaitingFor::ChooseManaColor {
+            let resume = WaitingFor::ChooseManaColor {
                 player: pending.player,
                 choice,
                 context: ManaChoiceContext::ManaAbility(Box::new(pending)),
-            });
+            };
+            if has_deferred_cost_events {
+                settle_mana_ability_cost_events(
+                    state,
+                    cursor.deferred_cost_events,
+                    events,
+                    cost_event_start,
+                );
+                if let Some(order_wf) =
+                    super::triggers::preserve_order_triggers_resume(state, resume.clone())
+                {
+                    return Ok(order_wf);
+                }
+            } else if events.len() > cost_event_start {
+                // CR 603.2 + CR 603.3b + CR 605.3b: A mana-color choice
+                // returns before the ordinary post-action pipeline runs.
+                // Its already-paid cost events therefore need their one
+                // normal trigger collection here. Replacement-paused events
+                // are deliberately excluded: their typed cursor owns them
+                // until `settle_mana_ability_cost_events` above.
+                let cost_events = events[cost_event_start..].to_vec();
+                super::triggers::process_triggers(state, &cost_events);
+            }
+            return Ok(resume);
         }
     }
 
-    let waiting_before_cost = state.waiting_for.clone();
-    resolve_mana_ability_with_selected_choices(
+    produce_mana_from_ability(
         state,
         pending.source_id,
         pending.player,
         &ability_def,
         events,
         pending.color_override.clone(),
-        &pending.chosen_tappers,
-        &pending.chosen_discards,
-        &pending.chosen_exiled,
-        &pending.chosen_sacrificed_battlefield,
-        pending.chosen_mana_payment.as_deref(),
-        pending.chosen_counter_count,
         pending.chosen_x,
         pending.cost_paid_object,
-        // CR 605.3c: Same as the interactive cost-payment site above — resume
-        // is a fresh activation root, the suspended-ancestor chain is empty.
-        &HashSet::new(),
-    )?;
-    if state.waiting_for != waiting_before_cost {
-        return Ok(state.waiting_for.clone());
-    }
-    complete_mana_ability_activation(
-        state,
-        pending.source_id,
-        pending.ability_index,
-        pending.player,
-        events,
     );
-    Ok(resume_waiting_for(pending.player, pending.resume))
-}
-
-/// Pay the full cost of a mana ability. This is the single authority for mana ability
-/// cost resolution — callers dispatch activation, they never inspect individual cost
-/// components. Handles `Tap`, `Composite { Tap, Sacrifice }`, and future cost variants.
-#[allow(clippy::too_many_arguments)]
-fn pay_mana_ability_cost(
-    state: &mut GameState,
-    source_id: ObjectId,
-    player: PlayerId,
-    cost: &Option<AbilityCost>,
-    events: &mut Vec<GameEvent>,
-    excluded_sources: &HashSet<ObjectId>,
-    sub_cost_demand: Option<&mana_payment::ColorDemand>,
-) -> Result<(), EngineError> {
-    pay_mana_ability_cost_with_choices(
-        state,
-        source_id,
-        player,
-        cost,
-        events,
-        &mut std::iter::empty(),
-        &mut std::iter::empty(),
-        &mut std::iter::empty(),
-        &mut std::iter::empty(),
-        None,
-        None,
-        None,
-        excluded_sources,
-        sub_cost_demand,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn resolve_mana_ability_with_selected_choices(
-    state: &mut GameState,
-    source_id: ObjectId,
-    player: PlayerId,
-    ability_def: &AbilityDefinition,
-    events: &mut Vec<GameEvent>,
-    color_override: Option<ProductionOverride>,
-    tapped_creatures: &[ObjectId],
-    discarded_cards: &[ObjectId],
-    exiled_battlefield: &[ObjectId],
-    sacrificed_battlefield: &[ObjectId],
-    chosen_hybrid_payment: Option<&[ManaType]>,
-    chosen_counter_count: Option<u32>,
-    chosen_x: Option<u32>,
-    cost_paid_object: Option<CostPaidObjectSnapshot>,
-    excluded_sources: &HashSet<ObjectId>,
-) -> Result<(), EngineError> {
-    let mut chosen = tapped_creatures.iter().copied();
-    let mut discarded = discarded_cards.iter().copied();
-    let mut exiled = exiled_battlefield.iter().copied();
-    let mut sacrificed = sacrificed_battlefield.iter().copied();
-    pay_mana_ability_cost_with_choices(
-        state,
-        source_id,
-        player,
-        &ability_def.cost,
-        events,
-        &mut chosen,
-        &mut discarded,
-        &mut exiled,
-        &mut sacrificed,
-        chosen_hybrid_payment,
-        chosen_counter_count,
-        chosen_x,
-        excluded_sources,
-        // CR 107.4b + CR 118.10: Selected-choices resume is a top-level
-        // activation with no outer cost on the stack — no colored demand.
-        None,
-    )?;
-    if chosen.next().is_some() {
-        return Err(EngineError::InvalidAction(
-            "Too many creatures selected for mana ability cost".to_string(),
-        ));
-    }
-    if exiled.next().is_some() {
-        return Err(EngineError::InvalidAction(
-            "Too many cards selected for mana ability exile cost".to_string(),
-        ));
-    }
-    if discarded.next().is_some() {
-        return Err(EngineError::InvalidAction(
-            "Too many cards selected for mana ability cost".to_string(),
-        ));
-    }
-    if sacrificed.next().is_some() {
-        return Err(EngineError::InvalidAction(
-            "Too many permanents selected for mana ability sacrifice cost".to_string(),
-        ));
-    }
-
-    // CR 117.1 + CR 202.3: Build a transient `ResolvedAbility` carrying the
-    // cost-paid object snapshot so production-count resolution sees it
-    // (Food Chain class).
-    let resolved_for_quantity = resolved_mana_ability_for_current_state(
-        state,
-        source_id,
-        player,
-        ability_def,
-        chosen_x,
-        cost_paid_object,
-    );
-
-    // CR 106.6: Thread restrictions, grants, and expiry through the
-    // selected-choices path too — otherwise color-picked or hybrid-paid mana
-    // abilities would still emit unrestricted mana.
-    let (produced_mana, restrictions, grants, expiry) = match &resolved_for_quantity.effect {
-        Effect::Mana {
-            produced,
-            restrictions,
-            grants,
-            expiry,
-            target: None,
-        } => {
-            let mana = match color_override {
-                Some(ProductionOverride::Combination(types)) => types,
-                Some(ProductionOverride::SingleColor(color)) => {
-                    resolve_single_color_override(state, produced, &resolved_for_quantity, color)
-                }
-                None => super::effects::mana::resolve_mana_types_for_ability(
-                    produced,
-                    &*state,
-                    &resolved_for_quantity,
-                ),
-            };
-            let concrete = resolve_restrictions(restrictions, &*state, source_id);
-            (mana, concrete, grants.clone(), *expiry)
-        }
-        _ => (Vec::new(), Vec::new(), Vec::new(), None),
-    };
-
-    // CR 106.12: a permanent is "tapped for mana" when the activated mana
-    // ability's cost includes the `{T}` symbol.
-    let tapped = mana_sources::has_tap_component(&ability_def.cost);
-    for &mana_type in &produced_mana {
-        mana_payment::produce_mana_with_attributes(
+    if !resolves_automatically {
+        complete_mana_ability_activation(
             state,
-            source_id,
-            mana_type,
-            player,
-            tapped,
-            &restrictions,
-            &grants,
-            expiry,
+            pending.source_id,
+            pending.ability_index,
+            pending.player,
             events,
         );
     }
-
-    // CR 106.12a: emit one `TappedForMana` per resolution of a `{T}`-cost mana
-    // ability that produces mana, so the `TapsForMana` matcher fires exactly
-    // once. Mirrors `produce_mana_from_ability`; this is the selected-choices /
-    // no-prompt resolution path.
-    if tapped && !produced_mana.is_empty() {
-        events.push(GameEvent::TappedForMana {
-            player_id: player,
-            source_id,
-            produced: produced_mana,
-            tap_state: ManaTapState::from_tap(tapped),
-        });
+    if let Some(parent) = parent {
+        let mut parent_cursor = *parent.cursor;
+        // CR 603.2 + CR 603.3b: The child now owns the complete old batch;
+        // append its current action exactly once, then transfer that batch to
+        // the parent before it retries its still-unpaid Mana component.
+        parent_cursor.deferred_cost_events = cursor.deferred_cost_events;
+        parent_cursor
+            .deferred_cost_events
+            .extend_from_slice(&events[cost_event_start..]);
+        let parent_event_start = events.len();
+        return continue_mana_ability_cost_payment(
+            state,
+            *parent.pending,
+            parent_cursor,
+            events,
+            parent_event_start,
+        );
+    }
+    let resume = resume_mana_ability_root(state, pending.player, pending.resume, events)?;
+    if super::casting::mana_ability_cost_payment_is_paused(state) {
+        defer_cost_events_into_active_mana_root(
+            state,
+            cursor.deferred_cost_events,
+            &events[cost_event_start..],
+        );
+        return Ok(resume);
     }
 
-    // CR 605.3b + CR 605.1a: Resolve the sub-ability chain inline (painlands'
-    // "deals 1 damage to you", Llanowar Wastes-style self-damage, etc.).
-    resolve_mana_ability_sub_chain(state, &resolved_for_quantity, events);
+    if has_deferred_cost_events {
+        settle_mana_ability_cost_events(
+            state,
+            cursor.deferred_cost_events,
+            events,
+            cost_event_start,
+        );
+        return Ok(
+            super::triggers::preserve_order_triggers_resume(state, resume.clone())
+                .unwrap_or(resume),
+        );
+    }
 
-    Ok(())
+    // A direct (non-paused) mana-ability action reaches the ordinary action
+    // trigger pipeline, which remains its settlement authority.  Only a
+    // replacement-paused root lacks that pipeline and therefore settles above.
+    Ok(resume)
+}
+
+/// CR 603.2 + CR 603.3b + CR 605.4a: The typed mana-cost root is the single
+/// settlement authority for every event emitted before and after a replacement
+/// pause. Deferred events were never scanned by their initiating action; current
+/// events are scanned here even when the nominal resume is Priority.
+fn settle_mana_ability_cost_events(
+    state: &mut GameState,
+    mut deferred: Vec<GameEvent>,
+    events: &mut Vec<GameEvent>,
+    current_start: usize,
+) {
+    let deferred_original_len = deferred.len();
+    super::triggers::resolve_tap_mana_triggers_inline(state, &mut deferred, 0);
+    events.extend(deferred[deferred_original_len..].iter().cloned());
+    super::triggers::resolve_tap_mana_triggers_inline(state, events, current_start);
+    deferred.extend_from_slice(&events[current_start..]);
+    if !deferred.is_empty() {
+        super::triggers::process_triggers(state, &deferred);
+    }
+    // The typed cursor has already collected the events emitted by this action.
+    // Claim their exact occurrences through the normal post-action authority so
+    // a Priority resume cannot scan the same events a second time.
+    state.consumed_before_priority_trigger_events.extend(
+        events
+            .iter()
+            .enumerate()
+            .skip(current_start)
+            .map(
+                |(index, event)| crate::game::triggers::ConsumedTriggerEventOccurrence {
+                    event: event.clone(),
+                    occurrence: events[..index]
+                        .iter()
+                        .filter(|prior| *prior == event)
+                        .count(),
+                },
+            ),
+    );
+}
+
+/// CR 603.2 + CR 603.3b: A parent payment can immediately pause again after
+/// its child completes. Transfer the child's unscanned batch into that next
+/// typed root so it remains exactly-once owned rather than being dropped.
+fn defer_cost_events_into_active_mana_root(
+    state: &mut GameState,
+    deferred: Vec<GameEvent>,
+    current: &[GameEvent],
+) {
+    let Some(PendingCostMoveResume::ManaAbilityPayment { cursor, .. }) =
+        state.pending_cost_move_resume.as_mut()
+    else {
+        return;
+    };
+    let local_start = cursor
+        .current_action_deferred_start
+        .min(cursor.deferred_cost_events.len());
+    let local_events = cursor.deferred_cost_events.split_off(local_start);
+    let inherited_current_len = current.len().saturating_sub(local_events.len());
+    cursor.deferred_cost_events.extend(deferred);
+    cursor
+        .deferred_cost_events
+        .extend_from_slice(&current[..inherited_current_len]);
+    cursor.deferred_cost_events.extend(local_events);
+    cursor.current_action_deferred_start = 0;
+}
+
+fn resume_mana_ability_root(
+    state: &mut GameState,
+    mana_source_controller: PlayerId,
+    resume: ManaAbilityResume,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    match resume {
+        ManaAbilityResume::EffectPayCost {
+            payer,
+            return_to,
+            ability,
+            cost,
+        } => match super::costs::pay_ability_cost_for_resolution(
+            state,
+            payer,
+            cost.as_ref(),
+            ability.as_ref(),
+            events,
+        )? {
+            super::costs::PaymentOutcome::Paid => {
+                super::effects::resolve_effect_pay_cost_rider(state, ability.as_ref(), events)
+                    .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
+                if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                    Ok(WaitingFor::Priority { player: return_to })
+                } else {
+                    Ok(state.waiting_for.clone())
+                }
+            }
+            super::costs::PaymentOutcome::Paused { .. } => Ok(state.waiting_for.clone()),
+            super::costs::PaymentOutcome::Failed { .. } => {
+                state.cost_payment_failed_flag = true;
+                super::effects::resolve_effect_pay_cost_rider(state, ability.as_ref(), events)
+                    .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
+                if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                    Ok(WaitingFor::Priority { player: return_to })
+                } else {
+                    Ok(state.waiting_for.clone())
+                }
+            }
+        },
+        ManaAbilityResume::PhyrexianCastPayment { caster, choices } => {
+            super::casting_costs::finalize_mana_payment_with_phyrexian_choices(
+                state, caster, &choices, events,
+            )
+        }
+        ManaAbilityResume::FinalizePendingManaPayment { player } => {
+            super::casting_costs::finalize_automatic_mana_payment(state, player, events)
+        }
+        resume => Ok(resume_waiting_for(mana_source_controller, resume)),
+    }
+}
+
+fn continue_mana_ability_cost_payment(
+    state: &mut GameState,
+    pending: PendingManaAbility,
+    mut cursor: ManaAbilityCostCursor,
+    events: &mut Vec<GameEvent>,
+    cost_event_start: usize,
+) -> Result<WaitingFor, EngineError> {
+    let ability_def = mana_ability_definition(state, &pending)?;
+    if cost_sacrifices_reserved_source(state, pending.source_id, &ability_def.cost) {
+        return Err(EngineError::ActionNotAllowed(
+            "This permanent is already committed to a spell sacrifice cost".to_string(),
+        ));
+    }
+    while let Some(cost) = cursor.remaining.first().cloned() {
+        match pay_mana_ability_cost_component(
+            state,
+            pending.clone(),
+            &mut cursor,
+            &cost,
+            events,
+            cost_event_start,
+        )? {
+            ManaAbilityPaymentProgress::Complete => {
+                cursor.remaining.remove(0);
+            }
+            ManaAbilityPaymentProgress::Paused => return Ok(state.waiting_for.clone()),
+        }
+    }
+    ensure_mana_ability_selection_cursor_consumed(&pending, &cursor)?;
+    finish_mana_ability_cost_payment(state, pending, cursor, events, cost_event_start)
+}
+
+/// CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: Resume the precise unpaid
+/// suffix of a mana ability's activation cost after the interrupted cost move
+/// was delivered or fully replaced. Mana production and its inline subchain
+/// run only when the cursor has no remaining components.
+pub(crate) fn resume_mana_ability_cost_move(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let Some(PendingCostMoveResume::ManaAbilityPayment { pending, cursor }) =
+        state.pending_cost_move_resume.take()
+    else {
+        unreachable!("mana ability cost-move resume requires its typed continuation")
+    };
+    continue_mana_ability_cost_payment(state, *pending, cursor, events, 0)
 }
 
 /// CR 605.3b + CR 605.1a: Run a mana ability's `sub_ability` chain inline.
@@ -1921,85 +2455,6 @@ fn resolve_mana_ability_sub_chain(
     let _ = super::effects::resolve_ability_chain(state, sub, events, 0);
 }
 
-struct ExileCostPayment<'a, I>
-where
-    I: Iterator<Item = ObjectId>,
-{
-    source_id: ObjectId,
-    player: PlayerId,
-    count: u32,
-    zone: Option<Zone>,
-    filter: Option<&'a TargetFilter>,
-    events: &'a mut Vec<GameEvent>,
-    chosen_exiled: &'a mut I,
-}
-
-fn pay_selected_exile_cost_for_mana_ability<I>(
-    state: &mut GameState,
-    payment: ExileCostPayment<'_, I>,
-) -> Result<(), EngineError>
-where
-    I: Iterator<Item = ObjectId>,
-{
-    let effective_zone = exile_cost_effective_zone(payment.zone, payment.filter);
-    if effective_zone == Zone::Library && payment.filter.is_some() {
-        return Err(EngineError::InvalidAction(
-            "Unsupported filtered library exile cost for mana ability".to_string(),
-        ));
-    }
-    let chosen: Vec<_> = (0..payment.count)
-        .map(|_| {
-            payment.chosen_exiled.next().ok_or_else(|| {
-                EngineError::InvalidAction(
-                    "Missing exiled card selection for mana ability".to_string(),
-                )
-            })
-        })
-        .collect::<Result<_, _>>()?;
-    if contains_duplicate_object_id(&chosen) {
-        return Err(EngineError::InvalidAction(
-            "Cannot exile the same card more than once for a mana ability cost".to_string(),
-        ));
-    }
-    let legal = eligible_exile_cost_objects(
-        state,
-        payment.player,
-        payment.source_id,
-        effective_zone,
-        payment.filter,
-        payment.count,
-    );
-    if effective_zone == Zone::Library {
-        if chosen != legal {
-            return Err(EngineError::ActionNotAllowed(
-                "Selected cards are no longer on top of your library".to_string(),
-            ));
-        }
-    } else {
-        for chosen_id in &chosen {
-            if deferred_spell_sacrifice_reserved(state, *chosen_id) {
-                return Err(EngineError::ActionNotAllowed(
-                    "Selected card is already committed to a spell sacrifice cost".to_string(),
-                ));
-            }
-            if !legal.contains(chosen_id) {
-                return Err(EngineError::ActionNotAllowed(
-                    "Selected card does not match the exile cost".to_string(),
-                ));
-            }
-        }
-    }
-    for chosen_id in chosen {
-        if chosen_id == payment.source_id {
-            return Err(EngineError::ActionNotAllowed(
-                "Source cannot satisfy its own exile cost".to_string(),
-            ));
-        }
-        super::zones::move_to_zone(state, chosen_id, Zone::Exile, payment.events);
-    }
-    Ok(())
-}
-
 fn contains_duplicate_object_id(ids: &[ObjectId]) -> bool {
     ids.iter()
         .enumerate()
@@ -2007,7 +2462,7 @@ fn contains_duplicate_object_id(ids: &[ObjectId]) -> bool {
 }
 
 #[allow(clippy::too_many_arguments)]
-fn pay_mana_ability_cost_with_choices<I, J, K, L>(
+fn pay_mana_ability_cost_with_choices<I, J, L>(
     state: &mut GameState,
     source_id: ObjectId,
     player: PlayerId,
@@ -2015,18 +2470,17 @@ fn pay_mana_ability_cost_with_choices<I, J, K, L>(
     events: &mut Vec<GameEvent>,
     chosen_tappers: &mut I,
     chosen_discards: &mut J,
-    chosen_exiled: &mut K,
     chosen_sacrificed_battlefield: &mut L,
     chosen_hybrid_payment: Option<&[ManaType]>,
     chosen_counter_count: Option<u32>,
     chosen_x: Option<u32>,
     excluded_sources: &HashSet<ObjectId>,
     sub_cost_demand: Option<&mana_payment::ColorDemand>,
+    parent: Option<&ManaAbilityCostParent>,
 ) -> Result<(), EngineError>
 where
     I: Iterator<Item = ObjectId>,
     J: Iterator<Item = ObjectId>,
-    K: Iterator<Item = ObjectId>,
     L: Iterator<Item = ObjectId>,
 {
     if cost_sacrifices_reserved_source(state, source_id, cost) {
@@ -2049,6 +2503,7 @@ where
                 events,
                 excluded_sources,
                 sub_cost_demand,
+                parent,
             )?;
         }
         // CR 605.1a + CR 701.17a: Bare `Mill` mana-ability cost. The Millikin
@@ -2175,287 +2630,10 @@ where
                 )?;
             }
         }
-        // CR 118.3 + CR 605.3b: Self-exile mana ability costs are paid
-        // atomically before mana production. The printed cost supplies the
-        // activation zone for hand/graveyard abilities; bare self-exile defaults
-        // to battlefield.
-        Some(AbilityCost::Exile {
-            filter: Some(TargetFilter::SelfRef),
-            zone,
-            count: 1,
-        }) => exile_self_for_mana_cost(state, source_id, *zone, events)?,
-        // CR 117.1 + CR 118.3 + CR 605.3b: Non-self exile as a mana ability
-        // cost. The activation flow has already captured the selected objects
-        // and the cost-paid snapshot; here we verify they are still legal and
-        // move them to exile.
-        Some(AbilityCost::Exile {
-            count,
-            zone,
-            filter,
-        }) if !matches!(filter, Some(TargetFilter::SelfRef)) => {
-            pay_selected_exile_cost_for_mana_ability(
-                state,
-                ExileCostPayment {
-                    source_id,
-                    player,
-                    count: *count,
-                    zone: *zone,
-                    filter: filter.as_ref(),
-                    events,
-                    chosen_exiled,
-                },
-            )?;
-        }
-        Some(AbilityCost::Composite { costs }) => {
-            let exclude_source = costs
-                .iter()
-                .any(|sub_cost| matches!(sub_cost, AbilityCost::Tap));
-            for sub_cost in costs {
-                match sub_cost {
-                    AbilityCost::Tap => tap_source(state, source_id, events)?,
-                    AbilityCost::PayLife { amount } => {
-                        // CR 119.4 + CR 903.4: Resolve dynamic life amount at activation.
-                        let resolved =
-                            super::quantity::resolve_quantity(state, amount, player, source_id)
-                                .max(0) as u32;
-                        pay_life_cost(state, player, resolved, events)?
-                    }
-                    AbilityCost::TapCreatures {
-                        requirement,
-                        filter,
-                    } => {
-                        // CR 605.1a: mana-ability tap costs are fixed-count only.
-                        let count = requirement.fixed_count().ok_or_else(|| {
-                            EngineError::InvalidAction(
-                                "Aggregate-power tap cost is not valid for a mana ability"
-                                    .to_string(),
-                            )
-                        })?;
-                        for _ in 0..count {
-                            let chosen_id = chosen_tappers.next().ok_or_else(|| {
-                                EngineError::InvalidAction(
-                                    "Missing tapped creature selection for mana ability"
-                                        .to_string(),
-                                )
-                            })?;
-                            tap_selected_creature_for_mana_cost(
-                                state,
-                                source_id,
-                                player,
-                                chosen_id,
-                                filter,
-                                exclude_source,
-                                events,
-                            )?;
-                        }
-                    }
-                    AbilityCost::Discard {
-                        count,
-                        filter,
-                        selection,
-                        self_scope,
-                    } => {
-                        if selection.is_random() {
-                            return Err(EngineError::InvalidAction(
-                                "Unsupported random discard cost for mana ability".to_string(),
-                            ));
-                        }
-                        if self_scope.is_source_card() {
-                            match crate::game::effects::discard::discard_as_cost(
-                                state, source_id, player, events,
-                            ) {
-                                crate::game::effects::discard::DiscardOutcome::Complete => {}
-                                crate::game::effects::discard::DiscardOutcome::NeedsReplacementChoice(_) => {}
-                            }
-                        } else {
-                            let resolved =
-                                super::quantity::resolve_quantity(state, count, player, source_id)
-                                    .max(0) as usize;
-                            for _ in 0..resolved {
-                                let chosen_id = chosen_discards.next().ok_or_else(|| {
-                                    EngineError::InvalidAction(
-                                        "Missing discarded card selection for mana ability"
-                                            .to_string(),
-                                    )
-                                })?;
-                                discard_selected_card_for_mana_cost(
-                                    state,
-                                    source_id,
-                                    player,
-                                    chosen_id,
-                                    filter.as_ref(),
-                                    events,
-                                )?;
-                            }
-                        }
-                    }
-                    AbilityCost::Sacrifice(cost)
-                        if matches!(cost.target, TargetFilter::SelfRef)
-                            && cost.requirement
-                                == crate::types::ability::SacrificeRequirement::count(1) =>
-                    {
-                        if deferred_spell_sacrifice_reserved(state, source_id) {
-                            return Err(EngineError::ActionNotAllowed(
-                                "This permanent is already committed to a spell sacrifice cost"
-                                    .to_string(),
-                            ));
-                        }
-                        if super::static_abilities::player_cant_sacrifice_as_cost(
-                            state, player, source_id,
-                        ) {
-                            return Err(EngineError::ActionNotAllowed(
-                                "Cannot sacrifice this permanent as a cost".to_string(),
-                            ));
-                        }
-                        let _ = sacrifice::sacrifice_permanent(state, source_id, player, events)?;
-                    }
-                    AbilityCost::Sacrifice(cost) => {
-                        let crate::types::ability::SacrificeRequirement::Count { count } =
-                            cost.requirement
-                        else {
-                            return Err(EngineError::InvalidAction(
-                                "Unsupported sacrifice cost requirement for mana ability"
-                                    .to_string(),
-                            ));
-                        };
-                        let target = &cost.target;
-                        for _ in 0..count {
-                            let chosen_id =
-                                chosen_sacrificed_battlefield.next().ok_or_else(|| {
-                                    EngineError::InvalidAction(
-                                        "Missing sacrificed permanent selection for mana ability"
-                                            .to_string(),
-                                    )
-                                })?;
-                            sacrifice_selected_permanent_for_mana_cost(
-                                state, source_id, player, chosen_id, target, events,
-                            )?;
-                        }
-                    }
-                    AbilityCost::Exile {
-                        filter: Some(TargetFilter::SelfRef),
-                        zone,
-                        count: 1,
-                    } => exile_self_for_mana_cost(state, source_id, *zone, events)?,
-                    AbilityCost::Exile {
-                        count,
-                        zone,
-                        filter,
-                    } if !matches!(filter, Some(TargetFilter::SelfRef)) => {
-                        pay_selected_exile_cost_for_mana_ability(
-                            state,
-                            ExileCostPayment {
-                                source_id,
-                                player,
-                                count: *count,
-                                zone: *zone,
-                                filter: filter.as_ref(),
-                                events,
-                                chosen_exiled,
-                            },
-                        )?;
-                    }
-                    // CR 122.1 + CR 601.2b: RemoveCounter-on-self as part of a
-                    // composite mana-ability cost (e.g. Gemstone Mine: `{T}, Remove
-                    // a mining counter from this land: Add one mana of any color`).
-                    // Resolves `CounterMatch::Any` (untyped "remove a counter")
-                    // to the concrete counter type currently present on the
-                    // source via `resolve_counter_match_for_removal`, then
-                    // delegates to the replacement-aware helper so replacement
-                    // effects on counter removal apply.
-                    AbilityCost::RemoveCounter {
-                        count,
-                        counter_type,
-                        target: None,
-                        ..
-                    } => {
-                        let count = match *count {
-                            REMOVE_COUNTER_COST_ANY_NUMBER => {
-                                chosen_counter_count.ok_or_else(|| {
-                                    EngineError::InvalidAction(
-                                        "Missing counter count for mana ability".to_string(),
-                                    )
-                                })?
-                            }
-                            REMOVE_COUNTER_COST_ALL => removable_counter_count_for_mana_cost(
-                                state,
-                                source_id,
-                                counter_type,
-                            ),
-                            count => count,
-                        };
-                        remove_counters_for_mana_cost(
-                            state,
-                            source_id,
-                            counter_type,
-                            count,
-                            events,
-                        );
-                    }
-                    // CR 605.3a + CR 601.2h + CR 107.4e: Mana sub-cost inside a
-                    // Composite mana-ability cost (filter lands' `{W/U}, {T}`).
-                    // The caller (via `chosen_mana_payment`) has already resolved
-                    // any hybrid color choices (CR 107.4e); auto-pay the remaining
-                    // cost from the activator's pool.
-                    AbilityCost::Mana { cost } => {
-                        pay_mana_sub_cost(
-                            state,
-                            source_id,
-                            player,
-                            cost,
-                            chosen_hybrid_payment,
-                            events,
-                            excluded_sources,
-                            sub_cost_demand,
-                        )?;
-                    }
-                    // CR 605.1a + CR 701.17a: `Mill` sub-cost inside a Composite
-                    // mana-ability cost — Millikin (`{T}, Mill a card: Add {C}`).
-                    // Mill is non-interactive (no choice gate in
-                    // `advance_mana_ability_activation`), so it is paid directly
-                    // here alongside the tap.
-                    AbilityCost::Mill { count } => {
-                        mill_for_mana_cost(state, player, *count, events)?;
-                    }
-                    // CR 605.2 + CR 701.59: Collect-evidence sub-cost inside a
-                    // Composite mana-ability cost (Cryptex). The exile was
-                    // already performed interactively via the
-                    // `CollectEvidenceChoice` resume (see
-                    // `advance_mana_ability_activation`); no-op here so the cost
-                    // is neither re-paid nor errored.
-                    AbilityCost::CollectEvidence { .. } => {}
-                    // CR 107.3a/.3c + CR 702.179f: `Pay X speed` sub-cost
-                    // inside a Composite mana-ability cost. Concretize the
-                    // announced X into a Fixed cost, then delegate to the
-                    // single-authority cost payer.
-                    AbilityCost::PaySpeed { amount } => {
-                        let cost = match chosen_x {
-                            Some(x) => AbilityCost::PaySpeed {
-                                amount: QuantityExpr::Fixed { value: x as i32 },
-                            },
-                            None => AbilityCost::PaySpeed {
-                                amount: amount.clone(),
-                            },
-                        };
-                        super::costs::pay_mana_ability_cost_synchronously(
-                            state, player, source_id, &cost, events,
-                        )?;
-                    }
-                    // Self-contained components (Untap {Q}, Exert, PayEnergy,
-                    // self-ReturnToHand, EffectCost) delegate to the
-                    // single-authority cost payer alongside the tap.
-                    c if is_self_contained_mana_subcost(c) => {
-                        super::costs::pay_mana_ability_cost_synchronously(
-                            state, player, source_id, c, events,
-                        )?;
-                    }
-                    other => {
-                        return Err(EngineError::InvalidAction(format!(
-                            "Unsupported mana ability sub-cost: {other:?}"
-                        )));
-                    }
-                }
-            }
+        Some(AbilityCost::Exile { .. }) => {
+            return Err(EngineError::InvalidAction(
+                "Mana ability exile costs must be paid by the activation cursor".to_string(),
+            ));
         }
         // CR 605.2 + CR 701.59: Bare collect-evidence mana-ability cost. The
         // exile already happened interactively via the `CollectEvidenceChoice`
@@ -2473,18 +2651,35 @@ where
                     amount: amount.clone(),
                 },
             };
-            super::costs::pay_mana_ability_cost_synchronously(
-                state, player, source_id, &cost, events,
-            )?;
+            if matches!(
+                super::costs::pay_ability_cost_for_activation(
+                    state, player, source_id, &cost, None, events,
+                )?,
+                super::costs::PaymentOutcome::Paused { .. }
+            ) {
+                return Err(EngineError::InvalidAction(
+                    "Mana ability replacement pause must be owned by the activation cursor"
+                        .to_string(),
+                ));
+            }
         }
         // Self-contained components (Untap, Exert, PayEnergy, self-ReturnToHand,
         // EffectCost) delegate to the single-authority cost payer.
         Some(c) if is_self_contained_mana_subcost(c) => {
-            super::costs::pay_mana_ability_cost_synchronously(state, player, source_id, c, events)?;
+            if matches!(
+                super::costs::pay_ability_cost_for_activation(
+                    state, player, source_id, c, None, events,
+                )?,
+                super::costs::PaymentOutcome::Paused { .. }
+            ) {
+                return Err(EngineError::InvalidAction(
+                    "Mana ability replacement pause must be owned by the activation cursor"
+                        .to_string(),
+                ));
+            }
         }
         // CR 122.1 + CR 601.2b: Standalone RemoveCounter-on-self mana-ability
         // cost (Pentad Prism, Crystalline Crawler, Druids' Repository class).
-        // Mirrors the Composite sub-cost arm above.
         Some(AbilityCost::RemoveCounter {
             count,
             counter_type,
@@ -2633,26 +2828,6 @@ fn pay_life_cost(
             EngineError::ActionNotAllowed("Cannot pay life cost for mana ability".to_string()),
         ),
     }
-}
-
-fn exile_self_for_mana_cost(
-    state: &mut GameState,
-    source_id: ObjectId,
-    zone: Option<Zone>,
-    events: &mut Vec<GameEvent>,
-) -> Result<(), EngineError> {
-    let required_zone = zone.unwrap_or(Zone::Battlefield);
-    let source = state.objects.get(&source_id).ok_or_else(|| {
-        EngineError::InvalidAction("Source object not found for exile cost".to_string())
-    })?;
-    if source.zone != required_zone {
-        return Err(EngineError::ActionNotAllowed(format!(
-            "Cannot exile from {:?}: source is not in that zone",
-            required_zone
-        )));
-    }
-    super::zones::move_to_zone(state, source_id, Zone::Exile, events);
-    Ok(())
 }
 
 /// CR 605.3a + CR 605.1a: Extract the nested `ManaCost` from an ability cost
@@ -2901,6 +3076,7 @@ fn pay_mana_sub_cost(
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
     sub_cost_demand: Option<&mana_payment::ColorDemand>,
+    parent: Option<&ManaAbilityCostParent>,
 ) -> Result<(), EngineError> {
     if hybrid_plan.is_none() {
         // CR 605.3c: Every source already in `excluded_sources` is an ancestor
@@ -2918,7 +3094,7 @@ fn pay_mana_sub_cost(
         // CR 605.1a: A mana ability never carries a power-up tag (power-up
         // abilities can't produce mana), so the tag-scoped activation context is
         // `None` here — Quinjet's {R}{R} must not pay another mana ability's cost.
-        return super::casting::pay_ability_mana_cost_excluding(
+        return super::casting::pay_ability_mana_cost_excluding_with_parent(
             state,
             player,
             source_id,
@@ -2927,6 +3103,7 @@ fn pay_mana_sub_cost(
             events,
             &excluded_sources,
             sub_cost_demand,
+            parent,
         );
     }
 
@@ -3381,27 +3558,38 @@ fn cost_has_source_tap_component(cost: &Option<AbilityCost>) -> bool {
     }
 }
 
-fn resume_waiting_for(player: PlayerId, resume: ManaAbilityResume) -> WaitingFor {
+fn resume_waiting_for(mana_source_controller: PlayerId, resume: ManaAbilityResume) -> WaitingFor {
     match resume {
-        ManaAbilityResume::Priority => WaitingFor::Priority { player },
-        ManaAbilityResume::ManaPayment { convoke_mode } => WaitingFor::ManaPayment {
-            player,
+        ManaAbilityResume::Priority => WaitingFor::Priority {
+            player: mana_source_controller,
+        },
+        ManaAbilityResume::ManaPayment {
+            outer_player,
+            convoke_mode,
+        } => WaitingFor::ManaPayment {
+            player: outer_player.unwrap_or(mana_source_controller),
             convoke_mode,
         },
         ManaAbilityResume::UnlessPayment {
+            outer_player,
             cost,
             pending_effect,
             trigger_event,
             effect_description,
             remaining,
         } => WaitingFor::UnlessPayment {
-            player,
+            player: outer_player.unwrap_or(mana_source_controller),
             cost: *cost,
             pending_effect,
             trigger_event,
             effect_description,
             remaining,
         },
+        ManaAbilityResume::EffectPayCost { .. }
+        | ManaAbilityResume::PhyrexianCastPayment { .. }
+        | ManaAbilityResume::FinalizePendingManaPayment { .. } => {
+            unreachable!("effect-cost resume is handled by resume_mana_ability_root")
+        }
     }
 }
 
@@ -6845,6 +7033,7 @@ mod tests {
             ability_snapshot: None,
             color_override: None,
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -6945,6 +7134,7 @@ mod tests {
             ability_index: 0,
             color_override: None,
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -7154,6 +7344,7 @@ mod tests {
                 ability_snapshot: None,
                 color_override: None,
                 resume: ManaAbilityResume::Priority,
+                cost_move_resume: None,
                 chosen_tappers: Vec::new(),
                 chosen_discards: Vec::new(),
                 chosen_mana_payment: None,
@@ -7385,6 +7576,7 @@ mod tests {
             ability_snapshot: None,
             color_override: None,
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -7489,6 +7681,7 @@ mod tests {
             ability_snapshot: None,
             color_override: None,
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -8391,6 +8584,7 @@ mod tests {
             ability_snapshot: None,
             color_override: None,
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -8761,6 +8955,7 @@ mod tests {
             ability_snapshot: None,
             color_override: None,
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -9324,6 +9519,7 @@ mod tests {
             ability_snapshot: None,
             color_override: None,
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -9395,6 +9591,7 @@ mod tests {
             ability_snapshot: None,
             color_override: Some(ProductionOverride::SingleColor(ManaType::Black)),
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -9521,6 +9718,7 @@ mod tests {
             ability_snapshot: None,
             color_override: Some(ProductionOverride::SingleColor(ManaType::Green)),
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -9585,6 +9783,7 @@ mod tests {
             ability_snapshot: None,
             color_override: Some(ProductionOverride::SingleColor(ManaType::Red)),
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -9740,6 +9939,7 @@ mod tests {
             ability_snapshot: None,
             color_override: Some(ProductionOverride::SingleColor(ManaType::Green)),
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -17,6 +17,9 @@ const HIDDEN_CARD_NAME: &str = "Hidden Card";
 /// viewer is explicitly allowed to see them.
 pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState {
     let mut filtered = state.clone();
+    // The replacement-resume cursor is server authority and can retain private
+    // object IDs and last-known snapshots from a cost payment.
+    filtered.pending_cost_move_resume = None;
     let replacement_candidate_source_ids = match &state.waiting_for {
         WaitingFor::ReplacementChoice { candidates, .. } => Some(
             candidates
@@ -1448,17 +1451,19 @@ mod tests {
     };
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, BeholdCostAction, Effect, ReplacementDefinition,
-        ResolvedAbility, TargetFilter,
+        AbilityDefinition, AbilityKind, BeholdCostAction, CostPaidObjectSnapshot, Effect,
+        ReplacementDefinition, ResolvedAbility, TargetFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::{CardType, CoreType};
     use crate::types::counter::CounterType;
     use crate::types::format::FormatConfig;
     use crate::types::game_state::{
-        AutoMayChoice, CastPaymentMode, CastingVariant, CostResume, ManaAbilityResume,
-        MayTriggerAutoChoiceKey, MayTriggerOrigin, PendingBeginGameAbility, PendingCast,
-        PendingManaAbility, PendingScopedLibrarySearch, PendingSearchFoundBatch,
+        AutoMayChoice, CastPaymentMode, CastingVariant, CostResume, ManaAbilityCostCursor,
+        ManaAbilityCostResolutionMode, ManaAbilityResume, MayTriggerAutoChoiceKey,
+        MayTriggerOrigin, PendingBeginGameAbility, PendingCast, PendingCostMoveCompletion,
+        PendingCostMoveResume, PendingManaAbility, PendingScopedLibrarySearch,
+        PendingSearchFoundBatch,
     };
     use crate::types::identifiers::CardId;
     use crate::types::mana::ManaCost;
@@ -1513,6 +1518,8 @@ mod tests {
             payment_mode: CastPaymentMode::Auto,
             assist_state: crate::types::game_state::AssistState::NotOffered,
             activation_residual: crate::types::game_state::ActivationResidual::None,
+            activation_target_selection:
+                crate::types::game_state::ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         })
     }
@@ -1528,6 +1535,7 @@ mod tests {
             ability_snapshot: None,
             color_override: None,
             resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
             chosen_tappers: Vec::new(),
             chosen_discards: Vec::new(),
             chosen_mana_payment: None,
@@ -4182,5 +4190,96 @@ mod tests {
         let controller_attrs = &controller_view.objects[&source].chosen_attributes;
         assert!(controller_attrs.contains(&ChosenAttribute::Number(3)));
         assert!(controller_attrs.contains(&ChosenAttribute::Number(5)));
+    }
+
+    #[test]
+    fn paused_cost_move_resume_is_server_authoritative_for_unauthorized_viewers() {
+        let mut state = GameState::new_two_player(42);
+        state.next_object_id = 70_001;
+        let hidden = create_object(
+            &mut state,
+            CardId(70_001),
+            PlayerId(0),
+            "Paused Cost Secret".to_string(),
+            Zone::Hand,
+        );
+        let mut pending = *dummy_pending_mana_ability(PlayerId(0), ObjectId(70_002));
+        pending.chosen_discards = vec![hidden];
+        pending.chosen_exiled = vec![hidden];
+        pending.cost_paid_object = Some(CostPaidObjectSnapshot {
+            object_id: hidden,
+            lki: state.objects[&hidden].snapshot_for_mana_spent(),
+        });
+        let mana_resume = PendingCostMoveResume::ManaAbilityPayment {
+            pending: Box::new(pending),
+            cursor: ManaAbilityCostCursor {
+                remaining: Vec::new(),
+                resolution_mode: ManaAbilityCostResolutionMode::Interactive,
+                excluded_sources: Vec::new(),
+                sub_cost_demand: None,
+                next_tapper: 0,
+                next_discard: 0,
+                next_exiled: 0,
+                next_sacrificed: 0,
+                selected_exile_remaining: Some(vec![hidden]),
+                deferred_cost_events: Vec::new(),
+                current_action_deferred_start: 0,
+                parent: None,
+            },
+        };
+        let resumes = vec![
+            PendingCostMoveResume::Cast {
+                player: PlayerId(0),
+                pending: Some(dummy_pending_cast(hidden, CardId(70_001), PlayerId(0))),
+                chosen: vec![hidden],
+                paused_at_index: 0,
+                destination: Zone::Exile,
+                completion: PendingCostMoveCompletion::FinishPending,
+            },
+            PendingCostMoveResume::Foretell {
+                player: PlayerId(0),
+                object_id: hidden,
+                cost: ManaCost::generic(1),
+                turn_foretold: 7,
+            },
+            mana_resume,
+        ];
+
+        for resume in resumes {
+            state.pending_cost_move_resume = Some(resume);
+            let authoritative_resume = serde_json::to_string(&state.pending_cost_move_resume)
+                .expect("the authoritative cost continuation serializes");
+            assert!(
+                authoritative_resume.contains("70001"),
+                "the authoritative continuation contains the private object ID"
+            );
+            if matches!(
+                &state.pending_cost_move_resume,
+                Some(PendingCostMoveResume::ManaAbilityPayment { .. })
+            ) {
+                assert!(
+                    authoritative_resume.contains("Paused Cost Secret"),
+                    "the mana continuation contains the private cost-payment LKI"
+                );
+            }
+
+            let opponent_view = filter_state_for_viewer(&state, PlayerId(1));
+            assert!(
+                opponent_view.pending_cost_move_resume.is_none(),
+                "a non-acting opponent must not receive a paused cost continuation"
+            );
+            let wire = serde_json::to_string(&opponent_view)
+                .expect("the filtered multiplayer snapshot serializes");
+            assert!(
+                !wire.contains("\"pendingCostMoveResume\":{\"type\"")
+                    && !wire.contains("\"pending_cost_move_resume\":{\"type\""),
+                "the viewer snapshot must not serialize a paused continuation's IDs or LKI"
+            );
+        }
+
+        assert!(
+            state.pending_cost_move_resume.is_some(),
+            "filtering must not alter the authoritative server continuation"
+        );
     }
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -144,10 +144,9 @@ pub enum ConvokeMode {
     Delve,
 }
 
-/// CR 702.132a: Tracks the once-per-cast Assist offer/decision on a `PendingCast`.
-/// A typed enum (not a bool) so the offered-once guard and the committed
-/// contribution share one field. `Committed` defers the helper's actual mana
-/// spend to `finalize_cast`, so cancelling the cast never leaks tapped lands.
+/// CR 702.132a + CR 601.2h: Tracks the once-per-cast Assist offer and payment
+/// lifecycle on a `PendingCast`. A typed enum (not a bool) keeps the selected
+/// contribution distinct from the irreversible helper-payment boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum AssistState {
     /// The Assist offer has not been made for this cast.
@@ -156,9 +155,17 @@ pub enum AssistState {
     /// The offer was made and the caster declined (or contributed nothing).
     Offered,
     /// The caster chose `helper`, who will pay `generic` of the spell's generic
-    /// mana. The caster's owed cost is reduced by `generic` now; the helper's
-    /// sources are tapped only at `finalize_cast` (the non-cancellable commit).
+    /// mana. The caster's owed cost is reduced by `generic` now, but the helper
+    /// has not yet begun paying; the cast remains cancellable.
     Committed { helper: PlayerId, generic: u32 },
+    /// The helper has started paying its committed contribution. This survives
+    /// a paused source-cost replacement so cancellation cannot strand a paid
+    /// prefix or allow the helper contribution to be applied twice on resume.
+    PaymentStarted { helper: PlayerId, generic: u32 },
+    /// The committed helper contribution has been paid. This checkpoint is
+    /// retained if the caster's later mana payment pauses on a replacement
+    /// choice, so the helper is never charged again on resume.
+    Paid { helper: PlayerId, generic: u32 },
 }
 
 /// CR 614.10 + CR 614.10a: Turn-scoped combat-phase skip lifecycle for a single
@@ -2341,6 +2348,28 @@ pub enum ActivationResidual {
     ManaLeg,
 }
 
+/// CR 601.2c + CR 602.2b: Tracks whether an activation's target-declaration
+/// step has completed before a later payment continuation reaches the stack.
+///
+/// This is intentionally distinct from `ActivationResidual`: the latter owns
+/// unpaid cost legs, while this lifecycle records the completed target step.
+/// A typed state prevents an explicitly declined optional target from being
+/// presented again after a cost-move replacement pause.
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum ActivationTargetSelection {
+    #[default]
+    Pending,
+    Settled,
+}
+
+impl ActivationTargetSelection {
+    /// `true` iff target declaration has not completed; used to omit the
+    /// default from serialized pending roots for legacy save compatibility.
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Self::Pending)
+    }
+}
+
 impl ActivationResidual {
     /// `true` iff no residual detour was taken. Used as the serde
     /// `skip_serializing_if` predicate so the default does not hit the wire.
@@ -2504,6 +2533,10 @@ pub struct PendingCast {
     /// across a multiplayer save/restore.
     #[serde(default, skip_serializing_if = "ActivationResidual::is_none")]
     pub activation_residual: ActivationResidual,
+    /// CR 601.2c + CR 602.2b: Preserves a completed activation target step
+    /// through a cost-payment continuation without conflating it with cost legs.
+    #[serde(default, skip_serializing_if = "ActivationTargetSelection::is_pending")]
+    pub activation_target_selection: ActivationTargetSelection,
     /// CR 118.9 + CR 601.2b: When this cast is offered a once-per-turn
     /// `CastWithAlternativeCost` grant (As Foretold), the granting permanent's id.
     /// Carried across the `OptionalCostChoice` round-trip so the accept handler can
@@ -2543,12 +2576,102 @@ pub enum PendingCostMoveCompletion {
     },
 }
 
-/// CR 601.2h + CR 614.12a + CR 616.1: A cost move paused for a replacement
+/// CR 605.3b: Selects whether completing a mana-ability cost payment may ask
+/// the activator to choose the produced mana. An auto-tap plan already selected
+/// production; a direct activation has not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ManaAbilityCostResolutionMode {
+    #[default]
+    Interactive,
+    AutoResolved,
+}
+
+/// CR 605.3b + CR 616.1: Re-entry ownership for a costed parent mana ability.
+/// This state exists only with a parent frame, so a parentless cursor cannot be
+/// marked suspended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ManaAbilityCostParentLifecycle {
+    #[default]
+    Synchronous,
+    Suspended,
+}
+
+/// CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: A parent mana ability while
+/// one of its mana sub-cost sources is resolving. The parent cursor still
+/// contains its current Mana component, because that component is unpaid until
+/// the child has produced mana and the parent can spend it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManaAbilityCostParent {
+    pub pending: Box<PendingManaAbility>,
+    pub cursor: Box<ManaAbilityCostCursor>,
+    #[serde(default)]
+    pub lifecycle: ManaAbilityCostParentLifecycle,
+}
+
+/// CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: The unpaid suffix of an
+/// activated mana ability's cost. The selected-list cursors prevent a
+/// replacement-choice resume from re-paying components or selections that
+/// already completed before the interrupted move.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManaAbilityCostCursor {
+    pub remaining: Vec<AbilityCost>,
+    /// Direct auto-tap resolution has already chosen its production path and
+    /// therefore must not surface an output-color prompt after a paused cost
+    /// move resumes. Interactive activation retains the prompt.
+    #[serde(default)]
+    pub resolution_mode: ManaAbilityCostResolutionMode,
+    /// CR 605.3c: Ancestor mana sources excluded while a nested mana sub-cost
+    /// is being auto-paid. Serialized with the root so a replacement choice
+    /// cannot re-enable a suspended source after the move resumes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub excluded_sources: Vec<ObjectId>,
+    /// CR 107.4b + CR 118.10: Colored demand from an outer mana payment.
+    /// Preserving it prevents a resumed nested activation from consuming mana
+    /// reserved for the outer cost.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sub_cost_demand: Option<[u32; 5]>,
+    #[serde(default)]
+    pub next_tapper: usize,
+    #[serde(default)]
+    pub next_discard: usize,
+    #[serde(default)]
+    pub next_exiled: usize,
+    #[serde(default)]
+    pub next_sacrificed: usize,
+    /// The current selected-exile component, after the move that paused has
+    /// been consumed. Its remaining objects must move before the cost cursor
+    /// advances to the next component.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_exile_remaining: Option<Vec<ObjectId>>,
+    /// CR 603.2 + CR 603.3b: Cost events produced before a replacement-choice
+    /// pause cannot reach the ordinary post-action pipeline. Keep them with
+    /// their typed payment root so observers are collected exactly once when
+    /// that root completes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub deferred_cost_events: Vec<GameEvent>,
+    /// Ephemeral split point for the active reducer action. It lets a newly
+    /// nested typed root prepend its parent's unscanned batch without copying
+    /// the local events this root already captured on pause. The split is
+    /// consumed before state is returned to a player, so it is not serialized.
+    #[serde(skip)]
+    pub current_action_deferred_start: usize,
+    /// A nested costed mana source owns this parent until it completes. This
+    /// is a typed activation stack, never an effect continuation: on child
+    /// completion the parent resumes its current unpaid Mana component without
+    /// replaying any paid prefix.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<Box<ManaAbilityCostParent>>,
+}
+
+/// CR 601.2h + CR 614.1 + CR 616.1: A cost move paused for a replacement
 /// choice. `Cast` resumes a cast or activation after its next object is
 /// delivered. `ReplacementMayCost` keeps the outer optional replacement parked
 /// while an inner MayCost move finishes through the replacement pipeline.
 /// `Foretell` records the special action until its replacement-aware exile move
-/// has been delivered or prevented.
+/// has been delivered or prevented. `ManaAbilityPayment` owns the exact
+/// activation and unpaid payment cursor until the move has settled.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PendingCostMoveResume {
     Cast {
@@ -2577,6 +2700,10 @@ pub enum PendingCostMoveResume {
         object_id: ObjectId,
         cost: ManaCost,
         turn_foretold: u32,
+    },
+    ManaAbilityPayment {
+        pending: Box<PendingManaAbility>,
+        cursor: ManaAbilityCostCursor,
     },
 }
 
@@ -2633,6 +2760,7 @@ impl PendingCast {
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
+            activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         }
     }
@@ -2667,10 +2795,20 @@ pub enum CollectEvidenceResume {
 pub enum ManaAbilityResume {
     Priority,
     ManaPayment {
+        /// The payer of the outer spell/ability cost. This is intentionally
+        /// independent from `PendingManaAbility::player`: Assist can activate
+        /// a helper-controlled mana source while returning to the caster's
+        /// `WaitingFor::ManaPayment` root.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        outer_player: Option<PlayerId>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         convoke_mode: Option<ConvokeMode>,
     },
     UnlessPayment {
+        /// The player who owns the outer unless-payment poll. It can differ
+        /// from the controller of a helper mana source activated while paying.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        outer_player: Option<PlayerId>,
         /// CR 118.12: Carried-through cost from `WaitingFor::UnlessPayment`.
         /// See the matching `WaitingFor::UnlessPayment.cost` doc-comment for
         /// the legacy-shape deserialization contract. Boxed so the
@@ -2688,6 +2826,33 @@ pub enum ManaAbilityResume {
         /// mana ability mid-payment.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         remaining: Vec<PlayerId>,
+    },
+    /// CR 118.12 + CR 605.3b + CR 616.1: A resolving `Effect::PayCost` whose
+    /// auto-tapped mana source paused on a replaceable cost move. The exact
+    /// payer-adjusted ability and concrete outer cost are retried by the cost
+    /// authority after that source finishes; this is not an effect-chain
+    /// continuation.
+    EffectPayCost {
+        payer: PlayerId,
+        return_to: PlayerId,
+        ability: Box<ResolvedAbility>,
+        cost: Box<AbilityCost>,
+    },
+    /// CR 107.4f + CR 601.2f-h + CR 605.3b + CR 616.1: Submitted
+    /// Phyrexian shard choices remain authoritative while a helper's or
+    /// caster's auto-tapped mana source pauses on a replaceable cost move.
+    /// The pending cast is restored by the finalizer; this root retries that
+    /// exact finalization rather than falling back to either player's priority.
+    PhyrexianCastPayment {
+        caster: PlayerId,
+        choices: Vec<ShardChoice>,
+    },
+    /// CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: An automatic cast or
+    /// mana-leg activation paused while an auto-tapped source paid a cost.
+    /// The live `PendingCast` is the authoritative root; retry its shared
+    /// finalizer rather than returning to priority or opening a manual window.
+    FinalizePendingManaPayment {
+        player: PlayerId,
     },
 }
 
@@ -2765,6 +2930,13 @@ pub struct PendingManaAbility {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color_override: Option<ProductionOverride>,
     pub resume: ManaAbilityResume,
+    /// CR 605.3b + CR 616.1: An auto-tapped mana source normally returns to
+    /// its immediate caller. If one of its own cost moves pauses, this is the
+    /// serialized outer payment root that must be promoted before resumption.
+    /// Keeping it separate prevents synchronous auto-taps from replaying an
+    /// already-live outer payment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_move_resume: Option<ManaAbilityResume>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub chosen_tappers: Vec<ObjectId>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -13039,6 +13211,7 @@ mod tests {
                 payment_mode: CastPaymentMode::Auto,
                 assist_state: AssistState::NotOffered,
                 activation_residual: ActivationResidual::None,
+                activation_target_selection: ActivationTargetSelection::Pending,
                 alt_cost_grant_source: None,
             })
         }
@@ -13409,6 +13582,7 @@ mod tests {
             payment_mode: CastPaymentMode::Auto,
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
+            activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
         });
         let choose_x = WaitingFor::ChooseXValue {
@@ -13474,6 +13648,7 @@ mod tests {
                     ability_snapshot: None,
                     color_override: None,
                     resume: ManaAbilityResume::Priority,
+                    cost_move_resume: None,
                     chosen_tappers: Vec::new(),
                     chosen_discards: Vec::new(),
                     chosen_mana_payment: None,

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -1,23 +1,31 @@
 use engine::database::synthesis::synthesize_plot;
-use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::effects::resolve_ability_chain;
+use engine::game::game_object::AttachTarget;
+use engine::game::mana_abilities::activate_mana_ability;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, CastingPermission, ChoiceType, Effect,
-    ModalChoice, QuantityExpr, ReplacementDefinition, ReplacementMode, SpellCastingOption,
-    TargetFilter, TargetSelectionMode,
+    AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, CastingPermission, ChoiceType,
+    DiscardSelfScope, Effect, ManaContribution, ManaProduction, ModalChoice, QuantityExpr,
+    ReplacementDefinition, ReplacementMode, ResolvedAbility, SacrificeCost, SpellCastingOption,
+    TargetFilter, TargetRef, TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
 use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
 use engine::types::events::GameEvent;
 use engine::types::game_state::{
-    CastPaymentMode, GameState, PayCostKind, PendingCostMoveResume, WaitingFor,
+    CastPaymentMode, GameState, ManaAbilityCostParentLifecycle, ManaAbilityCostResolutionMode,
+    ManaAbilityResume, PayCostKind, PendingCast, PendingCostMoveResume, PendingReplacement,
+    StackEntryKind, WaitingFor,
 };
 use engine::types::keywords::Keyword;
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
-use engine::types::proposed_event::ProposedEvent;
+use engine::types::proposed_event::{ProposedEvent, ReplacementId};
 use engine::types::replacements::ReplacementEvent;
+use engine::types::triggers::TriggerMode;
 use engine::types::zones::{EtbTapState, Zone};
 use std::sync::Arc;
 
@@ -48,6 +56,54 @@ fn prompt_after_moved_to_exile() -> ReplacementDefinition {
     redirect_moved_to_with_post_effect(Zone::Exile, Zone::Exile)
 }
 
+fn scry_after_moved_to_exile() -> ReplacementDefinition {
+    let mut replacement = redirect_moved_to(Zone::Exile, Zone::Exile);
+    replacement
+        .execute
+        .as_mut()
+        .expect("redirect helper always provides its replacement effect")
+        .sub_ability = Some(Box::new(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Scry {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+    )));
+    replacement
+}
+
+fn proliferate_after_moved_to_exile() -> ReplacementDefinition {
+    let mut replacement = redirect_moved_to(Zone::Exile, Zone::Exile);
+    replacement
+        .execute
+        .as_mut()
+        .expect("redirect helper always provides its replacement effect")
+        .sub_ability = Some(Box::new(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::Proliferate,
+    )));
+    replacement
+}
+
+fn optional_gain_life_after_moved_to_exile() -> ReplacementDefinition {
+    let mut replacement = redirect_moved_to(Zone::Exile, Zone::Exile);
+    replacement
+        .execute
+        .as_mut()
+        .expect("redirect helper always provides its replacement effect")
+        .sub_ability = Some(Box::new(
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+        )
+        .optional(),
+    ));
+    replacement
+}
+
 fn redirect_moved_to_with_post_effect(
     destination: Zone,
     redirected_to: Zone,
@@ -68,6 +124,92 @@ fn redirect_moved_to_with_post_effect(
         },
     )));
     replacement
+}
+
+fn mana_self_exile_cost_redirect_witness() -> (GameScenario, engine::types::identifiers::ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Mana Self-Exile Redirect Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    for name in [
+        "First Mana Self-Exile Redirect",
+        "Second Mana Self-Exile Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+
+    (scenario, source)
+}
+
+/// Drives the real replacement-choice dispatcher through its `Prevented` arm
+/// while retaining the paused mana-cost root created by the normal cost-move
+/// pipeline. Zone-change prevention is not yet an engine replacement outcome,
+/// so this uses the existing one-shot prevention producer to exercise the
+/// shared dispatcher seam.
+fn stage_prevented_mana_cost_move(
+    state: &mut GameState,
+    source: engine::types::identifiers::ObjectId,
+) {
+    state
+        .objects
+        .get_mut(&source)
+        .expect("mana source exists while its cost move is paused")
+        .replacement_definitions = vec![ReplacementDefinition::new(ReplacementEvent::Destroy)
+        .regeneration_shield()
+        .description("Prevent the staged mana cost move".to_string())]
+    .into();
+    state.pending_replacement = Some(PendingReplacement {
+        proposed: ProposedEvent::Destroy {
+            object_id: source,
+            source: None,
+            cant_regenerate: false,
+            applied: Default::default(),
+        },
+        sacrifice_provenance: None,
+        candidates: vec![ReplacementId { source, index: 0 }],
+        search_found_candidates: Vec::new(),
+        depth: 0,
+        is_optional: false,
+        library_placement: None,
+        excess_recipient: None,
+        lifelink_bonus: 0,
+        may_cost_paid: false,
+        may_cost_remaining: None,
+    });
+    state.waiting_for = WaitingFor::ReplacementChoice {
+        player: P0,
+        candidate_count: 1,
+        candidates: vec![],
+    };
 }
 
 #[test]
@@ -1054,7 +1196,7 @@ fn return_cost_keeps_selected_move_while_residual_self_move_pauses() {
         WaitingFor::ReplacementChoice { .. }
     ));
     assert!(matches!(
-        runner.state().pending_cost_move_resume,
+        runner.state().pending_cost_move_resume.as_ref(),
         Some(PendingCostMoveResume::Cast { .. })
     ));
     assert_eq!(runner.state().objects[&returned].zone, Zone::Battlefield);
@@ -1203,5 +1345,3746 @@ fn synthesized_plot_redirect_resumes_as_special_action() {
             .chain(second.events.iter())
             .all(|event| !matches!(event, GameEvent::AbilityActivated { .. })),
         "plot is a special action and must not emit AbilityActivated"
+    );
+}
+
+#[test]
+fn mana_self_exile_cost_redirect_serializes_and_resumes_mana_payment_once() {
+    let (scenario, source) = mana_self_exile_cost_redirect_witness();
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&source].card_id;
+    runner.state_mut().pending_cast = Some(Box::new(PendingCast::new(
+        source,
+        card_id,
+        ResolvedAbility::new(
+            Effect::Unimplemented {
+                name: "Mana Payment Witness".to_string(),
+                description: None,
+            },
+            vec![],
+            source,
+            P0,
+        ),
+        ManaCost::generic(1),
+    )));
+    let ability = runner.state().objects[&source].abilities[0].clone();
+    let mut initial_events = Vec::new();
+    let initial = activate_mana_ability(
+        runner.state_mut(),
+        source,
+        P0,
+        0,
+        &ability,
+        &mut initial_events,
+        ManaAbilityResume::ManaPayment {
+            outer_player: Some(P0),
+            convoke_mode: None,
+        },
+        None,
+    )
+    .expect("the mana ability activation should reach its self-exile cost");
+
+    assert!(
+        matches!(initial, WaitingFor::ReplacementChoice { .. }),
+        "a mana self-exile cost must consult competing Moved redirects"
+    );
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment {
+            pending,
+            cursor,
+        }) if matches!(&pending.resume, ManaAbilityResume::ManaPayment {
+            outer_player: Some(P0),
+            convoke_mode: None,
+        })
+            && cursor.remaining.is_empty()
+    ));
+    let json = serde_json::to_string(runner.state())
+        .expect("a paused mana self-exile replacement choice serializes");
+    assert!(
+        json.contains("ReplacementChoice"),
+        "the replacement choice must remain serialized while mana payment is paused"
+    );
+    let restored: GameState = serde_json::from_str(&json)
+        .expect("a paused mana self-exile replacement choice deserializes");
+    let mut runner = GameRunner::from_state(restored);
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect the mana self-exile cost");
+
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the resumed activation must produce its mana exactly once"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "resuming the cost move must not repay the earlier tap component"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(
+                |event| matches!(event, GameEvent::ManaAdded { player_id, .. } if *player_id == P0)
+            )
+            .count(),
+        1,
+        "the resumed activation must not produce mana twice"
+    );
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment {
+            player,
+            convoke_mode: None,
+        } if player == P0
+    ));
+}
+
+#[test]
+fn mana_self_exile_cost_redirect_serializes_and_resumes_unless_payment_once() {
+    let (scenario, source) = mana_self_exile_cost_redirect_witness();
+    let mut runner = scenario.build();
+    let ability = runner.state().objects[&source].abilities[0].clone();
+    let unless_cost = AbilityCost::Mana {
+        cost: ManaCost::generic(1),
+    };
+    let pending_effect = ResolvedAbility::new(
+        Effect::Unimplemented {
+            name: "Unless Payment Witness".to_string(),
+            description: None,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let resume = ManaAbilityResume::UnlessPayment {
+        outer_player: Some(P0),
+        cost: Box::new(unless_cost.clone()),
+        pending_effect: Box::new(pending_effect.clone()),
+        trigger_event: None,
+        effect_description: Some("unless payment witness".to_string()),
+        remaining: vec![P1],
+    };
+    let mut initial_events = Vec::new();
+    let initial = activate_mana_ability(
+        runner.state_mut(),
+        source,
+        P0,
+        0,
+        &ability,
+        &mut initial_events,
+        resume,
+        None,
+    )
+    .expect("the mana ability activation should reach its self-exile cost");
+
+    assert!(matches!(initial, WaitingFor::ReplacementChoice { .. }));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment {
+            pending,
+            cursor,
+        }) if matches!(
+            &pending.resume,
+            ManaAbilityResume::UnlessPayment {
+                outer_player: Some(P0),
+                cost,
+                pending_effect: paused_effect,
+                trigger_event: None,
+                effect_description: Some(description),
+                remaining,
+            } if cost.as_ref() == &unless_cost
+                && paused_effect.as_ref() == &pending_effect
+                && description == "unless payment witness"
+                && remaining == &vec![P1]
+        ) && cursor.remaining.is_empty()
+    ));
+
+    let json = serde_json::to_string(runner.state())
+        .expect("a paused unless-payment mana activation serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("a paused unless-payment mana activation deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect the mana self-exile cost");
+
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the resumed activation must produce its mana exactly once"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "resuming the cost move must not repay the earlier tap component"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    match &resumed.waiting_for {
+        WaitingFor::UnlessPayment {
+            player,
+            cost,
+            pending_effect: resumed_effect,
+            trigger_event,
+            effect_description,
+            remaining,
+        } => {
+            assert_eq!(*player, P0);
+            assert_eq!(cost, &unless_cost);
+            assert_eq!(resumed_effect.as_ref(), &pending_effect);
+            assert!(trigger_event.is_none());
+            assert_eq!(
+                effect_description.as_deref(),
+                Some("unless payment witness")
+            );
+            assert_eq!(remaining, &vec![P1]);
+        }
+        other => panic!("expected exact UnlessPayment resume, got {other:?}"),
+    }
+}
+
+#[test]
+fn auto_tap_cost_move_redirect_preserves_outer_mana_payment() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let spell = scenario
+        .add_spell_to_hand(P0, "Auto-Tap Cost-Move Payment Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+
+    let announced = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("manual spell payment should reach its mana window");
+    assert!(matches!(
+        announced.waiting_for,
+        WaitingFor::ManaPayment { .. }
+    ));
+
+    let paused = runner
+        .act(GameAction::PassPriority)
+        .expect("auto-tap must surface a mana source's replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, cursor })
+            if matches!(pending.resume, ManaAbilityResume::ManaPayment {
+                outer_player: Some(P0),
+                convoke_mode: None,
+            })
+                && cursor.remaining.is_empty()
+    ));
+    assert!(runner.state().pending_cast.is_some());
+    assert_eq!(
+        runner.state().players[P0.0 as usize].mana_pool.total(),
+        0,
+        "the spell's mana cost must not be spent before the source move settles"
+    );
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the auto-payment replacement pause serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the auto-payment replacement pause deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect the auto-tapped mana source's exile cost");
+
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment {
+            player,
+            convoke_mode: None,
+        } if player == P0
+    ));
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the source resumes once and leaves its mana available to the outer payment"
+    );
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("the outer spell payment resumes after the source move");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { player } if player == P0));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(resumed.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "resuming the outer payment must not repay the mana source's tap prefix"
+    );
+}
+
+#[test]
+fn auto_tap_cost_move_redirect_preserves_outer_unless_payment() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    scenario.add_basic_land(P0, ManaColor::Green);
+    let mut runner = scenario.build();
+    let unless_cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Green],
+                    generic: 0,
+                },
+            },
+            AbilityCost::Mana {
+                cost: ManaCost::generic(1),
+            },
+        ],
+    };
+    let pending_effect = ResolvedAbility::new(
+        Effect::Unimplemented {
+            name: "Auto-Tap Unless Payment Witness".to_string(),
+            description: None,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    runner.state_mut().waiting_for = WaitingFor::UnlessPayment {
+        player: P0,
+        cost: unless_cost.clone(),
+        pending_effect: Box::new(pending_effect.clone()),
+        trigger_event: None,
+        effect_description: Some("auto-tap unless payment witness".to_string()),
+        remaining: vec![P1],
+    };
+
+    let paused = runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("auto-tap must preserve an unless payment while the source move pauses");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, cursor }) if matches!(
+            &pending.resume,
+            ManaAbilityResume::UnlessPayment {
+                outer_player: Some(P0),
+                cost,
+                pending_effect: paused_effect,
+                trigger_event: None,
+                effect_description: Some(description),
+                remaining,
+            } if cost.as_ref() == &unless_cost
+                && paused_effect.as_ref() == &pending_effect
+                && description == "auto-tap unless payment witness"
+                && remaining == &vec![P1]
+        ) && cursor.remaining.is_empty()
+            && cursor.resolution_mode == ManaAbilityCostResolutionMode::AutoResolved
+    ));
+    assert_eq!(
+        runner.state().players[P0.0 as usize].mana_pool.total(),
+        1,
+        "the colored prefix may be produced, but the unsettled generic source must prevent spending the unless cost"
+    );
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the auto unless-payment replacement pause serializes");
+    let restored: GameState = serde_json::from_str(&json)
+        .expect("the auto unless-payment replacement pause deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect the auto-tapped source's exile cost");
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::UnlessPayment {
+            player,
+            ref cost,
+            ref remaining,
+            ..
+        } if player == P0 && cost == &unless_cost && remaining == &vec![P1]
+    ));
+
+    let paid = runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("the restored unless payment should spend the resumed mana");
+    assert!(matches!(paid.waiting_for, WaitingFor::Priority { player } if player == P0));
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+}
+
+#[test]
+fn effect_pay_cost_auto_tap_redirect_serializes_exact_cost_and_trailing_effect_once() {
+    let (scenario, source) = mana_self_exile_cost_redirect_witness();
+    let mut runner = scenario.build();
+    let cost = ManaCost::Cost {
+        shards: vec![ManaCostShard::Green],
+        generic: 0,
+    };
+    let mut ability = ResolvedAbility::new(
+        Effect::PayCost {
+            cost: AbilityCost::Mana { cost: cost.clone() },
+            scale: None,
+            payer: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    )));
+
+    let starting_life = runner.state().players[P0.0 as usize].life;
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("effect payment should pause only for the replacement choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. }) if matches!(
+            &pending.resume,
+            ManaAbilityResume::EffectPayCost {
+                payer: P0,
+                ability: paused_ability,
+                cost: paused_cost,
+                ..
+            } if paused_ability.as_ref() == &ability
+                && paused_cost.as_ref() == &AbilityCost::Mana { cost: cost.clone() }
+        )
+    ));
+
+    let json =
+        serde_json::to_string(runner.state()).expect("paused effect-cost mana payment serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("paused effect-cost mana payment deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirected source cost resumes the exact outer effect cost");
+
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        starting_life + 1,
+        "the trailing effect must resume exactly once after the outer cost is paid"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+}
+
+#[test]
+fn effect_pay_cost_rider_waits_for_scry_post_effect_before_typed_root_settles() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Effect PayCost Scry Ordering Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    let scry_card = scenario.add_card_to_library_top(P0, "Effect PayCost Scry Ordering Card");
+    scenario
+        .add_creature(P0, "Effect PayCost Scry Ordering Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(scry_after_moved_to_exile());
+
+    let mut runner = scenario.build();
+    let mut ability = ResolvedAbility::new(
+        Effect::PayCost {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Green],
+                    generic: 0,
+                },
+            },
+            scale: None,
+            payer: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    )));
+    let life_before = runner.state().players[P0.0 as usize].life;
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("effect PayCost reaches its source-cost replacement post-effect");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ScryChoice { player: P0, ref cards } if cards == &vec![scry_card]
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. })
+            if matches!(pending.resume, ManaAbilityResume::EffectPayCost { .. })
+    ));
+    assert!(
+        runner.state().pending_continuation.is_none(),
+        "only replacement post-effect work may drain before the typed Effect::PayCost root"
+    );
+    assert_eq!(runner.state().players[P0.0 as usize].life, life_before);
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the interactive post-effect and typed EffectPayCost root serialize together");
+    let restored: GameState = serde_json::from_str(&json)
+        .expect("the interactive post-effect and typed EffectPayCost root deserialize together");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::SelectCards {
+            cards: vec![scry_card],
+        })
+        .expect("settling Scry completes the typed root before releasing the PayCost rider");
+
+    let mana_added = resumed
+        .events
+        .iter()
+        .position(
+            |event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source),
+        )
+        .expect("the source produces its mana while the typed root settles");
+    let rider_life = resumed
+        .events
+        .iter()
+        .position(|event| matches!(event, GameEvent::LifeChanged { player_id, amount } if *player_id == P0 && *amount == 1))
+        .expect("the trailing PayCost rider resolves once");
+    assert!(
+        mana_added < rider_life,
+        "the trailing PayCost rider must remain parked until the Scry post-effect and typed mana root complete"
+    );
+    assert_eq!(runner.state().players[P0.0 as usize].life, life_before + 1);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+}
+
+fn assert_repeated_interactive_activation_cost(
+    mut runner: GameRunner,
+    source: engine::types::identifiers::ObjectId,
+    chosen: [engine::types::identifiers::ObjectId; 2],
+    one_of: bool,
+    expected_kind: impl Fn(&PayCostKind) -> bool,
+) {
+    let activated = runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("the activation starts its interactive cost payment");
+    if one_of {
+        assert!(matches!(
+            activated.waiting_for,
+            WaitingFor::ActivationCostOneOfChoice { .. }
+        ));
+        runner
+            .act(GameAction::ChooseActivationCostBranch { index: 0 })
+            .expect("the only disjunctive cost branch is payable");
+    } else {
+        assert!(matches!(
+            activated.waiting_for,
+            WaitingFor::PayCost { ref kind, .. } if expected_kind(kind)
+        ));
+    }
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost { ref kind, .. } if expected_kind(kind)
+    ));
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![chosen[0]],
+        })
+        .expect("the first repeated interactive cost leg is paid");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost { ref kind, .. } if expected_kind(kind)
+    ));
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![chosen[1]],
+        })
+        .expect("the second repeated interactive cost leg is paid");
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "the activation reaches the stack only after both selected cost legs"
+    );
+}
+
+fn repeated_discard_activation_witness(
+    one_of: bool,
+) -> (
+    GameRunner,
+    engine::types::identifiers::ObjectId,
+    [engine::types::identifiers::ObjectId; 2],
+) {
+    let discard = AbilityCost::Discard {
+        count: QuantityExpr::Fixed { value: 1 },
+        filter: None,
+        selection: CardSelectionMode::Chosen,
+        self_scope: DiscardSelfScope::FromHand,
+    };
+    let cost = AbilityCost::Composite {
+        costs: vec![discard.clone(), discard],
+    };
+    let cost = if one_of {
+        AbilityCost::OneOf { costs: vec![cost] }
+    } else {
+        cost
+    };
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Repeated Discard Activation Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(cost),
+        )
+        .id();
+    let first = scenario.add_card_to_hand(P0, "First Repeated Discard Witness");
+    let second = scenario.add_card_to_hand(P0, "Second Repeated Discard Witness");
+    (scenario.build(), source, [first, second])
+}
+
+fn repeated_sacrifice_activation_witness(
+    one_of: bool,
+) -> (
+    GameRunner,
+    engine::types::identifiers::ObjectId,
+    [engine::types::identifiers::ObjectId; 2],
+) {
+    let sacrifice = AbilityCost::Sacrifice(SacrificeCost::count(
+        TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+        1,
+    ));
+    let cost = AbilityCost::Composite {
+        costs: vec![sacrifice.clone(), sacrifice],
+    };
+    let cost = if one_of {
+        AbilityCost::OneOf { costs: vec![cost] }
+    } else {
+        cost
+    };
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Repeated Sacrifice Activation Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(cost),
+        )
+        .id();
+    let first = scenario
+        .add_creature(P0, "First Repeated Sacrifice Witness", 1, 1)
+        .as_artifact()
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second Repeated Sacrifice Witness", 1, 1)
+        .as_artifact()
+        .id();
+    (scenario.build(), source, [first, second])
+}
+
+fn repeated_exile_activation_witness(
+    one_of: bool,
+) -> (
+    GameRunner,
+    engine::types::identifiers::ObjectId,
+    [engine::types::identifiers::ObjectId; 2],
+) {
+    let exile = AbilityCost::Exile {
+        count: 1,
+        zone: Some(Zone::Hand),
+        filter: None,
+    };
+    let cost = AbilityCost::Composite {
+        costs: vec![exile.clone(), exile],
+    };
+    let cost = if one_of {
+        AbilityCost::OneOf { costs: vec![cost] }
+    } else {
+        cost
+    };
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Repeated Exile Activation Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(cost),
+        )
+        .id();
+    let first = scenario.add_card_to_hand(P0, "First Repeated Exile Witness");
+    let second = scenario.add_card_to_hand(P0, "Second Repeated Exile Witness");
+    (scenario.build(), source, [first, second])
+}
+
+fn repeated_unattach_activation_witness(
+    one_of: bool,
+) -> (
+    GameRunner,
+    engine::types::identifiers::ObjectId,
+    [engine::types::identifiers::ObjectId; 2],
+) {
+    let unattach = AbilityCost::UnattachFrom {
+        filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)),
+        count: 1,
+    };
+    let cost = AbilityCost::Composite {
+        costs: vec![unattach.clone(), unattach],
+    };
+    let cost = if one_of {
+        AbilityCost::OneOf { costs: vec![cost] }
+    } else {
+        cost
+    };
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Repeated Unattach Activation Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(cost),
+        )
+        .id();
+    let first = scenario
+        .add_creature(P0, "First Repeated Unattach Witness", 0, 1)
+        .as_artifact()
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second Repeated Unattach Witness", 0, 1)
+        .as_artifact()
+        .id();
+    let mut runner = scenario.build();
+    for attachment in [first, second] {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&attachment)
+            .unwrap()
+            .attached_to = Some(AttachTarget::Object(source));
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .attachments
+            .push(attachment);
+    }
+    (runner, source, [first, second])
+}
+
+#[test]
+fn repeated_and_one_of_interactive_activation_costs_surface_each_unpaid_leg() {
+    for one_of in [false, true] {
+        let (runner, source, chosen) = repeated_discard_activation_witness(one_of);
+        assert_repeated_interactive_activation_cost(runner, source, chosen, one_of, |kind| {
+            matches!(kind, PayCostKind::Discard)
+        });
+
+        let (runner, source, chosen) = repeated_sacrifice_activation_witness(one_of);
+        assert_repeated_interactive_activation_cost(runner, source, chosen, one_of, |kind| {
+            matches!(kind, PayCostKind::Sacrifice)
+        });
+
+        let (runner, source, chosen) = repeated_exile_activation_witness(one_of);
+        assert_repeated_interactive_activation_cost(runner, source, chosen, one_of, |kind| {
+            matches!(kind, PayCostKind::ExileFromZone { .. })
+        });
+
+        let (runner, source, chosen) = repeated_unattach_activation_witness(one_of);
+        assert_repeated_interactive_activation_cost(runner, source, chosen, one_of, |kind| {
+            matches!(kind, PayCostKind::UnattachFrom { .. })
+        });
+    }
+}
+
+#[test]
+fn mana_selected_exile_cost_redirect_resumes_after_the_paid_prefix_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Mana Selected-Exile Redirect Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 2,
+                        zone: Some(Zone::Battlefield),
+                        filter: None,
+                    },
+                ],
+            }),
+        )
+        .id();
+    let selected = scenario
+        .add_creature(P0, "Selected Exile Payment", 1, 1)
+        .id();
+    let second_selected = scenario
+        .add_creature(P0, "Second Selected Exile Payment", 1, 1)
+        .id();
+    for name in [
+        "First Mana Selected-Exile Redirect",
+        "Second Mana Selected-Exile Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+
+    let mut runner = scenario.build();
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("start the selected-exile mana ability");
+    let initial = runner
+        .act(GameAction::SelectCards {
+            cards: vec![selected, second_selected],
+        })
+        .expect("select the creature for the mana ability exile cost");
+
+    assert!(
+        matches!(initial.waiting_for, WaitingFor::ReplacementChoice { .. }),
+        "a selected mana-exile cost must consult competing Moved redirects"
+    );
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { cursor, .. })
+            if cursor.remaining.len() == 1
+                && cursor.selected_exile_remaining.as_deref() == Some(&[second_selected])
+    ));
+    let json = serde_json::to_string(runner.state())
+        .expect("a paused selected mana-exile replacement choice serializes");
+    let restored: GameState = serde_json::from_str(&json)
+        .expect("a paused selected mana-exile replacement choice deserializes");
+    let mut runner = GameRunner::from_state(restored);
+
+    let after_first_redirect = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect the first selected mana-exile cost");
+
+    assert_eq!(runner.state().objects[&selected].zone, Zone::Graveyard);
+    assert_eq!(
+        runner.state().objects[&second_selected].zone,
+        Zone::Battlefield
+    );
+    assert!(matches!(
+        after_first_redirect.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect the second selected mana-exile cost");
+
+    assert_eq!(
+        runner.state().objects[&second_selected].zone,
+        Zone::Graveyard
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the selected-exile activation must produce exactly one mana after resuming"
+    );
+    assert_eq!(
+        initial
+            .events
+            .iter()
+            .chain(after_first_redirect.events.iter())
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "the selected-exile resume must not replay the paid tap prefix"
+    );
+    assert_eq!(
+        initial
+            .events
+            .iter()
+            .chain(after_first_redirect.events.iter())
+            .chain(resumed.events.iter())
+            .filter(
+                |event| matches!(event, GameEvent::ManaAdded { player_id, .. } if *player_id == P0)
+            )
+            .count(),
+        1,
+        "the selected-exile resume must not produce mana twice"
+    );
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+}
+
+#[test]
+fn effect_pay_cost_composite_mana_life_suffix_serializes_and_rides_once() {
+    let (scenario, source) = mana_self_exile_cost_redirect_witness();
+    let mut runner = scenario.build();
+    let mana = ManaCost::Cost {
+        shards: vec![ManaCostShard::Green],
+        generic: 0,
+    };
+    let cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana { cost: mana.clone() },
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+            },
+        ],
+    };
+    let mut ability = ResolvedAbility::new(
+        Effect::PayCost {
+            cost: cost.clone(),
+            scale: None,
+            payer: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    )));
+
+    let life_before = runner.state().players[P0.0 as usize].life;
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("the composite effect cost reaches the mana source replacement choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life_before,
+        "neither the later life cost nor the rider may run before the typed mana root settles"
+    );
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. }) if matches!(
+            &pending.resume,
+            ManaAbilityResume::EffectPayCost { cost: paused_cost, .. }
+                if paused_cost.as_ref() == &cost
+        )
+    ));
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the complete composite effect-cost root serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the complete composite effect-cost root deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirected mana-source cost resumes the full Composite suffix");
+
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life_before - 1,
+        "the exact order is mana, PayLife once, then the +1-life rider once"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "the source's paid tap prefix is never replayed"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+}
+
+#[test]
+fn effect_pay_cost_composite_mana_life_prevention_serializes_and_rides_once() {
+    let (scenario, source) = mana_self_exile_cost_redirect_witness();
+    let mut runner = scenario.build();
+    let mana = ManaCost::Cost {
+        shards: vec![ManaCostShard::Green],
+        generic: 0,
+    };
+    let cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana { cost: mana },
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+            },
+        ],
+    };
+    let mut ability = ResolvedAbility::new(
+        Effect::PayCost {
+            cost,
+            scale: None,
+            payer: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    )));
+
+    let life_before = runner.state().players[P0.0 as usize].life;
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("the composite effect cost reaches a mana-source cost move pause");
+
+    // No ZoneChange replacement currently yields `Prevented`, so stage the
+    // canonical one-shot Prevented producer while retaining the real paused
+    // ManaAbilityPayment root. This drives the actual replacement-choice
+    // dispatcher branch that a future cost-move prevention will use.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&source)
+        .expect("mana source exists")
+        .replacement_definitions = vec![ReplacementDefinition::new(ReplacementEvent::Destroy)
+        .regeneration_shield()
+        .description("Prevent the staged cost move".to_string())]
+    .into();
+    runner.state_mut().pending_replacement = Some(PendingReplacement {
+        proposed: ProposedEvent::Destroy {
+            object_id: source,
+            source: None,
+            cant_regenerate: false,
+            applied: Default::default(),
+        },
+        sacrifice_provenance: None,
+        candidates: vec![ReplacementId { source, index: 0 }],
+        search_found_candidates: Vec::new(),
+        depth: 0,
+        is_optional: false,
+        library_placement: None,
+        excess_recipient: None,
+        lifelink_bonus: 0,
+        may_cost_paid: false,
+        may_cost_remaining: None,
+    });
+    runner.state_mut().waiting_for = WaitingFor::ReplacementChoice {
+        player: P0,
+        candidate_count: 1,
+        candidates: vec![],
+    };
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the prevented composite effect-cost root serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the prevented composite effect-cost root deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the Prevented dispatcher resumes the complete typed cost root");
+
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life_before - 1,
+        "prevention still settles mana then PayLife once before the rider"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "the prevented cost move cannot replay the source's paid tap prefix"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+}
+
+#[test]
+fn paused_mana_cost_events_create_observer_triggers_once_and_preserve_order_resume() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let observer_trigger = |amount| {
+        TriggerDefinition::new(TriggerMode::Taps)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: amount },
+                    player: TargetFilter::Controller,
+                },
+            ))
+            .valid_card(TargetFilter::Any)
+            .trigger_zones(vec![Zone::Battlefield])
+    };
+    for (name, amount) in [
+        ("First Cost Event Observer", 1),
+        ("Second Cost Event Observer", 2),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_trigger_definition(observer_trigger(amount));
+    }
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&source].card_id;
+    runner.state_mut().pending_cast = Some(Box::new(PendingCast::new(
+        source,
+        card_id,
+        ResolvedAbility::new(
+            Effect::Unimplemented {
+                name: "Cost event observer outer payment".to_string(),
+                description: None,
+            },
+            vec![],
+            source,
+            P0,
+        ),
+        ManaCost::generic(1),
+    )));
+    let ability = runner.state().objects[&source].abilities[0].clone();
+    let mut initial_events = Vec::new();
+    activate_mana_ability(
+        runner.state_mut(),
+        source,
+        P0,
+        0,
+        &ability,
+        &mut initial_events,
+        ManaAbilityResume::ManaPayment {
+            outer_player: Some(P0),
+            convoke_mode: None,
+        },
+        None,
+    )
+    .expect("the source pauses after its tap cost");
+    assert!(runner.state().stack.is_empty());
+
+    let json = serde_json::to_string(runner.state()).expect("paused cost event batch serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("paused cost event batch deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("resume the typed cost event settlement");
+
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::OrderTriggers { ref triggers, .. } if triggers.len() == 2
+    ));
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    let ordered = runner
+        .act(GameAction::OrderTriggers { order: vec![0, 1] })
+        .expect("both observer triggers remain orderable after the cost settles");
+    assert!(matches!(
+        ordered.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    assert_eq!(
+        runner.state().stack.len(),
+        2,
+        "each actual observer trigger is collected exactly once, not once per pause and resume"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "the resumed mana production itself is emitted once"
+    );
+}
+
+#[test]
+fn nested_costed_mana_source_serializes_parent_cursor_and_finishes_outer_payment() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let outer = scenario
+        .add_creature(P0, "Outer Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Mana {
+                        cost: ManaCost::generic(1),
+                    },
+                ],
+            }),
+        )
+        .id();
+    let inner = scenario
+        .add_creature(P0, "Inner Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Blue],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    for name in [
+        "First Nested Source Redirect",
+        "Second Nested Source Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+    let spell = scenario
+        .add_spell_to_hand(P0, "Nested Mana Payment Target", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    let cast = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the nested witness must announce a real pending cast");
+    assert!(matches!(
+        cast.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    let outer_ability = runner.state().objects[&outer].abilities[0].clone();
+    let mut initial_events = Vec::new();
+    let paused = activate_mana_ability(
+        runner.state_mut(),
+        outer,
+        P0,
+        0,
+        &outer_ability,
+        &mut initial_events,
+        ManaAbilityResume::ManaPayment {
+            outer_player: Some(P0),
+            convoke_mode: None,
+        },
+        None,
+    )
+    .expect("the inner source pauses on its self-exile cost");
+    assert!(matches!(paused, WaitingFor::ReplacementChoice { .. }));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, cursor })
+            if pending.source_id == inner
+                && cursor.parent.as_ref().is_some_and(|parent| {
+                    parent.lifecycle == ManaAbilityCostParentLifecycle::Suspended
+                        && parent.pending.source_id == outer
+                        && matches!(parent.cursor.remaining.as_slice(), [AbilityCost::Mana { .. }])
+                })
+    ));
+
+    let json =
+        serde_json::to_string(runner.state()).expect("the suspended parent mana cursor serializes");
+    assert!(
+        json.contains("Suspended"),
+        "the serialized parent frame must retain its typed re-entry ownership"
+    );
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the suspended parent mana cursor deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirect inner self-exile and resume the exact parent cursor");
+
+    assert_eq!(runner.state().objects[&inner].zone, Zone::Graveyard);
+    assert!(runner.state().objects[&outer].tapped);
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == outer))
+            .count(),
+        1,
+        "the outer tap prefix is retained by the parent cursor rather than replayed"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == inner))
+            .count(),
+        1,
+        "the inner source's tap cost is paid once across the replacement pause"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::ZoneChanged {
+                    object_id,
+                    from: Some(Zone::Battlefield),
+                    to: Zone::Graveyard,
+                    ..
+                } if *object_id == inner
+            ))
+            .count(),
+        1,
+        "the redirected inner self-exile cost is delivered once"
+    );
+    for source_id in [inner, outer] {
+        assert_eq!(
+            initial_events
+                .iter()
+                .chain(resumed.events.iter())
+                .filter(|event| matches!(event, GameEvent::ManaAdded { source_id: id, .. } if *id == source_id))
+                .count(),
+            1,
+            "each nested mana ability produces exactly once"
+        );
+    }
+
+    runner
+        .act(GameAction::PassPriority)
+        .expect("the outer spell payment consumes the outer mana once");
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+}
+
+fn two_source_assist_replacement_witness(
+    mana_cost: ManaCost,
+) -> (
+    GameRunner,
+    engine::types::identifiers::ObjectId,
+    [engine::types::identifiers::ObjectId; 2],
+) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let helper_sources = [
+        scenario
+            .add_creature(P1, "First Two-Source Assist Mana Witness", 1, 1)
+            .with_ability_definition(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::Fixed {
+                            colors: vec![ManaColor::Blue],
+                            contribution: ManaContribution::Base,
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Composite {
+                    costs: vec![
+                        AbilityCost::Tap,
+                        AbilityCost::Exile {
+                            count: 1,
+                            zone: None,
+                            filter: Some(TargetFilter::SelfRef),
+                        },
+                    ],
+                }),
+            )
+            .id(),
+        scenario
+            .add_creature(P1, "Second Two-Source Assist Mana Witness", 1, 1)
+            .with_ability_definition(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::Fixed {
+                            colors: vec![ManaColor::Blue],
+                            contribution: ManaContribution::Base,
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            )
+            .id(),
+    ];
+    for name in [
+        "First Two-Source Assist Redirect",
+        "Second Two-Source Assist Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+    let spell = scenario
+        .add_spell_to_hand(P0, "Two-Source Assist Payment Witness", true)
+        .with_mana_cost(mana_cost)
+        .with_keyword(Keyword::Assist)
+        .id();
+    (scenario.build(), spell, helper_sources)
+}
+
+#[test]
+fn committed_assist_retries_remaining_sources_after_serialized_ordinary_pause() {
+    let (mut runner, spell, helper_sources) =
+        two_source_assist_replacement_witness(ManaCost::generic(2));
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the Assist spell reaches its helper offer");
+    runner
+        .act(GameAction::ChooseAssistPlayer { player: Some(P1) })
+        .expect("choose the helper");
+    runner
+        .act(GameAction::CommitAssistPayment { generic: 2 })
+        .expect("commit the two generic helper contribution");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("the first helper source pauses on its replacement choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the ordinary two-source Assist pause serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the ordinary two-source Assist pause deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the first helper source completes without losing the remaining plan");
+    assert_eq!(
+        runner.state().objects[&helper_sources[0]].zone,
+        Zone::Graveyard
+    );
+    assert_eq!(runner.state().players[P1.0 as usize].mana_pool.total(), 1);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+
+    runner
+        .act(GameAction::PassPriority)
+        .expect("PaymentStarted must tap the remaining helper source before spending");
+    assert_eq!(
+        runner.state().objects[&helper_sources[1]].zone,
+        Zone::Battlefield
+    );
+    assert!(runner.state().objects[&helper_sources[1]].tapped);
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert!(runner.state().pending_cast.is_none());
+}
+
+#[test]
+fn committed_assist_retries_remaining_sources_after_serialized_phyrexian_pause() {
+    let (mut runner, spell, helper_sources) =
+        two_source_assist_replacement_witness(ManaCost::Cost {
+            shards: vec![ManaCostShard::PhyrexianGreen],
+            generic: 2,
+        });
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the Assist Phyrexian spell reaches its helper offer");
+    runner
+        .act(GameAction::ChooseAssistPlayer { player: Some(P1) })
+        .expect("choose the helper");
+    runner
+        .act(GameAction::CommitAssistPayment { generic: 2 })
+        .expect("commit the two generic helper contribution");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("the caster chooses the Phyrexian shard before helper payment");
+    runner
+        .act(GameAction::SubmitPhyrexianChoices {
+            choices: vec![engine::types::game_state::ShardChoice::PayLife],
+        })
+        .expect("the first helper source pauses after the submitted Phyrexian choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the Phyrexian two-source Assist pause serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the Phyrexian two-source Assist pause deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the exact Phyrexian root retries the remaining helper source plan");
+    assert_eq!(
+        runner.state().objects[&helper_sources[0]].zone,
+        Zone::Graveyard
+    );
+    assert_eq!(
+        runner.state().objects[&helper_sources[1]].zone,
+        Zone::Battlefield
+    );
+    assert!(runner.state().objects[&helper_sources[1]].tapped);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 18);
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert!(runner.state().pending_cast.is_none());
+}
+
+#[test]
+fn committed_assist_phyrexian_choice_serializes_helper_cost_pause_and_charges_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let helper_source = scenario
+        .add_creature(P1, "Assist Helper Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Blue],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    for name in [
+        "First Assist Helper Redirect",
+        "Second Assist Helper Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+    let spell = scenario
+        .add_spell_to_hand(P0, "Assist Phyrexian Costed Source Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::PhyrexianGreen],
+            generic: 1,
+        })
+        .with_keyword(Keyword::Assist)
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    let assist = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("Assist spell reaches the helper choice");
+    assert!(matches!(
+        assist.waiting_for,
+        WaitingFor::AssistChoosePlayer { player: P0, .. }
+    ));
+    runner
+        .act(GameAction::ChooseAssistPlayer { player: Some(P1) })
+        .expect("choose the helper");
+    runner
+        .act(GameAction::CommitAssistPayment { generic: 1 })
+        .expect("commit one generic from the helper");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    let phyrexian = runner
+        .act(GameAction::PassPriority)
+        .expect("the caster must choose the Phyrexian payment");
+    assert!(matches!(
+        phyrexian.waiting_for,
+        WaitingFor::PhyrexianPayment { player: P0, .. }
+    ));
+    assert!(matches!(
+        runner
+            .state()
+            .pending_cast
+            .as_ref()
+            .map(|pending| pending.assist_state),
+        Some(engine::types::game_state::AssistState::Committed {
+            helper: P1,
+            generic: 1
+        })
+    ));
+
+    let paused = runner
+        .act(GameAction::SubmitPhyrexianChoices {
+            choices: vec![engine::types::game_state::ShardChoice::PayLife],
+        })
+        .expect("submitted Phyrexian choice starts the committed helper payment");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. }) if matches!(
+            pending.resume,
+            ManaAbilityResume::PhyrexianCastPayment {
+                caster: P0,
+                ref choices,
+            } if choices == &vec![engine::types::game_state::ShardChoice::PayLife]
+        )
+    ));
+    assert!(matches!(
+        runner
+            .state()
+            .pending_cast
+            .as_ref()
+            .map(|pending| pending.assist_state),
+        Some(engine::types::game_state::AssistState::PaymentStarted {
+            helper: P1,
+            generic: 1
+        })
+    ));
+    assert_eq!(
+        runner.state().players[P1.0 as usize].mana_pool.total(),
+        0,
+        "a helper pause cannot spend mana before its source resolves"
+    );
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the committed Assist + submitted Phyrexian root serializes");
+    let restored: GameState = serde_json::from_str(&json)
+        .expect("the committed Assist + submitted Phyrexian root deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("helper source replacement retries the exact submitted choices");
+
+    assert_eq!(runner.state().objects[&helper_source].zone, Zone::Graveyard);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        18,
+        "the submitted PayLife choice is retained and paid exactly once"
+    );
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert!(runner.state().pending_cast.is_none());
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == helper_source))
+            .count(),
+        1,
+        "the helper source's paid tap prefix is never replayed"
+    );
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == helper_source))
+            .count(),
+        1,
+        "the helper produces and spends its committed mana once"
+    );
+}
+
+#[test]
+fn caster_phyrexian_finalization_serializes_costed_source_pause_and_retries_choices() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Caster Phyrexian Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Blue],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    for name in [
+        "First Caster Phyrexian Redirect",
+        "Second Caster Phyrexian Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+    let spell = scenario
+        .add_spell_to_hand(P0, "Caster Phyrexian Costed Source Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::PhyrexianGreen],
+            generic: 1,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    let cast = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the caster reaches the mana-payment window");
+    assert!(matches!(
+        cast.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    // The regular announcement above creates the real stack entry and
+    // `PendingCast`. Enter the exact LifeOnly-shard finalization prompt here
+    // so the witness exercises submitted-choice retry without relying on a
+    // source-selection heuristic to reach the prompt first.
+    runner.state_mut().waiting_for = WaitingFor::PhyrexianPayment {
+        player: P0,
+        spell_object: spell,
+        shards: vec![engine::types::game_state::PhyrexianShard {
+            shard_index: 0,
+            color: ManaColor::Green,
+            options: engine::types::game_state::ShardOptions::LifeOnly,
+        }],
+    };
+
+    let paused = runner
+        .act(GameAction::SubmitPhyrexianChoices {
+            choices: vec![engine::types::game_state::ShardChoice::PayLife],
+        })
+        .expect("caster's generic source pauses after the submitted Phyrexian choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. }) if matches!(
+            pending.resume,
+            ManaAbilityResume::PhyrexianCastPayment {
+                caster: P0,
+                ref choices,
+            } if choices == &vec![engine::types::game_state::ShardChoice::PayLife]
+        )
+    ));
+    assert!(runner.state().pending_cast.is_some());
+
+    let json = serde_json::to_string(runner.state())
+        .expect("caster Phyrexian costed-source pause serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("caster Phyrexian costed-source pause deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the typed caster Phyrexian root retries its submitted choice");
+
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 18);
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert!(runner.state().pending_cast.is_none());
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "the caster source's cost is paid once across the replacement pause"
+    );
+}
+
+#[test]
+fn committed_assist_mana_payment_serializes_helper_redirect_and_charges_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let helper_source = scenario
+        .add_creature(P1, "Assist Ordinary Helper Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Blue],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    for name in [
+        "First Ordinary Assist Helper Redirect",
+        "Second Ordinary Assist Helper Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+    let spell = scenario
+        .add_spell_to_hand(P0, "Assist Ordinary Costed Source Witness", true)
+        .with_mana_cost(ManaCost::generic(1))
+        .with_keyword(Keyword::Assist)
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    let offered = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the Assist spell reaches its helper offer");
+    assert!(matches!(
+        offered.waiting_for,
+        WaitingFor::AssistChoosePlayer { player: P0, .. }
+    ));
+    runner
+        .act(GameAction::ChooseAssistPlayer { player: Some(P1) })
+        .expect("choose the assisting player");
+    runner
+        .act(GameAction::CommitAssistPayment { generic: 1 })
+        .expect("commit the helper's generic contribution");
+
+    let paused = runner
+        .act(GameAction::PassPriority)
+        .expect("the helper's cost move pauses on its Moved replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. }) if matches!(
+            pending.resume,
+            ManaAbilityResume::ManaPayment {
+                outer_player: Some(P0),
+                convoke_mode: None,
+            }
+        )
+    ));
+    assert!(matches!(
+        runner
+            .state()
+            .pending_cast
+            .as_ref()
+            .map(|pending| pending.assist_state),
+        Some(engine::types::game_state::AssistState::PaymentStarted {
+            helper: P1,
+            generic: 1,
+        })
+    ));
+
+    let json =
+        serde_json::to_string(runner.state()).expect("the ordinary Assist helper pause serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the ordinary Assist helper pause deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the helper's typed outer payment root resumes after redirect");
+
+    assert_eq!(runner.state().objects[&helper_source].zone, Zone::Graveyard);
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    assert!(matches!(
+        runner
+            .state()
+            .pending_cast
+            .as_ref()
+            .map(|pending| pending.assist_state),
+        Some(engine::types::game_state::AssistState::PaymentStarted {
+            helper: P1,
+            generic: 1,
+        })
+    ));
+    assert_eq!(
+        runner.state().players[P1.0 as usize].mana_pool.total(),
+        1,
+        "the resumed helper produces its committed mana before the outer spend"
+    );
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("the original Assist payment finishes the cast");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert!(runner.state().pending_cast.is_none());
+    assert_eq!(runner.state().players[P1.0 as usize].mana_pool.total(), 0);
+    assert!(!matches!(
+        completed.waiting_for,
+        WaitingFor::AssistChoosePlayer { .. } | WaitingFor::AssistPayment { .. }
+    ));
+
+    let events = paused
+        .events
+        .iter()
+        .chain(resumed.events.iter())
+        .chain(completed.events.iter());
+    assert_eq!(
+        events
+            .clone()
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == helper_source))
+            .count(),
+        1,
+        "the helper's tap cost is retained across serialization and never replayed"
+    );
+    assert_eq!(
+        events
+            .clone()
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == helper_source))
+            .count(),
+        1,
+        "the helper produces exactly one mana for its committed Assist contribution"
+    );
+    assert_eq!(
+        events
+            .filter(|event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == spell))
+            .count(),
+        1,
+        "the outer spell finalizes exactly once without another Assist offer"
+    );
+}
+
+#[test]
+fn nested_composite_effect_cost_serializes_all_suffixes_and_rider_once() {
+    let (scenario, source) = mana_self_exile_cost_redirect_witness();
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].energy = 2;
+    let mana = ManaCost::Cost {
+        shards: vec![ManaCostShard::Green],
+        generic: 0,
+    };
+    let cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana { cost: mana.clone() },
+                    AbilityCost::PayLife {
+                        amount: QuantityExpr::Fixed { value: 2 },
+                    },
+                ],
+            },
+            AbilityCost::PayEnergy {
+                amount: QuantityExpr::Fixed { value: 2 },
+            },
+        ],
+    };
+    let mut ability = ResolvedAbility::new(
+        Effect::PayCost {
+            cost: cost.clone(),
+            scale: None,
+            payer: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    )));
+
+    let expected_resume_cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana { cost: mana },
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+            },
+            AbilityCost::PayEnergy {
+                amount: QuantityExpr::Fixed { value: 2 },
+            },
+        ],
+    };
+
+    let life_before = runner.state().players[P0.0 as usize].life;
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("the nested cost reaches the source's replacement pause");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. }) if matches!(
+            &pending.resume,
+            ManaAbilityResume::EffectPayCost { cost: paused_cost, .. }
+                if paused_cost.as_ref() == &expected_resume_cost
+        )
+    ));
+
+    let json =
+        serde_json::to_string(runner.state()).expect("the nested composite cost root serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the nested composite cost root deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the redirected source resumes every enclosing composite suffix");
+
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+    assert_eq!(runner.state().players[P0.0 as usize].energy, 0);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life_before - 1,
+        "PayLife settles once before the +1-life rider settles once"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::LifeChanged { amount: -2, .. }))
+            .count(),
+        1,
+        "the nested PayLife suffix is paid exactly once"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::LifeChanged { amount: 1, .. }))
+            .count(),
+        1,
+        "the rider runs exactly once after the complete nested cost"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "the source's paid tap prefix is not replayed"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+}
+
+#[test]
+fn mana_cost_post_replacement_named_choice_serializes_and_resumes_outer_payment_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Post-Effect Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    scenario
+        .add_creature(P0, "Mana Cost Post-Effect Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(prompt_after_moved_to_exile());
+    let spell = scenario
+        .add_spell_to_hand(P0, "Post-Effect Mana Payment Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the spell reaches its mana-payment window");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    let ability = runner.state().objects[&source].abilities[0].clone();
+    let mut activation_events = Vec::new();
+    let paused = activate_mana_ability(
+        runner.state_mut(),
+        source,
+        P0,
+        0,
+        &ability,
+        &mut activation_events,
+        ManaAbilityResume::ManaPayment {
+            outer_player: Some(P0),
+            convoke_mode: None,
+        },
+        None,
+    )
+    .expect("the mandatory replacement delivers and reaches its post-effect prompt");
+    assert!(matches!(
+        paused,
+        WaitingFor::NamedChoice { ref options, .. }
+            if options == &vec!["first".to_string(), "second".to_string()]
+    ));
+    assert_eq!(runner.state().objects[&source].zone, Zone::Exile);
+    assert_eq!(
+        activation_events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::ReplacementApplied { .. }))
+            .count(),
+        1,
+        "the mandatory identity replacement applies exactly once before prompting"
+    );
+    assert!(runner.state().pending_replacement.is_none());
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, cursor }) if matches!(
+            pending.resume,
+            ManaAbilityResume::ManaPayment {
+                outer_player: Some(P0),
+                convoke_mode: None,
+            }
+        ) && cursor.remaining.is_empty()
+    ));
+    assert!(runner.state().pending_cast.is_some());
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the post-effect prompt retains the typed mana-cost cursor on the wire");
+    let restored: GameState = serde_json::from_str(&json)
+        .expect("the post-effect prompt restores with the typed mana-cost cursor");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseOption {
+            choice: "first".to_string(),
+        })
+        .expect("answering the post-effect prompt resumes the parked mana-cost root");
+
+    assert_eq!(runner.state().objects[&source].zone, Zone::Exile);
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the parked cursor produces mana exactly once after the post-effect"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("the original outer mana payment spends the resumed mana once");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert!(runner.state().pending_cast.is_none());
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+
+    let events = activation_events
+        .iter()
+        .chain(resumed.events.iter())
+        .chain(completed.events.iter());
+    assert_eq!(
+        events
+            .clone()
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "the post-effect pause cannot replay the mana source's paid tap cost"
+    );
+    assert_eq!(
+        events
+            .clone()
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "the post-effect pause cannot produce mana twice"
+    );
+    assert_eq!(
+        events
+            .filter(|event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == spell))
+            .count(),
+        1,
+        "the original spell finalizes once after the post-effect prompt"
+    );
+}
+
+#[test]
+fn self_return_mana_cost_post_effect_serializes_without_advancing_planned_sources() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Self-Return Post-Effect Mana Source", 1, 1)
+        .as_land()
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::ReturnToHand {
+                        count: 1,
+                        filter: Some(TargetFilter::SelfRef),
+                        from_zone: None,
+                    },
+                ],
+            }),
+        )
+        .id();
+    let deferred_source = scenario
+        .add_creature(P0, "Deferred Planned Mana Source", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        )
+        .id();
+    scenario
+        .add_creature(P0, "Self-Return Post-Effect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to_with_post_effect(Zone::Hand, Zone::Hand));
+    let spell = scenario
+        .add_spell_to_hand(P0, "Two-Source Auto-Tap Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green, ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the spell reaches manual mana payment");
+    let paused = runner
+        .act(GameAction::PassPriority)
+        .expect("the first auto-tapped source reaches its replacement post-effect");
+
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::NamedChoice { ref options, .. }
+            if options == &vec!["first".to_string(), "second".to_string()]
+    ));
+    assert_eq!(runner.state().objects[&source].zone, Zone::Hand);
+    assert!(
+        !runner.state().objects[&deferred_source].tapped,
+        "the live post-effect prompt must stop the rest of the auto-tap plan"
+    );
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { cursor, .. })
+            if cursor.resolution_mode == ManaAbilityCostResolutionMode::AutoResolved
+    ));
+    assert!(runner.state().pending_replacement.is_none());
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the self-return post-effect pause serializes");
+    assert!(
+        json.contains("AutoResolved"),
+        "the serialized cursor must retain its typed auto-resolution mode"
+    );
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the self-return post-effect pause deserializes");
+    let mut runner = GameRunner::from_state(restored);
+
+    let resumed = runner
+        .act(GameAction::ChooseOption {
+            choice: "first".to_string(),
+        })
+        .expect("the post-effect response resumes the typed self-return cost root");
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    assert!(
+        !runner.state().objects[&deferred_source].tapped,
+        "resuming the first source must not advance the next planned source"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the resumed source produces exactly its own mana before the outer payment continues"
+    );
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("the remaining planned source completes the outer payment");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert!(runner.state().objects[&deferred_source].tapped);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+
+    for (object_id, label) in [
+        (source, "self-return source"),
+        (deferred_source, "deferred planned source"),
+    ] {
+        assert_eq!(
+            paused
+                .events
+                .iter()
+                .chain(resumed.events.iter())
+                .chain(completed.events.iter())
+                .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id: tapped, .. } if *tapped == object_id))
+                .count(),
+            1,
+            "the {label} is tapped exactly once across the paused auto-tap plan"
+        );
+        assert_eq!(
+            paused
+                .events
+                .iter()
+                .chain(resumed.events.iter())
+                .chain(completed.events.iter())
+                .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == object_id))
+                .count(),
+            1,
+            "the {label} produces mana exactly once across the paused auto-tap plan"
+        );
+    }
+}
+
+#[test]
+fn prevented_mana_cost_move_serializes_and_restores_mana_payment_root() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let spell = scenario
+        .add_spell_to_hand(P0, "Prevented Mana Payment Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the spell reaches its manual mana-payment window");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment {
+            player: P0,
+            convoke_mode: None,
+        }
+    ));
+    assert!(matches!(
+        runner.state().pending_cast.as_deref(),
+        Some(pending) if pending.object_id == spell && pending.card_id == card_id
+    ));
+    let ability = runner.state().objects[&source].abilities[0].clone();
+    let mut initial_events = Vec::new();
+    let paused = activate_mana_ability(
+        runner.state_mut(),
+        source,
+        P0,
+        0,
+        &ability,
+        &mut initial_events,
+        ManaAbilityResume::ManaPayment {
+            outer_player: Some(P0),
+            convoke_mode: None,
+        },
+        None,
+    )
+    .expect("the mana payment root pauses on its source cost move");
+    assert!(matches!(paused, WaitingFor::ReplacementChoice { .. }));
+    stage_prevented_mana_cost_move(runner.state_mut(), source);
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the staged prevented mana-payment root serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the staged prevented mana-payment root deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the prevented dispatcher restores the exact mana-payment prompt");
+
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment {
+            player: P0,
+            convoke_mode: None,
+        }
+    ));
+    assert!(matches!(
+        runner.state().pending_cast.as_deref(),
+        Some(pending) if pending.object_id == spell && pending.card_id == card_id
+    ));
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "prevention must not replay the source's paid tap prefix"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "prevention resumes mana production exactly once"
+    );
+}
+
+#[test]
+fn prevented_mana_cost_move_serializes_and_restores_unless_payment_root() {
+    let (scenario, source) = mana_self_exile_cost_redirect_witness();
+    let mut runner = scenario.build();
+    let ability = runner.state().objects[&source].abilities[0].clone();
+    let unless_cost = AbilityCost::Mana {
+        cost: ManaCost::generic(1),
+    };
+    let pending_effect = ResolvedAbility::new(
+        Effect::Unimplemented {
+            name: "Prevented Unless Payment Witness".to_string(),
+            description: None,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    let paused = activate_mana_ability(
+        runner.state_mut(),
+        source,
+        P0,
+        0,
+        &ability,
+        &mut initial_events,
+        ManaAbilityResume::UnlessPayment {
+            outer_player: Some(P0),
+            cost: Box::new(unless_cost.clone()),
+            pending_effect: Box::new(pending_effect.clone()),
+            trigger_event: None,
+            effect_description: Some("prevented unless payment witness".to_string()),
+            remaining: vec![P1],
+        },
+        None,
+    )
+    .expect("the unless-payment root pauses on its source cost move");
+    assert!(matches!(paused, WaitingFor::ReplacementChoice { .. }));
+    stage_prevented_mana_cost_move(runner.state_mut(), source);
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the staged prevented unless-payment root serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the staged prevented unless-payment root deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the prevented dispatcher restores the exact unless-payment prompt");
+
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::UnlessPayment {
+            player: P0,
+            ref cost,
+            pending_effect: ref resumed_effect,
+            trigger_event: None,
+            effect_description: Some(ref description),
+            ref remaining,
+        } if cost == &unless_cost
+            && resumed_effect.as_ref() == &pending_effect
+            && description == "prevented unless payment witness"
+            && remaining == &vec![P1]
+    ));
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "prevention must not replay the source's paid tap prefix"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "prevention resumes mana production exactly once"
+    );
+}
+
+#[test]
+fn paused_mana_cost_events_scan_current_and_deferred_observers_once() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let observer = |mode, amount| {
+        TriggerDefinition::new(mode)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: amount },
+                    player: TargetFilter::Controller,
+                },
+            ))
+            .valid_card(TargetFilter::Any)
+            .trigger_zones(vec![Zone::Battlefield])
+    };
+    scenario
+        .add_creature(P1, "Deferred Tap Observer", 0, 0)
+        .as_enchantment()
+        .with_trigger_definition(observer(TriggerMode::Taps, 1));
+    scenario
+        .add_creature(P0, "Current Mana Observer", 0, 0)
+        .as_enchantment()
+        .with_trigger_definition(observer(TriggerMode::ManaAdded, 2));
+
+    let mut runner = scenario.build();
+    let ability = runner.state().objects[&source].abilities[0].clone();
+    let mut initial_events = Vec::new();
+    activate_mana_ability(
+        runner.state_mut(),
+        source,
+        P0,
+        0,
+        &ability,
+        &mut initial_events,
+        ManaAbilityResume::Priority,
+        None,
+    )
+    .expect("the source pauses after its initial tap event");
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the replacement resume settles both event batches");
+    assert!(matches!(resumed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().stack.len(), 2);
+    for amount in [1, 2] {
+        assert_eq!(
+            runner
+                .state()
+                .stack
+                .iter()
+                .filter(|entry| matches!(
+                    &entry.kind,
+                    StackEntryKind::TriggeredAbility { ability, .. }
+                        if matches!(
+                            &ability.effect,
+                            Effect::GainLife {
+                                amount: QuantityExpr::Fixed { value },
+                                ..
+                            } if *value == amount
+                        )
+                ))
+                .count(),
+            1,
+            "the observer for amount {amount} is placed exactly once"
+        );
+    }
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "the deferred tap event remains exactly-once owned by the cursor"
+    );
+    assert_eq!(
+        resumed
+            .events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "the current ManaAdded event is emitted and scanned exactly once"
+    );
+}
+
+#[test]
+fn pre_phyrexian_auto_tap_redirect_preserves_manual_payment_root_without_forcing_prompt() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let spell = scenario
+        .add_spell_to_hand(P0, "Pre-Phyrexian Auto-Tap Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::PhyrexianGreen],
+            generic: 1,
+        })
+        .id();
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("a manual cast reaches its normal mana-payment window");
+    let paused = runner
+        .act(GameAction::PassPriority)
+        .expect("pre-Phyrexian auto-tap reaches the source-cost replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. }) if matches!(
+            pending.resume,
+            ManaAbilityResume::ManaPayment {
+                outer_player: Some(P0),
+                convoke_mode: None,
+            }
+        )
+    ));
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the pre-Phyrexian source-cost pause serializes");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the pre-Phyrexian source-cost pause deserializes");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirecting the source cost preserves the manual payment root");
+
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment {
+            player: P0,
+            convoke_mode: None,
+        }
+    ));
+    let phyrexian = runner
+        .act(GameAction::PassPriority)
+        .expect("the preserved root computes the real Phyrexian payment prompt");
+    assert!(matches!(
+        phyrexian.waiting_for,
+        WaitingFor::PhyrexianPayment { player: P0, .. }
+    ));
+    let completed = runner
+        .act(GameAction::SubmitPhyrexianChoices {
+            choices: vec![engine::types::game_state::ShardChoice::PayLife],
+        })
+        .expect("the real submitted Phyrexian choice finalizes the original cast");
+
+    assert_eq!(runner.state().players[P0.0 as usize].life, 18);
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert!(runner.state().pending_cast.is_none());
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(resumed.events.iter())
+            .chain(phyrexian.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::PermanentTapped { object_id, .. } if *object_id == source))
+            .count(),
+        1,
+        "the pre-Phyrexian source cost is paid exactly once"
+    );
+}
+
+#[test]
+fn automatic_phyrexian_cast_retries_the_original_payment_after_source_cost_redirect() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let spell = scenario
+        .add_spell_to_hand(P0, "Automatic Phyrexian Root Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::PhyrexianGreen],
+            generic: 1,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    let paused = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("automatic casting reaches the source-cost replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. })
+            if matches!(
+                pending.resume,
+                ManaAbilityResume::FinalizePendingManaPayment { player: P0 }
+            )
+    ));
+
+    let phyrexian = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirecting the automatic source cost resumes the original cast");
+    assert!(matches!(
+        phyrexian.waiting_for,
+        WaitingFor::PhyrexianPayment { player: P0, .. }
+    ));
+
+    let completed = runner
+        .act(GameAction::SubmitPhyrexianChoices {
+            choices: vec![engine::types::game_state::ShardChoice::PayLife],
+        })
+        .expect("the automatic Phyrexian cast completes after the replacement answer");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 18);
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(phyrexian.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == spell))
+            .count(),
+        1,
+        "the automatic cast finalizes exactly once"
+    );
+}
+
+#[test]
+fn automatic_ordinary_cast_retries_the_original_payment_after_source_cost_redirect() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let spell = scenario
+        .add_spell_to_hand(P0, "Automatic Ordinary Root Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    let paused = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("automatic casting reaches the source-cost replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. })
+            if matches!(
+                pending.resume,
+                ManaAbilityResume::FinalizePendingManaPayment { player: P0 }
+            )
+    ));
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirecting the automatic source cost resumes the original cast");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == spell))
+            .count(),
+        1,
+        "the automatic cast finalizes exactly once"
+    );
+}
+
+#[test]
+fn automatic_phyrexian_activation_retries_after_source_cost_redirect() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let activator = scenario
+        .add_creature(P0, "Automatic Activation Root Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::PhyrexianGreen],
+                    generic: 0,
+                },
+            }),
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let paused = runner
+        .act(GameAction::ActivateAbility {
+            source_id: activator,
+            ability_index: 0,
+        })
+        .expect("automatic activation reaches the source-cost replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. })
+            if matches!(
+                pending.resume,
+                ManaAbilityResume::FinalizePendingManaPayment { player: P0 }
+            )
+    ));
+
+    let phyrexian = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirecting the automatic source cost resumes the activation");
+    assert!(matches!(
+        phyrexian.waiting_for,
+        WaitingFor::PhyrexianPayment { player: P0, .. }
+    ));
+
+    let completed = runner
+        .act(GameAction::SubmitPhyrexianChoices {
+            choices: vec![engine::types::game_state::ShardChoice::PayLife],
+        })
+        .expect("the automatic activation completes after the replacement answer");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 18);
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(phyrexian.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::AbilityActivated { source_id, .. } if *source_id == activator))
+            .count(),
+        1,
+        "the automatic activation reaches the stack exactly once"
+    );
+}
+
+#[test]
+fn automatic_ordinary_activation_retries_after_source_cost_redirect() {
+    let (mut scenario, source) = mana_self_exile_cost_redirect_witness();
+    let activator = scenario
+        .add_creature(P0, "Automatic Ordinary Activation Root Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Green],
+                    generic: 0,
+                },
+            }),
+        )
+        .id();
+
+    let mut runner = scenario.build();
+    let paused = runner
+        .act(GameAction::ActivateAbility {
+            source_id: activator,
+            ability_index: 0,
+        })
+        .expect("ordinary activation reaches the source-cost replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, .. })
+            if matches!(
+                pending.resume,
+                ManaAbilityResume::FinalizePendingManaPayment { player: P0 }
+            )
+    ));
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirecting the ordinary source cost resumes the activation");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&source].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&activator].zone, Zone::Battlefield);
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::AbilityActivated { source_id, .. } if *source_id == activator))
+            .count(),
+        1,
+        "the ordinary activation reaches the stack exactly once"
+    );
+}
+
+#[test]
+fn targeted_mana_tap_hand_exile_cost_retries_after_source_cost_redirect_without_replaying_exile() {
+    let (mut scenario, mana_source) = mana_self_exile_cost_redirect_witness();
+    let activator = scenario
+        .add_creature(P0, "Targeted Exile Cost Activation Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                    damage_source: None,
+                    excess: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::Green],
+                            generic: 0,
+                        },
+                    },
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: Some(Zone::Hand),
+                        filter: None,
+                    },
+                ],
+            }),
+        )
+        .id();
+    let target = scenario
+        .add_creature(P1, "Targeted Exile Cost Target", 1, 1)
+        .id();
+    let fuel = scenario.add_card_to_hand(P0, "Targeted Exile Cost Fuel");
+
+    let mut runner = scenario.build();
+    let target_selection = runner
+        .act(GameAction::ActivateAbility {
+            source_id: activator,
+            ability_index: 0,
+        })
+        .expect("the targeted activation announces before paying its costs");
+    assert!(matches!(
+        target_selection.waiting_for,
+        WaitingFor::TargetSelection { player: P0, .. }
+    ));
+    let select_exile = runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(target)],
+        })
+        .expect("target selection surfaces the non-self hand exile cost first");
+    assert!(matches!(
+        select_exile.waiting_for,
+        WaitingFor::PayCost {
+            kind: PayCostKind::ExileFromZone { .. },
+            ..
+        }
+    ));
+
+    let fuel_paused = runner
+        .act(GameAction::SelectCards { cards: vec![fuel] })
+        .expect("the selected hand-exile cost reaches its redirect choice");
+    assert!(matches!(
+        fuel_paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    let source_paused = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the paid hand-exile prefix advances to the mana-source redirect");
+    assert!(matches!(
+        source_paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the mana-root resume must not replay the already paid hand-exile cost");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&fuel].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&mana_source].zone, Zone::Graveyard);
+    assert!(
+        runner.state().objects[&activator].tapped,
+        "the post-mana tap suffix is paid exactly once"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+
+    let stack_entry = runner
+        .state()
+        .stack
+        .back()
+        .expect("the activation reaches the stack after all cost suffixes settle");
+    let StackEntryKind::ActivatedAbility { ability, .. } = &stack_entry.kind else {
+        panic!(
+            "expected activated ability on the stack, got {:?}",
+            stack_entry.kind
+        );
+    };
+    assert_eq!(ability.targets, vec![TargetRef::Object(target)]);
+    assert_eq!(
+        fuel_paused
+            .events
+            .iter()
+            .chain(source_paused.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::ZoneChanged { object_id, .. } if *object_id == fuel))
+            .count(),
+        1,
+        "the selected hand-exile cost cannot replay after the mana source resumes"
+    );
+    assert_eq!(
+        target_selection
+            .events
+            .iter()
+            .chain(select_exile.events.iter())
+            .chain(fuel_paused.events.iter())
+            .chain(source_paused.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::AbilityActivated { source_id, .. } if *source_id == activator))
+            .count(),
+        1,
+        "the target-first activation is announced exactly once"
+    );
+}
+
+#[test]
+fn committed_assist_source_cost_pause_rejects_cast_cancellation() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let helper_source = scenario
+        .add_creature(P1, "Assist Cancellation Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Blue],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    for name in [
+        "First Assist Cancellation Redirect",
+        "Second Assist Cancellation Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+    }
+    let spell = scenario
+        .add_spell_to_hand(P0, "Assist Cancellation Witness", true)
+        .with_mana_cost(ManaCost::generic(1))
+        .with_keyword(Keyword::Assist)
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the Assist spell reaches its helper offer");
+    runner
+        .act(GameAction::ChooseAssistPlayer { player: Some(P1) })
+        .expect("choose the assisting player");
+    runner
+        .act(GameAction::CommitAssistPayment { generic: 1 })
+        .expect("commit the helper contribution");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("the helper source reaches its replacement choice");
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the helper source resumes the committed Assist payment");
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+
+    let cancelled = runner.act(GameAction::CancelCast);
+    assert!(matches!(
+        cancelled,
+        Err(engine::game::engine::EngineError::ActionNotAllowed(_))
+    ));
+    assert_eq!(runner.state().objects[&helper_source].zone, Zone::Graveyard);
+    assert_eq!(runner.state().players[P1.0 as usize].mana_pool.total(), 1);
+    assert!(runner.state().pending_cast.is_some());
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("the non-cancellable committed Assist payment still finalizes");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert_eq!(runner.state().players[P1.0 as usize].mana_pool.total(), 0);
+}
+
+#[test]
+fn mana_cost_scry_post_effect_serializes_until_answered_then_resumes_root_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Scry Post-Effect Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    let scry_card = scenario.add_card_to_library_top(P0, "Scry Post-Effect Card");
+    scenario
+        .add_creature(P0, "Scry Post-Effect Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(scry_after_moved_to_exile());
+    let spell = scenario
+        .add_spell_to_hand(P0, "Scry Post-Effect Mana Payment Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the spell reaches manual mana payment");
+    let ability = runner.state().objects[&source].abilities[0].clone();
+    let mut activation_events = Vec::new();
+    let paused = activate_mana_ability(
+        runner.state_mut(),
+        source,
+        P0,
+        0,
+        &ability,
+        &mut activation_events,
+        ManaAbilityResume::ManaPayment {
+            outer_player: Some(P0),
+            convoke_mode: None,
+        },
+        None,
+    )
+    .expect("the mandatory replacement delivers and reaches its Scry post-effect");
+    assert!(matches!(
+        paused,
+        WaitingFor::ScryChoice { player: P0, ref cards } if cards == &vec![scry_card]
+    ));
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+    assert!(runner.state().pending_cost_move_resume.is_some());
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the Scry post-effect retains the parked cost root on the wire");
+    let restored: GameState =
+        serde_json::from_str(&json).expect("the Scry post-effect restores the parked cost root");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::SelectCards {
+            cards: vec![scry_card],
+        })
+        .expect("answering Scry resumes the parked mana-cost root");
+
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the mana source resolves only after the Scry answer"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("the original outer payment spends the resumed mana");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert_eq!(
+        activation_events
+            .iter()
+            .chain(resumed.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "the Scry post-effect cannot replay mana production"
+    );
+}
+
+#[test]
+fn mana_cost_proliferate_post_effect_serializes_until_answered_then_resumes_root_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Proliferate Post-Effect Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    let proliferate_target = scenario
+        .add_creature(P0, "Proliferate Post-Effect Target", 1, 1)
+        .id();
+    scenario.with_counter(proliferate_target, CounterType::Plus1Plus1, 1);
+    scenario
+        .add_creature(P0, "Proliferate Post-Effect Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(proliferate_after_moved_to_exile());
+    let spell = scenario
+        .add_spell_to_hand(P0, "Proliferate Post-Effect Mana Payment Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the spell reaches manual mana payment");
+    let paused = runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("the real mana-ability action reaches its Proliferate post-effect");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ProliferateChoice { player: P0, .. }
+    ));
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+    assert!(runner.state().pending_cost_move_resume.is_some());
+
+    let json = serde_json::to_string(runner.state())
+        .expect("the Proliferate post-effect retains the parked cost root on the wire");
+    let restored: GameState = serde_json::from_str(&json)
+        .expect("the Proliferate post-effect restores the parked cost root");
+    let mut runner = GameRunner::from_state(restored);
+    let resumed = runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(proliferate_target)],
+        })
+        .expect("answering Proliferate resumes the parked mana-cost root");
+
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    assert_eq!(
+        runner.state().objects[&proliferate_target].counters[&CounterType::Plus1Plus1],
+        2,
+        "the interactive post-effect settles before the outer mana root resumes"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the mana source resolves only after the Proliferate answer"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("the original outer payment spends the resumed mana");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(resumed.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == spell))
+            .count(),
+        1,
+        "the Proliferate post-effect resumes the outer cast exactly once"
+    );
+}
+
+#[test]
+fn optional_post_effect_settles_before_resuming_the_parked_mana_root() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Optional Post-Effect Costed Mana Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Exile {
+                        count: 1,
+                        zone: None,
+                        filter: Some(TargetFilter::SelfRef),
+                    },
+                ],
+            }),
+        )
+        .id();
+    scenario
+        .add_creature(P0, "Optional Post-Effect Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(optional_gain_life_after_moved_to_exile());
+    let spell = scenario
+        .add_spell_to_hand(P0, "Optional Post-Effect Mana Payment Witness", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("the spell reaches manual mana payment");
+    let paused = runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("the mana ability's mandatory redirect reaches its optional post-effect");
+    assert!(
+        matches!(
+            paused.waiting_for,
+            WaitingFor::OptionalEffectChoice { player: P0, .. }
+        ),
+        "expected optional post-effect choice, got {:?}",
+        paused.waiting_for
+    );
+    assert!(runner.state().pending_cost_move_resume.is_some());
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 0);
+
+    let resumed = runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("answering the optional post-effect resumes the parked mana root");
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment { player: P0, .. }
+    ));
+    assert_eq!(runner.state().players[P0.0 as usize].life, 21);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1,
+        "the source resolves only after the optional effect is fully answered"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("the original payment spends the resumed mana");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+    assert_eq!(
+        paused
+            .events
+            .iter()
+            .chain(resumed.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == spell))
+            .count(),
+        1,
+        "the outer cast resumes exactly once after the optional post-effect"
     );
 }

--- a/crates/engine/tests/integration/printed_ability_order.rs
+++ b/crates/engine/tests/integration/printed_ability_order.rs
@@ -49,9 +49,11 @@
 //! exercises the interaction. See `ISSUES.md` #12.
 
 use engine::parser::oracle::parse_oracle_text;
-use engine::types::ability::{AbilityDefinition, ActivationRestriction};
+use engine::types::ability::{
+    AbilityDefinition, ActivationRestriction, Effect, ManaProduction, QuantityExpr,
+    TriggerDefinition,
+};
 use engine::types::triggers::TriggerMode;
-use engine::types::TriggerDefinition;
 
 /// The sole index of the element matching `pred`.
 ///
@@ -104,15 +106,10 @@ fn strings(items: &[&str]) -> Vec<String> {
 }
 
 fn parse_spacecraft(oracle: &str, name: &str) -> engine::parser::oracle::ParsedAbilities {
-    // Spacecraft print `Station` as an MTGJSON keyword ability; card-data is
-    // generated WITH it, so the `Station` reminder line is consumed as a keyword.
-    // Passing it here matches production — without it the bare `Station` line falls
-    // through to an `Unimplemented` ability that pollutes the `abilities` vector
-    // (irrelevant to the printed-ORDER property under test).
     parse_oracle_text(
         oracle,
         name,
-        &strings(&["Station"]),
+        &[],
         &strings(&["Artifact"]),
         &strings(&["Spacecraft"]),
     )
@@ -302,8 +299,9 @@ fn memory_test_triggers_are_in_printed_order() {
 // abilities — threshold / level blocks printed below a plain activated ability
 // ---------------------------------------------------------------------------
 
-/// Both abilities are `{T}` → mana, so mode and cost cannot tell them apart.
-/// The only discriminating field is `activation_restrictions`.
+/// The first and threshold abilities both tap for mana. The unclassified Station
+/// reminder also becomes an unrestricted activation in this synthetic fixture, so
+/// the first anchor must include its exact colorless-mana output.
 #[test]
 fn the_eternity_elevator_abilities_are_in_printed_order() {
     const ORACLE: &str = "{T}: Add {C}{C}{C}.\n\
@@ -318,7 +316,18 @@ fn the_eternity_elevator_abilities_are_in_printed_order() {
         "abilities",
         "unrestricted {T}: Add {C}{C}{C} (line 0)",
         &parsed.abilities,
-        unrestricted,
+        |ability| {
+            unrestricted(ability)
+                && matches!(
+                    ability.effect.as_ref(),
+                    Effect::Mana {
+                        produced: ManaProduction::Colorless {
+                            count: QuantityExpr::Fixed { value: 3 }
+                        },
+                        ..
+                    }
+                )
+        },
     );
     let gated = sole_index(
         card,

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -23,7 +23,6 @@ crates/engine/src/game/archenemy.rs	turn_face_down_to_bottom_of_scheme_deck	cont
 crates/engine/src/game/casting_costs.rs	handle_resolution_cast_rejection	mover	1
 crates/engine/src/game/conspiracy.rs	start_with_conspiracy	container	1
 crates/engine/src/game/conspiracy.rs	start_with_conspiracy	zone-assign	1
-crates/engine/src/game/costs.rs	pay_ability_cost_inner	mover	2
 crates/engine/src/game/deck_loading.rs	create_attraction_deck_card	container	1
 crates/engine/src/game/deck_loading.rs	create_contraption_deck_card	container	1
 crates/engine/src/game/deck_loading.rs	create_planar_deck_card	container	1
@@ -54,8 +53,6 @@ crates/engine/src/game/engine_payment_choices.rs	handle_unless_bounce_choice	mov
 crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	container	6
 crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	mover	9
 crates/engine/src/game/engine_resolution_choices.rs	route_rest_partition	mover	2
-crates/engine/src/game/mana_abilities.rs	exile_self_for_mana_cost	mover	1
-crates/engine/src/game/mana_abilities.rs	pay_selected_exile_cost_for_mana_ability	mover	1
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	container	1
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	zone-assign	1
 crates/engine/src/game/planechase.rs	planeswalk	container	2


### PR DESCRIPTION
Plan 03 step 6 cost tranche PR2. The remaining raw cost zone-movers
(mana_abilities.rs self-exile + selected-exile, and the costs.rs
pay_ability_cost_inner remainder) now route through zone_pipeline with
the typed PendingCostMoveResume::ManaAbilityPayment continuation:

- ManaAbilityCostCursor is the payment program counter (remaining cost
  legs, per-list cursors, deferred cost events collected exactly once
  per CR 603.2/603.3b, CR 605.3c excluded_sources, typed parent stack
  for nested costed mana sources).
- AssistState gains PaymentStarted/Paid checkpoints (CR 702.132a +
  CR 601.2h) so helpers are never double-charged across a pause.
- Replacement dispatcher resumes the parked cursor on both the
  delivered and prevented/substituted paths before draining the
  ordinary effect rider (CR 601.2h + CR 605.3b + CR 616.1).
- Interactive activation-cost legs are removed one-per-payment,
  including battlefield-exile legs; no-target activations route
  through the serialized residual dispatcher (CR 601.2c + CR 602.2b).
- The transitional ActivationCostMoveHandling enum from #5857 is
  dissolved.
- ~3,900 lines of synthetic-redirect witnesses in
  tests/integration/cost_zone_pipeline.rs; zone-authority baseline
  regenerated (60 hits / 41 rows, three migrated rows removed).
