### PR TITLE
fix(engine): preserve legal casting costs and mana-payment routes

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -1868,38 +1868,46 @@ pub fn candidate_actions_broad_with_probe(
             }));
             actions
         }
-        // CR 107.4f + CR 601.2f: AI picks per-shard Phyrexian payment.
-        // Heuristic (life threshold): with life > 6, the AI prefers 2-life per shard for
-        // tempo (keep mana for other plays); with life <= 6, the AI preserves life.
-        // Shards with only one viable option use that option.
+        // CR 107.4f + CR 601.2f: Every mana-or-life vector is a distinct
+        // payment route. Generate all structurally available combinations so
+        // the legality filter can retain every fully payable route.
         WaitingFor::PhyrexianPayment { player, shards, .. } => {
             use crate::types::game_state::{ShardChoice, ShardOptions};
-            let life = state
-                .players
-                .iter()
-                .find(|p| p.id == *player)
-                .map(|p| p.life)
-                .unwrap_or(0);
-            let prefer_life = life > 6;
-            let choices: Vec<ShardChoice> = shards
-                .iter()
-                .map(|shard| match shard.options {
-                    ShardOptions::ManaOnly => ShardChoice::PayMana,
-                    ShardOptions::LifeOnly => ShardChoice::PayLife,
-                    ShardOptions::ManaOrLife => {
-                        if prefer_life {
-                            ShardChoice::PayLife
-                        } else {
-                            ShardChoice::PayMana
-                        }
+            let mut routes = vec![Vec::with_capacity(shards.len())];
+            for shard in shards {
+                match shard.options {
+                    ShardOptions::ManaOnly => {
+                        routes
+                            .iter_mut()
+                            .for_each(|route| route.push(ShardChoice::PayMana));
                     }
+                    ShardOptions::LifeOnly => {
+                        routes
+                            .iter_mut()
+                            .for_each(|route| route.push(ShardChoice::PayLife));
+                    }
+                    ShardOptions::ManaOrLife => {
+                        let mut mana_routes = routes.clone();
+                        routes
+                            .iter_mut()
+                            .for_each(|route| route.push(ShardChoice::PayLife));
+                        mana_routes
+                            .iter_mut()
+                            .for_each(|route| route.push(ShardChoice::PayMana));
+                        routes.extend(mana_routes);
+                    }
+                }
+            }
+            routes
+                .into_iter()
+                .map(|choices| {
+                    candidate(
+                        GameAction::SubmitPhyrexianChoices { choices },
+                        TacticalClass::Selection,
+                        Some(*player),
+                    )
                 })
-                .collect();
-            vec![candidate(
-                GameAction::SubmitPhyrexianChoices { choices },
-                TacticalClass::Selection,
-                Some(*player),
-            )]
+                .collect()
         }
         // CR 601.2b: Defiler cycle — accept or decline life payment for mana reduction.
         WaitingFor::DefilerPayment { player, .. } => vec![
@@ -1916,7 +1924,8 @@ pub fn candidate_actions_broad_with_probe(
         ],
         // CR 118.3 + CR 601.2b + CR 605.3b: AI selects objects to pay a cost.
         // Single-object RemoveCounter chooses one source per candidate;
-        // from-among RemoveCounter and Sacrifice honor the [min, max] range;
+        // from-among RemoveCounter, Sacrifice, and optional zone-exile costs
+        // honor the [min, max] range;
         // every other kind selects exactly `count` objects.
         WaitingFor::PayCost {
             player,
@@ -1957,7 +1966,7 @@ pub fn candidate_actions_broad_with_probe(
         ),
         WaitingFor::PayCost {
             player,
-            kind: PayCostKind::Sacrifice,
+            kind: PayCostKind::Sacrifice | PayCostKind::ExileFromZone { .. },
             choices,
             count,
             min_count,

--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -796,6 +796,9 @@ fn filterprop_reads_only_candidate_fp(p: &FilterProp) -> bool {
         | FilterProp::HasSingleTarget
         | FilterProp::HasXInActivationCost
         | FilterProp::WasKicked
+        // CR 715.2: Adventure identity reads the stored alternate face, which
+        // is not part of the candidate fingerprint; memoizing it is unsound.
+        | FilterProp::HasAdventure
         | FilterProp::SameName
         | FilterProp::SameNameAsParentTarget
         | FilterProp::NameMatchesAnyPermanent { .. }

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -526,10 +526,11 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
             },
             GameAction::SelectCards { .. },
         ) => true,
-        // CR 118.3: Sacrifice honors the [min_count, count] range.
+        // CR 118.3: Sacrifice and optional zone-exile costs honor the
+        // [min_count, count] range.
         (
             WaitingFor::PayCost {
-                kind: PayCostKind::Sacrifice,
+                kind: PayCostKind::Sacrifice | PayCostKind::ExileFromZone { .. },
                 choices,
                 count,
                 min_count,

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -1394,7 +1394,11 @@ pub fn synthesize_bargain(face: &mut CardFace) {
         return;
     }
 
-    face.additional_cost = Some(AdditionalCost::Optional {
+    face.additional_cost = Some(bargain_additional_cost());
+}
+
+pub(crate) fn bargain_additional_cost() -> AdditionalCost {
+    AdditionalCost::Optional {
         cost: AbilityCost::Sacrifice(SacrificeCost::count(
             TargetFilter::Or {
                 filters: vec![
@@ -1408,7 +1412,7 @@ pub fn synthesize_bargain(face: &mut CardFace) {
             1,
         )),
         repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
-    });
+    }
 }
 
 /// Synthesize Gift optional cost and delivery effect.

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -2320,6 +2320,14 @@ pub fn synthesize_casualty(face: &mut CardFace) {
             TriggerDefinition::new(TriggerMode::SpellCast)
                 .valid_card(TargetFilter::SelfRef)
                 .trigger_zones(vec![Zone::Stack])
+                .condition(TriggerCondition::AdditionalCostPaid {
+                    source: AdditionalCostPaymentSource::NonKicker,
+                    origin: Some(AdditionalCostOrigin::Casualty),
+                    origin_ordinal: Some(casualty_ordinal),
+                    variant: None,
+                    kicker_cost: None,
+                    min_count: 1,
+                })
                 .execute(execute)
                 .description("Casualty — copy this spell when cast with casualty paid".to_string()),
         );
@@ -17912,6 +17920,19 @@ mod idempotency_tests {
             .execute
             .as_ref()
             .expect("casualty trigger must have an execute ability");
+
+        assert_eq!(
+            trig.condition,
+            Some(TriggerCondition::AdditionalCostPaid {
+                source: AdditionalCostPaymentSource::NonKicker,
+                origin: Some(AdditionalCostOrigin::Casualty),
+                origin_ordinal: Some(0),
+                variant: None,
+                kicker_cost: None,
+                min_count: 1,
+            }),
+            "intrinsic casualty must be gated when the spell is cast, not only when the copy trigger resolves"
+        );
 
         assert_eq!(
             **execute, canonical,

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2335,6 +2335,7 @@ fn legacy_filter_prop(p: &FilterProp) -> bool {
         | FilterProp::ManaCostIn { .. }
         | FilterProp::InZone { .. }
         | FilterProp::Foretold
+        | FilterProp::HasAdventure
         | FilterProp::EnchantedBy
         | FilterProp::EquippedBy
         | FilterProp::AttachedToSource
@@ -2595,6 +2596,7 @@ fn member_bound_filter_prop(p: &FilterProp) -> bool {
         | FilterProp::ManaCostIn { .. }
         | FilterProp::InZone { .. }
         | FilterProp::Foretold
+        | FilterProp::HasAdventure
         | FilterProp::EnchantedBy
         | FilterProp::EquippedBy
         | FilterProp::AttachedToSource

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3132,6 +3132,7 @@ fn scan_filter_prop(x: &FilterProp) -> Axes {
         | FilterProp::ManaCostIn { .. }
         | FilterProp::InZone { .. }
         | FilterProp::Foretold
+        | FilterProp::HasAdventure
         | FilterProp::EnchantedBy
         | FilterProp::EquippedBy
         | FilterProp::AttachedToSource

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -100,7 +100,7 @@ use crate::types::ability::{
     TriggerCondition, TypedFilter,
 };
 use crate::types::game_state::TargetSelectionConstraint;
-use crate::types::keywords::Keyword;
+use crate::types::keywords::{DisguiseCost, Keyword};
 
 /// The three independent classification axes, accumulated over one AST walk.
 /// `true` on an axis means "reads (or may read) that dimension"; the fail-safe
@@ -3904,6 +3904,8 @@ pub(crate) fn keyword_cost_reads_growing_class(kw: &Keyword) -> bool {
         | Keyword::Casualty(_)
         | Keyword::Assist => true,
 
+        Keyword::Disguise(DisguiseCost::Reduced { .. }) => true,
+
         // SAFE: no casting/activation cost that reads a growing board/graveyard class.
         Keyword::Flying
         | Keyword::FirstStrike
@@ -3995,7 +3997,7 @@ pub(crate) fn keyword_cost_reads_growing_class(kw: &Keyword) -> bool {
         | Keyword::Morph(_)
         | Keyword::Megamorph(_)
         | Keyword::Madness(_)
-        | Keyword::Disguise(_)
+        | Keyword::Disguise(DisguiseCost::Mana(_))
         | Keyword::Mayhem(_)
         | Keyword::Suspend { .. }
         | Keyword::Blitz(_)

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13223,7 +13223,7 @@ pub(super) fn can_feasibly_pay_mana_cost(
     can_feasibly_pay_mana_cost_with_probe(state, player, source_id, cost, None)
 }
 
-pub(super) fn has_manual_mana_ability_for_spell_payment(
+pub(crate) fn has_manual_mana_ability_for_spell_payment(
     state: &GameState,
     player: PlayerId,
     source_id: ObjectId,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -9550,6 +9550,15 @@ pub(super) fn initiate_cast_during_resolution(
         graveyard_replacement,
         cost,
     } = request;
+    // CR 608.2g + CR 712.8a: a paid cast granted by an effect uses the
+    // casting card's front face and printed mana cost unless that effect
+    // explicitly says to cast it transformed. Intrinsic graveyard methods such
+    // as disturb are separate alternatives and must not silently replace a
+    // Tinybones-style full-cost cast.
+    let full_cost_front_face = matches!(
+        &cost,
+        crate::types::ability::ResolutionCastCost::FullCost { .. }
+    ) && !cast_transformed;
     // CR 608.2g + CR 609.4b + CR 118.9: resolve the payment shape once.
     // `Free` zeroes the cost and auto-pays (Cascade/Discover/Suspend).
     // `FullCost` charges the card's live printed cost (`SelfManaCost`) and
@@ -9626,7 +9635,7 @@ pub(super) fn initiate_cast_during_resolution(
         state,
         player,
         hit_card,
-        None,
+        full_cost_front_face.then_some(CastingVariant::Normal),
         None,
         Some(casting_permission_index),
         CastingMode::Actual,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13075,6 +13075,33 @@ pub fn can_pay_cost_after_auto_tap(
     can_pay_cost_after_auto_tap_with_probe(state, player, source_id, cost, None)
 }
 
+/// Return the unpaid portion of an in-flight spell's mana cost after applying
+/// the caster's current mana pool, including spell-specific spending
+/// restrictions and any-color permissions.
+pub fn pending_cast_remaining_mana_cost(state: &GameState, player: PlayerId) -> Option<ManaCost> {
+    let pending = state.pending_cast.as_deref()?;
+    let player_data = state
+        .players
+        .iter()
+        .find(|candidate| candidate.id == player)?;
+    let spell_meta = build_spell_meta(state, player, pending.object_id);
+    let spell_ctx = spell_meta.as_ref().map(PaymentContext::Spell);
+    let any_color = player_can_spend_as_any_color_for_payment(
+        state,
+        player,
+        Some(pending.object_id),
+        spell_ctx.as_ref(),
+    );
+
+    Some(mana_payment::reduce_cost_by_pool(
+        &player_data.mana_pool,
+        &pending.cost,
+        spell_ctx.as_ref(),
+        any_color,
+        None,
+    ))
+}
+
 pub fn can_pay_cost_after_auto_tap_with_probe(
     state: &GameState,
     player: PlayerId,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12202,6 +12202,26 @@ pub fn can_cast_object_now(state: &GameState, player: PlayerId, object_id: Objec
     can_cast_object_now_with_probe(state, player, object_id, None)
 }
 
+/// CR 715.3a / CR 720.3a: Test one Adventure-family face without allowing
+/// castability of the other face to make this choice look legal.
+pub fn can_cast_adventure_face_now(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    creature: bool,
+) -> bool {
+    let mut sim = state.clone();
+    let Some(obj) = sim.objects.get_mut(&object_id) else {
+        return false;
+    };
+    if creature {
+        obj.back_face = None;
+    } else {
+        swap_to_alternative_spell_face(obj);
+    }
+    can_cast_object_now(&sim, player, object_id)
+}
+
 pub fn can_cast_object_now_with_probe(
     state: &GameState,
     player: PlayerId,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1925,6 +1925,105 @@ pub(super) fn build_spell_meta(
     })
 }
 
+/// CR 107.4f + CR 601.2f/h: Check an explicit Phyrexian payment route
+/// against the complete pending cost. Individual shard options deliberately
+/// do not reserve contested mana, so callers must validate the full vector
+/// before advertising or counting it.
+pub fn pending_phyrexian_route_is_payable(
+    state: &GameState,
+    player: PlayerId,
+    spell_object: ObjectId,
+    choices: &[crate::types::game_state::ShardChoice],
+) -> bool {
+    let Some(pending) = state.pending_cast.as_deref() else {
+        return false;
+    };
+    if pending.object_id != spell_object {
+        return false;
+    }
+    let Some(player_data) = state
+        .players
+        .iter()
+        .find(|candidate| candidate.id == player)
+    else {
+        return false;
+    };
+
+    let (source_types, source_subtypes, activation_tag) = pending
+        .activation_ability_index
+        .map(|ability_index| {
+            let (types, subtypes) = activation_source_types(state, spell_object);
+            (
+                types,
+                subtypes,
+                Some(activation_ability_tag(state, spell_object, ability_index)),
+            )
+        })
+        .unwrap_or_default();
+    let spell_meta = pending
+        .activation_ability_index
+        .is_none()
+        .then(|| build_spell_meta(state, player, spell_object))
+        .flatten();
+    let payment_context = if pending.activation_ability_index.is_some() {
+        Some(PaymentContext::Activation {
+            source_types: &source_types,
+            source_subtypes: &source_subtypes,
+            ability_tag: activation_tag.flatten(),
+        })
+    } else {
+        spell_meta.as_ref().map(PaymentContext::Spell)
+    };
+    let any_color = player_can_spend_as_any_color_for_payment(
+        state,
+        player,
+        Some(spell_object),
+        payment_context.as_ref(),
+    );
+    let permissions =
+        super::static_abilities::build_cost_permission_context(state, player, any_color);
+    let phyrexian_count = match &pending.cost {
+        ManaCost::Cost { shards, .. } => shards
+            .iter()
+            .filter(|shard| {
+                matches!(
+                    mana_payment::effective_shard_requirement(
+                        mana_payment::shard_to_mana_type(**shard),
+                        permissions.life_colors,
+                    ),
+                    mana_payment::ShardRequirement::Phyrexian(..)
+                        | mana_payment::ShardRequirement::HybridPhyrexian(..)
+                        | mana_payment::ShardRequirement::TwoGenericHybridPhyrexian(..)
+                )
+            })
+            .count(),
+        _ => 0,
+    };
+    if choices.len() != phyrexian_count
+        || choices
+            .iter()
+            .filter(|choice| matches!(choice, crate::types::game_state::ShardChoice::PayLife))
+            .count()
+            > permissions.max_life as usize
+    {
+        return false;
+    }
+
+    let hand_demand = mana_payment::compute_hand_color_demand(state, player, spell_object);
+    let mut pool = player_data.mana_pool.clone();
+    mana_payment::pay_cost_with_demand_and_choices(
+        &mut pool,
+        &pending.cost,
+        Some(&hand_demand),
+        payment_context.as_ref(),
+        any_color,
+        Some(choices),
+        permissions.life_colors,
+        &pending.pinned_pool_units,
+    )
+    .is_ok()
+}
+
 fn object_type_names(obj: &crate::game::game_object::GameObject) -> Vec<String> {
     let mut names = obj
         .card_types

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2033,6 +2033,12 @@ pub fn pending_phyrexian_route_is_payable(
         payment_context.as_ref(),
         &excluded_sources,
     );
+    // CR 605.3b + CR 616.1: A costed mana source can pause while a
+    // replacement choice is answered. The route remains potentially payable;
+    // live finalization will surface and resume that choice.
+    if mana_ability_cost_payment_is_paused(&preview) {
+        return true;
+    }
     super::triggers::resolve_tap_mana_triggers_inline(&mut preview, &mut preview_events, 0);
     let hand_demand = mana_payment::compute_hand_color_demand(&preview, player, spell_object);
     let mut pool = preview

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13219,9 +13219,9 @@ pub fn can_pay_cost_after_auto_tap(
     can_pay_cost_after_auto_tap_with_probe(state, player, source_id, cost, None)
 }
 
-/// Return the unpaid portion of an in-flight spell's mana cost after applying
-/// the caster's current mana pool, including spell-specific spending
-/// restrictions and any-color permissions.
+/// CR 601.2g + CR 601.2h: Return the unpaid portion of an in-flight spell's
+/// mana cost after applying the caster's current mana pool, including
+/// spell-specific spending restrictions and any-color permissions.
 pub fn pending_cast_remaining_mana_cost(state: &GameState, player: PlayerId) -> Option<ManaCost> {
     let pending = state.pending_cast.as_deref()?;
     let player_data = state

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12222,6 +12222,36 @@ pub fn can_cast_adventure_face_now(
     can_cast_object_now(&sim, player, object_id)
 }
 
+/// CR 709.3 + CR 712.11c: Test one split-card or spell//spell MDFC face
+/// without letting the other face make this choice appear affordable. This
+/// keeps an unaffordable half from entering its target-selection prompt. Land
+/// faces reach this prompt only after a legal play-land action and remain
+/// selectable without a mana-cost check.
+pub fn can_cast_modal_face_now(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    back_face: bool,
+) -> bool {
+    let mut sim = state.clone();
+    let Some(obj) = sim.objects.get_mut(&object_id) else {
+        return false;
+    };
+    if back_face {
+        simulate_chosen_split_spell_back_face(obj);
+    } else if let Some(back) = obj.back_face.as_mut() {
+        back.layout_kind = None;
+    }
+    if obj
+        .card_types
+        .core_types
+        .contains(&crate::types::card_type::CoreType::Land)
+    {
+        return true;
+    }
+    can_cast_object_now(&sim, player, object_id)
+}
+
 pub fn can_cast_object_now_with_probe(
     state: &GameState,
     player: PlayerId,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -13102,6 +13102,42 @@ pub fn pending_cast_remaining_mana_cost(state: &GameState, player: PlayerId) -> 
     ))
 }
 
+/// Return whether an activated mana ability can produce mana that is eligible
+/// to pay the spell currently being cast.
+///
+/// CR 106.6: activating a restricted mana ability is legal during payment,
+/// but mana such as Cavern of Souls' creature-only output cannot contribute to
+/// an artifact spell. Search should not spend an activation on that branch
+/// when selecting a cast-payment action.
+pub fn mana_ability_can_pay_pending_cast(
+    state: &GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    ability_index: usize,
+) -> bool {
+    let Some(pending) = state.pending_cast.as_deref() else {
+        return true;
+    };
+    let Some(ability) = state
+        .objects
+        .get(&source_id)
+        .and_then(|source| source.abilities.get(ability_index))
+    else {
+        return true;
+    };
+    let Effect::Mana { restrictions, .. } = &*ability.effect else {
+        return true;
+    };
+    let Some(spell_meta) = build_spell_meta(state, player, pending.object_id) else {
+        return true;
+    };
+    let spell_ctx = PaymentContext::Spell(&spell_meta);
+
+    super::effects::mana::resolve_restrictions(restrictions, state, source_id)
+        .iter()
+        .all(|restriction| restriction.allows(&spell_ctx))
+}
+
 pub fn can_pay_cost_after_auto_tap_with_probe(
     state: &GameState,
     player: PlayerId,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -12633,6 +12633,45 @@ fn can_cast_prepared_now_with_probe(
         }
     }
 
+    // CR 118.3 + CR 601.2f-h: A mandatory choice of additional costs is
+    // castable only when at least one branch can be paid with the spell's full
+    // mana cost. Reuse the declaration-time authority so discard/life,
+    // sacrifice/mana, and other choice shapes cannot reach target selection
+    // and then fail during payment after the cast has been announced.
+    if let Some(AdditionalCost::Choice(preferred, fallback)) = state
+        .objects
+        .get(&prepared.object_id)
+        .and_then(|o| o.additional_cost.as_ref())
+    {
+        let resolved = prepared.ability_def.as_ref().map_or_else(
+            || ResolvedAbility::new(Effect::NoOp, Vec::new(), prepared.object_id, player),
+            |def| build_resolved_from_def(def, prepared.object_id, player),
+        );
+        let mut pending = PendingCast::new(
+            prepared.object_id,
+            prepared.card_id,
+            resolved,
+            prepared.mana_cost.clone(),
+        );
+        pending.base_cost = Some(prepared.base_mana_cost.clone());
+        pending.casting_variant = prepared.casting_variant;
+        pending.cast_timing_permission = prepared.cast_timing_permission;
+        pending.origin_zone = prepared.origin_zone;
+        pending.payment_mode = prepared.payment_mode;
+        let branch_is_offerable = |cost: &AbilityCost| {
+            casting_costs::additional_cost_declaration_is_offerable(
+                state,
+                player,
+                &pending,
+                cost.clone(),
+            )
+            .unwrap_or(false)
+        };
+        if !branch_is_offerable(preferred) && !branch_is_offerable(fallback) {
+            return false;
+        }
+    }
+
     // CR 702.172: Spree spells must afford at least one mode to be castable.
     // CR 117.1d + CR 601.2g: Use the feasibility predicate so non-tap mana
     // abilities (Sacrifice / Discard / PayLife) the controller could activate

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2009,8 +2009,38 @@ pub fn pending_phyrexian_route_is_payable(
         return false;
     }
 
-    let hand_demand = mana_payment::compute_hand_color_demand(state, player, spell_object);
-    let mut pool = player_data.mana_pool.clone();
+    // CR 601.2h: Preview only the mana actually required by this route.
+    // PayLife shards must not consume an untapped producer, while PayMana
+    // routes remain available when their source has not yet been tapped.
+    let tap_cost = mana_payment::mana_cost_for_phyrexian_choices(
+        &pending.cost,
+        choices,
+        permissions.life_colors,
+    );
+    let excluded_sources = pending
+        .activation_cost
+        .as_ref()
+        .map(|cost| ability_mana_payment_excluded_sources(cost, spell_object))
+        .unwrap_or_default();
+    let mut preview = state.clone();
+    let mut preview_events = Vec::new();
+    super::casting_costs::auto_tap_mana_sources_with_context_excluding(
+        &mut preview,
+        player,
+        &tap_cost,
+        &mut preview_events,
+        Some(spell_object),
+        payment_context.as_ref(),
+        &excluded_sources,
+    );
+    super::triggers::resolve_tap_mana_triggers_inline(&mut preview, &mut preview_events, 0);
+    let hand_demand = mana_payment::compute_hand_color_demand(&preview, player, spell_object);
+    let mut pool = preview
+        .players
+        .iter()
+        .find(|candidate| candidate.id == player)
+        .map(|candidate| candidate.mana_pool.clone())
+        .unwrap_or_else(|| player_data.mana_pool.clone());
     mana_payment::pay_cost_with_demand_and_choices(
         &mut pool,
         &pending.cost,
@@ -14327,10 +14357,15 @@ fn auto_tap_and_pay_cost_excluding(
     parent: Option<&ManaAbilityCostParent>,
 ) -> Result<Vec<crate::types::mana::ManaUnit>, EngineError> {
     let events_before = events.len();
+    let life_colors = super::static_abilities::player_life_payment_colors(state, player);
+    let tap_cost = phyrexian_choices.map_or_else(
+        || cost.clone(),
+        |choices| mana_payment::mana_cost_for_phyrexian_choices(cost, choices, life_colors),
+    );
     super::casting_costs::auto_tap_mana_sources_with_context_excluding_and_resume(
         state,
         player,
-        cost,
+        &tap_cost,
         events,
         Some(source_id),
         ctx,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -8,7 +8,7 @@ use crate::types::ability::{
     CounterCostSelection, Effect, KickerVariant, ObjectProperty, QuantityExpr, QuantityRef,
     ReplacementDefinition, ResolvedAbility, SacrificeCost, SacrificeRequirement,
     SpellCastingOptionKind, SpellStackToGraveyardReplacement, StaticCondition,
-    TapCreaturesAggregate, TargetFilter, TypeFilter, TypedFilter, EXILE_COST_X,
+    TapCreaturesAggregate, TargetFilter, ThisWayCause, TypeFilter, TypedFilter, EXILE_COST_X,
 };
 use crate::types::card_type::CoreType;
 use crate::types::events::{GameEvent, ManaTapState};
@@ -518,7 +518,14 @@ pub(crate) fn handle_decide_additional_cost(
     // cost before mana payment begins. The recompute reads the in-flight cast's
     // flag via `state.pending_cast`, so publish `updated_pending` there for the
     // duration of the recompute, then restore the prior value.
-    if optional_cost_paid {
+    // CR 601.2f: An exile-this-way reduction cannot be calculated until the
+    // caster has selected the cards; recomputing here could count an unrelated
+    // older tracked set. The selection handler publishes the fresh set first.
+    if optional_cost_paid
+        && !cost_to_pay
+            .as_ref()
+            .is_some_and(is_exile_any_number_effect_cost)
+    {
         recompute_pending_cast_cost_after_additional_cost(state, player, &mut updated_pending);
     }
 
@@ -3457,11 +3464,56 @@ pub(crate) fn handle_exile_for_cost(
         (expected, expected),
         legal_cards,
         chosen,
+        None,
         events,
         "card(s)",
         "Selected card not eligible for exile",
         |state, player, id, _pending| {
             // Re-validate: chosen cards must still be in the cost's source zone.
+            let still_in_zone = state
+                .players
+                .get(player.0 as usize)
+                .is_some_and(|p| match zone {
+                    ExileCostSourceZone::Hand => p.hand.contains(&id),
+                    ExileCostSourceZone::Graveyard => p.graveyard.contains(&id),
+                });
+            if !still_in_zone {
+                return Err(EngineError::InvalidAction(format!(
+                    "Selected card is no longer in {:?}",
+                    zone.as_zone()
+                )));
+            }
+            Ok(())
+        },
+    )
+}
+
+/// CR 601.2b + CR 601.2h + CR 701.13: Complete an optional "exile any
+/// number" additional cost, preserving the selected set for its cast-time
+/// "for each card exiled this way" reduction.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn handle_exile_any_number_for_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    zone: ExileCostSourceZone,
+    pending: PendingCast,
+    maximum: usize,
+    legal_cards: &[ObjectId],
+    chosen: &[ObjectId],
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    finish_exile_selection_for_cost(
+        state,
+        player,
+        pending,
+        (0, maximum),
+        legal_cards,
+        chosen,
+        Some(ThisWayCause::Exiled),
+        events,
+        "card(s)",
+        "Selected card not eligible for exile",
+        |state, player, id, _pending| {
             let still_in_zone = state
                 .players
                 .get(player.0 as usize)
@@ -3507,6 +3559,7 @@ pub(crate) fn handle_exile_permanent_for_cost(
         (expected, expected),
         legal_cards,
         chosen,
+        None,
         events,
         "permanent(s)",
         "Selected permanent not eligible to exile as a cost",
@@ -3545,6 +3598,7 @@ fn finish_exile_selection_for_cost(
     bounds: (usize, usize),
     legal_cards: &[ObjectId],
     chosen: &[ObjectId],
+    this_way_cause: Option<ThisWayCause>,
     events: &mut Vec<GameEvent>,
     object_label: &str,
     illegal_message: &str,
@@ -3571,6 +3625,17 @@ fn finish_exile_selection_for_cost(
 
     for &id in chosen {
         revalidate(state, player, id, &pending)?;
+    }
+
+    // CR 601.2f: Cost reductions that count cards exiled this way read the
+    // fresh payment set, never an unrelated resolution's tracked set.
+    if let Some(cause) = this_way_cause {
+        state.chain_tracked_set_id = None;
+        super::effects::publish_tracked_set_with_causes(
+            state,
+            chosen.iter().copied().map(|id| (id, Some(cause))).collect(),
+        );
+        recompute_pending_cast_cost_after_additional_cost(state, player, &mut pending);
     }
 
     // CR 608.2k: Capture the first exiled object's public characteristics BEFORE
@@ -3744,6 +3809,7 @@ pub(crate) fn handle_exile_materials_for_cost(
         bounds,
         legal_cards,
         chosen,
+        None,
         events,
         "material(s)",
         "Selected object not eligible as craft material",
@@ -5809,6 +5875,31 @@ fn pay_additional_cost_with_source(
         cost
     };
 
+    // CR 601.2b + CR 601.2h: Legacy card data represents an optional
+    // "exile any number of [quality] cards" cost as ChangeZone. Surface every
+    // eligible card and allow the caster to select any subset.
+    if let Some((zone, filter)) = exile_any_number_effect_cost_parts(&cost) {
+        let eligible = super::casting::find_eligible_exile_for_cost_targets(
+            state,
+            player,
+            pending.object_id,
+            zone,
+            Some(filter),
+        );
+        return Ok(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::ExileFromZone { zone },
+            count: eligible.len(),
+            min_count: 0,
+            choices: eligible,
+            resume: CostResume::SpellCost {
+                spell: Box::new(pending),
+                cost: Box::new(cost),
+                source: cost_source,
+            },
+        });
+    }
+
     match cost {
         AbilityCost::PayLife { amount } => {
             // CR 118.3 + CR 119.4 + CR 119.8: Pay life as an additional cost via
@@ -6374,6 +6465,28 @@ fn pay_additional_cost_with_source(
     }
 
     finish_pending_cost_or_cast(state, player, pending, events)
+}
+
+pub(crate) fn is_exile_any_number_effect_cost(cost: &AbilityCost) -> bool {
+    exile_any_number_effect_cost_parts(cost).is_some()
+}
+
+fn exile_any_number_effect_cost_parts(
+    cost: &AbilityCost,
+) -> Option<(ExileCostSourceZone, &TargetFilter)> {
+    let AbilityCost::EffectCost { effect } = cost else {
+        return None;
+    };
+    let Effect::ChangeZone {
+        origin: Some(origin),
+        destination: Zone::Exile,
+        target,
+        ..
+    } = effect.as_ref()
+    else {
+        return None;
+    };
+    Some((ExileCostSourceZone::try_from_zone(*origin)?, target))
 }
 
 fn prepend_deferred_required_cost(cost: AbilityCost, pending: &mut PendingCast) -> AbilityCost {
@@ -7095,6 +7208,65 @@ fn condition_matches_with_additional_cost_paid(
         }),
         _ => super::layers::evaluate_condition(state, condition, controller, spell_id),
     }
+}
+
+fn exile_any_number_cost_reduction_capacity(
+    state: &GameState,
+    player: PlayerId,
+    spell_id: ObjectId,
+) -> u32 {
+    let Some(spell) = state.objects.get(&spell_id) else {
+        return 0;
+    };
+    let Some(AdditionalCost::Optional { cost, .. }) = spell.additional_cost.as_ref() else {
+        return 0;
+    };
+    let Some((zone, cost_filter)) = exile_any_number_effect_cost_parts(cost) else {
+        return 0;
+    };
+    let eligible = super::casting::find_eligible_exile_for_cost_targets(
+        state,
+        player,
+        spell_id,
+        zone,
+        Some(cost_filter),
+    );
+    let ctx = super::filter::FilterContext::from_source(state, spell_id);
+
+    spell
+        .static_definitions
+        .iter_all()
+        .filter_map(|definition| {
+            let StaticMode::ModifyCost {
+                mode: CostModifyMode::Reduce,
+                amount: ManaCost::Cost { generic, .. },
+                dynamic_count:
+                    Some(QuantityRef::FilteredTrackedSetSize {
+                        filter,
+                        caused_by: Some(ThisWayCause::Exiled),
+                    }),
+                ..
+            } = &definition.mode
+            else {
+                return None;
+            };
+            if !matches!(definition.affected, Some(TargetFilter::SelfRef)) {
+                return None;
+            }
+            let condition = definition.condition.as_ref()?;
+            if !sacrificed_this_way_condition_matches(state, condition, spell.controller, spell_id)
+            {
+                return None;
+            }
+            let count = eligible
+                .iter()
+                .filter(|&&id| super::filter::matches_target_filter(state, id, filter, &ctx))
+                .count()
+                .try_into()
+                .unwrap_or(u32::MAX);
+            Some(generic.saturating_mul(count))
+        })
+        .fold(0, u32::saturating_add)
 }
 
 pub(super) fn retrace_discard_land_cost() -> AbilityCost {
@@ -9958,7 +10130,12 @@ pub(super) fn max_x_value_excluding(
     // CR 107.1b: Each `ManaCostShard::X` in the cost contributes `value` generic,
     // so for `{X}{X}` each point of X costs 2 mana. Dividing by `x_count` yields
     // the largest X the caster can actually afford.
-    let available = pool + permanent_capacity + delve_capacity;
+    // CR 601.2f: An optional exile-this-way reduction expands the largest
+    // affordable X even though the card selection happens later in the cast.
+    let exile_reduction_capacity = object_id
+        .map(|spell_id| exile_any_number_cost_reduction_capacity(state, player, spell_id))
+        .unwrap_or(0);
+    let available = pool + permanent_capacity + delve_capacity + exile_reduction_capacity;
     let formula_max = available.saturating_sub(fixed_portion) / x_count;
 
     // An object-less X cost (the `max_x_value` public path used by the
@@ -20578,5 +20755,187 @@ its replicate cost was paid.)\nDraw a card.";
             "excluding one real card leaves insufficient Delve capacity for {{X}}{{X}}"
         );
         assert!(state.objects[&real_b].is_delve_eligible(PlayerId(0)));
+    }
+
+    #[test]
+    fn march_exiles_matching_hand_cards_and_reduces_the_chosen_x_cost() {
+        use crate::ai_support::candidate_actions;
+        use crate::parser::oracle::parse_oracle_text;
+
+        let caster = PlayerId(0);
+        let mut state = GameState::new_two_player(42);
+        let parsed = parse_oracle_text(
+            "As an additional cost to cast this spell, you may exile any number of white cards from your hand. This spell costs {2} less to cast for each card exiled this way.\nExile target artifact, creature, or enchantment with mana value X or less.",
+            "March of Otherworldly Light",
+            &[],
+            &["Instant".to_string()],
+            &[],
+        );
+        let additional_cost = parsed
+            .additional_cost
+            .clone()
+            .expect("March additional cost parses");
+        let symbolic_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::White],
+            generic: 0,
+        };
+        let march = create_object(
+            &mut state,
+            CardId(9_000),
+            caster,
+            "March of Otherworldly Light".to_string(),
+            Zone::Hand,
+        );
+        {
+            let object = state.objects.get_mut(&march).unwrap();
+            object.card_types.core_types.push(CoreType::Instant);
+            object.mana_cost = symbolic_cost.clone();
+            object.additional_cost = Some(additional_cost.clone());
+            for definition in parsed.statics {
+                object.static_definitions.push(definition);
+            }
+        }
+        let white = create_object(
+            &mut state,
+            CardId(9_001),
+            caster,
+            "White Card".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&white)
+            .unwrap()
+            .color
+            .push(ManaColor::White);
+        let second_white = create_object(
+            &mut state,
+            CardId(9_003),
+            caster,
+            "Second White Card".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&second_white)
+            .unwrap()
+            .color
+            .push(ManaColor::White);
+        let blue = create_object(
+            &mut state,
+            CardId(9_002),
+            caster,
+            "Blue Card".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&blue)
+            .unwrap()
+            .color
+            .push(ManaColor::Blue);
+        state.players[0].mana_pool.add(ManaUnit::new(
+            ManaType::White,
+            ObjectId(9_099),
+            false,
+            vec![],
+        ));
+
+        let ability = ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            march,
+            caster,
+        );
+        let mut pending = PendingCast::new(march, CardId(9_000), ability, symbolic_cost.clone());
+        pending.base_cost = Some(symbolic_cost.clone());
+        state.pending_cast = Some(Box::new(pending.clone()));
+        assert_eq!(
+            max_x_value_excluding(
+                &state,
+                caster,
+                &symbolic_cost,
+                Some(march),
+                &std::collections::HashSet::new(),
+            ),
+            4,
+            "each white card supplies two generic reduction toward X"
+        );
+
+        pending.ability.set_chosen_x_recursive(2);
+        pending.cost.concretize_x(2);
+        state.pending_cast = Some(Box::new(pending.clone()));
+        let mut events = Vec::new();
+        crate::game::stack::push_to_stack(
+            &mut state,
+            StackEntry {
+                id: march,
+                source_id: march,
+                controller: caster,
+                kind: StackEntryKind::Spell {
+                    card_id: CardId(9_000),
+                    ability: None,
+                    casting_variant: CastingVariant::Normal,
+                    actual_mana_spent: 0,
+                },
+            },
+            &mut events,
+        );
+        let waiting = handle_decide_additional_cost(
+            &mut state,
+            caster,
+            pending,
+            &additional_cost,
+            true,
+            &mut events,
+        )
+        .expect("March cost declaration succeeds");
+        assert!(matches!(
+            &waiting,
+            WaitingFor::PayCost {
+                kind: PayCostKind::ExileFromZone {
+                    zone: ExileCostSourceZone::Hand,
+                },
+                choices,
+                count: 2,
+                min_count: 0,
+                ..
+            } if choices == &vec![white, second_white]
+        ));
+
+        state.waiting_for = waiting;
+        let candidates = candidate_actions(&state);
+        assert!(candidates.iter().any(|candidate| matches!(
+            &candidate.action,
+            GameAction::SelectCards { cards } if cards.is_empty()
+        )));
+        assert!(candidates.iter().any(|candidate| matches!(
+            &candidate.action,
+            GameAction::SelectCards { cards } if cards == &vec![white]
+        )));
+        assert!(candidates.iter().any(|candidate| matches!(
+            &candidate.action,
+            GameAction::SelectCards { cards } if cards == &vec![white, second_white]
+        )));
+        assert!(!candidates.iter().any(|candidate| matches!(
+            &candidate.action,
+            GameAction::SelectCards { cards } if cards.contains(&blue)
+        )));
+
+        apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![white, second_white],
+            },
+        )
+        .expect("March exile payment succeeds");
+        assert_eq!(state.objects[&white].zone, Zone::Exile);
+        assert_eq!(state.objects[&second_white].zone, Zone::Exile);
+        assert_eq!(state.objects[&blue].zone, Zone::Hand);
+        assert!(state.stack.iter().any(|entry| entry.source_id == march));
+        assert_eq!(state.players[0].mana_pool.total(), 0);
     }
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -11354,7 +11354,7 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
     player: PlayerId,
     source_id: ObjectId,
     cost: &crate::types::mana::ManaCost,
-    _events: &mut Vec<GameEvent>,
+    events: &mut Vec<GameEvent>,
     payment_context: Option<&PaymentContext<'_>>,
     excluded_sources: &HashSet<ObjectId>,
     resume: Option<&ManaAbilityResume>,
@@ -11428,7 +11428,9 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
     // CR 605.3b + CR 616.1: A costed mana source can suspend auto-tap on a
     // replacement choice. Preserve that live choice; computing Phyrexian
     // shards here would overwrite its typed payment root.
-    if super::casting::mana_ability_cost_payment_is_paused(state) {
+    if super::casting::mana_ability_cost_payment_is_paused(&preview) {
+        *state = preview;
+        events.extend(preview_events);
         return Some(state.waiting_for.clone());
     }
     // CR 605.4a: Resolve coupled `TapsForMana` triggered mana abilities inline so

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -11342,8 +11342,8 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
 /// Phyrexian payment choice, and construct the matching `WaitingFor::PhyrexianPayment`
 /// if so.
 ///
-/// Auto-taps mana sources first (idempotent: already-tapped lands are skipped) so the
-/// shard-options computation reflects the pool the caster will actually spend from.
+/// Previews available mana sources without tapping them so the shard-options
+/// computation exposes both routes while preserving the no-tap life route.
 /// Returns `Some(WaitingFor::PhyrexianPayment {...})` when at least one Phyrexian shard
 /// can deduct life; otherwise returns `None` so the caller proceeds with the existing
 /// auto-decision path.
@@ -11353,7 +11353,7 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
     player: PlayerId,
     source_id: ObjectId,
     cost: &crate::types::mana::ManaCost,
-    events: &mut Vec<GameEvent>,
+    _events: &mut Vec<GameEvent>,
     payment_context: Option<&PaymentContext<'_>>,
     excluded_sources: &HashSet<ObjectId>,
     resume: Option<&ManaAbilityResume>,
@@ -11396,25 +11396,27 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
         _ => return None,
     }
 
-    // CR 601.2h + CR 605: Auto-tap mana sources before shard-options computation so
-    // the simulation reflects the actual post-tap pool.
-    let events_before = events.len();
+    // CR 601.2h + CR 605: Preview mana sources before shard-options
+    // computation. Tapping the live state here would make a later PayLife
+    // choice waste the source even though no mana was required.
+    let mut preview = state.clone();
+    let mut preview_events = Vec::new();
     if payment_context.is_none() && excluded_sources.is_empty() {
         auto_tap_mana_sources_with_context_and_resume(
-            state,
+            &mut preview,
             player,
             cost,
-            events,
+            &mut preview_events,
             Some(source_id),
             None,
             resume,
         );
     } else {
         auto_tap_mana_sources_with_context_excluding_and_resume(
-            state,
+            &mut preview,
             player,
             cost,
-            events,
+            &mut preview_events,
             Some(source_id),
             payment_context,
             excluded_sources,
@@ -11430,16 +11432,16 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
     }
     // CR 605.4a: Resolve coupled `TapsForMana` triggered mana abilities inline so
     // the bonus mana is in the pool before Phyrexian shard options are computed.
-    super::triggers::resolve_tap_mana_triggers_inline(state, events, events_before);
+    super::triggers::resolve_tap_mana_triggers_inline(&mut preview, &mut preview_events, 0);
 
     let spell_meta = payment_context
         .is_none()
-        .then(|| super::casting::build_spell_meta(state, player, source_id))
+        .then(|| super::casting::build_spell_meta(&preview, player, source_id))
         .flatten();
     let spell_ctx = spell_meta.as_ref().map(PaymentContext::Spell);
     let effective_payment_context = payment_context.or(spell_ctx.as_ref());
     let any_color = super::casting::player_can_spend_as_any_color_for_payment(
-        state,
+        &preview,
         player,
         Some(source_id),
         effective_payment_context,
@@ -11448,10 +11450,10 @@ pub(super) fn maybe_pause_for_phyrexian_choice(
     // `life_colors` through to `compute_phyrexian_shards` so K'rrik-promoted
     // shards surface in the pause UI.
     let permissions =
-        super::static_abilities::build_cost_permission_context(state, player, any_color);
+        super::static_abilities::build_cost_permission_context(&preview, player, any_color);
 
     let (shards, payable) = {
-        let player_data = state.players.iter().find(|p| p.id == player)?;
+        let player_data = preview.players.iter().find(|p| p.id == player)?;
         let shards = mana_payment::compute_phyrexian_shards(
             &player_data.mana_pool,
             cost,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -5035,7 +5035,7 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
     // CR 601.2b/f + CR 113.2c: non-kicker keyword additional costs with
     // independently functioning instances are announced through a queue. This
     // preserves one payment record per Casualty/Offspring/Squad/Replicate/
-    // Teamwork instance while leaving Kicker on its existing `kickers_paid` path.
+    // Bargain/Teamwork instance while leaving Kicker on its existing `kickers_paid` path.
     let mut additional_cost_queue = Vec::new();
     additional_cost_queue.extend(effective_casualty_additional_cost_instances(
         state, player, object_id,
@@ -5047,6 +5047,9 @@ pub(super) fn check_additional_cost_or_pay_with_distribute(
         state, player, object_id,
     ));
     additional_cost_queue.extend(effective_replicate_additional_cost_instances(
+        state, player, object_id,
+    ));
+    additional_cost_queue.extend(effective_bargain_additional_cost_instances(
         state, player, object_id,
     ));
     additional_cost_queue.extend(effective_teamwork_additional_cost_instances(
@@ -6918,6 +6921,28 @@ pub(super) fn effective_teamwork_additional_cost_instances(
                     },
                     repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
                 },
+            )
+        })
+        .collect()
+}
+
+/// CR 702.166a: Return each effective Bargain keyword as its own optional
+/// sacrifice cost. The dedicated queue record distinguishes a bargained spell
+/// from one that merely paid an unrelated additional cost.
+pub(super) fn effective_bargain_additional_cost_instances(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+) -> Vec<AdditionalCostInstance> {
+    super::casting::effective_spell_keyword_instances(state, player, object_id)
+        .into_iter()
+        .filter(|keyword| matches!(keyword, Keyword::Bargain))
+        .enumerate()
+        .map(|(ordinal, _)| {
+            AdditionalCostInstance::new_with_ordinal(
+                AdditionalCostOrigin::Bargain,
+                u32::try_from(ordinal).unwrap_or(u32::MAX),
+                crate::database::synthesis::bargain_additional_cost(),
             )
         })
         .collect()
@@ -11633,6 +11658,33 @@ mod tests {
             "only an explicit opponent-choice slot may record an announcing opponent"
         );
         assert_eq!(ability.context.announcing_opponent, None);
+    }
+
+    #[test]
+    fn bargain_additional_cost_instance_has_a_dedicated_origin() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(9_900),
+            PlayerId(0),
+            "Realm-Scorcher Hellkite".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .keywords
+            .push(Keyword::Bargain);
+
+        let instances = effective_bargain_additional_cost_instances(&state, PlayerId(0), source);
+
+        assert_eq!(instances.len(), 1);
+        assert_eq!(instances[0].origin, AdditionalCostOrigin::Bargain);
+        assert_eq!(
+            instances[0].cost,
+            crate::database::synthesis::bargain_additional_cost()
+        );
     }
 
     /// CR 614.1a + CR 608.2n (PLAN §8 Risk #2): the Invoke Calamity free-cast

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -232,6 +232,7 @@ pub(crate) fn additional_cost_declaration_is_offerable(
     pending: &PendingCast,
     cost: AbilityCost,
 ) -> Result<bool, EngineError> {
+    let exile_this_way_cost = is_exile_any_number_effect_cost(&cost);
     let split = split_declared_mana_addition_and_residual(state, pending, cost)?;
     if let Some(residual) = split.residual.as_ref() {
         if !residual.is_payable(state, player, pending.object_id) {
@@ -240,12 +241,26 @@ pub(crate) fn additional_cost_declaration_is_offerable(
     }
     let mut pending = pending.clone();
     pending.declared_mana_additions.extend(split.declared);
-    let total = super::casting::recompute_pending_mana_total(
+    let mut total = super::casting::recompute_pending_mana_total(
         state,
         player,
         &pending,
         pending.ability.chosen_x,
     );
+    // CR 601.2f: An optional exile-this-way cost can make the announced X
+    // payable. The declaration preview runs before the cards are selected, so
+    // account for the greatest legal generic reduction here; otherwise the
+    // prompt is incorrectly skipped and the cast fails at mana payment.
+    if exile_this_way_cost {
+        total = total.reduced_by_generic(exile_any_number_cost_reduction_capacity(
+            state,
+            player,
+            pending.object_id,
+        ));
+        if !cost_has_x(&total) {
+            super::casting::apply_cost_floor(state, player, pending.object_id, &mut total);
+        }
+    }
     if total.is_without_paying_mana() {
         return Ok(true);
     }
@@ -20868,6 +20883,43 @@ its replicate cost was paid.)\nDraw a card.";
         pending.ability.set_chosen_x_recursive(2);
         pending.cost.concretize_x(2);
         state.pending_cast = Some(Box::new(pending.clone()));
+        let optional_cost = match &additional_cost {
+            AdditionalCost::Optional { cost, .. } => cost.clone(),
+            other => panic!("expected optional March cost, got {other:?}"),
+        };
+        assert!(
+            additional_cost_declaration_is_offerable(
+                &state,
+                caster,
+                &pending,
+                optional_cost.clone()
+            )
+            .expect("March offerability preview succeeds"),
+            "the exile discount must make X=2 offerable with only {{W}} available"
+        );
+        let mut no_white_cards = state.clone();
+        no_white_cards
+            .objects
+            .get_mut(&white)
+            .unwrap()
+            .color
+            .clear();
+        no_white_cards
+            .objects
+            .get_mut(&second_white)
+            .unwrap()
+            .color
+            .clear();
+        assert!(
+            !additional_cost_declaration_is_offerable(
+                &no_white_cards,
+                caster,
+                &pending,
+                optional_cost,
+            )
+            .expect("March empty-hand offerability preview succeeds"),
+            "X=2 remains unpayable when no white card can supply the discount"
+        );
         let mut events = Vec::new();
         crate::game::stack::push_to_stack(
             &mut state,
@@ -20884,6 +20936,18 @@ its replicate cost was paid.)\nDraw a card.";
             },
             &mut events,
         );
+        assert!(matches!(
+            finish_pending_cast_cost_or_pay(
+                &mut state,
+                caster,
+                pending.clone(),
+                pending.ability.clone(),
+                pending.cost.clone(),
+                &mut events,
+            )
+            .expect("March post-target cost flow succeeds"),
+            WaitingFor::OptionalCostChoice { .. }
+        ));
         let waiting = handle_decide_additional_cost(
             &mut state,
             caster,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -9887,6 +9887,11 @@ pub(super) fn max_x_value_excluding(
 
     let tap_payment_mode =
         object_id.and_then(|oid| super::casting::spell_tap_payment_mode(state, player, oid));
+    // CR 106.6 + CR 601.2f: The X cap is a spell-payment preview. Restricted
+    // mana (for example, Sunken Citadel's two mana usable only for land
+    // abilities) must be evaluated against the spell being announced.
+    let spell_meta = object_id.and_then(|oid| super::casting::build_spell_meta(state, player, oid));
+    let spell_ctx = spell_meta.as_ref().map(PaymentContext::Spell);
 
     // CR 702.126a / 702.51a: tap-payment keywords (Improvise/Convoke/Waterbend)
     // let the caster pay generic mana by tapping permanents. The eligibility
@@ -9925,7 +9930,7 @@ pub(super) fn max_x_value_excluding(
         .iter()
         .filter(|id| !excluded_sources.contains(id))
         .map(|&id| {
-            let mana = mana_sources::feasible_mana_capacity(state, id, player, None);
+            let mana = mana_sources::feasible_mana_capacity(state, id, player, spell_ctx.as_ref());
             let tap = pred
                 .filter(|p| state.objects.get(&id).is_some_and(|o| p(o, player)))
                 .map_or(0, |_| 1);

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -800,7 +800,8 @@ fn next_offerable_kicker_option(
     EngineError,
 > {
     loop {
-        let Some((variant, cost, repeatability)) = next_kicker_option(state, player, pending) else {
+        let Some((variant, cost, repeatability)) = next_kicker_option(state, player, pending)
+        else {
             return Ok(None);
         };
         // CR 601.2f + CR 702.33a: a kicker can only be chosen when the

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -787,6 +787,46 @@ fn next_kicker_option(
     None
 }
 
+fn next_offerable_kicker_option(
+    state: &mut GameState,
+    player: PlayerId,
+    pending: &mut PendingCast,
+) -> Result<
+    Option<(
+        KickerVariant,
+        AbilityCost,
+        crate::types::ability::AdditionalCostRepeatability,
+    )>,
+    EngineError,
+> {
+    loop {
+        let Some((variant, cost, repeatability)) = next_kicker_option(state, player, pending) else {
+            return Ok(None);
+        };
+        // CR 601.2f + CR 702.33a: a kicker can only be chosen when the
+        // resulting total cost is payable. Preview the kicked state so reducers
+        // such as Vine Gecko participate, and skip an unavailable and/or
+        // kicker so a later, payable kicker remains selectable.
+        let mut preview = pending.clone();
+        preview.ability.context.additional_cost_paid = true;
+        preview.ability.context.kickers_paid.push(variant);
+        let prior_pending = state.pending_cast.replace(Box::new(preview));
+        let offerable =
+            additional_cost_declaration_is_offerable(state, player, pending, cost.clone());
+        state.pending_cast = prior_pending;
+        if offerable? {
+            return Ok(Some((variant, cost, repeatability)));
+        }
+        if repeatability.is_repeatable() {
+            pending.additional_cost_flow = None;
+            return Ok(None);
+        }
+        if !pending.declined_kickers.contains(&variant) {
+            pending.declined_kickers.push(variant);
+        }
+    }
+}
+
 fn handle_decide_repeatable_additional_cost(
     state: &mut GameState,
     player: PlayerId,
@@ -969,7 +1009,7 @@ fn finish_pending_cost_or_cast(
     ) {
         if pending.deferred_target_selection {
             if let Some((_, current_cost, repeatability)) =
-                next_kicker_option(state, player, &pending)
+                next_offerable_kicker_option(state, player, &mut pending)?
             {
                 // CR 702.33c/d: present the live Kicker cost (not a laundered
                 // Optional) so the frontend can render a kicker-aware modal and
@@ -992,7 +1032,8 @@ fn finish_pending_cost_or_cast(
                 return pay_additional_cost(state, player, cost, pending, events);
             }
         }
-        if let Some((_, current_cost, repeatability)) = next_kicker_option(state, player, &pending)
+        if let Some((_, current_cost, repeatability)) =
+            next_offerable_kicker_option(state, player, &mut pending)?
         {
             // CR 702.33c/d: present the live Kicker cost (not a laundered Optional)
             // so the frontend renders the kicker re-prompt with the running kick count.
@@ -18539,21 +18580,12 @@ it for each time it was kicked.\n{T}: Add {C} for each charge counter on this ar
             .act(GameAction::DecideOptionalCost { pay: true })
             .expect("second kick must be accepted");
 
-        // Re-prompt after two kicks.
-        match runner.state().waiting_for.clone() {
-            WaitingFor::OptionalCostChoice {
-                cost, times_kicked, ..
-            } => {
-                assert!(matches!(cost, AdditionalCost::Kicker { .. }));
-                assert_eq!(times_kicked, 2, "times_kicked must be 2 after two kicks");
-            }
-            other => panic!("expected OptionalCostChoice re-prompt, got {other:?}"),
-        }
-
-        // Decline ("Done") — finish casting; spell resolves.
-        runner
-            .act(GameAction::DecideOptionalCost { pay: false })
-            .expect("declining further kicks must finish the cast");
+        // CR 601.2f: all four mana are committed, so a third kick is not
+        // offerable. The cast must finish without an impossible re-prompt.
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
         runner.advance_until_stack_empty();
 
         assert_eq!(
@@ -18800,7 +18832,7 @@ Flashback {5}{U}{U}";
     fn declined_kicker_completes_cast_with_zero_counters() {
         use crate::types::GameAction;
         let (mut runner, spell_id, card_id) = everflowing_chalice_scenario();
-        // {0} base cost — no extra mana needed.
+        fund_colorless(&mut runner, 2); // Make the first kicker legally offerable.
 
         runner
             .act(GameAction::CastSpell {
@@ -19321,6 +19353,7 @@ its replicate cost was paid.)\nDraw a card.";
     fn cancel_cast_at_first_kicker_prompt_aborts_the_cast() {
         use crate::types::GameAction;
         let (mut runner, spell_id, card_id) = everflowing_chalice_scenario();
+        fund_colorless(&mut runner, 2); // Make the first kicker legally offerable.
 
         runner
             .act(GameAction::CastSpell {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -7292,6 +7292,8 @@ fn condition_matches_with_additional_cost_paid(
     }
 }
 
+/// CR 601.2f: Determine the greatest generic cost reduction available from
+/// eligible cards that may be exiled while paying an optional additional cost.
 fn exile_any_number_cost_reduction_capacity(
     state: &GameState,
     player: PlayerId,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -5305,6 +5305,200 @@ fn x_phyrexian_composite_mana_tap_activation_keeps_source_untapped_until_choice_
     assert_eq!(state.stack.len(), 1);
 }
 
+/// CR 107.4f + CR 602.2: a `{W/P}, {T}` activation such as Skrelv's must
+/// preserve both payment routes when an untapped white source is available.
+/// Paying 2 life must not eagerly tap that source, while choosing mana must
+/// tap and spend it. Unrelated floating colorless mana remains in the pool.
+#[test]
+fn phyrexian_tap_activation_preserves_life_and_mana_routes_without_eager_tap() {
+    use super::super::engine::apply_as_current;
+    use crate::types::game_state::{ShardChoice, ShardOptions};
+
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(59),
+        PlayerId(0),
+        "Skrelv Stand-In".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let object = state.objects.get_mut(&source).unwrap();
+        object.card_types.core_types.push(CoreType::Creature);
+        object.entered_battlefield_turn = Some(state.turn_number.saturating_sub(1));
+        object.summoning_sick = false;
+        Arc::make_mut(&mut object.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::PhyrexianWhite],
+                            generic: 0,
+                        },
+                    },
+                    AbilityCost::Tap,
+                ],
+            }),
+        );
+    }
+    let white_source = add_brushland_like_land(&mut state, CardId(60), "White Helper", false);
+    add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+    let life_before = state.players[0].life;
+
+    apply_as_current(
+        &mut state,
+        GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        },
+    )
+    .expect("the Phyrexian activation should be legal");
+    match &state.waiting_for {
+        WaitingFor::PhyrexianPayment { shards, .. } => {
+            assert_eq!(shards.len(), 1);
+            assert!(matches!(shards[0].options, ShardOptions::ManaOrLife));
+        }
+        other => panic!("expected PhyrexianPayment, got {other:?}"),
+    }
+    assert!(
+        !state.objects[&white_source].tapped,
+        "opening the Phyrexian choice must not eagerly tap an available white source"
+    );
+    assert_eq!(state.players[0].mana_pool.total(), 1);
+
+    let legal = crate::ai_support::legal_actions_for_viewer(&state, PlayerId(0)).0;
+    assert!(legal.iter().any(|candidate| {
+        *candidate
+            == GameAction::SubmitPhyrexianChoices {
+                choices: vec![ShardChoice::PayLife],
+            }
+    }));
+    assert!(legal.iter().any(|candidate| {
+        *candidate
+            == GameAction::SubmitPhyrexianChoices {
+                choices: vec![ShardChoice::PayMana],
+            }
+    }));
+
+    let mut mana_route = state.clone();
+    apply_as_current(
+        &mut mana_route,
+        GameAction::SubmitPhyrexianChoices {
+            choices: vec![ShardChoice::PayMana],
+        },
+    )
+    .expect("the mana route should tap and spend the white source");
+    assert!(mana_route.objects[&white_source].tapped);
+    assert!(mana_route.objects[&source].tapped);
+    assert_eq!(mana_route.players[0].life, life_before);
+    assert_eq!(mana_route.players[0].mana_pool.total(), 1);
+
+    apply_as_current(
+        &mut state,
+        GameAction::SubmitPhyrexianChoices {
+            choices: vec![ShardChoice::PayLife],
+        },
+    )
+    .expect("the life route should preserve the white source");
+    assert!(
+        !state.objects[&white_source].tapped,
+        "paying life must not tap the unused white source"
+    );
+    assert!(state.objects[&source].tapped);
+    assert_eq!(state.players[0].life, life_before - 2);
+    assert_eq!(state.players[0].mana_pool.total(), 1);
+}
+
+/// CR 107.4f + CR 602.2: a life-only Phyrexian activation must not advertise
+/// an unavailable mana route, and a directly submitted `PayMana` action must
+/// be rejected before it taps the source, spends mana, or changes life.
+#[test]
+fn phyrexian_tap_activation_rejects_unavailable_mana_route_without_mutation() {
+    use super::super::engine::apply_as_current;
+    use crate::types::game_state::{ShardChoice, ShardOptions};
+
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(61),
+        PlayerId(0),
+        "Skrelv Life-Only Stand-In".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let object = state.objects.get_mut(&source).unwrap();
+        object.card_types.core_types.push(CoreType::Creature);
+        object.entered_battlefield_turn = Some(state.turn_number.saturating_sub(1));
+        object.summoning_sick = false;
+        Arc::make_mut(&mut object.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::PhyrexianWhite],
+                            generic: 0,
+                        },
+                    },
+                    AbilityCost::Tap,
+                ],
+            }),
+        );
+    }
+    add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+    let life_before = state.players[0].life;
+
+    apply_as_current(
+        &mut state,
+        GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        },
+    )
+    .expect("the life-only Phyrexian activation should be legal");
+    match &state.waiting_for {
+        WaitingFor::PhyrexianPayment { shards, .. } => {
+            assert_eq!(shards.len(), 1);
+            assert!(matches!(shards[0].options, ShardOptions::LifeOnly));
+        }
+        other => panic!("expected life-only PhyrexianPayment, got {other:?}"),
+    }
+    let pay_mana = GameAction::SubmitPhyrexianChoices {
+        choices: vec![ShardChoice::PayMana],
+    };
+    let legal = crate::ai_support::legal_actions_for_viewer(&state, PlayerId(0)).0;
+    assert!(
+        !legal.contains(&pay_mana),
+        "an unavailable white-mana route must not reach the policy action space"
+    );
+
+    assert!(
+        apply_as_current(&mut state, pay_mana).is_err(),
+        "directly submitted unavailable PayMana must be rejected"
+    );
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::PhyrexianPayment { .. }
+    ));
+    assert!(!state.objects[&source].tapped);
+    assert_eq!(state.players[0].life, life_before);
+    assert_eq!(state.players[0].mana_pool.total(), 1);
+    assert!(state.stack.is_empty());
+}
+
 #[test]
 fn spell_cast_from_hand_moves_to_stack() {
     let mut state = setup_game_at_main_phase();

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -9096,6 +9096,97 @@ fn tolarian_terror_self_cost_reduction_applies_from_hand() {
     }
 }
 
+/// CR 601.2f + CR 715.2: Hearth Elemental's discount counts instant cards,
+/// sorcery cards, and permanent cards that have an Adventure exactly once.
+#[test]
+fn hearth_elemental_self_cost_reduction_counts_adventures() {
+    let mut state = setup_game_at_main_phase();
+    let hearth = create_object(
+        &mut state,
+        CardId(991),
+        PlayerId(0),
+        "Hearth Elemental".to_string(),
+        Zone::Hand,
+    );
+    {
+        let obj = state.objects.get_mut(&hearth).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 6,
+        };
+        obj.static_definitions.push(
+            parse_static_line(
+                "This spell costs {X} less to cast, where X is the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
+            )
+            .expect("Hearth Elemental cost reduction should parse"),
+        );
+    }
+
+    for (i, ty) in [CoreType::Instant, CoreType::Sorcery, CoreType::Creature]
+        .into_iter()
+        .enumerate()
+    {
+        let id = create_object(
+            &mut state,
+            CardId(920 + i as u64),
+            PlayerId(0),
+            format!("GY{i}"),
+            Zone::Graveyard,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(ty);
+        if i == 2 {
+            obj.back_face = Some(crate::game::game_object::BackFaceData {
+                name: "Adventure".to_string(),
+                power: None,
+                toughness: None,
+                loyalty: None,
+                defense: None,
+                card_types: Default::default(),
+                mana_cost: ManaCost::generic(1),
+                keywords: vec![],
+                abilities: vec![],
+                trigger_definitions: Default::default(),
+                replacement_definitions: Default::default(),
+                static_definitions: Default::default(),
+                color: vec![],
+                printed_ref: None,
+                modal: None,
+                additional_cost: None,
+                strive_cost: None,
+                casting_restrictions: vec![],
+                casting_options: vec![],
+                layout_kind: Some(crate::types::card::LayoutKind::Adventure),
+            });
+        }
+    }
+
+    let ordinary = create_object(
+        &mut state,
+        CardId(924),
+        PlayerId(0),
+        "Ordinary creature".to_string(),
+        Zone::Graveyard,
+    );
+    state
+        .objects
+        .get_mut(&ordinary)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+
+    let mut mana_cost = state.objects.get(&hearth).unwrap().mana_cost.clone();
+    super::super::casting::apply_self_spell_cost_modifiers(
+        &state,
+        PlayerId(0),
+        hearth,
+        &mut mana_cost,
+    );
+    assert!(matches!(mana_cost, ManaCost::Cost { generic: 3, .. }));
+}
+
 /// Apply an Alchemy "perpetually gains \"This spell costs {N} less/more to
 /// cast\"" grant to `spell_id` through the REAL resolution path
 /// (`parse_effect_chain` → `build_resolved_from_def` → `resolve_ability_chain`),

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -12475,6 +12475,91 @@ fn hand_spell_alternative_pay_life_cost_replaces_mana_cost() {
 }
 
 #[test]
+fn choice_additional_cost_filters_unpayable_casts() {
+    let mut state = setup_game_at_main_phase();
+    state.players[0].life = 2;
+
+    let spell_id = create_instant_in_hand(&mut state, PlayerId(0));
+    {
+        let spell = state.objects.get_mut(&spell_id).unwrap();
+        spell.name = "Bitter Triumph Stand-In".to_string();
+        spell.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 1,
+        };
+        spell.additional_cost = Some(AdditionalCost::Choice(
+            AbilityCost::Discard {
+                count: QuantityExpr::Fixed { value: 1 },
+                filter: None,
+                selection: crate::types::ability::CardSelectionMode::Chosen,
+                self_scope: crate::types::ability::DiscardSelfScope::FromHand,
+            },
+            AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 3 },
+            },
+        ));
+        let abilities = Arc::make_mut(&mut spell.abilities);
+        abilities.clear();
+        abilities.push(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Destroy {
+                target: TargetFilter::Typed(TypedFilter::creature()),
+                cant_regenerate: false,
+            },
+        ));
+    }
+    add_mana(&mut state, PlayerId(0), ManaType::Black, 1);
+    add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+    let target = create_object(
+        &mut state,
+        CardId(11),
+        PlayerId(1),
+        "Target Creature".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&target)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+
+    assert!(
+        !can_cast_object_now(&state, PlayerId(0), spell_id),
+        "a spell with no payable additional-cost branch must not be castable"
+    );
+    assert!(
+        !crate::ai_support::candidate_actions(&state)
+            .iter()
+            .any(|candidate| matches!(
+                candidate.action,
+                GameAction::CastSpell { object_id, .. } if object_id == spell_id
+            )),
+        "an unpayable discard-or-life spell must not be offered to search"
+    );
+
+    state.players[0].life = 3;
+    assert!(
+        can_cast_object_now(&state, PlayerId(0), spell_id),
+        "the life branch should make the same spell castable"
+    );
+
+    state.players[0].life = 2;
+    create_object(
+        &mut state,
+        CardId(12),
+        PlayerId(0),
+        "Discardable Card".to_string(),
+        Zone::Hand,
+    );
+    assert!(
+        can_cast_object_now(&state, PlayerId(0), spell_id),
+        "the discard branch should make the same spell castable"
+    );
+}
+
+#[test]
 fn cast_without_mana_cost_option_checks_commander_control() {
     let mut state = setup_game_at_main_phase();
 

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -583,6 +583,91 @@ fn x_spell_cap_excludes_mana_restricted_to_activated_abilities() {
 }
 
 #[test]
+fn worldsouls_rage_offered_x_is_payable_with_an_unchosen_citadel_copy() {
+    let mut state = setup_game_at_main_phase();
+    create_tap_mana_source(
+        &mut state,
+        "Unchosen Sunken Citadel Copy",
+        ManaProduction::ChosenColor {
+            count: QuantityExpr::Fixed { value: 1 },
+            contribution: ManaContribution::Base,
+            fixed_alternative: None,
+        },
+    );
+    for (name, color, count) in [
+        ("Forest Stand-In", ManaColor::Green, 2),
+        ("Island Stand-In", ManaColor::Blue, 4),
+        ("Mountain Stand-In", ManaColor::Red, 2),
+    ] {
+        for _ in 0..count {
+            create_tap_mana_source(
+                &mut state,
+                name,
+                ManaProduction::Fixed {
+                    colors: vec![color],
+                    contribution: ManaContribution::Base,
+                },
+            );
+        }
+    }
+
+    let spell = create_object(
+        &mut state,
+        CardId(9_019),
+        PlayerId(0),
+        "Worldsoul's Rage Stand-In".to_string(),
+        Zone::Hand,
+    );
+    {
+        let obj = state.objects.get_mut(&spell).unwrap();
+        obj.card_types.core_types.push(CoreType::Sorcery);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::Red, ManaCostShard::Green],
+            generic: 0,
+        };
+        Arc::make_mut(&mut obj.abilities).push(parse_effect_chain(
+            "~ deals X damage to any target. Put up to X land cards from your hand and/or graveyard onto the battlefield tapped.",
+            AbilityKind::Spell,
+        ));
+    }
+
+    let cast = apply_as_current(
+        &mut state,
+        GameAction::CastSpell {
+            object_id: spell,
+            card_id: CardId(9_019),
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        },
+    )
+    .expect("Worldsoul's Rage should begin casting");
+    let max = match cast.waiting_for {
+        WaitingFor::ChooseXValue { max, .. } => max,
+        other => panic!("expected X choice before target selection, got {other:?}"),
+    };
+    assert_eq!(max, 6, "the unchosen Citadel copy produces no mana, so eight basics must cap {{X}}{{R}}{{G}} at X=6");
+
+    let after_x = apply_as_current(&mut state, GameAction::ChooseX { value: max })
+        .expect("the offered maximum X must remain castable");
+    assert!(matches!(
+        after_x.waiting_for,
+        WaitingFor::TargetSelection { .. }
+    ));
+    let after_target = apply_as_current(
+        &mut state,
+        GameAction::ChooseTarget {
+            target: Some(TargetRef::Player(PlayerId(1))),
+        },
+    )
+    .expect("choosing a legal damage target must pay the mana cost");
+    assert!(matches!(
+        after_target.waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert_eq!(state.stack.len(), 1);
+}
+
+#[test]
 fn ability_condition_currently_met_gates_on_board_relative_quantity() {
     let mut state = GameState::new_two_player(42);
     // Hideaway-shaped source: a {T}-cost ability gated by "creatures you

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -1617,13 +1617,15 @@ fn pending_next_spell_cant_be_countered_stamped_on_stack() {
             source_id: None,
         });
     super::apply_pending_next_spell_stack_grants(&mut state, PlayerId(0), spell_id);
-    assert!(state
-        .objects
-        .get(&spell_id)
-        .unwrap()
-        .static_definitions
-        .iter_all()
-        .any(|sd| sd.mode == StaticMode::CantBeCountered));
+    assert!(
+        state
+            .objects
+            .get(&spell_id)
+            .unwrap()
+            .static_definitions
+            .iter_all()
+            .any(|sd| sd.mode == StaticMode::CantBeCountered)
+    );
     super::consume_pending_next_spell_modifiers(&mut state, PlayerId(0), spell_id);
     assert!(state.pending_next_spell_modifiers.is_empty());
 }
@@ -2778,10 +2780,11 @@ fn spell_meta_includes_supertypes_for_restricted_mana() {
 
     let meta = build_spell_meta(&state, PlayerId(0), commander_id).unwrap();
 
-    assert!(meta
-        .types
-        .iter()
-        .any(|type_name| type_name.eq_ignore_ascii_case("Legendary")));
+    assert!(
+        meta.types
+            .iter()
+            .any(|type_name| type_name.eq_ignore_ascii_case("Legendary"))
+    );
     assert!(ManaRestriction::OnlyForSpellType("Legendary".to_string()).allows_spell(&meta));
 }
 
@@ -5964,7 +5967,11 @@ fn jabari_influence_casts_scopes_defender_target_and_lands_chained_counter() {
     .expect("Jabari's Influence must be castable in the discriminator setup");
     match &state2.waiting_for {
         WaitingFor::TargetSelection { target_slots, .. } => {
-            assert_eq!(target_slots.len(), 1, "GainControl has a single target slot");
+            assert_eq!(
+                target_slots.len(),
+                1,
+                "GainControl has a single target slot"
+            );
             assert!(
                 target_slots[0]
                     .legal_targets
@@ -6700,12 +6707,12 @@ fn kessig_wolf_run_x_pump_grants_dynamic_power_and_trample() {
         obj.card_types.core_types.push(CoreType::Land);
         obj.base_card_types = obj.card_types.clone();
         let parsed = parse_oracle_text(
-                "{T}: Add {C}.\n{X}{R}{G}, {T}: Target creature gets +X/+0 and gains trample until end of turn.",
-                "Kessig Wolf Run",
-                &[],
-                &[String::from("Land")],
-                &[],
-            );
+            "{T}: Add {C}.\n{X}{R}{G}, {T}: Target creature gets +X/+0 and gains trample until end of turn.",
+            "Kessig Wolf Run",
+            &[],
+            &[String::from("Land")],
+            &[],
+        );
         Arc::make_mut(&mut obj.abilities).extend(parsed.abilities);
     }
 
@@ -7386,12 +7393,12 @@ fn grim_lavamancer_targets_before_graveyard_exile_cost() {
         obj.entered_battlefield_turn = Some(1);
         obj.summoning_sick = false;
         let parsed = crate::parser::oracle::parse_oracle_text(
-                "{R}, {T}, Exile two cards from your graveyard: This creature deals 2 damage to any target.",
-                "Grim Lavamancer",
-                &[],
-                &[String::from("Creature")],
-                &[String::from("Human"), String::from("Wizard")],
-            );
+            "{R}, {T}, Exile two cards from your graveyard: This creature deals 2 damage to any target.",
+            "Grim Lavamancer",
+            &[],
+            &[String::from("Creature")],
+            &[String::from("Human"), String::from("Wizard")],
+        );
         Arc::make_mut(&mut obj.abilities).extend(parsed.abilities);
     }
     add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
@@ -9231,6 +9238,43 @@ fn play_from_exile_cast_cost_raise_increases_generic() {
     );
 }
 
+#[test]
+fn gobakhan_play_from_exile_cost_raise_adds_two_generic() {
+    let mut state = setup_game_at_main_phase();
+    let obj_id = create_black_sorcery_with_keywords(
+        &mut state,
+        16014,
+        "Gobakhan Exiled Spell",
+        1,
+        Vec::new(),
+    );
+    let obj = state.objects.get_mut(&obj_id).unwrap();
+    obj.zone = Zone::Exile;
+    obj.casting_permissions.push(play_from_exile_raise(
+        PlayerId(0),
+        Some(ManaCost::Cost {
+            shards: vec![],
+            generic: 2,
+        }),
+    ));
+
+    let mut mana_cost = state.objects.get(&obj_id).unwrap().mana_cost.clone();
+    super::super::casting::apply_non_floor_cost_modifiers(
+        &state,
+        PlayerId(0),
+        obj_id,
+        &mut mana_cost,
+        None,
+    );
+    assert_eq!(
+        mana_cost,
+        ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 3,
+        }
+    );
+}
+
 /// CR 601.2f + CR 611.2a: The raise is scoped to the grantee — a permission
 /// granted to a different player must not tax P0's cast.
 #[test]
@@ -9391,13 +9435,13 @@ fn drag_to_the_underworld_devotion_cost_reduction_applies_from_hand() {
 
     let mut state = setup_game_at_main_phase();
     let parsed = crate::parser::oracle::parse_oracle_text(
-            "This spell costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\n\
+        "This spell costs {X} less to cast, where X is your devotion to black. (Each {B} in the mana costs of permanents you control counts toward your devotion to black.)\n\
              Destroy target creature.",
-            "Drag to the Underworld",
-            &[],
-            &[String::from("Instant")],
-            &[],
-        );
+        "Drag to the Underworld",
+        &[],
+        &[String::from("Instant")],
+        &[],
+    );
     assert_eq!(
         parsed.statics.len(),
         1,
@@ -10002,11 +10046,13 @@ fn transient_activation_cost_reduction_hits_only_controlled_artifact_tokens() {
         properties: vec![FilterProp::Token],
     });
     let effect = Effect::GenericEffect {
-        static_abilities: vec![StaticDefinition::new(reduce_mode.clone())
-            .affected(source_filter)
-            .modifications(vec![ContinuousModification::AddStaticMode {
-                mode: reduce_mode,
-            }])],
+        static_abilities: vec![
+            StaticDefinition::new(reduce_mode.clone())
+                .affected(source_filter)
+                .modifications(vec![ContinuousModification::AddStaticMode {
+                    mode: reduce_mode,
+                }]),
+        ],
         duration: Some(crate::types::ability::Duration::UntilEndOfTurn),
         target: None,
     };
@@ -10819,10 +10865,10 @@ fn x_cost_accounts_for_pending_cost_reduction_in_max() {
 #[test]
 fn x_cost_max_accounts_for_granted_affinity_exceeding_fixed_generic() {
     use super::super::engine::apply_as_current;
+    use crate::types::StaticDefinition;
     use crate::types::ability::{ControllerRef, QuantityRef, TypeFilter, TypedFilter};
     use crate::types::keywords::Keyword;
     use crate::types::statics::StaticMode;
-    use crate::types::StaticDefinition;
 
     // Build a {X}{B}{B} sorcery + a battlefield static granting
     // Affinity(Creature) to the controller's sorceries, with N creatures.
@@ -19646,12 +19692,14 @@ fn cancel_cast_uses_stamped_convoked_creatures_when_pending_snapshot_is_empty() 
     handle_cancel_cast(&mut state, &pending, &mut Vec::new());
 
     assert!(!state.objects.get(&helper).unwrap().tapped);
-    assert!(state
-        .objects
-        .get(&spell)
-        .unwrap()
-        .convoked_creatures
-        .is_empty());
+    assert!(
+        state
+            .objects
+            .get(&spell)
+            .unwrap()
+            .convoked_creatures
+            .is_empty()
+    );
     assert!(state.players[0].mana_pool.mana.is_empty());
 }
 
@@ -19804,15 +19852,17 @@ fn convoke_payment_offers_and_accepts_colored_creature_payment() {
     ));
 
     let (_, _, grouped) = crate::ai_support::legal_actions_full(&state);
-    assert!(grouped
-        .get(&creature)
-        .is_some_and(|actions| actions.iter().any(|action| matches!(
-            action,
-            GameAction::TapForConvoke {
-                object_id,
-                mana_type: ManaType::Green
-            } if *object_id == creature
-        ))));
+    assert!(
+        grouped
+            .get(&creature)
+            .is_some_and(|actions| actions.iter().any(|action| matches!(
+                action,
+                GameAction::TapForConvoke {
+                    object_id,
+                    mana_type: ManaType::Green
+                } if *object_id == creature
+            )))
+    );
     assert!(
         grouped.get(&artifact).is_none_or(|actions| actions
             .iter()
@@ -20153,12 +20203,16 @@ fn emit_targeting_events_own_object_no_crime() {
         PlayerId(0),
         &mut events,
     );
-    assert!(events
-        .iter()
-        .any(|e| matches!(e, GameEvent::BecomesTarget { .. })));
-    assert!(!events
-        .iter()
-        .any(|e| matches!(e, GameEvent::CrimeCommitted { .. })));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, GameEvent::BecomesTarget { .. }))
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, GameEvent::CrimeCommitted { .. }))
+    );
 }
 
 #[test]
@@ -20966,10 +21020,10 @@ fn first_kicked_spell_reducer_recomputes_after_kicker_declared() {
         panic!("expected ModeChoice, got {:?}", state.waiting_for);
     };
     assert_eq!(
-            pending_cast.cost,
-            ManaCost::generic(0),
-            "CR 601.2f + CR 702.33d: once kicker is declared, the first kicked spell reducer applies before mana payment"
-        );
+        pending_cast.cost,
+        ManaCost::generic(0),
+        "CR 601.2f + CR 702.33d: once kicker is declared, the first kicked spell reducer applies before mana payment"
+    );
 }
 
 #[test]
@@ -21390,15 +21444,21 @@ fn kicker_instead_target_paid_selects_replacement_target_only() {
     };
     assert!(pending_cast.ability.context.additional_cost_paid);
     assert_eq!(target_slots.len(), 1);
-    assert!(!target_slots[0]
-        .legal_targets
-        .contains(&TargetRef::Object(artifact_id)));
-    assert!(target_slots[0]
-        .legal_targets
-        .contains(&TargetRef::Object(creature_id)));
-    assert!(target_slots[0]
-        .legal_targets
-        .contains(&TargetRef::Object(second_creature_id)));
+    assert!(
+        !target_slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(artifact_id))
+    );
+    assert!(
+        target_slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(creature_id))
+    );
+    assert!(
+        target_slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(second_creature_id))
+    );
 }
 
 #[test]
@@ -21442,15 +21502,21 @@ fn kicked_bloodchiefs_thirst_like_spell_targets_three_mv_creature() {
     };
     assert!(pending_cast.ability.context.additional_cost_paid);
     assert_eq!(target_slots.len(), 1);
-    assert!(target_slots[0]
-        .legal_targets
-        .contains(&TargetRef::Object(two_mv_creature)));
-    assert!(target_slots[0]
-        .legal_targets
-        .contains(&TargetRef::Object(three_mv_creature)));
-    assert!(target_slots[0]
-        .legal_targets
-        .contains(&TargetRef::Object(four_mv_creature)));
+    assert!(
+        target_slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(two_mv_creature))
+    );
+    assert!(
+        target_slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(three_mv_creature))
+    );
+    assert!(
+        target_slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(four_mv_creature))
+    );
 }
 
 #[test]
@@ -21987,12 +22053,16 @@ fn modal_x_target_legality_chooses_x_before_targets() {
             ..
         } => {
             assert_eq!(target_slots.len(), 1);
-            assert!(target_slots[0]
-                .legal_targets
-                .contains(&TargetRef::Object(creature)));
-            assert!(target_slots[0]
-                .legal_targets
-                .contains(&TargetRef::Object(other_creature)));
+            assert!(
+                target_slots[0]
+                    .legal_targets
+                    .contains(&TargetRef::Object(creature))
+            );
+            assert!(
+                target_slots[0]
+                    .legal_targets
+                    .contains(&TargetRef::Object(other_creature))
+            );
             // CR 700.2 / CR 601.2c: the deferred-target path must surface the
             // per-mode label for the targeting UI (regression for issue #1543:
             // Kozilek's Command's mode-2 banner went blank after X was chosen
@@ -22208,16 +22278,16 @@ fn modal_x_target_selection_carries_per_mode_labels() {
 /// fresh hand-zone instant with the printed `{X}{C}{C}` cost.
 fn build_kozileks_command(state: &mut GameState, card_id: CardId) -> ObjectId {
     let parsed = crate::parser::oracle::parse_oracle_text(
-            "Choose two —\n\
+        "Choose two —\n\
              • Target player creates X 0/1 colorless Eldrazi Spawn creature tokens with \"Sacrifice this token: Add {C}.\"\n\
              • Target player scries X, then draws a card.\n\
              • Exile target creature with mana value X or less.\n\
              • Exile up to X target cards from graveyards.",
-            "Kozilek's Command",
-            &[],
-            &["Kindred".to_string(), "Instant".to_string()],
-            &["Eldrazi".to_string()],
-        );
+        "Kozilek's Command",
+        &[],
+        &["Kindred".to_string(), "Instant".to_string()],
+        &["Eldrazi".to_string()],
+    );
     assert_eq!(
         parsed.abilities.len(),
         4,
@@ -22313,10 +22383,10 @@ fn kozileks_command_modes_tokens_and_exile_creature_end_to_end() {
         "mode 2 must exile the targeted MV<=2 creature"
     );
     assert_eq!(
-            state.objects[&big].zone,
-            Zone::Battlefield,
-            "the untargeted MV-3 creature must remain on the battlefield (it was never declared as a target)"
-        );
+        state.objects[&big].zone,
+        Zone::Battlefield,
+        "the untargeted MV-3 creature must remain on the battlefield (it was never declared as a target)"
+    );
     // Mode 0: the targeted player (P0) receives exactly X = 2 Eldrazi Spawn
     // tokens, each a 0/1 with a Sacrifice: Add {C} ability.
     let spawns: Vec<ObjectId> = state
@@ -24345,12 +24415,12 @@ fn rowan_scion_of_war_reduces_black_red_spells_by_life_lost() {
 
     // Parse the real activated ability and pull out the GenericEffect clause.
     let parsed = crate::parser::parse_oracle_text(
-            "Menace\n{T}: Spells you cast this turn that are black and/or red cost {X} less to cast, where X is the amount of life you lost this turn. Activate only as a sorcery.",
-            "Rowan, Scion of War",
-            &["Menace".to_string()],
-            &["Legendary".to_string(), "Creature".to_string()],
-            &["Human".to_string()],
-        );
+        "Menace\n{T}: Spells you cast this turn that are black and/or red cost {X} less to cast, where X is the amount of life you lost this turn. Activate only as a sorcery.",
+        "Rowan, Scion of War",
+        &["Menace".to_string()],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Human".to_string()],
+    );
     let cost_ability = parsed
         .abilities
         .iter()
@@ -24447,12 +24517,12 @@ fn rowan_scion_of_war_zero_life_lost_at_resolution_snapshots_zero() {
     );
 
     let parsed = crate::parser::parse_oracle_text(
-            "Menace\n{T}: Spells you cast this turn that are black and/or red cost {X} less to cast, where X is the amount of life you lost this turn. Activate only as a sorcery.",
-            "Rowan, Scion of War",
-            &["Menace".to_string()],
-            &["Legendary".to_string(), "Creature".to_string()],
-            &["Human".to_string()],
-        );
+        "Menace\n{T}: Spells you cast this turn that are black and/or red cost {X} less to cast, where X is the amount of life you lost this turn. Activate only as a sorcery.",
+        "Rowan, Scion of War",
+        &["Menace".to_string()],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Human".to_string()],
+    );
     let cost_ability = parsed
         .abilities
         .iter()
@@ -24525,12 +24595,12 @@ fn will_scion_of_peace_reduces_white_blue_spells_by_life_gained() {
     );
 
     let parsed = crate::parser::parse_oracle_text(
-            "Vigilance\n{T}: Spells you cast this turn that are white and/or blue cost {X} less to cast, where X is the amount of life you gained this turn. Activate only as a sorcery.",
-            "Will, Scion of Peace",
-            &["Vigilance".to_string()],
-            &["Legendary".to_string(), "Creature".to_string()],
-            &["Human".to_string()],
-        );
+        "Vigilance\n{T}: Spells you cast this turn that are white and/or blue cost {X} less to cast, where X is the amount of life you gained this turn. Activate only as a sorcery.",
+        "Will, Scion of Peace",
+        &["Vigilance".to_string()],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Human".to_string()],
+    );
     let cost_ability = parsed
         .abilities
         .iter()
@@ -26016,9 +26086,9 @@ fn opponent_first_noncreature_tax_uses_caster_history() {
     );
 
     assert!(
-            can_cast_object_now(&state, PlayerId(1), spell),
-            "after that opponent has cast a noncreature spell this turn, the first-spell tax should no longer apply"
-        );
+        can_cast_object_now(&state, PlayerId(1), spell),
+        "after that opponent has cast a noncreature spell this turn, the first-spell tax should no longer apply"
+    );
 }
 
 #[test]
@@ -26295,9 +26365,11 @@ fn graveyard_spell_with_flashback_and_retrace_prompts_for_cast_variant() {
             player, options, ..
         } => {
             assert_eq!(player, PlayerId(0));
-            assert!(options
-                .iter()
-                .any(|option| option.variant == CastingVariant::Flashback));
+            assert!(
+                options
+                    .iter()
+                    .any(|option| option.variant == CastingVariant::Flashback)
+            );
             options
                 .iter()
                 .position(|option| option.variant == CastingVariant::Retrace)
@@ -26305,14 +26377,16 @@ fn graveyard_spell_with_flashback_and_retrace_prompts_for_cast_variant() {
         }
         other => panic!("expected CastingVariantChoice, got {other:?}"),
     };
-    assert!(crate::ai_support::legal_actions(&state)
-        .iter()
-        .any(|action| {
-            matches!(
-                action,
-                GameAction::ChooseCastingVariant { index } if *index == retrace_index
-            )
-        }));
+    assert!(
+        crate::ai_support::legal_actions(&state)
+            .iter()
+            .any(|action| {
+                matches!(
+                    action,
+                    GameAction::ChooseCastingVariant { index } if *index == retrace_index
+                )
+            })
+    );
 
     let result = crate::game::engine::apply_as_current(
         &mut state,
@@ -27358,12 +27432,12 @@ fn parsed_static_graveyard_escape_grant_makes_spell_castable() {
         Zone::Battlefield,
     );
     let parsed = crate::parser::oracle::parse_oracle_text(
-            "Each nonland card in your graveyard has escape.\nThe escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",
-            "Underworld Breach",
-            &[],
-            &[String::from("Enchantment")],
-            &[],
-        );
+        "Each nonland card in your graveyard has escape.\nThe escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",
+        "Underworld Breach",
+        &[],
+        &[String::from("Enchantment")],
+        &[],
+    );
     let source = state.objects.get_mut(&source_id).unwrap();
     source.card_types.core_types.push(CoreType::Enchantment);
     source.base_card_types = source.card_types.clone();
@@ -27599,12 +27673,12 @@ fn granted_escape_requires_exile_cost_payment() {
         Zone::Battlefield,
     );
     let parsed = crate::parser::oracle::parse_oracle_text(
-            "Each nonland card in your graveyard has escape.\nThe escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",
-            "Underworld Breach",
-            &[],
-            &[String::from("Enchantment")],
-            &[],
-        );
+        "Each nonland card in your graveyard has escape.\nThe escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",
+        "Underworld Breach",
+        &[],
+        &[String::from("Enchantment")],
+        &[],
+    );
     let source = state.objects.get_mut(&source_id).unwrap();
     source.card_types.core_types.push(CoreType::Enchantment);
     source.base_card_types = source.card_types.clone();
@@ -27665,12 +27739,12 @@ fn escape_grant_from_graveyard_source_does_not_apply_to_itself() {
         Zone::Graveyard,
     );
     let parsed = crate::parser::oracle::parse_oracle_text(
-            "Each nonland card in your graveyard has escape.\nThe escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",
-            "Underworld Breach",
-            &[],
-            &[String::from("Enchantment")],
-            &[],
-        );
+        "Each nonland card in your graveyard has escape.\nThe escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",
+        "Underworld Breach",
+        &[],
+        &[String::from("Enchantment")],
+        &[],
+    );
     let source = state.objects.get_mut(&source_id).unwrap();
     source.card_types.core_types.push(CoreType::Enchantment);
     source.base_card_types = source.card_types.clone();
@@ -27754,12 +27828,12 @@ fn escape_phyrexian_cost_deducts_life_after_exile() {
         Zone::Battlefield,
     );
     let parsed = crate::parser::oracle::parse_oracle_text(
-            "Each nonland card in your graveyard has escape.\nThe escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",
-            "Underworld Breach",
-            &[],
-            &[String::from("Enchantment")],
-            &[],
-        );
+        "Each nonland card in your graveyard has escape.\nThe escape cost is equal to the card's mana cost plus exile three other cards from your graveyard.",
+        "Underworld Breach",
+        &[],
+        &[String::from("Enchantment")],
+        &[],
+    );
     let source = state.objects.get_mut(&source_id).unwrap();
     source.card_types.core_types.push(CoreType::Enchantment);
     source.base_card_types = source.card_types.clone();
@@ -28360,9 +28434,9 @@ fn raise_cost_static_prevents_unaffordable_noncreature_cast() {
 
     // With Thalia's tax, Lightning Bolt costs {1}{R} but player has only 1 Mountain ({R}).
     assert!(
-            !can_cast_object_now(&state, PlayerId(0), bolt),
-            "Lightning Bolt should NOT be castable — Thalia tax makes it {{1}}{{R}} with only 1 Mountain"
-        );
+        !can_cast_object_now(&state, PlayerId(0), bolt),
+        "Lightning Bolt should NOT be castable — Thalia tax makes it {{1}}{{R}} with only 1 Mountain"
+    );
 
     // Must not appear in candidate or legal actions
     let candidates = candidate_actions(&state);
@@ -29331,9 +29405,9 @@ fn phyrexian_spell_prepass_honors_spell_mana_restrictions() {
         WaitingFor::PhyrexianPayment { shards, .. } => {
             assert_eq!(shards.len(), 1);
             assert!(
-                    matches!(shards[0].options, ShardOptions::LifeOnly),
-                    "spell-restricted mana must not create a false mana/life choice for an ineligible spell"
-                );
+                matches!(shards[0].options, ShardOptions::LifeOnly),
+                "spell-restricted mana must not create a false mana/life choice for an ineligible spell"
+            );
         }
         other => panic!("expected PhyrexianPayment (LifeOnly), got {other:?}"),
     }
@@ -29385,9 +29459,11 @@ fn phyrexian_multi_shard_all_life_deducts_per_shard() {
     match &result.waiting_for {
         WaitingFor::PhyrexianPayment { shards, .. } => {
             assert_eq!(shards.len(), 2);
-            assert!(shards
-                .iter()
-                .all(|s| matches!(s.options, ShardOptions::LifeOnly)));
+            assert!(
+                shards
+                    .iter()
+                    .all(|s| matches!(s.options, ShardOptions::LifeOnly))
+            );
         }
         other => panic!("expected PhyrexianPayment (two LifeOnly), got {other:?}"),
     }
@@ -29464,8 +29540,8 @@ fn phyrexian_mixed_one_mana_one_life() {
 fn phyrexian_cast_no_pause_when_all_shards_trivial() {
     let mut state = setup_game_at_main_phase();
     state.players[0].life = 1; // Life < 2 → LifeOnly impossible; combined with
-                               // an empty pool, cost becomes unpayable but let's
-                               // give mana so every shard is ManaOnly.
+    // an empty pool, cost becomes unpayable but let's
+    // give mana so every shard is ManaOnly.
     let spell = create_phyrexian_instant_in_hand(
         &mut state,
         PlayerId(0),
@@ -30371,12 +30447,12 @@ mod krrik_life_for_color {
             crate::types::game_state::WaitingFor::PhyrexianPayment { shards, .. } => {
                 assert_eq!(shards.len(), 1);
                 assert!(
-                        matches!(
-                            shards[0].options,
-                            crate::types::game_state::ShardOptions::ManaOrLife
-                        ),
-                        "CR 107.4f: with red mana + life available, hybrid Phyrexian shard must offer both"
-                    );
+                    matches!(
+                        shards[0].options,
+                        crate::types::game_state::ShardOptions::ManaOrLife
+                    ),
+                    "CR 107.4f: with red mana + life available, hybrid Phyrexian shard must offer both"
+                );
             }
             other => panic!("expected PhyrexianPayment for promoted hybrid, got {other:?}"),
         }
@@ -30917,8 +30993,8 @@ mod summoning_sickness_gate {
 mod remove_counter_cost {
     use super::*;
     use crate::types::ability::{
-        CounterCostSelection, TypeFilter, TypedFilter, REMOVE_COUNTER_COST_ANY_NUMBER,
-        REMOVE_COUNTER_COST_X,
+        CounterCostSelection, REMOVE_COUNTER_COST_ANY_NUMBER, REMOVE_COUNTER_COST_X, TypeFilter,
+        TypedFilter,
     };
     use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::game_state::CounterCostChoice;
@@ -31295,9 +31371,9 @@ mod remove_counter_cost {
             "choosing X=2 must remove exactly two counters after fixed mana is paid"
         );
         assert!(
-                state.stack.iter().any(|entry| entry.source_id == source),
-                "activated ability should reach the stack after paying the fixed mana and chosen X cost"
-            );
+            state.stack.iter().any(|entry| entry.source_id == source),
+            "activated ability should reach the stack after paying the fixed mana and chosen X cost"
+        );
     }
 
     #[test]
@@ -31446,9 +31522,9 @@ mod remove_counter_cost {
         );
 
         assert!(
-                can_activate_ability_now(&state, PlayerId(0), source, 0),
-                "target legality depending on X must not hide Remove-X-counter activations before X is chosen"
-            );
+            can_activate_ability_now(&state, PlayerId(0), source, 0),
+            "target legality depending on X must not hide Remove-X-counter activations before X is chosen"
+        );
     }
 
     #[test]
@@ -31633,12 +31709,12 @@ mod remove_counter_cost {
         let waiting =
             handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new()).unwrap();
         match &waiting {
-                WaitingFor::ChooseXValue { max, .. } => assert_eq!(
-                    *max, 3,
-                    "targeted X counter costs must cap by the largest single eligible source, not the sum"
-                ),
-                other => panic!("expected ChooseXValue, got {other:?}"),
-            }
+            WaitingFor::ChooseXValue { max, .. } => assert_eq!(
+                *max, 3,
+                "targeted X counter costs must cap by the largest single eligible source, not the sum"
+            ),
+            other => panic!("expected ChooseXValue, got {other:?}"),
+        }
         state.waiting_for = waiting;
 
         apply_as_current(&mut state, GameAction::ChooseX { value: 2 }).unwrap();
@@ -31741,9 +31817,9 @@ mod remove_counter_cost {
 
         apply_as_current(&mut state, GameAction::ChooseX { value: 2 }).unwrap();
         assert!(
-                !state.objects[&source].tapped,
-                "targeted X counter-cost detour must not pay the tap component before the counter-source choice"
-            );
+            !state.objects[&source].tapped,
+            "targeted X counter-cost detour must not pay the tap component before the counter-source choice"
+        );
 
         apply_as_current(
             &mut state,
@@ -31883,12 +31959,12 @@ mod remove_counter_cost {
         let waiting =
             handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new()).unwrap();
         match &waiting {
-                WaitingFor::ChooseXValue { max, .. } => assert_eq!(
-                    *max, 2,
-                    "untyped Remove-X-counter costs must cap by the largest concrete counter stack, not the sum across types"
-                ),
-                other => panic!("expected ChooseXValue, got {other:?}"),
-            }
+            WaitingFor::ChooseXValue { max, .. } => assert_eq!(
+                *max, 2,
+                "untyped Remove-X-counter costs must cap by the largest concrete counter stack, not the sum across types"
+            ),
+            other => panic!("expected ChooseXValue, got {other:?}"),
+        }
         state.waiting_for = waiting;
 
         apply_as_current(&mut state, GameAction::ChooseX { value: 2 }).unwrap();
@@ -32303,12 +32379,12 @@ mod remove_counter_cost {
 
         apply_as_current(&mut state, GameAction::SelectModes { indices: vec![1] }).unwrap();
         match &state.waiting_for {
-                WaitingFor::ChooseXValue { max, .. } => assert_eq!(
-                    *max, 3,
-                    "literal Remove-X-counter costs must prompt for X even when the selected mode does not use X"
-                ),
-                other => panic!("expected ChooseXValue after non-X mode choice, got {other:?}"),
-            }
+            WaitingFor::ChooseXValue { max, .. } => assert_eq!(
+                *max, 3,
+                "literal Remove-X-counter costs must prompt for X even when the selected mode does not use X"
+            ),
+            other => panic!("expected ChooseXValue after non-X mode choice, got {other:?}"),
+        }
 
         apply_as_current(&mut state, GameAction::ChooseX { value: 2 }).unwrap();
 
@@ -33704,9 +33780,9 @@ mod alt_cost_reduction_509 {
         );
 
         assert!(
-                can_cast_object_now(&state, PlayerId(0), emerge),
-                "Emerge must be castable when sacrificing a mana-value-4 creature reduces {{5}}{{U}}{{U}} to payable {{1}}{{U}}{{U}}"
-            );
+            can_cast_object_now(&state, PlayerId(0), emerge),
+            "Emerge must be castable when sacrificing a mana-value-4 creature reduces {{5}}{{U}}{{U}} to payable {{1}}{{U}}{{U}}"
+        );
 
         let mut events = Vec::new();
         let wf = handle_cast_spell(&mut state, PlayerId(0), emerge, CardId(800), &mut events)
@@ -33775,9 +33851,9 @@ mod alt_cost_reduction_509 {
         );
 
         assert!(
-                !can_cast_object_now(&state, PlayerId(0), emerge),
-                "Emerge reduces only generic mana by mana value: {{5}}{{U}}{{U}} minus mana value 4 is {{1}}{{U}}{{U}}, not {{3}}"
-            );
+            !can_cast_object_now(&state, PlayerId(0), emerge),
+            "Emerge reduces only generic mana by mana value: {{5}}{{U}}{{U}} minus mana value 4 is {{1}}{{U}}{{U}}, not {{3}}"
+        );
     }
 
     #[test]
@@ -33801,9 +33877,9 @@ mod alt_cost_reduction_509 {
             create_sacrifice_creature(&mut state, PlayerId(0), 808, ManaCost::generic(5));
 
         assert!(
-                can_cast_object_now(&state, PlayerId(0), emerge),
-                "Emerge under Trinisphere must be affordable only when the post-reduction {{2}}{{U}} floor is payable"
-            );
+            can_cast_object_now(&state, PlayerId(0), emerge),
+            "Emerge under Trinisphere must be affordable only when the post-reduction {{2}}{{U}} floor is payable"
+        );
 
         let mut events = Vec::new();
         let wf = handle_cast_spell(&mut state, PlayerId(0), emerge, CardId(807), &mut events)
@@ -33819,10 +33895,10 @@ mod alt_cost_reduction_509 {
 
         assert_eq!(state.objects[&emerge].zone, Zone::Stack);
         assert_eq!(
-                state.players[0].mana_pool.total(),
-                0,
-                "Trinisphere must floor the post-Emerge-reduction cost to {{2}}{{U}}, not leave it at {{U}}"
-            );
+            state.players[0].mana_pool.total(),
+            0,
+            "Trinisphere must floor the post-Emerge-reduction cost to {{2}}{{U}}, not leave it at {{U}}"
+        );
     }
 
     #[test]
@@ -33844,9 +33920,9 @@ mod alt_cost_reduction_509 {
         create_sacrifice_creature(&mut state, PlayerId(0), 810, ManaCost::generic(5));
 
         assert!(
-                !can_cast_object_now(&state, PlayerId(0), emerge),
-                "Emerge affordability must include the Trinisphere floor after mana-value reduction, so {{U}} alone cannot pay the final {{2}}{{U}} cost"
-            );
+            !can_cast_object_now(&state, PlayerId(0), emerge),
+            "Emerge affordability must include the Trinisphere floor after mana-value reduction, so {{U}} alone cannot pay the final {{2}}{{U}} cost"
+        );
     }
 
     #[test]
@@ -34563,18 +34639,20 @@ mod loyalty_gate {
             let obj = state.objects.get_mut(&eidolon).unwrap();
             obj.card_types.core_types.push(CoreType::Enchantment);
             obj.card_types.core_types.push(CoreType::Creature);
-            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode: CostModifyMode::Raise,
-                keyword: "loyalty".to_string(),
-                amount: 1,
-                minimum_mana: None,
-                dynamic_count: None,
-                exemption: ActivationExemption::None,
-                activator: None,
-            })
-            .affected(TargetFilter::Typed(
-                TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
-            ))]
+            obj.static_definitions = vec![
+                StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                    mode: CostModifyMode::Raise,
+                    keyword: "loyalty".to_string(),
+                    amount: 1,
+                    minimum_mana: None,
+                    dynamic_count: None,
+                    exemption: ActivationExemption::None,
+                    activator: None,
+                })
+                .affected(TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+                )),
+            ]
             .into();
         }
 
@@ -34629,8 +34707,8 @@ mod loyalty_gate {
                 let obj = state.objects.get_mut(&eidolon).unwrap();
                 obj.card_types.core_types.push(CoreType::Enchantment);
                 obj.card_types.core_types.push(CoreType::Creature);
-                obj.static_definitions =
-                    vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                obj.static_definitions = vec![
+                    StaticDefinition::new(StaticMode::ReduceAbilityCost {
                         mode: CostModifyMode::Raise,
                         keyword: "loyalty".to_string(),
                         amount: 1,
@@ -34642,8 +34720,9 @@ mod loyalty_gate {
                     .affected(TargetFilter::Typed(
                         TypedFilter::new(TypeFilter::Planeswalker)
                             .controller(ControllerRef::Opponent),
-                    ))]
-                    .into();
+                    )),
+                ]
+                .into();
             }
             (state, pw)
         }
@@ -34772,18 +34851,20 @@ mod loyalty_gate {
             let obj = state.objects.get_mut(&eidolon).unwrap();
             obj.card_types.core_types.push(CoreType::Enchantment);
             obj.card_types.core_types.push(CoreType::Creature);
-            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode: CostModifyMode::Raise,
-                keyword: "loyalty".to_string(),
-                amount: 1,
-                minimum_mana: None,
-                dynamic_count: None,
-                exemption: ActivationExemption::None,
-                activator: None,
-            })
-            .affected(TargetFilter::Typed(
-                TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
-            ))]
+            obj.static_definitions = vec![
+                StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                    mode: CostModifyMode::Raise,
+                    keyword: "loyalty".to_string(),
+                    amount: 1,
+                    minimum_mana: None,
+                    dynamic_count: None,
+                    exemption: ActivationExemption::None,
+                    activator: None,
+                })
+                .affected(TargetFilter::Typed(
+                    TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+                )),
+            ]
             .into();
         }
 
@@ -35444,10 +35525,10 @@ mod top_of_library_cast_permission_runtime {
         let unlimited_src = install_realmwalker_static(&mut state2, player, "Elf");
         let top2 = put_creature_on_top_of_library(&mut state2, player, CardId(907));
         assert_eq!(
-                top_of_library_selected_permission(&state2, player, top2),
-                Some((unlimited_src, CastFrequency::Unlimited)),
-                "Unlimited permission must be selected with Unlimited frequency — never consumes a slot"
-            );
+            top_of_library_selected_permission(&state2, player, top2),
+            Some((unlimited_src, CastFrequency::Unlimited)),
+            "Unlimited permission must be selected with Unlimited frequency — never consumes a slot"
+        );
 
         // Selection only applies to the actual top card. Place a second
         // creature BELOW the top so it is in the library but not on top.
@@ -36601,10 +36682,10 @@ fn bestow_illegal_target_at_resolution_reverts_to_creature() {
     // CR 702.103e: spell resolves as a creature spell.
     let result = state.objects.get(&bestow_id).unwrap();
     assert_eq!(
-            result.zone,
-            Zone::Battlefield,
-            "CR 702.103e: bestow spell with illegal target resolves as a creature on the battlefield (NOT to graveyard)"
-        );
+        result.zone,
+        Zone::Battlefield,
+        "CR 702.103e: bestow spell with illegal target resolves as a creature on the battlefield (NOT to graveyard)"
+    );
     assert!(
         result.card_types.core_types.contains(&CoreType::Creature),
         "CR 702.103e: reverted bestow spell is a Creature"
@@ -39502,9 +39583,9 @@ fn play_from_exile_single_use_tracks_overlapping_sets_from_same_source() {
         "the consumed tracked set must no longer be castable"
     );
     assert!(
-            after.contains(&second),
-            "an overlapping grant from the same source but a different tracked set must remain castable"
-        );
+        after.contains(&second),
+        "an overlapping grant from the same source but a different tracked set must remain castable"
+    );
 }
 
 /// Add a vanilla land card into exile owned by `player`. Mirrors
@@ -40345,14 +40426,14 @@ mod flash_timing_grant_seam {
     /// through the production pipeline (parser → effect.rs::resolve → TCE).
     fn grant_teferi_flash(state: &mut GameState, controller: PlayerId, teferi: ObjectId) {
         let parsed = parse_oracle_text(
-                "Each opponent can cast spells only any time they could cast a sorcery.\n\
+            "Each opponent can cast spells only any time they could cast a sorcery.\n\
                  [+1]: Until your next turn, you may cast sorcery spells as though they had flash.\n\
                  [\u{2212}3]: Return up to one target artifact, creature, or enchantment to its owner's hand. Draw a card.",
-                "Teferi, Time Raveler",
-                &[],
-                &["Planeswalker".to_string()],
-                &["Teferi".to_string()],
-            );
+            "Teferi, Time Raveler",
+            &[],
+            &["Planeswalker".to_string()],
+            &["Teferi".to_string()],
+        );
         // abilities[0] is the +1 GenericEffect grant.
         let ability = ResolvedAbility::new(
             (*parsed.abilities[0].effect).clone(),
@@ -41109,11 +41190,13 @@ fn thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker() {
         let o = state.objects.get_mut(&goblin).unwrap();
         o.card_types.core_types.push(CoreType::Creature);
     }
-    state.attacker_declarations_this_turn = vec![state
-        .objects
-        .get(&goblin)
-        .unwrap()
-        .snapshot_for_attack_declaration(goblin)];
+    state.attacker_declarations_this_turn = vec![
+        state
+            .objects
+            .get(&goblin)
+            .unwrap()
+            .snapshot_for_attack_declaration(goblin),
+    ];
     let mut def_wrong = make_def();
     apply_cost_reduction(&state, &mut def_wrong, PlayerId(0), src);
     assert_eq!(
@@ -41171,11 +41254,13 @@ fn thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker() {
         o.card_types.core_types.push(CoreType::Artifact);
         o.card_types.subtypes.push("Spacecraft".to_string());
     }
-    state_opp.attacker_declarations_this_turn = vec![state_opp
-        .objects
-        .get(&opp_ship)
-        .unwrap()
-        .snapshot_for_attack_declaration(opp_ship)];
+    state_opp.attacker_declarations_this_turn = vec![
+        state_opp
+            .objects
+            .get(&opp_ship)
+            .unwrap()
+            .snapshot_for_attack_declaration(opp_ship),
+    ];
     let mut def_opp = make_def();
     apply_cost_reduction(&state_opp, &mut def_opp, PlayerId(0), src2);
     assert_eq!(
@@ -41225,20 +41310,22 @@ fn boom_scholar_reduces_other_permanents_exhaust_ability_cost() {
         obj.card_types
             .core_types
             .push(crate::types::card_type::CoreType::Creature);
-        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
-            mode: crate::types::statics::CostModifyMode::Reduce,
-            keyword: "exhaust".to_string(),
-            amount: 2,
-            minimum_mana: None,
-            dynamic_count: None,
-            exemption: crate::types::statics::ActivationExemption::None,
-            activator: None,
-        })
-        .affected(TargetFilter::Typed(
-            TypedFilter::permanent()
-                .controller(ControllerRef::You)
-                .properties(vec![FilterProp::Another]),
-        ))]
+        obj.static_definitions = vec![
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: crate::types::statics::CostModifyMode::Reduce,
+                keyword: "exhaust".to_string(),
+                amount: 2,
+                minimum_mana: None,
+                dynamic_count: None,
+                exemption: crate::types::statics::ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::permanent()
+                    .controller(ControllerRef::You)
+                    .properties(vec![FilterProp::Another]),
+            )),
+        ]
         .into();
     }
 
@@ -41351,16 +41438,18 @@ fn skyseer_increases_chosen_name_activated_ability_cost() {
             .push(crate::types::card_type::CoreType::Artifact);
         obj.chosen_attributes
             .push(ChosenAttribute::CardName("Targeted Source".to_string()));
-        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
-            mode: CostModifyMode::Raise,
-            keyword: "activated".to_string(),
-            amount: 2,
-            minimum_mana: None,
-            dynamic_count: None,
-            exemption: crate::types::statics::ActivationExemption::None,
-            activator: None,
-        })
-        .affected(TargetFilter::HasChosenName)]
+        obj.static_definitions = vec![
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Raise,
+                keyword: "activated".to_string(),
+                amount: 2,
+                minimum_mana: None,
+                dynamic_count: None,
+                exemption: crate::types::statics::ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::HasChosenName),
+        ]
         .into();
     }
 
@@ -41477,18 +41566,20 @@ fn eidolon_of_obstruction_taxes_opponent_loyalty_ability() {
         let obj = state.objects.get_mut(&eidolon).unwrap();
         obj.card_types.core_types.push(CoreType::Enchantment);
         obj.card_types.core_types.push(CoreType::Creature);
-        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
-            mode: CostModifyMode::Raise,
-            keyword: "loyalty".to_string(),
-            amount: 1,
-            minimum_mana: None,
-            dynamic_count: None,
-            exemption: crate::types::statics::ActivationExemption::None,
-            activator: None,
-        })
-        .affected(TargetFilter::Typed(
-            TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
-        ))]
+        obj.static_definitions = vec![
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Raise,
+                keyword: "loyalty".to_string(),
+                amount: 1,
+                minimum_mana: None,
+                dynamic_count: None,
+                exemption: crate::types::statics::ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+            )),
+        ]
         .into();
     }
 
@@ -41637,20 +41728,22 @@ fn agatha_dynamic_power_reduces_controlled_creature_ability_cost() {
             .push(crate::types::card_type::CoreType::Creature);
         obj.power = Some(3);
         obj.toughness = Some(1);
-        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
-            mode: CostModifyMode::Reduce,
-            keyword: "activated".to_string(),
-            amount: 1,
-            minimum_mana: Some(1),
-            dynamic_count: Some(QuantityRef::Power {
-                scope: ObjectScope::Source,
-            }),
-            exemption: crate::types::statics::ActivationExemption::None,
-            activator: None,
-        })
-        .affected(TargetFilter::Typed(
-            TypedFilter::creature().controller(ControllerRef::You),
-        ))]
+        obj.static_definitions = vec![
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Reduce,
+                keyword: "activated".to_string(),
+                amount: 1,
+                minimum_mana: Some(1),
+                dynamic_count: Some(QuantityRef::Power {
+                    scope: ObjectScope::Source,
+                }),
+                exemption: crate::types::statics::ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            )),
+        ]
         .into();
     }
 
@@ -41907,20 +42000,22 @@ fn agatha_reduced_creature_ability_activates_via_production_path() {
                 "Agatha of the Vile Cauldron".to_string(),
                 Zone::Battlefield,
             );
-            let statics = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode: CostModifyMode::Reduce,
-                keyword: "activated".to_string(),
-                amount: 1,
-                minimum_mana: Some(1),
-                dynamic_count: Some(QuantityRef::Power {
-                    scope: ObjectScope::Source,
-                }),
-                exemption: crate::types::statics::ActivationExemption::None,
-                activator: None,
-            })
-            .affected(TargetFilter::Typed(
-                TypedFilter::creature().controller(ControllerRef::You),
-            ))];
+            let statics = vec![
+                StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                    mode: CostModifyMode::Reduce,
+                    keyword: "activated".to_string(),
+                    amount: 1,
+                    minimum_mana: Some(1),
+                    dynamic_count: Some(QuantityRef::Power {
+                        scope: ObjectScope::Source,
+                    }),
+                    exemption: crate::types::statics::ActivationExemption::None,
+                    activator: None,
+                })
+                .affected(TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::You),
+                )),
+            ];
             let obj = state.objects.get_mut(&agatha).unwrap();
             obj.card_types
                 .core_types
@@ -42678,16 +42773,18 @@ fn firion_reduces_self_equip_ability_cost() {
             .core_types
             .push(crate::types::card_type::CoreType::Artifact);
         obj.card_types.subtypes.push("Equipment".to_string());
-        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
-            mode: CostModifyMode::Reduce,
-            keyword: "equip".to_string(),
-            amount: 2,
-            minimum_mana: None,
-            dynamic_count: None,
-            exemption: crate::types::statics::ActivationExemption::None,
-            activator: None,
-        })
-        .affected(TargetFilter::SelfRef)]
+        obj.static_definitions = vec![
+            StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Reduce,
+                keyword: "equip".to_string(),
+                amount: 2,
+                minimum_mana: None,
+                dynamic_count: None,
+                exemption: crate::types::statics::ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::SelfRef),
+        ]
         .into();
     }
 

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -9959,6 +9959,7 @@ fn gobakhan_play_from_exile_cost_raise_adds_two_generic() {
         obj_id,
         &mut mana_cost,
         None,
+        None,
     );
     assert_eq!(
         mana_cost,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -183,6 +183,119 @@ fn pure_chosen_color_without_choice_does_not_auto_pay_from_preview_colors() {
     );
 }
 
+#[test]
+fn powerstones_do_not_make_go_for_the_throat_castable() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_object(
+        &mut state,
+        CardId(9_013),
+        PlayerId(0),
+        "Go for the Throat".to_string(),
+        Zone::Hand,
+    );
+    {
+        let obj = state.objects.get_mut(&spell).unwrap();
+        obj.card_types.core_types.push(CoreType::Instant);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 1,
+        };
+        Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Destroy {
+                target: TargetFilter::Typed(
+                    TypedFilter::creature()
+                        .with_type(TypeFilter::Non(Box::new(TypeFilter::Artifact))),
+                ),
+                cant_regenerate: false,
+            },
+        ));
+    }
+    let target = create_object(
+        &mut state,
+        CardId(9_014),
+        PlayerId(1),
+        "Creature Target".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&target)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+    create_tap_mana_source(
+        &mut state,
+        "Shipwreck Marsh",
+        ManaProduction::Fixed {
+            colors: vec![ManaColor::Black],
+            contribution: ManaContribution::Base,
+        },
+    );
+    for card_id in [9_015, 9_016] {
+        let source = create_object(
+            &mut state,
+            CardId(card_id),
+            PlayerId(0),
+            "Powerstone".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&source).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Colorless {
+                        count: QuantityExpr::Fixed { value: 1 },
+                    },
+                    restrictions: vec![ManaSpendRestriction::SpellTypeOrAbilityActivation {
+                        spell_type: "Artifact".to_string(),
+                        ability: crate::types::mana::AbilityActivationScope::OfSpellType,
+                    }],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        );
+    }
+
+    let cost = state.objects[&spell].mana_cost.clone();
+    assert!(
+        !can_pay_cost_after_auto_tap(&state, PlayerId(0), spell, &cost),
+        "Powerstone mana cannot pay the generic part of a nonartifact spell"
+    );
+    assert!(
+        !can_feasibly_pay_mana_cost_without_x(&state, PlayerId(0), Some(spell), &cost),
+        "the feasibility path must not count Powerstones for a nonartifact spell"
+    );
+    assert!(
+        !can_cast_object_now(&state, PlayerId(0), spell),
+        "Go for the Throat needs an additional unrestricted mana source"
+    );
+    let probe = PriorityCastProbe::new(&state, PlayerId(0));
+    assert!(
+        !can_cast_object_now_with_probe(probe.state(), PlayerId(0), spell, Some(&probe)),
+        "the cached priority probe must not offer an unaffordable nonartifact spell"
+    );
+
+    create_tap_mana_source(
+        &mut state,
+        "Mountain",
+        ManaProduction::Fixed {
+            colors: vec![ManaColor::Red],
+            contribution: ManaContribution::Base,
+        },
+    );
+    assert!(
+        can_cast_object_now(&state, PlayerId(0), spell),
+        "one additional unrestricted mana source makes Go for the Throat castable"
+    );
+}
+
 fn install_optional_discard_replacement(state: &mut GameState) -> ObjectId {
     let replacement_source = create_object(
         state,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -84,6 +84,129 @@ fn create_tap_mana_source(state: &mut GameState, name: &str, produced: ManaProdu
 }
 
 #[test]
+fn tapped_relic_can_use_a_new_legend_to_pay_a_second_creature_spell() {
+    let mut state = setup_game_at_main_phase();
+    let spell =
+        create_generic_creature_in_hand(&mut state, 9_014, PlayerId(0), "Slogurk Stand-In", 0);
+    state.objects.get_mut(&spell).unwrap().mana_cost = ManaCost::Cost {
+        shards: vec![ManaCostShard::Green, ManaCostShard::Blue],
+        generic: 0,
+    };
+
+    create_tap_mana_source(
+        &mut state,
+        "Xander's Lounge Stand-In",
+        ManaProduction::AnyOneColor {
+            count: QuantityExpr::Fixed { value: 1 },
+            color_options: vec![ManaColor::Blue, ManaColor::Black, ManaColor::Red],
+            contribution: ManaContribution::Base,
+        },
+    );
+    let relic = create_object(
+        &mut state,
+        CardId(9_015),
+        PlayerId(0),
+        "Relic of Legends Stand-In".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&relic).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.tapped = true;
+        Arc::make_mut(&mut obj.abilities).push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::AnyOneColor {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        color_options: vec![
+                            ManaColor::White,
+                            ManaColor::Blue,
+                            ManaColor::Black,
+                            ManaColor::Red,
+                            ManaColor::Green,
+                        ],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::TapCreatures {
+                requirement: crate::types::ability::TapCreaturesRequirement::count(1),
+                filter: TypedFilter::creature()
+                    .controller(ControllerRef::You)
+                    .properties(vec![FilterProp::HasSupertype {
+                        value: Supertype::Legendary,
+                    }])
+                    .into(),
+            }),
+        );
+    }
+    let legend = create_object(
+        &mut state,
+        CardId(9_016),
+        PlayerId(0),
+        "New Legend".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&legend).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.card_types.supertypes.push(Supertype::Legendary);
+        obj.summoning_sick = true;
+    }
+
+    let cost = state.objects[&spell].mana_cost.clone();
+    assert!(!can_pay_cost_after_auto_tap(
+        &state,
+        PlayerId(0),
+        spell,
+        &cost
+    ));
+    assert!(has_manual_mana_ability_for_spell_payment(
+        &state,
+        PlayerId(0),
+        spell
+    ));
+    assert!(can_feasibly_pay_mana_cost(
+        &state,
+        PlayerId(0),
+        Some(spell),
+        &cost
+    ));
+
+    let result = apply_as_current(
+        &mut state,
+        GameAction::CastSpell {
+            object_id: spell,
+            card_id: CardId(9_014),
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        },
+    )
+    .expect("the legal cast must enter mana payment, not fail after announcement");
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ManaPayment {
+            player: PlayerId(0),
+            convoke_mode: None,
+        }
+    ));
+    assert!(crate::ai_support::candidate_actions(&state)
+        .iter()
+        .any(|candidate| matches!(
+            candidate.action,
+            GameAction::ActivateAbility {
+                source_id,
+                ability_index: 0,
+            } if source_id == relic
+        )));
+}
+
+#[test]
 fn fixed_alternative_chosen_color_auto_tap_replays_selected_fixed_color() {
     let mut state = setup_game_at_main_phase();
     let spell = create_generic_creature_in_hand(&mut state, 9_011, PlayerId(0), "Blue Spell", 0);

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -492,6 +492,97 @@ fn add_activation_only_colorless_source(
 }
 
 #[test]
+fn x_spell_cap_excludes_mana_restricted_to_activated_abilities() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_instant_in_hand(&mut state, PlayerId(0));
+    state.objects.get_mut(&spell).unwrap().mana_cost = ManaCost::Cost {
+        shards: vec![ManaCostShard::X, ManaCostShard::White],
+        generic: 0,
+    };
+    create_tap_mana_source(
+        &mut state,
+        "Meticulous Archive Stand-In",
+        ManaProduction::Fixed {
+            colors: vec![ManaColor::White],
+            contribution: ManaContribution::Base,
+        },
+    );
+    create_tap_mana_source(
+        &mut state,
+        "Island Stand-In",
+        ManaProduction::Fixed {
+            colors: vec![ManaColor::Blue],
+            contribution: ManaContribution::Base,
+        },
+    );
+    let citadel = create_object(
+        &mut state,
+        CardId(9_017),
+        PlayerId(0),
+        "Sunken Citadel Stand-In".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&citadel).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        let abilities = Arc::make_mut(&mut obj.abilities);
+        abilities.push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::White],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        );
+        abilities.push(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::AnyOneColor {
+                        count: QuantityExpr::Fixed { value: 2 },
+                        color_options: vec![ManaColor::White],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: vec![ManaSpendRestriction::ActivateOnly],
+                    grants: vec![],
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Tap),
+        );
+    }
+
+    let card_id = state.objects[&spell].card_id;
+    let waiting = handle_cast_spell(&mut state, PlayerId(0), spell, card_id, &mut Vec::new())
+        .expect("the X spell should begin casting");
+    state.waiting_for = waiting;
+    let waiting = apply_as_current(
+        &mut state,
+        GameAction::SelectTargets {
+            targets: vec![TargetRef::Player(PlayerId(1))],
+        },
+    )
+    .expect("the target should be selected before X")
+    .waiting_for;
+    match waiting {
+        WaitingFor::ChooseXValue { max, .. } => assert_eq!(
+            max, 2,
+            "three spell-usable mana sources must cap {{X}}{{W}} at X=2"
+        ),
+        other => panic!("expected ChooseXValue, got {other:?}"),
+    }
+}
+
+#[test]
 fn ability_condition_currently_met_gates_on_board_relative_quantity() {
     let mut state = GameState::new_two_player(42);
     // Hideaway-shaped source: a {T}-cost ability gated by "creatures you

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -23172,6 +23172,83 @@ fn voltage_surge_deals_four_when_its_artifact_cost_is_paid() {
     outcome.assert_zone(&[artifact], Zone::Graveyard);
 }
 
+fn resolve_torch_the_tower(
+    bargain: bool,
+) -> (crate::game::scenario::CastOutcome, ObjectId, ObjectId) {
+    use crate::game::scenario::{GameScenario, P0, P1};
+
+    const TORCH_ORACLE: &str = "Bargain (You may sacrifice an artifact, enchantment, or token as you cast this spell.)\nTorch the Tower deals 2 damage to target creature or planeswalker. If this spell was bargained, instead it deals 3 damage to that permanent and you scry 1.\nIf a permanent dealt damage by Torch the Tower would die this turn, exile it instead.";
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::Red);
+    scenario.with_library_top(P0, &["Scry Target"]);
+    let target = scenario.add_creature(P1, "Target Creature", 2, 5).id();
+    let artifact = create_object(
+        &mut scenario.state,
+        CardId(91_002),
+        P0,
+        "Blood Token".to_string(),
+        Zone::Battlefield,
+    );
+    scenario
+        .state
+        .objects
+        .get_mut(&artifact)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Artifact);
+    let mut spell = scenario.add_spell_to_hand(P0, "Torch the Tower", true);
+    spell
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 0,
+        })
+        .from_oracle_text_with_keywords(&["bargain"], TORCH_ORACLE);
+    let spell_id = spell.id();
+    let mut runner = scenario.build();
+    let cast = runner.cast(spell_id).target_object(target);
+    let outcome = if bargain {
+        cast.accept_optional().sacrifice_with(&[artifact]).resolve()
+    } else {
+        cast.decline_optional().resolve()
+    };
+    (outcome, target, artifact)
+}
+
+#[test]
+fn torch_the_tower_deals_two_without_bargaining() {
+    let (outcome, target, artifact) = resolve_torch_the_tower(false);
+    assert_eq!(outcome.state().objects[&target].damage_marked, 2);
+    outcome.assert_zone(&[artifact], Zone::Battlefield);
+    assert!(!outcome.events().iter().any(|event| {
+        matches!(
+            event,
+            crate::types::events::GameEvent::PlayerPerformedAction {
+                action: crate::types::events::PlayerActionKind::Scry,
+                ..
+            }
+        )
+    }));
+}
+
+#[test]
+fn torch_the_tower_deals_three_and_scries_when_bargained() {
+    let (outcome, target, artifact) = resolve_torch_the_tower(true);
+    assert_eq!(outcome.state().objects[&target].damage_marked, 3);
+    outcome.assert_zone(&[artifact], Zone::Graveyard);
+    assert!(outcome.events().iter().any(|event| {
+        matches!(
+            event,
+            crate::types::events::GameEvent::PlayerPerformedAction {
+                action: crate::types::events::PlayerActionKind::Scry,
+                ..
+            }
+        )
+    }));
+}
+
 /// Deadly Cover-Up fixture: P1 owns two `Grizzly Bears` in GY + one in hand
 /// (same-named), a `Llanowar Elves` decoy in GY and hand, and a two-card library
 /// with no Bears (so a draw is the only library change). P0 owns a same-named

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -2029,15 +2029,13 @@ fn pending_next_spell_cant_be_countered_stamped_on_stack() {
             source_id: None,
         });
     super::apply_pending_next_spell_stack_grants(&mut state, PlayerId(0), spell_id);
-    assert!(
-        state
-            .objects
-            .get(&spell_id)
-            .unwrap()
-            .static_definitions
-            .iter_all()
-            .any(|sd| sd.mode == StaticMode::CantBeCountered)
-    );
+    assert!(state
+        .objects
+        .get(&spell_id)
+        .unwrap()
+        .static_definitions
+        .iter_all()
+        .any(|sd| sd.mode == StaticMode::CantBeCountered));
     super::consume_pending_next_spell_modifiers(&mut state, PlayerId(0), spell_id);
     assert!(state.pending_next_spell_modifiers.is_empty());
 }
@@ -3192,11 +3190,10 @@ fn spell_meta_includes_supertypes_for_restricted_mana() {
 
     let meta = build_spell_meta(&state, PlayerId(0), commander_id).unwrap();
 
-    assert!(
-        meta.types
-            .iter()
-            .any(|type_name| type_name.eq_ignore_ascii_case("Legendary"))
-    );
+    assert!(meta
+        .types
+        .iter()
+        .any(|type_name| type_name.eq_ignore_ascii_case("Legendary")));
     assert!(ManaRestriction::OnlyForSpellType("Legendary".to_string()).allows_spell(&meta));
 }
 
@@ -10743,13 +10740,11 @@ fn transient_activation_cost_reduction_hits_only_controlled_artifact_tokens() {
         properties: vec![FilterProp::Token],
     });
     let effect = Effect::GenericEffect {
-        static_abilities: vec![
-            StaticDefinition::new(reduce_mode.clone())
-                .affected(source_filter)
-                .modifications(vec![ContinuousModification::AddStaticMode {
-                    mode: reduce_mode,
-                }]),
-        ],
+        static_abilities: vec![StaticDefinition::new(reduce_mode.clone())
+            .affected(source_filter)
+            .modifications(vec![ContinuousModification::AddStaticMode {
+                mode: reduce_mode,
+            }])],
         duration: Some(crate::types::ability::Duration::UntilEndOfTurn),
         target: None,
     };
@@ -11562,10 +11557,10 @@ fn x_cost_accounts_for_pending_cost_reduction_in_max() {
 #[test]
 fn x_cost_max_accounts_for_granted_affinity_exceeding_fixed_generic() {
     use super::super::engine::apply_as_current;
-    use crate::types::StaticDefinition;
     use crate::types::ability::{ControllerRef, QuantityRef, TypeFilter, TypedFilter};
     use crate::types::keywords::Keyword;
     use crate::types::statics::StaticMode;
+    use crate::types::StaticDefinition;
 
     // Build a {X}{B}{B} sorcery + a battlefield static granting
     // Affinity(Creature) to the controller's sorceries, with N creatures.
@@ -20474,14 +20469,12 @@ fn cancel_cast_uses_stamped_convoked_creatures_when_pending_snapshot_is_empty() 
     handle_cancel_cast(&mut state, &pending, &mut Vec::new());
 
     assert!(!state.objects.get(&helper).unwrap().tapped);
-    assert!(
-        state
-            .objects
-            .get(&spell)
-            .unwrap()
-            .convoked_creatures
-            .is_empty()
-    );
+    assert!(state
+        .objects
+        .get(&spell)
+        .unwrap()
+        .convoked_creatures
+        .is_empty());
     assert!(state.players[0].mana_pool.mana.is_empty());
 }
 
@@ -20634,17 +20627,15 @@ fn convoke_payment_offers_and_accepts_colored_creature_payment() {
     ));
 
     let (_, _, grouped) = crate::ai_support::legal_actions_full(&state);
-    assert!(
-        grouped
-            .get(&creature)
-            .is_some_and(|actions| actions.iter().any(|action| matches!(
-                action,
-                GameAction::TapForConvoke {
-                    object_id,
-                    mana_type: ManaType::Green
-                } if *object_id == creature
-            )))
-    );
+    assert!(grouped
+        .get(&creature)
+        .is_some_and(|actions| actions.iter().any(|action| matches!(
+            action,
+            GameAction::TapForConvoke {
+                object_id,
+                mana_type: ManaType::Green
+            } if *object_id == creature
+        ))));
     assert!(
         grouped.get(&artifact).is_none_or(|actions| actions
             .iter()
@@ -20985,16 +20976,12 @@ fn emit_targeting_events_own_object_no_crime() {
         PlayerId(0),
         &mut events,
     );
-    assert!(
-        events
-            .iter()
-            .any(|e| matches!(e, GameEvent::BecomesTarget { .. }))
-    );
-    assert!(
-        !events
-            .iter()
-            .any(|e| matches!(e, GameEvent::CrimeCommitted { .. }))
-    );
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, GameEvent::BecomesTarget { .. })));
+    assert!(!events
+        .iter()
+        .any(|e| matches!(e, GameEvent::CrimeCommitted { .. })));
 }
 
 #[test]
@@ -22322,21 +22309,15 @@ fn kicker_instead_target_paid_selects_replacement_target_only() {
     };
     assert!(pending_cast.ability.context.additional_cost_paid);
     assert_eq!(target_slots.len(), 1);
-    assert!(
-        !target_slots[0]
-            .legal_targets
-            .contains(&TargetRef::Object(artifact_id))
-    );
-    assert!(
-        target_slots[0]
-            .legal_targets
-            .contains(&TargetRef::Object(creature_id))
-    );
-    assert!(
-        target_slots[0]
-            .legal_targets
-            .contains(&TargetRef::Object(second_creature_id))
-    );
+    assert!(!target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(artifact_id)));
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(creature_id)));
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(second_creature_id)));
 }
 
 #[test]
@@ -22380,21 +22361,15 @@ fn kicked_bloodchiefs_thirst_like_spell_targets_three_mv_creature() {
     };
     assert!(pending_cast.ability.context.additional_cost_paid);
     assert_eq!(target_slots.len(), 1);
-    assert!(
-        target_slots[0]
-            .legal_targets
-            .contains(&TargetRef::Object(two_mv_creature))
-    );
-    assert!(
-        target_slots[0]
-            .legal_targets
-            .contains(&TargetRef::Object(three_mv_creature))
-    );
-    assert!(
-        target_slots[0]
-            .legal_targets
-            .contains(&TargetRef::Object(four_mv_creature))
-    );
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(two_mv_creature)));
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(three_mv_creature)));
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(four_mv_creature)));
 }
 
 #[test]
@@ -22931,16 +22906,12 @@ fn modal_x_target_legality_chooses_x_before_targets() {
             ..
         } => {
             assert_eq!(target_slots.len(), 1);
-            assert!(
-                target_slots[0]
-                    .legal_targets
-                    .contains(&TargetRef::Object(creature))
-            );
-            assert!(
-                target_slots[0]
-                    .legal_targets
-                    .contains(&TargetRef::Object(other_creature))
-            );
+            assert!(target_slots[0]
+                .legal_targets
+                .contains(&TargetRef::Object(creature)));
+            assert!(target_slots[0]
+                .legal_targets
+                .contains(&TargetRef::Object(other_creature)));
             // CR 700.2 / CR 601.2c: the deferred-target path must surface the
             // per-mode label for the targeting UI (regression for issue #1543:
             // Kozilek's Command's mode-2 banner went blank after X was chosen
@@ -27395,11 +27366,9 @@ fn graveyard_spell_with_flashback_and_retrace_prompts_for_cast_variant() {
             player, options, ..
         } => {
             assert_eq!(player, PlayerId(0));
-            assert!(
-                options
-                    .iter()
-                    .any(|option| option.variant == CastingVariant::Flashback)
-            );
+            assert!(options
+                .iter()
+                .any(|option| option.variant == CastingVariant::Flashback));
             options
                 .iter()
                 .position(|option| option.variant == CastingVariant::Retrace)
@@ -27407,16 +27376,14 @@ fn graveyard_spell_with_flashback_and_retrace_prompts_for_cast_variant() {
         }
         other => panic!("expected CastingVariantChoice, got {other:?}"),
     };
-    assert!(
-        crate::ai_support::legal_actions(&state)
-            .iter()
-            .any(|action| {
-                matches!(
-                    action,
-                    GameAction::ChooseCastingVariant { index } if *index == retrace_index
-                )
-            })
-    );
+    assert!(crate::ai_support::legal_actions(&state)
+        .iter()
+        .any(|action| {
+            matches!(
+                action,
+                GameAction::ChooseCastingVariant { index } if *index == retrace_index
+            )
+        }));
 
     let result = crate::game::engine::apply_as_current(
         &mut state,
@@ -30489,11 +30456,9 @@ fn phyrexian_multi_shard_all_life_deducts_per_shard() {
     match &result.waiting_for {
         WaitingFor::PhyrexianPayment { shards, .. } => {
             assert_eq!(shards.len(), 2);
-            assert!(
-                shards
-                    .iter()
-                    .all(|s| matches!(s.options, ShardOptions::LifeOnly))
-            );
+            assert!(shards
+                .iter()
+                .all(|s| matches!(s.options, ShardOptions::LifeOnly)));
         }
         other => panic!("expected PhyrexianPayment (two LifeOnly), got {other:?}"),
     }
@@ -30570,8 +30535,8 @@ fn phyrexian_mixed_one_mana_one_life() {
 fn phyrexian_cast_no_pause_when_all_shards_trivial() {
     let mut state = setup_game_at_main_phase();
     state.players[0].life = 1; // Life < 2 → LifeOnly impossible; combined with
-    // an empty pool, cost becomes unpayable but let's
-    // give mana so every shard is ManaOnly.
+                               // an empty pool, cost becomes unpayable but let's
+                               // give mana so every shard is ManaOnly.
     let spell = create_phyrexian_instant_in_hand(
         &mut state,
         PlayerId(0),
@@ -32023,8 +31988,8 @@ mod summoning_sickness_gate {
 mod remove_counter_cost {
     use super::*;
     use crate::types::ability::{
-        CounterCostSelection, REMOVE_COUNTER_COST_ANY_NUMBER, REMOVE_COUNTER_COST_X, TypeFilter,
-        TypedFilter,
+        CounterCostSelection, TypeFilter, TypedFilter, REMOVE_COUNTER_COST_ANY_NUMBER,
+        REMOVE_COUNTER_COST_X,
     };
     use crate::types::counter::{CounterMatch, CounterType};
     use crate::types::game_state::CounterCostChoice;
@@ -35669,20 +35634,18 @@ mod loyalty_gate {
             let obj = state.objects.get_mut(&eidolon).unwrap();
             obj.card_types.core_types.push(CoreType::Enchantment);
             obj.card_types.core_types.push(CoreType::Creature);
-            obj.static_definitions = vec![
-                StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                    mode: CostModifyMode::Raise,
-                    keyword: "loyalty".to_string(),
-                    amount: 1,
-                    minimum_mana: None,
-                    dynamic_count: None,
-                    exemption: ActivationExemption::None,
-                    activator: None,
-                })
-                .affected(TargetFilter::Typed(
-                    TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
-                )),
-            ]
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Raise,
+                keyword: "loyalty".to_string(),
+                amount: 1,
+                minimum_mana: None,
+                dynamic_count: None,
+                exemption: ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+            ))]
             .into();
         }
 
@@ -35737,8 +35700,8 @@ mod loyalty_gate {
                 let obj = state.objects.get_mut(&eidolon).unwrap();
                 obj.card_types.core_types.push(CoreType::Enchantment);
                 obj.card_types.core_types.push(CoreType::Creature);
-                obj.static_definitions = vec![
-                    StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                obj.static_definitions =
+                    vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
                         mode: CostModifyMode::Raise,
                         keyword: "loyalty".to_string(),
                         amount: 1,
@@ -35750,9 +35713,8 @@ mod loyalty_gate {
                     .affected(TargetFilter::Typed(
                         TypedFilter::new(TypeFilter::Planeswalker)
                             .controller(ControllerRef::Opponent),
-                    )),
-                ]
-                .into();
+                    ))]
+                    .into();
             }
             (state, pw)
         }
@@ -35881,20 +35843,18 @@ mod loyalty_gate {
             let obj = state.objects.get_mut(&eidolon).unwrap();
             obj.card_types.core_types.push(CoreType::Enchantment);
             obj.card_types.core_types.push(CoreType::Creature);
-            obj.static_definitions = vec![
-                StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                    mode: CostModifyMode::Raise,
-                    keyword: "loyalty".to_string(),
-                    amount: 1,
-                    minimum_mana: None,
-                    dynamic_count: None,
-                    exemption: ActivationExemption::None,
-                    activator: None,
-                })
-                .affected(TargetFilter::Typed(
-                    TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
-                )),
-            ]
+            obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Raise,
+                keyword: "loyalty".to_string(),
+                amount: 1,
+                minimum_mana: None,
+                dynamic_count: None,
+                exemption: ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+            ))]
             .into();
         }
 
@@ -42220,13 +42180,11 @@ fn thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker() {
         let o = state.objects.get_mut(&goblin).unwrap();
         o.card_types.core_types.push(CoreType::Creature);
     }
-    state.attacker_declarations_this_turn = vec![
-        state
-            .objects
-            .get(&goblin)
-            .unwrap()
-            .snapshot_for_attack_declaration(goblin),
-    ];
+    state.attacker_declarations_this_turn = vec![state
+        .objects
+        .get(&goblin)
+        .unwrap()
+        .snapshot_for_attack_declaration(goblin)];
     let mut def_wrong = make_def();
     apply_cost_reduction(&state, &mut def_wrong, PlayerId(0), src);
     assert_eq!(
@@ -42284,13 +42242,11 @@ fn thaumaton_torpedo_cost_reduction_requires_spacecraft_attacker() {
         o.card_types.core_types.push(CoreType::Artifact);
         o.card_types.subtypes.push("Spacecraft".to_string());
     }
-    state_opp.attacker_declarations_this_turn = vec![
-        state_opp
-            .objects
-            .get(&opp_ship)
-            .unwrap()
-            .snapshot_for_attack_declaration(opp_ship),
-    ];
+    state_opp.attacker_declarations_this_turn = vec![state_opp
+        .objects
+        .get(&opp_ship)
+        .unwrap()
+        .snapshot_for_attack_declaration(opp_ship)];
     let mut def_opp = make_def();
     apply_cost_reduction(&state_opp, &mut def_opp, PlayerId(0), src2);
     assert_eq!(
@@ -42340,22 +42296,20 @@ fn boom_scholar_reduces_other_permanents_exhaust_ability_cost() {
         obj.card_types
             .core_types
             .push(crate::types::card_type::CoreType::Creature);
-        obj.static_definitions = vec![
-            StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode: crate::types::statics::CostModifyMode::Reduce,
-                keyword: "exhaust".to_string(),
-                amount: 2,
-                minimum_mana: None,
-                dynamic_count: None,
-                exemption: crate::types::statics::ActivationExemption::None,
-                activator: None,
-            })
-            .affected(TargetFilter::Typed(
-                TypedFilter::permanent()
-                    .controller(ControllerRef::You)
-                    .properties(vec![FilterProp::Another]),
-            )),
-        ]
+        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+            mode: crate::types::statics::CostModifyMode::Reduce,
+            keyword: "exhaust".to_string(),
+            amount: 2,
+            minimum_mana: None,
+            dynamic_count: None,
+            exemption: crate::types::statics::ActivationExemption::None,
+            activator: None,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::permanent()
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::Another]),
+        ))]
         .into();
     }
 
@@ -42468,18 +42422,16 @@ fn skyseer_increases_chosen_name_activated_ability_cost() {
             .push(crate::types::card_type::CoreType::Artifact);
         obj.chosen_attributes
             .push(ChosenAttribute::CardName("Targeted Source".to_string()));
-        obj.static_definitions = vec![
-            StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode: CostModifyMode::Raise,
-                keyword: "activated".to_string(),
-                amount: 2,
-                minimum_mana: None,
-                dynamic_count: None,
-                exemption: crate::types::statics::ActivationExemption::None,
-                activator: None,
-            })
-            .affected(TargetFilter::HasChosenName),
-        ]
+        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Raise,
+            keyword: "activated".to_string(),
+            amount: 2,
+            minimum_mana: None,
+            dynamic_count: None,
+            exemption: crate::types::statics::ActivationExemption::None,
+            activator: None,
+        })
+        .affected(TargetFilter::HasChosenName)]
         .into();
     }
 
@@ -42596,20 +42548,18 @@ fn eidolon_of_obstruction_taxes_opponent_loyalty_ability() {
         let obj = state.objects.get_mut(&eidolon).unwrap();
         obj.card_types.core_types.push(CoreType::Enchantment);
         obj.card_types.core_types.push(CoreType::Creature);
-        obj.static_definitions = vec![
-            StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode: CostModifyMode::Raise,
-                keyword: "loyalty".to_string(),
-                amount: 1,
-                minimum_mana: None,
-                dynamic_count: None,
-                exemption: crate::types::statics::ActivationExemption::None,
-                activator: None,
-            })
-            .affected(TargetFilter::Typed(
-                TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
-            )),
-        ]
+        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Raise,
+            keyword: "loyalty".to_string(),
+            amount: 1,
+            minimum_mana: None,
+            dynamic_count: None,
+            exemption: crate::types::statics::ActivationExemption::None,
+            activator: None,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Planeswalker).controller(ControllerRef::Opponent),
+        ))]
         .into();
     }
 
@@ -42758,22 +42708,20 @@ fn agatha_dynamic_power_reduces_controlled_creature_ability_cost() {
             .push(crate::types::card_type::CoreType::Creature);
         obj.power = Some(3);
         obj.toughness = Some(1);
-        obj.static_definitions = vec![
-            StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode: CostModifyMode::Reduce,
-                keyword: "activated".to_string(),
-                amount: 1,
-                minimum_mana: Some(1),
-                dynamic_count: Some(QuantityRef::Power {
-                    scope: ObjectScope::Source,
-                }),
-                exemption: crate::types::statics::ActivationExemption::None,
-                activator: None,
-            })
-            .affected(TargetFilter::Typed(
-                TypedFilter::creature().controller(ControllerRef::You),
-            )),
-        ]
+        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
+            keyword: "activated".to_string(),
+            amount: 1,
+            minimum_mana: Some(1),
+            dynamic_count: Some(QuantityRef::Power {
+                scope: ObjectScope::Source,
+            }),
+            exemption: crate::types::statics::ActivationExemption::None,
+            activator: None,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ))]
         .into();
     }
 
@@ -43030,22 +42978,20 @@ fn agatha_reduced_creature_ability_activates_via_production_path() {
                 "Agatha of the Vile Cauldron".to_string(),
                 Zone::Battlefield,
             );
-            let statics = vec![
-                StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                    mode: CostModifyMode::Reduce,
-                    keyword: "activated".to_string(),
-                    amount: 1,
-                    minimum_mana: Some(1),
-                    dynamic_count: Some(QuantityRef::Power {
-                        scope: ObjectScope::Source,
-                    }),
-                    exemption: crate::types::statics::ActivationExemption::None,
-                    activator: None,
-                })
-                .affected(TargetFilter::Typed(
-                    TypedFilter::creature().controller(ControllerRef::You),
-                )),
-            ];
+            let statics = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Reduce,
+                keyword: "activated".to_string(),
+                amount: 1,
+                minimum_mana: Some(1),
+                dynamic_count: Some(QuantityRef::Power {
+                    scope: ObjectScope::Source,
+                }),
+                exemption: crate::types::statics::ActivationExemption::None,
+                activator: None,
+            })
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))];
             let obj = state.objects.get_mut(&agatha).unwrap();
             obj.card_types
                 .core_types
@@ -43803,18 +43749,16 @@ fn firion_reduces_self_equip_ability_cost() {
             .core_types
             .push(crate::types::card_type::CoreType::Artifact);
         obj.card_types.subtypes.push("Equipment".to_string());
-        obj.static_definitions = vec![
-            StaticDefinition::new(StaticMode::ReduceAbilityCost {
-                mode: CostModifyMode::Reduce,
-                keyword: "equip".to_string(),
-                amount: 2,
-                minimum_mana: None,
-                dynamic_count: None,
-                exemption: crate::types::statics::ActivationExemption::None,
-                activator: None,
-            })
-            .affected(TargetFilter::SelfRef),
-        ]
+        obj.static_definitions = vec![StaticDefinition::new(StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Reduce,
+            keyword: "equip".to_string(),
+            amount: 2,
+            minimum_mana: None,
+            dynamic_count: None,
+            exemption: crate::types::statics::ActivationExemption::None,
+            activator: None,
+        })
+        .affected(TargetFilter::SelfRef)]
         .into();
     }
 

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -23097,6 +23097,81 @@ fn kozileks_command_modes_scry_draw_and_exile_graveyard_end_to_end() {
 
 const DEADLY_ORACLE: &str = "As an additional cost to cast this spell, you may collect evidence 6.\nDestroy all creatures. If evidence was collected, exile a card from an opponent's graveyard. Then search its owner's graveyard, hand, and library for any number of cards with that name and exile them. That player shuffles, then draws a card for each card exiled from their hand this way.";
 
+fn resolve_voltage_surge(
+    sacrifice_artifact: bool,
+) -> (
+    crate::game::scenario::CastOutcome,
+    ObjectId,
+    Option<ObjectId>,
+) {
+    use crate::game::scenario::{GameScenario, P0, P1};
+
+    const VOLTAGE_ORACLE: &str = "As an additional cost to cast this spell, you may sacrifice an artifact.\nVoltage Surge deals 2 damage to target creature or planeswalker. If this spell's additional cost was paid, Voltage Surge deals 4 damage instead.";
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::Red);
+    let target = scenario
+        .add_creature(P1, "Dennick, Pious Apprentice", 2, 5)
+        .id();
+    let artifact = sacrifice_artifact.then(|| {
+        let id = create_object(
+            &mut scenario.state,
+            CardId(91_001),
+            P0,
+            "Blood Token".to_string(),
+            Zone::Battlefield,
+        );
+        scenario
+            .state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Artifact);
+        id
+    });
+    let mut spell =
+        scenario.add_spell_to_hand_from_oracle(P0, "Voltage Surge", true, VOLTAGE_ORACLE);
+    spell.with_mana_cost(ManaCost::Cost {
+        shards: vec![ManaCostShard::Red],
+        generic: 0,
+    });
+    let spell_id = spell.id();
+    let mut runner = scenario.build();
+    let cast = runner.cast(spell_id).target_object(target);
+    let outcome = if let Some(artifact) = artifact {
+        cast.accept_optional().sacrifice_with(&[artifact]).resolve()
+    } else {
+        cast.decline_optional().resolve()
+    };
+    (outcome, target, artifact)
+}
+
+#[test]
+fn voltage_surge_deals_two_without_a_sacrificeable_artifact() {
+    let (outcome, target, artifact) = resolve_voltage_surge(false);
+    assert!(artifact.is_none());
+    assert_eq!(
+        outcome.state().objects[&target].damage_marked,
+        2,
+        "Voltage Surge must remain castable and deal 2 when its optional sacrifice cost is unavailable"
+    );
+}
+
+#[test]
+fn voltage_surge_deals_four_when_its_artifact_cost_is_paid() {
+    let (outcome, target, artifact) = resolve_voltage_surge(true);
+    let artifact = artifact.expect("artifact fixture must exist");
+    assert_eq!(
+        outcome.state().objects[&target].damage_marked,
+        4,
+        "paying Voltage Surge's optional sacrifice cost must replace 2 damage with 4"
+    );
+    outcome.assert_zone(&[artifact], Zone::Graveyard);
+}
+
 /// Deadly Cover-Up fixture: P1 owns two `Grizzly Bears` in GY + one in hand
 /// (same-named), a `Llanowar Elves` decoy in GY and hand, and a two-card library
 /// with no Bears (so a draw is the only library change). P0 owns a same-named

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -21341,6 +21341,101 @@ fn modal_kicker_declined_caps_modes_before_mode_choice() {
 }
 
 #[test]
+fn modal_kicker_skips_unpayable_kicker_before_mode_choice() {
+    let mut state = setup_game_at_main_phase();
+    let obj_id = create_kicker_modal_charm(&mut state, PlayerId(0));
+    add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
+
+    let mut events = Vec::new();
+    state.waiting_for =
+        handle_cast_spell(&mut state, PlayerId(0), obj_id, CardId(50), &mut events).unwrap();
+
+    match &state.waiting_for {
+        WaitingFor::ModeChoice {
+            modal,
+            pending_cast,
+            ..
+        } => {
+            assert_eq!(modal.max_choices, 1);
+            assert!(!pending_cast.ability.context.additional_cost_paid);
+            assert!(pending_cast.ability.context.kickers_paid.is_empty());
+        }
+        other => panic!("an unpayable kicker must not be offered, got {other:?}"),
+    }
+}
+
+#[test]
+fn modal_kicker_skips_only_the_unpayable_and_or_kicker() {
+    let mut state = setup_game_at_main_phase();
+    let obj_id = create_kicker_modal_charm(&mut state, PlayerId(0));
+    state.objects.get_mut(&obj_id).unwrap().additional_cost = Some(AdditionalCost::Kicker {
+        costs: vec![
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Green],
+                    generic: 0,
+                },
+            },
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Red],
+                    generic: 0,
+                },
+            },
+        ],
+        repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
+    });
+    add_mana(&mut state, PlayerId(0), ManaType::Red, 2);
+
+    let mut events = Vec::new();
+    state.waiting_for =
+        handle_cast_spell(&mut state, PlayerId(0), obj_id, CardId(50), &mut events).unwrap();
+
+    match &state.waiting_for {
+        WaitingFor::OptionalCostChoice {
+            cost: AdditionalCost::Kicker { costs, .. },
+            pending_cast,
+            ..
+        } => {
+            assert_eq!(
+                costs,
+                &vec![AbilityCost::Mana {
+                    cost: ManaCost::Cost {
+                        shards: vec![ManaCostShard::Red],
+                        generic: 0,
+                    },
+                }]
+            );
+            assert_eq!(pending_cast.declined_kickers, vec![KickerVariant::First]);
+            assert!(pending_cast.ability.context.kickers_paid.is_empty());
+        }
+        other => panic!("the payable second kicker must remain available, got {other:?}"),
+    }
+}
+
+#[test]
+fn kicked_spell_reducer_makes_kicker_offerable() {
+    let mut state = setup_game_at_main_phase();
+    let obj_id = create_kicker_modal_charm(&mut state, PlayerId(0));
+    state.objects.get_mut(&obj_id).unwrap().mana_cost = ManaCost::generic(1);
+    install_first_kicked_spell_reducer(&mut state, PlayerId(0));
+    add_mana(&mut state, PlayerId(0), ManaType::Green, 1);
+
+    let mut events = Vec::new();
+    state.waiting_for =
+        handle_cast_spell(&mut state, PlayerId(0), obj_id, CardId(50), &mut events).unwrap();
+
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::OptionalCostChoice {
+            cost: AdditionalCost::Kicker { .. },
+            ..
+        }
+    ));
+    assert!(state.pending_cast.is_none());
+}
+
+#[test]
 fn modal_kicker_paid_allows_extra_modes_and_reaches_stack_context() {
     let mut state = setup_game_at_main_phase();
     let obj_id = create_kicker_modal_charm(&mut state, PlayerId(0));
@@ -21766,6 +21861,7 @@ fn kicker_instead_target_declines_before_base_target_selection() {
     let mut state = setup_game_at_main_phase();
     let (spell_id, artifact_id, _) = create_kicker_instead_target_spell(&mut state);
     add_mana(&mut state, PlayerId(0), ManaType::Green, 1);
+    add_mana(&mut state, PlayerId(0), ManaType::Black, 1);
     add_mana(&mut state, PlayerId(0), ManaType::Colorless, 3);
 
     let mut events = Vec::new();

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1019,6 +1019,7 @@ fn fmt_typed_filter(tf: &TypedFilter) -> String {
             // CR 608.2c: "chosen this way" / a member of the resolution-chain set.
             FilterProp::InTrackedSet { .. } => parts.push("chosen this way".into()),
             FilterProp::HasXInManaCost => parts.push("with {X} in cost".into()),
+            FilterProp::HasAdventure => parts.push("with an Adventure".into()),
             FilterProp::WasKicked => parts.push("kicked".into()),
             FilterProp::HasXInActivationCost => parts.push("with {X} in activation cost".into()),
             FilterProp::HasManaAbility => parts.push("with a mana ability".into()),

--- a/crates/engine/src/game/effects/cloak.rs
+++ b/crates/engine/src/game/effects/cloak.rs
@@ -250,7 +250,7 @@ mod tests {
     fn disguise_creature(scenario: &mut GameScenario, name: &str) -> ObjectId {
         scenario
             .add_creature(P0, name, 2, 2)
-            .with_keyword(Keyword::Disguise(ManaCost::generic(3)))
+            .with_keyword(Keyword::Disguise(ManaCost::generic(3).into()))
             .id()
     }
 
@@ -386,7 +386,7 @@ mod tests {
         scenario.at_phase(Phase::PreCombatMain);
         let creature = scenario
             .add_creature(P0, "Countered Disguise", 2, 2)
-            .with_keyword(Keyword::Disguise(ManaCost::generic(3)))
+            .with_keyword(Keyword::Disguise(ManaCost::generic(3).into()))
             .with_plus_counters(1)
             .id();
         let spell = scenario

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -2409,7 +2409,7 @@ fn powerstone_ability() -> AbilityDefinition {
             },
             restrictions: vec![ManaSpendRestriction::SpellTypeOrAbilityActivation {
                 spell_type: "Artifact".to_string(),
-                ability: crate::types::mana::AbilityActivationScope::OfSpellType,
+                ability: crate::types::mana::AbilityActivationScope::Any,
             }],
             grants: vec![],
             expiry: None,
@@ -4070,7 +4070,19 @@ mod tests {
     fn predefined_powerstone_has_colorless_mana() {
         let abilities = predefined_token_abilities("Powerstone");
         assert_eq!(abilities.len(), 1);
-        assert!(matches!(*abilities[0].effect, Effect::Mana { .. }));
+        assert!(matches!(
+            *abilities[0].effect,
+            Effect::Mana {
+                ref restrictions,
+                ..
+            } if matches!(
+                restrictions.as_slice(),
+                [crate::types::ability::ManaSpendRestriction::SpellTypeOrAbilityActivation {
+                    spell_type,
+                    ability: crate::types::mana::AbilityActivationScope::Any,
+                }] if spell_type == "Artifact"
+            )
+        ));
     }
 
     #[test]

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5022,14 +5022,6 @@ fn apply_action(
                                 "Cannot pay life for shard — only mana available".to_string(),
                             ));
                         }
-                        (
-                            crate::types::game_state::ShardChoice::PayMana,
-                            crate::types::game_state::ShardOptions::LifeOnly,
-                        ) => {
-                            return Err(EngineError::ActionNotAllowed(
-                                "Cannot pay mana for shard — only life available".to_string(),
-                            ));
-                        }
                         _ => {}
                     }
                 }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5013,16 +5013,14 @@ fn apply_action(
                     ));
                 }
                 for (choice, shard) in choices.iter().zip(current_shards.iter()) {
-                    match (choice, shard.options) {
-                        (
-                            crate::types::game_state::ShardChoice::PayLife,
-                            crate::types::game_state::ShardOptions::ManaOnly,
-                        ) => {
-                            return Err(EngineError::ActionNotAllowed(
-                                "Cannot pay life for shard — only mana available".to_string(),
-                            ));
-                        }
-                        _ => {}
+                    if let (
+                        crate::types::game_state::ShardChoice::PayLife,
+                        crate::types::game_state::ShardOptions::ManaOnly,
+                    ) = (choice, shard.options)
+                    {
+                        return Err(EngineError::ActionNotAllowed(
+                            "Cannot pay life for shard — only mana available".to_string(),
+                        ));
                     }
                 }
                 if !casting::pending_phyrexian_route_is_payable(

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3985,6 +3985,24 @@ fn apply_action(
                     &chosen,
                     &mut events,
                 )?,
+                // CR 601.2h: A ChangeZone effect-as-cost carries the optional
+                // any-number exile selection and its cast-time reduction.
+                PayCostKind::ExileFromZone { zone }
+                    if paid_cost.as_ref().is_some_and(|payment| {
+                        casting_costs::is_exile_any_number_effect_cost(payment.cost)
+                    }) =>
+                {
+                    casting_costs::handle_exile_any_number_for_cost(
+                        state,
+                        *player,
+                        *zone,
+                        *pending_cast.clone(),
+                        *count,
+                        choices,
+                        &chosen,
+                        &mut events,
+                    )?
+                }
                 PayCostKind::ExileFromZone { zone } => engine_casting::handle_exile_for_cost(
                     state,
                     *player,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5033,6 +5033,16 @@ fn apply_action(
                         _ => {}
                     }
                 }
+                if !casting::pending_phyrexian_route_is_payable(
+                    state,
+                    player,
+                    spell_object,
+                    &choices,
+                ) {
+                    return Err(EngineError::ActionNotAllowed(
+                        "Cannot pay mana cost with selected Phyrexian route".to_string(),
+                    ));
+                }
             }
             // CR 118.3a: `finalize_mana_payment_with_phyrexian_choices` clears
             // `active_payment_pins` itself on every Ok/Err path; no caller clear.

--- a/crates/engine/src/game/engine_mdfc_land_tests.rs
+++ b/crates/engine/src/game/engine_mdfc_land_tests.rs
@@ -547,6 +547,80 @@ fn spell_mdfc_castable_when_only_back_face_affordable() {
     );
 }
 
+#[test]
+fn spell_mdfc_offers_only_the_affordable_face_after_cast_choice() {
+    use crate::types::mana::ManaType;
+    let mut state = setup_game_at_main_phase();
+    let (obj_id, card_id) = create_spell_mdfc_in_hand(&mut state);
+    add_pool_mana(
+        &mut state,
+        PlayerId(0),
+        &[
+            ManaType::White,
+            ManaType::Blue,
+            ManaType::Black,
+            ManaType::Red,
+            ManaType::Green,
+        ],
+    );
+
+    let result = apply_as_current(
+        &mut state,
+        GameAction::CastSpell {
+            object_id: obj_id,
+            card_id,
+            targets: vec![],
+            payment_mode: crate::types::game_state::CastPaymentMode::Auto,
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ModalFaceChoice { .. }
+    ));
+
+    let actions = crate::ai_support::legal_actions(&state);
+    assert!(actions.contains(&GameAction::ChooseModalFace { back_face: true }));
+    assert!(
+        !actions.contains(&GameAction::ChooseModalFace { back_face: false }),
+        "the unaffordable front face must not be offered after the cast begins: {actions:?}"
+    );
+}
+
+#[test]
+fn spell_mdfc_does_not_offer_unaffordable_back_face_after_cast_choice() {
+    use crate::types::mana::ManaType;
+    let mut state = setup_game_at_main_phase();
+    let (obj_id, card_id) = create_spell_mdfc_in_hand(&mut state);
+    add_pool_mana(
+        &mut state,
+        PlayerId(0),
+        &[ManaType::White, ManaType::Green, ManaType::Green],
+    );
+
+    let result = apply_as_current(
+        &mut state,
+        GameAction::CastSpell {
+            object_id: obj_id,
+            card_id,
+            targets: vec![],
+            payment_mode: crate::types::game_state::CastPaymentMode::Auto,
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ModalFaceChoice { .. }
+    ));
+
+    let actions = crate::ai_support::legal_actions(&state);
+    assert!(actions.contains(&GameAction::ChooseModalFace { back_face: false }));
+    assert!(
+        !actions.contains(&GameAction::ChooseModalFace { back_face: true }),
+        "the unaffordable back face must not be offered after the cast begins: {actions:?}"
+    );
+}
+
 // CR 712.11b: Casting a spell//spell MDFC prompts a face choice, and choosing
 // the back face puts the back-face spell on the stack.
 #[test]

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -9018,7 +9018,7 @@ fn disguise_face_down_has_ward_morph_does_not() {
 
     assert!(
         cast_face_down(crate::types::keywords::Keyword::Disguise(
-            ManaCost::generic(4)
+            ManaCost::generic(4).into()
         )),
         "CR 702.168a: a disguise face-down 2/2 must have ward {{2}}"
     );

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -194,6 +194,7 @@ fn filter_prop_uses_object_population(prop: &FilterProp) -> bool {
         | FilterProp::InZone { .. }
         | FilterProp::Owned { .. }
         | FilterProp::Foretold
+        | FilterProp::HasAdventure
         | FilterProp::EnchantedBy
         | FilterProp::EquippedBy
         | FilterProp::AttachedToSource
@@ -435,6 +436,7 @@ fn entered_object_perturbs_filter_prop(
         | FilterProp::InZone { .. }
         | FilterProp::Owned { .. }
         | FilterProp::Foretold
+        | FilterProp::HasAdventure
         | FilterProp::EnchantedBy
         | FilterProp::EquippedBy
         | FilterProp::AttachedToSource
@@ -3328,6 +3330,7 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         | FilterProp::Counters { .. }
         | FilterProp::Owned { .. }
         | FilterProp::Foretold
+        | FilterProp::HasAdventure
         | FilterProp::EnchantedBy
         | FilterProp::EquippedBy
         | FilterProp::AttachedToSource
@@ -3848,6 +3851,11 @@ fn matches_filter_prop(
         // CR 702.143c-d: Foretold is a designation of a card in exile, tracked
         // directly on the object. It is not equivalent to `KeywordKind::Foretell`.
         FilterProp::Foretold => obj.foretold,
+        // CR 715.2: A card has an Adventure when its stored alternate face is
+        // an Adventure face; the front face is normally a permanent card.
+        FilterProp::HasAdventure => obj.back_face.as_ref().is_some_and(|face| {
+            face.layout_kind == Some(crate::types::card::LayoutKind::Adventure)
+        }),
         // CR 107.3 + CR 202.1: "spell with {X} in its mana cost" — inspects the
         // printed mana cost for an `{X}` shard. Applies to spells on the stack
         // and to any live-object evaluation path (e.g. static-ability filters).
@@ -4998,6 +5006,7 @@ fn zone_change_record_matches_property(
         | FilterProp::FaceDown
         | FilterProp::Transformed
         | FilterProp::Foretold
+        | FilterProp::HasAdventure
         // CR 201.2: Name-matches-any-permanent is a live-battlefield predicate
         // — a zone-change snapshot cannot represent it. Fail closed.
         | FilterProp::NameMatchesAnyPermanent { .. } => false,

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -568,6 +568,37 @@ fn is_phyrexian_requirement(req: &ShardRequirement) -> bool {
     )
 }
 
+/// CR 107.4f + CR 601.2h: Build the mana demand for auto-tapping after the
+/// player has chosen mana or life for each Phyrexian-shaped shard. A shard
+/// paid with life must not cause an otherwise-unused mana source to tap.
+pub(super) fn mana_cost_for_phyrexian_choices(
+    cost: &ManaCost,
+    choices: &[ShardChoice],
+    life_colors: crate::types::mana::LifePaymentColors,
+) -> ManaCost {
+    let ManaCost::Cost { shards, generic } = cost else {
+        return cost.clone();
+    };
+    let mut choice_index = 0usize;
+    let shards = shards
+        .iter()
+        .copied()
+        .filter(|shard| {
+            let requirement = effective_shard_requirement(shard_to_mana_type(*shard), life_colors);
+            if !is_phyrexian_requirement(&requirement) {
+                return true;
+            }
+            let keep = !matches!(choices.get(choice_index), Some(ShardChoice::PayLife));
+            choice_index += 1;
+            keep
+        })
+        .collect();
+    ManaCost::Cost {
+        shards,
+        generic: *generic,
+    }
+}
+
 /// CR 107.4f + CR 118.3: Order shard indices so every non-Phyrexian shard is
 /// resolved before any Phyrexian-shape shard, mirroring `can_pay_for_spell`'s
 /// deferral. Deciding a Phyrexian shard against the pool *after* strict

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -1464,10 +1464,11 @@ pub fn compute_phyrexian_shards(
     let mut sim = pool.clone();
     let mut results = Vec::new();
     let mut preferred_hybrid_colors: Vec<(ManaType, ManaType, ManaType)> = Vec::new();
-    // CR 107.4f + CR 118.3 + CR 119.8: Mana preference within the dry-run matches
-    // `pay_cost_with_demand_and_choices`' auto-decision. `life_budget` tracks how many
-    // life payments remain unspent — once exhausted, subsequent shards report `ManaOnly`
-    // (or `LifeOnly`/unpayable would have failed `can_pay_for_spell` upstream).
+    // CR 107.4f + CR 118.3 + CR 119.8: Strict shards and forced Phyrexian
+    // payments consume the simulated resources. A ManaOrLife shard must leave
+    // both resources uncommitted: another identical shard may legally take the
+    // contested mana while this one pays life. Aggregate route feasibility is
+    // checked when the complete choice vector is generated and submitted.
     let mut life_budget = max_life_payments;
 
     // CR 107.4f + CR 118.3: Resolve non-Phyrexian shards first (consuming their
@@ -1520,15 +1521,13 @@ pub fn compute_phyrexian_shards(
                     color: mana_type_to_color_fallback(color),
                     options,
                 });
-                // Simulated commit: prefer mana path for later shard availability;
-                // if mana is unavailable or would starve generic, consume life budget.
-                if effective_mana {
+                if matches!(options, ShardOptions::ManaOnly) {
                     let _ = if any_color {
                         spend_any_for_required_colors(&mut sim, &[color], spell, None, &[])
                     } else {
                         spend_eligible(&mut sim, color, spell, &[])
                     };
-                } else {
+                } else if matches!(options, ShardOptions::LifeOnly) {
                     life_budget = life_budget.saturating_sub(1);
                 }
             }
@@ -1586,7 +1585,7 @@ pub fn compute_phyrexian_shards(
                     color: mana_type_to_color_fallback(a),
                     options,
                 });
-                if effective_mana {
+                if matches!(options, ShardOptions::ManaOnly) {
                     let _ = if any_color {
                         spend_any_for_required_colors(&mut sim, &[a, b], spell, None, &[])
                     } else {
@@ -1602,7 +1601,7 @@ pub fn compute_phyrexian_shards(
                         );
                         spend_eligible(&mut sim, color, spell, &[])
                     };
-                } else {
+                } else if matches!(options, ShardOptions::LifeOnly) {
                     life_budget = life_budget.saturating_sub(1);
                 }
             }
@@ -1642,7 +1641,7 @@ pub fn compute_phyrexian_shards(
                     color: mana_type_to_color_fallback(color),
                     options,
                 });
-                if effective_mana {
+                if matches!(options, ShardOptions::ManaOnly) {
                     // Mirror `pay_cost_with_demand_and_choices`'s preference:
                     // prefer 1 colored, then atomic 2-generic fallback.
                     if any_color {
@@ -1655,7 +1654,7 @@ pub fn compute_phyrexian_shards(
                             sim = backup;
                         }
                     }
-                } else {
+                } else if matches!(options, ShardOptions::LifeOnly) {
                     life_budget = life_budget.saturating_sub(1);
                 }
             }

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -1430,35 +1430,39 @@ fn group_profiles_by_object(
     grouped.into_iter().collect()
 }
 
-fn apply_profile_kind(
+fn profile_applications(
     profile: &ActivatableManaProfileKind,
     requirements: &[Vec<ManaType>],
-) -> Option<(Vec<Vec<ManaType>>, u32)> {
+) -> Vec<(Vec<Vec<ManaType>>, u32)> {
     match profile {
         ActivatableManaProfileKind::Exact(types) => {
             let mut remaining = requirements.to_vec();
             for mana_type in types {
-                let pos = remaining.iter().position(|opts| opts.contains(mana_type))?;
+                let Some(pos) = remaining.iter().position(|opts| opts.contains(mana_type)) else {
+                    return Vec::new();
+                };
                 remaining.remove(pos);
             }
-            Some((remaining, types.len() as u32))
+            vec![(remaining, types.len() as u32)]
         }
-        ActivatableManaProfileKind::AnyOneColor { count, options } => {
-            options.iter().find_map(|&color| {
-                combination_assign(*count, std::slice::from_ref(&color), requirements)
+        ActivatableManaProfileKind::AnyOneColor { count, options } => options
+            .iter()
+            .flat_map(|&color| {
+                combination_assignments(*count, std::slice::from_ref(&color), requirements)
             })
-        }
+            .collect(),
         ActivatableManaProfileKind::AnyCombination { count, options } => {
-            combination_assign(*count, options, requirements)
+            combination_assignments(*count, options, requirements)
         }
-        ActivatableManaProfileKind::CombinationChoices(choices) => {
-            choices.iter().find_map(|choice| {
-                apply_profile_kind(
+        ActivatableManaProfileKind::CombinationChoices(choices) => choices
+            .iter()
+            .flat_map(|choice| {
+                profile_applications(
                     &ActivatableManaProfileKind::Exact(choice.clone()),
                     requirements,
                 )
             })
-        }
+            .collect(),
     }
 }
 
@@ -1479,7 +1483,7 @@ fn assign_profiles_to_requirements(
         return Some(consumed);
     }
     for profile in &objects[object_index].1 {
-        if let Some((remaining, consumed)) = apply_profile_kind(profile, &requirements) {
+        for (remaining, consumed) in profile_applications(profile, &requirements) {
             if let Some(rest) =
                 assign_profiles_to_requirements(objects, object_index + 1, remaining)
             {
@@ -1490,21 +1494,26 @@ fn assign_profiles_to_requirements(
     None
 }
 
-fn combination_assign(
+/// CR 106.1 + CR 601.2g: Enumerate the colored shards one flexible source can
+/// cover, allowing later sources to cover the remainder. A one-mana
+/// `AnyOneColor` source must not be rejected simply because the spell has two
+/// colored shards; Relic of Legends plus a dual land is the common case.
+fn combination_assignments(
     count: u32,
     options: &[ManaType],
     requirements: &[Vec<ManaType>],
-) -> Option<(Vec<Vec<ManaType>>, u32)> {
+) -> Vec<(Vec<Vec<ManaType>>, u32)> {
     if requirements.is_empty() {
         // All shards are covered; any leftover `count` is simply surplus mana
         // the player never produces (or lets drain). Rejecting over-production
         // here would falsely mark e.g. a power-3 combination source as unable
         // to pay a two-shard cost.
-        return Some((Vec::new(), 0));
+        return vec![(Vec::new(), 0)];
     }
     if count == 0 {
-        return None;
+        return vec![(requirements.to_vec(), 0)];
     }
+    let mut applications = Vec::new();
     for (index, payment_options) in requirements.iter().enumerate() {
         for &color in payment_options {
             if !options.contains(&color) {
@@ -1512,14 +1521,14 @@ fn combination_assign(
             }
             let mut next_requirements = requirements.to_vec();
             next_requirements.remove(index);
-            if let Some((remaining, inner)) =
-                combination_assign(count - 1, options, &next_requirements)
+            for (remaining, inner) in
+                combination_assignments(count - 1, options, &next_requirements)
             {
-                return Some((remaining, 1 + inner));
+                applications.push((remaining, 1 + inner));
             }
         }
     }
-    None
+    applications
 }
 
 fn assign_profiles_to_shards(

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -1173,7 +1173,11 @@ pub(crate) fn feasible_mana_capacity(
     match explicit_max {
         Some(amount) => amount,
         // CR 305.1: Subtype-only basic-land fallback (same as `max_mana_yield`).
-        None if !activatable_mana_options(state, object_id, controller).is_empty() => 1,
+        None if obj.card_types.core_types.contains(&CoreType::Land)
+            && !activatable_mana_options(state, object_id, controller).is_empty() =>
+        {
+            1
+        }
         None => 0,
     }
 }

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -1769,7 +1769,14 @@ fn scan_mana_abilities(
         let penalty = object_mana_ability_penalty(state, object_id, ability);
         let source_could_produce_two_or_more_colors =
             source_could_produce_two_or_more_colors(state, object_id, controller);
-        for row in emit_source_rows(state, controller, object_id, ability_index, ability) {
+        for row in emit_source_rows(
+            state,
+            controller,
+            object_id,
+            ability_index,
+            ability,
+            require_current_payability,
+        ) {
             let option = ManaSourceOption {
                 object_id,
                 ability_index: Some(ability_index),
@@ -1803,6 +1810,7 @@ fn emit_source_rows(
     object_id: ObjectId,
     _ability_index: usize,
     ability: &AbilityDefinition,
+    require_current_payability: bool,
 ) -> Vec<SourceRow> {
     let Effect::Mana {
         produced,
@@ -1847,6 +1855,21 @@ fn emit_source_rows(
                 atomic_combination: (types.len() > 1).then_some(types),
                 restrictions: concrete_restrictions.clone(),
             }]
+        }
+        // CR 106.5: a pure chosen-color source with no color chosen cannot
+        // produce mana. Display/preview paths may show all five colors, but
+        // auto-tap must not plan a payment around an undefined mana type.
+        ManaProduction::ChosenColor {
+            fixed_alternative: None,
+            ..
+        } if !require_current_payability
+            && state
+                .objects
+                .get(&object_id)
+                .and_then(|obj| obj.chosen_color())
+                .is_none() =>
+        {
+            Vec::new()
         }
         _ => mana_options_from_production(state, controller, object_id, produced)
             .into_iter()

--- a/crates/engine/src/game/marksman_tests.rs
+++ b/crates/engine/src/game/marksman_tests.rs
@@ -15,7 +15,9 @@ use crate::game::ability_utils::build_resolved_from_def;
 use crate::game::effects::resolve_ability_chain;
 use crate::game::scenario::GameScenario;
 use crate::parser::oracle::{parse_oracle_text, ParsedAbilities};
-use crate::types::ability::{ModalChoice, QuantityExpr, QuantityRef, TargetRef};
+use crate::types::ability::{
+    AbilityCondition, Effect, ModalChoice, QuantityExpr, QuantityRef, TargetRef,
+};
 use crate::types::actions::GameAction;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::mana::{ManaType, ManaUnit};
@@ -28,6 +30,12 @@ const HAWKEYE_ORACLE: &str = "First strike, reach\n\
      • Net — Target creature can't block this turn.\n\
      • Explosive — Hawkeye deals 2 damage to target player.\n\
      • Boomerang — Discard a card, then draw a card.";
+
+const FRILLBACK_ORACLE: &str = "When this creature enters, you may pay {G} up to three times. \
+     When you pay this cost one or more times, choose up to that many —\n\
+     • Destroy target artifact or enchantment.\n\
+     • Exile target player's graveyard.\n\
+     • You gain 4 life.";
 
 const P0: PlayerId = PlayerId(0);
 const P1: PlayerId = PlayerId(1);
@@ -79,6 +87,71 @@ fn hawkeye_modal_parses_with_resolution_local_dynamic_cap() {
         }),
         "the cap binds to the resolution-local repeated-payment count"
     );
+}
+
+#[test]
+fn tranquil_frillback_parses_as_repeated_green_payment_modal() {
+    let parsed = parse_oracle_text(
+        FRILLBACK_ORACLE,
+        "Tranquil Frillback",
+        &[],
+        &["Creature".to_string()],
+        &["Dinosaur".to_string()],
+    );
+    let execute = parsed.triggers[0].execute.as_deref().expect("ETB execute");
+    assert!(matches!(execute.effect.as_ref(), Effect::PayCost { .. }));
+    assert!(execute.optional);
+    assert_eq!(execute.repeat_for, Some(QuantityExpr::Fixed { value: 3 }));
+    let modal = execute.sub_ability.as_deref().expect("reflexive modal");
+    assert_eq!(modal.condition, Some(AbilityCondition::WhenYouDo));
+    assert_eq!(
+        modal
+            .modal
+            .as_ref()
+            .and_then(|modal| modal.dynamic_max_choices.clone()),
+        Some(QuantityExpr::Ref {
+            qty: QuantityRef::TimesCostPaidThisResolution
+        })
+    );
+}
+
+#[test]
+fn tranquil_frillback_paying_once_and_choosing_life_gains_four() {
+    let mut scenario = GameScenario::new();
+    scenario.with_life(P0, 20);
+    let frillback = scenario
+        .add_creature_from_oracle(P0, "Tranquil Frillback", 3, 3, FRILLBACK_ORACLE)
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(
+            ManaType::Green,
+            crate::types::identifiers::ObjectId(9_999),
+            false,
+            vec![],
+        )],
+    );
+    let mut runner = scenario.build();
+    let parsed = parse_oracle_text(
+        FRILLBACK_ORACLE,
+        "Tranquil Frillback",
+        &[],
+        &["Creature".to_string()],
+        &["Dinosaur".to_string()],
+    );
+    let execute = parsed.triggers[0].execute.as_deref().expect("ETB execute");
+    let resolved = build_resolved_from_def(execute, frillback, P0);
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut Vec::new(), 0)
+        .expect("resolve Frillback ETB");
+
+    decide(&mut runner, true);
+    decide(&mut runner, false);
+    assert_eq!(modal_cap(runner.state()), Some((0, 1)));
+    runner
+        .act(GameAction::SelectModes { indices: vec![2] })
+        .expect("select Frillback life mode");
+    runner.advance_until_stack_empty();
+    assert_eq!(runner.state().players[0].life, 24);
 }
 
 // ── Runtime harness ─────────────────────────────────────────────────────

--- a/crates/engine/src/game/morph.rs
+++ b/crates/engine/src/game/morph.rs
@@ -271,7 +271,34 @@ pub(crate) fn turn_face_up_prepare(
         .keywords
         .iter()
         .find_map(|k| match k {
-            Keyword::Morph(c) | Keyword::Megamorph(c) | Keyword::Disguise(c) => Some(c.clone()),
+            Keyword::Morph(c) | Keyword::Megamorph(c) => Some(c.clone()),
+            Keyword::Disguise(crate::types::keywords::DisguiseCost::Mana(c)) => Some(c.clone()),
+            Keyword::Disguise(crate::types::keywords::DisguiseCost::Reduced {
+                cost,
+                reduction,
+            }) => {
+                let condition_met = reduction.condition.as_ref().is_none_or(|condition| {
+                    crate::game::restrictions::evaluate_condition(
+                        state, player, object_id, condition,
+                    )
+                });
+                let count = if condition_met {
+                    crate::game::quantity::resolve_quantity(
+                        state,
+                        &reduction.count,
+                        player,
+                        object_id,
+                    )
+                    .max(0) as u32
+                } else {
+                    0
+                };
+                let mut cost = cost.clone();
+                if let ManaCost::Cost { generic, .. } = &mut cost {
+                    *generic = generic.saturating_sub(reduction.amount_per.saturating_mul(count));
+                }
+                Some(cost)
+            }
             _ => None,
         })
         .or_else(|| {
@@ -551,6 +578,58 @@ mod tests {
         assert!(obj.keywords.is_empty());
         assert!(obj.abilities.is_empty());
         assert!(obj.color.is_empty());
+    }
+
+    /// CR 702.168d + CR 118.7a: Fugitive Codebreaker's disguise discount is
+    /// evaluated when the special action is taken and cannot reduce the red pip.
+    #[test]
+    fn disguise_turn_face_up_cost_counts_instant_and_sorcery_cards() {
+        use crate::types::ability::{CostReduction, CountScope, QuantityRef, TypeFilter, ZoneRef};
+        use crate::types::keywords::DisguiseCost;
+        use crate::types::mana::ManaCostShard;
+
+        let mut state = GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let id = setup_morph_creature(&mut state, player);
+        state.objects.get_mut(&id).unwrap().keywords =
+            vec![Keyword::Disguise(DisguiseCost::Reduced {
+                cost: ManaCost::Cost {
+                    generic: 5,
+                    shards: vec![ManaCostShard::Red],
+                },
+                reduction: Box::new(CostReduction {
+                    amount_per: 1,
+                    count: QuantityExpr::Ref {
+                        qty: QuantityRef::ZoneCardCount {
+                            zone: ZoneRef::Graveyard,
+                            card_types: vec![TypeFilter::Instant, TypeFilter::Sorcery],
+                            filter: None,
+                            scope: CountScope::Controller,
+                        },
+                    },
+                    condition: None,
+                }),
+            })];
+        for (offset, card_type) in [CoreType::Instant, CoreType::Sorcery, CoreType::Creature]
+            .into_iter()
+            .enumerate()
+        {
+            let gy = create_object(
+                &mut state,
+                CardId(20 + offset as u64),
+                player,
+                format!("GY{offset}"),
+                Zone::Graveyard,
+            );
+            state.objects.get_mut(&gy).unwrap().card_types.core_types = vec![card_type];
+        }
+        play_face_down(&mut state, player, id, &mut Vec::new()).unwrap();
+        let cost = turn_face_up_prepare(&state, id, player).expect("disguise can turn face up");
+        assert!(matches!(
+            cost,
+            ManaCost::Cost { generic: 3, shards }
+                if shards.as_slice() == [ManaCostShard::Red]
+        ));
     }
 
     /// CR 616.1 + CR 708.3 discriminating test (fail-first): a face-down morph

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -22120,6 +22120,11 @@ pub mod tests {
     fn printed_casualty_no_copy_when_not_paid() {
         let mut state = setup();
         let caster = PlayerId(0);
+        let mut face = crate::types::card::CardFace::default();
+        face.card_type.core_types.push(CoreType::Instant);
+        face.keywords.push(Keyword::Casualty(2));
+        crate::database::synthesis::synthesize_casualty(&mut face);
+        let casualty_trigger = face.triggers.remove(0);
 
         let spell = create_object(
             &mut state,
@@ -22140,6 +22145,7 @@ pub mod tests {
                 repeatability: crate::types::ability::AdditionalCostRepeatability::Once,
             });
             obj.keywords.push(Keyword::Casualty(2));
+            obj.trigger_definitions.push(casualty_trigger);
         }
         let ability = ResolvedAbility::new(
             Effect::Draw {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -22336,26 +22336,91 @@ pub mod tests {
             "Kicked Creature".to_string(),
             Zone::Battlefield,
         );
+        let condition = TriggerCondition::AdditionalCostPaid {
+            source: crate::types::ability::AdditionalCostPaymentSource::Kicker,
+            origin: None,
+            origin_ordinal: None,
+            variant: None,
+            kicker_cost: None,
+            min_count: 2,
+        };
         state
             .objects
             .get_mut(&source)
             .unwrap()
             .kickers_paid
-            .extend([KickerVariant::First, KickerVariant::First]);
+            .push(KickerVariant::First);
 
-        assert!(check_trigger_condition(
+        assert!(!check_trigger_condition(
             &state,
-            &TriggerCondition::AdditionalCostPaid {
-                source: crate::types::ability::AdditionalCostPaymentSource::Kicker,
-                origin: None,
-                origin_ordinal: None,
-                variant: None,
-                kicker_cost: None,
-                min_count: 2,
-            },
+            &condition,
             PlayerId(0),
             Some(source),
             None,
+        ));
+
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .kickers_paid
+            .push(KickerVariant::Second);
+
+        assert!(check_trigger_condition(
+            &state,
+            &condition,
+            PlayerId(0),
+            Some(source),
+            None,
+        ));
+    }
+
+    #[test]
+    fn additional_cost_paid_checks_bargained_entering_object() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Bargained Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let event = zone_changed_event(
+            source,
+            Zone::Stack,
+            Zone::Battlefield,
+            vec![CoreType::Creature],
+            vec![],
+        );
+        let condition = TriggerCondition::AdditionalCostPaid {
+            source: crate::types::ability::AdditionalCostPaymentSource::NonKicker,
+            origin: None,
+            origin_ordinal: None,
+            variant: None,
+            kicker_cost: None,
+            min_count: 1,
+        };
+
+        assert!(!check_trigger_condition(
+            &state,
+            &condition,
+            PlayerId(0),
+            Some(source),
+            Some(&event),
+        ));
+
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .additional_cost_payment_count = 1;
+
+        assert!(check_trigger_condition(
+            &state,
+            &condition,
+            PlayerId(0),
+            Some(source),
+            Some(&event),
         ));
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -22430,6 +22430,71 @@ pub mod tests {
         ));
     }
 
+    #[test]
+    fn bargained_etb_does_not_accept_an_unrelated_additional_cost() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Realm-Scorcher Hellkite".to_string(),
+            Zone::Battlefield,
+        );
+        let event = zone_changed_event(
+            source,
+            Zone::Stack,
+            Zone::Battlefield,
+            vec![CoreType::Creature],
+            vec![],
+        );
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Bargain\nWhen this creature enters, if it was bargained, add four mana in any combination of colors.",
+            "Realm-Scorcher Hellkite",
+            &[String::from("Bargain")],
+            &[String::from("Creature")],
+            &[String::from("Dragon")],
+        );
+        let condition = parsed.triggers[0]
+            .condition
+            .as_ref()
+            .expect("bargained ETB must have an intervening-if condition");
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .additional_cost_payments =
+            vec![crate::types::ability::AdditionalCostInstancePayment::new(
+                AdditionalCostOrigin::Other,
+                1,
+            )];
+
+        assert!(!check_trigger_condition(
+            &state,
+            condition,
+            PlayerId(0),
+            Some(source),
+            Some(&event),
+        ));
+
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .additional_cost_payments =
+            vec![crate::types::ability::AdditionalCostInstancePayment::new(
+                AdditionalCostOrigin::Bargain,
+                1,
+            )];
+
+        assert!(check_trigger_condition(
+            &state,
+            condition,
+            PlayerId(0),
+            Some(source),
+            Some(&event),
+        ));
+    }
+
     /// CR 121.1 + CR 504.1 + CR 603.4 — `ExceptFirstDrawInDrawStep` gates
     /// Orcish Bowmasters' trigger so the active player's mandatory first draw
     /// of their draw step does NOT fire it. Subsequent draws (extra draws,

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1,9 +1,9 @@
-use nom::Parser;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till1, take_until};
 use nom::character::complete::{multispace0, multispace1, satisfy};
 use nom::combinator::{all_consuming, eof, map, not, opt, peek, rest, value, verify};
 use nom::sequence::{preceded, terminated};
+use nom::Parser;
 
 use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower, split_once_on_lower};
 use super::super::oracle_nom::duration::{
@@ -21,7 +21,7 @@ use super::super::oracle_target::{
     parse_anaphoric_target_ref, parse_target, parse_target_with_ctx, parse_that_clause_suffix,
     parse_type_phrase_with_ctx,
 };
-use super::super::oracle_util::{TextPair, parse_comparator_prefix, parse_count_expr, strip_after};
+use super::super::oracle_util::{parse_comparator_prefix, parse_count_expr, strip_after, TextPair};
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
@@ -11426,17 +11426,15 @@ mod token_anaphor_rewrite_tests {
     #[test]
     fn generic_effect_rewrites_outer_target_without_inner_affected_rewrite() {
         let mut effect = Effect::GenericEffect {
-            static_abilities: vec![
-                StaticDefinition::continuous()
-                    .affected(TargetFilter::Typed(TypedFilter::creature()))
-                    .modifications(vec![ContinuousModification::GrantStaticAbility {
-                        definition: Box::new(
-                            StaticDefinition::continuous()
-                                .affected(TargetFilter::Typed(TypedFilter::creature()))
-                                .modifications(vec![ContinuousModification::AddPower { value: 1 }]),
-                        ),
-                    }]),
-            ],
+            static_abilities: vec![StaticDefinition::continuous()
+                .affected(TargetFilter::Typed(TypedFilter::creature()))
+                .modifications(vec![ContinuousModification::GrantStaticAbility {
+                    definition: Box::new(
+                        StaticDefinition::continuous()
+                            .affected(TargetFilter::Typed(TypedFilter::creature()))
+                            .modifications(vec![ContinuousModification::AddPower { value: 1 }]),
+                    ),
+                }])],
             duration: None,
             target: Some(TargetFilter::ParentTarget),
         };

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1,9 +1,9 @@
+use nom::Parser;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till1, take_until};
 use nom::character::complete::{multispace0, multispace1, satisfy};
 use nom::combinator::{all_consuming, eof, map, not, opt, peek, rest, value, verify};
 use nom::sequence::{preceded, terminated};
-use nom::Parser;
 
 use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower, split_once_on_lower};
 use super::super::oracle_nom::duration::{
@@ -21,7 +21,7 @@ use super::super::oracle_target::{
     parse_anaphoric_target_ref, parse_target, parse_target_with_ctx, parse_that_clause_suffix,
     parse_type_phrase_with_ctx,
 };
-use super::super::oracle_util::{parse_comparator_prefix, parse_count_expr, strip_after, TextPair};
+use super::super::oracle_util::{TextPair, parse_comparator_prefix, parse_count_expr, strip_after};
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
@@ -1073,8 +1073,8 @@ pub(super) fn attach_graveyard_redirect_rider_to_prior_cast_from_zone(
     true
 }
 
-/// CR 601.2f: Detect the "each spell cast this way costs {N} more to cast"
-/// rider sentence (Lightstall Inquisitor) and return the cost increase. This is
+/// CR 601.2f: Detect an "each/a spell cast this way costs {N} more to cast"
+/// rider sentence (Lightstall Inquisitor, Invasion of Gobakhan) and return the cost increase. This is
 /// a cost-raise scoped to spells cast via the immediately-preceding
 /// `PlayFromExile` grant ("this way" = the just-granted exile play), not a
 /// global static cost increase — so it folds into the grant's `cast_cost_raise`
@@ -1091,7 +1091,11 @@ pub(super) fn cast_cost_raise_rider(clause: &ClauseIr) -> Option<ManaCost> {
         clause.source.fragment().unwrap_or_default().trim(),
         lower.trim(),
         |i| {
-            let (i, _) = tag("each spell cast this way costs ").parse(i)?;
+            let (i, _) = alt((
+                tag("each spell cast this way costs "),
+                tag("a spell cast this way costs "),
+            ))
+            .parse(i)?;
             let (i, cost) = nom_primitives::parse_mana_cost(i)?;
             let (i, _) = tag(" more to cast").parse(i)?;
             let (i, _) = opt(tag(".")).parse(i)?;
@@ -10538,7 +10542,9 @@ mod tests {
             collect(&def, &mut effects);
 
             assert!(
-                effects.iter().any(|e| matches!(e, Effect::ExtraTurn { .. })),
+                effects
+                    .iter()
+                    .any(|e| matches!(e, Effect::ExtraTurn { .. })),
                 "expected an ExtraTurn effect in {text:?}, got {effects:?}"
             );
             let delayed_lose = effects.iter().any(|e| {
@@ -10557,7 +10563,7 @@ mod tests {
             assert!(
                 delayed_lose,
                 "expected a delayed LoseTheGame at the extra turn's end step in {text:?}, got {effects:?}"
-                        );
+            );
         }
     }
 
@@ -11420,15 +11426,17 @@ mod token_anaphor_rewrite_tests {
     #[test]
     fn generic_effect_rewrites_outer_target_without_inner_affected_rewrite() {
         let mut effect = Effect::GenericEffect {
-            static_abilities: vec![StaticDefinition::continuous()
-                .affected(TargetFilter::Typed(TypedFilter::creature()))
-                .modifications(vec![ContinuousModification::GrantStaticAbility {
-                    definition: Box::new(
-                        StaticDefinition::continuous()
-                            .affected(TargetFilter::Typed(TypedFilter::creature()))
-                            .modifications(vec![ContinuousModification::AddPower { value: 1 }]),
-                    ),
-                }])],
+            static_abilities: vec![
+                StaticDefinition::continuous()
+                    .affected(TargetFilter::Typed(TypedFilter::creature()))
+                    .modifications(vec![ContinuousModification::GrantStaticAbility {
+                        definition: Box::new(
+                            StaticDefinition::continuous()
+                                .affected(TargetFilter::Typed(TypedFilter::creature()))
+                                .modifications(vec![ContinuousModification::AddPower { value: 1 }]),
+                        ),
+                    }]),
+            ],
             duration: None,
             target: Some(TargetFilter::ParentTarget),
         };

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21975,7 +21975,7 @@ fn trailing_bare_article_only(input: &str) -> bool {
         all_consuming(terminated(take_until::<_, _, E>(" a"), tag(" a"))),
     )))
     .parse(input.trim())
-    .is_ok()
+    .is_ok_and(|(_, article)| article.is_some())
 }
 
 /// Merge the pre-`from it` card phrase with the plain trailing restriction

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -6262,6 +6262,8 @@ pub(super) fn parse_followup_continuation_ast(
             let choice_optional = alt((
                 tag::<_, _, OracleError<'_>>("you may choose "),
                 tag("may choose "),
+                tag("you may exile "),
+                tag("may exile "),
             ))
             .parse(lower.as_str())
             .is_ok();

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -3912,7 +3912,7 @@ mod tests {
     /// CR 702.168d + CR 118.7a: Fugitive Codebreaker's red pip and dynamic
     /// turn-face-up discount both survive keyword extraction.
     #[test]
-    fn extract_keyword_line_disguise_with_graveyard_reduction() {
+    fn extract_router_keyword_line_disguise_with_graveyard_reduction() {
         use crate::types::ability::{CountScope, QuantityRef, TypeFilter, ZoneRef};
 
         let keyword = parse_router_keyword_line(

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -3915,14 +3915,13 @@ mod tests {
     fn extract_keyword_line_disguise_with_graveyard_reduction() {
         use crate::types::ability::{CountScope, QuantityRef, TypeFilter, ZoneRef};
 
-        let keywords = extract_keyword_line(
+        let keyword = parse_router_keyword_line(
             "Disguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard. (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
-            &["disguise".to_string()],
         )
+        .and_then(|routed| routed.keyword)
         .expect("compound disguise keyword should extract");
-        assert_eq!(keywords.len(), 1);
-        let Keyword::Disguise(DisguiseCost::Reduced { cost, reduction }) = &keywords[0] else {
-            panic!("expected reduced disguise cost, got {keywords:?}");
+        let Keyword::Disguise(DisguiseCost::Reduced { cost, reduction }) = &keyword else {
+            panic!("expected reduced disguise cost, got {keyword:?}");
         };
         assert!(matches!(
             cost,
@@ -3942,10 +3941,10 @@ mod tests {
             } if card_types == &[TypeFilter::Instant, TypeFilter::Sorcery]
         ));
 
-        let serialized = serde_json::to_value(&keywords[0]).expect("serialize reduced disguise");
+        let serialized = serde_json::to_value(&keyword).expect("serialize reduced disguise");
         let round_trip: Keyword =
             serde_json::from_value(serialized).expect("deserialize reduced disguise");
-        assert_eq!(round_trip, keywords[0]);
+        assert_eq!(round_trip, keyword);
         let legacy: Keyword = serde_json::from_value(serde_json::json!({
             "Disguise": {"type": "Cost", "generic": 5, "shards": ["Red"]}
         }))

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -15,13 +15,13 @@ use super::oracle_quantity::parse_cda_quantity;
 use super::oracle_target::parse_type_phrase;
 use super::oracle_util::{strip_reminder_text, strip_where_x_is_clause};
 use crate::types::ability::{
-    AbilityCost, ActivationRestriction, AdditionalCost, ControllerRef, CostObjectCount, Effect,
-    EffectScope, FilterProp, QuantityExpr, SacrificeRequirement, TapStateChange, TargetFilter,
-    TypeFilter, TypedFilter,
+    AbilityCost, ActivationRestriction, AdditionalCost, ControllerRef, CostObjectCount,
+    CostReduction, Effect, EffectScope, FilterProp, QuantityExpr, SacrificeRequirement,
+    TapStateChange, TargetFilter, TypeFilter, TypedFilter,
 };
 use crate::types::keywords::{
-    normalize_bands_with_other_quality, BloodthirstValue, BuybackCost, CyclingCost, EmbalmCost,
-    EscapeCost, EternalizeCost, FlashbackCost, Keyword, WardCost,
+    normalize_bands_with_other_quality, BloodthirstValue, BuybackCost, CyclingCost, DisguiseCost,
+    EmbalmCost, EscapeCost, EternalizeCost, FlashbackCost, Keyword, WardCost,
 };
 use crate::types::mana::{ManaCost, ManaCostShard};
 use crate::types::zones::Zone;
@@ -421,6 +421,12 @@ fn parse_keyword_list_with_policy(
             if kw == Keyword::Bloodthirst(BloodthirstValue::Fixed(1)) {
                 return Some(Vec::new());
             }
+            return Some(vec![kw]);
+        }
+    }
+
+    if mtgjson_keyword_names.iter().any(|n| n == "disguise") {
+        if let Some(kw) = parse_disguise_keyword_line(line) {
             return Some(vec![kw]);
         }
     }
@@ -1210,6 +1216,44 @@ pub(crate) fn classify_cant_be_targeted(predicate_lower: &str) -> Option<CantBeT
     (bare || unqualified_scope).then_some(CantBeTargetedScope::AnyPlayer)
 }
 
+/// CR 702.168d + CR 118.7a: Parse a disguise line with a trailing generic
+/// reduction. The reduction belongs to the turn-face-up special action, not
+/// to casting the creature or its face-down spell.
+fn parse_disguise_keyword_line(text: &str) -> Option<Keyword> {
+    let stripped = strip_reminder_text(text);
+    let upper = stripped.trim().to_ascii_uppercase();
+    let (after_for_each, (_, cost, _, amount, _)) = (
+        tag::<_, _, OracleError<'_>>("DISGUISE "),
+        nom_primitives::parse_mana_cost,
+        tag(". THIS COST IS REDUCED BY "),
+        nom_primitives::parse_mana_cost,
+        tag(" FOR EACH "),
+    )
+        .parse(upper.as_str())
+        .ok()?;
+    let ManaCost::Cost {
+        generic: amount_per,
+        shards,
+    } = amount
+    else {
+        return None;
+    };
+    if !shards.is_empty() {
+        return None;
+    }
+    let count_text = after_for_each.to_ascii_lowercase();
+    let (_, qty) =
+        super::oracle_nom::quantity::parse_for_each_clause_ref_complete(&count_text).ok()?;
+    Some(Keyword::Disguise(DisguiseCost::Reduced {
+        cost,
+        reduction: Box::new(CostReduction {
+            amount_per,
+            count: QuantityExpr::Ref { qty },
+            condition: None,
+        }),
+    }))
+}
+
 /// Remainder-preserving keyword core — the SINGLE authority for keyword-line
 /// parsing. Returns the typed keyword plus the input it did **not** consume.
 ///
@@ -1230,6 +1274,10 @@ pub(crate) fn classify_cant_be_targeted(predicate_lower: &str) -> Option<CantBeT
 /// handling the "from" preposition used by protection keywords.
 pub(crate) fn parse_keyword_line_core(text: &str) -> Option<(Keyword, &str)> {
     use crate::types::keywords::PartnerType;
+
+    if let Some(kw) = parse_disguise_keyword_line(text) {
+        return Some((kw, ""));
+    }
 
     // CR 702.124: Partner variant keywords — must come BEFORE generic "partner" match.
     // MTGJSON sends Character Select, Friends Forever, and generic Partner all as keyword "Partner".
@@ -3859,6 +3907,70 @@ mod tests {
         let keywords = result.unwrap();
         assert_eq!(keywords.len(), 1);
         assert!(matches!(keywords[0], Keyword::Transmute(_)));
+    }
+
+    /// CR 702.168d + CR 118.7a: Fugitive Codebreaker's red pip and dynamic
+    /// turn-face-up discount both survive keyword extraction.
+    #[test]
+    fn extract_keyword_line_disguise_with_graveyard_reduction() {
+        use crate::types::ability::{CountScope, QuantityRef, TypeFilter, ZoneRef};
+
+        let keywords = extract_keyword_line(
+            "Disguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard. (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)",
+            &["disguise".to_string()],
+        )
+        .expect("compound disguise keyword should extract");
+        assert_eq!(keywords.len(), 1);
+        let Keyword::Disguise(DisguiseCost::Reduced { cost, reduction }) = &keywords[0] else {
+            panic!("expected reduced disguise cost, got {keywords:?}");
+        };
+        assert!(matches!(
+            cost,
+            ManaCost::Cost { generic: 5, shards }
+                if shards.as_slice() == [ManaCostShard::Red]
+        ));
+        assert_eq!(reduction.amount_per, 1);
+        assert!(matches!(
+            reduction.count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::ZoneCardCount {
+                    zone: ZoneRef::Graveyard,
+                    ref card_types,
+                    filter: None,
+                    scope: CountScope::Controller,
+                },
+            } if card_types == &[TypeFilter::Instant, TypeFilter::Sorcery]
+        ));
+
+        let serialized = serde_json::to_value(&keywords[0]).expect("serialize reduced disguise");
+        let round_trip: Keyword =
+            serde_json::from_value(serialized).expect("deserialize reduced disguise");
+        assert_eq!(round_trip, keywords[0]);
+        let legacy: Keyword = serde_json::from_value(serde_json::json!({
+            "Disguise": {"type": "Cost", "generic": 5, "shards": ["Red"]}
+        }))
+        .expect("legacy disguise mana cost remains readable");
+        assert!(matches!(legacy, Keyword::Disguise(DisguiseCost::Mana(_))));
+
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Prowess, haste\nDisguise {5}{R}. This cost is reduced by {1} for each instant and sorcery card in your graveyard. (You may cast this card face down for {3} as a 2/2 creature with ward {2}. Turn it face up any time for its disguise cost.)\nWhen this creature is turned face up, discard your hand, then draw three cards.",
+            "Fugitive Codebreaker",
+            &["prowess".to_string(), "haste".to_string(), "disguise".to_string()],
+            &["Creature".to_string()],
+            &["Human".to_string(), "Detective".to_string()],
+        );
+        assert!(
+            parsed
+                .extracted_keywords
+                .iter()
+                .any(|kw| matches!(kw, Keyword::Disguise(DisguiseCost::Reduced { .. }))),
+            "full Oracle parse should retain the reduced disguise cost: {parsed:#?}"
+        );
+        assert!(
+            parsed.parse_warnings.is_empty(),
+            "fully represented Fugitive line should not report a swallowed dynamic quantity: {:?}",
+            parsed.parse_warnings
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -965,7 +965,13 @@ fn split_reflexive_optional_cost(trigger_line: &str) -> Option<(String, String)>
     // repeated-payment form, "when you pay this cost one or more times".
     let when_you_do =
         nom_condition::match_when_you_do(connector).is_ok_and(|(rest, ())| rest.is_empty());
-    if !when_you_do && connector.trim() != "when you pay this cost one or more times" {
+    let repeated_payment = terminated(
+        tag::<_, _, OracleError<'_>>("when you pay this cost one or more times"),
+        multispace0,
+    )
+    .parse(connector.trim())
+    .is_ok_and(|(rest, _)| rest.is_empty());
+    if !when_you_do && !repeated_payment {
         return None;
     }
 

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -961,9 +961,11 @@ fn split_reflexive_optional_cost(trigger_line: &str) -> Option<(String, String)>
         terminated(take_until::<_, _, OracleError<'_>>(". "), tag(". "))
             .parse(after_marker)
             .ok()?;
-    // The connector remainder must be exactly the reflexive "when you do".
-    let (rest, ()) = nom_condition::match_when_you_do(connector).ok()?;
-    if !rest.is_empty() {
+    // The connector remainder must be the reflexive "when you do" or its
+    // repeated-payment form, "when you pay this cost one or more times".
+    let when_you_do =
+        nom_condition::match_when_you_do(connector).is_ok_and(|(rest, ())| rest.is_empty());
+    if !when_you_do && connector.trim() != "when you pay this cost one or more times" {
         return None;
     }
 
@@ -1922,11 +1924,8 @@ fn scan_modal_count_override(text: &str) -> Option<ModalCountSpec> {
             ),
             // CR 603.12a + CR 700.2d: "choose up to that many." (Hawkeye, Master
             // Marksman) caps the modal at the resolution-local count of repeated
-            // optional payments. MED-1: match the PERIOD/bare/bullet-terminated
-            // header form ONLY — the negative lookahead rejects a following
-            // em-dash (Tranquil Frillback's "choose up to that many —", whose
-            // reflexive condition is NOT WhenYouDo and so is not handled by the
-            // repeated-optional-payment driver) and a following noun phrase (the
+            // optional payments. Accept the em-dash modal form used by Tranquil
+            // Frillback while rejecting a following noun phrase (the
             // non-modal selection clauses "choose up to that many target
             // creatures you control" / "...creatures tapped this way"). Only a
             // clean termination (period / end / bullet) yields the dynamic cap,
@@ -1937,10 +1936,7 @@ fn scan_modal_count_override(text: &str) -> Option<ModalCountSpec> {
                 },
                 terminated(
                     tag::<_, _, OracleError<'_>>("choose up to that many"),
-                    not(preceded(
-                        multispace0,
-                        alt((tag("\u{2014}"), tag("\u{2013}"), tag("-"), alpha1)),
-                    )),
+                    not(preceded(multispace0, alpha1)),
                 ),
             ),
             // CR 700.2a / CR 700.2d: "choose up to N —" is a modal header where
@@ -2274,18 +2270,16 @@ mod tests {
         );
     }
 
-    // MED-1 guard: the "that many" arm must NOT match the em-dash header
-    // (Tranquil Frillback, whose reflexive condition is not WhenYouDo and so is
-    // not handled by the repeated-optional-payment driver — matching it would
-    // false-green an unhandled card) nor the non-modal selection clauses
-    // ("choose up to that many target creatures you control"). These fall to the
-    // fixed default. Revert the negative lookahead → both wrongly become Dynamic.
+    // Tranquil Frillback's em-dash header is a repeated-payment modal, while a
+    // following noun phrase is a non-modal selection clause and stays fixed.
     #[test]
-    fn parse_modal_choose_count_up_to_that_many_em_dash_and_noun_are_not_dynamic() {
+    fn parse_modal_choose_count_up_to_that_many_em_dash_is_dynamic_and_noun_is_not() {
         // Tranquil Frillback (em-dash continuation).
         assert_eq!(
             parse_modal_choose_count("choose up to that many \u{2014}"),
-            fixed(1, 1)
+            ModalCountSpec::Dynamic {
+                qty: QuantityRef::TimesCostPaidThisResolution
+            }
         );
         // Heroic Feast (non-modal selection clause).
         assert_eq!(

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1956,13 +1956,38 @@ fn parse_zone_card_count(input: &str) -> OracleResult<'_, QuantityRef> {
         }
     }
     let (rest, (zone, scope)) = parse_scoped_zone_ref(rest)?;
+    // CR 715.2: Hearth Elemental counts cards that are instants, sorceries,
+    // and/or have an Adventure. Adventure cards have their permanent face's
+    // types in the graveyard, so type filters alone undercount this set.
+    let (rest, includes_adventure) = opt(nom::bytes::complete::tag_no_case(
+        " that are instant cards, sorcery cards, and/or have an adventure",
+    ))
+    .parse(rest)?;
+    let (card_types, filter) = if includes_adventure.is_some() {
+        (
+            Vec::new(),
+            Some(TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Typed(TypedFilter::new(TypeFilter::AnyOf(vec![
+                        TypeFilter::Instant,
+                        TypeFilter::Sorcery,
+                    ]))),
+                    TargetFilter::Typed(
+                        TypedFilter::card().properties(vec![FilterProp::HasAdventure]),
+                    ),
+                ],
+            }),
+        )
+    } else {
+        (card_types, None)
+    };
     Ok((
         rest,
         QuantityRef::ZoneCardCount {
             zone,
             card_types,
             scope,
-            filter: None,
+            filter,
         },
     ))
 }
@@ -7462,6 +7487,36 @@ mod tests {
             }
         );
         assert_eq!(rest, "");
+    }
+
+    /// CR 715.2: Hearth Elemental includes Adventure cards whose front face is
+    /// a permanent, in addition to instant and sorcery cards.
+    #[test]
+    fn test_parse_quantity_ref_instant_sorcery_or_adventure_in_graveyard() {
+        let (rest, q) = parse_quantity_ref(
+            "cards in your graveyard that are instant cards, sorcery cards, and/or have an adventure",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        assert_eq!(
+            q,
+            QuantityRef::ZoneCardCount {
+                zone: ZoneRef::Graveyard,
+                card_types: vec![],
+                scope: CountScope::Controller,
+                filter: Some(TargetFilter::Or {
+                    filters: vec![
+                        TargetFilter::Typed(TypedFilter::new(TypeFilter::AnyOf(vec![
+                            TypeFilter::Instant,
+                            TypeFilter::Sorcery,
+                        ]))),
+                        TargetFilter::Typed(
+                            TypedFilter::card().properties(vec![FilterProp::HasAdventure]),
+                        ),
+                    ],
+                }),
+            }
+        );
     }
 
     /// CR 604.3: Plain `" or "` joining is also valid in Oracle text — both

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -3005,7 +3005,11 @@ pub(crate) fn parse_static_line_inner(
                     amount,
                     minimum_mana,
                     dynamic_count,
-                    exemption: ActivationExemption::None,
+                    exemption: if tp.lower.contains("unless they're mana abilities") {
+                        ActivationExemption::ManaAbilities
+                    } else {
+                        ActivationExemption::None
+                    },
                     // Source-scoped ("Activated/Loyalty abilities of <filter>"):
                     // scope is the `affected` filter below; no activator gate.
                     activator: None,

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -3005,7 +3005,10 @@ pub(crate) fn parse_static_line_inner(
                     amount,
                     minimum_mana,
                     dynamic_count,
-                    exemption: if tp.lower.contains("unless they're mana abilities") {
+                    exemption: if nom_primitives::scan_contains(
+                        tp.lower,
+                        "unless they're mana abilities",
+                    ) {
                         ActivationExemption::ManaAbilities
                     } else {
                         ActivationExemption::None

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2956,7 +2956,7 @@ pub(crate) fn parse_static_line_inner(
     // runtime gate matches `keyword == "loyalty"` against a loyalty ability's cost.
     // Combinator: prefix → subject → " cost {N} " → direction. The subject is
     // either the chosen-name source phrase (→ HasChosenName) or a type phrase.
-    if let Some(((amount_n, is_x, mode, subject_filter, dynamic_count, keyword), _)) =
+    if let Some(((amount_n, is_x, mode, subject_filter, dynamic_count, keyword, exemption), _)) =
         nom_on_lower(tp.original, tp.lower, |i| {
             // CR 601.2f + CR 606.1: shared grammar head (also used by the transient
             // this-turn form, which lowers to a `GenericEffect` carrying this same
@@ -2967,6 +2967,10 @@ pub(crate) fn parse_static_line_inner(
             // CR 208.1 + CR 113.7: optional dynamic referent for `{X}`
             // ("where X is ~'s power", Agatha).
             let (i, dynamic_count) = opt(parse_where_x_is_self_stat).parse(i)?;
+            // CR 605.1a: consume the optional mana-ability carve-out at the
+            // source-scoped grammar boundary, accepting both apostrophe forms.
+            let (i, exemption) =
+                opt(super::shared::parse_mana_ability_exemption_suffix).parse(i)?;
             Ok((
                 i,
                 (
@@ -2976,6 +2980,7 @@ pub(crate) fn parse_static_line_inner(
                     subject.to_string(),
                     dynamic_count,
                     keyword,
+                    exemption,
                 ),
             ))
         })
@@ -3005,10 +3010,7 @@ pub(crate) fn parse_static_line_inner(
                     amount,
                     minimum_mana,
                     dynamic_count,
-                    exemption: if nom_primitives::scan_contains(
-                        tp.lower,
-                        "unless they're mana abilities",
-                    ) {
+                    exemption: if exemption.is_some() {
                         ActivationExemption::ManaAbilities
                     } else {
                         ActivationExemption::None

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -21865,25 +21865,28 @@ fn static_reduce_ability_cost_global_with_mana_exemption() {
 /// but its explicit mana-ability exception still applies to the named source.
 #[test]
 fn static_reduce_ability_cost_chosen_name_with_mana_exemption() {
-    let def = parse_static_line(
+    for text in [
         "Activated abilities of sources with the chosen name cost {2} more to activate unless they're mana abilities.",
-    )
-    .expect("Anointed Peacekeeper chosen-name activated-ability tax must parse");
-    assert!(matches!(def.affected, Some(TargetFilter::HasChosenName)));
-    assert!(
-        matches!(
-            &def.mode,
-            StaticMode::ReduceAbilityCost {
-                mode: CostModifyMode::Raise,
-                keyword,
-                amount: 2,
-                exemption: ActivationExemption::ManaAbilities,
-                ..
-            } if keyword == "activated"
-        ),
-        "expected Raise/activated/2 with ManaAbilities exemption, got {:?}",
-        def.mode
-    );
+        "Activated abilities of sources with the chosen name cost {2} more to activate unless they\u{2019}re mana abilities.",
+    ] {
+        let def = parse_static_line(text)
+            .expect("Anointed Peacekeeper chosen-name activated-ability tax must parse");
+        assert!(matches!(def.affected, Some(TargetFilter::HasChosenName)));
+        assert!(
+            matches!(
+                &def.mode,
+                StaticMode::ReduceAbilityCost {
+                    mode: CostModifyMode::Raise,
+                    keyword,
+                    amount: 2,
+                    exemption: ActivationExemption::ManaAbilities,
+                    ..
+                } if keyword == "activated"
+            ),
+            "expected Raise/activated/2 with ManaAbilities exemption for {text:?}, got {:?}",
+            def.mode
+        );
+    }
 }
 
 /// CR 601.2f + CR 602.2 + CR 605.1a: The activator-scoped "Abilities you activate

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -21832,6 +21832,31 @@ fn static_reduce_ability_cost_global_with_mana_exemption() {
     );
 }
 
+/// CR 601.2f + CR 605.1a: Anointed Peacekeeper's chosen-name tax is source-scoped,
+/// but its explicit mana-ability exception still applies to the named source.
+#[test]
+fn static_reduce_ability_cost_chosen_name_with_mana_exemption() {
+    let def = parse_static_line(
+        "Activated abilities of sources with the chosen name cost {2} more to activate unless they're mana abilities.",
+    )
+    .expect("Anointed Peacekeeper chosen-name activated-ability tax must parse");
+    assert!(matches!(def.affected, Some(TargetFilter::HasChosenName)));
+    assert!(
+        matches!(
+            &def.mode,
+            StaticMode::ReduceAbilityCost {
+                mode: CostModifyMode::Raise,
+                keyword,
+                amount: 2,
+                exemption: ActivationExemption::ManaAbilities,
+                ..
+            } if keyword == "activated"
+        ),
+        "expected Raise/activated/2 with ManaAbilities exemption, got {:?}",
+        def.mode
+    );
+}
+
 /// CR 601.2f + CR 602.2 + CR 605.1a: The activator-scoped "Abilities you activate
 /// that aren't mana abilities cost {N} less to activate" (Zirda, the Dawnwaker)
 /// form keys off WHO activates the ability — the static's controller ("you") —

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5202,6 +5202,35 @@ fn static_this_spell_cost_less_self_scoped_in_castable_zones() {
     );
 }
 
+/// CR 601.2f + CR 715.2: Hearth Elemental's variable reduction must retain the
+/// instant/sorcery/Adventure graveyard predicate and function from hand.
+#[test]
+fn static_hearth_elemental_cost_reduction_includes_adventures() {
+    let def = parse_static_line(
+        "This spell costs {X} less to cast, where X is the number of cards in your graveyard that are instant cards, sorcery cards, and/or have an Adventure.",
+    )
+    .expect("Hearth Elemental cost reduction should parse");
+    assert!(matches!(
+        def.mode,
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
+            amount: ManaCost::Cost { generic: 1, .. },
+            dynamic_count: Some(QuantityRef::ZoneCardCount {
+                zone: ZoneRef::Graveyard,
+                ref card_types,
+                filter: Some(TargetFilter::Or { .. }),
+                scope: CountScope::Controller,
+            }),
+            ..
+        } if card_types.is_empty()
+    ));
+    assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
+    assert_eq!(
+        def.active_zones,
+        crate::types::zones::self_spell_cost_mod_active_zones()
+    );
+}
+
 /// Issue #1372: Demilich's self-spell reduction must function from the graveyard
 /// during cast-time cost determination.
 #[test]

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::parser::oracle_effect::parse_effect_chain;
 use crate::types::ability::{
-    AdditionalCostPaymentSource, CountScope, CounterAdjustment, DoorLockOp,
+    AdditionalCostOrigin, AdditionalCostPaymentSource, CountScope, CounterAdjustment, DoorLockOp,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 
@@ -3883,12 +3883,21 @@ fn bargained_etb_intervening_if_is_gated_at_trigger_time() {
         trigger.condition,
         Some(TriggerCondition::AdditionalCostPaid {
             source: AdditionalCostPaymentSource::NonKicker,
+            origin: Some(AdditionalCostOrigin::Bargain),
             variant: None,
             kicker_cost: None,
             min_count: 1,
             ..
         })
     ));
+    assert_eq!(
+        serde_json::to_value(&trigger.condition).unwrap(),
+        serde_json::json!({
+            "type": "AdditionalCostPaid",
+            "source": "NonKicker",
+            "origin": "Bargain",
+        })
+    );
     assert!(trigger
         .execute
         .as_ref()

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::parser::oracle_effect::parse_effect_chain;
-use crate::types::ability::{CountScope, CounterAdjustment, DoorLockOp};
+use crate::types::ability::{
+    AdditionalCostPaymentSource, CountScope, CounterAdjustment, DoorLockOp,
+};
 use crate::types::counter::{CounterMatch, CounterType};
 
 /// CR 122.1 + CR 608.2d + CR 702.62b (Clockspinning): the whole card parses
@@ -3832,6 +3834,65 @@ fn kicker_and_or_line_sets_two_kicker_costs() {
         }
         other => panic!("expected two-cost Kicker, got {other:?}"),
     }
+}
+
+#[test]
+fn kicker_etb_intervening_if_is_gated_at_trigger_time() {
+    let parsed = parse(
+        "Kicker {B} and/or {R}\n\
+         When ~ enters, if it was kicked, it deals 2 damage to any target.\n\
+         When ~ enters, if it was kicked twice, it deals 2 damage to any target.",
+        "Archangel of Wrath",
+        &[],
+        &["Creature"],
+        &["Angel"],
+    );
+
+    assert_eq!(parsed.triggers.len(), 2);
+    for (trigger, min_count) in parsed.triggers.iter().zip([1, 2]) {
+        assert!(matches!(
+            &trigger.condition,
+            Some(TriggerCondition::AdditionalCostPaid {
+                source: AdditionalCostPaymentSource::Kicker,
+                variant: None,
+                kicker_cost: None,
+                min_count: actual,
+                ..
+            }) if *actual == min_count
+        ));
+        assert!(trigger
+            .execute
+            .as_ref()
+            .is_some_and(|ability| ability.condition.is_none()));
+    }
+}
+
+#[test]
+fn bargained_etb_intervening_if_is_gated_at_trigger_time() {
+    let parsed = parse(
+        "Bargain\nWhen ~ enters, if it was bargained, add four mana in any combination of colors.",
+        "Realm-Scorcher Hellkite",
+        &[Keyword::Bargain],
+        &["Creature"],
+        &["Dragon"],
+    );
+
+    assert_eq!(parsed.triggers.len(), 1);
+    let trigger = &parsed.triggers[0];
+    assert!(matches!(
+        trigger.condition,
+        Some(TriggerCondition::AdditionalCostPaid {
+            source: AdditionalCostPaymentSource::NonKicker,
+            variant: None,
+            kicker_cost: None,
+            min_count: 1,
+            ..
+        })
+    ));
+    assert!(trigger
+        .execute
+        .as_ref()
+        .is_some_and(|ability| ability.condition.is_none()));
 }
 
 #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -40,14 +40,15 @@ use super::oracle_util::{
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::ManaProduction;
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AggregateFunction, AttachmentKind,
-    AttackersDeclaredCountSubject, CastManaObjectScope, CastManaSpentMetric, CastVariantPaid,
-    CoinFlipResult, Comparator, ControllerRef, CountScope, CounterTriggerFilter, DamageKindFilter,
-    DestinationConstraint, DieResultFilter, Effect, FilterProp, ObjectScope, OriginConstraint,
-    ParsedCondition, PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef,
-    RenownSubject, SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, SharedQuality,
-    StaticCondition, TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint,
-    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
+    AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AdditionalCostPaymentSource,
+    AggregateFunction, AttachmentKind, AttackersDeclaredCountSubject, CastManaObjectScope,
+    CastManaSpentMetric, CastVariantPaid, CoinFlipResult, Comparator, ControllerRef, CountScope,
+    CounterTriggerFilter, DamageKindFilter, DestinationConstraint, DieResultFilter, Effect,
+    FilterProp, ObjectScope, OriginConstraint, ParsedCondition, PlayerFilter, PlayerScope, PtStat,
+    PtValueScope, QuantityExpr, QuantityRef, RenownSubject, SacrificeAggregateStat, SacrificeCost,
+    SacrificeRequirement, SharedQuality, StaticCondition, TapCreaturesRequirement, TargetFilter,
+    TriggerCondition, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
+    UnlessPayModifier, ZoneChangeClause,
 };
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
@@ -4748,6 +4749,21 @@ fn extract_if_condition_with_card_name(
     // --- Source-referential patterns (cannot be StaticConditions) ---
     // These require trigger-source context that StaticCondition can't express.
 
+    // CR 603.4 + CR 702.33d-f + CR 702.166a: an ETB "if it was kicked
+    // [twice]" or "if it was bargained" clause is an
+    // intervening-if, so an unpaid trigger must never be put on the stack or
+    // ask for targets. The effect parser's resolution-time condition is too
+    // late for this shape.
+    if let Some((before, condition, rest)) =
+        scan_preceded(&lower, parse_additional_cost_intervening_if)
+    {
+        let clause_len = lower.len() - before.len() - rest.len();
+        return (
+            strip_condition_clause(text, before.len(), clause_len),
+            Some(condition),
+        );
+    }
+
     // CR 603.4 + CR 601.2: "if you didn't cast it from your hand/graveyard/exile"
     // — negated zone-specific cast check (Chainer, Nightmare Adept; Phage the
     // Untouchable). The entering object must NOT have been cast from the named
@@ -6610,6 +6626,34 @@ fn parse_cast_using_variant_intervening_if(input: &str) -> OracleResult<'_, Trig
     Ok((
         input,
         TriggerCondition::CastVariantPaidPersistent { variant },
+    ))
+}
+
+fn parse_additional_cost_intervening_if(input: &str) -> OracleResult<'_, TriggerCondition> {
+    let (input, _) = tag("if ").parse(input)?;
+    let (input, source) = alt((
+        value(
+            AdditionalCostPaymentSource::Kicker,
+            alt((tag("it was kicked"), tag("~ was kicked"))),
+        ),
+        value(
+            AdditionalCostPaymentSource::NonKicker,
+            alt((tag("it was bargained"), tag("~ was bargained"))),
+        ),
+    ))
+    .parse(input)?;
+    let (input, min_count) =
+        alt((value(2, tag(" twice")), value(1, peek(tag(","))))).parse(input)?;
+    Ok((
+        input,
+        TriggerCondition::AdditionalCostPaid {
+            source,
+            origin: None,
+            origin_ordinal: None,
+            variant: None,
+            kicker_cost: None,
+            min_count,
+        },
     ))
 }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -40,15 +40,15 @@ use super::oracle_util::{
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::ManaProduction;
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AdditionalCostPaymentSource,
-    AggregateFunction, AttachmentKind, AttackersDeclaredCountSubject, CastManaObjectScope,
-    CastManaSpentMetric, CastVariantPaid, CoinFlipResult, Comparator, ControllerRef, CountScope,
-    CounterTriggerFilter, DamageKindFilter, DestinationConstraint, DieResultFilter, Effect,
-    FilterProp, ObjectScope, OriginConstraint, ParsedCondition, PlayerFilter, PlayerScope, PtStat,
-    PtValueScope, QuantityExpr, QuantityRef, RenownSubject, SacrificeAggregateStat, SacrificeCost,
-    SacrificeRequirement, SharedQuality, StaticCondition, TapCreaturesRequirement, TargetFilter,
-    TriggerCondition, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
-    UnlessPayModifier, ZoneChangeClause,
+    AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AdditionalCostOrigin,
+    AdditionalCostPaymentSource, AggregateFunction, AttachmentKind, AttackersDeclaredCountSubject,
+    CastManaObjectScope, CastManaSpentMetric, CastVariantPaid, CoinFlipResult, Comparator,
+    ControllerRef, CountScope, CounterTriggerFilter, DamageKindFilter, DestinationConstraint,
+    DieResultFilter, Effect, FilterProp, ObjectScope, OriginConstraint, ParsedCondition,
+    PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, RenownSubject,
+    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, SharedQuality, StaticCondition,
+    TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition,
+    TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
 };
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
@@ -6648,7 +6648,8 @@ fn parse_additional_cost_intervening_if(input: &str) -> OracleResult<'_, Trigger
         input,
         TriggerCondition::AdditionalCostPaid {
             source,
-            origin: None,
+            origin: matches!(source, AdditionalCostPaymentSource::NonKicker)
+                .then_some(AdditionalCostOrigin::Bargain),
             origin_ordinal: None,
             variant: None,
             kicker_cost: None,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -8442,6 +8442,10 @@ pub enum AdditionalCostOrigin {
     Offspring,
     Squad,
     Replicate,
+    /// CR 702.166a: Bargain's optional sacrifice of an artifact, enchantment,
+    /// or token. A dedicated origin prevents an unrelated additional cost from
+    /// satisfying an "if it was bargained" rider.
+    Bargain,
     /// CR 601.2b/f: Teamwork's optional "tap any number of creatures with total
     /// power N or more" additional cost. A dedicated origin lets "this spell was
     /// cast using teamwork" riders test the Teamwork payment specifically (not

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3551,6 +3551,10 @@ pub enum FilterProp {
     /// This is a status of the exiled card, not equivalent to having the
     /// Foretell keyword or a generic exile casting permission.
     Foretold,
+    /// CR 715.2: Matches a card that has an Adventure. Outside the stack, an
+    /// Adventure card has only the characteristics of its permanent half, so
+    /// this must inspect the stored alternate face rather than its card types.
+    HasAdventure,
     EnchantedBy,
     EquippedBy,
     /// CR 301.5 + CR 303.4: True when the matched object's `attached_to` field

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -644,6 +644,7 @@ impl EventObjectSnapshot {
             | FilterProp::ManaCostIn { .. }
             | FilterProp::ManaSymbolCount { .. }
             | FilterProp::Foretold
+            | FilterProp::HasAdventure
             | FilterProp::AttachedToSource
             | FilterProp::AttachedToRecipient
             | FilterProp::Unpaired

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use super::ability::ControllerRef;
 use super::ability::{
-    AbilityCost, ActivationRestriction, Comparator, CostObjectCount, FilterProp, QuantityExpr,
-    TargetFilter, TypeFilter, TypedFilter,
+    AbilityCost, ActivationRestriction, Comparator, CostObjectCount, CostReduction, FilterProp,
+    QuantityExpr, TargetFilter, TypeFilter, TypedFilter,
 };
 use super::counter::{parse_counter_type, CounterType};
 use super::mana::{ManaColor, ManaCost};
@@ -235,7 +235,7 @@ pub enum KeywordKind {
     Madness,
     /// CR 702.168: Disguise — see `Keyword::Disguise`. A discriminant-level kind
     /// (like Morph/Mutate) so `FilterProp::HasKeywordKind { Disguise }` can name
-    /// the class regardless of the `Disguise(ManaCost)` parameter payload.
+    /// the class regardless of the `Disguise(DisguiseCost)` parameter payload.
     Disguise,
     /// CR 702.187: Mayhem — see `Keyword::Mayhem`.
     Mayhem,
@@ -551,6 +551,25 @@ pub enum BloodthirstValue {
     X,
 }
 
+/// CR 702.168d + CR 118.7a: A disguise cost can be fixed or carry its own
+/// dynamic generic reduction (Fugitive Codebreaker). The untagged mana form
+/// preserves the existing card-data representation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum DisguiseCost {
+    Mana(ManaCost),
+    Reduced {
+        cost: ManaCost,
+        reduction: Box<CostReduction>,
+    },
+}
+
+impl From<ManaCost> for DisguiseCost {
+    fn from(cost: ManaCost) -> Self {
+        Self::Mana(cost)
+    }
+}
+
 /// All MTG keywords as typed enum variants.
 /// Simple (unit) variants for keywords with no parameters.
 /// Parameterized variants carry associated data (ManaCost for costs, amounts, etc.).
@@ -734,7 +753,7 @@ pub enum Keyword {
     Foretell(ManaCost),
     Mutate(ManaCost),
     Disturb(ManaCost),
-    Disguise(ManaCost),
+    Disguise(DisguiseCost),
     Blitz(ManaCost),
     Overload(ManaCost),
     Spectacle(ManaCost),
@@ -2267,7 +2286,7 @@ impl FromStr for Keyword {
                 "foretell" => return Ok(Keyword::Foretell(parse_keyword_mana_cost(p))),
                 "mutate" => return Ok(Keyword::Mutate(parse_keyword_mana_cost(p))),
                 "disturb" => return Ok(Keyword::Disturb(parse_keyword_mana_cost(p))),
-                "disguise" => return Ok(Keyword::Disguise(parse_keyword_mana_cost(p))),
+                "disguise" => return Ok(Keyword::Disguise(parse_keyword_mana_cost(p).into())),
                 "blitz" => return Ok(Keyword::Blitz(parse_keyword_mana_cost(p))),
                 "overload" => return Ok(Keyword::Overload(parse_keyword_mana_cost(p))),
                 // CR 702.162a: More Than Meets the Eye {cost} — alternative cost to cast converted.
@@ -3109,7 +3128,10 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Foretell" => Ok(Keyword::Foretell(mana(data)?)),
         "Mutate" => Ok(Keyword::Mutate(mana(data)?)),
         "Disturb" => Ok(Keyword::Disturb(mana(data)?)),
-        "Disguise" => Ok(Keyword::Disguise(mana(data)?)),
+        "Disguise" => Ok(Keyword::Disguise(
+            serde_json::from_value::<DisguiseCost>(data.clone())
+                .or_else(|_| mana(data).map(DisguiseCost::Mana))?,
+        )),
         "Blitz" => Ok(Keyword::Blitz(mana(data)?)),
         "Overload" => Ok(Keyword::Overload(mana(data)?)),
         // CR 702.162a: More Than Meets the Eye {cost} — alternative cost to cast converted.

--- a/crates/engine/tests/integration/issue_3272_lightstall_inquisitor.rs
+++ b/crates/engine/tests/integration/issue_3272_lightstall_inquisitor.rs
@@ -8,7 +8,8 @@
 
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
-    AbilityDefinition, CastingPermission, Duration, Effect, PermissionGrantee,
+    AbilityDefinition, CastingPermission, Duration, Effect, PermissionGrantee, TargetFilter,
+    TypeFilter,
 };
 use engine::types::mana::ManaCost;
 use engine::types::zones::EtbTapState;
@@ -16,6 +17,10 @@ use engine::types::zones::EtbTapState;
 const LIGHTSTALL_ORACLE: &str = "Vigilance\nWhen this creature enters, each opponent exiles a \
 card from their hand and may play that card for as long as it remains exiled. Each spell cast \
 this way costs {1} more to cast. Each land played this way enters tapped.";
+
+const GOBAKHAN_ORACLE: &str = "When this Siege enters, look at target opponent's hand. You may \
+exile a nonland card from it. For as long as that card remains exiled, its owner may play it. A \
+spell cast this way costs {2} more to cast.";
 
 /// Walk an ability definition and its `sub_ability` / `else_ability` chain,
 /// returning the first `PlayFromExile` grant together with its grantee.
@@ -108,5 +113,60 @@ fn lightstall_etb_grants_owner_play_with_cost_raise_and_land_tapped() {
         *land_enter_tapped,
         EtbTapState::Tapped,
         "the land-tapped rider must fold into the grant's land_enter_tapped"
+    );
+}
+
+#[test]
+fn gobakhan_exiles_only_nonlands_and_raises_the_exiled_spell_cost() {
+    let parsed = parse_oracle_text(
+        GOBAKHAN_ORACLE,
+        "Invasion of Gobakhan",
+        &[],
+        &["Battle".to_string()],
+        &["Siege".to_string()],
+    );
+    let execute = parsed
+        .triggers
+        .iter()
+        .filter_map(|trigger| trigger.execute.as_deref())
+        .find(|execute| matches!(execute.effect.as_ref(), Effect::RevealHand { .. }))
+        .expect("Gobakhan must have an ETB hand-reveal trigger");
+
+    let Effect::RevealHand {
+        card_filter,
+        choice_optional,
+        ..
+    } = execute.effect.as_ref()
+    else {
+        unreachable!("matched RevealHand above")
+    };
+    assert!(*choice_optional);
+    assert!(matches!(
+        card_filter,
+        TargetFilter::Typed(filter)
+            if filter.type_filters.iter().any(|kind| matches!(
+                kind,
+                TypeFilter::Non(inner) if **inner == TypeFilter::Land
+            ))
+    ));
+
+    let (permission, grantee) = find_play_from_exile_grant(execute)
+        .expect("Gobakhan must grant the exiled card's owner permission to play it");
+    assert_eq!(*grantee, PermissionGrantee::ObjectOwner);
+    let CastingPermission::PlayFromExile {
+        duration,
+        cast_cost_raise,
+        ..
+    } = permission
+    else {
+        unreachable!("matched PlayFromExile above")
+    };
+    assert_eq!(*duration, Duration::Permanent);
+    assert_eq!(
+        *cast_cost_raise,
+        Some(ManaCost::Cost {
+            shards: vec![],
+            generic: 2,
+        })
     );
 }

--- a/crates/engine/tests/integration/issue_3272_lightstall_inquisitor.rs
+++ b/crates/engine/tests/integration/issue_3272_lightstall_inquisitor.rs
@@ -141,14 +141,17 @@ fn gobakhan_exiles_only_nonlands_and_raises_the_exiled_spell_cost() {
         unreachable!("matched RevealHand above")
     };
     assert!(*choice_optional);
-    assert!(matches!(
-        card_filter,
-        TargetFilter::Typed(filter)
-            if filter.type_filters.iter().any(|kind| matches!(
-                kind,
-                TypeFilter::Non(inner) if **inner == TypeFilter::Land
-            ))
-    ));
+    assert!(
+        matches!(
+            card_filter,
+            TargetFilter::Typed(filter)
+                if filter.type_filters.iter().any(|kind| matches!(
+                    kind,
+                    TypeFilter::Non(inner) if **inner == TypeFilter::Land
+                ))
+        ),
+        "Gobakhan's exile choice must exclude lands, got {card_filter:?}"
+    );
 
     let (permission, grantee) = find_play_from_exile_grant(execute)
         .expect("Gobakhan must grant the exiled card's owner permission to play it");

--- a/crates/mtgish-import/src/convert/keyword.rs
+++ b/crates/mtgish-import/src/convert/keyword.rs
@@ -163,7 +163,7 @@ pub fn try_convert(rule: &Rule, path: &str) -> ConvResult<Option<Keyword>> {
         Rule::Blitz(c) => Keyword::Blitz(pure_mana(c, "Rule::Blitz", path)?),
         Rule::Dash(c) => Keyword::Dash(pure_mana(c, "Rule::Dash", path)?),
         Rule::Disturb(c) => Keyword::Disturb(pure_mana(c, "Rule::Disturb", path)?),
-        Rule::Disguise(c) => Keyword::Disguise(pure_mana(c, "Rule::Disguise", path)?),
+        Rule::Disguise(c) => Keyword::Disguise(pure_mana(c, "Rule::Disguise", path)?.into()),
         Rule::Echo(c) => Keyword::Echo(engine::types::keywords::EchoCost::Mana(pure_mana(
             c,
             "Rule::Echo",


### PR DESCRIPTION
## Summary

Fixes core casting, additional-cost, and mana-payment rules paths so legal costs remain payable, illegal routes are rejected, and optional choices such as kicker, bargain, and Phyrexian mana are represented correctly. The branch includes Adventure, split/MDFC, Powerstone, restricted/flexible mana, X-cost, and exile-discount regressions; each commit records a concrete Before/Rule/After example.

The current-main integration also classifies the new Adventure predicate as non-memoizable because the stored alternate face is absent from the legality fingerprint, preventing an incorrect cached eligibility verdict.

## Rules fixes

### CR 601.2f–h — determining and paying the total cost

1. **Invasion of Gobakhan:** casting the exiled card requires the additional `{2}`; the engine no longer offers the printed cost alone. (f65a18bd3f5afa549338c1e80badcc2f4967f66c)
2. **Mandatory choice costs:** a spell requiring one of several additional costs is offered only if at least one complete choice is payable. (993a6044e8ff66278a560e88404c64c6de00d716)
3. **Exile-this-way discounts:** selected cards are exiled before calculating the reduction. Discounted spells and correctly reduced `X` values are accepted instead of being rejected using the unreduced cost. (40644dddcb61bcba62ed8691b75ac20f345cdb8e, c2fbfce91795c7d66253c7b3811e50fdbc49c003)
4. **Kicker:** the engine stops offering additional kicks once the kicked total becomes unpayable, while still allowing fewer or zero kicks. (d34b5030262ebc50b41807e06cd6871a3adbe60b)
5. **Remaining colored cost:** partially paid spells retain every outstanding colored requirement and cannot finalize early. (d4ab4b47058c7ec18257dba41e820e9e636db587)
6. **Unusable lands:** merely controlling a land no longer makes a spell appear castable when that land cannot contribute to its payment. (c2fc54c6300489d8252fe2bbfd9162af647ca5d6)
7. **Voltage Surge:** the optional artifact sacrifice correctly distinguishes two damage without payment from four damage with payment. (d7b9a60b9ffe794c0145c801bae6eaf8d845a36f)
8. **Anointed Peacekeeper:** the chosen-name `{2}` tax applies where appropriate but does not tax an exempt mana ability. (8645d3e48e0a326b9fbf740413ff791e95dcdb2c)

### CR 106.1, 106.5–6, and 601.2g — mana production and spending restrictions

1. **Powerstones casting spells:** Powerstone mana cannot satisfy even the generic portion of a nonartifact spell, such as `Go for the Throat`. (04b4b5e9c8c3a19a13140b63c1a835eabc8d771c)
2. **Powerstones activating abilities:** the same restriction does not prohibit spending Powerstone mana on a nonartifact permanent's activated ability. (b27bd328310c44e6bddbe22f43a74e5f6b5fa663)
3. **Flexible sources:** multiple sources that can each produce different colors are combined correctly, so jointly payable colored costs remain legal. (a75c04c1133b72235c7ce21e177d93f57f3511e1)
4. **Restricted mana and `X`:** mana that cannot be spent on the spell neither creates a false cast offer nor inflates the maximum legal `X`. (f52624a1d06e90c0498b6bf496302a5c5da04bd6, 85bfb4c1e290c168411090dce1872333095c807f)
5. **Chosen-color sources:** a source with no color chosen is not treated as producing usable colored mana during auto-tap. (137a3927c00cb544b91521ef6840b4e8bdc382a6)

### CR 709.3, 712.8a/11c, 715.2–3a, and 720.3a — split, modal, and Adventure faces

1. **Adventure casting:** an affordable creature face does not make an unaffordable Adventure face castable; each face is evaluated using its own cost and characteristics. (306e83ef6941a32f307b16c51248302e452b7635)
2. **Split cards and spell/spell MDFCs:** an unaffordable face is filtered independently without hiding an independently payable face. (fe9ad70176b2a82c5960c269babf0c11e81da99c)
3. **Granted graveyard casts:** permission to cast the front face from the graveyard does not implicitly grant or substitute an alternate face. (a9c5274988ac2672bcf1b35d290dfca01b50b371)
4. **Hearth Elemental:** instant cards, sorcery cards, and cards that have an Adventure in the graveyard all contribute to the printed cost reduction, even when an Adventure card's front face is a creature. (88ce158c3cb9207ab8c96e1fb1813d38eeddb78a)
5. **Adventure legality caching:** Adventure identity is read from the stored alternate face and is excluded from an incomplete candidate fingerprint, preventing an ineligible card from inheriting another card's cached legality verdict. (39e7a3dc63669a016bfda379fdc8818e5c9d86ba)

### CR 603.4/603.12, 702.33, 702.153a, and 702.166a — conditional payments and additional-cost triggers

1. **Tranquil Frillback:** each selected enter-the-battlefield mode requires its corresponding `{G}` payment; selecting a mode cannot grant its effect for free. (ab7ccf0d7431768546a0a2b53638cf31d22ebeb1)
2. **Kicked permanents:** an “if it was kicked” enter-the-battlefield rider occurs only when the relevant kicker cost was actually paid. (a33d8c52257ae6e77a31421c6ee69965e4fd510b)
3. **Bargained spells and permanents:** bargained riders and triggers require the artifact, enchantment, or token sacrifice; separate bargain costs are tracked independently. (a33d8c52257ae6e77a31421c6ee69965e4fd510b, e2ed977f2c18dd6288fbde8c098c64c97ed1c0fa)
4. **Casualty:** the copy trigger is created only when the casualty creature sacrifice was paid. (7d75f6e90715d4d2b8f63b6a1fd6c26acabf3677)

### CR 107.4f, 118.3, 119.8, 601.2h, 602.2, and 605 — Phyrexian mana and activation payment

1. **Phyrexian spells:** when two Phyrexian symbols compete for one colored mana, the engine preserves every legal combination of mana and life instead of prematurely consuming the mana or accepting an impossible route. (d91c30871860e3e8309c660e85a264bb6e14aadf)
2. **Phyrexian activations:** an activation such as Skrelv's `{W/P}, {T}` preserves both legal mana and life routes, rejects an illegal life payment, taps only the mana sources actually required, and still applies the activation's tap cost. (3b0e545e9e1f46793ae63231c663e4d340bec858)

### CR 118.7a and 702.168d — alternative-cost reductions

1. **Fugitive Codebreaker:** the number of instant and sorcery cards in the graveyard reduces the generic portion of its disguise cost without reducing or dropping the required `{R}`. (f8bb25509fa757a0356ca66e69fbd738ac73cbb6)

## Related issues

Fixes #3306 (Phyrexian mana autotap).

Related: #4941 (multiple kicker choices), #5948 (sacrifice additional costs), #1234 (colored-shard feasibility with non-tap mana), and #5683 (conditional “instead” clauses).

## Validation

- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo check -p engine --lib`
