### PR TITLE
refactor(engine): migrate the Delve fuel cost mover onto zone_pipeline

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -12,7 +12,7 @@ use crate::types::events::{BendingType, ContestRound, GameEvent, ManaTapState, P
 use crate::types::game_state::{
     ActionResult, AssistState, AutoMayChoice, AutoPassMode, AutoPassRequest, CastOfferKind,
     ConvokeMode, CostResume, GameState, LandPlayRecord, LoopDetectionMode, MayTriggerAutoChoiceKey,
-    PayCostKind, RetargetScope, StackEntry, StackEntryKind, WaitingFor,
+    PayCostKind, PendingCostMoveResume, RetargetScope, StackEntry, StackEntryKind, WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::match_config::MatchType;
@@ -52,6 +52,8 @@ use super::splice;
 use super::triggers;
 use super::turn_control;
 use super::turns;
+use super::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
+#[cfg(test)]
 use super::zones;
 
 pub use super::engine_resolve_batch::{
@@ -2185,13 +2187,47 @@ pub(super) fn resume_pending_continuation_if_priority(
         if matches!(state.waiting_for, WaitingFor::Priority { .. })
             && matches!(
                 state.pending_cost_move_resume,
-                Some(crate::types::game_state::PendingCostMoveResume::ManaAbilityPayment { .. })
+                Some(PendingCostMoveResume::DelveManaPayment { .. })
+            )
+        {
+            state.waiting_for = resume_delve_mana_payment(state);
+        }
+        if matches!(state.waiting_for, WaitingFor::Priority { .. })
+            && matches!(
+                state.pending_cost_move_resume,
+                Some(PendingCostMoveResume::ManaAbilityPayment { .. })
             )
         {
             state.waiting_for = mana_abilities::resume_mana_ability_cost_move(state, events)?;
         }
     }
     Ok(())
+}
+
+/// CR 702.66a: Finish one Delve payment after its graveyard-to-exile cost move
+/// was delivered or fully replaced. The move's `TrackBySource` delivery tail
+/// records only cards actually delivered to exile; this typed root restores the
+/// exact Delve payment prompt and its one-generic cost reduction without
+/// finalizing the pending cast.
+pub(super) fn resume_delve_mana_payment(state: &mut GameState) -> WaitingFor {
+    let Some(PendingCostMoveResume::DelveManaPayment { player, fuel_id }) =
+        state.pending_cost_move_resume.take()
+    else {
+        unreachable!("delve cost-move resume requires its typed continuation")
+    };
+    // CR 118.3a: The generic-only marker is consumed by the shared mana-payment
+    // finalizer and cannot be pinned or spent on a colored cost.
+    state.add_mana_to_pool(
+        player,
+        crate::types::mana::ManaUnit::convoke_payment(
+            crate::types::mana::ManaType::Colorless,
+            fuel_id,
+        ),
+    );
+    WaitingFor::ManaPayment {
+        player,
+        convoke_mode: Some(ConvokeMode::Delve),
+    }
 }
 
 /// Decision emitted by the auto-pass loop's per-iteration check.
@@ -5169,9 +5205,7 @@ fn apply_action(
         // generic mana. Unlike convoke/improvise (which tap a permanent), the
         // source is a graveyard card that is exiled. The contribution is a
         // generic-only colorless marker (like Improvise) that can't leak into the
-        // pool. (Tracking which cards were exiled — for Murktide Regent's "+1/+1
-        // for each card exiled with it" — is a follow-up that also needs the
-        // QuantityRef/parser wiring; the core payment is independent of it.)
+        // pool.
         (
             WaitingFor::ManaPayment {
                 player,
@@ -5197,24 +5231,32 @@ fn apply_action(
                     "Can only delve a card from your own graveyard".to_string(),
                 ));
             }
-            zones::move_to_zone(state, object_id, Zone::Exile, &mut events);
-            // CR 702.66a + CR 607.2a: Delved cards are exiled "with" the spell
-            // being cast (Murktide Regent ETB counters — issue #1322).
-            if let Some(spell_id) = state.pending_cast.as_ref().map(|p| p.object_id) {
-                crate::game::exile_links::push_tracked_by_source(state, object_id, spell_id);
-            }
-            // CR 118.3a: route through the stamping authority (delve marker is a
-            // generic-only convoke marker, never pinned).
-            state.add_mana_to_pool(
+            let spell_id = state
+                .pending_cast
+                .as_ref()
+                .map(|pending| pending.object_id)
+                .ok_or_else(|| {
+                    EngineError::InvalidAction("No pending cast for delve".to_string())
+                })?;
+            state.pending_cost_move_resume = Some(PendingCostMoveResume::DelveManaPayment {
                 player,
-                crate::types::mana::ManaUnit::convoke_payment(
-                    crate::types::mana::ManaType::Colorless,
-                    object_id,
-                ),
-            );
-            WaitingFor::ManaPayment {
-                player,
-                convoke_mode: Some(ConvokeMode::Delve),
+                fuel_id: object_id,
+            });
+            // CR 702.66a + CR 614.1 + CR 616.1: The cost move must consult Moved
+            // replacements. `track_exiled_by_source` carries
+            // `ExileLinkSpec { duration: None, tracking: TrackBySource }`, so the
+            // delivery tail links only fuel that actually reaches exile.
+            match zone_pipeline::move_object(
+                state,
+                ZoneMoveRequest::cost(object_id, Zone::Exile, spell_id)
+                    .track_exiled_by_source(),
+                &mut events,
+            ) {
+                ZoneMoveResult::Done => resume_delve_mana_payment(state),
+                ZoneMoveResult::NeedsChoice(_) => state.waiting_for.clone(),
+                ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                    unreachable!("a delve cost move to exile cannot require an Aura attachment")
+                }
             }
         }
         (WaitingFor::MulliganDecision { .. }, GameAction::MulliganDecision { choice }) => {

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -1041,6 +1041,19 @@ pub(super) fn handle_replacement_choice(
                 waiting_for = super::casting::resume_foretell_cost_move(state, events);
             }
 
+            // CR 702.66a + CR 614.1 + CR 616.1: A delivered or redirected
+            // Delve fuel move still pays one generic component. Its delivery
+            // tail linked only an actual exile destination; resume must restore
+            // ManaPayment rather than finish the pending cast.
+            if matches!(waiting_for, WaitingFor::Priority { .. })
+                && matches!(
+                    state.pending_cost_move_resume,
+                    Some(PendingCostMoveResume::DelveManaPayment { .. })
+                )
+            {
+                waiting_for = super::engine::resume_delve_mana_payment(state);
+            }
+
             // CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: The selected
             // replacement has delivered the interrupted mana-ability cost move.
             // Resume only its unpaid cursor suffix; it owns production and the
@@ -1266,6 +1279,16 @@ pub(super) fn handle_replacement_choice(
                 Some(PendingCostMoveResume::Foretell { .. })
             ) {
                 return Ok(super::casting::resume_foretell_cost_move(state, events));
+            }
+            // CR 702.66a + CR 614.1 + CR 616.1: A prevented Delve move still
+            // pays its generic component, but has no delivered exile link.
+            if matches!(
+                state.pending_cost_move_resume,
+                Some(PendingCostMoveResume::DelveManaPayment { .. })
+            ) {
+                let waiting_for = super::engine::resume_delve_mana_payment(state);
+                state.waiting_for = waiting_for.clone();
+                return Ok(waiting_for);
             }
             // CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: A fully
             // prevented or substituted mana-ability cost move still pays that

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -4242,6 +4242,10 @@ mod tests {
                 cost: ManaCost::generic(1),
                 turn_foretold: 7,
             },
+            PendingCostMoveResume::DelveManaPayment {
+                player: PlayerId(0),
+                fuel_id: hidden,
+            },
             mana_resume,
         ];
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2672,6 +2672,8 @@ pub struct ManaAbilityCostCursor {
 /// `Foretell` records the special action until its replacement-aware exile move
 /// has been delivered or prevented. `ManaAbilityPayment` owns the exact
 /// activation and unpaid payment cursor until the move has settled.
+/// `DelveManaPayment` owns the single Delve fuel's post-move payment state;
+/// the zone pipeline's delivery tail owns its delivered-only exile link.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PendingCostMoveResume {
     Cast {
@@ -2700,6 +2702,10 @@ pub enum PendingCostMoveResume {
         object_id: ObjectId,
         cost: ManaCost,
         turn_foretold: u32,
+    },
+    DelveManaPayment {
+        player: PlayerId,
+        fuel_id: ObjectId,
     },
     ManaAbilityPayment {
         pending: Box<PendingManaAbility>,

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -5088,3 +5088,183 @@ fn optional_post_effect_settles_before_resuming_the_parked_mana_root() {
         "the outer cast resumes exactly once after the optional post-effect"
     );
 }
+
+#[test]
+fn delve_mana_payment_honors_moved_redirect_without_linking_redirected_fuel() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand(P0, "Delve Redirect Payment Witness", true)
+        .with_mana_cost(ManaCost::generic(1))
+        .with_keyword(Keyword::Delve)
+        .id();
+    let fuel = scenario
+        .add_spell_to_graveyard(P0, "Redirected Delve Fuel", true)
+        .id();
+    for name in ["First Delve Exile Redirect", "Second Delve Exile Redirect"] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Hand));
+    }
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    let announced = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("delve spell reaches its mana-payment window");
+    assert!(matches!(
+        announced.waiting_for,
+        WaitingFor::ManaPayment {
+            player: P0,
+            convoke_mode: Some(engine::types::game_state::ConvokeMode::Delve),
+        }
+    ));
+
+    let paused = runner
+        .act(GameAction::TapForConvoke {
+            object_id: fuel,
+            mana_type: engine::types::mana::ManaType::Colorless,
+        })
+        .expect("delve fuel must consult competing Moved redirects");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirected delve fuel restores the mana-payment root");
+    assert_eq!(runner.state().objects[&fuel].zone, Zone::Hand);
+    assert!(
+        !runner
+            .state()
+            .exile_links
+            .iter()
+            .any(|link| link.exiled_id == fuel && link.source_id == spell),
+        "fuel redirected away from exile must not be linked as exiled with the spell"
+    );
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment {
+            player: P0,
+            convoke_mode: Some(engine::types::game_state::ConvokeMode::Delve),
+        }
+    ));
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("redirected delve fuel still pays its generic cost component");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+}
+
+#[test]
+fn delve_murktide_link_tracks_only_fuel_delivered_to_exile() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand(P0, "Murktide Regent", true)
+        .with_mana_cost(ManaCost::generic(2))
+        .with_keyword(Keyword::Delve)
+        .id();
+    let delivered_fuel = scenario
+        .add_spell_to_graveyard(P0, "Delivered Delve Fuel", true)
+        .id();
+    let redirected_fuel = scenario
+        .add_spell_to_graveyard(P0, "Redirected Murktide Fuel", true)
+        .id();
+    let first_redirect = scenario
+        .add_creature(P0, "First Murktide Exile Redirect", 0, 0)
+        .as_enchantment()
+        .id();
+    let second_redirect = scenario
+        .add_creature(P0, "Second Murktide Exile Redirect", 0, 0)
+        .as_enchantment()
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("Murktide-shaped delve spell reaches mana payment");
+    runner
+        .act(GameAction::TapForConvoke {
+            object_id: delivered_fuel,
+            mana_type: engine::types::mana::ManaType::Colorless,
+        })
+        .expect("first delve fuel is delivered to exile");
+
+    for redirect in [first_redirect, second_redirect] {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&redirect)
+            .expect("redirect source remains on the battlefield")
+            .replacement_definitions = vec![redirect_moved_to(Zone::Exile, Zone::Hand)].into();
+    }
+
+    let paused = runner
+        .act(GameAction::TapForConvoke {
+            object_id: redirected_fuel,
+            mana_type: engine::types::mana::ManaType::Colorless,
+        })
+        .expect("second delve fuel must consult competing Moved redirects");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("redirected fuel resumes the Murktide-shaped mana payment");
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ManaPayment {
+            player: P0,
+            convoke_mode: Some(engine::types::game_state::ConvokeMode::Delve),
+        }
+    ));
+    assert_eq!(runner.state().objects[&delivered_fuel].zone, Zone::Exile);
+    assert_eq!(runner.state().objects[&redirected_fuel].zone, Zone::Hand);
+    let tracked_ids: Vec<_> = runner
+        .state()
+        .exile_links
+        .iter()
+        .filter(|link| link.source_id == spell)
+        .map(|link| link.exiled_id)
+        .collect();
+    assert_eq!(tracked_ids, vec![delivered_fuel]);
+    assert_eq!(
+        runner
+            .state()
+            .cards_exiled_with_source_this_turn
+            .get(&spell)
+            .cloned()
+            .unwrap_or_default(),
+        vec![delivered_fuel],
+        "Murktide's tracked set contains precisely its delivered exile"
+    );
+
+    let completed = runner
+        .act(GameAction::PassPriority)
+        .expect("both delve components pay the generic mana after redirect");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Stack);
+}

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -46,7 +46,6 @@ crates/engine/src/game/effects/put_on_top.rs	resolve	mover	2
 crates/engine/src/game/effects/return_as_aura.rs	resolve	mover	1
 crates/engine/src/game/effects/token.rs	commit_liminal_token_entry_with_post_actions	mover	1
 crates/engine/src/game/elimination.rs	do_eliminate	container	1
-crates/engine/src/game/engine.rs	apply_action	mover	1
 crates/engine/src/game/engine.rs	normalize_recast_frame	exempt	3
 crates/engine/src/game/engine_debug.rs	apply_debug_action	mover	1
 crates/engine/src/game/engine_payment_choices.rs	handle_unless_bounce_choice	mover	1


### PR DESCRIPTION
Route the Delve graveyard-fuel exile (engine.rs delve payment arm) through
zone_pipeline::move_object with a typed PendingCostMoveResume::DelveManaPayment
continuation, removing the last raw cost-side zone mover.

- Resume re-installs the exact Delve WaitingFor::ManaPayment state (generic-only
  marker included) rather than routing through the generic cast resume, which
  would wrongly finish the pending cast (CR 601.2h + 602.2b).
- The exile link uses ExileLinkSpec { duration: None, tracking: TrackBySource }
  so Murktide Regent-style 'cards exiled with this source' counts survive
  (issue #1322); the delivery tail links only fuel actually delivered to Exile —
  redirected fuel is not linked but still pays its generic component
  (CR 702.66a + CR 614.1 + CR 616.1).
- Watched-red witnesses: neutering the resume dispatch reds both delve
  redirect witnesses on resume loss; dropping TrackBySource reds the Murktide
  link witness (left: [] right: [ObjectId(2)]).
- zone-authority baseline regenerated: exactly the engine.rs apply_action
  mover row removed (Gate B: 59 hits / 40 rows).
