### PR TITLE
fix(parser): scope 'defending player' edicts to the defending player (Kibo, +7)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -18533,6 +18533,17 @@ fn player_filter_as_controller_ref(filter: &TargetFilter) -> Option<ControllerRe
         // surfaces a player target slot and `resolve_sacrifice_scope` reads the
         // chosen player at resolution — identical to the "target opponent" path.
         TargetFilter::Player => Some(ControllerRef::TargetPlayer),
+        // CR 508.5 + CR 701.21a: A bare "defending player" subject on an
+        // attack-trigger edict ("Whenever ~ attacks, defending player
+        // sacrifices an artifact of their choice" — Kibo, Uktabi Prince). Like
+        // "target player" this lowers to a unit player filter
+        // (`TargetFilter::DefendingPlayer`) that otherwise fell through to
+        // `None`, dropping the controller scope so the edict defaulted to the
+        // attacking controller. Promoting it to `DefendingPlayer` lets the
+        // Sacrifice injection arm stamp the filter's `controller` and
+        // `resolve_sacrifice_scope` route the sacrifice to the defending player
+        // (resolved from combat state, no target slot) at resolution time.
+        TargetFilter::DefendingPlayer => Some(ControllerRef::DefendingPlayer),
         _ => None,
     }
 }

--- a/crates/engine/tests/integration/kibo_uktabi_prince_defending_player_sacrifice.rs
+++ b/crates/engine/tests/integration/kibo_uktabi_prince_defending_player_sacrifice.rs
@@ -1,0 +1,110 @@
+//! Regression for GitHub issue #6011 — Kibo, Uktabi Prince's attack trigger.
+//!
+//! Oracle (attack trigger):
+//!   "Whenever Kibo attacks, defending player sacrifices an artifact of their
+//!    choice."
+//!
+//! Bug: the "defending player" subject was dropped by the parser, so the
+//! `Sacrifice` effect's target filter had `controller: None` and defaulted to
+//! the ability's controller — the ATTACKING player. The attacker was forced to
+//! sacrifice their own artifact instead of the defending player.
+//!
+//! Root cause: `player_filter_as_controller_ref` (parser/oracle_effect/mod.rs)
+//! mapped `TargetFilter::Player` → `TargetPlayer` (Diabolic Edict) but had no
+//! arm for `TargetFilter::DefendingPlayer`, so the sacrifice injection arm never
+//! stamped the filter's controller. The runtime `resolve_sacrifice_scope`
+//! already routes `ControllerRef::DefendingPlayer` to the combat defender
+//! (CR 508.5) — only the parser dropped the scope.
+//!
+//! This test drives the full pipeline through `apply`: Kibo attacks P1, the
+//! attack trigger resolves, and the DEFENDING player (P1), not the attacker
+//! (P0), sacrifices their artifact.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+// Verbatim attack-trigger line from Kibo, Uktabi Prince. Isolated from the
+// card's other abilities (the graveyard +1/+1 trigger and the Banana mana
+// ability) so the sacrifice resolves without a follow-on trigger cascade;
+// this exact sentence is what the real card's parser sees for this ability.
+const KIBO_ATTACK_TRIGGER: &str =
+    "Whenever Kibo attacks, defending player sacrifices an artifact of their choice.";
+
+fn zone_of(runner: &GameRunner, id: ObjectId) -> Zone {
+    runner.state().objects.get(&id).expect("object exists").zone
+}
+
+/// Drive the attack trigger to resolution, answering the defending player's
+/// sacrifice choice by picking their artifact.
+fn resolve_trigger(runner: &mut GameRunner, defender_artifact: ObjectId) {
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    return;
+                }
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![] })
+                    .expect("order triggers");
+            }
+            other => panic!("unexpected waiting state during Kibo trigger: {other:?}"),
+        }
+    }
+    let _ = defender_artifact;
+    panic!("Kibo attack trigger did not resolve");
+}
+
+/// CR 508.5 + CR 701.21a: Kibo's attack trigger makes the DEFENDING player
+/// sacrifice one of their artifacts. Reverting the parser fix routes the
+/// sacrifice to the attacking controller instead.
+#[test]
+fn kibo_attack_trigger_defending_player_sacrifices_their_artifact() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let kibo = scenario
+        .add_creature_from_oracle(P0, "Kibo, Uktabi Prince", 2, 2, KIBO_ATTACK_TRIGGER)
+        .id();
+
+    // Attacker (P0) and defender (P1) each control exactly one artifact.
+    let attacker_artifact = {
+        let mut b = scenario.add_creature(P0, "Attacker Artifact", 0, 1);
+        b.as_artifact();
+        b.id()
+    };
+    let defender_artifact = {
+        let mut b = scenario.add_creature(P1, "Defender Artifact", 0, 1);
+        b.as_artifact();
+        b.id()
+    };
+
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(kibo, AttackTarget::Player(P1))])
+        .expect("declare Kibo attacking P1");
+
+    resolve_trigger(&mut runner, defender_artifact);
+
+    // The DEFENDING player's artifact is sacrificed; the attacker's remains.
+    assert_eq!(
+        zone_of(&runner, defender_artifact),
+        Zone::Graveyard,
+        "issue #6011: the DEFENDING player must sacrifice their artifact"
+    );
+    assert_eq!(
+        zone_of(&runner, attacker_artifact),
+        Zone::Battlefield,
+        "issue #6011: the ATTACKING player must NOT sacrifice their artifact"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -550,6 +550,7 @@ mod kaito_integration;
 mod kaya_geist_hunter;
 mod kaya_spirits_justice_per_opponent_exile;
 mod kaysa_green_anthem;
+mod kibo_uktabi_prince_defending_player_sacrifice;
 mod knighthood_first_strike_grant;
 mod knollspine_dragon_target_damage_draw;
 mod kodama_anti_recursion_intervening_if;


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8
Thinking: high

Closes #6011.

## Summary

Kibo, Uktabi Prince — *"Whenever Kibo attacks, defending player sacrifices an artifact of their choice."* — forced the **attacking** player (the ability's controller) to sacrifice, instead of the **defending** player.

`player_filter_as_controller_ref` maps a player-subject filter to the `ControllerRef` that the Sacrifice/edict injection arm stamps onto the effect. It handled `TargetFilter::Player → TargetPlayer` (Diabolic Edict's "target player") but had **no arm** for `TargetFilter::DefendingPlayer`, so it fell through to `None`. With no controller scope stamped, the edict defaulted to the ability's controller — the attacker.

**Fix** (one match arm): `TargetFilter::DefendingPlayer => Some(ControllerRef::DefendingPlayer)`. The runtime was already ready — `resolve_sacrifice_scope` (`game/effects/sacrifice.rs`) already routes `ControllerRef::DefendingPlayer` to the combat defender (read from combat state, no target slot). Pure parser gap.

## Gate A

Engine parser fix via a single enum match arm — no string-matching. Three-dot diff of `crates/engine/src/parser/**` grepped for forbidden methods (`.contains("`, `.split_once(`, …): **empty**.

## Anchored on

- `crates/engine/src/parser/oracle_effect/mod.rs` — the new `TargetFilter::DefendingPlayer` arm in `player_filter_as_controller_ref`.
- `crates/engine/src/game/effects/sacrifice.rs` — `resolve_sacrifice_scope` already resolves `ControllerRef::DefendingPlayer` to the combat defender (the runtime this fix unlocks).

## Verification

- `cargo fmt --all` — clean.
- Parser combinator gate — empty.
- `cargo clippy -p engine --tests -- -D warnings` — clean.
- Regression test `kibo_attack_trigger_defending_player_sacrifices_their_artifact` in `crates/engine/tests/integration/kibo_uktabi_prince_defending_player_sacrifice.rs` (registered in `tests/integration/main.rs`) — drives the full pipeline (Kibo attacks P1) and asserts P1's artifact moves to the graveyard while P0's stays on the battlefield. **Fails before** (attacker sacrificed), **passes after**. 10 neighboring tests (edicts, sacrifice-scope) still pass.
- CR verified against `docs/MagicCompRules.txt`: 508.5 (defending player), 701.21a (sacrifice).
- **Blast radius:** rebuilt `oracle-gen`, regenerated `card-data.json`, diffed the full database — **exactly 8 cards changed**, all the same class (each gained `DefendingPlayer` scope 0→1): Kibo Uktabi Prince, Bane of Bala Ged, Gisa's Favorite Shovel, Labyrinth Raptor, Nefarox Overlord of Grixis, Thraximundar, Thresher Beast, Witch-king Bringer of Ruin — all "defending player [sacrifices/exiles] … of their choice" attack/block edicts that had the identical dropped-scope bug. No collateral, no regressions.

## Scope Expansion

None.
