### PR TITLE
test(engine): pin Learn's no-lesson-available settle path

### DIFF
--- a/crates/engine/src/game/effects/learn.rs
+++ b/crates/engine/src/game/effects/learn.rs
@@ -1,14 +1,16 @@
-use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::types::ability::{
+    Effect, EffectError, EffectKind, OutsideGameSourcePool, QuantityExpr, ResolvedAbility,
+    TargetFilter, TypeFilter, TypedFilter,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
 
 /// CR 701.48a: Learn — "You may discard a card. If you do, draw a card.
 /// If you didn't discard a card, you may reveal a Lesson card you own from
 /// outside the game and put it into your hand."
-///
-/// Current implementation supports rummage (discard→draw) and skip.
-/// Lesson/sideboard access is deferred until sideboard infrastructure exists.
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,
@@ -26,7 +28,11 @@ pub fn resolve(
         .unwrap_or_default();
 
     if hand_cards.is_empty() {
-        // No cards to discard and no Lesson access yet — auto-skip.
+        // CR 701.48a: with no card available to discard, the "if you didn't
+        // discard a card" branch applies unconditionally — offer the Lesson
+        // search from outside the game.
+        let lesson_search = lesson_search_ability(ability.source_id, player);
+        let _ = super::resolve_ability_chain(state, &lesson_search, events, 0);
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::Learn,
             source_id: ability.source_id,
@@ -38,6 +44,27 @@ pub fn resolve(
     // Present the choice: rummage one card or skip.
     state.waiting_for = WaitingFor::LearnChoice { player, hand_cards };
     Ok(())
+}
+
+/// CR 701.48a: "reveal a Lesson card you own from outside the game and put it
+/// into your hand" — the "if you didn't discard a card" branch, built as a
+/// `SearchOutsideGame` ability so it reuses the same sideboard-access
+/// machinery as Wish-class effects.
+pub(crate) fn lesson_search_ability(source_id: ObjectId, controller: PlayerId) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::SearchOutsideGame {
+            filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype(
+                "Lesson".to_string(),
+            ))),
+            count: QuantityExpr::up_to(QuantityExpr::Fixed { value: 1 }),
+            reveal: true,
+            destination: Zone::Hand,
+            source_pool: OutsideGameSourcePool::Sideboard,
+        },
+        vec![],
+        source_id,
+        controller,
+    )
 }
 
 #[cfg(test)]

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1675,7 +1675,20 @@ pub(super) fn handle_resolution_choice(
                     );
                     let _ = effects::resolve_ability_chain(state, &draw_ability, events, 0);
                 }
-                LearnOption::Skip => {}
+                LearnOption::Skip => {
+                    // CR 701.48a: "if you didn't discard a card" — offer the
+                    // Lesson search from outside the game.
+                    let lesson_search = effects::learn::lesson_search_ability(ObjectId(0), player);
+                    let _ = effects::resolve_ability_chain(state, &lesson_search, events, 0);
+                    if matches!(state.waiting_for, WaitingFor::OutsideGameChoice { .. }) {
+                        events.push(GameEvent::EffectResolved {
+                            kind: EffectKind::Learn,
+                            source_id: ObjectId(0),
+                            subject: None,
+                        });
+                        return Ok(action_result_outcome(events, state.waiting_for.clone()));
+                    }
+                }
             }
 
             events.push(GameEvent::EffectResolved {

--- a/crates/engine/tests/integration/eyetwitch_learn_decline_lesson.rs
+++ b/crates/engine/tests/integration/eyetwitch_learn_decline_lesson.rs
@@ -272,3 +272,54 @@ fn eyetwitch_learn_rummage_does_not_offer_lesson() {
         "rummage draws the seeded library card after discarding"
     );
 }
+
+/// Declining to discard with no Lesson card anywhere in the sideboard must
+/// still settle the ability (priority returns) instead of leaving Learn
+/// stuck waiting on an offer that will never be made.
+#[test]
+fn eyetwitch_learn_decline_with_no_lesson_in_sideboard_settles_priority() {
+    let mut state = state_with_sideboard(vec![DeckEntry {
+        card: face("Lightning Bolt", CoreType::Instant, &[]),
+        count: 1,
+    }]);
+    create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Forest".to_string(),
+        Zone::Hand,
+    );
+
+    let ability = eyetwitch_learn_ability(&mut state);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    let player = match &state.waiting_for {
+        WaitingFor::LearnChoice { player, .. } => *player,
+        other => panic!("expected LearnChoice, got {other:?}"),
+    };
+
+    apply(
+        &mut state,
+        player,
+        GameAction::LearnDecision {
+            choice: LearnOption::Skip,
+        },
+    )
+    .expect("declining to discard should be a legal Learn decision");
+
+    assert!(
+        !matches!(state.waiting_for, WaitingFor::OutsideGameChoice { .. }),
+        "no Lesson card is available to offer"
+    );
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "resolution must settle back to priority instead of stalling, got {:?}",
+        state.waiting_for
+    );
+    assert_eq!(
+        hand_names(&state, player),
+        vec!["Forest"],
+        "the undiscarded card stays in hand and nothing is added"
+    );
+}

--- a/crates/engine/tests/integration/eyetwitch_learn_decline_lesson.rs
+++ b/crates/engine/tests/integration/eyetwitch_learn_decline_lesson.rs
@@ -1,0 +1,274 @@
+//! Integration tests for issue #6015 — Learn's "if you didn't discard a
+//! card" branch was a no-op: declining to discard (or having no card to
+//! discard) dropped the Lesson-search offer entirely instead of letting the
+//! player reveal a Lesson card from their sideboard and put it into hand.
+//!
+//! Oracle text (Eyetwitch, verified via Scryfall):
+//!   Flying
+//!   When this creature dies, learn. (You may reveal a Lesson card you own
+//!   from outside the game and put it into your hand, or discard a card to
+//!   draw a card.)
+//!
+//! CR 701.48a: "Learn" means "You may discard a card. If you do, draw a
+//! card. If you didn't discard a card, you may reveal a Lesson card you own
+//! from outside the game and put it into your hand."
+//!
+//! These tests drive the real resolution pipeline: Eyetwitch's dies trigger
+//! is parsed from its actual Oracle text into a `ResolvedAbility` and
+//! resolved via `resolve_ability_chain`; the Learn/outside-game decisions are
+//! submitted as `GameAction`s through `apply`, mirroring the pattern used by
+//! `braids_arisen_nightmare_decline.rs`.
+
+use std::sync::Arc;
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::deck_loading::DeckEntry;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::engine::apply;
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::actions::{GameAction, LearnOption, OutsideGameSelection};
+use engine::types::card::CardFace;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::format::FormatConfig;
+use engine::types::game_state::{GameState, PlayerDeckPool, WaitingFor};
+use engine::types::identifiers::CardId;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const EYETWITCH_ORACLE: &str = "Flying\nWhen this creature dies, learn.";
+
+fn face(name: &str, core_type: CoreType, subtypes: &[&str]) -> CardFace {
+    CardFace {
+        name: name.to_string(),
+        card_type: CardType {
+            core_types: vec![core_type],
+            subtypes: subtypes.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn state_with_sideboard(sideboard: Vec<DeckEntry>) -> GameState {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.deck_pools = vec![PlayerDeckPool {
+        player: PlayerId(0),
+        current_sideboard: Arc::new(sideboard),
+        ..Default::default()
+    }];
+    state
+}
+
+/// Build Eyetwitch's "dies" trigger execute chain as a `ResolvedAbility`.
+fn eyetwitch_learn_ability(state: &mut GameState) -> engine::types::ability::ResolvedAbility {
+    let source = create_object(
+        state,
+        CardId(100),
+        PlayerId(0),
+        "Eyetwitch".to_string(),
+        Zone::Graveyard,
+    );
+    let parsed = parse_oracle_text(
+        EYETWITCH_ORACLE,
+        "Eyetwitch",
+        &[],
+        &["Creature".to_string()],
+        &["Eye".to_string(), "Bat".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("Eyetwitch has a dies trigger");
+    let execute = trigger
+        .execute
+        .as_deref()
+        .expect("Eyetwitch's dies trigger has an execute chain");
+    build_resolved_from_def(execute, source, PlayerId(0))
+}
+
+fn hand_names(state: &GameState, player: PlayerId) -> Vec<String> {
+    state.players[player.0 as usize]
+        .hand
+        .iter()
+        .filter_map(|id| state.objects.get(id).map(|obj| obj.name.clone()))
+        .collect()
+}
+
+/// Declining to discard must offer the Lesson search — not silently no-op.
+/// Choosing the Lesson card must put it into hand from the sideboard.
+#[test]
+fn eyetwitch_learn_decline_discard_reveals_lesson_into_hand() {
+    let mut state = state_with_sideboard(vec![
+        DeckEntry {
+            card: face(
+                "Introduction to Annihilation",
+                CoreType::Sorcery,
+                &["Lesson"],
+            ),
+            count: 1,
+        },
+        DeckEntry {
+            card: face("Lightning Bolt", CoreType::Instant, &[]),
+            count: 1,
+        },
+    ]);
+    // A card in hand so the "may discard" choice is genuinely offered.
+    create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Forest".to_string(),
+        Zone::Hand,
+    );
+
+    let ability = eyetwitch_learn_ability(&mut state);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    let player = match &state.waiting_for {
+        WaitingFor::LearnChoice { player, .. } => *player,
+        other => panic!("expected LearnChoice, got {other:?}"),
+    };
+
+    apply(
+        &mut state,
+        player,
+        GameAction::LearnDecision {
+            choice: LearnOption::Skip,
+        },
+    )
+    .expect("declining to discard should be a legal Learn decision");
+
+    // The non-Lesson sideboard card must not be offered — only the Lesson.
+    match &state.waiting_for {
+        WaitingFor::OutsideGameChoice { choices, .. } => {
+            assert_eq!(
+                choices.len(),
+                1,
+                "only the Lesson card should be offered, got {choices:?}"
+            );
+            assert_eq!(choices[0].name, "Introduction to Annihilation");
+        }
+        other => panic!("declining to discard must offer the Lesson search, got {other:?}"),
+    }
+
+    apply(
+        &mut state,
+        player,
+        GameAction::ChooseOutsideGameCards {
+            selections: vec![OutsideGameSelection::Sideboard { sideboard_index: 0 }],
+        },
+    )
+    .expect("choosing the offered Lesson card should succeed");
+
+    assert_eq!(
+        hand_names(&state, player),
+        vec!["Forest", "Introduction to Annihilation"],
+        "the chosen Lesson card must join the undiscarded hand card"
+    );
+    assert_eq!(
+        state.deck_pools[0].current_sideboard[0].count, 1,
+        "the sideboard entry itself is unchanged (only usage is tracked)"
+    );
+}
+
+/// An empty hand means the player *can't* discard, so CR 701.48a's "if you
+/// didn't discard a card" branch must apply unconditionally rather than
+/// silently skipping the ability.
+#[test]
+fn eyetwitch_learn_with_empty_hand_offers_lesson_directly() {
+    let mut state = state_with_sideboard(vec![DeckEntry {
+        card: face(
+            "Introduction to Annihilation",
+            CoreType::Sorcery,
+            &["Lesson"],
+        ),
+        count: 1,
+    }]);
+
+    let ability = eyetwitch_learn_ability(&mut state);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    match &state.waiting_for {
+        WaitingFor::OutsideGameChoice { choices, .. } => {
+            assert_eq!(choices.len(), 1);
+            assert_eq!(choices[0].name, "Introduction to Annihilation");
+        }
+        other => panic!("an empty hand must go straight to the Lesson search, got {other:?}"),
+    }
+
+    apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::ChooseOutsideGameCards {
+            selections: vec![OutsideGameSelection::Sideboard { sideboard_index: 0 }],
+        },
+    )
+    .expect("choosing the offered Lesson card should succeed");
+
+    assert_eq!(
+        hand_names(&state, PlayerId(0)),
+        vec!["Introduction to Annihilation"]
+    );
+}
+
+/// Rummage (discard→draw) must remain unaffected by the Lesson-search fix —
+/// no Lesson prompt should appear when the player actually discarded.
+#[test]
+fn eyetwitch_learn_rummage_does_not_offer_lesson() {
+    let mut state = state_with_sideboard(vec![DeckEntry {
+        card: face(
+            "Introduction to Annihilation",
+            CoreType::Sorcery,
+            &["Lesson"],
+        ),
+        count: 1,
+    }]);
+    let discard_target = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Forest".to_string(),
+        Zone::Hand,
+    );
+    let library_card = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(0),
+        "Island".to_string(),
+        Zone::Library,
+    );
+    state.players[0].library.push_back(library_card);
+
+    let ability = eyetwitch_learn_ability(&mut state);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    let player = match &state.waiting_for {
+        WaitingFor::LearnChoice { player, .. } => *player,
+        other => panic!("expected LearnChoice, got {other:?}"),
+    };
+
+    apply(
+        &mut state,
+        player,
+        GameAction::LearnDecision {
+            choice: LearnOption::Rummage {
+                card_id: discard_target,
+            },
+        },
+    )
+    .expect("rummaging should be a legal Learn decision");
+
+    assert!(
+        !matches!(state.waiting_for, WaitingFor::OutsideGameChoice { .. }),
+        "having discarded a card must not offer the Lesson search"
+    );
+    assert_eq!(
+        hand_names(&state, player),
+        vec!["Island"],
+        "rummage draws the seeded library card after discarding"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -128,6 +128,7 @@ mod exchange_life_totals_cards;
 mod exhibition_tidecaller_target_player_mill;
 mod export_runtime_canaries;
 mod exquisite_blood_routing;
+mod eyetwitch_learn_decline_lesson;
 mod fact_or_fiction_pile_separation;
 mod fateful_handoff_target_mana_value_draw;
 mod festival_of_embers_graveyard_additional_cost;


### PR DESCRIPTION
## Summary

Learn's "if you didn't discard a card" branch was a no-op: declining the
discard (or having an empty hand, which forces that branch since there's
nothing to discard) did nothing instead of letting the player reveal a
Lesson card from their sideboard and put it into hand.

The engine already has the exact machinery this needs — Wish-class effects
(Burning Wish, Karn's -2, etc.) use `Effect::SearchOutsideGame` to offer
matching cards from a player's registered sideboard through
`WaitingFor::OutsideGameChoice`. Learn's decline branch now builds that
same ability scoped to the `Lesson` subtype (up to 1, revealed, destination
hand) and resolves it through the existing pipeline, so it gets
sideboard-availability tracking, AI legal-action generation, and
opponent-visibility redaction for free instead of reimplementing any of it.

## Files changed

- `crates/engine/src/game/effects/learn.rs` — new `lesson_search_ability`
  helper building the `SearchOutsideGame` ability for the Lesson branch;
  the empty-hand path now runs it instead of silently no-op'ing.
- `crates/engine/src/game/engine_resolution_choices.rs` — `LearnOption::Skip`
  now runs the same Lesson search instead of `{}`.
- `crates/engine/tests/integration/eyetwitch_learn_decline_lesson.rs` (new)
  — runtime regression driving Eyetwitch's real "when this creature dies,
  learn" trigger through parse → resolve → apply.
- `crates/engine/tests/integration/main.rs` — registers the new test module.

## CR references

- CR 701.48a: `Learn` means "You may discard a card. If you do, draw a
  card. If you didn't discard a card, you may reveal a Lesson card you own
  from outside the game and put it into your hand." (verified via
  `grep -n "^701.48" docs/MagicCompRules.txt`)
- CR 400.11a / CR 406.3: sideboard-as-outside-the-game pool and its
  candidate-filtering rules, already implemented by `search_outside_game.rs`
  and reused unchanged here.

## Implementation method

Method: manual (traced `search_outside_game.rs` / the Burning Wish test
fixture as the analogous "Wish-class" building block before writing the
fix; no `/engine-implementer` run for this one).

## Track

Developer

## LLM

Model: Claude (Sonnet 5) / Thinking: standard / Tier: N/A

## Verification

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p engine --all-targets -- -D warnings` — clean
- [x] `cargo test -p engine --test integration eyetwitch_learn` — 4 passed
- [x] `cargo test -p engine --lib -- learn:: search_outside_game::` — 13 passed (no regressions)
- [x] Revert check: reverted both production files, reran the new tests —
      2 of 4 failed exactly as expected (`declining to discard must offer
      the Lesson search, got Priority { .. }` / same for the empty-hand
      case); the rummage and no-lesson-available tests still passed
      unaffected. Restored the fix and reran green.

```
running 4 tests
test eyetwitch_learn_decline_lesson::eyetwitch_learn_decline_with_no_lesson_in_sideboard_settles_priority ... ok
test eyetwitch_learn_decline_lesson::eyetwitch_learn_with_empty_hand_offers_lesson_directly ... ok
test eyetwitch_learn_decline_lesson::eyetwitch_learn_rummage_does_not_offer_lesson ... ok
test eyetwitch_learn_decline_lesson::eyetwitch_learn_decline_discard_reveals_lesson_into_hand ... ok
```

## Gate A

Gate A PASS head=c721f0dc4d5deb8a79a1a95d5ba82931abb7dadd base=3b52c67a9025cd20da8b68243667eb8cdad76060

## Anchored on

- `crates/engine/src/game/effects/search_outside_game.rs:191` —
  `put_sideboard_entry_into_game`, the same sideboard-to-hand primitive
  Wish-class effects use, now reused by Learn.
- `crates/engine/src/game/effects/search_outside_game.rs:314` (test module)
  — `wish_chain`, the existing `SearchOutsideGame` construction pattern
  `lesson_search_ability` mirrors for the Lesson filter/count/destination
  shape.

## Final review-impl PASS

Self-reviewed the diff against the review-impl checklist: correct seam
(reused `SearchOutsideGame`/`OutsideGameChoice` rather than inventing new
sideboard-access plumbing), no new bool/sibling variant introduced,
`source_id: ObjectId(0)` in the `Skip` handler matches the existing
placeholder idiom already used by the adjacent `Rummage` branch in the
same function (`WaitingFor::LearnChoice` carries no `source_id` field —
pre-existing, out of scope here) and is inert because Learn's pool is
`Sideboard`-only (never `SideboardAndFaceUpExile`, so the placeholder is
never consumed). No CI failures, no scope expansion, no validation
failures.

## Claimed parse impact

None — no parser files touched; `Effect::Learn` parsing/coverage
classification is unchanged. This is a pure runtime-resolution fix.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

Closes #6015
