### PR TITLE
ship/t158 l2 rest pile

### DIFF
--- a/crates/engine/src/game/effects/dig.rs
+++ b/crates/engine/src/game/effects/dig.rs
@@ -5,8 +5,8 @@ use crate::types::ability::{
     TargetFilter,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
-use crate::types::zones::Zone;
+use crate::types::game_state::{BatchCompletion, GameState, WaitingFor};
+use crate::types::zones::{EtbTapState, Zone};
 
 /// CR 701.20e + CR 608.2c: Look at top N cards (shown only to the looking player),
 /// select some to keep per the effect's instructions, rest go elsewhere.
@@ -296,9 +296,25 @@ fn resolve_from_prior_look(
     // cards to rest_dest without any interactive prompt.
     if raw_keep_count == 0 {
         if let Some(dest) = rest_dest {
-            crate::game::engine_resolution_choices::route_rest_partition(
-                state, &cards, dest, events,
-            );
+            match crate::game::engine_resolution_choices::route_rest_partition(
+                state,
+                &cards,
+                dest,
+                Some(ability.source_id),
+                events,
+            ) {
+                crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                    crate::game::zone_pipeline::defer_completion_on_pause(
+                        state,
+                        BatchCompletion::DigPriorLookRestComplete {
+                            player: ability.controller,
+                            source_id: ability.source_id,
+                        },
+                    );
+                    return Ok(());
+                }
+            }
         }
         state.private_look_ids.clear();
         state.private_look_player = None;
@@ -327,9 +343,25 @@ fn resolve_from_prior_look(
     // rest_dest instead of surfacing an impossible DigChoice prompt.
     if selectable_cards.is_empty() {
         if let Some(dest) = rest_dest {
-            crate::game::engine_resolution_choices::route_rest_partition(
-                state, &cards, dest, events,
-            );
+            match crate::game::engine_resolution_choices::route_rest_partition(
+                state,
+                &cards,
+                dest,
+                Some(ability.source_id),
+                events,
+            ) {
+                crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                    crate::game::zone_pipeline::defer_completion_on_pause(
+                        state,
+                        BatchCompletion::DigPriorLookRestComplete {
+                            player: ability.controller,
+                            source_id: ability.source_id,
+                        },
+                    );
+                    return Ok(());
+                }
+            }
         }
         state.private_look_ids.clear();
         state.private_look_player = None;
@@ -379,12 +411,10 @@ fn resolve_from_prior_look(
 /// admits no player choice.
 ///
 /// The rest pile is routed first (a deterministic library/zone placement), so a
-/// rare CR 303.4f/616.1 battlefield-entry pause on a kept card cannot strand it.
-/// The kept cards then move through the zone-change pipeline (CR 614.1c — ETB
-/// triggers fire, intrinsic enters-with counters seed). On a kept-card pause the
-/// remaining kept moves and the tracked-set publish are deferred onto a
-/// `RevealRestPile` completion (empty rest pile — already placed), mirroring the
-/// `DigChoice` handler's deferral contract.
+/// replacement-choice pause cannot let the selected delivery or its tracked-set
+/// publication overtake the printed rest instruction. Selected cards then move
+/// as one pipeline batch, with a typed completion that publishes only cards that
+/// actually reached the requested destination after every redirect settles.
 #[allow(clippy::too_many_arguments)]
 fn resolve_mass_put_all(
     state: &mut GameState,
@@ -404,64 +434,74 @@ fn resolve_mass_put_all(
 
     // Route the (deterministic) rest pile first so a kept-card pause cannot
     // strand it. None => bottom of library (CR 701.20a "in a random order").
-    crate::game::engine_resolution_choices::route_rest_partition(
+    match crate::game::engine_resolution_choices::route_rest_partition(
         state,
         &rest,
         rest_destination.unwrap_or(Zone::Library),
+        Some(ability.source_id),
         events,
-    );
-
-    if dest == Zone::Battlefield {
-        // CR 614.1c + CR 306.5b / CR 310.4b: route battlefield entries through
-        // the batch zone-change pipeline so ETB triggers fire, intrinsic
-        // enters-with counters / tap state seed, and any CR 303.4f / CR 616.1
-        // pause preserves the remaining kept tail. CR 400.7: attribute entries
-        // to the Dig's source.
-        let reqs: Vec<_> = selectable
-            .iter()
-            .map(|&obj_id| {
-                let mut req = crate::game::zone_pipeline::ZoneMoveRequest::effect(
-                    obj_id,
-                    Zone::Battlefield,
-                    ability.source_id,
-                );
-                req.mods.enter_tapped =
-                    crate::types::zones::EtbTapState::from_legacy_bool(enter_tapped);
-                req
-            })
-            .collect();
-        match crate::game::zone_pipeline::move_objects_simultaneously(state, reqs, events) {
-            crate::game::zone_pipeline::BatchMoveResult::Done => {}
-            crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
-                crate::game::zone_pipeline::defer_completion_on_pause(
-                    state,
-                    crate::types::game_state::BatchCompletion::RevealRestPile {
-                        player: ability.controller,
-                        rest_cards: Vec::new(),
-                        rest_destination: rest_destination.unwrap_or(Zone::Library),
-                        clear_markers: Vec::new(),
-                        publish_tracked_set: Some(selectable.to_vec()),
-                        emit_reveal_until_resolved: None,
-                    },
-                );
-                return;
-            }
-        }
-    } else {
-        for &obj_id in selectable {
-            crate::game::zones::move_to_zone(state, obj_id, dest, events);
+    ) {
+        crate::game::zone_pipeline::BatchMoveResult::Done => move_mass_put_all_selected(
+            state,
+            ability.controller,
+            ability.source_id,
+            selectable.to_vec(),
+            dest,
+            EtbTapState::from_legacy_bool(enter_tapped),
+            events,
+        ),
+        crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+            crate::game::zone_pipeline::defer_completion_on_pause(
+                state,
+                BatchCompletion::DigMassPutAllRestComplete {
+                    player: ability.controller,
+                    source_id: ability.source_id,
+                    selected: selectable.to_vec(),
+                    destination: dest,
+                    enter_tapped: EtbTapState::from_legacy_bool(enter_tapped),
+                },
+            );
         }
     }
+}
 
-    // CR 701.20b + CR 608.2c: publish the kept (revealed) cards as a fresh
-    // tracked set so any downstream sub_ability can route them by type.
-    super::publish_fresh_tracked_set(state, selectable.to_vec());
-
-    events.push(GameEvent::EffectResolved {
-        kind: EffectKind::from(&ability.effect),
-        source_id: ability.source_id,
-        subject: None,
-    });
+/// CR 608.2c + CR 614.1 + CR 616.1: Deliver the selected half of a deterministic
+/// mass Dig. The typed batch completion is the single authority for publication
+/// and the parent result, so a replacement pause cannot expose a pre-redirect
+/// selected set to a chained instruction.
+pub(crate) fn move_mass_put_all_selected(
+    state: &mut GameState,
+    player: crate::types::player::PlayerId,
+    source_id: crate::types::identifiers::ObjectId,
+    selected: Vec<crate::types::identifiers::ObjectId>,
+    destination: Zone,
+    enter_tapped: EtbTapState,
+    events: &mut Vec<GameEvent>,
+) {
+    let requests = selected
+        .iter()
+        .map(|&object_id| {
+            let mut request = crate::game::zone_pipeline::ZoneMoveRequest::effect(
+                object_id,
+                destination,
+                source_id,
+            );
+            request.mods.enter_tapped = enter_tapped;
+            request
+        })
+        .collect();
+    let completion = BatchCompletion::DigMassPutAllComplete {
+        player,
+        source_id,
+        selected,
+        destination,
+    };
+    crate::game::zone_pipeline::move_objects_simultaneously_then(
+        state,
+        requests,
+        Some(completion),
+        events,
+    );
 }
 
 #[cfg(test)]

--- a/crates/engine/src/game/effects/reveal_until.rs
+++ b/crates/engine/src/game/effects/reveal_until.rs
@@ -232,6 +232,7 @@ pub fn resolve(
                                 state,
                                 BatchCompletion::RevealRestPile {
                                     player: revealing_player,
+                                    source_id: Some(ability.source_id),
                                     rest_cards: revealed_misses,
                                     rest_destination,
                                     clear_markers,
@@ -281,6 +282,7 @@ pub fn resolve(
                                 state,
                                 BatchCompletion::RevealRestPile {
                                     player: revealing_player,
+                                    source_id: Some(ability.source_id),
                                     rest_cards: revealed_misses,
                                     rest_destination,
                                     clear_markers,
@@ -313,6 +315,7 @@ pub fn resolve(
                                 state,
                                 BatchCompletion::RevealRestPile {
                                     player: revealing_player,
+                                    source_id: Some(ability.source_id),
                                     rest_cards: revealed_misses,
                                     rest_destination,
                                     clear_markers,
@@ -352,6 +355,7 @@ pub fn resolve(
                 state,
                 BatchCompletion::RevealRestPile {
                     player: revealing_player,
+                    source_id: Some(ability.source_id),
                     rest_cards: Vec::new(),
                     rest_destination,
                     clear_markers,

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -261,7 +261,7 @@ fn finish_search_found_batch(
                 };
                 return Ok(state.waiting_for.clone());
             }
-            let _ = apply_search_partition(
+            match apply_search_partition(
                 state,
                 &batch.survivors,
                 &[],
@@ -269,7 +269,12 @@ fn finish_search_found_batch(
                 source_id,
                 player,
                 events,
-            );
+            )? {
+                crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                    return Ok(state.waiting_for.clone());
+                }
+            }
             set_priority(state, player);
             // CR 605.3b + CR 616.1: resume-aware — a parked mana-cost cursor
             // settles before (and instead of stranding) the ordinary rider.
@@ -482,51 +487,25 @@ pub(crate) fn route_rest_partition(
     state: &mut GameState,
     rest_ids: &[ObjectId],
     rest_zone: Zone,
+    source_id: Option<ObjectId>,
     events: &mut Vec<GameEvent>,
-) {
-    match rest_zone {
-        Zone::Library => {
-            for &obj_id in rest_ids {
-                zones::move_to_library_position(state, obj_id, false, events);
+) -> crate::game::zone_pipeline::BatchMoveResult {
+    let requests = rest_ids
+        .iter()
+        .map(|&obj_id| {
+            let request = crate::game::zone_pipeline::ZoneMoveRequest::effect(
+                obj_id,
+                rest_zone,
+                source_id.unwrap_or(obj_id),
+            );
+            if rest_zone == Zone::Library {
+                request.at_library_position(LibraryPosition::Bottom)
+            } else {
+                request
             }
-        }
-        zone => {
-            // ZONE-PIPELINE GAP (documented deferral): the dig/search "rest into
-            // your graveyard" partition (65 Dig cards + the `null`→Graveyard
-            // default) is delivered raw here, so a `Moved` graveyard→exile redirect
-            // (Rest in Peace / Leyline of the Void) does NOT yet fire on these
-            // rest cards. The sibling dig unkept-loop (handle_resolution_choice
-            // DigChoice) and the reveal-until rest pile (effects::reveal_until::
-            // move_rest_then) ARE migrated; this shared partition helper is not,
-            // because it has three callers — two synchronous (search-split at
-            // `apply_search_partition`, dig at the kept block) and ONE inside
-            // `run_batch_completion`'s RevealRestPile arm.
-            //
-            // RE-PAUSE CONTRACT STATUS (updated): the "pause from inside a
-            // completion" blocker named here previously is RESOLVED — the
-            // re-pause contract documented on
-            // `zone_pipeline::drain_pending_batch_deliveries` now covers a fresh
-            // park raised FROM a completion (the drain `.take()`s the old record
-            // BEFORE invoking the completion, so a completion that re-enters the
-            // batch machinery installs a clean record; see the
-            // `AttractionOpenRemainder` arm, which already pauses + re-defers
-            // through this exact path). The ONLY remaining work to migrate this
-            // helper onto `move_objects_simultaneously` is threading the
-            // `BatchMoveResult::NeedsChoice` return through the two SYNCHRONOUS
-            // callers (`apply_search_partition` and the dig kept-block), each of
-            // which currently returns `Result<(), _>` / `()` and would need to
-            // surface a parked prompt the same way the migrated DigChoice
-            // unkept-loop does (`defer_completion_on_pause` + early return). That
-            // is a cross-cutting signature change across both callers; tracked for
-            // a follow-up so it lands as one reviewable unit rather than a partial
-            // migration here. (Practical exposure: a graveyard-redirect on a dig
-            // REST pile — the non-kept cards — with RIP/Leyline on the
-            // battlefield.)
-            for &obj_id in rest_ids {
-                zones::move_to_zone(state, obj_id, zone, events);
-            }
-        }
-    }
+        })
+        .collect();
+    crate::game::zone_pipeline::move_objects_simultaneously(state, requests, events)
 }
 
 /// CR 701.22a / CR 701.25a: Scry and surveil put the kept cards on top of the
@@ -690,7 +669,7 @@ fn apply_search_partition(
     source_id: ObjectId,
     controller: crate::types::player::PlayerId,
     events: &mut Vec<GameEvent>,
-) -> Result<(), EngineError> {
+) -> Result<crate::game::zone_pipeline::BatchMoveResult, EngineError> {
     if !primary_ids.is_empty() {
         // CR 614.1 / CR 110.5b: Synthesize a ChangeZone over the explicit primary
         // targets and route through the ETB pipeline so the permanent enters
@@ -722,10 +701,16 @@ fn apply_search_partition(
         crate::game::effects::resolve_ability_chain(state, &change_zone, events, 0)
             .map_err(|e| EngineError::InvalidAction(format!("search-split primary move: {e:?}")))?;
     }
-    // Rest is never Battlefield across the A/B/C cluster; the standard rest mover
-    // (Library => bottom per CR 401.4, else move_to_zone) is correct.
-    route_rest_partition(state, rest_ids, split.rest_destination, events);
-    Ok(())
+    // CR 701.23a + CR 401.4 + CR 616.1: Rest is never Battlefield across the
+    // A/B/C cluster. Surface a replacement-ordering pause so callers do not
+    // drain their shuffle continuation past the still-parked rest-pile batch.
+    Ok(route_rest_partition(
+        state,
+        rest_ids,
+        split.rest_destination,
+        Some(source_id),
+        events,
+    ))
 }
 
 /// CR 701.38: The mutable round state of a `WaitingFor::VoteChoice`. Bundles
@@ -1077,6 +1062,7 @@ pub(super) fn handle_resolution_choice(
                         state,
                         crate::types::game_state::BatchCompletion::RevealRestPile {
                             player,
+                            source_id: Some(source_id),
                             rest_cards: graveyard_cards,
                             rest_destination: Zone::Graveyard,
                             clear_markers: cards.clone(),
@@ -1304,6 +1290,7 @@ pub(super) fn handle_resolution_choice(
                                 state,
                                 crate::types::game_state::BatchCompletion::RevealRestPile {
                                     player,
+                                    source_id: Some(source_id),
                                     rest_cards: misses,
                                     rest_destination,
                                     clear_markers,
@@ -1379,6 +1366,7 @@ pub(super) fn handle_resolution_choice(
                 rest_destination,
                 Some(crate::types::game_state::BatchCompletion::RevealRestPile {
                     player,
+                    source_id: Some(source_id),
                     rest_cards: Vec::new(),
                     rest_destination,
                     clear_markers,
@@ -2364,6 +2352,7 @@ pub(super) fn handle_resolution_choice(
                                 state,
                                 crate::types::game_state::BatchCompletion::RevealRestPile {
                                     player,
+                                    source_id: dig_source_id,
                                     rest_cards: Vec::new(),
                                     rest_destination: zone,
                                     clear_markers: Vec::new(),
@@ -2436,6 +2425,7 @@ pub(super) fn handle_resolution_choice(
                                     state,
                                     crate::types::game_state::BatchCompletion::RevealRestPile {
                                         player,
+                                        source_id: dig_source_id,
                                         rest_cards: unkept.clone(),
                                         rest_destination: rest_destination
                                             .unwrap_or(Zone::Graveyard),
@@ -2471,23 +2461,50 @@ pub(super) fn handle_resolution_choice(
                 } else {
                     kept.clone()
                 };
-            effects::publish_fresh_tracked_set(state, publish_set);
             // None => Graveyard; map to a concrete zone so the rest mover
             // (shared with the search-split partition) has a single Zone.
             // When a continuation owns the unkept pile (Expressive Iteration
-            // bottom/exile tail), do not pre-route here.
+            // bottom/exile tail), do not pre-route here. A `Moved` replacement
+            // can pause this batch, so the tracked-set publication and
+            // continuation wiring stay below the result match: neither may see
+            // a pre-redirect rest pile.
             let defer_rest_routing = state
                 .pending_continuation
                 .as_ref()
                 .is_some_and(|cont| dig_continuation_needs_full_looked_at_tracked_set(&cont.chain));
             if !defer_rest_routing {
-                route_rest_partition(
+                match route_rest_partition(
                     state,
                     &unkept,
                     rest_destination.unwrap_or(Zone::Graveyard),
+                    dig_source_id,
                     events,
-                );
+                ) {
+                    crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                    crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                        // CR 701.20e + CR 616.1: `route_rest_partition` has
+                        // parked the undelivered suffix. Its cleanup tail owns
+                        // the publication and continuation work, so the drain
+                        // performs it exactly once only after the true batch end.
+                        crate::game::zone_pipeline::defer_completion_on_pause(
+                            state,
+                            crate::types::game_state::BatchCompletion::RevealRestPile {
+                                player,
+                                source_id: dig_source_id,
+                                rest_cards: Vec::new(),
+                                rest_destination: rest_destination.unwrap_or(Zone::Graveyard),
+                                clear_markers: Vec::new(),
+                                publish_tracked_set: Some(publish_set),
+                                emit_reveal_until_resolved: None,
+                            },
+                        );
+                        return Ok(ResolutionChoiceOutcome::WaitingFor(
+                            state.waiting_for.clone(),
+                        ));
+                    }
+                }
             }
+            effects::publish_fresh_tracked_set(state, publish_set);
             if let Some(cont) = state.pending_continuation.as_mut() {
                 // CR 608.2c: ParentTarget continuations (Hideaway conceal, dig
                 // conditionals on the kept card) bind to the kept selection.
@@ -2744,7 +2761,22 @@ pub(super) fn handle_resolution_choice(
                 // CR 609.3 fast-path: found <= primary_count, so ALL chosen go to
                 // the primary destination and the rest is empty. No second prompt.
                 let events_before_drain = events.len();
-                apply_search_partition(state, &chosen, &[], &split, source_id, player, events)?;
+                match apply_search_partition(
+                    state,
+                    &chosen,
+                    &[],
+                    &split,
+                    source_id,
+                    player,
+                    events,
+                )? {
+                    crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                    crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                        return Ok(ResolutionChoiceOutcome::WaitingFor(
+                            state.waiting_for.clone(),
+                        ));
+                    }
+                }
                 set_priority(state, player);
                 super::engine::resume_pending_continuation_if_priority(state, events)
                     .expect("a settled search choice must resume its continuation");
@@ -2800,7 +2832,7 @@ pub(super) fn handle_resolution_choice(
                 rest_destination,
             };
             let events_before_partition = events.len();
-            apply_search_partition(
+            match apply_search_partition(
                 state,
                 &primary_chosen,
                 &rest_ids,
@@ -2808,7 +2840,14 @@ pub(super) fn handle_resolution_choice(
                 source_id,
                 player,
                 events,
-            )?;
+            )? {
+                crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                    return Ok(ResolutionChoiceOutcome::WaitingFor(
+                        state.waiting_for.clone(),
+                    ));
+                }
+            }
             set_priority(state, player);
             super::engine::resume_pending_continuation_if_priority(state, events)
                 .expect("a settled search choice must resume its continuation");
@@ -5318,6 +5357,7 @@ fn route_kept_card_or_defer(
                 state,
                 crate::types::game_state::BatchCompletion::RevealRestPile {
                     player,
+                    source_id: Some(source_id),
                     rest_cards: misses.to_vec(),
                     rest_destination,
                     clear_markers,
@@ -5478,6 +5518,7 @@ pub(crate) fn run_batch_completion(
         // tail the synchronous path runs inline.
         BatchCompletion::RevealRestPile {
             player,
+            source_id,
             rest_cards,
             rest_destination,
             clear_markers,
@@ -5490,7 +5531,25 @@ pub(crate) fn run_batch_completion(
             // Library-bottom placement and any CR 616.1 pause. Dispatch on the
             // dig-only payload so each site keeps its synchronous semantics.
             if publish_tracked_set.is_some() {
-                route_rest_partition(state, &rest_cards, rest_destination, events);
+                match route_rest_partition(state, &rest_cards, rest_destination, source_id, events)
+                {
+                    crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                    crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                        crate::game::zone_pipeline::defer_completion_on_pause(
+                            state,
+                            BatchCompletion::RevealRestPile {
+                                player,
+                                source_id,
+                                rest_cards: Vec::new(),
+                                rest_destination,
+                                clear_markers,
+                                publish_tracked_set,
+                                emit_reveal_until_resolved,
+                            },
+                        );
+                        return;
+                    }
+                }
             } else if !rest_cards.is_empty() {
                 // CR 701.20a + CR 616.1: Reveal-until rest piles are fully
                 // pipeline-owned, including Library-bottom placement. If a
@@ -5499,6 +5558,7 @@ pub(crate) fn run_batch_completion(
                 // continuation drain run after the pile actually lands.
                 let cleanup = BatchCompletion::RevealRestPile {
                     player,
+                    source_id,
                     rest_cards: Vec::new(),
                     rest_destination,
                     clear_markers,
@@ -5533,6 +5593,63 @@ pub(crate) fn run_batch_completion(
                     subject: None,
                 });
             }
+            finish_with_continuation(state, player, events);
+        }
+        BatchCompletion::DigMassPutAllRestComplete {
+            player,
+            source_id,
+            selected,
+            destination,
+            enter_tapped,
+        } => {
+            crate::game::effects::dig::move_mass_put_all_selected(
+                state,
+                player,
+                source_id,
+                selected,
+                destination,
+                enter_tapped,
+                events,
+            );
+        }
+        BatchCompletion::DigMassPutAllComplete {
+            player: _,
+            source_id,
+            selected,
+            destination,
+        } => {
+            // CR 608.2c + CR 614.1: A replacement can redirect an individual
+            // selected card, so "those" refers only to cards that actually
+            // reached the requested destination after the full batch settles.
+            let delivered = selected
+                .into_iter()
+                .filter(|id| {
+                    state
+                        .objects
+                        .get(id)
+                        .is_some_and(|obj| obj.zone == destination)
+                })
+                .collect();
+            effects::publish_fresh_tracked_set(state, delivered);
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::Dig,
+                source_id,
+                subject: None,
+            });
+            // The synchronous resolver still owns its own sub-ability traversal;
+            // on a paused path `engine_replacement` drains the already-stashed
+            // continuation after this batch completion returns. Do not drain it
+            // here, or a synchronous mass Dig could run an outer continuation
+            // ahead of its own child instruction.
+        }
+        BatchCompletion::DigPriorLookRestComplete { player, source_id } => {
+            state.private_look_ids.clear();
+            state.private_look_player = None;
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::Dig,
+                source_id,
+                subject: None,
+            });
             finish_with_continuation(state, player, events);
         }
         // CR 610.3: the exile-until-leaves return pile has fully landed (after a

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1870,6 +1870,11 @@ pub enum BatchCompletion {
     RevealRestPile {
         /// The player whose continuation drains after the pile lands.
         player: PlayerId,
+        /// CR 400.7: The resolving effect's source, preserved so any rest-pile
+        /// requests rebuilt after an earlier kept-card pause retain their
+        /// original attribution. `None` retains the legacy self-anchor only for
+        /// synthesized test/compatibility states that have no ability source.
+        source_id: Option<ObjectId>,
         /// Unkept cards to move once the kept card finishes entering.
         rest_cards: Vec<ObjectId>,
         /// Where the rest pile goes (`Library` => bottom in a reposition, else
@@ -1888,6 +1893,33 @@ pub enum BatchCompletion {
         /// must too. `None` for the kept-choice / dig paths, which emit their own
         /// `EffectResolved` before the pause (or rely on the continuation).
         emit_reveal_until_resolved: Option<ObjectId>,
+    },
+    /// CR 608.2c + CR 616.1: The rest half of a deterministic mass Dig settled
+    /// after a replacement choice. Resume its selected-card delivery only now,
+    /// preserving the printed rest-before-kept sequence across the pause.
+    DigMassPutAllRestComplete {
+        player: PlayerId,
+        source_id: ObjectId,
+        selected: Vec<ObjectId>,
+        destination: Zone,
+        enter_tapped: EtbTapState,
+    },
+    /// CR 608.2c + CR 616.1: Every selected card of a deterministic mass Dig
+    /// has settled. Publish only cards that actually reached `destination`, then
+    /// emit the parent Dig result; the normal resolver/resume path owns the
+    /// continuation drain.
+    DigMassPutAllComplete {
+        player: PlayerId,
+        source_id: ObjectId,
+        selected: Vec<ObjectId>,
+        destination: Zone,
+    },
+    /// CR 608.2c + CR 616.1: A prior-look Dig's automatic rest move settled.
+    /// The private-look window and parent resolution event remain live until the
+    /// full replacement-aware batch has finished.
+    DigPriorLookRestComplete {
+        player: PlayerId,
+        source_id: ObjectId,
     },
     /// CR 610.3 + CR 614.1c: An "exile until ~ leaves" return (Banisher Priest /
     /// Fiend Hunter / Oblivion Ring class) routed its exiled cards back to the

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -6,9 +6,10 @@ use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, CastingPermission, ChoiceType,
-    DiscardSelfScope, Effect, ManaContribution, ManaProduction, ModalChoice, QuantityExpr,
-    ReplacementDefinition, ReplacementMode, ResolvedAbility, SacrificeCost, SpellCastingOption,
-    TargetFilter, TargetRef, TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
+    DigSource, DiscardSelfScope, Effect, ManaContribution, ManaProduction, ModalChoice,
+    QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode, ResolvedAbility,
+    SacrificeCost, SpellCastingOption, TargetFilter, TargetRef, TargetSelectionMode,
+    TriggerDefinition, TypeFilter, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
@@ -16,9 +17,9 @@ use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
 use engine::types::events::GameEvent;
 use engine::types::game_state::{
-    CastPaymentMode, CollectEvidenceResume, GameState, ManaAbilityCostParentLifecycle,
-    ManaAbilityCostResolutionMode, ManaAbilityResume, PayCostKind, PendingCast,
-    PendingCostMoveResume, PendingReplacement, StackEntryKind, WaitingFor,
+    BatchCompletion, CastPaymentMode, CollectEvidenceResume, GameState,
+    ManaAbilityCostParentLifecycle, ManaAbilityCostResolutionMode, ManaAbilityResume, PayCostKind,
+    PendingCast, PendingCostMoveResume, PendingReplacement, StackEntryKind, WaitingFor,
 };
 use engine::types::keywords::Keyword;
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
@@ -50,6 +51,570 @@ fn redirect_moved_to(destination: Zone, redirected_to: Zone) -> ReplacementDefin
                 enters_modified_if: None,
             },
         ))
+}
+
+/// W-R1 (red first): a Dig rest pile sent to the library bottom is an
+/// effect-owned batch. Competing Library-destination `Moved` replacements must
+/// pause before the kept tracked set is published, then re-pause safely while
+/// the rest pile drains.
+#[test]
+fn dig_rest_pile_library_redirect_pauses_before_tracked_set_publish() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Dig Rest-Pile Redirect Source", 1, 1)
+        .id();
+    let kept = scenario
+        .add_spell_to_library_top(P0, "Dig Kept Card", true)
+        .id();
+    let rest_a = scenario
+        .add_spell_to_library_top(P0, "Dig Rest Card A", true)
+        .id();
+    let rest_b = scenario
+        .add_spell_to_library_top(P0, "Dig Rest Card B", true)
+        .id();
+    let redirect_sources = [
+        scenario
+            .add_creature(P0, "Dig Library To Graveyard", 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Library, Zone::Graveyard))
+            .id(),
+        scenario
+            .add_creature(P0, "Dig Library To Exile", 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Library, Zone::Exile))
+            .id(),
+    ];
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![kept, rest_a, rest_b];
+    let ability = ResolvedAbility::new(
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 3 },
+            destination: None,
+            keep_count: Some(1),
+            keep_count_expr: None,
+            up_to: false,
+            filter: TargetFilter::Any,
+            rest_destination: Some(Zone::Library),
+            reveal: true,
+            enter_tapped: false,
+            source: DigSource::Library,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("Dig reaches its selection");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::DigChoice { .. }
+    ));
+
+    let paused = runner
+        .act(GameAction::SelectCards { cards: vec![kept] })
+        .expect("Dig submits the kept card and reaches the first bottom placement");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    let parked_order = runner
+        .state()
+        .pending_batch_deliveries
+        .as_ref()
+        .expect("the second rest card is parked behind the first replacement choice")
+        .remaining
+        .clone();
+    assert_eq!(parked_order.len(), 1);
+    assert!(
+        runner.state().chain_tracked_set_id.is_none(),
+        "the kept set cannot publish while a rest placement remains undecided"
+    );
+    for card_id in [kept, rest_a, rest_b] {
+        assert!(
+            runner.state().revealed_cards.contains(&card_id),
+            "reveal bookkeeping must remain intact while the rest-pile batch is parked"
+        );
+    }
+
+    let first_redirect = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("first rest-card redirect resolves");
+    assert!(matches!(
+        first_redirect.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(
+        runner.state().chain_tracked_set_id.is_none(),
+        "a re-paused rest batch still cannot publish its tracked set"
+    );
+    for redirect_source in redirect_sources {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&redirect_source)
+            .expect("synthetic redirect source remains on the battlefield")
+            .replacement_definitions
+            .clear();
+    }
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("unredirected rest-pile suffix drains");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    let tracked = runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &runner
+                .state()
+                .chain_tracked_set_id
+                .expect("Dig publishes a tracked set once its rest pile settles"),
+        )
+        .expect("the freshly-published Dig tracked set exists");
+    assert_eq!(tracked, &vec![kept]);
+    let redirected_id = [rest_a, rest_b]
+        .into_iter()
+        .find(|id| !parked_order.contains(id))
+        .expect("first attempted rest card is outside the parked suffix");
+    assert_ne!(runner.state().objects[&redirected_id].zone, Zone::Library);
+    assert_eq!(runner.state().objects[&parked_order[0]].zone, Zone::Library);
+}
+
+/// W-R3 (red first): deterministic Dig's nonbattlefield kept batch must defer
+/// its tracked-set publication and downstream tracked-set consumer until every
+/// selected card has either reached the requested destination or been
+/// redirected elsewhere.
+#[test]
+fn dig_mass_put_all_nonbattlefield_redirect_publishes_only_delivered_set() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Mass Dig Redirect Source", 1, 1)
+        .id();
+    let selected_a = scenario
+        .add_spell_to_library_top(P0, "Mass Dig Selected A", true)
+        .id();
+    let selected_b = scenario
+        .add_spell_to_library_top(P0, "Mass Dig Selected B", true)
+        .id();
+    let drawn = scenario
+        .add_spell_to_library_top(P0, "Mass Dig Tracked-Set Draw", true)
+        .id();
+    let redirect_sources = [
+        scenario
+            .add_creature(P0, "Mass Dig Hand To Exile", 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Hand, Zone::Exile))
+            .id(),
+        scenario
+            .add_creature(P0, "Mass Dig Hand To Graveyard", 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Hand, Zone::Graveyard))
+            .id(),
+    ];
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![selected_a, selected_b, drawn];
+    let mut ability = ResolvedAbility::new(
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 2 },
+            destination: Some(Zone::Hand),
+            keep_count: Some(u32::MAX),
+            keep_count_expr: None,
+            up_to: false,
+            filter: TargetFilter::Any,
+            rest_destination: Some(Zone::Library),
+            reveal: true,
+            enter_tapped: false,
+            source: DigSource::Library,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::Draw {
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::TrackedSetSize,
+            },
+            target: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    )));
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("mass Dig reaches its first kept-card delivery");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    let parked_order = runner
+        .state()
+        .pending_batch_deliveries
+        .as_ref()
+        .expect("the second selected card is batch-owned behind the first redirect")
+        .remaining
+        .clone();
+    assert_eq!(parked_order.len(), 1);
+    assert!(
+        runner
+            .state()
+            .tracked_object_sets
+            .values()
+            .all(|set| !set.contains(&selected_a) && !set.contains(&selected_b)),
+        "a nested replacement may allocate an unrelated empty tracked set, but the mass Dig's selected cards cannot publish before their batch settles"
+    );
+    assert_eq!(
+        runner.state().objects[&drawn].zone,
+        Zone::Library,
+        "the chained tracked-set consumer cannot run while the selected batch is parked"
+    );
+    assert!(
+        !initial_events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: engine::types::ability::EffectKind::Dig,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "the parent Dig result must wait for the selected batch"
+    );
+
+    let first_redirect = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("first selected-card redirect resolves");
+    assert!(matches!(
+        first_redirect.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(runner
+        .state()
+        .tracked_object_sets
+        .values()
+        .all(|set| !set.contains(&selected_a) && !set.contains(&selected_b)));
+    for redirect_source in redirect_sources {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&redirect_source)
+            .expect("synthetic redirect source remains on the battlefield")
+            .replacement_definitions
+            .clear();
+    }
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the remaining selected card reaches hand and the mass Dig completes");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+
+    let redirected_id = [selected_a, selected_b]
+        .into_iter()
+        .find(|id| !parked_order.contains(id))
+        .expect("first selected card is outside the parked suffix");
+    let delivered_id = parked_order[0];
+    assert_ne!(runner.state().objects[&redirected_id].zone, Zone::Hand);
+    assert_eq!(runner.state().objects[&delivered_id].zone, Zone::Hand);
+    let tracked = runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &runner
+                .state()
+                .chain_tracked_set_id
+                .expect("mass Dig publishes only after the kept batch settles"),
+        )
+        .expect("the mass Dig tracked set exists");
+    assert_eq!(tracked, &vec![delivered_id]);
+    assert_eq!(
+        runner.state().objects[&drawn].zone,
+        Zone::Hand,
+        "the chained tracked-set draw sees exactly the delivered selected-card count"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(first_redirect.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::Dig,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the parent Dig completion fires exactly once after the kept batch settles"
+    );
+}
+
+/// W-REG: The migration keeps the no-replacement fast paths synchronous for
+/// both interactive and deterministic Dig; the search split fast path remains
+/// covered by `cultivate_split_destination`.
+#[test]
+fn uninterrupted_dig_rest_and_mass_put_all_complete_synchronously() {
+    let mut dig_scenario = GameScenario::new();
+    dig_scenario.at_phase(Phase::PreCombatMain);
+    let dig_source = dig_scenario
+        .add_creature(P0, "Synchronous Dig Source", 1, 1)
+        .id();
+    let kept = dig_scenario
+        .add_spell_to_library_top(P0, "Synchronous Dig Kept", true)
+        .id();
+    let rest_a = dig_scenario
+        .add_spell_to_library_top(P0, "Synchronous Dig Rest A", true)
+        .id();
+    let rest_b = dig_scenario
+        .add_spell_to_library_top(P0, "Synchronous Dig Rest B", true)
+        .id();
+    let mut dig_runner = dig_scenario.build();
+    dig_runner.state_mut().players[P0.0 as usize].library = im::vector![kept, rest_a, rest_b];
+    let dig = ResolvedAbility::new(
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 3 },
+            destination: None,
+            keep_count: Some(1),
+            keep_count_expr: None,
+            up_to: false,
+            filter: TargetFilter::Any,
+            rest_destination: Some(Zone::Library),
+            reveal: false,
+            enter_tapped: false,
+            source: DigSource::Library,
+        },
+        vec![],
+        dig_source,
+        P0,
+    );
+    let mut dig_events = Vec::new();
+    resolve_ability_chain(dig_runner.state_mut(), &dig, &mut dig_events, 0)
+        .expect("uninterrupted Dig reaches its selection");
+    let dig_completed = dig_runner
+        .act(GameAction::SelectCards { cards: vec![kept] })
+        .expect("uninterrupted Dig rest batch completes inline");
+    assert!(matches!(
+        dig_completed.waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert!(dig_runner.state().pending_batch_deliveries.is_none());
+    assert_eq!(dig_runner.state().objects[&rest_a].zone, Zone::Library);
+    assert_eq!(dig_runner.state().objects[&rest_b].zone, Zone::Library);
+    let dig_tracked = dig_runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &dig_runner
+                .state()
+                .chain_tracked_set_id
+                .expect("synchronous Dig publishes its kept set"),
+        )
+        .expect("synchronous Dig tracked set exists");
+    assert_eq!(dig_tracked, &vec![kept]);
+
+    let mut mass_scenario = GameScenario::new();
+    mass_scenario.at_phase(Phase::PreCombatMain);
+    let mass_source = mass_scenario
+        .add_creature(P0, "Synchronous Mass Dig Source", 1, 1)
+        .id();
+    let selected_a = mass_scenario
+        .add_spell_to_library_top(P0, "Synchronous Mass Dig A", true)
+        .id();
+    let selected_b = mass_scenario
+        .add_spell_to_library_top(P0, "Synchronous Mass Dig B", true)
+        .id();
+    let mut mass_runner = mass_scenario.build();
+    mass_runner.state_mut().players[P0.0 as usize].library = im::vector![selected_a, selected_b];
+    let mass_dig = ResolvedAbility::new(
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 2 },
+            destination: Some(Zone::Hand),
+            keep_count: Some(u32::MAX),
+            keep_count_expr: None,
+            up_to: false,
+            filter: TargetFilter::Any,
+            rest_destination: Some(Zone::Library),
+            reveal: false,
+            enter_tapped: false,
+            source: DigSource::Library,
+        },
+        vec![],
+        mass_source,
+        P0,
+    );
+    let mut mass_events = Vec::new();
+    resolve_ability_chain(mass_runner.state_mut(), &mass_dig, &mut mass_events, 0)
+        .expect("uninterrupted deterministic Dig resolves inline");
+    assert!(matches!(
+        mass_runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert!(mass_runner.state().pending_batch_deliveries.is_none());
+    assert_eq!(mass_runner.state().objects[&selected_a].zone, Zone::Hand);
+    assert_eq!(mass_runner.state().objects[&selected_b].zone, Zone::Hand);
+    let mass_tracked = mass_runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &mass_runner
+                .state()
+                .chain_tracked_set_id
+                .expect("synchronous mass Dig publishes after its batch"),
+        )
+        .expect("synchronous mass Dig tracked set exists");
+    assert_eq!(mass_tracked, &vec![selected_a, selected_b]);
+}
+
+/// W-R2: A `RevealRestPile` already deferred behind a kept-card replacement can
+/// itself start a Library-bottom batch that re-pauses while draining. Its cleanup
+/// must survive both pause boundaries and publish exactly once at the true end.
+#[test]
+fn dig_deferred_reveal_rest_pile_repauses_and_completes_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Deferred Dig Rest-Pile Source", 1, 1)
+        .id();
+    let kept = scenario
+        .add_spell_to_library_top(P0, "Deferred Dig Kept", true)
+        .id();
+    let rest_a = scenario
+        .add_spell_to_library_top(P0, "Deferred Dig Rest A", true)
+        .id();
+    let rest_b = scenario
+        .add_spell_to_library_top(P0, "Deferred Dig Rest B", true)
+        .id();
+    for (name, destination) in [
+        ("Deferred Dig Battlefield Redirect A", Zone::Graveyard),
+        ("Deferred Dig Battlefield Redirect B", Zone::Exile),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Battlefield, destination));
+    }
+    let library_redirect_sources = [
+        scenario
+            .add_creature(P0, "Deferred Dig Library Redirect A", 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Library, Zone::Graveyard))
+            .id(),
+        scenario
+            .add_creature(P0, "Deferred Dig Library Redirect B", 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Library, Zone::Exile))
+            .id(),
+    ];
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![kept, rest_a, rest_b];
+    let ability = ResolvedAbility::new(
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 3 },
+            destination: Some(Zone::Battlefield),
+            keep_count: Some(1),
+            keep_count_expr: None,
+            up_to: false,
+            filter: TargetFilter::Any,
+            rest_destination: Some(Zone::Library),
+            reveal: true,
+            enter_tapped: false,
+            source: DigSource::Library,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Dig reaches its kept-card selection");
+
+    let kept_pause = runner
+        .act(GameAction::SelectCards { cards: vec![kept] })
+        .expect("kept battlefield entry reaches a replacement choice");
+    assert!(matches!(
+        kept_pause.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner
+            .state()
+            .pending_batch_deliveries
+            .as_ref()
+            .and_then(|pending| pending.completion.as_ref()),
+        Some(BatchCompletion::RevealRestPile { .. })
+    ));
+
+    let rest_pause = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("kept-card resolution enters the deferred rest-pile route");
+    assert!(matches!(
+        rest_pause.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    let first_rest_park = runner
+        .state()
+        .pending_batch_deliveries
+        .as_ref()
+        .expect("the second rest placement is parked behind the first redirect");
+    assert_eq!(first_rest_park.remaining.len(), 1);
+    assert!(matches!(
+        first_rest_park.completion.as_ref(),
+        Some(BatchCompletion::RevealRestPile { .. })
+    ));
+    assert!(runner.state().chain_tracked_set_id.is_none());
+
+    let reparking = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the rest batch re-parks on its remaining library placement");
+    assert!(matches!(
+        reparking.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(matches!(
+        runner
+            .state()
+            .pending_batch_deliveries
+            .as_ref()
+            .and_then(|pending| pending.completion.as_ref()),
+        Some(BatchCompletion::RevealRestPile { .. })
+    ));
+    assert!(runner.state().chain_tracked_set_id.is_none());
+
+    for redirect_source in library_redirect_sources {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&redirect_source)
+            .expect("synthetic redirect source remains on the battlefield")
+            .replacement_definitions
+            .clear();
+    }
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the final rest placement drains the deferred completion");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    let tracked = runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &runner
+                .state()
+                .chain_tracked_set_id
+                .expect("the Dig completion publishes after the true batch end"),
+        )
+        .expect("the tracked set exists");
+    assert_eq!(tracked, &vec![kept]);
 }
 
 fn redirect_self_moved_to(destination: Zone, redirected_to: Zone) -> ReplacementDefinition {

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -32,7 +32,6 @@ crates/engine/src/game/effects/cast_from_zone.rs	grant_lingering_permissions	mov
 crates/engine/src/game/effects/choose_from_zone.rs	drain_pending_per_category_zone_choice	mover	1
 crates/engine/src/game/effects/cloak.rs	resolve	mover	1
 crates/engine/src/game/effects/copy_spell.rs	resolve	zone-assign	1
-crates/engine/src/game/effects/dig.rs	resolve_mass_put_all	mover	1
 crates/engine/src/game/effects/drawn_this_turn_choice.rs	handle_topdeck_choice	mover	1
 crates/engine/src/game/effects/epic.rs	resolve	zone-assign	1
 crates/engine/src/game/effects/explore.rs	resolve_explore_effect	mover	1
@@ -45,7 +44,6 @@ crates/engine/src/game/engine.rs	normalize_recast_frame	exempt	3
 crates/engine/src/game/engine_debug.rs	apply_debug_action	mover	1
 crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	container	6
 crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	mover	7
-crates/engine/src/game/engine_resolution_choices.rs	route_rest_partition	mover	2
 crates/engine/src/game/engine_resolution_choices.rs	run_batch_completion	mover	2
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	container	1
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	zone-assign	1


### PR DESCRIPTION
- **refactor(engine): route rest-pile and mass-Dig batches through the zone pipeline (L2/R0)**
- **chore: tighten zone-authority baseline after L2/R0 rest-pile migration**
