### PR TITLE
fix(parser): parse Minimus Containment's Treasure grant + ability wipe (#6000)

### DIFF
--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -17821,6 +17821,60 @@ fn imprisoned_in_the_moon_becomes_colorless_land_with_granted_mana_ability() {
     }
 }
 
+// CR 205.1a + CR 613.1f (issue #6000): Minimus Containment — the sibling of
+// Imprisoned in the Moon whose grant is NOT prefixed "colorless" and whose strip
+// clause reads "and it loses all other abilities" (no "card types and"). It must
+// still emit the full type change + Treasure subtype + RemoveAllAbilities +
+// GrantAbility, but WITHOUT a SetColor (Minimus never recolors the permanent).
+#[test]
+fn minimus_containment_becomes_treasure_artifact_with_granted_mana_ability() {
+    let def = parse_static_line(
+        "Enchanted permanent is a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other abilities.",
+    )
+    .unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let mods = &def.modifications;
+    assert!(
+        mods.contains(&ContinuousModification::SetCardTypes {
+            core_types: vec![crate::types::card_type::CoreType::Artifact],
+        }),
+        "must become an artifact: {mods:?}"
+    );
+    assert!(
+        mods.iter().any(|m| matches!(
+            m,
+            ContinuousModification::AddSubtype { subtype } if subtype == "Treasure"
+        )),
+        "must gain the Treasure subtype: {mods:?}"
+    );
+    // The permanent is NOT recolored — Minimus never says "colorless".
+    assert!(
+        !mods
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::SetColor { .. })),
+        "must NOT emit SetColor (Minimus does not recolor the permanent): {mods:?}"
+    );
+    let remove_idx = mods
+        .iter()
+        .position(|m| matches!(m, ContinuousModification::RemoveAllAbilities))
+        .expect("must strip the permanent's own abilities");
+    let grant_idx = mods
+        .iter()
+        .position(|m| matches!(m, ContinuousModification::GrantAbility { .. }))
+        .expect("must grant the quoted mana ability");
+    assert!(
+        remove_idx < grant_idx,
+        "RemoveAllAbilities must precede GrantAbility so the granted ability survives: {mods:?}"
+    );
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => assert!(
+            tf.properties.contains(&FilterProp::EnchantedBy),
+            "affected must be the enchanted permanent: {tf:?}"
+        ),
+        other => panic!("expected Typed EnchantedBy filter, got {other:?}"),
+    }
+}
+
 // CR 205.1a + CR 702.6: Bram, Baguette Brawler / Bludgeon Brawl — "Each
 // <subject> is an Equipment with equip {N} and "Equipped creature gets +N/+M.""
 // Each matching permanent gains the Equipment subtype (replacing its artifact

--- a/crates/engine/src/parser/oracle_static/type_change.rs
+++ b/crates/engine/src/parser/oracle_static/type_change.rs
@@ -676,7 +676,13 @@ pub(crate) fn parse_enchanted_becomes_type_with_ability(
     let (r, _) = alt((tag::<_, _, OracleError<'_>>(" is a "), tag(" is an ")))
         .parse(r)
         .ok()?;
-    let (r, _) = tag::<_, _, OracleError<'_>>("colorless ").parse(r).ok()?;
+    // CR 105.2: "colorless" is optional. Minimus Containment ("is a Treasure
+    // artifact with ...") sets a card type without recoloring; Imprisoned in the
+    // Moon / Sugar Coat ("colorless land" / "colorless Food artifact") also make
+    // the permanent colorless. Only emit `SetColor([])` when it is stated.
+    let (r, colorless) = opt(tag::<_, _, OracleError<'_>>("colorless "))
+        .parse(r)
+        .ok()?;
     // CR 205.3: optional subtype(s) preceding the core card type — Sugar Coat
     // ("colorless Food artifact ...") vs Imprisoned ("colorless land ...").
     // `parse_subtype` is case-insensitive (runs on the lowered slice) and a core
@@ -717,20 +723,42 @@ pub(crate) fn parse_enchanted_becomes_type_with_ability(
         .parse(after_quote)
         .ok()?;
     let (after_quote, _) = tag::<_, _, OracleError<'_>>("\"").parse(after_quote).ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>("and loses all other card types and abilities")
+    // Trailing ability-strip clause — two attested shapes, composed from optional
+    // spans rather than enumerated:
+    //   "and loses all other card types and abilities" (Imprisoned in the Moon)
+    //   "and it loses all other abilities"              (Minimus Containment)
+    // The "it" subject and the "card types and " span are each optional; the
+    // effect is a full Layer-6 ability wipe either way (the `SetCardTypes` above
+    // already replaced the card types, so an unstated "card types" phrase loses
+    // nothing). A comma may sit between the closing quote and the clause.
+    let after_strip = opt(tag::<_, _, OracleError<'_>>(","))
         .parse(after_quote.trim_start())
+        .ok()?
+        .0
+        .trim_start();
+    let (rest, _) = tag::<_, _, OracleError<'_>>("and ")
+        .parse(after_strip)
         .ok()?;
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>("it ")).parse(rest).ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("loses all other ")
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>("card types and "))
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("abilities").parse(rest).ok()?;
     let (rest, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(rest).ok()?;
     if !rest.trim().is_empty() {
         return None;
     }
 
-    let mut modifications = vec![
-        ContinuousModification::SetCardTypes {
-            core_types: vec![core_type],
-        },
-        ContinuousModification::SetColor { colors: Vec::new() },
-    ];
+    let mut modifications = vec![ContinuousModification::SetCardTypes {
+        core_types: vec![core_type],
+    }];
+    // CR 105.2 (Layer 5): only recolor to colorless when the text states it.
+    if colorless.is_some() {
+        modifications.push(ContinuousModification::SetColor { colors: Vec::new() });
+    }
     // CR 205.1a (Layer 4): grant each parsed subtype (Sugar Coat → Food). Placed
     // with the other type-identity modifications, before the Layer-6 ability wipe.
     // Setting a subtype REPLACES the object's existing subtypes from the same

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -892,6 +892,7 @@ mod mad_mage_lost_level_scry_runtime;
 mod mass_unsuspect_701_60a;
 mod memory_vessel_std_s25;
 mod menace_requires_two_blockers;
+mod minimus_containment_treasure_grant;
 mod modal_enters_becomes_choice;
 mod modal_mode_labels;
 mod molten_core_maestro_2384;

--- a/crates/engine/tests/integration/minimus_containment_treasure_grant.rs
+++ b/crates/engine/tests/integration/minimus_containment_treasure_grant.rs
@@ -1,0 +1,113 @@
+//! Realizability for issue #6000: Minimus Containment makes the enchanted
+//! permanent a Treasure artifact that HAS "{T}, Sacrifice this artifact: Add one
+//! mana of any color" and loses its own abilities. Before the parser fix the
+//! quoted granted ability and the "loses all other abilities" clause were both
+//! dropped (only the type + Treasure subtype survived), so the enchanted
+//! permanent kept its abilities and could not make mana.
+//!
+//! This drives the production Layer engine (`evaluate_layers`) — the same path
+//! `granted_ability_self_binding.rs` uses — to prove the `type_change` static's
+//! `GrantAbility` + `RemoveAllAbilities` actually apply to the host.
+//!
+//! https://github.com/phase-rs/phase/issues/6000
+
+use std::sync::Arc;
+
+use engine::game::game_object::AttachTarget;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{ContinuousModification, Effect, StaticDefinition};
+use engine::types::card_type::CoreType;
+use engine::types::phase::Phase;
+
+const MINIMUS: &str = "Enchanted permanent is a Treasure artifact with \"{T}, Sacrifice this artifact: Add one mana of any color,\" and it loses all other abilities.";
+
+fn minimus_static() -> StaticDefinition {
+    let parsed = parse_oracle_text(
+        MINIMUS,
+        "Minimus Containment",
+        &[],
+        &["Enchantment".to_string(), "Aura".to_string()],
+        &["Aura".to_string()],
+    );
+    parsed
+        .statics
+        .into_iter()
+        .find(|s| {
+            s.modifications
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::GrantAbility { .. }))
+        })
+        .expect("Minimus must emit a GrantAbility type-change static")
+}
+
+#[test]
+fn minimus_containment_makes_host_a_treasure_with_granted_mana_ability() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Host: a creature whose ONLY ability is a non-mana "{T}: Draw a card" — so a
+    // surviving Draw effect proves the wipe failed, and the granted mana ability
+    // proves the grant landed.
+    let host = scenario
+        .add_creature_from_oracle(P0, "Studious Bear", 2, 2, "{T}: Draw a card.")
+        .id();
+    let aura = scenario.add_creature(P0, "Minimus Containment", 0, 0).id();
+
+    let grant = minimus_static();
+    let mut runner = scenario.build();
+    {
+        let st = runner.state_mut();
+        let aura_obj = st.objects.get_mut(&aura).unwrap();
+        aura_obj.card_types.core_types = vec![CoreType::Enchantment];
+        aura_obj.card_types.subtypes = vec!["Aura".to_string()];
+        aura_obj.base_card_types = aura_obj.card_types.clone();
+        aura_obj.power = None;
+        aura_obj.toughness = None;
+        aura_obj.base_power = None;
+        aura_obj.base_toughness = None;
+        aura_obj.attached_to = Some(AttachTarget::Object(host));
+        aura_obj.static_definitions.push(grant.clone());
+        Arc::make_mut(&mut aura_obj.base_static_definitions).push(grant);
+        st.layers_dirty.mark_full();
+    }
+    evaluate_layers(runner.state_mut());
+
+    let host_obj = &runner.state().objects[&host];
+
+    // Type change (CR 205.1a, Layer 4): becomes an Artifact, is no longer a Creature.
+    assert!(
+        host_obj.card_types.core_types.contains(&CoreType::Artifact),
+        "host must become an Artifact, got {:?}",
+        host_obj.card_types.core_types
+    );
+    assert!(
+        !host_obj.card_types.core_types.contains(&CoreType::Creature),
+        "host must lose its Creature type (SetCardTypes replaces), got {:?}",
+        host_obj.card_types.core_types
+    );
+    assert!(
+        host_obj.card_types.subtypes.iter().any(|s| s == "Treasure"),
+        "host must gain the Treasure subtype, got {:?}",
+        host_obj.card_types.subtypes
+    );
+
+    // GrantAbility (Layer 6): the host carries the granted mana ability…
+    assert!(
+        host_obj
+            .abilities
+            .iter()
+            .any(|a| matches!(*a.effect, Effect::Mana { .. })),
+        "host must carry the granted Treasure mana ability after the wipe, got {:?}",
+        host_obj.abilities
+    );
+    // …and RemoveAllAbilities wiped its original non-mana "{T}: Draw a card".
+    assert!(
+        !host_obj
+            .abilities
+            .iter()
+            .any(|a| matches!(*a.effect, Effect::Draw { .. })),
+        "host must lose its own \"{{T}}: Draw a card\" ability, got {:?}",
+        host_obj.abilities
+    );
+}


### PR DESCRIPTION
Closes #6000

## Summary

`Enchanted permanent is a Treasure artifact with "{T}, Sacrifice this artifact: Add one mana of any color," and it loses all other abilities.` (Minimus Containment) parsed to only `SetCardTypes[Artifact]` + `AddSubtype[Treasure]` — the granted Treasure mana ability **and** the "loses all other abilities" clause were both dropped, so an enchanted creature became a Treasure artifact that **kept its own abilities and could not make mana**. This extends the existing `parse_enchanted_becomes_type_with_ability` handler to cover Minimus's surface variant.

## Files changed

- `crates/engine/src/parser/oracle_static/type_change.rs` — extend `parse_enchanted_becomes_type_with_ability`.
- `crates/engine/src/parser/oracle_static/tests.rs` — parser test.
- `crates/engine/tests/integration/minimus_containment_treasure_grant.rs` — realizability test (`evaluate_layers`).
- `crates/engine/tests/integration/main.rs` — mod line.

## CR references

- CR 205.1a — a type-changing effect replaces the object's card types / subtypes (Layer 4); `SetCardTypes[Artifact]` + `RemoveAllSubtypes` + `AddSubtype[Treasure]`.
- CR 105.2 — an object's color; `SetColor([])` is emitted only when the text says "colorless" (Imprisoned/Sugar Coat), never for Minimus which does not recolor.
- CR 613.1f — Layer 6 ability-adding/removing; `RemoveAllAbilities` before `GrantAbility` so the granted mana ability survives the wipe.

## Implementation method (required)

Method: not-applicable — authored directly against the `oracle-parser` skill. Pure parser AST-shape change (extends an existing handler); no new variant, no new runtime, no card-data regeneration.

## Track

Developer

## LLM

Model: claude-opus-4-8
Thinking: high

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Verification below is for the current committed head (`5eb007118`).
- [x] Final review below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Results on head `5eb007118`:

- `cargo test -p engine --lib parser::oracle_static::tests` — **ok. 1107 passed; 0 failed** (new Minimus test + Imprisoned/Sugar Coat regression-pinned).
- `cargo test -p engine --lib parser` — **ok. 8247 passed; 0 failed** (snapshot tests unaffected).
- `cargo test -p engine --test integration minimus_containment` — **ok. 1 passed** (realizability via `evaluate_layers`).
- `CARGO_INCREMENTAL=0 cargo clippy -p engine --all-targets --features proptest -- -D warnings` — **Finished, 0 warnings (exit 0)**.
- `cargo fmt --all` — clean.
- `./scripts/check-parser-combinators.sh` — see `## Gate A`.

### Parse diff (Minimus Containment)

Before — the grant and the ability-strip are dropped; the host keeps its abilities and makes no mana:

```
modifications: [ SetCardTypes[Artifact], AddSubtype[Treasure] ]
```

After — full type change + wipe + granted mana ability:

```
modifications: [
  SetCardTypes[Artifact], RemoveAllSubtypes{Artifact}, AddSubtype[Treasure],
  RemoveAllAbilities,
  GrantAbility{ Composite{Tap, Sacrifice(SelfRef)} -> Mana(AnyOneColor), is_mana_ability },
]
```

No `SetColor` — Minimus never recolors the permanent (Imprisoned/Sugar Coat still emit `SetColor([])`).

### Realizability (integration test)

Applying the parsed static through the production Layer engine (`evaluate_layers`) makes the enchanted host an **Artifact** (no longer a Creature) with the **Treasure** subtype, carrying the granted **`Effect::Mana`** ability, and having **lost** its own `{T}: Draw a card` — proving the `GrantAbility` + `RemoveAllAbilities` actually apply. The composite `{T}, Sacrifice` cost's activate/resolve pipeline is already proven by `granted_ability_self_binding.rs` (Deconstruction Hammer).

## Gate A

```
Gate A PASS head=5eb007118227abb6d6b58f24b8e735c55b55622e base=3205d4bb4eac0b725724fec78e5b1cd871743bac
```

## Anchored on

- `crates/engine/src/parser/oracle_static/type_change.rs:664` (`parse_enchanted_becomes_type_with_ability`) — the exact handler being extended; it already emits `SetCardTypes` + `RemoveAllAbilities` + `GrantAbility` for Imprisoned in the Moon / Sugar Coat. The change composes the "colorless" prefix and the trailing strip clause from optional nom spans instead of requiring one fixed shape.
- `crates/engine/src/parser/oracle_static/keyword_grant.rs:1790` (`parse_quoted_ability_modifications`) — the shared quoted-ability authority reused unchanged; it already parses Minimus's composite `{T}, Sacrifice this artifact: Add one mana of any color` into a `GrantAbility`.
- `crates/engine/tests/integration/granted_ability_self_binding.rs` (`equip_and_layer` / Deconstruction Hammer) — the `evaluate_layers` grant-realization test pattern the new realizability test mirrors.

## Final review

Self-review against the review-impl lenses.

- **No regression:** the two attested existing cards, Imprisoned in the Moon ("colorless land … and loses all other card types and abilities") and Sugar Coat ("colorless Food artifact …"), still parse to the identical mods including `SetColor([])` — regression-pinned. 8247 parser tests (incl. snapshots) pass.
- **Faithfulness:** the optional-span trailing clause (`"and " opt("it ") "loses all other " opt("card types and ") "abilities"`) accepts exactly the two attested shapes; the `SetColor` is now gated on the presence of "colorless", so Minimus keeps the host's color (correct — Minimus never recolors) while the colorless cards are unchanged. The comma inside Minimus's closing quote is captured by the existing `take_until("\"")`, and a comma outside is tolerated.
- **Realizability verified end-to-end** (integration test), not just the parse — the granted mana ability lands on the host and the host's own ability is wiped.
- **Combinator purity:** the extension is nom `tag`/`opt` throughout; Gate A passes.

## Claimed parse impact

- Minimus Containment
- the general "enchanted `<permanent>` is a[n] `[subtype]` `<type>` with '`<ability>`' and [it] loses all other abilities" variant (no "colorless" prefix required)

The CI `coverage-parse-diff` sticky enumerates the full affected set for the current head.

## Validation Failures

None.

## CI Failures

None.
