### PR TITLE
fix(engine): keep hidden card information private

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -898,15 +898,10 @@ fn foretell_special_action_exiles_and_grants_later_turn_permission() {
     let mut state = setup_game_at_main_phase();
     let object_id = add_foretell_sorcery(&mut state);
     add_mana(&mut state, PlayerId(0), ManaType::Colorless, 2);
+    let mut events = Vec::new();
 
-    let waiting = handle_foretell(
-        &mut state,
-        PlayerId(0),
-        object_id,
-        CardId(143),
-        &mut Vec::new(),
-    )
-    .unwrap();
+    let waiting =
+        handle_foretell(&mut state, PlayerId(0), object_id, CardId(143), &mut events).unwrap();
 
     assert_eq!(
         waiting,
@@ -925,6 +920,17 @@ fn foretell_special_action_exiles_and_grants_later_turn_permission() {
         [CastingPermission::Foretold { cost, turn_foretold }]
             if *cost == foretell_test_cost() && *turn_foretold == state.turn_number
     ));
+    let opponent_events =
+        crate::game::visibility::filter_events_for_viewer(&events, &state, PlayerId(1));
+    assert!(opponent_events.iter().all(|event| !matches!(
+        event,
+        GameEvent::ZoneChanged {
+            object_id: moved,
+            from: Some(Zone::Hand),
+            to: Zone::Exile,
+            ..
+        } if *moved == object_id
+    )));
 }
 
 #[test]

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -515,10 +515,8 @@ pub fn create_attraction_deck_card(
 }
 
 fn load_player_attraction_deck(state: &mut GameState, entries: &[DeckEntry], owner: PlayerId) {
-    for entry in entries {
-        for _ in 0..entry.count {
-            create_attraction_deck_card(state, &entry.card, owner);
-        }
+    for face in shuffled_entry_faces(state, entries) {
+        create_attraction_deck_card(state, face, owner);
     }
 }
 
@@ -542,10 +540,8 @@ pub fn create_planar_deck_card(
 
 fn load_shared_planar_deck(state: &mut GameState, entries: &[DeckEntry], owner: PlayerId) {
     state.planar_deck.clear();
-    for entry in entries {
-        for _ in 0..entry.count {
-            create_planar_deck_card(state, &entry.card, owner);
-        }
+    for face in shuffled_entry_faces(state, entries) {
+        create_planar_deck_card(state, face, owner);
     }
     state.planar_controller = Some(owner);
     crate::game::planechase::restamp_planar_objects_to_controller(state);
@@ -571,10 +567,8 @@ pub fn create_scheme_deck_card(
 
 fn load_shared_scheme_deck(state: &mut GameState, entries: &[DeckEntry], owner: PlayerId) {
     state.scheme_deck.clear();
-    for entry in entries {
-        for _ in 0..entry.count {
-            create_scheme_deck_card(state, &entry.card, owner);
-        }
+    for face in shuffled_entry_faces(state, entries) {
+        create_scheme_deck_card(state, face, owner);
     }
     state.archenemy = Some(owner);
 }
@@ -603,10 +597,8 @@ pub fn create_contraption_deck_card(
 }
 
 fn load_player_contraption_deck(state: &mut GameState, entries: &[DeckEntry], owner: PlayerId) {
-    for entry in entries {
-        for _ in 0..entry.count {
-            create_contraption_deck_card(state, &entry.card, owner);
-        }
+    for face in shuffled_entry_faces(state, entries) {
+        create_contraption_deck_card(state, face, owner);
     }
 }
 
@@ -940,14 +932,21 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
 /// intentionally separate: revealed ID/name pairs carry no information about
 /// the current order of unrevealed cards.
 fn load_player_library(state: &mut GameState, entries: &[DeckEntry], owner: PlayerId) {
-    let mut faces = entries
-        .iter()
-        .flat_map(|entry| std::iter::repeat(&entry.card).take(entry.count as usize))
-        .collect::<Vec<_>>();
-    faces.shuffle(&mut state.rng);
-    for face in faces {
+    for face in shuffled_entry_faces(state, entries) {
         create_object_from_card_face(state, face, owner);
     }
+}
+
+/// Produces a fresh ID-allocation order for every hidden-order deck before its
+/// usual game-start shuffle. This prevents a public object ID from encoding the
+/// submitted deck-list position once the card is later revealed.
+fn shuffled_entry_faces(state: &mut GameState, entries: &[DeckEntry]) -> Vec<&CardFace> {
+    let mut faces = entries
+        .iter()
+        .flat_map(|entry| std::iter::repeat_n(&entry.card, entry.count as usize))
+        .collect::<Vec<_>>();
+    faces.shuffle(&mut state.rng);
+    faces
 }
 
 /// Canonical init sequence for every transport layer: load the decks into

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -940,7 +940,7 @@ fn load_player_library(state: &mut GameState, entries: &[DeckEntry], owner: Play
 /// Produces a fresh ID-allocation order for every hidden-order deck before its
 /// usual game-start shuffle. This prevents a public object ID from encoding the
 /// submitted deck-list position once the card is later revealed.
-fn shuffled_entry_faces(state: &mut GameState, entries: &[DeckEntry]) -> Vec<&CardFace> {
+fn shuffled_entry_faces<'a>(state: &mut GameState, entries: &'a [DeckEntry]) -> Vec<&'a CardFace> {
     let mut faces = entries
         .iter()
         .flat_map(|entry| std::iter::repeat_n(&entry.card, entry.count as usize))

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use rand::seq::SliceRandom;
 use serde::{Deserialize, Serialize};
 
 use crate::database::CardDatabase;
@@ -752,26 +753,13 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
             });
     }
 
-    for entry in &payload.player.main_deck {
-        for _ in 0..entry.count {
-            create_object_from_card_face(state, &entry.card, PlayerId(0));
-        }
-    }
-
-    for entry in &payload.opponent.main_deck {
-        for _ in 0..entry.count {
-            create_object_from_card_face(state, &entry.card, PlayerId(1));
-        }
-    }
+    load_player_library(state, &payload.player.main_deck, PlayerId(0));
+    load_player_library(state, &payload.opponent.main_deck, PlayerId(1));
 
     // Load additional AI decks into PlayerId(2), PlayerId(3), etc.
     for (i, ai_deck) in payload.ai_decks.iter().enumerate() {
         let player_id = PlayerId((2 + i) as u8);
-        for entry in &ai_deck.main_deck {
-            for _ in 0..entry.count {
-                create_object_from_card_face(state, &entry.card, player_id);
-            }
-        }
+        load_player_library(state, &ai_deck.main_deck, player_id);
     }
 
     // CR 903.6 + CR 408.1: Place commanders in the command zone at game start.
@@ -942,6 +930,23 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
         crate::util::im_ext::shuffle_vector(&mut player.library, rng);
         crate::util::im_ext::shuffle_vector(&mut player.attraction_deck, rng);
         crate::util::im_ext::shuffle_vector(&mut player.contraption_deck, rng);
+    }
+}
+
+/// Assign library object/card IDs in an order independent of the submitted
+/// deck list. Public stack/battlefield objects retain their `ObjectId`, so
+/// allocating IDs in deck-list order would let opponents recover the hidden
+/// identity behind any later face-down spell. The normal library shuffle is
+/// intentionally separate: revealed ID/name pairs carry no information about
+/// the current order of unrevealed cards.
+fn load_player_library(state: &mut GameState, entries: &[DeckEntry], owner: PlayerId) {
+    let mut faces = entries
+        .iter()
+        .flat_map(|entry| std::iter::repeat(&entry.card).take(entry.count as usize))
+        .collect::<Vec<_>>();
+    faces.shuffle(&mut state.rng);
+    for face in faces {
+        create_object_from_card_face(state, face, owner);
     }
 }
 
@@ -1540,6 +1545,59 @@ mod tests {
         // Check that the order differs from insertion order (Card 0, Card 1, ...)
         let insertion_order: Vec<String> = (0..20).map(|i| format!("Card {}", i)).collect();
         assert_ne!(names, insertion_order, "Library should be shuffled");
+    }
+
+    #[test]
+    fn library_object_ids_do_not_encode_submitted_deck_order() {
+        let entries = (0..20)
+            .map(|i| DeckEntry {
+                card: CardFace {
+                    name: format!("Card {i}"),
+                    ..make_creature_face()
+                },
+                count: 1,
+            })
+            .collect::<Vec<_>>();
+        let payload = DeckPayload {
+            player: PlayerDeckPayload {
+                main_deck: entries,
+                ..Default::default()
+            },
+            opponent: PlayerDeckPayload::default(),
+            ..Default::default()
+        };
+        let mut first = GameState::new_two_player(42);
+        let mut repeated = GameState::new_two_player(42);
+        load_deck_into_state(&mut first, &payload);
+        load_deck_into_state(&mut repeated, &payload);
+
+        let names_by_id = |state: &GameState| {
+            let mut objects = state
+                .objects
+                .iter()
+                .filter(|(_, object)| object.owner == PlayerId(0))
+                .collect::<Vec<_>>();
+            objects.sort_by_key(|(id, _)| **id);
+            objects
+                .into_iter()
+                .map(|(id, object)| {
+                    assert_eq!(object.card_id.0, id.0);
+                    object.name.clone()
+                })
+                .collect::<Vec<_>>()
+        };
+        let insertion_order = (0..20).map(|i| format!("Card {i}")).collect::<Vec<_>>();
+        let first_names = names_by_id(&first);
+
+        assert_ne!(
+            first_names, insertion_order,
+            "public object IDs must not reveal submitted deck order"
+        );
+        assert_eq!(
+            first_names,
+            names_by_id(&repeated),
+            "ID assignment must stay deterministic for replay"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -23,7 +23,7 @@ pub fn resolve_log_entries(events: &[GameEvent], state: &GameState) -> Vec<GameL
 
 /// Returns true for events that should be excluded from log output.
 /// Covers hidden-information leaks and low-signal stack bookkeeping.
-fn should_exclude_event(event: &GameEvent, _state: &GameState) -> bool {
+fn should_exclude_event(event: &GameEvent, state: &GameState) -> bool {
     match event {
         // Library-origin moves and mulligan/tuck moves from hand to library
         // expose hidden card identity. Public discard/moves remain loggable.
@@ -36,6 +36,18 @@ fn should_exclude_event(event: &GameEvent, _state: &GameState) -> bool {
             to: crate::types::zones::Zone::Library,
             ..
         } => true,
+        GameEvent::ZoneChanged {
+            object_id,
+            from: Some(crate::types::zones::Zone::Hand),
+            to: crate::types::zones::Zone::Exile,
+            ..
+        } if state
+            .objects
+            .get(object_id)
+            .is_some_and(|obj| obj.foretold && obj.face_down) =>
+        {
+            true
+        }
         // CardDrawn also reveals which specific card was drawn
         GameEvent::CardDrawn { .. } => true,
         // StackPushed/StackResolved are low-signal bookkeeping —
@@ -1261,14 +1273,9 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
             text(" revoked debug actions from "),
             player_seg(state, *player_id),
         ],
-        GameEvent::Foretold {
-            player_id,
-            object_id,
-        } => vec![
-            player_seg(state, *player_id),
-            text(" foretold "),
-            card_seg(state, *object_id),
-        ],
+        GameEvent::Foretold { player_id, .. } => {
+            vec![player_seg(state, *player_id), text(" foretold a card")]
+        }
         // CR 702.143d: an effect made an exiled card foretold (no foretelling
         // player — the card itself became foretold).
         GameEvent::BecameForetold { object_id } => {
@@ -1368,6 +1375,49 @@ mod tests {
         assert!(entries.iter().all(|entry| entry.segments.iter().all(
             |segment| !matches!(segment, LogSegment::CardName { name, .. } if name == "Secret Mulligan Card")
         )));
+    }
+
+    #[test]
+    fn public_log_hides_foretold_card_name_and_hand_to_exile_record() {
+        use crate::types::game_state::ZoneChangeRecord;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        let foretold = create_object(
+            &mut state,
+            CardId(704),
+            PlayerId(1),
+            "Secret Foretell".to_string(),
+            Zone::Exile,
+        );
+        let obj = state.objects.get_mut(&foretold).unwrap();
+        obj.foretold = true;
+        obj.face_down = true;
+        let mut record = ZoneChangeRecord::test_minimal(foretold, Some(Zone::Hand), Zone::Exile);
+        record.name = "Secret Foretell".to_string();
+        record.owner = PlayerId(1);
+        let entries = resolve_log_entries(
+            &[
+                GameEvent::ZoneChanged {
+                    object_id: foretold,
+                    from: Some(Zone::Hand),
+                    to: Zone::Exile,
+                    record: Box::new(record),
+                },
+                GameEvent::Foretold {
+                    player_id: PlayerId(1),
+                    object_id: foretold,
+                },
+            ],
+            &state,
+        );
+
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(
+            entries[0].segments.as_slice(),
+            [LogSegment::PlayerName { player_id, .. }, LogSegment::Text(text)]
+                if *player_id == PlayerId(1) && text == " foretold a card"
+        ));
     }
 
     #[test]

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -25,9 +25,15 @@ pub fn resolve_log_entries(events: &[GameEvent], state: &GameState) -> Vec<GameL
 /// Covers hidden-information leaks and low-signal stack bookkeeping.
 fn should_exclude_event(event: &GameEvent, _state: &GameState) -> bool {
     match event {
-        // Individual card draws from library leak card identity — CardsDrawn summary suffices
+        // Library-origin moves and mulligan/tuck moves from hand to library
+        // expose hidden card identity. Public discard/moves remain loggable.
         GameEvent::ZoneChanged {
             from: Some(crate::types::zones::Zone::Library),
+            ..
+        }
+        | GameEvent::ZoneChanged {
+            from: Some(crate::types::zones::Zone::Hand),
+            to: crate::types::zones::Zone::Library,
             ..
         } => true,
         // CardDrawn also reveals which specific card was drawn
@@ -1311,6 +1317,57 @@ mod tests {
             has_card_name,
             "Expected CardName segment with 'Lightning Bolt'"
         );
+    }
+
+    #[test]
+    fn public_log_hides_hand_to_library_but_keeps_public_discard() {
+        use crate::types::game_state::ZoneChangeRecord;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        let mulligan = create_object(
+            &mut state,
+            CardId(98),
+            PlayerId(1),
+            "Secret Mulligan Card".to_string(),
+            Zone::Library,
+        );
+        let discarded = create_object(
+            &mut state,
+            CardId(99),
+            PlayerId(1),
+            "Public Discard".to_string(),
+            Zone::Graveyard,
+        );
+        let mut mulligan_record =
+            ZoneChangeRecord::test_minimal(mulligan, Some(Zone::Hand), Zone::Library);
+        mulligan_record.name = "Secret Mulligan Card".to_string();
+        let mut discard_record =
+            ZoneChangeRecord::test_minimal(discarded, Some(Zone::Hand), Zone::Graveyard);
+        discard_record.name = "Public Discard".to_string();
+        let events = vec![
+            GameEvent::ZoneChanged {
+                object_id: mulligan,
+                from: Some(Zone::Hand),
+                to: Zone::Library,
+                record: Box::new(mulligan_record),
+            },
+            GameEvent::ZoneChanged {
+                object_id: discarded,
+                from: Some(Zone::Hand),
+                to: Zone::Graveyard,
+                record: Box::new(discard_record),
+            },
+        ];
+
+        let entries = resolve_log_entries(&events, &state);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].segments.iter().any(
+            |segment| matches!(segment, LogSegment::CardName { name, .. } if name == "Public Discard")
+        ));
+        assert!(entries.iter().all(|entry| entry.segments.iter().all(
+            |segment| !matches!(segment, LogSegment::CardName { name, .. } if name == "Secret Mulligan Card")
+        )));
     }
 
     #[test]

--- a/crates/engine/src/game/log.rs
+++ b/crates/engine/src/game/log.rs
@@ -44,7 +44,7 @@ fn should_exclude_event(event: &GameEvent, state: &GameState) -> bool {
         } if state
             .objects
             .get(object_id)
-            .is_some_and(|obj| obj.foretold && obj.face_down) =>
+            .is_some_and(|obj| obj.face_down) =>
         {
             true
         }
@@ -1278,9 +1278,7 @@ fn format_segments(event: &GameEvent, state: &GameState) -> Vec<LogSegment> {
         }
         // CR 702.143d: an effect made an exiled card foretold (no foretelling
         // player — the card itself became foretold).
-        GameEvent::BecameForetold { object_id } => {
-            vec![card_seg(state, *object_id), text(" becomes foretold")]
-        }
+        GameEvent::BecameForetold { .. } => vec![text("An exiled card becomes foretold")],
         // CR 106.12a: `TappedForMana` is the per-resolution trigger event for
         // `TapsForMana` matchers. The per-unit `ManaAdded` events already
         // produce the user-facing "adds X mana" log lines, so this event is

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1149,10 +1149,10 @@ fn viewer_has_private_access_to_player(
 /// filtered `GameState`. Unlike the state snapshot, this array was broadcast
 /// verbatim to every seat and spectator — leaking hidden library information
 /// through `GameEvent::CardDrawn` (specific `object_id`) and
-/// `GameEvent::ZoneChanged` records emitted on library → hand moves (the
-/// `ZoneChangeRecord` embeds the full card name and type line). The structured
-/// game log already excludes these events; this closes the same hole on the
-/// raw event channel clients also consume.
+/// `GameEvent::ZoneChanged` records emitted on library → hand or hand → library
+/// moves (the `ZoneChangeRecord` embeds the full card name and type line).
+/// The structured game log already excludes these events; this closes the same
+/// hole on the raw event channel clients also consume.
 pub fn filter_events_for_viewer(
     events: &[GameEvent],
     state: &GameState,
@@ -1187,6 +1187,15 @@ fn event_visible_to_viewer(event: &GameEvent, state: &GameState, viewer: PlayerI
             record,
             &can_view_private_for_player,
         ),
+        // CR 400.2: A mulligan moves cards from one hidden zone to another.
+        // The record contains the original hand identity, so only the owner
+        // or a viewer with private-zone authority may receive it.
+        GameEvent::ZoneChanged {
+            from: Some(Zone::Hand),
+            to: Zone::Library,
+            record,
+            ..
+        } => can_view_private_for_player(record.owner),
         _ => true,
     }
 }
@@ -1716,6 +1725,59 @@ mod tests {
         let controller =
             filter_events_for_viewer(std::slice::from_ref(&event), &state, PlayerId(0));
         assert_eq!(controller, vec![event]);
+    }
+
+    #[test]
+    fn filters_opponent_mulligan_hand_to_library_events() {
+        let state = GameState::new_two_player(42);
+        let owner = PlayerId(1);
+        let opponent = PlayerId(0);
+
+        let mut mulligan = crate::types::game_state::ZoneChangeRecord::test_minimal(
+            ObjectId(98),
+            Some(Zone::Hand),
+            Zone::Library,
+        );
+        mulligan.name = "Secret Mulligan Card".to_string();
+        mulligan.owner = owner;
+        let mut discard = crate::types::game_state::ZoneChangeRecord::test_minimal(
+            ObjectId(99),
+            Some(Zone::Hand),
+            Zone::Graveyard,
+        );
+        discard.name = "Public Discard".to_string();
+        discard.owner = owner;
+        let events = vec![
+            GameEvent::ZoneChanged {
+                object_id: ObjectId(98),
+                from: Some(Zone::Hand),
+                to: Zone::Library,
+                record: Box::new(mulligan),
+            },
+            GameEvent::ZoneChanged {
+                object_id: ObjectId(99),
+                from: Some(Zone::Hand),
+                to: Zone::Graveyard,
+                record: Box::new(discard),
+            },
+        ];
+
+        assert_eq!(filter_events_for_viewer(&events, &state, owner), events);
+        let visible = filter_events_for_viewer(&events, &state, opponent);
+        assert_eq!(visible.len(), 1);
+        assert!(matches!(
+            &visible[0],
+            GameEvent::ZoneChanged {
+                from: Some(Zone::Hand),
+                to: Zone::Graveyard,
+                record,
+                ..
+            } if record.name == "Public Discard"
+        ));
+        assert_eq!(
+            filter_events_for_viewer(&events, &state, PlayerId(u8::MAX)),
+            visible
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::types::events::GameEvent;
 use crate::types::game_state::{CastOfferKind, GameState, PayCostKind, WaitingFor};
-use crate::types::identifiers::ObjectId;
+use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::player::PlayerId;
 use crate::types::zones::{ExileCostSourceZone, Zone};
 
@@ -1161,7 +1161,24 @@ pub fn filter_events_for_viewer(
     events
         .iter()
         .filter(|event| event_visible_to_viewer(event, state, viewer))
-        .cloned()
+        .map(|event| match event {
+            // `CardId` is assigned from the pre-shuffle object sequence when a
+            // deck loads. An opponent can use it to recover hidden deck order,
+            // including the identity of a face-down spell; only the public
+            // stack-object reference is safe to retain here.
+            GameEvent::SpellCast {
+                controller,
+                object_id,
+                ..
+            } if !viewer_has_private_access_to_player(state, viewer, *controller) => {
+                GameEvent::SpellCast {
+                    card_id: CardId(0),
+                    controller: *controller,
+                    object_id: *object_id,
+                }
+            }
+            other => other.clone(),
+        })
         .collect()
 }
 
@@ -1920,6 +1937,64 @@ mod tests {
         } else {
             panic!("expected ZoneChanged");
         }
+    }
+
+    #[test]
+    fn opponent_spell_cast_hides_stable_card_id_but_keeps_public_stack_reference() {
+        let mut state = GameState::new_two_player(42);
+        let face_down_spell = create_object(
+            &mut state,
+            CardId(701),
+            PlayerId(1),
+            "Secret Morph".to_string(),
+            Zone::Stack,
+        );
+        state.objects.get_mut(&face_down_spell).unwrap().face_down = true;
+        let own_spell = create_object(
+            &mut state,
+            CardId(702),
+            PlayerId(0),
+            "Known Spell".to_string(),
+            Zone::Stack,
+        );
+        let events = vec![
+            GameEvent::SpellCast {
+                card_id: CardId(701),
+                controller: PlayerId(1),
+                object_id: face_down_spell,
+            },
+            GameEvent::SpellCast {
+                card_id: CardId(702),
+                controller: PlayerId(0),
+                object_id: own_spell,
+            },
+        ];
+
+        let viewer = filter_events_for_viewer(&events, &state, PlayerId(0));
+        assert!(matches!(
+            viewer.as_slice(),
+            [
+                GameEvent::SpellCast {
+                    card_id: CardId(0),
+                    controller: PlayerId(1),
+                    object_id,
+                },
+                GameEvent::SpellCast {
+                    card_id: CardId(702),
+                    controller: PlayerId(0),
+                    ..
+                },
+            ] if *object_id == face_down_spell
+        ));
+
+        let spectator = filter_events_for_viewer(&events, &state, PlayerId(u8::MAX));
+        assert!(spectator.iter().all(|event| matches!(
+            event,
+            GameEvent::SpellCast {
+                card_id: CardId(0),
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1170,7 +1170,12 @@ pub fn filter_events_for_viewer(
                 controller,
                 object_id,
                 ..
-            } if !viewer_has_private_access_to_player(state, viewer, *controller) => {
+            } if !viewer_has_private_access_to_player(state, viewer, *controller)
+                && state
+                    .objects
+                    .get(object_id)
+                    .is_some_and(|obj| obj.face_down) =>
+            {
                 GameEvent::SpellCast {
                     card_id: CardId(0),
                     controller: *controller,
@@ -1974,6 +1979,13 @@ mod tests {
             "Known Spell".to_string(),
             Zone::Stack,
         );
+        let opponent_face_up_spell = create_object(
+            &mut state,
+            CardId(703),
+            PlayerId(1),
+            "Known Opponent Spell".to_string(),
+            Zone::Stack,
+        );
         let events = vec![
             GameEvent::SpellCast {
                 card_id: CardId(701),
@@ -1984,6 +1996,11 @@ mod tests {
                 card_id: CardId(702),
                 controller: PlayerId(0),
                 object_id: own_spell,
+            },
+            GameEvent::SpellCast {
+                card_id: CardId(703),
+                controller: PlayerId(1),
+                object_id: opponent_face_up_spell,
             },
         ];
 
@@ -2001,7 +2018,12 @@ mod tests {
                     controller: PlayerId(0),
                     ..
                 },
-            ] if *object_id == face_down_spell
+                GameEvent::SpellCast {
+                    card_id: CardId(703),
+                    controller: PlayerId(1),
+                    object_id: face_up_object_id,
+                },
+            ] if *object_id == face_down_spell && *face_up_object_id == opponent_face_up_spell
         ));
 
         let spectator = filter_events_for_viewer(&events, &state, PlayerId(u8::MAX));

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1213,6 +1213,23 @@ fn event_visible_to_viewer(event: &GameEvent, state: &GameState, viewer: PlayerI
             record,
             ..
         } => can_view_private_for_player(record.owner),
+        // CR 702.143a: foretell exiles a hand card face down. The zone-change
+        // record snapshots its real name, so it is visible only to a viewer
+        // who may look at that face-down exiled card.
+        GameEvent::ZoneChanged {
+            object_id,
+            from: Some(Zone::Hand),
+            to: Zone::Exile,
+            ..
+        } => state.objects.get(object_id).is_none_or(|obj| {
+            !obj.face_down
+                || face_down_exile_visible_to_viewer(
+                    state,
+                    *object_id,
+                    obj,
+                    &can_view_private_for_player,
+                )
+        }),
         _ => true,
     }
 }
@@ -1995,6 +2012,50 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[test]
+    fn foretold_hand_to_exile_zone_change_is_hidden_from_opponent_and_spectator() {
+        let mut state = GameState::new_two_player(42);
+        let owner = PlayerId(1);
+        let foretold = create_object(
+            &mut state,
+            CardId(704),
+            owner,
+            "Secret Foretell".to_string(),
+            Zone::Exile,
+        );
+        let obj = state.objects.get_mut(&foretold).unwrap();
+        obj.foretold = true;
+        obj.face_down = true;
+        let mut record = crate::types::game_state::ZoneChangeRecord::test_minimal(
+            foretold,
+            Some(Zone::Hand),
+            Zone::Exile,
+        );
+        record.name = "Secret Foretell".to_string();
+        record.owner = owner;
+        let events = vec![
+            GameEvent::ZoneChanged {
+                object_id: foretold,
+                from: Some(Zone::Hand),
+                to: Zone::Exile,
+                record: Box::new(record),
+            },
+            GameEvent::Foretold {
+                player_id: owner,
+                object_id: foretold,
+            },
+        ];
+
+        assert_eq!(filter_events_for_viewer(&events, &state, owner), events);
+        for viewer in [PlayerId(0), PlayerId(u8::MAX)] {
+            let visible = filter_events_for_viewer(&events, &state, viewer);
+            assert!(matches!(
+                visible.as_slice(),
+                [GameEvent::Foretold { object_id, .. }] if *object_id == foretold
+            ));
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1158,6 +1158,7 @@ pub fn filter_events_for_viewer(
     state: &GameState,
     viewer: PlayerId,
 ) -> Vec<GameEvent> {
+    let spectator = !state.players.iter().any(|player| player.id == viewer);
     events
         .iter()
         .filter(|event| event_visible_to_viewer(event, state, viewer))
@@ -1171,10 +1172,11 @@ pub fn filter_events_for_viewer(
                 object_id,
                 ..
             } if !viewer_has_private_access_to_player(state, viewer, *controller)
-                && state
-                    .objects
-                    .get(object_id)
-                    .is_some_and(|obj| obj.face_down) =>
+                && (spectator
+                    || state
+                        .objects
+                        .get(object_id)
+                        .is_some_and(|obj| obj.face_down)) =>
             {
                 GameEvent::SpellCast {
                     card_id: CardId(0),


### PR DESCRIPTION
## Summary

Fixes information-leak paths involving mulligans, Foretell, stable object identifiers, and library state. Hidden cards and their identities remain private to the appropriate player while preserving legal actions and the current replacement-aware Foretell movement path. Each commit records a concrete Before/Rule/After example.

No directly matching Phase issue was found in the repository issue search.

## Rules fixes

### CR 400.2 — hidden-zone information

1. **Opponent mulligans:** a card moved from hand to library during a mulligan exposes the movement but not its name or stable identity to an opponent. (cbe92354b7f29d22256b388b0daddbbdb514ae0b)
2. **Public game log:** hidden hand-to-library mulligan moves are omitted from the public log, while genuinely public discards remain visible. (919c0bab96f5d1f7f90d2b22b5db9be88278921e)
3. **Stable spell identities:** opponent-facing events can reference an observable spell on the stack without exposing a persistent hidden-card identifier that would allow the card to be tracked across zones. (21282749dee20afdf0c4c924c92c9bcde99a592a)

### CR 702.143a — face-down Foretell exile

1. **Foretelling a card:** opponents can observe that a card was foretold and moved to exile, but the exile event and public log do not reveal its name or stable identity. (19c1fc517d124c3cc6129e093488e18c26241c9c)

### CR 401.2 and 701.20 — hidden, randomized library order

1. **Library identifiers:** object IDs are allocated using a deterministic replay-safe shuffle instead of submitted deck-list order, preventing observers from inferring hidden card identity or library order from otherwise opaque IDs. (3f0bba53fd23571603c30a4001cca67cd64ec568)

## Validation

- `cargo fmt --all -- --check`
- `git diff --check upstream/main...HEAD`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo check -p engine --lib`
