### PR TITLE
refactor(engine): route collect-evidence and unless-bounce cost moves through the zone pipeline

### DIFF
--- a/crates/engine/src/game/effects/collect_evidence.rs
+++ b/crates/engine/src/game/effects/collect_evidence.rs
@@ -1,7 +1,8 @@
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
-    CollectEvidenceResume, GameState, PendingCast, PendingManaAbility, WaitingFor,
+    CollectEvidenceResume, GameState, PendingCast, PendingCostMoveResume, PendingManaAbility,
+    WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
@@ -9,6 +10,7 @@ use crate::types::zones::Zone;
 use std::collections::HashSet;
 
 use super::super::engine::EngineError;
+use super::super::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 
 fn graveyard_cards(state: &GameState, player: PlayerId) -> Vec<ObjectId> {
     state
@@ -189,15 +191,68 @@ pub(crate) fn handle_choice(
         )));
     }
 
-    for &id in chosen {
-        // Phase E tranche 2: collect-evidence exile is a COST payment
-        // (CR 701.59a) routed via `handle_choice`, which has no source object in
-        // scope (the paying spell/ability lives nested in `resume`). Migrating it
-        // needs `Cause::Cost` with the source extracted from the resume — left for
-        // the cost-payment tranche.
-        super::super::zones::move_to_zone(state, id, Zone::Exile, events);
+    move_evidence_costs(state, player, chosen.to_vec(), 0, resume.clone(), events)
+}
+
+fn cost_source_id(resume: &CollectEvidenceResume) -> ObjectId {
+    match resume {
+        CollectEvidenceResume::Casting { pending_cast, .. } => pending_cast.object_id,
+        CollectEvidenceResume::Effect { pending_ability } => pending_ability.source_id,
+        CollectEvidenceResume::ManaAbility {
+            pending_mana_ability,
+        } => pending_mana_ability.source_id,
+    }
+}
+
+/// CR 701.59a + CR 614.1 + CR 616.1: Pay the selected evidence cards through
+/// the replacement-aware cost-move pipeline. The typed root stores the exact
+/// unpaid suffix only when a player choice interrupts this action.
+fn move_evidence_costs(
+    state: &mut GameState,
+    player: PlayerId,
+    chosen: Vec<ObjectId>,
+    start_index: usize,
+    resume: CollectEvidenceResume,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let source_id = cost_source_id(&resume);
+    for index in start_index..chosen.len() {
+        match zone_pipeline::move_object(
+            state,
+            ZoneMoveRequest::cost(chosen[index], Zone::Exile, source_id),
+            events,
+        ) {
+            ZoneMoveResult::Done => {}
+            ZoneMoveResult::NeedsChoice(_) => {
+                state.pending_cost_move_resume =
+                    Some(PendingCostMoveResume::CollectEvidencePayment {
+                        player,
+                        chosen,
+                        paused_at_index: index,
+                        resume: Box::new(resume),
+                    });
+                return Ok(state.waiting_for.clone());
+            }
+            ZoneMoveResult::NeedsAuraAttachmentChoice => {
+                unreachable!(
+                    "a collect-evidence cost move to exile cannot require an Aura attachment"
+                )
+            }
+        }
     }
 
+    complete_cost_payment(state, player, chosen, resume, events)
+}
+
+/// CR 701.59a + CR 118.11: Finish collecting evidence after every selected
+/// cost move settled, including a redirected or fully substituted move.
+fn complete_cost_payment(
+    state: &mut GameState,
+    player: PlayerId,
+    chosen: Vec<ObjectId>,
+    resume: CollectEvidenceResume,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
     events.push(GameEvent::PlayerPerformedAction {
         player_id: player,
         action: PlayerActionKind::CollectEvidence,
@@ -208,9 +263,9 @@ pub(crate) fn handle_choice(
             pending_cast,
             source,
         } => {
-            let mut pending = pending_cast.as_ref().clone();
+            let mut pending = *pending_cast;
             pending.ability.context.additional_cost_paid = true;
-            pending.additional_cost_source = *source;
+            pending.additional_cost_source = source;
             // CR 602.2b: An ACTIVATED ability paying collect evidence as its cost
             // (Kylox's Voltstrider) goes on the stack via the activation
             // authority, not the spell-cast path. The exile loop above already
@@ -243,22 +298,40 @@ pub(crate) fn handle_choice(
         }
         CollectEvidenceResume::Effect { pending_ability } => {
             state.waiting_for = WaitingFor::Priority { player };
-            super::resolve_ability_chain(state, pending_ability, events, 0)
+            super::resolve_ability_chain(state, &pending_ability, events, 0)
                 .map_err(|e| EngineError::InvalidAction(format!("{e:?}")))?;
             Ok(state.waiting_for.clone())
         }
         // CR 605.2 + CR 701.59: Resume the parked mana-ability activation with
-        // the exiled cards stamped in. `resume` is a shared borrow, so clone the
-        // boxed pending (mirrors the `Casting` arm) — moving out of `*` would be
-        // E0507. The exile loop above already moved the chosen cards to exile.
+        // the selected evidence stamped in. The owned continuation can move its
+        // pending activation directly after every cost move has settled.
         CollectEvidenceResume::ManaAbility {
             pending_mana_ability,
         } => {
-            let mut pending = pending_mana_ability.as_ref().clone();
-            pending.collected_evidence = chosen.to_vec();
+            let mut pending = *pending_mana_ability;
+            pending.collected_evidence = chosen;
             super::super::mana_abilities::advance_mana_ability_activation(state, pending, events)
         }
     }
+}
+
+/// CR 701.59a + CR 118.11 + CR 616.1: Resume exactly the unpaid evidence
+/// suffix after the replacement dispatcher settles its paused move.
+pub(crate) fn resume_cost_move_payment(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let Some(PendingCostMoveResume::CollectEvidencePayment {
+        player,
+        chosen,
+        paused_at_index,
+        resume,
+    }) = state.pending_cost_move_resume.take()
+    else {
+        unreachable!("collect-evidence cost-move resume requires its typed continuation")
+    };
+
+    move_evidence_costs(state, player, chosen, paused_at_index + 1, *resume, events)
 }
 
 #[cfg(test)]

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -2200,6 +2200,8 @@ pub(crate) fn drain_pending_cost_move_resume(
                 PendingCostMoveResume::Cast { .. }
                     | PendingCostMoveResume::SacrificeForCost { .. }
                     | PendingCostMoveResume::ReplacementMayCost { .. }
+                    | PendingCostMoveResume::CollectEvidencePayment { .. }
+                    | PendingCostMoveResume::UnlessBouncePayment { .. }
                     | PendingCostMoveResume::DelveManaPayment { .. }
                     | PendingCostMoveResume::ManaAbilityPayment { .. }
             )
@@ -2211,6 +2213,8 @@ pub(crate) fn drain_pending_cost_move_resume(
                     | PendingCostMoveResume::SacrificeForCost { .. }
                     | PendingCostMoveResume::ReplacementMayCost { .. }
                     | PendingCostMoveResume::Foretell { .. }
+                    | PendingCostMoveResume::CollectEvidencePayment { .. }
+                    | PendingCostMoveResume::UnlessBouncePayment { .. }
                     | PendingCostMoveResume::DelveManaPayment { .. }
                     | PendingCostMoveResume::ManaAbilityPayment { .. }
             )
@@ -2249,6 +2253,16 @@ pub(crate) fn drain_pending_cost_move_resume(
         Some(PendingCostMoveResume::Foretell { .. })
     ) {
         super::casting::resume_foretell_cost_move(state, events)
+    } else if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::CollectEvidencePayment { .. })
+    ) {
+        super::effects::collect_evidence::resume_cost_move_payment(state, events)?
+    } else if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::UnlessBouncePayment { .. })
+    ) {
+        engine_payment_choices::resume_unless_bounce_cost_move(state, events)?
     } else if matches!(
         state.pending_cost_move_resume,
         Some(PendingCostMoveResume::DelveManaPayment { .. })

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -6,7 +6,7 @@ use crate::types::ability::{
 };
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
-    ActionResult, AutoMayChoice, GameState, PendingContinuation, WaitingFor,
+    ActionResult, AutoMayChoice, GameState, PendingContinuation, PendingCostMoveResume, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -23,7 +23,7 @@ use super::engine::{
 };
 use super::engine_priority;
 use super::mana_abilities;
-use super::zones;
+use super::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 
 pub(super) fn handle_optional_effect_choice(
     state: &mut GameState,
@@ -1708,12 +1708,52 @@ pub(super) fn handle_unless_bounce_choice(
         ));
     }
 
-    zones::move_to_zone(state, chosen[0], Zone::Hand, events);
+    let moved = chosen[0];
+    match zone_pipeline::move_object(
+        state,
+        ZoneMoveRequest::cost(moved, Zone::Hand, pending_effect.source_id),
+        events,
+    ) {
+        ZoneMoveResult::Done => finish_unless_bounce_payment(
+            state,
+            player,
+            moved,
+            permanents,
+            pending_effect,
+            remaining,
+            events,
+        ),
+        ZoneMoveResult::NeedsChoice(_) => {
+            state.pending_cost_move_resume = Some(PendingCostMoveResume::UnlessBouncePayment {
+                player,
+                moved,
+                permanents,
+                pending_effect,
+                remaining,
+            });
+            Ok(state.waiting_for.clone())
+        }
+        ZoneMoveResult::NeedsAuraAttachmentChoice => {
+            unreachable!("an unless return-to-hand cost cannot require an Aura attachment")
+        }
+    }
+}
 
+/// CR 118.11 + CR 118.12 + CR 616.1: Complete the paid unless-return tail
+/// after the replacement-aware cost move was delivered or fully substituted.
+fn finish_unless_bounce_payment(
+    state: &mut GameState,
+    player: PlayerId,
+    moved: ObjectId,
+    permanents: Vec<ObjectId>,
+    pending_effect: Box<ResolvedAbility>,
+    remaining: u32,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
     if remaining > 1 {
         let eligible: Vec<ObjectId> = permanents
             .into_iter()
-            .filter(|&id| id != chosen[0] && state.objects.contains_key(&id))
+            .filter(|&id| id != moved && state.objects.contains_key(&id))
             .collect();
         state.waiting_for = WaitingFor::UnlessBounceChoice {
             player,
@@ -1733,6 +1773,34 @@ pub(super) fn handle_unless_bounce_choice(
     set_active_priority(state);
     resume_pending_continuation_if_priority(state, events)?;
     Ok(state.waiting_for.clone())
+}
+
+/// CR 118.11 + CR 118.12 + CR 616.1: Resume the typed unless-return cost
+/// root after its selected permanent's replacement event settles.
+pub(super) fn resume_unless_bounce_cost_move(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let Some(PendingCostMoveResume::UnlessBouncePayment {
+        player,
+        moved,
+        permanents,
+        pending_effect,
+        remaining,
+    }) = state.pending_cost_move_resume.take()
+    else {
+        unreachable!("unless bounce cost-move resume requires its typed continuation")
+    };
+
+    finish_unless_bounce_payment(
+        state,
+        player,
+        moved,
+        permanents,
+        pending_effect,
+        remaining,
+        events,
+    )
 }
 
 fn set_active_priority(state: &mut GameState) {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2692,7 +2692,8 @@ pub enum PendingSacrificeCostCompletion {
 /// the zone pipeline's delivery tail owns its delivered-only exile link.
 /// `SacrificeForCost` owns a full selected sacrifice component across one or
 /// more replacement-choice action boundaries, including its event span and
-/// LKI record identities.
+/// LKI record identities. `CollectEvidencePayment` and `UnlessBouncePayment`
+/// retain their selected-object program counters and exact completion tails.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PendingCostMoveResume {
     Cast {
@@ -2743,6 +2744,26 @@ pub enum PendingCostMoveResume {
     DelveManaPayment {
         player: PlayerId,
         fuel_id: ObjectId,
+    },
+    /// CR 701.59a + CR 614.1 + CR 616.1: The selected evidence cards are
+    /// exiled one at a time as a cost. A replacement choice settles the card
+    /// at `paused_at_index`; resumption continues with the unpaid suffix and
+    /// performs the linked completion exactly once.
+    CollectEvidencePayment {
+        player: PlayerId,
+        chosen: Vec<ObjectId>,
+        paused_at_index: usize,
+        resume: Box<CollectEvidenceResume>,
+    },
+    /// CR 118.12 + CR 614.1 + CR 616.1: A selected return-to-hand unless cost
+    /// awaits its replacement outcome. Its typed tail either surfaces the next
+    /// return choice or records that the unless payment avoided the effect.
+    UnlessBouncePayment {
+        player: PlayerId,
+        moved: ObjectId,
+        permanents: Vec<ObjectId>,
+        pending_effect: Box<ResolvedAbility>,
+        remaining: u32,
     },
     ManaAbilityPayment {
         pending: Box<PendingManaAbility>,

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -16,9 +16,9 @@ use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
 use engine::types::events::GameEvent;
 use engine::types::game_state::{
-    CastPaymentMode, GameState, ManaAbilityCostParentLifecycle, ManaAbilityCostResolutionMode,
-    ManaAbilityResume, PayCostKind, PendingCast, PendingCostMoveResume, PendingReplacement,
-    StackEntryKind, WaitingFor,
+    CastPaymentMode, CollectEvidenceResume, GameState, ManaAbilityCostParentLifecycle,
+    ManaAbilityCostResolutionMode, ManaAbilityResume, PayCostKind, PendingCast,
+    PendingCostMoveResume, PendingReplacement, StackEntryKind, WaitingFor,
 };
 use engine::types::keywords::Keyword;
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
@@ -175,14 +175,11 @@ fn mana_self_exile_cost_redirect_witness() -> (GameScenario, engine::types::iden
 }
 
 /// Drives the real replacement-choice dispatcher through its `Prevented` arm
-/// while retaining the paused mana-cost root created by the normal cost-move
-/// pipeline. Zone-change prevention is not yet an engine replacement outcome,
-/// so this uses the existing one-shot prevention producer to exercise the
-/// shared dispatcher seam.
-fn stage_prevented_mana_cost_move(
-    state: &mut GameState,
-    source: engine::types::identifiers::ObjectId,
-) {
+/// while retaining the paused typed cost-move root created by the normal
+/// cost-move pipeline. Zone-change prevention is not yet an engine replacement
+/// outcome, so this uses the existing one-shot prevention producer to exercise
+/// the shared dispatcher seam.
+fn stage_prevented_cost_move(state: &mut GameState, source: engine::types::identifiers::ObjectId) {
     state
         .objects
         .get_mut(&source)
@@ -214,6 +211,376 @@ fn stage_prevented_mana_cost_move(
         candidate_count: 1,
         candidates: vec![],
     };
+}
+
+#[test]
+fn collect_evidence_cost_pauses_for_moved_redirect_before_resuming_its_effect() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Collect Evidence Redirect Source", 1, 1)
+        .id();
+    let evidence = scenario
+        .add_creature_to_graveyard(P0, "Collect Evidence Redirect Fuel", 1, 1)
+        .with_mana_cost(ManaCost::generic(3))
+        .id();
+    for name in [
+        "First Collect Evidence Redirect",
+        "Second Collect Evidence Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Hand));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().waiting_for = WaitingFor::CollectEvidenceChoice {
+        player: P0,
+        minimum_mana_value: 3,
+        cards: vec![evidence],
+        resume: Box::new(CollectEvidenceResume::Effect {
+            pending_ability: Box::new(ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                source,
+                P0,
+            )),
+        }),
+    };
+
+    let result = runner
+        .act(GameAction::SelectCards {
+            cards: vec![evidence],
+        })
+        .expect("collect-evidence payment should inspect Moved replacements");
+
+    assert!(
+        matches!(result.waiting_for, WaitingFor::ReplacementChoice { .. }),
+        "the selected graveyard-to-exile cost move must pause for competing Moved replacements"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        20,
+        "the linked effect must not resolve before the selected cost move settles"
+    );
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::CollectEvidencePayment {
+            player,
+            chosen,
+            paused_at_index: 0,
+            ..
+        }) if *player == P0 && chosen == &vec![evidence]
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the selected evidence move resumes its typed payment root");
+    assert!(matches!(resumed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().objects[&evidence].zone, Zone::Hand);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 21);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert_eq!(
+        resumed
+            .events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::PlayerPerformedAction {
+                    player_id: P0,
+                    action: engine::types::events::PlayerActionKind::CollectEvidence,
+                }
+            ))
+            .count(),
+        1,
+        "the selected evidence payment completes exactly once after the replacement choice"
+    );
+}
+
+#[test]
+fn collect_evidence_cost_completes_when_the_replacement_dispatcher_prevents_its_move() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Prevented Collect Evidence Source", 1, 1)
+        .id();
+    let evidence = scenario
+        .add_creature_to_graveyard(P0, "Prevented Collect Evidence Fuel", 1, 1)
+        .with_mana_cost(ManaCost::generic(3))
+        .id();
+    for name in [
+        "First Prevented Collect Evidence Redirect",
+        "Second Prevented Collect Evidence Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Hand));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().waiting_for = WaitingFor::CollectEvidenceChoice {
+        player: P0,
+        minimum_mana_value: 3,
+        cards: vec![evidence],
+        resume: Box::new(CollectEvidenceResume::Effect {
+            pending_ability: Box::new(ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                source,
+                P0,
+            )),
+        }),
+    };
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![evidence],
+        })
+        .expect("collect-evidence payment reaches its replacement pause");
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::CollectEvidencePayment { .. })
+    ));
+
+    // A Moved event has no natural prevention producer in the current engine.
+    // Re-stage the existing one-shot prevention witness while the typed cost
+    // root is parked, exercising the shared `ReplacementPrevented` drain.
+    stage_prevented_cost_move(runner.state_mut(), source);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("a fully substituted cost event still resumes collect evidence");
+
+    assert!(matches!(resumed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().objects[&evidence].zone, Zone::Graveyard);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 21);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert_eq!(
+        resumed
+            .events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::PlayerPerformedAction {
+                    player_id: P0,
+                    action: engine::types::events::PlayerActionKind::CollectEvidence,
+                }
+            ))
+            .count(),
+        1,
+        "the prevented cost event still completes the evidence payment once"
+    );
+}
+
+#[test]
+fn unless_bounce_cost_pauses_for_moved_redirect_before_avoiding_the_effect() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let bounced = scenario
+        .add_creature(P0, "Unless Bounce Redirect Witness", 1, 1)
+        .id();
+    for name in [
+        "First Unless Bounce Redirect",
+        "Second Unless Bounce Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Hand, Zone::Graveyard));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().waiting_for = WaitingFor::UnlessBounceChoice {
+        player: P0,
+        permanents: vec![bounced],
+        pending_effect: Box::new(ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            bounced,
+            P0,
+        )),
+        remaining: 1,
+    };
+
+    let result = runner
+        .act(GameAction::SelectCards {
+            cards: vec![bounced],
+        })
+        .expect("unless bounce payment should inspect Moved replacements");
+
+    assert!(
+        matches!(result.waiting_for, WaitingFor::ReplacementChoice { .. }),
+        "the selected battlefield-to-hand cost move must pause for competing Moved replacements"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        20,
+        "the paid unless cost must keep the pending effect avoided while replacement choice is open"
+    );
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::UnlessBouncePayment {
+            player,
+            moved,
+            remaining: 1,
+            ..
+        }) if *player == P0 && *moved == bounced
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the selected return resumes its typed unless-payment root");
+    assert!(matches!(resumed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().objects[&bounced].zone, Zone::Graveyard);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        20,
+        "the redirected unless cost remains paid, so its avoided effect must not fire"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+}
+
+#[test]
+fn unless_bounce_cost_remains_paid_when_the_replacement_dispatcher_prevents_its_move() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let bounced = scenario
+        .add_creature(P0, "Prevented Unless Bounce Witness", 1, 1)
+        .id();
+    for name in [
+        "First Prevented Unless Bounce Redirect",
+        "Second Prevented Unless Bounce Redirect",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Hand, Zone::Graveyard));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().waiting_for = WaitingFor::UnlessBounceChoice {
+        player: P0,
+        permanents: vec![bounced],
+        pending_effect: Box::new(ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            bounced,
+            P0,
+        )),
+        remaining: 1,
+    };
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![bounced],
+        })
+        .expect("unless-bounce payment reaches its replacement pause");
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::UnlessBouncePayment { .. })
+    ));
+
+    stage_prevented_cost_move(runner.state_mut(), bounced);
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("a fully substituted return-to-hand cost still avoids the unless effect");
+
+    assert!(matches!(resumed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().objects[&bounced].zone, Zone::Battlefield);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        20,
+        "the prevented return was still a paid unless cost, so the effect remains avoided"
+    );
+    assert!(runner.state().pending_cost_move_resume.is_none());
+}
+
+#[test]
+fn collect_evidence_and_unless_bounce_costs_complete_synchronously_without_replacements() {
+    let mut evidence_scenario = GameScenario::new();
+    evidence_scenario.at_phase(Phase::PreCombatMain);
+    let evidence_source = evidence_scenario
+        .add_creature(P0, "Uninterrupted Collect Evidence Source", 1, 1)
+        .id();
+    let evidence = evidence_scenario
+        .add_creature_to_graveyard(P0, "Uninterrupted Collect Evidence Fuel", 1, 1)
+        .with_mana_cost(ManaCost::generic(3))
+        .id();
+    let mut evidence_runner = evidence_scenario.build();
+    evidence_runner.state_mut().waiting_for = WaitingFor::CollectEvidenceChoice {
+        player: P0,
+        minimum_mana_value: 3,
+        cards: vec![evidence],
+        resume: Box::new(CollectEvidenceResume::Effect {
+            pending_ability: Box::new(ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                evidence_source,
+                P0,
+            )),
+        }),
+    };
+    let evidence_result = evidence_runner
+        .act(GameAction::SelectCards {
+            cards: vec![evidence],
+        })
+        .expect("uninterrupted evidence cost resolves synchronously");
+    assert!(matches!(
+        evidence_result.waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert_eq!(evidence_runner.state().objects[&evidence].zone, Zone::Exile);
+    assert_eq!(evidence_runner.state().players[P0.0 as usize].life, 21);
+    assert!(evidence_runner.state().pending_cost_move_resume.is_none());
+
+    let mut bounce_scenario = GameScenario::new();
+    bounce_scenario.at_phase(Phase::PreCombatMain);
+    let bounced = bounce_scenario
+        .add_creature(P0, "Uninterrupted Unless Bounce Witness", 1, 1)
+        .id();
+    let mut bounce_runner = bounce_scenario.build();
+    bounce_runner.state_mut().waiting_for = WaitingFor::UnlessBounceChoice {
+        player: P0,
+        permanents: vec![bounced],
+        pending_effect: Box::new(ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            bounced,
+            P0,
+        )),
+        remaining: 1,
+    };
+    let bounce_result = bounce_runner
+        .act(GameAction::SelectCards {
+            cards: vec![bounced],
+        })
+        .expect("uninterrupted unless-bounce cost resolves synchronously");
+    assert!(matches!(
+        bounce_result.waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert_eq!(bounce_runner.state().objects[&bounced].zone, Zone::Hand);
+    assert_eq!(bounce_runner.state().players[P0.0 as usize].life, 20);
+    assert!(bounce_runner.state().pending_cost_move_resume.is_none());
 }
 
 #[test]
@@ -4481,7 +4848,7 @@ fn prevented_mana_cost_move_serializes_and_restores_mana_payment_root() {
     )
     .expect("the mana payment root pauses on its source cost move");
     assert!(matches!(paused, WaitingFor::ReplacementChoice { .. }));
-    stage_prevented_mana_cost_move(runner.state_mut(), source);
+    stage_prevented_cost_move(runner.state_mut(), source);
 
     let json = serde_json::to_string(runner.state())
         .expect("the staged prevented mana-payment root serializes");
@@ -4561,7 +4928,7 @@ fn prevented_mana_cost_move_serializes_and_restores_unless_payment_root() {
     )
     .expect("the unless-payment root pauses on its source cost move");
     assert!(matches!(paused, WaitingFor::ReplacementChoice { .. }));
-    stage_prevented_mana_cost_move(runner.state_mut(), source);
+    stage_prevented_cost_move(runner.state_mut(), source);
 
     let json = serde_json::to_string(runner.state())
         .expect("the staged prevented unless-payment root serializes");

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -33,7 +33,6 @@ crates/engine/src/game/effects/cast_copy_of_card.rs	cast_one_copy	zone-assign	1
 crates/engine/src/game/effects/cast_from_zone.rs	grant_lingering_permissions	mover	1
 crates/engine/src/game/effects/choose_from_zone.rs	drain_pending_per_category_zone_choice	mover	1
 crates/engine/src/game/effects/cloak.rs	resolve	mover	1
-crates/engine/src/game/effects/collect_evidence.rs	handle_choice	mover	1
 crates/engine/src/game/effects/copy_spell.rs	resolve	zone-assign	1
 crates/engine/src/game/effects/dig.rs	resolve_mass_put_all	mover	1
 crates/engine/src/game/effects/discover.rs	shuffle_to_bottom	mover	1
@@ -48,7 +47,6 @@ crates/engine/src/game/effects/token.rs	commit_liminal_token_entry_with_post_act
 crates/engine/src/game/elimination.rs	do_eliminate	container	1
 crates/engine/src/game/engine.rs	normalize_recast_frame	exempt	3
 crates/engine/src/game/engine_debug.rs	apply_debug_action	mover	1
-crates/engine/src/game/engine_payment_choices.rs	handle_unless_bounce_choice	mover	1
 crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	container	6
 crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	mover	9
 crates/engine/src/game/engine_resolution_choices.rs	route_rest_partition	mover	2


### PR DESCRIPTION
Migrate the last two semantic-cost raw zone movers onto
zone_pipeline::move_object with ZoneMoveRequest::cost:

- collect_evidence::handle_choice (CR 701.59a): selected evidence cards
  exile one at a time through the replacement-aware pipeline; a
  replacement choice parks the new typed
  PendingCostMoveResume::CollectEvidencePayment root (program-counter
  resume over the unpaid suffix, completion exactly once).
- handle_unless_bounce_choice (CR 118.12): the selected return-to-hand
  unless cost parks PendingCostMoveResume::UnlessBouncePayment; the paid
  cost keeps the avoided effect avoided across delivered, redirected,
  and prevented outcomes (CR 118.11).

Both roots resume only through drain_pending_cost_move_resume at the
delivered and prevented boundaries — the eligibility tables are
extended, no dispatch-site sequential-ifs, no PostReplacementContinuation
growth, no pending_continuation reuse.

Witnesses: redirect-pause, prevented-boundary, and synchronous
regression coverage for both roots in cost_zone_pipeline; exactly-once
completion asserted on the CollectEvidence action event.
