### PR TITLE
fix(engine): pause sacrifice-for-cost on a mid-loop replacement choice

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -17,7 +17,8 @@ use crate::types::game_state::{
     ConvokeMode, CostResume, CounterCostChoice, CounterRemoveChoice, DeferredSacrificeSelection,
     DistributionUnit, GameState, ManaAbilityCostParent, ManaAbilityResume, PayCostKind,
     PendingCast, PendingCostMoveCompletion, PendingCostMoveResume, PendingDiscardForCostResume,
-    SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot, WaitingFor,
+    PendingSacrificeCostCompletion, SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot,
+    WaitingFor,
 };
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::Keyword;
@@ -1797,6 +1798,17 @@ pub(crate) fn resume_interrupted_cost_payment(
 ) -> Result<WaitingFor, EngineError> {
     if matches!(
         state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::SacrificeForCost { .. })
+    ) {
+        return resume_sacrifice_for_cost(
+            state,
+            events,
+            replacement_action_cost_event_start.unwrap_or(events.len()),
+        );
+    }
+
+    if matches!(
+        state.pending_cost_move_resume,
         Some(PendingCostMoveResume::Cast { .. })
     ) {
         let Some(PendingCostMoveResume::Cast {
@@ -2209,6 +2221,215 @@ fn park_deferred_cost_triggers_if_paused(
     crate::game::triggers::collect_triggers_into_deferred(state, &cost_events);
 }
 
+/// CR 603.10a: Retain the state-ledger identities for every selected permanent
+/// that has actually left the battlefield in this action fragment. The matching
+/// event copy is kept separately in the typed resume root so terminal stamping
+/// can update both event buffers and the authoritative LKI ledger.
+fn record_sacrifice_cost_departure_records(
+    departure_record_indices: &mut Vec<usize>,
+    events: &[GameEvent],
+    chosen: &[ObjectId],
+) {
+    for event in events {
+        if let GameEvent::ZoneChanged {
+            object_id,
+            from: Some(Zone::Battlefield),
+            record,
+            ..
+        } = event
+        {
+            if chosen.contains(object_id)
+                && !departure_record_indices.contains(&record.turn_zone_change_index)
+            {
+                departure_record_indices.push(record.turn_zone_change_index);
+            }
+        }
+    }
+}
+
+/// CR 601.2h + CR 602.2b + CR 616.1: Park one selected sacrifice component
+/// without exposing a partial event group to trigger collection. The currently
+/// paused object is delivered or prevented by the replacement action; the
+/// typed root resumes at the following program-counter index.
+#[allow(clippy::too_many_arguments)]
+fn pause_sacrifice_for_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    pending: PendingCast,
+    chosen: Vec<ObjectId>,
+    paused_at_index: usize,
+    completion: PendingSacrificeCostCompletion,
+    mut deferred_cost_events: Vec<GameEvent>,
+    mut departure_record_indices: Vec<usize>,
+    events: &[GameEvent],
+    cost_event_start: usize,
+    choice_player: PlayerId,
+) -> WaitingFor {
+    record_sacrifice_cost_departure_records(
+        &mut departure_record_indices,
+        &events[cost_event_start..],
+        &chosen,
+    );
+    deferred_cost_events.extend_from_slice(&events[cost_event_start..]);
+    state.pending_cost_move_resume = Some(PendingCostMoveResume::SacrificeForCost {
+        player,
+        pending: Box::new(pending),
+        chosen,
+        paused_at_index,
+        completion,
+        deferred_cost_events,
+        departure_record_indices,
+    });
+    // The inner sacrifice-zone-change pipeline has normally already installed
+    // this prompt. Preserve a delivery-tail prompt if one owns the action
+    // instead; only a live CR 616.1 replacement needs synthesis here.
+    if state.pending_replacement.is_some() {
+        super::costs::pause_cost_payment_for_replacement_choice(state, choice_player);
+    }
+    state.waiting_for.clone()
+}
+
+/// CR 603.2 + CR 603.3b: The typed sacrifice root owns every cost event that
+/// crossed a replacement-choice action boundary. Collect the full stamped set
+/// once, and claim the current action occurrences so its normal Priority
+/// pipeline cannot collect the same events again.
+fn settle_sacrifice_for_cost_events(
+    state: &mut GameState,
+    mut deferred_cost_events: Vec<GameEvent>,
+    events: &[GameEvent],
+    current_start: usize,
+    current_end: usize,
+) {
+    deferred_cost_events.extend_from_slice(&events[current_start..current_end]);
+    if !deferred_cost_events.is_empty() {
+        crate::game::triggers::collect_triggers_into_deferred(state, &deferred_cost_events);
+    }
+    state.consumed_before_priority_trigger_events.extend(
+        events[current_start..current_end]
+            .iter()
+            .enumerate()
+            .map(|(offset, event)| {
+                let index = current_start + offset;
+                crate::game::triggers::ConsumedTriggerEventOccurrence {
+                    event: event.clone(),
+                    occurrence: events[..index]
+                        .iter()
+                        .filter(|prior| *prior == event)
+                        .count(),
+                }
+            }),
+    );
+}
+
+/// CR 603.10a + CR 601.2h + CR 602.2b: Run the one terminal epilogue for a
+/// selected or SelfRef sacrifice cost after every selected object has delivered
+/// or been fully replaced. No earlier pause may invoke this path.
+#[allow(clippy::too_many_arguments)]
+fn finish_sacrifice_for_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    mut pending: PendingCast,
+    chosen: &[ObjectId],
+    completion: PendingSacrificeCostCompletion,
+    mut deferred_cost_events: Vec<GameEvent>,
+    mut departure_record_indices: Vec<usize>,
+    events: &mut Vec<GameEvent>,
+    current_start: usize,
+) -> Result<WaitingFor, EngineError> {
+    record_sacrifice_cost_departure_records(
+        &mut departure_record_indices,
+        &events[current_start..],
+        chosen,
+    );
+    let departed = crate::game::zones::departed_subset(state, chosen);
+    crate::game::zones::mark_simultaneous_departures(&mut deferred_cost_events, &departed);
+    crate::game::zones::mark_simultaneous_departures(&mut events[current_start..], &departed);
+    crate::game::zones::mark_simultaneous_departure_records(
+        state,
+        &departure_record_indices,
+        &departed,
+    );
+    let current_end = events.len();
+
+    // Cost-trigger collection must see the fully stamped, cross-action group
+    // before a later cast/activation prompt can hide this action's event span.
+    settle_sacrifice_for_cost_events(
+        state,
+        deferred_cost_events,
+        events,
+        current_start,
+        current_end,
+    );
+
+    if matches!(completion, PendingSacrificeCostCompletion::SelectedNonSelf)
+        && pending.activation_ability_index.is_some()
+    {
+        pending.activation_cost = pending
+            .activation_cost
+            .take()
+            .and_then(super::casting::remove_selected_non_self_sacrifice_cost);
+    }
+
+    finish_pending_cost_or_cast(state, player, pending, events)
+}
+
+/// CR 601.2h + CR 602.2b + CR 616.1: Continue the exact unpaid suffix of a
+/// replacement-paused sacrifice cost. The replacement action has settled the
+/// `paused_at_index` object, so this resumes only later selections.
+pub(crate) fn resume_sacrifice_for_cost(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+    replacement_action_cost_event_start: usize,
+) -> Result<WaitingFor, EngineError> {
+    let Some(PendingCostMoveResume::SacrificeForCost {
+        player,
+        pending,
+        chosen,
+        paused_at_index,
+        completion,
+        deferred_cost_events,
+        departure_record_indices,
+    }) = state.pending_cost_move_resume.take()
+    else {
+        unreachable!("sacrifice cost-move resume requires its typed continuation")
+    };
+
+    for index in paused_at_index + 1..chosen.len() {
+        match super::sacrifice::sacrifice_permanent(state, chosen[index], player, events)
+            .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+        {
+            super::sacrifice::SacrificeOutcome::Complete => {}
+            super::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                return Ok(pause_sacrifice_for_cost(
+                    state,
+                    player,
+                    *pending,
+                    chosen,
+                    index,
+                    completion,
+                    deferred_cost_events,
+                    departure_record_indices,
+                    events,
+                    replacement_action_cost_event_start,
+                    choice_player,
+                ));
+            }
+        }
+    }
+
+    finish_sacrifice_for_cost(
+        state,
+        player,
+        *pending,
+        &chosen,
+        completion,
+        deferred_cost_events,
+        departure_record_indices,
+        events,
+        replacement_action_cost_event_start,
+    )
+}
+
 pub(crate) fn handle_sacrifice_for_cost(
     state: &mut GameState,
     player: PlayerId,
@@ -2367,22 +2588,38 @@ pub(crate) fn handle_sacrifice_for_cost(
     // block after `finish_pending_cost_or_cast`).
     let cost_event_start = events.len();
 
-    // Sacrifice each chosen permanent
-    for &id in chosen {
-        super::sacrifice::sacrifice_permanent(state, id, player, events)
-            .map_err(|e| EngineError::InvalidAction(format!("{e}")))?;
+    // CR 601.2h + CR 616.1: A selected cost sacrifice can pause at any
+    // selected object. Keep the complete selection and event span on the
+    // typed root; resumption starts after the object resolved by the chooser.
+    for (index, &id) in chosen.iter().enumerate() {
+        match super::sacrifice::sacrifice_permanent(state, id, player, events)
+            .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+        {
+            super::sacrifice::SacrificeOutcome::Complete => {}
+            super::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                return Ok(pause_sacrifice_for_cost(
+                    state,
+                    player,
+                    pending,
+                    chosen.to_vec(),
+                    index,
+                    PendingSacrificeCostCompletion::SelectedNonSelf,
+                    Vec::new(),
+                    Vec::new(),
+                    events,
+                    cost_event_start,
+                    choice_player,
+                ));
+            }
+        }
     }
 
-    // CR 603.10a + CR 701.21a + CR 601.2h + CR 118.8: permanents sacrificed to pay
-    // one cost component leave the battlefield together; a co-departing observer
-    // among them observes the rest (look-back-in-time). Single authority — identical
-    // wiring to `effects::sacrifice::resolve`. `departed_subset` drops any permanent
-    // that did not actually leave (CantBeSacrificed, replacement).
+    // No action boundary split this component, so the ordinary post-action
+    // pipeline remains its trigger settlement authority.
     crate::game::zones::mark_simultaneous_departures(
         events,
         &crate::game::zones::departed_subset(state, chosen),
     );
-    let cost_event_end = events.len();
 
     if pending.activation_ability_index.is_some() {
         pending.activation_cost = pending
@@ -2392,37 +2629,14 @@ pub(crate) fn handle_sacrifice_for_cost(
     }
 
     let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
-
-    // CR 603.6c + CR 603.10a + CR 603.3b: When `finish_pending_cost_or_cast`
-    // lands on `Priority` the cast completed in THIS action, so
-    // `run_post_action_pipeline` will scan `events` (including the
-    // cost-sacrifice `ZoneChanged` records stamped just above) and the
-    // leaves-the-battlefield / dies observers fire normally.
-    //
-    // But when the cast PAUSES on a later target/kicker/modal choice
-    // (a non-`Priority` `WaitingFor`), `apply_action` does NOT run the
-    // post-action pipeline over this action's `events` (engine.rs gates the
-    // pipeline on `WaitingFor::Priority`), and the cast lands in a LATER
-    // action whose fresh `events` vector no longer carries these records — so
-    // the producer co-departed stamp would be unreadable and a "whenever a
-    // creature you control dies" / leaves-the-battlefield observer among the
-    // co-sacrificed permanents would under-observe. Mirror the established
-    // B2 parking pattern in `engine_resolution_choices::batch_or_drain_observer_triggers`:
-    // collect the cost-payment observer triggers into `deferred_triggers` now,
-    // where the stamped records are still in scope. They are NOT drained while
-    // the announced spell remains on the stack (`should_drain_deferred_triggers_now`
-    // refuses to drain with a `Spell` entry present), so they reach the stack
-    // at the next true resolution boundary after the cast completes — CR 603.3
-    // ("the next time a player would receive priority").
     if !matches!(waiting_for, WaitingFor::Priority { .. }) {
-        let cost_events: Vec<GameEvent> = events[cost_event_start..cost_event_end]
+        let cost_events: Vec<GameEvent> = events[cost_event_start..]
             .iter()
-            .filter(|ev| !matches!(ev, GameEvent::PhaseChanged { .. }))
+            .filter(|event| !matches!(event, GameEvent::PhaseChanged { .. }))
             .cloned()
             .collect();
         crate::game::triggers::collect_triggers_into_deferred(state, &cost_events);
     }
-
     Ok(waiting_for)
 }
 
@@ -5747,9 +5961,32 @@ fn pay_additional_cost_with_source(
                         "Cannot sacrifice this permanent as a cost".into(),
                     ));
                 }
-                // CR 118.3: Self-sacrifice is atomic — no player choice needed
-                super::sacrifice::sacrifice_permanent(state, pending.object_id, player, events)
-                    .map_err(|e| EngineError::InvalidAction(format!("{e}")))?;
+                // CR 118.3 + CR 616.1: The cost itself has no selection prompt,
+                // but its battlefield-to-graveyard move can still require a
+                // replacement ordering choice. Preserve the automatic tail on
+                // the same typed root used by selected sacrifice costs.
+                let cost_event_start = events.len();
+                let object_id = pending.object_id;
+                match super::sacrifice::sacrifice_permanent(state, object_id, player, events)
+                    .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+                {
+                    super::sacrifice::SacrificeOutcome::Complete => {}
+                    super::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                        return Ok(pause_sacrifice_for_cost(
+                            state,
+                            player,
+                            pending,
+                            vec![object_id],
+                            0,
+                            PendingSacrificeCostCompletion::SelfRef,
+                            Vec::new(),
+                            Vec::new(),
+                            events,
+                            cost_event_start,
+                            choice_player,
+                        ));
+                    }
+                }
             } else {
                 // CR 118.3: Non-self sacrifice needs interactive selection
                 let eligible = super::casting::find_eligible_sacrifice_targets(

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -2174,31 +2174,113 @@ fn apply_as_current_with_mode(
     apply_action_boundary(state, actor, action, mode)
 }
 
+/// The action boundary at which a typed cost-move root is allowed to resume.
+/// Keeping this finite boundary vocabulary prevents a cost payment from being
+/// drained by an unrelated effect continuation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CostMoveDrainBoundary {
+    ReplacementDelivered { action_event_start: usize },
+    ReplacementPrevented { action_event_start: usize },
+    PriorityBoundary,
+}
+
+/// CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: Drain the one typed cost-move
+/// root eligible at this exact reducer boundary. Replacement delivery happens
+/// before ordinary continuations; the common Priority boundary only resumes
+/// Delve and mana-ability cursors after those continuations have settled.
+pub(crate) fn drain_pending_cost_move_resume(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+    boundary: CostMoveDrainBoundary,
+) -> Result<Option<WaitingFor>, EngineError> {
+    let eligible = match boundary {
+        CostMoveDrainBoundary::ReplacementDelivered { .. } => matches!(
+            state.pending_cost_move_resume,
+            Some(
+                PendingCostMoveResume::Cast { .. }
+                    | PendingCostMoveResume::SacrificeForCost { .. }
+                    | PendingCostMoveResume::ReplacementMayCost { .. }
+                    | PendingCostMoveResume::DelveManaPayment { .. }
+                    | PendingCostMoveResume::ManaAbilityPayment { .. }
+            )
+        ),
+        CostMoveDrainBoundary::ReplacementPrevented { .. } => matches!(
+            state.pending_cost_move_resume,
+            Some(
+                PendingCostMoveResume::Cast { .. }
+                    | PendingCostMoveResume::SacrificeForCost { .. }
+                    | PendingCostMoveResume::ReplacementMayCost { .. }
+                    | PendingCostMoveResume::Foretell { .. }
+                    | PendingCostMoveResume::DelveManaPayment { .. }
+                    | PendingCostMoveResume::ManaAbilityPayment { .. }
+            )
+        ),
+        CostMoveDrainBoundary::PriorityBoundary => matches!(
+            state.pending_cost_move_resume,
+            Some(
+                PendingCostMoveResume::DelveManaPayment { .. }
+                    | PendingCostMoveResume::ManaAbilityPayment { .. }
+            )
+        ),
+    };
+    if !eligible {
+        return Ok(None);
+    }
+
+    let action_event_start = match boundary {
+        CostMoveDrainBoundary::ReplacementDelivered { action_event_start }
+        | CostMoveDrainBoundary::ReplacementPrevented { action_event_start } => {
+            Some(action_event_start)
+        }
+        CostMoveDrainBoundary::PriorityBoundary => None,
+    };
+    let waiting_for = if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::Cast { .. } | PendingCostMoveResume::SacrificeForCost { .. })
+    ) {
+        casting_costs::resume_interrupted_cost_payment(state, events, action_event_start)?
+    } else if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::ReplacementMayCost { .. })
+    ) {
+        super::costs::resume_replacement_may_cost_move(state, events)?
+    } else if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::Foretell { .. })
+    ) {
+        super::casting::resume_foretell_cost_move(state, events)
+    } else if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::DelveManaPayment { .. })
+    ) {
+        resume_delve_mana_payment(state)
+    } else if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::ManaAbilityPayment { .. })
+    ) {
+        mana_abilities::resume_mana_ability_cost_move(state, events)?
+    } else {
+        unreachable!("eligible cost-move root must remain parked")
+    };
+    state.waiting_for = waiting_for.clone();
+    Ok(Some(waiting_for))
+}
+
 pub(super) fn resume_pending_continuation_if_priority(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
     if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
         effects::drain_pending_continuation(state, events);
-        // CR 605.3b + CR 616.1: Any interactive replacement post-effect may
-        // finish at this common prompt boundary. Once ordinary effect
-        // continuations have drained, resume a parked mana-cost cursor exactly
-        // once; do not depend on a particular choice handler or effect shape.
-        if matches!(state.waiting_for, WaitingFor::Priority { .. })
-            && matches!(
-                state.pending_cost_move_resume,
-                Some(PendingCostMoveResume::DelveManaPayment { .. })
-            )
-        {
-            state.waiting_for = resume_delve_mana_payment(state);
-        }
-        if matches!(state.waiting_for, WaitingFor::Priority { .. })
-            && matches!(
-                state.pending_cost_move_resume,
-                Some(PendingCostMoveResume::ManaAbilityPayment { .. })
-            )
-        {
-            state.waiting_for = mana_abilities::resume_mana_ability_cost_move(state, events)?;
+        // CR 605.3b + CR 616.1: A post-replacement prompt reaches this common
+        // boundary only after ordinary continuations drain. The shared typed
+        // dispatcher owns the remaining eligible payment roots.
+        if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+            let _ = drain_pending_cost_move_resume(
+                state,
+                events,
+                CostMoveDrainBoundary::PriorityBoundary,
+            )?;
         }
     }
     Ok(())

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -1003,68 +1003,20 @@ pub(super) fn handle_replacement_choice(
                 }
             }
 
-            // CR 601.2h + CR 602.2b + CR 616.1: Resume a cast or activation
-            // cost move after the replacement delivered its current object.
-            if matches!(waiting_for, WaitingFor::Priority { .. })
-                && matches!(
-                    state.pending_cost_move_resume,
-                    Some(PendingCostMoveResume::Cast { .. })
-                )
-            {
-                waiting_for = super::casting_costs::resume_interrupted_cost_payment(
+            // CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: A delivered cost
+            // move resumes through the single typed dispatcher before ordinary
+            // effect continuations. Foretell completed above at its dedicated
+            // delivery boundary and is intentionally ineligible here.
+            if matches!(waiting_for, WaitingFor::Priority { .. }) {
+                if let Some(resumed) = super::engine::drain_pending_cost_move_resume(
                     state,
                     events,
-                    Some(replacement_action_event_start),
-                )?;
-            }
-
-            // CR 614.12a + CR 616.1: Finish the inner forced MayCost moves
-            // before re-entering the optional outer replacement they paid for.
-            if matches!(waiting_for, WaitingFor::Priority { .. })
-                && matches!(
-                    state.pending_cost_move_resume,
-                    Some(PendingCostMoveResume::ReplacementMayCost { .. })
-                )
-            {
-                waiting_for = super::costs::resume_replacement_may_cost_move(state, events)?;
-            }
-
-            // CR 702.143a-c + CR 614.1 + CR 616.1: Finish a foretell special
-            // action after its replacement-aware move is delivered. The
-            // foretell resume stamps the card only if it arrived in exile.
-            if matches!(waiting_for, WaitingFor::Priority { .. })
-                && matches!(
-                    state.pending_cost_move_resume,
-                    Some(PendingCostMoveResume::Foretell { .. })
-                )
-            {
-                waiting_for = super::casting::resume_foretell_cost_move(state, events);
-            }
-
-            // CR 702.66a + CR 614.1 + CR 616.1: A delivered or redirected
-            // Delve fuel move still pays one generic component. Its delivery
-            // tail linked only an actual exile destination; resume must restore
-            // ManaPayment rather than finish the pending cast.
-            if matches!(waiting_for, WaitingFor::Priority { .. })
-                && matches!(
-                    state.pending_cost_move_resume,
-                    Some(PendingCostMoveResume::DelveManaPayment { .. })
-                )
-            {
-                waiting_for = super::engine::resume_delve_mana_payment(state);
-            }
-
-            // CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: The selected
-            // replacement has delivered the interrupted mana-ability cost move.
-            // Resume only its unpaid cursor suffix; it owns production and the
-            // inline subchain after every cost component has settled.
-            if matches!(waiting_for, WaitingFor::Priority { .. })
-                && matches!(
-                    state.pending_cost_move_resume,
-                    Some(PendingCostMoveResume::ManaAbilityPayment { .. })
-                )
-            {
-                waiting_for = super::mana_abilities::resume_mana_ability_cost_move(state, events)?;
+                    super::engine::CostMoveDrainBoundary::ReplacementDelivered {
+                        action_event_start: replacement_action_event_start,
+                    },
+                )? {
+                    waiting_for = resumed;
+                }
             }
 
             // CR 118.12 + CR 605.3b + CR 616.1: The ordinary effect rider may
@@ -1255,55 +1207,22 @@ pub(super) fn handle_replacement_choice(
             state.waiting_for = WaitingFor::Priority {
                 player: state.active_player,
             };
-            if matches!(
-                state.pending_cost_move_resume,
-                Some(PendingCostMoveResume::Cast { .. })
-            ) {
-                return super::casting_costs::resume_interrupted_cost_payment(
-                    state,
-                    events,
-                    Some(replacement_action_event_start),
-                );
-            }
-            if matches!(
-                state.pending_cost_move_resume,
-                Some(PendingCostMoveResume::ReplacementMayCost { .. })
-            ) {
-                return super::costs::resume_replacement_may_cost_move(state, events);
-            }
-            // CR 702.143a-c + CR 614.1 + CR 616.1: A fully substituted
-            // foretell move completes the special action without stamping a
-            // card that was not delivered to exile.
-            if matches!(
-                state.pending_cost_move_resume,
-                Some(PendingCostMoveResume::Foretell { .. })
-            ) {
-                return Ok(super::casting::resume_foretell_cost_move(state, events));
-            }
-            // CR 702.66a + CR 614.1 + CR 616.1: A prevented Delve move still
-            // pays its generic component, but has no delivered exile link.
-            if matches!(
-                state.pending_cost_move_resume,
-                Some(PendingCostMoveResume::DelveManaPayment { .. })
-            ) {
-                let waiting_for = super::engine::resume_delve_mana_payment(state);
-                state.waiting_for = waiting_for.clone();
-                return Ok(waiting_for);
-            }
-            // CR 601.2h + CR 602.2b + CR 605.3b + CR 616.1: A fully
-            // prevented or substituted mana-ability cost move still pays that
-            // component, so drain the exact unpaid cursor suffix.
-            if matches!(
+            let resumed_mana_ability_cost = matches!(
                 state.pending_cost_move_resume,
                 Some(PendingCostMoveResume::ManaAbilityPayment { .. })
-            ) {
-                let waiting_for =
-                    super::mana_abilities::resume_mana_ability_cost_move(state, events)?;
-                state.waiting_for = waiting_for.clone();
-                // CR 118.12 + CR 605.3b + CR 616.1: A prevented or substituted
-                // cost move has the same sequencing as a delivered move: settle
-                // the typed cost root first, then exactly once drain its rider.
-                if matches!(waiting_for, WaitingFor::Priority { .. })
+            );
+            if let Some(waiting_for) = super::engine::drain_pending_cost_move_resume(
+                state,
+                events,
+                super::engine::CostMoveDrainBoundary::ReplacementPrevented {
+                    action_event_start: replacement_action_event_start,
+                },
+            )? {
+                // CR 118.12 + CR 605.3b + CR 616.1: A prevented mana cost has
+                // the same rider ordering as a delivered one: its typed root
+                // settles before any ordinary continuation drains.
+                if resumed_mana_ability_cost
+                    && matches!(waiting_for, WaitingFor::Priority { .. })
                     && (state.pending_continuation.is_some()
                         || state.pending_change_zone_iteration.is_some())
                 {

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1710,6 +1710,7 @@ fn mana_ability_cost_cursor(
         next_exiled: 0,
         next_sacrificed: 0,
         selected_exile_remaining: None,
+        selected_sacrifice_remaining: None,
         // CR 603.2 + CR 603.3b: A nested child takes over every unscanned
         // event already owned by its suspended parent.  It appends only newly
         // emitted events if it pauses, then hands the one batch back on
@@ -1961,6 +1962,77 @@ fn pay_selected_mana_ability_exile_cost(
     Ok(ManaAbilityPaymentProgress::Complete)
 }
 
+/// CR 601.2h + CR 605.3b + CR 616.1: Pay a selected sacrifice component from
+/// the mana-ability cursor. The selected list is consumed before proposing each
+/// sacrifice, so a replacement-choice resume cannot re-sacrifice the object
+/// whose move the replacement action just settled.
+#[allow(clippy::too_many_arguments)]
+fn pay_selected_mana_ability_sacrifice_cost(
+    state: &mut GameState,
+    pending: PendingManaAbility,
+    cursor: &mut ManaAbilityCostCursor,
+    count: u32,
+    filter: &TargetFilter,
+    events: &mut Vec<GameEvent>,
+    cost_event_start: usize,
+) -> Result<ManaAbilityPaymentProgress, EngineError> {
+    if cursor.selected_sacrifice_remaining.is_none() {
+        let end = cursor.next_sacrificed + count as usize;
+        let selected = pending
+            .chosen_sacrificed_battlefield
+            .get(cursor.next_sacrificed..end)
+            .ok_or_else(|| {
+                EngineError::InvalidAction(
+                    "Missing sacrificed permanent selection for mana ability".to_string(),
+                )
+            })?;
+        if contains_duplicate_object_id(selected) {
+            return Err(EngineError::InvalidAction(
+                "Cannot sacrifice the same permanent more than once for a mana ability cost"
+                    .to_string(),
+            ));
+        }
+        cursor.next_sacrificed = end;
+        cursor.selected_sacrifice_remaining = Some(selected.to_vec());
+    }
+
+    while let Some(object_id) = cursor
+        .selected_sacrifice_remaining
+        .as_ref()
+        .and_then(|remaining| remaining.first())
+        .copied()
+    {
+        cursor
+            .selected_sacrifice_remaining
+            .as_mut()
+            .expect("selected sacrifice cursor was checked above")
+            .remove(0);
+        match sacrifice_selected_permanent_for_mana_cost(
+            state,
+            pending.source_id,
+            pending.player,
+            object_id,
+            filter,
+            events,
+        )? {
+            sacrifice::SacrificeOutcome::Complete => {}
+            sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                pause_mana_ability_cost_payment(
+                    state,
+                    Some(choice_player),
+                    pending,
+                    cursor.clone(),
+                    events,
+                    cost_event_start,
+                );
+                return Ok(ManaAbilityPaymentProgress::Paused);
+            }
+        }
+    }
+    cursor.selected_sacrifice_remaining = None;
+    Ok(ManaAbilityPaymentProgress::Complete)
+}
+
 fn pay_mana_ability_cost_component(
     state: &mut GameState,
     pending: PendingManaAbility,
@@ -2019,6 +2091,61 @@ fn pay_mana_ability_cost_component(
                 *count,
                 *zone,
                 filter.as_ref(),
+                events,
+                cost_event_start,
+            )
+        }
+        AbilityCost::Sacrifice(cost)
+            if matches!(cost.target, TargetFilter::SelfRef)
+                && cost.requirement == crate::types::ability::SacrificeRequirement::count(1) =>
+        {
+            if deferred_spell_sacrifice_reserved(state, pending.source_id) {
+                return Err(EngineError::ActionNotAllowed(
+                    "This permanent is already committed to a spell sacrifice cost".to_string(),
+                ));
+            }
+            if super::static_abilities::player_cant_sacrifice_as_cost(
+                state,
+                pending.player,
+                pending.source_id,
+            ) {
+                return Err(EngineError::ActionNotAllowed(
+                    "Cannot sacrifice this permanent as a cost".to_string(),
+                ));
+            }
+            match sacrifice::sacrifice_permanent(state, pending.source_id, pending.player, events)?
+            {
+                sacrifice::SacrificeOutcome::Complete => Ok(ManaAbilityPaymentProgress::Complete),
+                sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                    pause_mana_ability_cost_payment(
+                        state,
+                        Some(choice_player),
+                        pending,
+                        mana_ability_cursor_after_current_component(cursor),
+                        events,
+                        cost_event_start,
+                    );
+                    Ok(ManaAbilityPaymentProgress::Paused)
+                }
+            }
+        }
+        AbilityCost::Sacrifice(cost)
+            if !matches!(cost.target, TargetFilter::SelfRef)
+                && matches!(
+                    cost.requirement,
+                    crate::types::ability::SacrificeRequirement::Count { .. }
+                ) =>
+        {
+            let crate::types::ability::SacrificeRequirement::Count { count } = cost.requirement
+            else {
+                unreachable!("guarded above");
+            };
+            pay_selected_mana_ability_sacrifice_cost(
+                state,
+                pending,
+                cursor,
+                count,
+                &cost.target,
                 events,
                 cost_event_start,
             )
@@ -2601,7 +2728,15 @@ where
                     "Cannot sacrifice this permanent as a cost".to_string(),
                 ));
             }
-            let _ = sacrifice::sacrifice_permanent(state, source_id, player, events)?;
+            if matches!(
+                sacrifice::sacrifice_permanent(state, source_id, player, events)?,
+                sacrifice::SacrificeOutcome::NeedsReplacementChoice(_)
+            ) {
+                return Err(EngineError::InvalidAction(
+                    "Mana ability sacrifice replacement pause must be owned by the activation cursor"
+                        .to_string(),
+                ));
+            }
         }
         // CR 117.1 + CR 118.3 + CR 605.3b: Non-self sacrifice-from-battlefield
         // as a mana ability cost (Phyrexian Altar class). The interactive flow
@@ -2625,9 +2760,17 @@ where
                         "Missing sacrificed permanent selection for mana ability".to_string(),
                     )
                 })?;
-                sacrifice_selected_permanent_for_mana_cost(
-                    state, source_id, player, chosen_id, target, events,
-                )?;
+                if matches!(
+                    sacrifice_selected_permanent_for_mana_cost(
+                        state, source_id, player, chosen_id, target, events,
+                    )?,
+                    sacrifice::SacrificeOutcome::NeedsReplacementChoice(_)
+                ) {
+                    return Err(EngineError::InvalidAction(
+                        "Mana ability sacrifice replacement pause must be owned by the activation cursor"
+                            .to_string(),
+                    ));
+                }
             }
         }
         Some(AbilityCost::Exile { .. }) => {
@@ -3518,7 +3661,7 @@ fn sacrifice_selected_permanent_for_mana_cost(
     chosen_id: ObjectId,
     filter: &TargetFilter,
     events: &mut Vec<GameEvent>,
-) -> Result<(), EngineError> {
+) -> Result<sacrifice::SacrificeOutcome, EngineError> {
     let obj = state.objects.get(&chosen_id).ok_or_else(|| {
         EngineError::InvalidAction("Selected permanent for sacrifice cost not found".to_string())
     })?;
@@ -3542,10 +3685,7 @@ fn sacrifice_selected_permanent_for_mana_cost(
             "Selected permanent cannot be sacrificed as a cost".to_string(),
         ));
     }
-    match sacrifice::sacrifice_permanent(state, chosen_id, player, events)? {
-        sacrifice::SacrificeOutcome::Complete => Ok(()),
-        sacrifice::SacrificeOutcome::NeedsReplacementChoice(_) => Ok(()),
-    }
+    sacrifice::sacrifice_permanent(state, chosen_id, player, events)
 }
 
 fn cost_has_source_tap_component(cost: &Option<AbilityCost>) -> bool {

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -4222,6 +4222,7 @@ mod tests {
                 next_exiled: 0,
                 next_sacrificed: 0,
                 selected_exile_remaining: Some(vec![hidden]),
+                selected_sacrifice_remaining: None,
                 deferred_cost_events: Vec::new(),
                 current_action_deferred_start: 0,
                 parent: None,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2645,6 +2645,11 @@ pub struct ManaAbilityCostCursor {
     /// advances to the next component.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub selected_exile_remaining: Option<Vec<ObjectId>>,
+    /// The current selected-sacrifice component, after the sacrifice that
+    /// paused has been consumed. Its remaining objects must be sacrificed
+    /// before the cost cursor advances to the next component.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub selected_sacrifice_remaining: Option<Vec<ObjectId>>,
     /// CR 603.2 + CR 603.3b: Cost events produced before a replacement-choice
     /// pause cannot reach the ordinary post-action pipeline. Keep them with
     /// their typed payment root so observers are collected exactly once when
@@ -2665,6 +2670,17 @@ pub struct ManaAbilityCostCursor {
     pub parent: Option<Box<ManaAbilityCostParent>>,
 }
 
+/// CR 601.2h + CR 602.2b + CR 616.1: The typed terminal path for a
+/// replacement-paused sacrifice cost. Selected sacrifices remove their
+/// activation-cost component; a SelfRef sacrifice resumes the automatic
+/// additional-cost path without replaying the sacrifice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum PendingSacrificeCostCompletion {
+    SelectedNonSelf,
+    SelfRef,
+}
+
 /// CR 601.2h + CR 614.1 + CR 616.1: A cost move paused for a replacement
 /// choice. `Cast` resumes a cast or activation after its next object is
 /// delivered. `ReplacementMayCost` keeps the outer optional replacement parked
@@ -2674,6 +2690,9 @@ pub struct ManaAbilityCostCursor {
 /// activation and unpaid payment cursor until the move has settled.
 /// `DelveManaPayment` owns the single Delve fuel's post-move payment state;
 /// the zone pipeline's delivery tail owns its delivered-only exile link.
+/// `SacrificeForCost` owns a full selected sacrifice component across one or
+/// more replacement-choice action boundaries, including its event span and
+/// LKI record identities.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PendingCostMoveResume {
     Cast {
@@ -2685,6 +2704,24 @@ pub enum PendingCostMoveResume {
         paused_at_index: usize,
         destination: Zone,
         completion: PendingCostMoveCompletion,
+    },
+    SacrificeForCost {
+        player: PlayerId,
+        pending: Box<PendingCast>,
+        chosen: Vec<ObjectId>,
+        /// Index into `chosen` whose sacrifice completes or is prevented by
+        /// the replacement action. Resumption continues at the next index.
+        paused_at_index: usize,
+        completion: PendingSacrificeCostCompletion,
+        /// CR 603.2 + CR 603.10a: Cost events emitted in earlier actions of
+        /// this one logical sacrifice payment. They are stamped and settled
+        /// only when every selected sacrifice has completed.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        deferred_cost_events: Vec<GameEvent>,
+        /// CR 603.10a: Per-turn LKI record identities emitted by completed
+        /// sacrifices before a replacement-choice boundary.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        departure_record_indices: Vec<usize>,
     },
     ReplacementMayCost {
         source_id: ObjectId,

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -52,6 +52,10 @@ fn redirect_moved_to(destination: Zone, redirected_to: Zone) -> ReplacementDefin
         ))
 }
 
+fn redirect_self_moved_to(destination: Zone, redirected_to: Zone) -> ReplacementDefinition {
+    redirect_moved_to(destination, redirected_to).valid_card(TargetFilter::SelfRef)
+}
+
 fn prompt_after_moved_to_exile() -> ReplacementDefinition {
     redirect_moved_to_with_post_effect(Zone::Exile, Zone::Exile)
 }
@@ -210,6 +214,531 @@ fn stage_prevented_mana_cost_move(
         candidate_count: 1,
         candidates: vec![],
     };
+}
+
+#[test]
+fn village_rites_sacrifice_cost_pauses_for_competing_graveyard_replacements() {
+    const VILLAGE_RITES: &str =
+        "As an additional cost to cast this spell, sacrifice a creature.\nDraw two cards.";
+    const DARKSTEEL_COLOSSUS: &str = "Trample (This creature can deal excess combat damage to the player or planeswalker it's attacking.)\nIndestructible (Effects that say \"destroy\" don't destroy this creature. A creature with indestructible can't be destroyed by damage.)\nIf Darksteel Colossus would be put into a graveyard from anywhere, reveal Darksteel Colossus and shuffle it into its owner's library instead.";
+    const REST_IN_PEACE: &str = "When this enchantment enters, exile all graveyards.\nIf a card or token would be put into a graveyard from anywhere, exile it instead.";
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let village_rites = scenario
+        .add_spell_to_hand_from_oracle(P0, "Village Rites", true, VILLAGE_RITES)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 0,
+        })
+        .id();
+    let darksteel = scenario
+        .add_creature_from_oracle(P0, "Darksteel Colossus", 11, 11, DARKSTEEL_COLOSSUS)
+        .id();
+    let rest_in_peace = scenario
+        .add_creature(P0, "Rest in Peace", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(REST_IN_PEACE)
+        .id();
+    scenario.add_basic_land(P0, ManaColor::Blue);
+
+    let mut runner = scenario.build();
+    let initial_state = runner.state().clone();
+    let card_id = runner.state().objects[&village_rites].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: village_rites,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("Village Rites should announce before its additional cost is selected");
+    assert!(
+        runner.state().objects[&village_rites].zone == Zone::Hand,
+        "the spell object must remain in hand until its cost is fully paid"
+    );
+
+    let result = runner
+        .act(GameAction::SelectCards {
+            cards: vec![darksteel],
+        })
+        .expect("the chosen sacrifice cost should reach its replacement pipeline");
+
+    assert!(
+        matches!(result.waiting_for, WaitingFor::ReplacementChoice { .. }),
+        "the interrupted sacrifice cost must surface its CR 616.1 replacement choice"
+    );
+    assert!(
+        matches!(
+            runner.state().pending_cost_move_resume.as_ref(),
+            Some(PendingCostMoveResume::SacrificeForCost {
+                player,
+                chosen,
+                paused_at_index: 0,
+                ..
+            }) if *player == P0 && chosen == &vec![darksteel]
+        ),
+        "the interrupted sacrifice cost must retain a typed cost-move continuation"
+    );
+    assert!(
+        runner.state().objects[&village_rites].zone == Zone::Hand
+            && !result.events.iter().any(
+                |event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == village_rites)
+            ),
+        "the spell must not complete its cast while the sacrifice cost is unpaid"
+    );
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+        "the engine must not grant priority while the cost is unpaid"
+    );
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::ReplacementChoice { ref candidates, .. }
+                if candidates.iter().any(|candidate| candidate.source_id == rest_in_peace)
+        ),
+        "Rest in Peace must be one of the material replacement choices"
+    );
+
+    let rest_in_peace_index = match &runner.state().waiting_for {
+        WaitingFor::ReplacementChoice { candidates, .. } => candidates
+            .iter()
+            .position(|candidate| candidate.source_id == rest_in_peace)
+            .expect("Rest in Peace replacement is selectable"),
+        waiting_for => panic!("expected replacement choice, got {waiting_for:?}"),
+    };
+    let completed = runner
+        .act(GameAction::ChooseReplacement {
+            index: rest_in_peace_index,
+        })
+        .expect("Rest in Peace should replace the sacrifice destination");
+
+    assert_eq!(runner.state().objects[&darksteel].zone, Zone::Exile);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    assert!(
+        completed
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == village_rites)),
+        "Village Rites must finish casting once its paid sacrifice reaches exile"
+    );
+
+    let mut darksteel_first_runner = GameRunner::from_state(initial_state);
+    let card_id = darksteel_first_runner.state().objects[&village_rites].card_id;
+    darksteel_first_runner
+        .act(GameAction::CastSpell {
+            object_id: village_rites,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("announce the symmetric Village Rites cast");
+    darksteel_first_runner
+        .act(GameAction::SelectCards {
+            cards: vec![darksteel],
+        })
+        .expect("select Darksteel Colossus for the symmetric sacrifice cost");
+    let darksteel_index = match &darksteel_first_runner.state().waiting_for {
+        WaitingFor::ReplacementChoice { candidates, .. } => candidates
+            .iter()
+            .position(|candidate| candidate.source_id == darksteel)
+            .expect("Darksteel Colossus replacement is selectable"),
+        waiting_for => panic!("expected replacement choice, got {waiting_for:?}"),
+    };
+    let darksteel_completed = darksteel_first_runner
+        .act(GameAction::ChooseReplacement {
+            index: darksteel_index,
+        })
+        .expect("Darksteel Colossus should replace its own sacrifice");
+    assert_eq!(
+        darksteel_first_runner.state().objects[&darksteel].zone,
+        Zone::Library,
+        "choosing Darksteel Colossus first must use its library redirect"
+    );
+    assert!(
+        darksteel_completed.events.iter().any(
+            |event| matches!(event, GameEvent::SpellCast { object_id, .. } if *object_id == village_rites)
+        ),
+        "the symmetric redirect must still complete Village Rites exactly once"
+    );
+}
+
+fn count_two_sacrifice_activation_witness(
+    with_departure_observer: bool,
+) -> (
+    GameRunner,
+    engine::types::identifiers::ObjectId,
+    engine::types::identifiers::ObjectId,
+    engine::types::identifiers::ObjectId,
+) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Count-Two Sacrifice Activation Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+                TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                2,
+            ))),
+        )
+        .id();
+    let first = scenario
+        .add_creature(P0, "First Count-Two Sacrifice Witness", 1, 1)
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second Count-Two Sacrifice Witness", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let mut runner = scenario.build();
+    if with_departure_observer {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&first)
+            .expect("the first selected creature exists before the sacrifice")
+            .trigger_definitions
+            .push(
+                TriggerDefinition::new(TriggerMode::ChangesZone)
+                    .valid_card(TargetFilter::SelfRef)
+                    .origin(Zone::Battlefield)
+                    .destination(Zone::Graveyard)
+                    .trigger_zones(vec![Zone::Battlefield])
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Spell,
+                        Effect::GainLife {
+                            amount: QuantityExpr::Fixed { value: 1 },
+                            player: TargetFilter::Controller,
+                        },
+                    )),
+            );
+    }
+    (runner, source, first, second)
+}
+
+#[test]
+fn count_two_sacrifice_cost_resumes_at_second_object_and_activates_once() {
+    let (mut runner, source, first, second) = count_two_sacrifice_activation_witness(false);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("begin the count-two sacrifice activation");
+
+    let initial = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("the second sacrifice should reach its replacement pipeline");
+    assert_eq!(runner.state().objects[&first].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Battlefield);
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::SacrificeForCost {
+            chosen,
+            paused_at_index: 1,
+            ..
+        }) if chosen == &vec![first, second]
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("deliver the second selected sacrifice");
+    assert_ne!(runner.state().objects[&second].zone, Zone::Battlefield);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(matches!(resumed.waiting_for, WaitingFor::Priority { .. }));
+
+    let events = initial.events.iter().chain(resumed.events.iter());
+    assert_eq!(
+        events
+            .clone()
+            .filter(|event| matches!(event, GameEvent::PermanentSacrificed { object_id, .. } if *object_id == first))
+            .count(),
+        1,
+        "the resume must not replay the first selected sacrifice"
+    );
+    assert_eq!(
+        events
+            .clone()
+            .filter(|event| matches!(event, GameEvent::PermanentSacrificed { object_id, .. } if *object_id == second))
+            .count(),
+        1,
+        "the paused second sacrifice must complete exactly once"
+    );
+    assert_eq!(
+        events
+            .filter(|event| matches!(event, GameEvent::AbilityActivated { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "the selected activation cost is removed once and the activation proceeds once"
+    );
+}
+
+#[test]
+fn paused_sacrifice_cost_stamps_cross_action_departures_and_collects_dies_once() {
+    let (mut runner, source, first, second) = count_two_sacrifice_activation_witness(true);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("begin the observed count-two sacrifice activation");
+    let initial = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("the second sacrifice pauses after the first dies");
+    assert!(matches!(
+        initial.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the replacement completion must settle the complete sacrifice group");
+    assert!(resumed.events.iter().any(|event| matches!(
+        event,
+        GameEvent::ZoneChanged { object_id, record, .. }
+            if *object_id == second && record.co_departed == vec![first]
+    )));
+    for (object_id, other) in [(first, second), (second, first)] {
+        assert!(
+            runner.state().zone_changes_this_turn.iter().any(|record| {
+                record.object_id == object_id
+                    && record.from_zone == Some(Zone::Battlefield)
+                    && record.co_departed == vec![other]
+            }),
+            "the authoritative LKI ledger must retain the complete co-departure group"
+        );
+    }
+    assert_eq!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .filter(|entry| matches!(
+                entry.kind,
+                StackEntryKind::TriggeredAbility { source_id, .. } if source_id == first
+            ))
+            .count(),
+        1,
+        "the deferred first departure trigger is collected once after the full group is stamped"
+    );
+}
+
+#[test]
+fn self_sacrifice_mana_cost_waits_for_replacement_before_producing_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Self-Sacrifice Mana Replacement Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+                TargetFilter::SelfRef,
+                1,
+            ))),
+        )
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let mut runner = scenario.build();
+
+    let initial = runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("the self-sacrifice mana ability reaches its replacement choice");
+    assert!(matches!(
+        initial.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        0,
+        "mana must not be produced before the sacrifice cost finishes"
+    );
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the replacement completion resumes the mana cursor");
+    assert_ne!(runner.state().objects[&source].zone, Zone::Battlefield);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1
+    );
+    assert_eq!(
+        initial
+            .events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "the resumed self-sacrifice cost produces mana exactly once"
+    );
+}
+
+#[test]
+fn selected_sacrifice_mana_cost_resumes_without_repaying_its_prefix() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Selected-Sacrifice Mana Replacement Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+                TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                2,
+            ))),
+        )
+        .id();
+    let first = scenario
+        .add_creature(P0, "First Selected-Sacrifice Mana Witness", 1, 1)
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second Selected-Sacrifice Mana Witness", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let mut runner = scenario.build();
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("begin the selected-sacrifice mana ability");
+    let initial = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("the second selected mana sacrifice reaches its replacement choice");
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::ManaAbilityPayment { cursor, .. })
+            if cursor.next_sacrificed == 2
+                && cursor.selected_sacrifice_remaining.as_deref() == Some(&[])
+    ));
+    assert_eq!(runner.state().objects[&first].zone, Zone::Graveyard);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        0,
+        "the mana ability cannot produce its output before every selected sacrifice settles"
+    );
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("resuming the selected sacrifice cursor produces mana");
+    assert_ne!(runner.state().objects[&second].zone, Zone::Battlefield);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1
+    );
+    let events = initial.events.iter().chain(resumed.events.iter());
+    assert_eq!(
+        events
+            .clone()
+            .filter(|event| matches!(event, GameEvent::PermanentSacrificed { object_id, .. } if *object_id == first))
+            .count(),
+        1,
+        "the cursor must not re-pay the first selected sacrifice"
+    );
+    assert_eq!(
+        events
+            .filter(|event| matches!(event, GameEvent::ManaAdded { source_id, .. } if *source_id == source))
+            .count(),
+        1,
+        "the selected sacrifice cursor settles its cost events and produces mana once"
+    );
+}
+
+#[test]
+fn mandatory_single_sacrifice_redirect_completes_without_a_pause() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Mandatory Single Sacrifice Redirect Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+                TargetFilter::SelfRef,
+                1,
+            ))),
+        )
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .id();
+    let mut runner = scenario.build();
+
+    let result = runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("the unambiguous sacrifice redirect must resolve synchronously");
+    assert!(matches!(result.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().objects[&source].zone, Zone::Exile);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(engine::types::mana::ManaType::Green),
+        1
+    );
 }
 
 #[test]


### PR DESCRIPTION
handle_sacrifice_for_cost discarded SacrificeOutcome, so a cost sacrifice
whose battlefield->graveyard move needed a CR 616.1 replacement-ordering
choice was silently skipped: the spell went on the stack and priority was
granted while the permanent stayed on the battlefield and the choice sat
stranded in pending_replacement. Runtime-witnessed with real pool cards
(Village Rites + Darksteel Colossus + Rest in Peace: two mandatory
graveyard redirects make ordering material).

Design (per the #153 census + lead rulings):
- New PendingCostMoveResume::SacrificeForCost typed cost root: boxed
  PendingCast, full chosen vector, paused_at_index program counter
  (ManaAbilityCostCursor precedent), typed PendingSacrificeCostCompletion
  (SelectedNonSelf | SelfRef), deferred_cost_events, and
  departure_record_indices. Parked by handle_sacrifice_for_cost (selected
  costs) and pay_additional_cost_with_source (automatic SelfRef costs).
- Terminal epilogue runs exactly once after the last selected object
  settles: CR 603.10a co-departure stamping over the FULL chosen set into
  the deferred event copies, the current action's cost-event slice, and
  the persisted zone_changes_this_turn records (cross-action LKI), then
  exactly-once trigger settlement over both actions' event spans with
  current-action occurrences claimed against re-collection, then
  activation-cost component removal and finish_pending_cost_or_cast.
- Mana-ability sacrifice costs (self + selected) move onto
  ManaAbilityCostCursor with a selected_sacrifice_remaining remainder,
  pausing via pause_mana_ability_cost_payment before any mana production;
  the legacy fallback paths now fail loud instead of silently dropping.
- Shared drain helper drain_pending_cost_move_resume(state, events,
  CostMoveDrainBoundary) replaces the 3 sites x 5 variants of sequential
  guarded dispatch (engine_replacement.rs delivered + prevented arms,
  engine.rs priority boundary). Foretell drains only at the prevented
  boundary (delivered Foretell completes early at its delivery tail);
  the priority boundary drains only Delve/mana roots after ordinary
  continuations.

Evidence: W1 real-card witness watched red pre-fix (failed CR 616.1
assertion at cost_zone_pipeline.rs); mutation probe on
mark_simultaneous_departure_records redded the cross-action LKI witness
and was restored to a byte-identical file (sha256 12cbd4e0...); 54/54
cost_zone_pipeline + 7/7 delve integration tests green; visibility lib
tests green. Ward payment sites and resolution/debug sacrifice sites are
tracked follow-ups (#162/#163); casting_costs deferred-commit stays
fail-loud by ruling.
