### PR TITLE
fix(engine): classify City-of-Brass-shaped self-tap damage into mana-source penalty (#5912)

### DIFF
--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -756,7 +756,8 @@ fn activate_ability_is_meaningful_priority(
     state.objects.get(&source_id).is_some_and(|obj| {
         obj.abilities.get(ability_index).is_some_and(|ability| {
             !mana_abilities::is_mana_ability(ability)
-                || mana_sources::mana_ability_penalty(ability).is_meaningful_priority_activation()
+                || mana_sources::object_mana_ability_penalty(state, source_id, ability)
+                    .is_meaningful_priority_activation()
         })
     })
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -10949,7 +10949,8 @@ mod tests {
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, Comparator, ControllerRef, Effect, FilterProp,
         ManaProduction, PtStat, PtValue, PtValueScope, QuantityExpr, ReplacementDefinition,
-        ReplacementMode, StaticDefinition, TargetFilter, TargetRef, TypeFilter, TypedFilter,
+        ReplacementMode, StaticDefinition, TargetFilter, TargetRef, TriggerDefinition, TypeFilter,
+        TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
@@ -10958,6 +10959,7 @@ mod tests {
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::replacements::ReplacementEvent;
     use crate::types::statics::StaticMode;
+    use crate::types::triggers::TriggerMode;
 
     #[test]
     fn announcing_opponent_preflight_ignores_scoped_player_chooser() {
@@ -13524,6 +13526,97 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, GameEvent::LifeChanged { amount: -1, .. })),
             "auto-pay should not emit a life payment when an equivalent non-life line exists"
+        );
+    }
+
+    /// Issue #5912: City of Brass prints its self-damage as a *separate*
+    /// "Whenever this land becomes tapped, it deals 1 damage to you" trigger
+    /// (`TriggerMode::Taps`), not folded into the `{T}: Add one mana of any
+    /// color.` ability's own resolution chain like a painland. Before
+    /// `object_mana_ability_penalty` accounted for this sibling trigger,
+    /// City of Brass classified byte-identically to a basic land (`None`
+    /// penalty), so auto-tap could pick it over a truly free Island for the
+    /// same generic slot. Auto-tap must prefer the Island.
+    #[test]
+    fn auto_tap_prefers_free_land_over_city_of_brass_self_damage_trigger() {
+        let mut state = GameState::new_two_player(42);
+        let city_of_brass = create_object(
+            &mut state,
+            CardId(20),
+            PlayerId(0),
+            "City of Brass".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&city_of_brass).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            Arc::make_mut(&mut obj.abilities).push(
+                AbilityDefinition::new(
+                    AbilityKind::Activated,
+                    Effect::Mana {
+                        produced: ManaProduction::AnyOneColor {
+                            count: QuantityExpr::Fixed { value: 1 },
+                            color_options: ManaColor::ALL.to_vec(),
+                            contribution: crate::types::ability::ManaContribution::Base,
+                        },
+                        restrictions: vec![],
+                        grants: vec![],
+                        expiry: None,
+                        target: None,
+                    },
+                )
+                .cost(AbilityCost::Tap),
+            );
+            obj.trigger_definitions.push(
+                TriggerDefinition::new(TriggerMode::Taps)
+                    .valid_card(TargetFilter::SelfRef)
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Database,
+                        Effect::DealDamage {
+                            amount: QuantityExpr::Fixed { value: 1 },
+                            target: TargetFilter::Controller,
+                            damage_source: None,
+                            excess: None,
+                        },
+                    )),
+            );
+        }
+        let island = create_object(
+            &mut state,
+            CardId(21),
+            PlayerId(0),
+            "Island".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&island).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            obj.card_types.subtypes.push("Island".to_string());
+        }
+
+        let mut events = Vec::new();
+        auto_tap_mana_sources(
+            &mut state,
+            PlayerId(0),
+            &ManaCost::Cost {
+                shards: vec![],
+                generic: 1,
+            },
+            &mut events,
+            None,
+        );
+
+        assert!(
+            state.objects.get(&island).unwrap().tapped,
+            "the free Island must be tapped for the generic cost"
+        );
+        assert!(
+            !state.objects.get(&city_of_brass).unwrap().tapped,
+            "City of Brass must NOT be tapped when a truly free source can pay the same cost"
+        );
+        assert_eq!(
+            state.players[0].life, 20,
+            "auto-pay must avoid the self-damage source when an equivalent free line exists"
         );
     }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3274,7 +3274,10 @@ fn apply_action(
                 // allows undo — painlands (damage on resolution), pay-life
                 // sources, and sacrifice sources all commit irreversible
                 // state atomically with CR 605.3b resolution.
-                if is_land && mana_sources::mana_ability_penalty(&ability_def).is_undoable() {
+                if is_land
+                    && mana_sources::object_mana_ability_penalty(state, source_id, &ability_def)
+                        .is_undoable()
+                {
                     state
                         .lands_tapped_for_mana
                         .entry(state.priority_player)

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -458,14 +458,15 @@ pub(crate) fn mana_ability_penalty(ability: &AbilityDefinition) -> ManaSourcePen
 }
 
 /// CR 603.2e + CR 701.26: Controller-harm amount from a self-referential
-/// `TriggerMode::Taps` sibling trigger on `object_id` — City of Brass and
-/// Tarnished Citadel print their self-damage as a *separate* "Whenever this
-/// land becomes tapped, it deals 1 damage to you" triggered ability (fires on
-/// ANY tap, not only a mana activation), rather than folding the damage into
-/// the mana ability's own resolution chain the way painlands do (Adarkar
-/// Wastes: "{T}: Add {W} or {U}. This land deals 1 damage to you." is ONE
-/// ability). `mana_ability_penalty` only walks the mana ability's own chain,
-/// so it never sees this sibling trigger.
+/// `TriggerMode::Taps` sibling trigger on `object_id` — City of Brass prints
+/// its self-damage as a *separate* "Whenever this land becomes tapped, it
+/// deals 1 damage to you" triggered ability (fires on ANY tap, not only a mana
+/// activation), rather than folding the damage into the mana ability's own
+/// resolution chain the way painlands do (Adarkar Wastes: "{T}: Add {W} or
+/// {U}. This land deals 1 damage to you." is ONE ability). Tarnished Citadel
+/// likewise has a mana penalty, but its colored mana ability embeds the damage
+/// in its own chain. `mana_ability_penalty` only walks a mana ability's own
+/// chain, so it never sees City of Brass's sibling trigger.
 ///
 /// Returns `Some(amount)` when at least one such trigger is found (summed the
 /// same way `chain_harms_controller_amount` sums a single chain), `None` when
@@ -518,6 +519,9 @@ pub(crate) fn object_mana_ability_penalty(
     ability: &AbilityDefinition,
 ) -> ManaSourcePenalty {
     let own = mana_ability_penalty(ability);
+    if !has_tap_component(&ability.cost) {
+        return own;
+    }
     if matches!(
         own,
         ManaSourcePenalty::Sacrifices | ManaSourcePenalty::PaysLifeOnActivation { .. }
@@ -3444,6 +3448,63 @@ mod tests {
         assert!(
             penalty.priority_amount() > ManaSourcePenalty::None.priority_amount(),
             "must sort strictly worse than a truly free source (Island) in the same tier_byte"
+        );
+    }
+
+    /// A sibling `Taps` trigger fires only when the selected mana ability taps
+    /// its source. A no-cost mana ability on the same City-of-Brass-shaped
+    /// object must retain its own penalty classification rather than borrowing
+    /// damage from an event it cannot cause.
+    #[test]
+    fn object_mana_ability_penalty_ignores_self_tap_trigger_for_no_tap_ability() {
+        let mut state = GameState::new_two_player(42);
+        let city_of_brass = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "City of Brass".to_string(),
+            Zone::Battlefield,
+        );
+        let ability_index;
+        {
+            let obj = state.objects.get_mut(&city_of_brass).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            let ability = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::AnyOneColor {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        color_options: ManaColor::ALL.to_vec(),
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            );
+            ability_index = obj.abilities.len();
+            Arc::make_mut(&mut obj.abilities).push(ability);
+            obj.trigger_definitions.push(
+                TriggerDefinition::new(TriggerMode::Taps)
+                    .valid_card(TargetFilter::SelfRef)
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Database,
+                        Effect::DealDamage {
+                            amount: QuantityExpr::Fixed { value: 1 },
+                            target: TargetFilter::Controller,
+                            damage_source: None,
+                            excess: None,
+                        },
+                    )),
+            );
+        }
+
+        let ability = state.objects.get(&city_of_brass).unwrap().abilities[ability_index].clone();
+        assert_eq!(
+            object_mana_ability_penalty(&state, city_of_brass, &ability),
+            ManaSourcePenalty::None,
+            "a no-tap mana ability cannot fire the sibling Taps trigger"
         );
     }
 

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -473,30 +473,22 @@ pub(crate) fn mana_ability_penalty(ability: &AbilityDefinition) -> ManaSourcePen
 /// the object carries no self-referential harmful `Taps` trigger.
 fn object_self_tap_harm_amount(state: &GameState, object_id: ObjectId) -> Option<Option<u16>> {
     let obj = state.objects.get(&object_id)?;
-    let mut found = false;
-    let mut total = Some(0_u16);
-    for trigger in obj.trigger_definitions.iter_all() {
-        if trigger.mode != TriggerMode::Taps {
-            continue;
-        }
-        let self_referential = match &trigger.valid_card {
-            None => true,
-            Some(filter) => super::trigger_matchers::target_filter_matches_object(
-                state, object_id, filter, object_id,
-            ),
-        };
-        if !self_referential {
-            continue;
-        }
-        let Some(execute) = trigger.execute.as_deref() else {
-            continue;
-        };
-        if let Some(amount) = chain_harms_controller_amount(execute) {
-            found = true;
-            total = fold_amount(total, amount);
-        }
-    }
-    found.then_some(total)
+    let mut harm_amounts = obj
+        .trigger_definitions
+        .iter_all()
+        .filter(|trigger| trigger.mode == TriggerMode::Taps)
+        .filter(|trigger| {
+            trigger.valid_card.as_ref().is_none_or(|filter| {
+                super::trigger_matchers::target_filter_matches_object(
+                    state, object_id, filter, object_id,
+                )
+            })
+        })
+        .filter_map(|trigger| trigger.execute.as_deref())
+        .filter_map(chain_harms_controller_amount)
+        .peekable();
+    harm_amounts.peek()?;
+    Some(harm_amounts.fold(Some(0_u16), fold_amount))
 }
 
 /// CR 605.3b: Single classification authority for a mana-source OBJECT's full

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -457,6 +457,86 @@ pub(crate) fn mana_ability_penalty(ability: &AbilityDefinition) -> ManaSourcePen
     ManaSourcePenalty::None
 }
 
+/// CR 603.2e + CR 701.26: Controller-harm amount from a self-referential
+/// `TriggerMode::Taps` sibling trigger on `object_id` — City of Brass and
+/// Tarnished Citadel print their self-damage as a *separate* "Whenever this
+/// land becomes tapped, it deals 1 damage to you" triggered ability (fires on
+/// ANY tap, not only a mana activation), rather than folding the damage into
+/// the mana ability's own resolution chain the way painlands do (Adarkar
+/// Wastes: "{T}: Add {W} or {U}. This land deals 1 damage to you." is ONE
+/// ability). `mana_ability_penalty` only walks the mana ability's own chain,
+/// so it never sees this sibling trigger.
+///
+/// Returns `Some(amount)` when at least one such trigger is found (summed the
+/// same way `chain_harms_controller_amount` sums a single chain), `None` when
+/// the object carries no self-referential harmful `Taps` trigger.
+fn object_self_tap_harm_amount(state: &GameState, object_id: ObjectId) -> Option<Option<u16>> {
+    let obj = state.objects.get(&object_id)?;
+    let mut found = false;
+    let mut total = Some(0_u16);
+    for trigger in obj.trigger_definitions.iter_all() {
+        if trigger.mode != TriggerMode::Taps {
+            continue;
+        }
+        let self_referential = match &trigger.valid_card {
+            None => true,
+            Some(filter) => super::trigger_matchers::target_filter_matches_object(
+                state, object_id, filter, object_id,
+            ),
+        };
+        if !self_referential {
+            continue;
+        }
+        let Some(execute) = trigger.execute.as_deref() else {
+            continue;
+        };
+        if let Some(amount) = chain_harms_controller_amount(execute) {
+            found = true;
+            total = fold_amount(total, amount);
+        }
+    }
+    found.then_some(total)
+}
+
+/// CR 605.3b: Single classification authority for a mana-source OBJECT's full
+/// penalty axis — [`mana_ability_penalty`]'s ability-chain classification
+/// merged with any self-referential `Taps` sibling trigger that harms the
+/// controller ([`object_self_tap_harm_amount`]). This is the version every
+/// real consumer (auto-tap sort, the priority-meaningful gate,
+/// `UntapLandForMana` undoability) must call instead of `mana_ability_penalty`
+/// directly, so a City-of-Brass-shaped card can never be misclassified as
+/// `None` just because its damage lives on a sibling trigger instead of the
+/// mana ability's own chain.
+///
+/// A `Sacrifices`/`PaysLifeOnActivation` classification from the ability's own
+/// chain is already worse than or equal to anything a sibling `Taps` trigger
+/// could add, so those short-circuit unchanged. Otherwise, a sibling harm
+/// amount folds into (or replaces) `DealsDamageOnResolution`.
+pub(crate) fn object_mana_ability_penalty(
+    state: &GameState,
+    object_id: ObjectId,
+    ability: &AbilityDefinition,
+) -> ManaSourcePenalty {
+    let own = mana_ability_penalty(ability);
+    if matches!(
+        own,
+        ManaSourcePenalty::Sacrifices | ManaSourcePenalty::PaysLifeOnActivation { .. }
+    ) {
+        return own;
+    }
+    match object_self_tap_harm_amount(state, object_id) {
+        Some(sibling_amount) => ManaSourcePenalty::DealsDamageOnResolution {
+            fixed_amount: match own {
+                ManaSourcePenalty::DealsDamageOnResolution { fixed_amount } => {
+                    fold_amount(fixed_amount, sibling_amount)
+                }
+                _ => sibling_amount,
+            },
+        },
+        None => own,
+    }
+}
+
 /// CR 119.3 (life) / CR 120.3 (damage → life loss): The benefit twin of
 /// [`effect_controller_harm_amount`]. Returns `true` iff a single `Effect`
 /// favors the player who caused the trigger (the tapper): opponent-scoped
@@ -1677,7 +1757,7 @@ fn scan_mana_abilities(
             continue;
         }
 
-        let penalty = mana_ability_penalty(ability);
+        let penalty = object_mana_ability_penalty(state, object_id, ability);
         let source_could_produce_two_or_more_colors =
             source_could_produce_two_or_more_colors(state, object_id, controller);
         for row in emit_source_rows(state, controller, object_id, ability_index, ability) {
@@ -3266,6 +3346,104 @@ mod tests {
         assert!(
             penalty.priority_amount() > fixed_max.priority_amount(),
             "unknown amount (None) must sort strictly worse than any known amount (conservative worst)"
+        );
+    }
+
+    /// Issue #5912: City of Brass prints its self-damage as a *separate*
+    /// "Whenever this land becomes tapped, it deals 1 damage to you" trigger
+    /// (`TriggerMode::Taps`, `valid_card: SelfRef`), NOT folded into the
+    /// `{T}: Add one mana of any color.` ability's own resolution chain like a
+    /// painland. `mana_ability_penalty` only walks the ability's own chain, so
+    /// it misclassifies this shape as `None` (byte-identical to a basic land) —
+    /// this is the reach-guard proving the gap exists before the fix.
+    #[test]
+    fn city_of_brass_ability_alone_misclassifies_as_none() {
+        let ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::AnyOneColor {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    color_options: ManaColor::ALL.to_vec(),
+                    contribution: ManaContribution::Base,
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap);
+
+        assert_eq!(
+            mana_ability_penalty(&ability),
+            ManaSourcePenalty::None,
+            "the ability's own chain is pure Effect::Mana with no embedded damage"
+        );
+    }
+
+    /// Issue #5912: [`object_mana_ability_penalty`] must see past the ability
+    /// chain and classify a City-of-Brass-shaped object (mana ability + sibling
+    /// self-referential `Taps` damage trigger) as `DealsDamageOnResolution`, so
+    /// auto-tap sorts it worse than a truly free source (Island) for the same
+    /// generic-mana slot.
+    #[test]
+    fn object_mana_ability_penalty_sees_city_of_brass_self_tap_damage_trigger() {
+        let mut state = GameState::new_two_player(42);
+        let city_of_brass = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "City of Brass".to_string(),
+            Zone::Battlefield,
+        );
+        let ability_index;
+        {
+            let obj = state.objects.get_mut(&city_of_brass).unwrap();
+            obj.card_types.core_types.push(CoreType::Land);
+            let ability = AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::AnyOneColor {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        color_options: ManaColor::ALL.to_vec(),
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Tap);
+            ability_index = obj.abilities.len();
+            Arc::make_mut(&mut obj.abilities).push(ability);
+            obj.trigger_definitions.push(
+                TriggerDefinition::new(TriggerMode::Taps)
+                    .valid_card(TargetFilter::SelfRef)
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Database,
+                        Effect::DealDamage {
+                            amount: QuantityExpr::Fixed { value: 1 },
+                            target: TargetFilter::Controller,
+                            damage_source: None,
+                            excess: None,
+                        },
+                    )),
+            );
+        }
+
+        let ability = state.objects.get(&city_of_brass).unwrap().abilities[ability_index].clone();
+        let penalty = object_mana_ability_penalty(&state, city_of_brass, &ability);
+        assert_eq!(
+            penalty,
+            ManaSourcePenalty::DealsDamageOnResolution {
+                fixed_amount: Some(1)
+            },
+            "the sibling self-tap damage trigger must be folded into the classification"
+        );
+        assert!(
+            penalty.priority_amount() > ManaSourcePenalty::None.priority_amount(),
+            "must sort strictly worse than a truly free source (Island) in the same tier_byte"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #5912.

City of Brass (and reprints like Tarnished Citadel) print their self-damage
as a *separate* triggered ability — "Whenever this land becomes tapped, it
deals 1 damage to you." (`TriggerMode::Taps`) — rather than folding the
damage into the `{T}: Add one mana of any color.` ability's own resolution
chain the way painlands do (Adarkar Wastes: "{T}: Add {W} or {U}. This land
deals 1 damage to you." is a single ability).

`mana_ability_penalty` only walks the mana ability's own effect chain
(`ability.effect`/`sub_ability`/`else_ability`), so it never sees a sibling
`TriggerDefinition` on the same object. That misclassified City of Brass as
`ManaSourcePenalty::None` — byte-identical to a basic land — so auto-tap had
no reason to prefer a truly free source (Island) over it for a shared
generic-mana slot. Reported case: casting a `{1}{G}` spell with City of
Brass + Llanowar Elves in play tapped City of Brass (1 damage) instead of
Island, even though Island could pay the generic cost for free.

`object_mana_ability_penalty` (`mana_sources.rs`) merges the existing
ability-chain classification with a scan of the object's own
self-referential `Taps` triggers (`object_self_tap_harm_amount`), reusing the
same `chain_harms_controller_amount` walk a painland's embedded damage
already goes through. All three real consumers of the penalty classification
now route through it instead of the ability-only `mana_ability_penalty`, so
the fix can't drift between them:

- `scan_mana_abilities` (auto-tap source sort — the reported bug)
- `activate_ability_is_meaningful_priority` (priority-meaningful gate)
- the `UntapLandForMana` undoability check in `engine.rs` (a City-of-Brass
  tap was previously misclassified as undoable even though its damage
  trigger had already resolved)

## Files changed

- `crates/engine/src/game/mana_sources.rs` — `object_self_tap_harm_amount`,
  `object_mana_ability_penalty`, wired into `scan_mana_abilities`; two new
  unit tests.
- `crates/engine/src/game/casting_costs.rs` — new end-to-end auto-tap
  regression test.
- `crates/engine/src/ai_support/mod.rs` — `activate_ability_is_meaningful_priority`
  now calls `object_mana_ability_penalty`.
- `crates/engine/src/game/engine.rs` — `UntapLandForMana` undo check now
  calls `object_mana_ability_penalty`.

## CR references

- CR 605.3b — mana ability resolution is atomic/inline; single
  classification authority for the penalty axis.
- CR 603.2e — "becomes tapped" trigger semantics (fires per discrete tap
  event, not on persisting state).
- CR 701.26 — tap/untap definitions.
- CR 119.3 / CR 120.3 — life loss / damage-as-life-loss, the harm axis
  `chain_harms_controller_amount` already classifies for painlands.

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets --features engine/proptest -- -D warnings` — 0 warnings.
- `cargo test -p engine --lib` — 16754 passed, 0 failed, 7 ignored.
- `cargo test -p engine` (integration suite) — 3208 passed, 0 failed, 2 ignored.
- New tests specifically:
  - `game::mana_sources::tests::city_of_brass_ability_alone_misclassifies_as_none`
    (reach-guard: proves the ability-only classifier alone still returns
    `None`, i.e. the gap this PR closes).
  - `game::mana_sources::tests::object_mana_ability_penalty_sees_city_of_brass_self_tap_damage_trigger`
  - `game::casting_costs::tests::auto_tap_prefers_free_land_over_city_of_brass_self_damage_trigger`
    (drives the real `auto_tap_mana_sources` pipeline; fails against the
    pre-fix code because auto-tap would tap City of Brass and pay 1 life).
- `./scripts/check-parser-combinators.sh origin/main` — `Gate A PASS
  head=d5f81e071168fad4ade8489dfce50003d56ec60b
  base=3b52c67a9025cd20da8b68243667eb8cdad76060` (no parser files touched by
  this change).

## Anchored on

- `crates/engine/src/game/mana_sources.rs:378` (`chain_harms_controller_amount`) —
  reused unmodified for the sibling trigger's `execute` chain.
- `crates/engine/src/game/casting_costs.rs:13487`
  (`auto_tap_prefers_non_life_mana_sources_when_equivalent`) — existing
  end-to-end auto-tap regression pattern the new test mirrors.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

## Claimed parse impact

None — no parser files touched; this is a runtime/AI-support classification
fix only.


Closes #6020
