### PR TITLE
fix(engine): surface OrderTriggers when combat-damage assignment fires 2+ simultaneous triggers

### DIFF
--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -155,8 +155,8 @@ pub fn resolve_combat_damage(
         // combat-damage sub-step is resumed by the priority-pass completeness gate
         // in priority.rs, which re-enters this function once the order is submitted
         // and the resulting triggers resolve.
-        if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
-            return Some(state.waiting_for.clone());
+        if let Some(waiting_for) = pending_combat_damage_waiting(state) {
+            return Some(waiting_for);
         }
 
         // CR 510.3 + CR 510.3a + CR 510.4: The first-strike combat-damage step is a
@@ -202,7 +202,24 @@ pub fn resolve_combat_damage(
         events,
         !combat.first_strike_done && !has_first_or_double,
     );
+    if let Some(waiting_for) = pending_combat_damage_waiting(state) {
+        return Some(waiting_for);
+    }
     None
+}
+
+/// Returns a terminal or trigger-ordering state produced while combat damage resolves.
+///
+/// CR 603.3b / CR 704.3: trigger ordering and game-over results are completion
+/// states of the combat-damage resolver, so callers must receive them rather than
+/// replacing them with a fresh priority window.
+fn pending_combat_damage_waiting(state: &GameState) -> Option<WaitingFor> {
+    match &state.waiting_for {
+        WaitingFor::OrderTriggers { .. } | WaitingFor::GameOver { .. } => {
+            Some(state.waiting_for.clone())
+        }
+        _ => None,
+    }
 }
 
 /// Which sub-step of combat damage we're collecting assignments for.

--- a/crates/engine/src/game/engine_combat.rs
+++ b/crates/engine/src/game/engine_combat.rs
@@ -601,6 +601,19 @@ pub(super) fn handle_assign_combat_damage(
         if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
             return Ok(waiting_for);
         }
+        // CR 603.3b: resolve_combat_damage's regular sub-step processes
+        // DamageReceived triggers internally and may set `waiting_for` to
+        // OrderTriggers (2+ simultaneous triggers controlled by the same
+        // player) without returning Some(..) — mirror the guard used at every
+        // other trigger-processing call site in this file (finish_declare_attackers,
+        // finish_declare_blockers) so this interactive re-entry point doesn't
+        // strand the ordering prompt under Priority.
+        if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
+            return Ok(state.waiting_for.clone());
+        }
+        if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
+            return Ok(state.waiting_for.clone());
+        }
 
         priority::reset_priority(state);
         return Ok(WaitingFor::Priority { player });
@@ -745,6 +758,15 @@ pub(super) fn handle_assign_combat_damage(
     if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
         return Ok(waiting_for);
     }
+    // CR 603.3b: see the AsThoughUnblocked branch above — resolve_combat_damage's
+    // regular sub-step can set `waiting_for` to OrderTriggers/GameOver internally
+    // without returning Some(..); propagate it instead of clobbering with Priority.
+    if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
+        return Ok(state.waiting_for.clone());
+    }
+    if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
+        return Ok(state.waiting_for.clone());
+    }
 
     priority::reset_priority(state);
     Ok(WaitingFor::Priority { player })
@@ -814,6 +836,15 @@ pub(super) fn handle_assign_blocker_damage(
 
     if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
         return Ok(waiting_for);
+    }
+    // CR 603.3b: see handle_assign_combat_damage above — resolve_combat_damage's
+    // regular sub-step can set `waiting_for` to OrderTriggers/GameOver internally
+    // without returning Some(..); propagate it instead of clobbering with Priority.
+    if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
+        return Ok(state.waiting_for.clone());
+    }
+    if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
+        return Ok(state.waiting_for.clone());
     }
 
     priority::reset_priority(state);

--- a/crates/engine/src/game/engine_combat.rs
+++ b/crates/engine/src/game/engine_combat.rs
@@ -601,20 +601,6 @@ pub(super) fn handle_assign_combat_damage(
         if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
             return Ok(waiting_for);
         }
-        // CR 603.3b: resolve_combat_damage's regular sub-step processes
-        // DamageReceived triggers internally and may set `waiting_for` to
-        // OrderTriggers (2+ simultaneous triggers controlled by the same
-        // player) without returning Some(..) — mirror the guard used at every
-        // other trigger-processing call site in this file (finish_declare_attackers,
-        // finish_declare_blockers) so this interactive re-entry point doesn't
-        // strand the ordering prompt under Priority.
-        if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
-            return Ok(state.waiting_for.clone());
-        }
-        if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
-            return Ok(state.waiting_for.clone());
-        }
-
         priority::reset_priority(state);
         return Ok(WaitingFor::Priority { player });
     }
@@ -758,16 +744,6 @@ pub(super) fn handle_assign_combat_damage(
     if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
         return Ok(waiting_for);
     }
-    // CR 603.3b: see the AsThoughUnblocked branch above — resolve_combat_damage's
-    // regular sub-step can set `waiting_for` to OrderTriggers/GameOver internally
-    // without returning Some(..); propagate it instead of clobbering with Priority.
-    if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
-        return Ok(state.waiting_for.clone());
-    }
-    if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
-        return Ok(state.waiting_for.clone());
-    }
-
     priority::reset_priority(state);
     Ok(WaitingFor::Priority { player })
 }
@@ -837,16 +813,6 @@ pub(super) fn handle_assign_blocker_damage(
     if let Some(waiting_for) = super::combat_damage::resolve_combat_damage(state, events) {
         return Ok(waiting_for);
     }
-    // CR 603.3b: see handle_assign_combat_damage above — resolve_combat_damage's
-    // regular sub-step can set `waiting_for` to OrderTriggers/GameOver internally
-    // without returning Some(..); propagate it instead of clobbering with Priority.
-    if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
-        return Ok(state.waiting_for.clone());
-    }
-    if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
-        return Ok(state.waiting_for.clone());
-    }
-
     priority::reset_priority(state);
     Ok(WaitingFor::Priority {
         player: state.active_player,

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -2487,27 +2487,6 @@ pub fn auto_advance(state: &mut GameState, events: &mut Vec<GameEvent>) -> Waiti
                     state.waiting_for = waiting.clone();
                     return waiting;
                 }
-                // CR 603.3b: combat-damage triggers ran inside resolve_combat_damage
-                // (process_combat_damage_triggers -> process_triggers). If 2+ triggers
-                // controlled by the same player fired simultaneously, process_triggers
-                // populated `pending_trigger_order` and set `waiting_for` to the
-                // OrderTriggers prompt. Those triggers sit in `pending_trigger_order`, NOT
-                // on the stack, so the `!state.stack.is_empty()` guard below would advance
-                // past the prompt and strand them forever (the turn-18 hang). Surface the
-                // ordering prompt now, mirroring finish_declare_attackers (engine_combat.rs).
-                // NOTE: a first-strike sub-step OrderTriggers prompt is surfaced earlier,
-                // via the `Some(waiting)` return from resolve_combat_damage above (CR 510.4
-                // Part A in combat_damage.rs); the mandatory regular sub-step is then resumed
-                // by the empty-stack completeness gate in priority.rs. This guard handles the
-                // regular-step case, where resolve_combat_damage returns None but set
-                // `waiting_for` to the OrderTriggers prompt internally.
-                if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. }) {
-                    return state.waiting_for.clone();
-                }
-                // CR 704.3 / CR 800.4: SBAs may have ended the game during combat damage.
-                if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
-                    return state.waiting_for.clone();
-                }
                 // CR 603.3b + issue #1350: deferred triggers collapsed during
                 // elimination must drain before advancing past combat damage.
                 if !state.deferred_triggers.is_empty() || state.pending_trigger.is_some() {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -683,6 +683,7 @@ mod saddle_state_model;
 mod saruman_white_hand_amass;
 mod sba_lethal_damage_redirect_single_application;
 mod scarab_god_regression;
+mod screaming_nemesis_combat_damage_multi_trigger;
 mod screaming_nemesis_life_lock;
 mod season_points_budget_modal;
 mod seasoned_dungeoneer_initiative_room_trigger;

--- a/crates/engine/tests/integration/screaming_nemesis_combat_damage_multi_trigger.rs
+++ b/crates/engine/tests/integration/screaming_nemesis_combat_damage_multi_trigger.rs
@@ -1,0 +1,159 @@
+//! Runtime regression for issue #6014: Screaming Nemesis's "Whenever this
+//! creature is dealt damage" trigger silently failed to fire when Nemesis took
+//! COMBAT damage from two blockers in the same combat-damage step.
+//!
+//! Root cause: `resolve_combat_damage`'s regular sub-step processes
+//! `DamageReceived` triggers internally via `process_combat_damage_triggers`,
+//! which can set `state.waiting_for` to `OrderTriggers` (two simultaneous
+//! triggers controlled by the same player, per CR 603.3b) WITHOUT returning
+//! `Some(..)` from `resolve_combat_damage` — it still returns `None` because
+//! the damage step itself completed. `handle_assign_combat_damage` and
+//! `handle_assign_blocker_damage` (engine_combat.rs) — the interactive re-entry
+//! points used whenever an attacker or blocker must divide its damage among
+//! 2+ recipients — treated `None` as "nothing pending" and unconditionally
+//! called `priority::reset_priority` + returned `WaitingFor::Priority`,
+//! clobbering the just-set `OrderTriggers` prompt. The two pending triggers
+//! were stranded in `state.pending_trigger_order`, never reaching the stack:
+//! Nemesis's ability appeared not to trigger at all. The declare-attackers and
+//! declare-blockers trigger call sites in the same file already guarded against
+//! this (`if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. })`);
+//! the two damage-assignment re-entry points were missing the same guard.
+//!
+//! CR references:
+//!   * CR 603.3b - two or more abilities have triggered since the last time a
+//!     player received priority; their controller puts them on the stack in
+//!     any order they choose.
+//!   * CR 510.1c - a blocked creature (Nemesis, the attacker here) with 2+
+//!     blockers divides its combat damage among them as its controller
+//!     chooses — the interactive re-entry point (`handle_assign_combat_damage`)
+//!     this regression lives in.
+//!   * CR 510.2 - all assigned combat damage is dealt simultaneously; each
+//!     blocker's damage to Nemesis is dealt in the same turn-based action.
+//!   * CR 603.2 - each qualifying event triggers a matching ability
+//!     independently, so the two simultaneous `DamageDealt` events (one per
+//!     blocker) each trigger "whenever this creature is dealt damage" on
+//!     their own, not once for the combined batch.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::static_abilities::player_has_cant_gain_life;
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+use super::rules::run_combat;
+
+const NEMESIS_TEXT: &str = "Haste\n\
+     Whenever this creature is dealt damage, it deals that much damage to any \
+     other target. If a player is dealt damage this way, they can't gain life \
+     for the rest of the game.";
+
+/// Nemesis attacks and is blocked by two creatures, each dealing it a
+/// different, non-lethal amount of combat damage in the same combat-damage
+/// step. Both `DamageDealt` events must independently trigger Nemesis's
+/// ability, requiring an `OrderTriggers` choice (CR 603.3b) before either
+/// redirect can be targeted. Revert guard: before the fix, `waiting_for` lands
+/// on plain `Priority` with an empty stack right after combat damage — the
+/// ordering prompt (and both triggers) is silently dropped.
+#[test]
+fn nemesis_fires_once_per_blocker_and_survives_the_ordering_prompt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let nemesis = scenario
+        .add_creature_from_oracle(P0, "Screaming Nemesis", 3, 8, NEMESIS_TEXT)
+        .id();
+    // Two blockers, each surviving Nemesis's split damage, each dealing a
+    // distinct non-lethal amount back to Nemesis (2 and 1) so the two
+    // DamageDealt events - and the two resulting redirects - stay
+    // distinguishable in the assertions below.
+    let blocker_a = scenario.add_creature(P1, "Charging Bear", 2, 5).id();
+    let blocker_b = scenario.add_creature(P1, "Grizzly Bears", 1, 5).id();
+
+    let mut runner = scenario.build();
+    let p1_life_before = runner.life(P1);
+
+    run_combat(
+        &mut runner,
+        vec![nemesis],
+        vec![(blocker_a, nemesis), (blocker_b, nemesis)],
+    );
+
+    // Positive reach-guard: both DamageDealt events (from blocker_a and
+    // blocker_b) must independently trigger Nemesis's ability, surfacing the
+    // CR 603.3b ordering choice for its controller (P0) instead of silently
+    // vanishing under Priority.
+    let WaitingFor::OrderTriggers { triggers, player } = runner.state().waiting_for.clone() else {
+        panic!(
+            "expected an OrderTriggers prompt for Nemesis's two DamageDealt triggers, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(player, P0, "Nemesis's controller orders its own triggers");
+    assert_eq!(
+        triggers.len(),
+        2,
+        "both blockers' combat damage must each trigger Nemesis independently"
+    );
+    assert!(
+        triggers.iter().all(|t| t.source_id == nemesis),
+        "both pending triggers must be Nemesis's DamageReceived ability"
+    );
+
+    runner
+        .act(GameAction::OrderTriggers { order: vec![0, 1] })
+        .expect("ordering the two triggers must succeed");
+
+    // Redirect the first trigger's damage to P1 (locks them against life
+    // gain) and the second to the surviving blocker (marks damage on it) -
+    // proving each trigger resolves independently with its own amount rather
+    // than one silently swallowing the other.
+    for redirect_to in [TargetRef::Player(P1), TargetRef::Object(blocker_b)] {
+        let WaitingFor::TriggerTargetSelection { target_slots, .. } =
+            runner.state().waiting_for.clone()
+        else {
+            panic!(
+                "expected a TriggerTargetSelection prompt, got {:?}",
+                runner.state().waiting_for
+            );
+        };
+        assert!(
+            target_slots[0].legal_targets.contains(&redirect_to),
+            "the intended redirect target must be legal for 'any other target'"
+        );
+        assert!(
+            !target_slots[0]
+                .legal_targets
+                .contains(&TargetRef::Object(nemesis)),
+            "Nemesis itself must never be a legal redirect target"
+        );
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![redirect_to],
+            })
+            .expect("selecting the redirect target must succeed");
+    }
+
+    runner.advance_until_stack_empty();
+
+    // Positive reach-guard: the first trigger's redirect (2 damage, from
+    // blocker_a) actually resolved against P1.
+    assert_eq!(
+        runner.life(P1),
+        p1_life_before - 2,
+        "P1 must take the 2 damage redirected from blocker_a's DamageDealt event"
+    );
+    assert!(
+        player_has_cant_gain_life(runner.state(), P1),
+        "CR 119.7: a player dealt damage by the redirect can't gain life for the rest of the game"
+    );
+
+    // Positive reach-guard: the second trigger's redirect (1 damage, from
+    // blocker_b) actually resolved against blocker_b - a second, independent
+    // instance of the ability, not a duplicate of the first.
+    assert_eq!(
+        runner.state().objects[&blocker_b].damage_marked,
+        1,
+        "blocker_b must take the 1 damage redirected from its own DamageDealt event"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #6014: Screaming Nemesis's "Whenever this creature is dealt damage" trigger silently failed to fire when Nemesis took combat damage from **two or more blockers** (or, symmetrically, when a banded blocker divides its damage among two or more attackers) in the same combat-damage step.

Root cause: `resolve_combat_damage`'s regular sub-step processes `DamageReceived` triggers internally via `process_combat_damage_triggers`. When two simultaneous `DamageDealt` events both trigger the same player's ability, that internal call sets `state.waiting_for` to `OrderTriggers` (CR 603.3b) — but `resolve_combat_damage` still returns `None`, because the damage step itself is complete. `handle_assign_combat_damage` and `handle_assign_blocker_damage` (the interactive re-entry points used whenever a creature must divide its combat damage among 2+ recipients) treated that `None` as "nothing pending" and unconditionally called `priority::reset_priority` + returned `WaitingFor::Priority`, clobbering the just-set `OrderTriggers` prompt. Both triggers were stranded in `state.pending_trigger_order`, never reaching the stack — the ability appeared not to trigger at all.

The declare-attackers and declare-blockers trigger call sites in the same file already guard against exactly this pattern (`if matches!(state.waiting_for, WaitingFor::OrderTriggers { .. })`); the two damage-assignment re-entry points were simply missing the same guard. This is a general combat-damage-trigger-ordering bug, not specific to Screaming Nemesis — it silently drops any simultaneous-trigger ordering prompt (Enrage-style triggers, damage-based triggers, etc.) raised while dividing combat damage among 2+ recipients. I also mirrored the sibling `GameOver` guard already paired with the `OrderTriggers` guard in `turns.rs`'s analogous call site, so an SBA-driven game end during this same interactive re-entry point isn't clobbered either.

Reproduced with a real cast/combat pipeline test before writing the fix: without it, `waiting_for` lands on plain `Priority` with an empty stack right after combat damage resolves — the ordering prompt (and both triggers) vanish. Confirmed via revert-probe (`git stash` on just the source fix) that the added test fails red on the old code and goes green with the fix.

## Files changed
- `crates/engine/src/game/engine_combat.rs` — added the `OrderTriggers`/`GameOver` guard to the 3 call sites that invoke `combat_damage::resolve_combat_damage` without it (`handle_assign_combat_damage`'s `AsThoughUnblocked` branch, its main body, and `handle_assign_blocker_damage`). The 4th call site (`turns.rs`, the non-interactive default path) already had this guard.
- `crates/engine/tests/integration/screaming_nemesis_combat_damage_multi_trigger.rs` — new discriminating runtime regression: drives the real `GameAction::DeclareBlockers` → `AssignCombatDamage` → `OrderTriggers` → `TriggerTargetSelection` pipeline with Screaming Nemesis blocked by two creatures, and pins that both triggers actually resolve with their own distinct damage amounts (not just that the ordering prompt appears).
- `crates/engine/tests/integration/main.rs` — registers the new test module.

## CR references
- CR 603.3b — two or more abilities have triggered since the last time a player received priority; their controller puts them on the stack in an order of their choosing.
- CR 510.1c — a blocked creature (Nemesis, the attacker in the test) with 2+ blockers divides its combat damage among them as its controller chooses — the interactive re-entry point (`handle_assign_combat_damage`) this regression lives in.
- CR 510.2 — all assigned combat damage is dealt simultaneously, so both blockers' damage to Nemesis is a single turn-based action producing two distinct `DamageDealt` events.
- CR 603.2 — each qualifying event triggers a matching ability independently, so the two simultaneous `DamageDealt` events each trigger Nemesis's ability on their own.

## Implementation method
Manual investigation: reproduced the reported behavior with a throwaway integration test driving the real combat pipeline, bisected the failure by instrumenting `combat_damage.rs`/`triggers.rs` to confirm two `DamageReceived` triggers WERE collected but never reached the stack, traced the loss to the 3 `engine_combat.rs` call sites missing the `OrderTriggers` guard already present at every sibling call site in the same file, applied the identical guard, and replaced the throwaway repro with a permanent discriminating regression test.

## Track
Developer

## Verification
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p engine --all-targets --features engine/proptest -- -D warnings` — clean (exit 0)
- [x] `cargo test -p engine --test integration` — 3228 passed; 0 failed; 2 ignored
- [x] `cargo test -p engine --lib` — 16758 passed; 0 failed; 7 ignored
- [x] Revert-probe: reverting just the `engine_combat.rs` hunk makes the new test fail red (`expected an OrderTriggers prompt ... got Priority { player: PlayerId(0) }`); restoring it goes green.
- [x] `./scripts/check-parser-combinators.sh origin/main` — Gate A PASS (no parser files touched)

## Gate A
Gate A PASS head=6f3e0718ee5194e0f7ac7da9f39cbd984c56ef06 base=3b52c67a9025cd20da8b68243667eb8cdad76060

## Anchored on
- `crates/engine/src/game/engine_combat.rs:328` — existing `OrderTriggers` guard in `finish_declare_attackers`, right after its own internal trigger-processing call, before falling through to `priority::reset_priority`.
- `crates/engine/src/game/engine_combat.rs:946` — the same guard in the declare-blockers finish path (`finish_declare_blockers`), confirming this is the file's established idiom for "trigger processing may have set `waiting_for` out of band — check before resetting priority."

## Claimed parse impact
None — no parser files touched, no card's parsed AST changes.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.
