### PR TITLE
fix(engine): retain Sakashima's own abilities when it copies a creature (#6009)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2723,6 +2723,7 @@ fn legacy_continuous_modification(m: &ContinuousModification) -> bool {
         | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::RetainAllOtherAbilitiesFromSource
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }
         | ContinuousModification::SetStartingLoyalty { .. }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4203,6 +4203,9 @@ fn fmt_modification(m: &crate::types::ability::ContinuousModification) -> String
         ContinuousModification::RetainPrintedAbilityFromSource {
             source_ability_index,
         } => format!("retain printed ability {source_ability_index}"),
+        ContinuousModification::RetainAllOtherAbilitiesFromSource => {
+            "retain source's other abilities".into()
+        }
         ContinuousModification::AddSupertype { supertype } => {
             format!("add supertype {supertype}")
         }

--- a/crates/engine/src/game/effects/become_copy.rs
+++ b/crates/engine/src/game/effects/become_copy.rs
@@ -1620,6 +1620,79 @@ mod tests {
         );
     }
 
+    /// CR 707.9a (issue #6009): Sakashima of a Thousand Faces — "except it has
+    /// ~'s other abilities" retains the SOURCE's entire other ability surface
+    /// (static abilities + keywords here) on the copy, not just a single
+    /// indexed ability like `RetainPrintedAbilityFromSource`.
+    #[test]
+    fn become_copy_retains_all_other_abilities_from_source() {
+        use crate::game::static_abilities::{check_static_ability, StaticCheckContext};
+        use crate::types::ability::{
+            ContinuousModification, ControllerRef, StaticDefinition, TypedFilter,
+        };
+        use crate::types::keywords::PartnerType;
+        use crate::types::statics::StaticMode;
+
+        let mut state = GameState::new_two_player(42);
+        let target = create_creature(&mut state, 1, PlayerId(0), "Target Bear", 2, 2);
+
+        let source = create_creature(&mut state, 2, PlayerId(0), "Sakashima", 3, 1);
+        {
+            let src = state.objects.get_mut(&source).unwrap();
+            src.base_keywords = vec![Keyword::Partner(PartnerType::Generic)];
+            src.base_static_definitions = Arc::new(vec![StaticDefinition::new(
+                StaticMode::LegendRuleDoesntApply,
+            )
+            .affected(TargetFilter::Typed(
+                TypedFilter::default().controller(ControllerRef::You),
+            ))]);
+        }
+
+        let ability = ResolvedAbility::new(
+            Effect::BecomeCopy {
+                recipient: TargetFilter::SelfRef,
+                target: TargetFilter::Any,
+                duration: None,
+                mana_value_limit: None,
+                additional_modifications: vec![
+                    ContinuousModification::RetainAllOtherAbilitiesFromSource,
+                ],
+            },
+            vec![TargetRef::Object(target)],
+            source,
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+        evaluate_layers(&mut state);
+
+        let copied = state.objects.get(&source).unwrap();
+        // The copy target's characteristics (name, P/T) are copied normally.
+        assert_eq!(copied.name, "Target Bear");
+        assert_eq!(copied.power, Some(2));
+        assert_eq!(copied.toughness, Some(2));
+        // Sakashima's own other abilities survive the copy.
+        assert!(
+            copied
+                .keywords
+                .contains(&Keyword::Partner(PartnerType::Generic)),
+            "Partner keyword must be retained; got {:?}",
+            copied.keywords
+        );
+        assert!(
+            check_static_ability(
+                &state,
+                StaticMode::LegendRuleDoesntApply,
+                &StaticCheckContext {
+                    target_id: Some(source),
+                    ..Default::default()
+                },
+            ),
+            "LegendRuleDoesntApply static must be retained on the copy"
+        );
+    }
+
     // ── Reset regression: abilities revert when copy ends ─────────────────
     #[test]
     fn abilities_revert_to_empty_when_copy_expires() {

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -4360,6 +4360,7 @@ fn depends_on(a: &ActiveContinuousEffect, b: &ActiveContinuousEffect, _state: &G
             | ContinuousModification::GrantStaticAbility { .. }
             | ContinuousModification::RetainPrintedTriggerFromSource { .. }
             | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+            | ContinuousModification::RetainAllOtherAbilitiesFromSource
     );
 
     if b_changes_abilities && filter_references_ability(&a.affected_filter) {
@@ -5082,6 +5083,27 @@ fn apply_continuous_effect_filtered(
     } else {
         None
     };
+    // CR 707.9a: Pre-read the source's entire "other abilities" surface —
+    // printed activated abilities, triggers, statics, and keywords — for the
+    // unbounded retain (Sakashima of a Thousand Faces: "except it has ~'s
+    // other abilities"). The ability granting the copy effect is a
+    // `ReplacementDefinition` (or lives outside these four lists), so no
+    // exclusion index is needed, unlike the single-index retains above.
+    let retained_other_abilities = if matches!(
+        effect.modification,
+        ContinuousModification::RetainAllOtherAbilitiesFromSource
+    ) {
+        state.objects.get(&effect.source_id).map(|src| {
+            (
+                src.base_abilities.as_ref().clone(),
+                src.base_trigger_definitions.as_ref().clone(),
+                src.base_static_definitions.as_ref().clone(),
+                src.base_keywords.clone(),
+            )
+        })
+    } else {
+        None
+    };
     let all_creature_types = state.all_creature_types.clone();
 
     for id in affected_ids {
@@ -5704,6 +5726,39 @@ fn apply_continuous_effect_filtered(
                     }
                 }
             }
+            // CR 707.9a: Retain ALL of the source's other printed abilities on
+            // the copy — activated abilities, triggers, statics, and keywords.
+            // After `CopyValues` overwrote these sets with the copy target's
+            // values, merge the source's own sets back in. Idempotent per-item
+            // (structurally-equal entries collapse into one), mirroring the
+            // single-index retains above.
+            ContinuousModification::RetainAllOtherAbilitiesFromSource => {
+                if let Some((abilities, triggers, statics, keywords)) =
+                    retained_other_abilities.clone()
+                {
+                    let obj_abilities = Arc::make_mut(&mut obj.abilities);
+                    for ability in abilities.iter() {
+                        if !obj_abilities.contains(ability) {
+                            obj_abilities.push(ability.clone());
+                        }
+                    }
+                    for trigger in triggers.iter() {
+                        if !obj.trigger_definitions.iter_all().any(|t| t == trigger) {
+                            obj.trigger_definitions.push(trigger.clone());
+                        }
+                    }
+                    for static_def in statics.iter() {
+                        if !obj.static_definitions.iter_all().any(|s| s == static_def) {
+                            obj.static_definitions.push(static_def.clone());
+                        }
+                    }
+                    for keyword in keywords {
+                        if !obj.keywords.contains(&keyword) {
+                            obj.keywords.push(keyword);
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -5897,6 +5952,37 @@ pub(crate) fn compute_current_copiable_values(
                     let abilities = Arc::make_mut(&mut values.abilities);
                     if !abilities.iter().any(|a| a == &ability) {
                         abilities.push(ability);
+                    }
+                }
+            }
+            // CR 707.9a: The unbounded "~'s other abilities" retain makes the
+            // source's entire ability/trigger/static/keyword surface part of
+            // the copiable values, so a further copy of this copy (a Clone of
+            // Sakashima-copying-a-Bear, say) still sees them.
+            ContinuousModification::RetainAllOtherAbilitiesFromSource => {
+                if let Some(src) = state.objects.get(&effect.source_id) {
+                    let abilities = Arc::make_mut(&mut values.abilities);
+                    for ability in src.base_abilities.iter() {
+                        if !abilities.contains(ability) {
+                            abilities.push(ability.clone());
+                        }
+                    }
+                    let triggers = Arc::make_mut(&mut values.trigger_definitions);
+                    for trigger in src.base_trigger_definitions.iter() {
+                        if !triggers.contains(trigger) {
+                            triggers.push(trigger.clone());
+                        }
+                    }
+                    let statics = Arc::make_mut(&mut values.static_definitions);
+                    for static_def in src.base_static_definitions.iter() {
+                        if !statics.contains(static_def) {
+                            statics.push(static_def.clone());
+                        }
+                    }
+                    for keyword in &src.base_keywords {
+                        if !values.keywords.contains(keyword) {
+                            values.keywords.push(keyword.clone());
+                        }
                     }
                 }
             }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -5734,7 +5734,7 @@ fn apply_continuous_effect_filtered(
             // single-index retains above.
             ContinuousModification::RetainAllOtherAbilitiesFromSource => {
                 if let Some((abilities, triggers, statics, keywords)) =
-                    retained_other_abilities.clone()
+                    retained_other_abilities.as_ref()
                 {
                     let obj_abilities = Arc::make_mut(&mut obj.abilities);
                     for ability in abilities.iter() {
@@ -5753,8 +5753,8 @@ fn apply_continuous_effect_filtered(
                         }
                     }
                     for keyword in keywords {
-                        if !obj.keywords.contains(&keyword) {
-                            obj.keywords.push(keyword);
+                        if !obj.keywords.contains(keyword) {
+                            obj.keywords.push(keyword.clone());
                         }
                     }
                 }

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -794,6 +794,7 @@ fn walk_continuous_mod(modification: &ContinuousModification, out: &mut Vec<Stri
         | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::RetainAllOtherAbilitiesFromSource
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }
         | ContinuousModification::AddCounterOnEnter { .. }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -504,6 +504,7 @@ pub(crate) fn continuous_modification_dynamic_quantity(
         | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::RetainAllOtherAbilitiesFromSource
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }
         | ContinuousModification::RemoveManaCost => None,

--- a/crates/engine/src/parser/oracle_effect/become_copy_except.rs
+++ b/crates/engine/src/parser/oracle_effect/become_copy_except.rs
@@ -162,6 +162,7 @@ pub(crate) fn parse_except_clause<'a>(
 ///   - `<subject pronoun> has this ability`
 ///     → RetainPrintedTriggerFromSource or RetainPrintedAbilityFromSource
 ///     (when ctx provides the trigger or activated-ability index)
+///   - `<subject pronoun> has ~'s other abilities`              → RetainAllOtherAbilitiesFromSource
 ///   - `it's a(n) {core_type} in addition to its other types`  → AddType
 ///   - `it's a(n) {subtype} in addition to its other types`    → AddSubtype
 ///   - `is a(n) {core_type|subtype} in addition to its other types`
@@ -185,6 +186,9 @@ pub(crate) fn parse_except_body<'a>(
     }
     if let Some((rest, mods)) = parse_subject_pt_and_types(input) {
         return Some((rest, mods));
+    }
+    if let Some((rest, modification)) = parse_has_source_other_abilities(input) {
+        return Some((rest, vec![modification]));
     }
     if let Some((rest, modification)) = parse_has_this_ability(input, ctx) {
         return Some((rest, vec![modification]));
@@ -711,6 +715,36 @@ fn append_color_and_type_modifications(
         });
     }
     mods.extend(type_mods);
+}
+
+/// CR 707.9a: "<subject pronoun> has ~'s other abilities" — the source's
+/// entire OTHER ability surface (activated abilities, triggers, statics,
+/// keywords) becomes part of the copy's copiable values, unbounded by a
+/// single indexed ability (Sakashima of a Thousand Faces: "except it has
+/// Sakashima's other abilities" — normalized to "it has ~'s other
+/// abilities" by `normalize_card_name_refs`).
+///
+/// Distinct from `parse_has_this_ability`, which retains exactly ONE
+/// indexed ability (the one containing the BecomeCopy effect) and requires
+/// `ctx.current_trigger_index`/`current_ability_index` to be set. This arm
+/// needs no such index — the retained set is "everything else the source
+/// has printed" — so it works for the replacement-form clone (Sakashima's
+/// `AsPermanentEnters` framing), which parses with `ParseContext::default()`.
+///
+/// Subject pronouns accepted: `he`, `she`, `it` (and `they` for plural).
+fn parse_has_source_other_abilities(input: &str) -> Option<(&str, ContinuousModification)> {
+    let (rest, _) = alt((
+        tag::<_, _, OracleError<'_>>("he has ~'s other abilities"),
+        tag("she has ~'s other abilities"),
+        tag("it has ~'s other abilities"),
+        tag("they have ~'s other abilities"),
+    ))
+    .parse(input)
+    .ok()?;
+    Some((
+        rest,
+        ContinuousModification::RetainAllOtherAbilitiesFromSource,
+    ))
 }
 
 /// CR 707.9a: "<subject pronoun> has this ability" — emit a retain modification

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -8800,6 +8800,7 @@ fn apply_where_x_continuous_modification(
         | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::RetainAllOtherAbilitiesFromSource
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }
         | ContinuousModification::RemoveManaCost => {}
@@ -8897,6 +8898,7 @@ fn rebind_target_anaphor_continuous_modification(modification: &mut ContinuousMo
         | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::RetainAllOtherAbilitiesFromSource
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }
         | ContinuousModification::RemoveManaCost => {}

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -16141,6 +16141,55 @@ mod tests {
         );
     }
 
+    /// CR 707.9a (issue #6009): Sakashima of a Thousand Faces — "except it has
+    /// Sakashima's other abilities" must retain ALL of Sakashima's own printed
+    /// abilities (the legend-rule exemption static, Partner) on the copy, not
+    /// just a single indexed ability like the "except it has this ability"
+    /// class (Irma / Cryptoplasm).
+    #[test]
+    fn clone_sakashima_of_a_thousand_faces_retains_all_other_abilities() {
+        let def = parse_replacement_line(
+            "You may have Sakashima enter as a copy of another creature you control, \
+             except it has Sakashima's other abilities.",
+            "Sakashima of a Thousand Faces",
+        )
+        .unwrap();
+        assert!(matches!(
+            def.mode,
+            ReplacementMode::Optional { decline: None }
+        ));
+        let execute = def.execute.as_ref().unwrap();
+        match &*execute.effect {
+            Effect::BecomeCopy {
+                additional_modifications,
+                target,
+                ..
+            } => {
+                assert!(
+                    additional_modifications.iter().any(|m| matches!(
+                        m,
+                        ContinuousModification::RetainAllOtherAbilitiesFromSource
+                    )),
+                    "expected RetainAllOtherAbilitiesFromSource, got {additional_modifications:?}"
+                );
+                // "another creature you control" — copy source is restricted to
+                // the controller's own OTHER creatures (CR 707.2).
+                match target {
+                    TargetFilter::Typed(tf) => {
+                        assert!(
+                            tf.properties
+                                .iter()
+                                .any(|p| matches!(p, FilterProp::Another)),
+                            "expected Another filter property, got {target:?}"
+                        );
+                    }
+                    other => panic!("expected Typed target filter, got {other:?}"),
+                }
+            }
+            other => panic!("expected BecomeCopy, got {other:?}"),
+        }
+    }
+
     #[test]
     fn clone_enchantment() {
         // Estrid's Invocation, Copy Enchantment

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -19850,6 +19850,21 @@ pub enum ContinuousModification {
     RetainPrintedAbilityFromSource {
         source_ability_index: usize,
     },
+    /// CR 707.9a: Retain ALL of the source object's other printed abilities —
+    /// activated abilities, triggered abilities, static abilities, and
+    /// keywords — on the copy. Used by "becomes a copy of <X>, except it has
+    /// ~'s other abilities" patterns (Sakashima of a Thousand Faces), where
+    /// the retained set is unbounded rather than a single indexed ability.
+    /// The ability granting the copy effect itself lives in a
+    /// `ReplacementDefinition` or a triggered/activated ability that is not
+    /// surfaced through `base_abilities` / `base_trigger_definitions` /
+    /// `base_static_definitions`, so no exclusion index is needed.
+    ///
+    /// Applied at Layer 1 because CR 707.9a states the retained abilities
+    /// "become part of the copiable values for the copy". The runtime reads
+    /// the source object's base ability sets directly (no index) and merges
+    /// any entry not already present onto the affected object.
+    RetainAllOtherAbilitiesFromSource,
     /// CR 205.4 + CR 707.9d: Add a supertype to the affected object's
     /// supertypes (e.g., Sarkhan, Soul Aflame: "it's legendary in addition
     /// to its other types"). Idempotent: pushing an already-present supertype

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -166,7 +166,8 @@ impl ContinuousModification {
             // CopyValues / SetName so downstream copy effects observe the
             // retained ability when reading copiable values.
             ContinuousModification::RetainPrintedTriggerFromSource { .. }
-            | ContinuousModification::RetainPrintedAbilityFromSource { .. } => Layer::Copy,
+            | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+            | ContinuousModification::RetainAllOtherAbilitiesFromSource => Layer::Copy,
         }
     }
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -950,6 +950,7 @@ mod s07_coiling_rebirth_full_cast;
 mod s07_create_token_sequence_middle;
 mod s07_malamet_castpath;
 mod s07_this_way_conditions;
+mod sakashima_of_a_thousand_faces_retains_other_abilities;
 mod same_is_true_type_statics;
 mod sandman_reanimate_self_and_land_s25;
 mod sandswirl_wanderglyph_attacked_you_cant_cast;

--- a/crates/engine/tests/integration/sakashima_of_a_thousand_faces_retains_other_abilities.rs
+++ b/crates/engine/tests/integration/sakashima_of_a_thousand_faces_retains_other_abilities.rs
@@ -1,0 +1,207 @@
+//! Production-path regression for issue #6009 / PR #6058: Sakashima of a
+//! Thousand Faces ("You may have Sakashima enter as a copy of another
+//! creature you control, except it has Sakashima's other abilities.") must
+//! retain Sakashima's ENTIRE other-ability surface (CR 707.9a) — here,
+//! Partner and the controller-scoped "legend rule doesn't apply" static —
+//! on the copy, not just a single indexed ability.
+//!
+//! Unlike `become_copy.rs::become_copy_retains_all_other_abilities_from_source`
+//! (a hand-built `ResolvedAbility`) this drives the real production pipeline:
+//! Sakashima's Oracle text is parsed by the actual parser (via
+//! `CardDatabase::from_mtgjson`), cast from hand, and resolved through the
+//! `AsPermanentEnters` replacement-choice/copy-target-choice flow so Layer 1
+//! (`RetainAllOtherAbilitiesFromSource`) is exercised end to end. It then
+//! proves the retained legend-rule exemption FUNCTIONS (not merely that the
+//! static is present): a second legendary permanent under the same
+//! controller is not forced through CR 704.5j's `ChooseLegend` prompt while
+//! the copy's retained static is active.
+
+use std::path::Path;
+use std::sync::OnceLock;
+
+use engine::database::card_db::CardDatabase;
+use engine::game::sba::{check_state_based_actions, legend_rule_exempt};
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::scenario_db::GameScenarioDbExt;
+use engine::game::triggers::process_triggers;
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::keywords::{Keyword, PartnerType};
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+fn sakashima_db() -> &'static CardDatabase {
+    static DB: OnceLock<CardDatabase> = OnceLock::new();
+    DB.get_or_init(|| {
+        CardDatabase::from_mtgjson(
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("../../data/mtgjson/test_fixture.json"),
+        )
+        .expect("parser fixture must contain Sakashima of a Thousand Faces")
+    })
+}
+
+fn add_mana(runner: &mut GameRunner, mana: &[ManaType]) {
+    let dummy = engine::types::identifiers::ObjectId(0);
+    let pool = &mut runner.state_mut().players[0].mana_pool;
+    for m in mana {
+        pool.add(ManaUnit::new(*m, dummy, false, vec![]));
+    }
+}
+
+fn drive_until_stack_empty(runner: &mut GameRunner) {
+    for _ in 0..128 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ReplacementChoice { .. } => {
+                runner
+                    .act(GameAction::ChooseReplacement { index: 0 })
+                    .expect("accept enter-as-copy replacement");
+            }
+            WaitingFor::CopyTargetChoice { valid_targets, .. } => {
+                let target = valid_targets[0];
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(TargetRef::Object(target)),
+                    })
+                    .expect("choose copy target");
+            }
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept optional copy");
+            }
+            WaitingFor::TargetSelection { .. } | WaitingFor::TriggerTargetSelection { .. } => {
+                runner.choose_first_legal_target().expect("choose target");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::ManaPayment { .. } => {
+                runner.act(GameAction::PassPriority).expect("pay mana");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => return,
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            other => panic!("unexpected waiting_for while resolving: {other:?}"),
+        }
+    }
+    panic!("resolution loop exhausted");
+}
+
+#[test]
+fn sakashima_becomes_copy_and_retains_partner_and_legend_rule_exemption() {
+    let db = sakashima_db();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let bears = scenario.add_real_card(P0, "Grizzly Bears", Zone::Battlefield, db);
+    let jace_incumbent =
+        scenario.add_real_card(P0, "Jace, the Mind Sculptor", Zone::Battlefield, db);
+    let sakashima = scenario.add_real_card(P0, "Sakashima of a Thousand Faces", Zone::Hand, db);
+    let jace_challenger = scenario.add_real_card(P0, "Jace, the Mind Sculptor", Zone::Hand, db);
+    let mut runner = scenario.build();
+    engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
+
+    // {3}{U} for Sakashima.
+    add_mana(
+        &mut runner,
+        &[
+            ManaType::Blue,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+        ],
+    );
+    let sakashima_card_id = runner.state().objects[&sakashima].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: sakashima,
+            card_id: sakashima_card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Sakashima of a Thousand Faces");
+
+    drive_until_stack_empty(&mut runner);
+
+    let copy_id = runner
+        .state()
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            *id != bears && {
+                let obj = &runner.state().objects[id];
+                obj.name == "Grizzly Bears" && obj.controller == P0
+            }
+        })
+        .expect("Sakashima should enter as a copy of Grizzly Bears");
+
+    let copy = runner.state().objects.get(&copy_id).unwrap();
+    // The copy target's characteristics (name, P/T) are copied normally.
+    assert_eq!(copy.name, "Grizzly Bears");
+    assert_eq!(copy.power, Some(2));
+    assert_eq!(copy.toughness, Some(2));
+    // Sakashima's own other abilities survive the copy (CR 707.9a).
+    assert!(
+        copy.keywords
+            .contains(&Keyword::Partner(PartnerType::Generic)),
+        "Partner keyword must be retained on the copy; got {:?}",
+        copy.keywords
+    );
+    assert!(
+        legend_rule_exempt(runner.state(), copy_id),
+        "the copy's own legend-rule exemption static must report itself exempt"
+    );
+
+    // Functional proof, not just structural: the retained static must exempt
+    // *other* legendary permanents this controller controls (CR 704.5j), even
+    // though the exemption's source object is no longer named "Sakashima".
+    assert!(
+        legend_rule_exempt(runner.state(), jace_incumbent),
+        "the retained controller-scoped exemption must cover this player's other legendaries"
+    );
+
+    // {2}{U}{U} for the second Jace.
+    add_mana(
+        &mut runner,
+        &[
+            ManaType::Blue,
+            ManaType::Blue,
+            ManaType::Colorless,
+            ManaType::Colorless,
+        ],
+    );
+    let jace_card_id = runner.state().objects[&jace_challenger].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: jace_challenger,
+            card_id: jace_card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast the second Jace, the Mind Sculptor");
+
+    drive_until_stack_empty(&mut runner);
+
+    let mut events = Vec::new();
+    check_state_based_actions(runner.state_mut(), &mut events);
+    process_triggers(runner.state_mut(), &events);
+
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::ChooseLegend { .. }),
+        "the retained legend-rule exemption must suppress CR 704.5j's choose-legend prompt"
+    );
+    assert_eq!(
+        runner.state().objects[&jace_incumbent].zone,
+        Zone::Battlefield,
+        "the incumbent Jace must survive the legend-rule SBA sweep"
+    );
+    assert_eq!(
+        runner.state().objects[&jace_challenger].zone,
+        Zone::Battlefield,
+        "the second Jace must survive the legend-rule SBA sweep"
+    );
+}

--- a/crates/phase-ai/src/policies/x_reference.rs
+++ b/crates/phase-ai/src/policies/x_reference.rs
@@ -214,6 +214,7 @@ fn continuous_modification_references_x(modification: &ContinuousModification) -
         | ContinuousModification::SetChosenName
         | ContinuousModification::RetainPrintedTriggerFromSource { .. }
         | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::RetainAllOtherAbilitiesFromSource
         | ContinuousModification::AddSupertype { .. }
         | ContinuousModification::RemoveSupertype { .. }
         | ContinuousModification::SetStartingLoyalty { .. }

--- a/data/mtgjson/test_fixture.json
+++ b/data/mtgjson/test_fixture.json
@@ -58,6 +58,40 @@
                 }
             }
         ],
+        "Sakashima of a Thousand Faces": [
+            {
+                "name": "Sakashima of a Thousand Faces",
+                "manaCost": "{3}{U}",
+                "manaValue": 4.0,
+                "colors": [
+                    "U"
+                ],
+                "colorIdentity": [
+                    "U"
+                ],
+                "types": [
+                    "Creature"
+                ],
+                "subtypes": [
+                    "Human",
+                    "Rogue"
+                ],
+                "supertypes": [
+                    "Legendary"
+                ],
+                "power": "3",
+                "toughness": "1",
+                "text": "You may have Sakashima enter as a copy of another creature you control, except it has Sakashima's other abilities.\nThe \"legend rule\" doesn't apply to permanents you control.\nPartner (You can have two commanders if both have partner.)",
+                "layout": "normal",
+                "type": "Legendary Creature — Human Rogue",
+                "keywords": [
+                    "Partner"
+                ],
+                "identifiers": {
+                    "scryfallOracleId": "8ecdaf4b-4442-42da-9714-4257a83faf50"
+                }
+            }
+        ],
         "Counterspell": [
             {
                 "name": "Counterspell",

--- a/scripts/gen-test-fixture.py
+++ b/scripts/gen-test-fixture.py
@@ -33,10 +33,11 @@ TESTS_DIR = REPO_ROOT / "crates/engine/tests"
 SRC_DIR = REPO_ROOT / "crates/engine/src"
 FIXTURE_PATH = REPO_ROOT / "crates/engine/tests/fixtures/integration_cards.json"
 
-# This fixture must exercise Witherbloom Apprentice through the raw-MTGJSON
-# parser, not a hand-maintained card-data export entry. Keep the set narrow:
-# every other referenced card is selected from the production export below.
-PARSER_BACKED_FIXTURE_CARDS = {"witherbloom apprentice"}
+# This fixture must exercise Witherbloom Apprentice and Sakashima of a
+# Thousand Faces through the raw-MTGJSON parser, not a hand-maintained
+# card-data export entry. Keep the set narrow: every other referenced card is
+# selected from the production export below.
+PARSER_BACKED_FIXTURE_CARDS = {"witherbloom apprentice", "sakashima of a thousand faces"}
 
 # A few non-test-named source files contain test-only card references or corpus
 # rows consumed by tests that load the curated fixture.


### PR DESCRIPTION
fix(engine): retain Sakashima's own abilities when it copies a creature (#6009)

Sakashima of a Thousand Faces reads "except it has Sakashima's other
abilities" — a CR 707.9a exception that keeps ALL of Sakashima's own
printed abilities (the legend-rule exemption static, Partner) on the
copy, not just a single indexed ability. The existing "except it has
this ability" handling only retains the one ability containing the
BecomeCopy effect, so Sakashima's legend-rule exemption and Partner
were silently dropped whenever it copied a creature.

Added RetainAllOtherAbilitiesFromSource, an unbounded sibling of
RetainPrintedTriggerFromSource/RetainPrintedAbilityFromSource that
pulls the source's entire activated/triggered/static/keyword surface
into the copy's Layer 1 copiable values instead of a single index.

Closes #6009

