### PR TITLE
fix(parser): keep a bare imperative "Draw a card" on the controller after a player-target clause (Stone of Erech)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -18435,7 +18435,7 @@ fn repeat_for_each_this_way_suffix(pred_lower: &str) -> Option<QuantityExpr> {
 /// (`Controller`), a bare "that player" placeholder (`Player`), or the generic
 /// subject-parser default (`ParentTargetController`). Does not touch effects
 /// that already carry an explicit owner anaphor (`ParentTargetOwner`).
-fn apply_anchor_subject(effect: &mut Effect, anchor: &TargetFilter) {
+fn apply_anchor_subject(effect: &mut Effect, anchor: &TargetFilter, draw_inherits_anchor: bool) {
     if !target_filter_can_target_player(anchor) {
         return;
     }
@@ -18468,13 +18468,22 @@ fn apply_anchor_subject(effect: &mut Effect, anchor: &TargetFilter) {
         // player puts the cards in their hand on the bottom of their library …,
         // then draws that many cards" (Teferi's Puzzle Box, #4241; CR 102.1).
         // Mirrors the `Shuffle` arm above (same caster-default set).
+        //
+        // CR 121.1 + CR 601.2c (issue #5998): gated on `draw_inherits_anchor` —
+        // only a subject-less CONJUGATED continuation ("…, then draws …") carries
+        // the earlier player. A bare IMPERATIVE sentence ("Exile target player's
+        // graveyard. Draw a card." — Stone of Erech) is addressed to the ability's
+        // controller, so it must keep its `Controller` default; inheriting the
+        // anchor there both draws for the wrong player and surfaces a second
+        // target slot.
         Effect::Draw { target, .. }
-            if matches!(
-                *target,
-                TargetFilter::Controller
-                    | TargetFilter::Player
-                    | TargetFilter::ParentTargetController
-            ) =>
+            if draw_inherits_anchor
+                && matches!(
+                    *target,
+                    TargetFilter::Controller
+                        | TargetFilter::Player
+                        | TargetFilter::ParentTargetController
+                ) =>
         {
             *target = anchor.clone();
         }
@@ -18487,14 +18496,26 @@ fn apply_anchor_subject_to_clause(
     anchor: &TargetFilter,
     text_lower: &str,
 ) {
+    let draw_inherits_anchor = chunk_continues_anchored_subject(text_lower);
     apply_their_library_reveal_anchor(&mut clause.effect, anchor, text_lower);
-    apply_anchor_subject(&mut clause.effect, anchor);
+    apply_anchor_subject(&mut clause.effect, anchor, draw_inherits_anchor);
     let mut sub = clause.sub_ability.as_deref_mut();
     while let Some(def) = sub {
         apply_their_library_reveal_anchor(def.effect.as_mut(), anchor, text_lower);
-        apply_anchor_subject(def.effect.as_mut(), anchor);
+        apply_anchor_subject(def.effect.as_mut(), anchor, draw_inherits_anchor);
         sub = def.sub_ability.as_deref_mut();
     }
+}
+
+/// CR 121.1 + CR 601.2c: True iff `text_lower` is a subject-less CONJUGATED
+/// continuation of the anchored player's instruction ("…, then draws a card")
+/// rather than a bare IMPERATIVE addressed to the ability's controller ("Draw a
+/// card."). A conjugated verb ("draws") is not itself a clause starter but
+/// deconjugates to one, which is exactly the shared grammar distinction
+/// `inherits_carried_targeted_player_subject` uses for the same question.
+fn chunk_continues_anchored_subject(text_lower: &str) -> bool {
+    !sequence::starts_clause_text(text_lower)
+        && sequence::starts_clause_text_or_conjugated(text_lower)
 }
 
 /// CR 608.2c: A subjectless reveal continuation that explicitly says

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -46575,3 +46575,66 @@ fn alien_invasion_creates_one_token_and_pumps_it_per_counter() {
         "the enchantment must still gain one invasion counter: {effects:#?}"
     );
 }
+
+/// CR 121.1 + CR 601.2c (issue #5998) — Stone of Erech. "Exile target player's
+/// graveyard. Draw a card." is a bare IMPERATIVE second sentence: the ability's
+/// CONTROLLER draws. The player anchor from the preceding "target player's
+/// graveyard" clause must not leak into it, which previously both drew for the
+/// targeted opponent and surfaced a second target slot.
+#[test]
+fn bare_imperative_draw_after_player_target_keeps_controller() {
+    use super::parse_effect_chain;
+    use crate::types::ability::Effect;
+
+    for text in [
+        "exile target player's graveyard. draw a card",
+        "exile target opponent's graveyard. draw a card",
+    ] {
+        let def = parse_effect_chain(text, AbilityKind::Spell);
+        let draw = def
+            .sub_ability
+            .as_deref()
+            .expect("the draw must chain off the exile");
+        let Effect::Draw { target, .. } = &*draw.effect else {
+            panic!("expected a Draw sub-ability, got {:?}", draw.effect);
+        };
+        assert_eq!(
+            *target,
+            TargetFilter::Controller,
+            "a bare imperative \"draw a card\" must draw for the controller, not the \
+             anchored player ({text:?})"
+        );
+    }
+}
+
+/// CR 121.1 (issue #5998, the inclusion side): a subject-less CONJUGATED
+/// continuation ("…, then draws …") DOES inherit the anchored player — the
+/// acting player draws, not the source's controller. Canonical: The End /
+/// Deadly Cover-Up / Teferi's Puzzle Box. This pins that the imperative gate
+/// does not regress the case the anchor arm exists for.
+#[test]
+fn conjugated_draw_continuation_still_inherits_player_anchor() {
+    use super::parse_effect_chain;
+    use crate::types::ability::Effect;
+
+    let def = parse_effect_chain(
+        "target player shuffles their library, then draws a card",
+        AbilityKind::Spell,
+    );
+    let mut found = None;
+    let mut next = Some(&def);
+    while let Some(d) = next {
+        if let Effect::Draw { target, .. } = &*d.effect {
+            found = Some(target.clone());
+            break;
+        }
+        next = d.sub_ability.as_deref();
+    }
+    let target = found.expect("expected a Draw in the chain");
+    assert_ne!(
+        target,
+        TargetFilter::Controller,
+        "a conjugated \"then draws\" continuation must inherit the anchored player, \
+         not fall back to the controller"
+    );
+}


### PR DESCRIPTION
## Problem

Stone of Erech (#5998):

> `{2}, {T}, Sacrifice Stone of Erech:` **Exile target player's graveyard. Draw a card.**

It asked for **two targets**, and **drew the card for the targeted opponent** instead of the controller.

The parse showed both symptoms in one place:

```
ChangeZoneAll { origin: Graveyard, destination: Exile, target: Player }   <- "Exile target player's graveyard"
sub_ability: Draw { count: 1, target: Player }                            <- BUG: should be Controller
```

`Draw { target: Player }` is a fresh player filter, so `collect_target_slots` surfaces a **second target slot** (the extra prompt), and at resolution the **chosen opponent draws**.

## Root cause

`apply_anchor_subject` inherits an earlier player anchor into a caster-defaulted `Effect::Draw`. That arm exists for a subject-less **CONJUGATED** continuation --

- "That player shuffles, **then draws** a card for each card exiled from their hand this way" (The End, Deadly Cover-Up)
- "... **then draws** that many cards" (Teferi's Puzzle Box, #4241)

-- where the acting player draws. But it also fired on a bare **IMPERATIVE** sentence, which is addressed to the ability's controller.

The leak is general, not Stone-specific -- a preceding *creature* target is fine, a preceding *player* target leaks:

| chain | Draw target (before) |
|---|---|
| `draw a card` | `Controller` (ok) |
| `destroy target creature. draw a card` | `Controller` (ok) |
| `exile target player's graveyard. draw a card` | **`Player`** (bug) |
| `exile target opponent's graveyard. draw a card` | **`Typed{controller: Opponent}`** (bug) |

## Fix

Gate the `Draw` arm on `chunk_continues_anchored_subject`, which reuses the **shared clause-starter authority** rather than introducing new grammar: a conjugated verb ("draws") is not itself a `starts_clause_text` starter but deconjugates to one, while a bare imperative ("draw") is a starter outright.

```rust
fn chunk_continues_anchored_subject(text_lower: &str) -> bool {
    !sequence::starts_clause_text(text_lower)
        && sequence::starts_clause_text_or_conjugated(text_lower)
}
```

This is the same distinction `inherits_carried_targeted_player_subject` already uses for the same question. Only the `Draw` arm is gated; `Shuffle` / `SearchLibrary` / `ChangeZoneAll` keep their current behavior.

## Tests

- `bare_imperative_draw_after_player_target_keeps_controller` -- the Draw keeps `Controller` for **both** the `target player's` and `target opponent's` anchored forms (the class, not one card).
- `conjugated_draw_continuation_still_inherits_player_anchor` -- the inclusion side: "target player shuffles their library, then draws a card" still inherits the anchor, pinning that the gate does not regress the case the arm exists for.

Full `engine` lib suite green (16,749 passed, 0 failed); `cargo fmt`, `clippy -p engine --tests`, and the parser-combinator gate clean.

Closes #5998
