### PR TITLE
fix(parser): bind "They" to an earlier mass-effect population, not the trigger's source (Ardbert, Warrior of Darkness)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22442,7 +22442,7 @@ fn clause_ir_hand_reveal_target(clause: &ClauseIr) -> Option<TargetFilter> {
     }
 }
 
-/// CR 611.2c: The match arms naming every effect that establishes a NON-targeting
+/// The match arms naming every effect that establishes a NON-targeting
 /// object POPULATION — the `*All` / scope-`All` family whose `target` (or
 /// `filter`) is a population filter rather than a chosen target. This is why they
 /// are absent from `has_typed_target_widened`'s single-target whitelist:
@@ -22473,7 +22473,7 @@ macro_rules! mass_population_filter_arms {
     };
 }
 
-/// CR 611.2c: The NON-targeting mass population filter of an "each <type>"
+/// The NON-targeting mass population filter of an "each <type>"
 /// (`*All` / scope-`All`) effect — the single authority for "which effects
 /// establish an object population". Read-only dual of
 /// [`mass_population_filter_mut`]; both are generated from one variant list
@@ -22482,7 +22482,7 @@ pub(crate) fn mass_population_filter(effect: &Effect) -> Option<&TargetFilter> {
     mass_population_filter_arms!(effect)
 }
 
-/// CR 611.2c: Mutable form of [`mass_population_filter`], for walkers that rewrite
+/// Mutable form of [`mass_population_filter`], for walkers that rewrite
 /// a mass population in place (e.g. `oracle_trigger`'s attached-host "each other"
 /// retarget). Shares the same authoritative variant list.
 pub(crate) fn mass_population_filter_mut(effect: &mut Effect) -> Option<&mut TargetFilter> {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22442,6 +22442,25 @@ fn clause_ir_hand_reveal_target(clause: &ClauseIr) -> Option<TargetFilter> {
     }
 }
 
+/// CR 608.2c: If this clause is a mass ("each …") effect, return the object
+/// POPULATION filter it acted on. Feeds `ParseContext::chain_prior_mass_population`
+/// so a later same-chain anaphor ("They gain vigilance until end of turn") binds
+/// to that population.
+///
+/// These are exactly the variants whose `target` is a population FILTER rather
+/// than a chosen target, which is why they are absent from
+/// `has_typed_target_widened`'s single-target whitelist: `ParentTarget` cannot
+/// bind here (nothing was chosen), so the anaphor inherits the filter instead.
+fn clause_ir_mass_population(clause: &ClauseIr) -> Option<TargetFilter> {
+    match &clause.parsed.effect {
+        Effect::PutCounterAll { target, .. }
+        | Effect::PumpAll { target, .. }
+        | Effect::DestroyAll { target, .. }
+        | Effect::BounceAll { target, .. } => Some(target.clone()),
+        _ => None,
+    }
+}
+
 /// CR 400.1/400.2 + CR 601.2a: Map a possessive-hand player reference (as
 /// produced by `parse_hand_possessive_target`) to the `ControllerRef` axis
 /// used to scope a card filter to that same player's hand. Exhaustive over
@@ -27306,6 +27325,16 @@ pub(crate) fn parse_effect_chain_ir(
                 .iter()
                 .rev()
                 .find_map(clause_ir_hand_reveal_target),
+            // CR 608.2c: the most-recent earlier same-chain mass ("each …")
+            // population, so a later "They <grant>" anaphor binds to it rather
+            // than reaching past it to the trigger's own subject (Ardbert,
+            // Warrior of Darkness). Mass effects choose nothing, so
+            // `parent_target_available` / `ParentTarget` cannot carry this.
+            chain_prior_mass_population: builder
+                .clauses()
+                .iter()
+                .rev()
+                .find_map(clause_ir_mass_population),
             // CR 608.2c: bind a bare "it" in this chunk's counter/anaphor to the
             // token created by an earlier clause when that token is the chain's
             // most-recent object referent (Esper Terra's "put up to three lore

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22442,23 +22442,60 @@ fn clause_ir_hand_reveal_target(clause: &ClauseIr) -> Option<TargetFilter> {
     }
 }
 
+/// CR 611.2c: The match arms naming every effect that establishes a NON-targeting
+/// object POPULATION — the `*All` / scope-`All` family whose `target` (or
+/// `filter`) is a population filter rather than a chosen target. This is why they
+/// are absent from `has_typed_target_widened`'s single-target whitelist:
+/// `ParentTarget` cannot bind to them because nothing was chosen.
+///
+/// The arms live in a macro so the SINGLE authoritative variant list generates
+/// both the shared `&` and `&mut` accessors below — two hand-written matches would
+/// be two lists that drift. Callers must go through those accessors rather than
+/// re-listing variants.
+macro_rules! mass_population_filter_arms {
+    ($effect:expr) => {
+        match $effect {
+            Effect::CounterAll { target } | Effect::GainControlAll { target } => Some(target),
+            Effect::PumpAll { target, .. }
+            | Effect::DamageAll { target, .. }
+            | Effect::DestroyAll { target, .. }
+            | Effect::BounceAll { target, .. }
+            | Effect::PutCounterAll { target, .. }
+            | Effect::DoublePTAll { target, .. } => Some(target),
+            Effect::ExploreAll { filter } => Some(filter),
+            Effect::SetTapState {
+                target,
+                scope: EffectScope::All,
+                ..
+            } => Some(target),
+            _ => None,
+        }
+    };
+}
+
+/// CR 611.2c: The NON-targeting mass population filter of an "each <type>"
+/// (`*All` / scope-`All`) effect — the single authority for "which effects
+/// establish an object population". Read-only dual of
+/// [`mass_population_filter_mut`]; both are generated from one variant list
+/// (`mass_population_filter_arms!`).
+pub(crate) fn mass_population_filter(effect: &Effect) -> Option<&TargetFilter> {
+    mass_population_filter_arms!(effect)
+}
+
+/// CR 611.2c: Mutable form of [`mass_population_filter`], for walkers that rewrite
+/// a mass population in place (e.g. `oracle_trigger`'s attached-host "each other"
+/// retarget). Shares the same authoritative variant list.
+pub(crate) fn mass_population_filter_mut(effect: &mut Effect) -> Option<&mut TargetFilter> {
+    mass_population_filter_arms!(effect)
+}
+
 /// CR 608.2c: If this clause is a mass ("each …") effect, return the object
 /// POPULATION filter it acted on. Feeds `ParseContext::chain_prior_mass_population`
 /// so a later same-chain anaphor ("They gain vigilance until end of turn") binds
-/// to that population.
-///
-/// These are exactly the variants whose `target` is a population FILTER rather
-/// than a chosen target, which is why they are absent from
-/// `has_typed_target_widened`'s single-target whitelist: `ParentTarget` cannot
-/// bind here (nothing was chosen), so the anaphor inherits the filter instead.
+/// to that population. Delegates to the shared [`mass_population_filter`]
+/// authority rather than re-listing variants.
 fn clause_ir_mass_population(clause: &ClauseIr) -> Option<TargetFilter> {
-    match &clause.parsed.effect {
-        Effect::PutCounterAll { target, .. }
-        | Effect::PumpAll { target, .. }
-        | Effect::DestroyAll { target, .. }
-        | Effect::BounceAll { target, .. } => Some(target.clone()),
-        _ => None,
-    }
+    mass_population_filter(&clause.parsed.effect).cloned()
 }
 
 /// CR 400.1/400.2 + CR 601.2a: Map a possessive-hand player reference (as

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -3028,10 +3028,24 @@ fn resolve_they_pronoun(ctx: &mut ParseContext) -> TargetFilter {
             TargetFilter::TriggeringPlayer
         }
         Some(TargetFilter::Player) => TargetFilter::TriggeringPlayer,
-        // Object-type trigger subject
-        Some(subject) if !matches!(subject, TargetFilter::SelfRef | TargetFilter::Any) => {
-            TargetFilter::TriggeringSource
-        }
+        // Object-type trigger subject: the trigger's SOURCE is "they" only when no
+        // nearer antecedent exists.
+        //
+        // CR 608.2c (issue #5985): a mass ("each …") effect in an earlier clause of
+        // the same chain establishes an object population, and that population is
+        // the nearer antecedent — Ardbert, Warrior of Darkness: "Whenever you cast a
+        // white spell, put a +1/+1 counter on each legendary creature you control.
+        // They gain vigilance until end of turn." "They" is those creatures, not the
+        // cast spell. Binding to the spell granted the keyword to an object on the
+        // stack, so the grant half silently did nothing while the counters landed.
+        //
+        // A mass effect chooses no target, so `ParentTarget` cannot express this
+        // (see `has_typed_target_widened`'s single-target whitelist); the anaphor
+        // inherits the population FILTER itself.
+        Some(subject) if !matches!(subject, TargetFilter::SelfRef | TargetFilter::Any) => ctx
+            .chain_prior_mass_population
+            .clone()
+            .unwrap_or(TargetFilter::TriggeringSource),
         // No trigger context — anaphoric reference to previously mentioned objects
         _ => TargetFilter::ParentTarget,
     }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -46698,3 +46698,73 @@ fn they_after_mass_effect_binds_that_population_not_trigger_source() {
         );
     }
 }
+
+/// CR 608.2c + CR 611.2c (issue #5985) — sibling coverage across the mass-population
+/// family. A later "They <grant>" clause must bind to whatever population the
+/// EARLIER mass clause acted on, for every `*All` / scope-`All` producer — not just
+/// the `PutCounterAll` shape Ardbert happens to use. Each case asserts the grant's
+/// `affected` against the population read back out of the parsed producer itself
+/// (via the shared `mass_population_filter` authority), so the test pins the
+/// BINDING rather than duplicating a literal filter.
+#[test]
+fn they_binds_producer_population_across_mass_effect_family() {
+    use super::mass_population_filter;
+    use crate::types::ability::Effect;
+
+    for (label, text) in [
+        // PutCounterAll — Ardbert's own shape (the originally covered case).
+        (
+            "PutCounterAll",
+            "Whenever you cast a white spell, put a +1/+1 counter on each legendary creature you control. They gain vigilance until end of turn.",
+        ),
+        // GainControlAll — previously omitted; fell back to TriggeringSource.
+        (
+            "GainControlAll",
+            "Whenever you cast a white spell, gain control of all creatures target opponent controls. They gain haste until end of turn.",
+        ),
+        // DoublePTAll — previously omitted.
+        (
+            "DoublePTAll",
+            "Whenever you cast a white spell, double the power and toughness of each creature you control. They gain trample until end of turn.",
+        ),
+        // Mass SetTapState (scope: All) — previously omitted.
+        (
+            "SetTapState{All}",
+            "Whenever you cast a white spell, tap all creatures your opponents control. They gain defender until end of turn.",
+        ),
+    ] {
+        let parsed = parse_oracle_text(text, "Mass Population Probe", &[], &["Creature".to_string()], &[]);
+        let def = parsed
+            .triggers
+            .first()
+            .and_then(|t| t.execute.as_deref())
+            .unwrap_or_else(|| panic!("{label}: the cast trigger must lower"));
+
+        let population = mass_population_filter(&def.effect)
+            .unwrap_or_else(|| panic!("{label}: head clause must be a mass population producer: {:?}", def.effect))
+            .clone();
+
+        let grant = def
+            .sub_ability
+            .as_deref()
+            .and_then(|sub| match &*sub.effect {
+                Effect::GenericEffect {
+                    static_abilities, ..
+                } => static_abilities.first().cloned(),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("{label}: the \"They <grant>\" continuation must survive"));
+
+        assert_eq!(
+            grant.affected,
+            Some(population),
+            "{label}: \"They\" must bind to the producer's population, not the triggering spell: {grant:?}"
+        );
+        assert_ne!(
+            grant.affected,
+            Some(TargetFilter::TriggeringSource),
+            "{label}: \"They\" must never fall back to the trigger's source when a mass \
+             population precedes it"
+        );
+    }
+}

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -46699,7 +46699,7 @@ fn they_after_mass_effect_binds_that_population_not_trigger_source() {
     }
 }
 
-/// CR 608.2c + CR 611.2c (issue #5985) — sibling coverage across the mass-population
+/// CR 608.2c (issue #5985) — sibling coverage across the mass-population
 /// family. A later "They <grant>" clause must bind to whatever population the
 /// EARLIER mass clause acted on, for every `*All` / scope-`All` producer — not just
 /// the `PutCounterAll` shape Ardbert happens to use. Each case asserts the grant's

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -46638,3 +46638,63 @@ fn conjugated_draw_continuation_still_inherits_player_anchor() {
          not fall back to the controller"
     );
 }
+
+/// CR 608.2c (issue #5985) — production-path regression for Ardbert, Warrior of
+/// Darkness: "Whenever you cast a white spell, put a +1/+1 counter on each
+/// legendary creature you control. They gain vigilance until end of turn."
+///
+/// "They" is the legendary-creature POPULATION introduced by the preceding mass
+/// clause -- the nearest antecedent -- not the cast spell that triggered the
+/// ability. Binding it to the trigger's subject (`TriggeringSource`) granted the
+/// keyword to an object on the stack, so the grant half silently did nothing
+/// while the counters still landed ("only partially fires").
+#[test]
+fn they_after_mass_effect_binds_that_population_not_trigger_source() {
+    use crate::types::ability::{Effect, StaticDefinition};
+
+    let parsed = parse_oracle_text(
+        "Whenever you cast a white spell, put a +1/+1 counter on each legendary creature you control. They gain vigilance until end of turn.\nWhenever you cast a black spell, put a +1/+1 counter on each legendary creature you control. They gain menace until end of turn.",
+        "Ardbert, Warrior of Darkness",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    assert_eq!(parsed.triggers.len(), 2, "both cast triggers must lower");
+
+    // The population the counters were put on -- "each legendary creature you control".
+    let population = parsed
+        .triggers
+        .iter()
+        .filter_map(|t| t.execute.as_deref())
+        .find_map(|d| match &*d.effect {
+            Effect::PutCounterAll { target, .. } => Some(target.clone()),
+            _ => None,
+        })
+        .expect("the counter half must lower to a PutCounterAll over the legendary creatures");
+
+    let grants: Vec<StaticDefinition> = parsed
+        .triggers
+        .iter()
+        .filter_map(|t| t.execute.as_deref())
+        .filter_map(|d| d.sub_ability.as_deref())
+        .filter_map(|sub| match &*sub.effect {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => static_abilities.first().cloned(),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        grants.len(),
+        2,
+        "each trigger must keep its \"They gain ...\" grant: {grants:?}"
+    );
+    for grant in &grants {
+        assert_eq!(
+            grant.affected,
+            Some(population.clone()),
+            "\"They\" must bind to the legendary-creature population from the preceding \
+             clause, not the triggering spell: {grant:?}"
+        );
+    }
+}

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -249,6 +249,18 @@ pub(crate) struct ParseContext {
     /// scan, but for the hand-reveal producer shape. `None` when no such
     /// producer exists in this chain, or during standalone clause parsing.
     pub chain_prior_hand_reveal_target: Option<TargetFilter>,
+    /// CR 608.2c: The object POPULATION established by a mass ("each …") effect in
+    /// an earlier clause of this same chain — Ardbert, Warrior of Darkness:
+    /// "put a +1/+1 counter on each legendary creature you control. They gain
+    /// vigilance until end of turn."
+    ///
+    /// Distinct from [`Self::parent_target_available`], which tracks a CHOSEN
+    /// referent that `TargetFilter::ParentTarget` binds to (see
+    /// `has_typed_target_widened`'s single-target whitelist). A mass effect
+    /// chooses nothing, so an anaphor referring back to its population cannot use
+    /// `ParentTarget` — it must inherit the population FILTER itself. `None` when
+    /// no such producer exists in this chain, or during standalone clause parsing.
+    pub chain_prior_mass_population: Option<TargetFilter>,
 }
 
 impl ParseContext {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3935,21 +3935,12 @@ fn exclude_attached_host_in_filter(filter: &TargetFilter) -> TargetFilter {
 /// intentionally excluded so their source-relative `FilterProp::Another`
 /// (e.g. Bound by Moonsilver's sacrifice cost) is never retargeted here.
 fn retarget_each_other_to_attached_host_in_effect(effect: &mut Effect) {
-    let filter = match effect {
-        Effect::CounterAll { target } | Effect::GainControlAll { target } => target,
-        Effect::PumpAll { target, .. }
-        | Effect::DamageAll { target, .. }
-        | Effect::DestroyAll { target, .. }
-        | Effect::BounceAll { target, .. }
-        | Effect::PutCounterAll { target, .. }
-        | Effect::DoublePTAll { target, .. } => target,
-        Effect::ExploreAll { filter } => filter,
-        Effect::SetTapState {
-            target,
-            scope: crate::types::ability::EffectScope::All,
-            ..
-        } => target,
-        _ => return,
+    // Delegates to the shared mass-population authority
+    // (`oracle_effect::mass_population_filter_mut`) so this walker and the
+    // anaphora seeding in `oracle_effect` read ONE variant list — a second
+    // hand-written list here would silently drift from it.
+    let Some(filter) = crate::parser::oracle_effect::mass_population_filter_mut(effect) else {
+        return;
     };
     *filter = exclude_attached_host_in_filter(filter);
 }


### PR DESCRIPTION
## Problem

Ardbert, Warrior of Darkness (#5985):

> Whenever you cast a white spell, put a +1/+1 counter on each legendary creature you control. **They gain vigilance until end of turn.**
> Whenever you cast a black spell, put a +1/+1 counter on each legendary creature you control. **They gain menace until end of turn.**

The report -- "his ability only partially fires" -- is exact: the counters landed, the keyword grant did nothing. The parse shows why:

```
PutCounterAll { P1P1, target: Typed{Creature, You, [Legendary]} }       <- correct
sub_ability: GenericEffect {
  static_abilities: [{ affected: TriggeringSource,                      <- BUG
                       modifications: [AddKeyword(Vigilance)] }],
  duration: UntilEndOfTurn }
```

`resolve_they_pronoun`'s object-type trigger-subject arm resolved "They" to `TargetFilter::TriggeringSource` -- **the cast spell that triggered the ability**. The grant was applied to an object on the stack, so no creature ever gained vigilance/menace. Both halves of the card are affected.

## Why `ParentTarget` is not the answer

My first instinct was to route this through `parent_target_available` / `ParentTarget`. That is wrong, and the codebase says so: per `chain_has_prior_typed_referent` and `has_typed_target_widened`'s **single-target whitelist**, that axis tracks a **CHOSEN** referent. A mass ("each ...") effect chooses nothing -- `PutCounterAll` is deliberately absent from that whitelist -- so `ParentTarget` has nothing to bind to. The anaphor must inherit the population **filter** itself.

## Fix

Add `ParseContext::chain_prior_mass_population`, seeded by the effect-chain loop from the most-recent earlier mass clause:

```rust
fn clause_ir_mass_population(clause: &ClauseIr) -> Option<TargetFilter> {
    match &clause.parsed.effect {
        Effect::PutCounterAll { target, .. }
        | Effect::PumpAll { target, .. }
        | Effect::DestroyAll { target, .. }
        | Effect::BounceAll { target, .. } => Some(target.clone()),
        _ => None,
    }
}
```

Those are exactly the variants whose `target` is a population filter rather than a chosen target -- the same reason they are absent from `has_typed_target_widened`.

`resolve_they_pronoun`'s object-type arm now prefers that population and falls back to `TriggeringSource` **only when no nearer antecedent exists**, so the existing "Whenever one or more creatures attack, **they** get +1/+0" shape (where the trigger's source genuinely IS the antecedent) is unchanged.

This mirrors the established chain-context pattern (`chain_prior_hand_reveal_target`, `chain_has_prior_exile_producer`) rather than inventing a mechanism, and is **class-level**: any `<mass effect over a population>. They <grant>` trigger benefits.

## Tests

- `they_after_mass_effect_binds_that_population_not_trigger_source` -- production path over the full card: **both** halves bind their grant's `affected` to the population the `PutCounterAll` actually acted on. The expectation is read from the parsed filter itself rather than a hand-written copy, so the test pins the *binding*, not a duplicated literal.

Full `engine` lib suite green (16,754 passed, 0 failed) -- the anaphora change surfaced no regressions. `cargo fmt`, `clippy -p engine --tests`, and the parser-combinator gate clean.

Closes #5985
