### PR TITLE
ship/t159 r1 rejection

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -5418,17 +5418,19 @@ fn finish_with_continuation(
     state.waiting_for.clone()
 }
 
-/// CR 701.25a / manifest dread: run the post-loop cleanup a rest-pile batch
-/// deferred when it paused mid-pile. Called by
+/// CR 701.25a / CR 616.1: Run the post-loop cleanup a rest-pile batch deferred
+/// when it paused mid-pile. Called by
 /// `zone_pipeline::drain_pending_batch_deliveries` the moment the batch tail
 /// empties, so the kept-card placement / reveal-marker cleanup and the
 /// continuation drain happen exactly once — the same effect the synchronous
-/// (never-paused) path runs inline.
+/// (never-paused) path runs inline. The result reports whether this completion
+/// itself parked another replacement-aware delivery, so the enclosing batch
+/// caller cannot overwrite the CR 616.1 choice with a later tail.
 pub(crate) fn run_batch_completion(
     state: &mut GameState,
     completion: crate::types::game_state::BatchCompletion,
     events: &mut Vec<GameEvent>,
-) {
+) -> crate::game::zone_pipeline::BatchMoveResult {
     use crate::types::game_state::BatchCompletion;
     match completion {
         BatchCompletion::CascadeBottomComplete {
@@ -5446,6 +5448,7 @@ pub(crate) fn run_batch_completion(
                 source_id,
                 subject: None,
             });
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::DiscoverBottomComplete { source_id } => {
             events.push(GameEvent::EffectResolved {
@@ -5453,6 +5456,7 @@ pub(crate) fn run_batch_completion(
                 source_id,
                 subject: None,
             });
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::DiscoverPlacementComplete { source_id } => {
             events.push(GameEvent::EffectResolved {
@@ -5460,26 +5464,57 @@ pub(crate) fn run_batch_completion(
                 source_id,
                 subject: None,
             });
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::DiscoverDeclined {
             player,
             hit_card,
             source_id,
         } => {
-            zones::move_to_zone(state, hit_card, Zone::Hand, events);
+            // CR 701.57a + CR 614.1: The hit's printed hand delivery is its own
+            // replaceable resolution effect, after the misses reach the library
+            // bottom. Carry only the tail through its batch so a CR 616.1 choice
+            // pauses before the Discover completion/continuation run.
+            crate::game::zone_pipeline::move_objects_simultaneously_then(
+                state,
+                vec![crate::game::zone_pipeline::ZoneMoveRequest::effect(
+                    hit_card,
+                    Zone::Hand,
+                    source_id,
+                )],
+                Some(BatchCompletion::DiscoverDeclinedComplete { player, source_id }),
+                events,
+            )
+        }
+        BatchCompletion::DiscoverDeclinedComplete { player, source_id } => {
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::Discover,
                 source_id,
                 subject: None,
             });
             finish_with_continuation(state, player, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::ResolutionCastRejectedToHand {
             player,
             hit_card,
             source_id,
         } => {
-            zones::move_to_zone(state, hit_card, Zone::Hand, events);
+            // CR 608.2g + CR 701.57a + CR 614.1: A rejected Discover cast
+            // returns the hit through the same replaceable effect-owned Hand
+            // delivery. Its priority tail must wait for that delivery to settle.
+            crate::game::zone_pipeline::move_objects_simultaneously_then(
+                state,
+                vec![crate::game::zone_pipeline::ZoneMoveRequest::effect(
+                    hit_card,
+                    Zone::Hand,
+                    source_id,
+                )],
+                Some(BatchCompletion::ResolutionCastRejectionComplete { player, source_id }),
+                events,
+            )
+        }
+        BatchCompletion::ResolutionCastRejectionComplete { player, source_id } => {
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::Discover,
                 source_id,
@@ -5487,6 +5522,7 @@ pub(crate) fn run_batch_completion(
             });
             crate::game::priority::clear_priority_passes(state);
             state.waiting_for = WaitingFor::Priority { player };
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::PutOnTopComplete {
             source_id,
@@ -5500,16 +5536,19 @@ pub(crate) fn run_batch_completion(
                 source_id,
                 subject: None,
             });
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::SurveilKeepOnTop { player, top_cards } => {
             surveil_keep_on_top(state, player, &top_cards);
             finish_with_continuation(state, player, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::ManifestDreadCleanup { player, revealed } => {
             for card_id in &revealed {
                 state.revealed_cards.remove(card_id);
             }
             finish_with_continuation(state, player, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         // CR 701.20b: The kept card's battlefield entry paused (aura host pick /
         // replacement ordering). Now that it has resolved, move the unkept rest
@@ -5547,7 +5586,7 @@ pub(crate) fn run_batch_completion(
                                 emit_reveal_until_resolved,
                             },
                         );
-                        return;
+                        return crate::game::zone_pipeline::BatchMoveResult::NeedsChoice;
                     }
                 }
             } else if !rest_cards.is_empty() {
@@ -5565,16 +5604,13 @@ pub(crate) fn run_batch_completion(
                     publish_tracked_set: None,
                     emit_reveal_until_resolved,
                 };
-                match effects::reveal_until::move_rest_then(
+                return effects::reveal_until::move_rest_then(
                     state,
                     &rest_cards,
                     rest_destination,
                     Some(cleanup),
                     events,
-                ) {
-                    crate::game::zone_pipeline::BatchMoveResult::Done
-                    | crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => return,
-                }
+                );
             }
             for card_id in &clear_markers {
                 state.revealed_cards.remove(card_id);
@@ -5594,6 +5630,7 @@ pub(crate) fn run_batch_completion(
                 });
             }
             finish_with_continuation(state, player, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::DigMassPutAllRestComplete {
             player,
@@ -5611,6 +5648,7 @@ pub(crate) fn run_batch_completion(
                 enter_tapped,
                 events,
             );
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::DigMassPutAllComplete {
             player: _,
@@ -5641,6 +5679,7 @@ pub(crate) fn run_batch_completion(
             // continuation after this batch completion returns. Do not drain it
             // here, or a synchronous mass Dig could run an outer continuation
             // ahead of its own child instruction.
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::DigPriorLookRestComplete { player, source_id } => {
             state.private_look_ids.clear();
@@ -5651,6 +5690,7 @@ pub(crate) fn run_batch_completion(
                 subject: None,
             });
             finish_with_continuation(state, player, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         // CR 610.3: the exile-until-leaves return pile has fully landed (after a
         // returned creature's as-enters / aura-host pause resolved). Drop the
@@ -5662,6 +5702,7 @@ pub(crate) fn run_batch_completion(
             state
                 .exile_links
                 .retain(|link| !returned_ids.contains(&link.exiled_id));
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         // CR 702.49 + CR 616.1: the ninja's parked battlefield entry resolved —
         // run the deferred post-entry ninjutsu work (cast-variant tag,
@@ -5684,6 +5725,7 @@ pub(crate) fn run_batch_completion(
                 attack_target,
                 events,
             );
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         // CR 701.51 + CR 616.1: the paused Attraction's entry resolved — finish
         // its open bookkeeping, then run the remaining opens of the same
@@ -5701,6 +5743,7 @@ pub(crate) fn run_batch_completion(
                 let _ =
                     crate::game::attractions::open_attractions(state, player, remaining, events);
             }
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::ContraptionAssembleRemainder {
             player,
@@ -5721,6 +5764,7 @@ pub(crate) fn run_batch_completion(
                     events,
                 );
             }
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::ScopedLibrarySearchDelivery {
             player,
@@ -5740,21 +5784,26 @@ pub(crate) fn run_batch_completion(
                 events,
             )
             .expect("scoped library search batch completion must resolve");
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::SearchFoundZoneDelivery { .. } => {
             resume_search_found_after_zone_delivery(state, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::MeldExile { context } => {
             crate::game::meld::finish_meld_exile(state, context, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::MeldEntry {
             context,
             attack_target,
         } => {
             crate::game::meld::finish_meld_delivery(state, context, attack_target, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::MeldRedirect { source_id } => {
             crate::game::meld::finish_deferred_meld_resolution(state, source_id, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
         }
     }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -5487,6 +5487,9 @@ pub(crate) fn run_batch_completion(
             )
         }
         BatchCompletion::DiscoverDeclinedComplete { player, source_id } => {
+            // CR 701.57a: the declined hit's hand delivery settled (including
+            // any CR 616.1 redirect), so the Discover result and continuation
+            // run exactly once.
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::Discover,
                 source_id,
@@ -5515,6 +5518,9 @@ pub(crate) fn run_batch_completion(
             )
         }
         BatchCompletion::ResolutionCastRejectionComplete { player, source_id } => {
+            // CR 608.2g + CR 701.57a: the rejected hit's hand delivery settled
+            // (including any CR 616.1 redirect), so the Discover result and
+            // priority restoration run exactly once.
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::Discover,
                 source_id,

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -1115,6 +1115,14 @@ pub(crate) fn drain_pending_batch_deliveries(state: &mut GameState, events: &mut
                 // when `deliver_batch` did NOT re-park, so the completion fires at
                 // most once per batch.
                 if let Some(completion) = completion {
+                    // The parked/settled result is deliberately unused here: the
+                    // drain's callers are state-mediated (engine_replacement
+                    // re-reads `state.waiting_for` after the drain and gates
+                    // every later drain stage on Priority), so a completion that
+                    // parks a new CR 616.1 choice propagates via the parked
+                    // prompt + fresh `pending_batch_deliveries` record, not via
+                    // this return value. Witnessed by the compound double-pause
+                    // test (miss batch redirect, then hit-delivery redirect).
                     let _ = run_batch_completion(state, completion, events);
                 }
             }

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -829,13 +829,14 @@ pub(crate) fn move_object(
 
 /// Result of a batch zone-move (`move_objects_simultaneously`).
 pub(crate) enum BatchMoveResult {
-    /// Every requested object was delivered.
+    /// Every requested object and any inline completion tail were delivered.
     Done,
-    /// A per-object `Moved` replacement surfaced a CR 616.1 choice mid-batch.
-    /// `state.waiting_for` is already parked (with the choosing player) and the
-    /// undelivered tail is stashed in `state.pending_batch_deliveries`, so the
-    /// caller only needs to know that it paused — the resume path
-    /// (`drain_pending_batch_deliveries`) finishes the batch.
+    /// A per-object `Moved` replacement surfaced a CR 616.1 choice while
+    /// delivering the batch or an inline completion tail. `state.waiting_for`
+    /// is already parked (with the choosing player) and the undelivered tail is
+    /// stashed in `state.pending_batch_deliveries`, so the caller only needs to
+    /// know that it paused — the resume path (`drain_pending_batch_deliveries`)
+    /// finishes the batch.
     NeedsChoice,
 }
 
@@ -875,7 +876,10 @@ pub(crate) fn move_objects_simultaneously(
 /// reorder; manifest dread graveyard pile + reveal-marker cleanup): the moves run
 /// through the pipeline so each card's `Moved` redirects fire, and the cleanup
 /// that used to run inline at the end of the loop now rides on the parked tail so
-/// a pause can never run it early or twice.
+/// a pause can never run it early or twice. Its return value covers the whole
+/// delivery, including an inline completion tail: `Done` means that tail also
+/// settled; `NeedsChoice` means a CR 616.1 replacement choice parked it. Callers
+/// may therefore restore priority or run their own tail only after `Done`.
 pub(crate) fn move_objects_simultaneously_then(
     state: &mut GameState,
     reqs: Vec<ZoneMoveRequest>,
@@ -887,11 +891,10 @@ pub(crate) fn move_objects_simultaneously_then(
     match deliver_batch(state, reqs, &ids, events) {
         BatchMoveResult::Done => {
             // Synchronous completion (the common single-redirect path): run the
-            // cleanup now.
-            if let Some(completion) = completion {
-                run_batch_completion(state, completion, events);
-            }
-            BatchMoveResult::Done
+            // cleanup now, and surface a pause it raises to the enclosing caller.
+            completion.map_or(BatchMoveResult::Done, |completion| {
+                run_batch_completion(state, completion, events)
+            })
         }
         BatchMoveResult::NeedsChoice => {
             // Paused mid-pile. `deliver_batch` stashed the undelivered tail when
@@ -918,8 +921,8 @@ fn run_batch_completion(
     state: &mut GameState,
     completion: BatchCompletion,
     events: &mut Vec<GameEvent>,
-) {
-    crate::game::engine_resolution_choices::run_batch_completion(state, completion, events);
+) -> BatchMoveResult {
+    crate::game::engine_resolution_choices::run_batch_completion(state, completion, events)
 }
 
 /// CR 303.4f / CR 616.1 + CR 603.10a: Hang a [`BatchCompletion`] off the current
@@ -1112,7 +1115,7 @@ pub(crate) fn drain_pending_batch_deliveries(state: &mut GameState, events: &mut
                 // when `deliver_batch` did NOT re-park, so the completion fires at
                 // most once per batch.
                 if let Some(completion) = completion {
-                    run_batch_completion(state, completion, events);
+                    let _ = run_batch_completion(state, completion, events);
                 }
             }
             BatchMoveResult::NeedsChoice => {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1825,20 +1825,34 @@ pub enum BatchCompletion {
     /// every miss after its cast/hand decision. Its resolution event waits for
     /// that batch.
     DiscoverPlacementComplete { source_id: ObjectId },
-    /// CR 701.57a + CR 616.1: A declined Discover's miss batch settled; keep
-    /// the printed hit-to-hand instruction after the bottom placements without
-    /// routing that separate move through this tranche's library migration.
+    /// CR 701.57a + CR 616.1: A declined Discover's miss batch settled; carry
+    /// the printed hit-to-hand instruction through its own replacement-aware
+    /// delivery before the Discover completion tail.
     DiscoverDeclined {
         player: PlayerId,
         hit_card: ObjectId,
         source_id: ObjectId,
     },
     /// CR 608.2g + CR 701.57a + CR 616.1: A Discover cast rejected at
-    /// finalization waits for the miss batch before its already-existing raw
-    /// hit-to-hand instruction and priority return.
+    /// finalization waits for the miss batch before its replacement-aware
+    /// hit-to-hand delivery and priority tail.
     ResolutionCastRejectedToHand {
         player: PlayerId,
         hit_card: ObjectId,
+        source_id: ObjectId,
+    },
+    /// CR 701.57a + CR 616.1: The declined Discover's replacement-aware
+    /// hit-to-hand delivery settled, so its resolution event and continuation
+    /// may run exactly once.
+    DiscoverDeclinedComplete {
+        player: PlayerId,
+        source_id: ObjectId,
+    },
+    /// CR 608.2g + CR 701.57a + CR 616.1: The rejected Discover hit's
+    /// replacement-aware hand delivery settled, so its resolution event and
+    /// priority restoration may run exactly once.
+    ResolutionCastRejectionComplete {
+        player: PlayerId,
         source_id: ObjectId,
     },
     /// CR 401.4 + CR 616.1: All requested library placements for one

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -7214,6 +7214,437 @@ fn discover_bottom_batch_pauses_before_its_hit_and_continuation_complete() {
     );
 }
 
+/// W-D1 (red first): a declined Discover's printed hit-to-hand instruction is
+/// a replacement-aware delivery. A Hand redirect must park before the Discover
+/// completion and its chained tail run.
+#[test]
+fn discover_declined_hit_to_hand_redirect_pauses_before_tail() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Discover Hand Redirect Source", 1, 1)
+        .id();
+    let miss = scenario
+        .add_spell_to_library_top(P0, "Discover Hand Redirect Miss", true)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let hit = scenario
+        .add_spell_to_library_top(P0, "Discover Hand Redirect Hit", true)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+    for (name, destination) in [
+        ("Discover Hand To Graveyard", Zone::Graveyard),
+        ("Discover Hand To Exile", Zone::Exile),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Hand, destination));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![miss, hit];
+    let mut ability = ResolvedAbility::new(
+        Effect::Discover {
+            mana_value_limit: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    )));
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("Discover reaches its cast offer");
+
+    let paused = runner
+        .act(GameAction::DiscoverChoice {
+            choice: engine::types::actions::CastChoice::Decline,
+        })
+        .expect("the synchronous miss batch reaches the replaceable Hand delivery");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Exile);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 20);
+    assert!(
+        !paused.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: engine::types::ability::EffectKind::Discover,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "the Discover tail must not run before the Hand redirect choice"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the chosen Hand redirect resumes the typed completion tail");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Graveyard);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 21);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(paused.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::Discover,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "Discover completes exactly once after its redirected Hand delivery"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(paused.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::GainLife,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the Discover continuation runs exactly once after its redirected Hand delivery"
+    );
+}
+
+/// W-D3 (red first): a declined Discover can park once while bottoming its
+/// miss, then again while delivering its hit to Hand. The two typed tails must
+/// preserve that order and complete exactly once.
+#[test]
+fn discover_declined_miss_and_hit_redirects_pause_in_order() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Discover Compound Redirect Source", 1, 1)
+        .id();
+    let miss = scenario
+        .add_spell_to_library_top(P0, "Discover Compound Redirect Miss", true)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let hit = scenario
+        .add_spell_to_library_top(P0, "Discover Compound Redirect Hit", true)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+    for (name, destination, redirected_to) in [
+        (
+            "Discover Compound Library To Graveyard",
+            Zone::Library,
+            Zone::Graveyard,
+        ),
+        (
+            "Discover Compound Library To Exile",
+            Zone::Library,
+            Zone::Exile,
+        ),
+        (
+            "Discover Compound Hand To Graveyard",
+            Zone::Hand,
+            Zone::Graveyard,
+        ),
+        ("Discover Compound Hand To Exile", Zone::Hand, Zone::Exile),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(destination, redirected_to));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![miss, hit];
+    let ability = ResolvedAbility::new(
+        Effect::Discover {
+            mana_value_limit: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("Discover reaches its cast offer");
+
+    let miss_paused = runner
+        .act(GameAction::DiscoverChoice {
+            choice: engine::types::actions::CastChoice::Decline,
+        })
+        .expect("the miss bottom placement reaches its replacement choice");
+    assert!(matches!(
+        miss_paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Exile);
+
+    let hand_paused = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the resolved miss reaches the replaceable hit-to-Hand delivery");
+    assert!(matches!(
+        hand_paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&miss].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Exile);
+    assert!(
+        !hand_paused.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: engine::types::ability::EffectKind::Discover,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "the Discover completion waits for the second replacement choice"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the redirected Hand delivery completes Discover");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Graveyard);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(miss_paused.events.iter())
+            .chain(hand_paused.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::Discover,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the two sequential replacement pauses run Discover's tail exactly once"
+    );
+}
+
+/// W-D2 (red first): a rejected cast during Discover resolution routes its hit
+/// through the same replacement-aware Hand delivery. Its synchronous miss batch
+/// must propagate that completion pause instead of restoring priority over it.
+#[test]
+fn discover_rejected_cast_hit_to_hand_redirect_pauses_before_priority() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Discover Rejection Redirect Source", 1, 1)
+        .id();
+    let target = scenario
+        .add_creature(P1, "Discover Rejection Target", 1, 1)
+        .id();
+    let miss = scenario
+        .add_spell_to_library_top(P0, "Discover Rejection Miss", true)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let hit = scenario
+        .add_spell_to_library_top(P0, "Discover Rejection X Hit", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::X],
+            generic: 0,
+        })
+        .from_oracle_text("Destroy target creature.")
+        .id();
+    for (name, destination) in [
+        ("Discover Rejection Hand To Graveyard", Zone::Graveyard),
+        ("Discover Rejection Hand To Exile", Zone::Exile),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Hand, destination));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![miss, hit];
+    let ability = ResolvedAbility::new(
+        Effect::Discover {
+            mana_value_limit: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("Discover reaches its cast offer");
+
+    let selecting_target = runner
+        .act(GameAction::DiscoverChoice {
+            choice: engine::types::actions::CastChoice::Cast,
+        })
+        .expect("the legal Discover hit starts its during-resolution cast");
+    assert!(matches!(
+        selecting_target.waiting_for,
+        WaitingFor::TargetSelection { player: P0, .. }
+    ));
+    match &mut runner.state_mut().waiting_for {
+        WaitingFor::TargetSelection { pending_cast, .. } => pending_cast.ability.chosen_x = Some(2),
+        waiting_for => panic!("expected the target-selection cast, got {waiting_for:?}"),
+    }
+
+    let paused = runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(target)],
+        })
+        .expect("the seeded resulting mana value rejects the Discover cast");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Exile);
+    assert!(runner.state().stack.iter().all(|entry| entry.id != hit));
+    assert!(
+        !paused.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: engine::types::ability::EffectKind::Discover,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "priority and EffectResolved must wait for the Hand redirect choice"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the redirected rejected hit completes its priority tail");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Exile);
+    assert_eq!(runner.state().objects[&miss].zone, Zone::Library);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(selecting_target.events.iter())
+            .chain(paused.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::Discover,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the rejected cast emits Discover completion exactly once after its Hand delivery"
+    );
+}
+
+/// W-REG: An uninterrupted Discover rejection still sends the hit to Hand and
+/// returns priority synchronously, with the usual single Discover completion.
+#[test]
+fn discover_rejected_cast_without_redirect_stays_synchronous() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Uninterrupted Discover Rejection Source", 1, 1)
+        .id();
+    let target = scenario
+        .add_creature(P1, "Uninterrupted Discover Rejection Target", 1, 1)
+        .id();
+    let miss = scenario
+        .add_spell_to_library_top(P0, "Uninterrupted Discover Rejection Miss", true)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let hit = scenario
+        .add_spell_to_library_top(P0, "Uninterrupted Discover Rejection X Hit", true)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::X],
+            generic: 0,
+        })
+        .from_oracle_text("Destroy target creature.")
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![miss, hit];
+    let ability = ResolvedAbility::new(
+        Effect::Discover {
+            mana_value_limit: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("Discover reaches its cast offer");
+    runner
+        .act(GameAction::DiscoverChoice {
+            choice: engine::types::actions::CastChoice::Cast,
+        })
+        .expect("the legal Discover hit starts its during-resolution cast");
+    match &mut runner.state_mut().waiting_for {
+        WaitingFor::TargetSelection { pending_cast, .. } => pending_cast.ability.chosen_x = Some(2),
+        waiting_for => panic!("expected the target-selection cast, got {waiting_for:?}"),
+    }
+
+    let completed = runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(target)],
+        })
+        .expect("the seeded resulting mana value rejects the Discover cast");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Hand);
+    assert_eq!(runner.state().objects[&miss].zone, Zone::Library);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::Discover,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the uninterrupted rejection retains the existing one-event completion"
+    );
+}
+
 /// W-REG: In the absence of a Library-destination replacement, all three
 /// migrated effect paths finish synchronously with their ordinary ordering and
 /// completion behavior intact.

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -44,7 +44,6 @@ crates/engine/src/game/engine.rs	normalize_recast_frame	exempt	3
 crates/engine/src/game/engine_debug.rs	apply_debug_action	mover	1
 crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	container	6
 crates/engine/src/game/engine_resolution_choices.rs	handle_resolution_choice	mover	7
-crates/engine/src/game/engine_resolution_choices.rs	run_batch_completion	mover	2
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	container	1
 crates/engine/src/game/planechase.rs	finish_player_left_game_handoff	zone-assign	1
 crates/engine/src/game/planechase.rs	planeswalk	container	2


### PR DESCRIPTION
- **refactor(engine): propagate completion-raised pauses through the batch API; effect-owned rejection/decline hit delivery (R1)**
- **chore: tighten zone-authority baseline after R1 rejection/decline migration**
