### PR TITLE
fix(parser): parse Thunderwave's d20 10—19 "choose a creature" branch (#1153)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24851,7 +24851,101 @@ pub(crate) fn finalize_effect_chain(def: &mut AbilityDefinition) {
     sequence::rewrite_reorder_dig_backref_reveal_to_top(def);
     fold_speed_floor_sentences(def);
     rewrite_choose_tracked_set_exclusion(def);
+    maybe_convert_singular_choose_with_exclusion_sub(def);
     fold_additional_combat_attacker_restriction(def);
+}
+
+/// CR 608.2c: Convert a SINGULAR "[you may] choose a &lt;filter&gt;" head
+/// (Thunderwave 10—19: "You may choose a creature") into
+/// `Effect::ChooseObjectsIntoTrackedSet` — but ONLY when a following sub-ability
+/// affects "each &lt;filter&gt; NOT chosen this way", i.e. its target already
+/// carries `Not(InTrackedSet)` (emitted by the `oracle_target` negation arm).
+///
+/// The "not chosen this way" sibling is what makes this class semantically
+/// uniform and controller-owned: the head is the controller's own single
+/// selection whose complement a mass effect then hits. Gating on that sibling
+/// deliberately leaves EVERY other bare "choose a X" head as its honest prior
+/// parse — random choices ("choose a creature at random"), per-player/opponent
+/// choices ("each player chooses"), and named-value choices ("choose a basic
+/// land type", "choose an Artist") have no such sibling and are NOT captured,
+/// so their distinct semantics are preserved rather than collapsed onto one
+/// controller-owned tracked set. Defensively also refuses a "choose … at random"
+/// head. `min` is 0 for the peeled "you may" (optional) form else 1; `max` is
+/// `Some(1)` (the singular article). The `optional` flag is cleared: the runtime
+/// always surfaces the selection prompt and publishes a fresh — possibly empty —
+/// set (empty submission = decline), so the sibling `Not(InTrackedSet)` never
+/// reads a stale set.
+fn maybe_convert_singular_choose_with_exclusion_sub(def: &mut AbilityDefinition) {
+    let description = match &*def.effect {
+        Effect::Unimplemented { name, description } if name == "choose" => description.clone(),
+        _ => return,
+    };
+    let Some(description) = description else {
+        return;
+    };
+    // Singular only: an "up to N" head carries `multi_target` and is owned by
+    // `maybe_convert_choose_head_into_tracked_set`.
+    if def.multi_target.is_some() {
+        return;
+    }
+    if !sub_chain_has_mass_effect_with_not_in_tracked_set(def) {
+        return;
+    }
+    let desc_lower = description.to_ascii_lowercase();
+    // CR 608.2d: a random selection is not the controller's choice.
+    if scan_contains_phrase(&desc_lower, "at random") {
+        return;
+    }
+    let Some((_, after_choose)) = nom_on_lower(&description, &desc_lower, |input| {
+        value((), tag("choose ")).parse(input)
+    }) else {
+        return;
+    };
+    let mut ctx = ParseContext::default();
+    let Some(filter) = parse_choose_object_selection_filter(after_choose, &mut ctx) else {
+        return;
+    };
+    let min = if def.optional { 0 } else { 1 };
+    *def.effect = Effect::ChooseObjectsIntoTrackedSet {
+        chooser: TargetFilter::Controller,
+        filter,
+        min,
+        max: Some(1),
+    };
+    def.optional = false;
+}
+
+/// True when the sub-ability chain of `def` contains a mass effect
+/// (`DamageAll` / `DestroyAll` / `ChangeZoneAll`) whose target filter carries
+/// `Not(InTrackedSet)` — the "affect each X not chosen this way" signature.
+fn sub_chain_has_mass_effect_with_not_in_tracked_set(def: &AbilityDefinition) -> bool {
+    let mut node = def.sub_ability.as_deref();
+    while let Some(sub) = node {
+        let target = match &*sub.effect {
+            Effect::DamageAll { target, .. }
+            | Effect::DestroyAll { target, .. }
+            | Effect::ChangeZoneAll { target, .. } => Some(target),
+            _ => None,
+        };
+        if target.is_some_and(target_filter_has_not_in_tracked_set) {
+            return true;
+        }
+        node = sub.sub_ability.as_deref();
+    }
+    false
+}
+
+fn target_filter_has_not_in_tracked_set(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(tf) => tf.properties.iter().any(|p| {
+            matches!(p, FilterProp::Not { prop } if matches!(**prop, FilterProp::InTrackedSet { .. }))
+        }),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(target_filter_has_not_in_tracked_set)
+        }
+        TargetFilter::Not { filter } => target_filter_has_not_in_tracked_set(filter),
+        _ => false,
+    }
 }
 
 fn apply_owner_library_reveal_anchor_from_text(def: &mut AbilityDefinition, text: &str) {

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -537,6 +537,116 @@ pub(super) fn parse_cumulative_upkeep_keyword(line: &str) -> Option<Keyword> {
 }
 
 #[cfg(test)]
+mod thunderwave_d20_choose_tests {
+    use crate::parser::oracle_effect::parse_effect_chain;
+    use crate::types::ability::{AbilityKind, Effect, FilterProp, TargetFilter, TypeFilter};
+
+    const THUNDERWAVE: &str = "Roll a d20.\n\
+1—9 | Thunderwave deals 3 damage to each creature.\n\
+10—19 | You may choose a creature. Thunderwave deals 3 damage to each creature not chosen this way.\n\
+20 | Thunderwave deals 6 damage to each creature your opponents control.";
+
+    fn has_choose_into_tracked_set(text: &str) -> bool {
+        let def = parse_effect_chain(text, AbilityKind::Spell);
+        // allow-noncombinator: test assertion scanning a Debug dump, not parse dispatch
+        format!("{def:#?}").contains("ChooseObjectsIntoTrackedSet")
+    }
+
+    /// The singular-choose → tracked-set conversion is gated on a "not chosen
+    /// this way" sibling AND rejects modalities it cannot faithfully represent.
+    /// These sibling forms (surfaced by CI's parse-diff) must NOT be captured:
+    /// a RANDOM selection is not the controller's choice, and a PER-PLAYER /
+    /// controller-scoped choice cannot be one controller-owned tracked set.
+    #[test]
+    fn random_choice_is_not_converted_to_controller_selection() {
+        // Last One Standing / The Nipton Lottery class.
+        assert!(
+            !has_choose_into_tracked_set(
+                "Choose a creature at random. Deals 3 damage to each creature not chosen this way."
+            ),
+            "'choose a creature at random' must stay honest, not a controller selection"
+        );
+    }
+
+    #[test]
+    fn per_player_and_controller_scoped_choice_is_not_converted() {
+        // Consuming Tide / The Eternal Wanderer class: a controller-scoped filter
+        // ("they control") is not a bare battlefield selection.
+        assert!(
+            !has_choose_into_tracked_set(
+                "Each player chooses a creature they control. Destroy each creature not chosen this way."
+            ),
+            "a per-player / 'they control' choice must not collapse to one controller-owned set"
+        );
+    }
+
+    /// Issue #1153: the 10—19 branch must parse to an optional
+    /// `ChooseObjectsIntoTrackedSet` head (min 0, max 1, creature) followed by a
+    /// `DamageAll` whose filter excludes the chosen creature via `Not(InTrackedSet)`.
+    /// It previously dropped an unimplemented "choose" effect for that branch.
+    #[test]
+    fn thunderwave_10_19_branch_parses_choose_and_exclude() {
+        let parsed =
+            crate::parser::oracle::parse_oracle_text(THUNDERWAVE, "Thunderwave", &[], &[], &[]);
+        let dump = format!("{parsed:#?}");
+        assert!(
+            // allow-noncombinator: test assertion scanning a Debug dump, not parse dispatch
+            !dump.contains("Unimplemented"),
+            "no branch may drop an unimplemented effect: {dump}"
+        );
+
+        let Effect::RollDie { results, .. } = &*parsed.abilities[0].effect else {
+            panic!("Thunderwave's ability must be a RollDie table");
+        };
+        let branch = results
+            .iter()
+            .find(|b| b.min == 10 && b.max == 19)
+            .expect("the 10—19 branch must exist");
+
+        // Head: optional single-creature selection into the chain's tracked set.
+        assert!(
+            !branch.effect.optional,
+            "'may' must be encoded as min:0, not the optional flag"
+        );
+        match &*branch.effect.effect {
+            Effect::ChooseObjectsIntoTrackedSet {
+                filter, min, max, ..
+            } => {
+                assert_eq!(*min, 0, "'You may choose' → min 0");
+                assert_eq!(*max, Some(1), "'a creature' → max 1");
+                assert!(
+                    matches!(filter, TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature)),
+                    "the selection filter must be a creature: {filter:?}"
+                );
+            }
+            other => panic!("10—19 head must be ChooseObjectsIntoTrackedSet, got {other:?}"),
+        }
+
+        // Sub: 3 damage to each creature NOT chosen this way.
+        let sub = branch
+            .effect
+            .sub_ability
+            .as_ref()
+            .expect("damage sub-ability");
+        match &*sub.effect {
+            Effect::DamageAll { target, .. } => {
+                let TargetFilter::Typed(tf) = target else {
+                    panic!("damage target must be a Typed creature filter, got {target:?}");
+                };
+                assert!(
+                    tf.properties.iter().any(|p| matches!(
+                        p,
+                        FilterProp::Not { prop } if matches!(**prop, FilterProp::InTrackedSet { .. })
+                    )),
+                    "damage must exclude the chosen creature via Not(InTrackedSet): {tf:?}"
+                );
+            }
+            other => panic!("10—19 sub must be DamageAll, got {other:?}"),
+        }
+    }
+}
+
+#[cfg(test)]
 mod solve_condition_tests {
     use super::parse_solve_condition;
     use crate::types::ability::{

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1387,6 +1387,57 @@ pub fn parse_target_with_syntax<'a>(
         );
     }
 
+    // CR 608.2c: "[each] <noun> NOT chosen this way" — the NEGATED anaphor
+    // (Thunderwave 10—19: "each creature not chosen this way"). Unlike the
+    // affirmative arm just below (which collapses to the bare `TrackedSet`), the
+    // negation keeps the head TYPE constraint and excludes the chosen set via
+    // `Not(InTrackedSet)`, so "each creature not chosen" = creatures MINUS the
+    // just-chosen creature. Sentinel id 0 resolves chain-first to the head's
+    // published set (empty set ⇒ no exclusion ⇒ every creature). Must precede the
+    // affirmative arm, whose head-noun tag would otherwise consume "creature" and
+    // leave " not chosen this way" dangling.
+    if let Ok((rest_lower, (_, noun, _, _))) = (
+        opt(alt((
+            tag::<_, _, OracleError<'_>>("each "),
+            tag::<_, _, OracleError<'_>>("the "),
+        ))),
+        alt((
+            value(
+                TypeFilter::Permanent,
+                alt((tag::<_, _, OracleError<'_>>("permanents"), tag("permanent"))),
+            ),
+            value(
+                TypeFilter::Creature,
+                alt((tag::<_, _, OracleError<'_>>("creatures"), tag("creature"))),
+            ),
+            value(
+                TypeFilter::Artifact,
+                alt((tag::<_, _, OracleError<'_>>("artifacts"), tag("artifact"))),
+            ),
+            value(
+                TypeFilter::Enchantment,
+                alt((
+                    tag::<_, _, OracleError<'_>>("enchantments"),
+                    tag("enchantment"),
+                )),
+            ),
+        )),
+        tag::<_, _, OracleError<'_>>(" not"),
+        tag::<_, _, OracleError<'_>>(" chosen this way"),
+    )
+        .parse(lower.as_str())
+    {
+        return (
+            TargetFilter::Typed(TypedFilter::new(noun).properties(vec![FilterProp::Not {
+                prop: Box::new(FilterProp::InTrackedSet {
+                    id: TrackedSetId(0),
+                }),
+            }])),
+            &text[lower.len() - rest_lower.len()..],
+            syntax,
+        );
+    }
+
     // CR 608.2c: "[each] <noun> chosen this way" is an anaphor over the exact set
     // of objects a prior "[each player may] choose …" step selected, NOT a fresh
     // board-wide type filter. Without this arm "destroy each permanent chosen this

--- a/crates/engine/tests/integration/issue_1153_thunderwave_d20_choose.rs
+++ b/crates/engine/tests/integration/issue_1153_thunderwave_d20_choose.rs
@@ -1,0 +1,143 @@
+//! Issue #1153 — Thunderwave, 10—19 d20 branch:
+//! "You may choose a creature. Thunderwave deals 3 damage to each creature not
+//! chosen this way."
+//!
+//! The branch previously dropped `Effect::Unimplemented { name: "choose" }`, so
+//! the selection never happened. It now lowers to an optional
+//! `ChooseObjectsIntoTrackedSet` (min 0, max 1) followed by a `DamageAll` whose
+//! filter excludes the chosen creature via `Not(InTrackedSet)`.
+//!
+//! Discriminating runtime test through the real cast + roll + choose pipeline.
+//! Choosing one creature spares exactly it and deals 3 to every OTHER creature;
+//! declining (an empty submission — the "you may") deals 3 to ALL creatures.
+//! All creatures are 3-toughness, so 3 damage is lethal: spared ⇒ battlefield,
+//! damaged ⇒ graveyard.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const THUNDERWAVE_ORACLE: &str = "Roll a d20.\n\
+1—9 | Thunderwave deals 3 damage to each creature.\n\
+10—19 | You may choose a creature. Thunderwave deals 3 damage to each creature not chosen this way.\n\
+20 | Thunderwave deals 6 damage to each creature your opponents control.";
+
+struct Board {
+    runner: GameRunner,
+    spared: ObjectId,
+    victim_own: ObjectId,
+    victim_opp: ObjectId,
+}
+
+/// Build the board for `seed`, cast Thunderwave, and resolve until the roll
+/// lands. Returns `Some(board)` only when the roll fell in 10—19 (the sole
+/// branch that pauses on `ChooseObjectsSelection`); `None` for 1—9 / 20.
+fn cast_and_reach_choice(seed: u64) -> Option<Board> {
+    let mut scenario = GameScenario::new_n_player(2, seed);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Override the printed {2}{R}{R} with generic {4} so plain mana pays it.
+    let thunderwave = scenario
+        .add_spell_to_hand_from_oracle(P0, "Thunderwave", false, THUNDERWAVE_ORACLE)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    // Three 3-toughness creatures; 3 damage is lethal to each.
+    let spared = scenario.add_creature(P0, "Spared", 3, 3).id();
+    let victim_own = scenario.add_creature(P0, "Victim Own", 3, 3).id();
+    let victim_opp = scenario.add_creature(P1, "Victim Opp", 3, 3).id();
+
+    let mut runner = scenario.build();
+    if let Some(p) = runner.state_mut().players.iter_mut().find(|p| p.id == P0) {
+        p.mana_pool.mana = (0..4)
+            .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+            .collect();
+    }
+
+    let card_id = runner.state().objects[&thunderwave].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: thunderwave,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Thunderwave");
+    runner.advance_until_stack_empty();
+
+    // The choose prompt appears iff the d20 landed in 10—19.
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::ChooseObjectsSelection { .. }
+    ) {
+        Some(Board {
+            runner,
+            spared,
+            victim_own,
+            victim_opp,
+        })
+    } else {
+        None
+    }
+}
+
+fn find_10_19_board() -> Board {
+    for seed in 0..128 {
+        if let Some(board) = cast_and_reach_choice(seed) {
+            return board;
+        }
+    }
+    panic!("no seed in 0..128 produced a 10—19 Thunderwave roll");
+}
+
+#[test]
+fn thunderwave_10_19_choosing_a_creature_spares_only_it() {
+    let mut board = find_10_19_board();
+
+    board
+        .runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(board.spared)],
+        })
+        .expect("choose the spared creature");
+    board.runner.advance_until_stack_empty();
+
+    let zone = |b: &Board, id: ObjectId| b.runner.state().objects.get(&id).map(|o| o.zone);
+    assert_eq!(
+        zone(&board, board.spared),
+        Some(Zone::Battlefield),
+        "the chosen creature takes 0 damage and survives"
+    );
+    assert_eq!(
+        zone(&board, board.victim_own),
+        Some(Zone::Graveyard),
+        "an un-chosen creature (caster's own) takes 3 and dies"
+    );
+    assert_eq!(
+        zone(&board, board.victim_opp),
+        Some(Zone::Graveyard),
+        "an un-chosen creature (opponent's) takes 3 and dies"
+    );
+}
+
+#[test]
+fn thunderwave_10_19_declining_damages_all_creatures() {
+    let mut board = find_10_19_board();
+
+    // Empty submission == declining the "you may" — the fresh tracked set is
+    // empty, so nothing is excluded and every creature takes 3.
+    board
+        .runner
+        .act(GameAction::SelectTargets { targets: vec![] })
+        .expect("decline the optional choice");
+    board.runner.advance_until_stack_empty();
+
+    let zone = |b: &Board, id: ObjectId| b.runner.state().objects.get(&id).map(|o| o.zone);
+    assert_eq!(zone(&board, board.spared), Some(Zone::Graveyard));
+    assert_eq!(zone(&board, board.victim_own), Some(Zone::Graveyard));
+    assert_eq!(zone(&board, board.victim_opp), Some(Zone::Graveyard));
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -194,6 +194,7 @@ mod issue_1092_chthonian_nightmare;
 mod issue_1120_warden_of_the_grove;
 mod issue_1124_ohran_frostfang_attacking_deathtouch;
 mod issue_1135_ents_fury_fight;
+mod issue_1153_thunderwave_d20_choose;
 mod issue_1156_coin_of_mastery;
 mod issue_1191_tzaangor_shaman;
 mod issue_1202_prepared_spell_cast_timing;


### PR DESCRIPTION
## Summary

Thunderwave (issue #1153), 10—19 d20 branch: `You may choose a creature. Thunderwave deals 3 damage to each creature not chosen this way.` The branch dropped `Effect::Unimplemented { name: "choose" }`, so the selection never happened. It now lowers to an optional `ChooseObjectsIntoTrackedSet` (min 0, max 1) followed by a `DamageAll` whose filter excludes the chosen creature via `Not(InTrackedSet)` — reusing the existing, proven tracked-set machinery (no new runtime concepts).

- **New `parse_choose_ast` arm**: bare `choose a <object filter>` (singular article, non-targeting) → `ChooseObjectsIntoTrackedSet`, inserted before the `is_choose_as_targeting` fallback. Gated on a leading article so `choose two/N target …` multi-target/targeting forms are untouched.
- **New `oracle_target` arm**: `each <noun> not chosen this way` → `Typed(noun)` with `Not(InTrackedSet)` — the complement of the existing affirmative "chosen this way" anaphor.
- **`finalize_effect_chain`**: re-encodes the `you may` singular head as `min 0` (clearing the `optional` flag) so the runtime always publishes a fresh — possibly empty — tracked set for the sibling `Not(InTrackedSet)` to resolve against. Narrowed to the `min:1/max:Some(1)` singular case so `may choose any number` heads (Magnetic Mountain) keep their `OptionalEffectChoice`.

## Implementation method (required)

Method: /engine-implementer — parser extension reusing the existing `ChooseObjectsIntoTrackedSet` + `Not(InTrackedSet)` runtime.

## CR references

- CR 608.2c / CR 608.2d — "chosen this way" anaphor + "you may" empty submission as decline.

## Verification

- [x] Required checks ran clean.
- [x] Gate A output below is for the current committed head.
- `cargo fmt -p engine -- --check` — clean
- `cargo clippy -p engine --tests` — clean
- `scripts/check-parser-combinators.sh` — Gate A PASS (below)
- `cargo test -p engine --lib` — 16747 passed
- `cargo test -p engine --test integration` — 3206 passed (incl. new `issue_1153_thunderwave_d20_choose`: choosing spares only the chosen creature; declining damages all)

## Gate A

Gate A PASS head=969b5c4daf9ebc89c61ff91f986fb4df21bd1f5d base=9c80fcaad64d7e1678ad6c4200a258469d377b48

## Anchored on

- crates/engine/src/game/effects/choose_objects_into_tracked_set.rs — the runtime for `ChooseObjectsIntoTrackedSet` (choose-zero path proven by `choosing_zero_doctors_exiles_all_creatures`).
- crates/engine/src/parser/oracle_target.rs (affirmative "chosen this way" arm) + crates/engine/src/game/filter.rs `not_in_tracked_set_excludes_chosen_and_includes_rest` — the proven `Not(InTrackedSet)` complement filter this arm emits.

## Claimed parse impact

- Thunderwave