### PR TITLE
test(engine): regression for Ajani flip when Cat token is sacrificed to outlet

### DIFF
--- a/crates/engine/tests/integration/ajani_nacatl_pariah_sacrifice_outlet_6018.rs
+++ b/crates/engine/tests/integration/ajani_nacatl_pariah_sacrifice_outlet_6018.rs
@@ -1,0 +1,184 @@
+//! Regression for GitHub issue #6018 — Ajani, Nacatl Pariah's transform trigger
+//! when another Cat dies via a sacrifice outlet.
+//!
+//! Discord repro board: Ajani, Nacatl Pariah + Cat Warrior token + Goblin
+//! Bombardment + Guide of Souls.
+//!
+//! Oracle (Ajani): "Whenever one or more other Cats you control die, you may
+//! exile Ajani, then return him to the battlefield transformed under his
+//! owner's control."
+//!
+//! The #503 regression covered a Lightning Bolt kill of a nontoken Cat; this
+//! test drives the sacrifice-outlet path (Goblin Bombardment: "Sacrifice a
+//! creature: This enchantment deals 1 damage to any target") so dies-triggers
+//! collected during the activation's sacrifice cost still reach the stack and
+//! Ajani's optional exile/return chain resolves with `him` bound to Ajani.
+//!
+//! CR 608.2c: the anaphor "him" in clause 2 binds to Ajani (`exile ~` in
+//! clause 1), not the sacrificed Cat.
+//! CR 712.14a: a double-faced card put onto the battlefield transformed
+//! enters with its back face up.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{PayCostKind, WaitingFor};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use crate::support::shared_card_db as load_db;
+const GOBLIN_BOMBARDMENT: &str =
+    "Sacrifice a creature: This enchantment deals 1 damage to any target.";
+
+/// Sacrificing Ajani's Cat Warrior token to Goblin Bombardment must still flip
+/// Ajani to his planeswalker back face when the optional trigger is accepted.
+#[test]
+fn ajani_returns_transformed_when_cat_token_sacrificed_to_outlet() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let ajani = scenario.add_real_card(P0, "Ajani, Nacatl Pariah", Zone::Battlefield, db);
+    let _guide = scenario.add_real_card(P0, "Guide of Souls", Zone::Battlefield, db);
+    let bombardment = scenario
+        .add_creature(P0, "Goblin Bombardment", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(GOBLIN_BOMBARDMENT)
+        .id();
+
+    // Ajani's 2/1 white Cat Warrior token from his ETB ability.
+    let cat_token = scenario
+        .add_creature(P0, "Cat Warrior", 2, 1)
+        .with_subtypes(vec!["Cat", "Warrior"])
+        .id();
+
+    scenario.add_basic_land(P0, ManaColor::Red);
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&cat_token)
+        .unwrap()
+        .is_token = true;
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    // Precondition: Ajani is front-face on the battlefield.
+    {
+        let obj = runner.state().objects.get(&ajani).expect("Ajani exists");
+        assert!(!obj.transformed, "precondition: Ajani starts front-face");
+        assert!(
+            obj.back_face.is_some(),
+            "precondition: Ajani's DFC back face must be hydrated"
+        );
+    }
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: bombardment,
+            ability_index: 0,
+        })
+        .expect("activating Goblin Bombardment must succeed");
+
+    let mut sacrificed = false;
+    let mut targeted = false;
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::PayCost {
+                kind: PayCostKind::Sacrifice,
+                choices,
+                ..
+            } => {
+                assert!(
+                    choices.contains(&cat_token),
+                    "the Cat Warrior token must be a legal sacrifice"
+                );
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![cat_token],
+                    })
+                    .expect("sacrificing the Cat Warrior token must succeed");
+                sacrificed = true;
+            }
+            WaitingFor::TargetSelection { target_slots, .. } => {
+                assert!(
+                    target_slots[0]
+                        .legal_targets
+                        .contains(&TargetRef::Player(P1)),
+                    "the opponent must be a legal damage target"
+                );
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Player(P1)],
+                    })
+                    .expect("targeting the opponent must succeed");
+                targeted = true;
+            }
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept Ajani's optional exile/return trigger");
+            }
+            _ => {
+                runner.advance_until_stack_empty();
+                if !runner.state().stack.is_empty() {
+                    continue;
+                }
+                if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+                    break;
+                }
+            }
+        }
+    }
+
+    assert!(
+        sacrificed,
+        "must have paid Goblin Bombardment's sacrifice cost"
+    );
+    assert!(targeted, "must have selected a damage target");
+
+    // CR 111.2: tokens cease to exist in the graveyard — the object is removed
+    // from `state.objects` rather than lingering with `zone == Graveyard`.
+    assert!(
+        runner.state().objects.get(&cat_token).is_none()
+            || runner
+                .state()
+                .objects
+                .get(&cat_token)
+                .is_some_and(|o| o.zone != Zone::Battlefield),
+        "the Cat Warrior token must no longer be on the battlefield"
+    );
+
+    let ajani_obj = runner
+        .state()
+        .objects
+        .get(&ajani)
+        .expect("Ajani object still exists");
+    assert_eq!(
+        ajani_obj.zone,
+        Zone::Battlefield,
+        "Ajani must return to the battlefield (CR 608.2c: 'him' binds to Ajani)"
+    );
+    assert!(
+        ajani_obj.transformed,
+        "Ajani must enter transformed (CR 712.14a)"
+    );
+    assert!(
+        ajani_obj
+            .card_types
+            .core_types
+            .contains(&CoreType::Planeswalker),
+        "transformed Ajani must show his Avenger back face, got {:?}",
+        ajani_obj.card_types.core_types
+    );
+    assert!(
+        ajani_obj.loyalty.is_some(),
+        "the planeswalker back face must carry loyalty"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -3,6 +3,7 @@ mod abundance_optional_draw_replacement;
 mod ad_nauseam_repeat;
 mod adapter_contract_fixtures;
 mod advanced_reconstruction_regression;
+mod ajani_nacatl_pariah_sacrifice_outlet_6018;
 mod ajani_nacatl_pariah_transform;
 mod alchemists_gift_pump_modal_keyword_choice;
 mod ambuscade_one_sided_fight_anaphoric;


### PR DESCRIPTION
Fixes #6018

## Summary

Discord report for [Ajani, Nacatl Pariah](https://github.com/phase-rs/phase/issues/6018) listed the card as fully supported with repro board: Ajani + Cat Warrior token + Goblin Bombardment (+ Guide of Souls). The issue body did not describe a specific failure mode (stuck in exile, softlock, etc.).

Investigation showed the engine already handles this path correctly on `main`:

- Ajani's transform trigger parses with `SelfRef` on both exile and return clauses (the #503 anaphor fix).
- Sacrificing the Cat Warrior token to Goblin Bombardment during activation correctly parks dies-triggers while target selection is pending, then drains them once the ability is announced on the stack.
- Accepting the optional trigger returns Ajani transformed to his planeswalker back face.

The gap was **test coverage**: the existing #503 regression (`ajani_nacatl_pariah_transform.rs`) only killed a nontoken Cat with Lightning Bolt. This PR adds an integration test that mirrors the Discord repro — sacrifice outlet, token death, deferred-trigger path, and optional flip acceptance.

## Changes

- **`crates/engine/tests/integration/ajani_nacatl_pariah_sacrifice_outlet_6018.rs`** — new regression test:
  - Board: Ajani, Guide of Souls, Goblin Bombardment (oracle text), 2/1 Cat/Warrior token, Mountain.
  - Activate Bombardment → sacrifice token → target opponent → accept optional Ajani trigger.
  - Assert Ajani returns to the battlefield transformed (planeswalker back face with loyalty).
  - Documents CR 111.2 token cleanup (token object removed from `state.objects` after sacrifice, not left in graveyard).
- **`crates/engine/tests/integration/main.rs`** — register the new module.

No engine or parser code changes — behavior was already correct.

## Test plan

```bash
cargo fmt --all -- --check
cargo test -p engine ajani_nacatl_pariah
```

Expected: both Ajani integration tests pass.

```bash
cargo test -p engine ajani_returns_transformed_when_cat_token_sacrificed_to_outlet
cargo test -p engine ajani_nacatl_pariah_returns_transformed_when_another_cat_dies
```

## Notes for reviewers

- Ajani's flip trigger is **optional** (`you may exile Ajani, then return him…`). Declining the prompt is rules-correct; a player who expects an automatic flip may perceive that as a bug.
- If the original reporter saw Ajani stranded in exile after accepting the trigger, that would be a #503-class anaphor bug — this test would fail. It passes on current `main`.
- Guide of Souls is on the battlefield in the test for repro fidelity; it is not load-bearing for the flip assertion.
