### PR TITLE
feat(parser): dynamic damage-modification replacements (Fated Firepower, Neriv)

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -6591,6 +6591,33 @@ fn parse_that_much_damage_offset(
                     .map(|value| DamageModification::Plus { value })
             },
         ),
+        // CR 614.1a: dynamic additive offset phrased as "plus an amount of
+        // damage equal to <quantity> instead" (Fated Firepower: "...the number
+        // of fire counters on this enchantment") — a replacement effect keyed on
+        // "instead". The counter-quantity's own rules live in the reused
+        // `parse_cda_quantity` (already annotated). Mirrors the "plus x, where X
+        // is" arm for the "an amount of damage equal to" surface form.
+        // Placed before the bare "plus x" freeze and the numeric fallback so a
+        // recognized dynamic quantity is not shadowed by "an"->1. The leading
+        // `terminated(take_until(" instead"), tag(" instead"))` strips the trailing
+        // " instead" so `parse_cda_quantity` receives a clean quantity phrase
+        // ("the number of fire counters on ~"); a bare `rest` would append
+        // " instead" and fail parse_cda_quantity's strict counter suffix. map_opt
+        // delegates parse_cda_quantity's Option (fail-closed on unrecognized
+        // quantity → falls through to the numeric arm).
+        map_opt(
+            preceded(
+                tag("plus an amount of damage equal to "),
+                alt((
+                    terminated(take_until(" instead"), tag(" instead")),
+                    nom::combinator::rest,
+                )),
+            ),
+            |q: &str| {
+                crate::parser::oracle_quantity::parse_cda_quantity(q)
+                    .map(|value| DamageModification::Plus { value })
+            },
+        ),
         // "plus X" with no binding — variable offset frozen at install. Tried
         // before the numeric arm so the literal "x" token is not consumed by
         // parse_number.
@@ -6619,7 +6646,14 @@ fn parse_damage_modification_phrase(
     alt((
         value(
             DamageModification::Double,
-            alt((tag("double that damage"), tag("deals double that damage"))),
+            alt((
+                tag("double that damage"),
+                tag("deals double that damage"),
+                // CR 701.10g: "To double an amount of damage a source would
+                // deal, that source instead deals twice that much damage. This
+                // is a replacement effect." (Neriv, Heart of the Storm).
+                tag("twice that much damage"),
+            )),
         ),
         value(
             DamageModification::Triple,
@@ -15886,6 +15920,201 @@ mod tests {
         assert!(
             serde_json::from_str::<DamageModification>(r#"{"type":"Plus","value":"x"}"#).is_err()
         );
+    }
+
+    // DynQty subgroup A — damage-modification replacement (CR 614.1a).
+
+    /// Test A — `parse_that_much_damage_offset` (Change 1). The new "plus an
+    /// amount of damage equal to <quantity> instead" arm (Fated Firepower)
+    /// carries the live fire-counter quantity as `Plus { Ref(CountersOn(..)) }`.
+    #[test]
+    fn fated_firepower_dynamic_offset_arm() {
+        use crate::types::ability::ObjectScope;
+
+        // A-positive (LOAD-BEARING; FLIPS on revert of Change 1): reverting the
+        // new arm lets the numeric fallback read "an" -> 1 (Plus{Fixed{1}}).
+        let (_, positive) = parse_that_much_damage_offset(
+            "that much damage plus an amount of damage equal to the number of fire counters on ~ instead",
+        )
+        .expect("dynamic additive offset must parse");
+        assert_eq!(
+            positive,
+            DamageModification::Plus {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Source,
+                        counter_type: Some(CounterType::Generic("fire".to_string())),
+                    }
+                }
+            },
+            "Fated Firepower must carry the live fire-counter Ref, not Fixed(1)"
+        );
+
+        // A-sibling: the pre-existing "plus x, where X is <quantity>" arm
+        // (Hawkeye) is not shadowed by the new arm.
+        let (_, hawkeye) =
+            parse_that_much_damage_offset("that much damage plus x, where x is ~'s power.")
+                .unwrap();
+        assert_eq!(
+            hawkeye,
+            DamageModification::Plus {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::Source
+                    }
+                }
+            }
+        );
+
+        // A-sibling: literal numeric offset still Fixed.
+        let (_, two) = parse_that_much_damage_offset("that much damage plus 2").unwrap();
+        assert_eq!(
+            two,
+            DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 }
+            }
+        );
+
+        // A-hostile (fail-closed GATE — explicitly NON-flipping): an
+        // unrecognized quantity makes `map_opt` fail, so the new arm yields to
+        // the numeric arm, which reads "an" -> 1. This asserts the ACTUAL
+        // result (Fixed(1)), not Err/None. It is Fixed(1) both WITH and WITHOUT
+        // Change 1, so it does not flip on revert — it guards that garbage never
+        // panics or mis-binds a dynamic quantity.
+        let (_, hostile) = parse_that_much_damage_offset(
+            "that much damage plus an amount of damage equal to florble glorp instead",
+        )
+        .unwrap();
+        assert_eq!(
+            hostile,
+            DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 1 }
+            },
+            "garbage quantity must fail closed to the numeric 'an'->1 arm"
+        );
+    }
+
+    /// Test B — `parse_damage_modification_phrase` (Change 2). The new "twice
+    /// that much damage" leaf (Neriv, Heart of the Storm) maps to `Double`.
+    #[test]
+    fn neriv_twice_that_much_damage_phrase() {
+        // B-positive (LOAD-BEARING; FLIPS on revert of Change 2 -> Err).
+        let (_, positive) = parse_damage_modification_phrase("twice that much damage").unwrap();
+        assert_eq!(positive, DamageModification::Double);
+
+        // B-siblings: pre-existing Double / Triple leaves unaffected.
+        assert_eq!(
+            parse_damage_modification_phrase("double that damage")
+                .unwrap()
+                .1,
+            DamageModification::Double
+        );
+        assert_eq!(
+            parse_damage_modification_phrase("triple that damage")
+                .unwrap()
+                .1,
+            DamageModification::Triple
+        );
+
+        // B-negative: an unsupported synonym does not match.
+        assert!(parse_damage_modification_phrase("half that much damage").is_err());
+    }
+
+    /// Test C — assembled Fated Firepower via the real pipeline
+    /// (`parse_replacement_line` normalizes "this enchantment" -> `~` and reaches
+    /// `parse_damage_modification_replacement`). FLIPS on revert of Change 1
+    /// (damage_modification becomes `Plus{Fixed{1}}`).
+    #[test]
+    fn fated_firepower_assembled_replacement() {
+        use crate::types::ability::ObjectScope;
+        let def = parse_replacement_line(
+            "If a source you control would deal damage to an opponent or a permanent an opponent controls, it deals that much damage plus an amount of damage equal to the number of fire counters on this enchantment instead.",
+            "Fated Firepower",
+        )
+        .expect("Fated Firepower damage-modification replacement must parse");
+        assert_eq!(
+            def.damage_modification,
+            Some(DamageModification::Plus {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOn {
+                        scope: ObjectScope::Source,
+                        counter_type: Some(CounterType::Generic("fire".to_string())),
+                    }
+                }
+            }),
+            "FF must carry the live fire-counter amount (revert -> Plus{{Fixed{{1}}}})"
+        );
+        assert_eq!(
+            def.damage_target_filter,
+            Some(damage_target_opponent_or_permanents())
+        );
+        assert_eq!(def.combat_scope, None);
+        match def.damage_source_filter.unwrap() {
+            TargetFilter::Typed(tf) => {
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+                assert!(tf.properties.is_empty());
+            }
+            other => panic!("Expected Typed source filter, got {other:?}"),
+        }
+    }
+
+    /// Test D — assembled Neriv via a direct call to
+    /// `parse_damage_modification_replacement`. Neriv has no self-reference in
+    /// the clause, so the `~`-normalized lowercase form is exactly the lowercase
+    /// text the pipeline produces. Reverting Change 2 makes the DIRECT call
+    /// return `None` outright (the function opens with
+    /// `scan_damage_modification(norm_lower)?`), so `is_some()` flips.
+    #[test]
+    fn neriv_assembled_replacement_direct() {
+        let text = "If a creature you control that entered this turn would deal damage, it deals twice that much damage instead.";
+        let norm_lower = text.to_lowercase();
+        let def = parse_damage_modification_replacement(&norm_lower, text)
+            .expect("Neriv doubling replacement must assemble (revert Change 2 -> None)");
+        assert_eq!(def.damage_modification, Some(DamageModification::Double));
+        assert_eq!(def.combat_scope, None);
+        assert_eq!(def.damage_target_filter, None);
+        match def.damage_source_filter.unwrap() {
+            TargetFilter::Typed(tf) => {
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+                assert!(
+                    tf.properties
+                        .iter()
+                        .any(|p| matches!(p, FilterProp::EnteredThisTurn)),
+                    "Neriv source is a creature that entered this turn"
+                );
+            }
+            other => panic!("Expected Typed source filter, got {other:?}"),
+        }
+    }
+
+    /// Test E — regression guard: Ojer Axonil, Deepest Might is unchanged by
+    /// this PR (no production change touches SetToSourcePower). Guards that the
+    /// Change-1 `take_until(" instead")` does not over-capture on Ojer's text
+    /// (which also contains "instead"). Ojer routes through the
+    /// `parse_damage_modification_phrase` scan (SetToSourcePower) BEFORE the
+    /// `parse_that_much_damage_offset` scan, so the new arm never runs.
+    #[test]
+    fn ojer_axonil_set_to_source_power_unchanged() {
+        let def = parse_replacement_line(
+            "If a red source you control would deal an amount of noncombat damage less than Ojer Axonil's power to an opponent, that source deals damage equal to Ojer Axonil's power instead.",
+            "Ojer Axonil, Deepest Might",
+        )
+        .expect("Ojer Axonil damage-modification replacement must parse");
+        assert_eq!(
+            def.damage_modification,
+            Some(DamageModification::SetToSourcePower)
+        );
+        assert_eq!(def.combat_scope, Some(CombatDamageScope::NoncombatOnly));
+        assert_eq!(def.damage_target_filter, Some(damage_target_opponent()));
+        match def.damage_source_filter.unwrap() {
+            TargetFilter::Typed(tf) => {
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+                assert!(tf.properties.contains(&FilterProp::HasColor {
+                    color: ManaColor::Red,
+                }));
+            }
+            other => panic!("Expected Typed source filter, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -31,11 +31,11 @@ use super::oracle_ir::feature::{
 use super::swallow_evidence::UnitEvidence;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, CastingPermission, Comparator,
-    ContinuousModification, CopyRetargetPermission, DelayedTriggerCondition, Duration, Effect,
-    FilterProp, ManaProduction, ModalSelectionConstraint, OpponentMayScope, ParsedCondition,
-    PlayerFilter, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementMode,
-    RestrictionExpiry, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition,
-    TriggerConstraint, TriggerDefinition, UnlessPayScaling,
+    ContinuousModification, CopyRetargetPermission, DamageModification, DelayedTriggerCondition,
+    Duration, Effect, FilterProp, ManaProduction, ModalSelectionConstraint, OpponentMayScope,
+    ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef, ReplacementCondition,
+    ReplacementMode, RestrictionExpiry, StaticCondition, StaticDefinition, TargetFilter,
+    TriggerCondition, TriggerConstraint, TriggerDefinition, UnlessPayScaling,
 };
 use crate::types::game_state::RetargetScope;
 use crate::types::keywords::Keyword;
@@ -2030,6 +2030,21 @@ fn any_ability_has_apnap_ordering(parsed: &ParsedAbilities) -> bool {
 
 // ── Detector F: DynamicQty ──────────────────────────────────────────────
 
+/// Dynamic-quantity marker phrases other than " twice " (which each caller
+/// handles per-site: the has_marker gate ORs it with its activation-limit
+/// guard; the *_is_only_dynamic_marker helpers treat it as the sole/second
+/// marker). Extracted so the list can't drift across the three call sites.
+const OTHER_DYNAMIC_MARKERS: &[&str] = &[
+    " equal to ",
+    "for each ",
+    "where x is ",
+    "the number of ",
+    "half your ",
+    "half their ",
+    "half its ",
+    "half the ",
+];
+
 /// Oracle text contains dynamic-quantity grammar ("equal to", "for each",
 /// "twice", "where x is", "the number of", "half [poss]") but the parsed
 /// AST contains no dynamic carrier (Ref, Multiply, DivideRounded, Offset,
@@ -2049,15 +2064,8 @@ fn detect_dynamic_qty(
     let twice_is_activation_limit = cleaned.contains("twice each turn") // allow-noncombinator: swallow detector marker scan on classified text
         && !cleaned.contains("twice that") // allow-noncombinator: swallow detector marker scan on classified text
         && !cleaned.contains("twice x"); // allow-noncombinator: swallow detector marker scan on classified text
-    let has_marker = cleaned.contains(" equal to ") // allow-noncombinator: swallow detector marker scan on classified text
-        || cleaned.contains("for each ") // allow-noncombinator: swallow detector marker scan on classified text
-        || (cleaned.contains(" twice ") && !twice_is_activation_limit) // allow-noncombinator: swallow detector marker scan on classified text
-        || cleaned.contains("where x is ") // allow-noncombinator: swallow detector marker scan on classified text
-        || cleaned.contains("the number of ") // allow-noncombinator: swallow detector marker scan on classified text
-        || cleaned.contains("half your ") // allow-noncombinator: swallow detector marker scan on classified text
-        || cleaned.contains("half their ") // allow-noncombinator: swallow detector marker scan on classified text
-        || cleaned.contains("half its ") // allow-noncombinator: swallow detector marker scan on classified text
-        || cleaned.contains("half the "); // allow-noncombinator: swallow detector marker scan on classified text
+    let has_marker = (cleaned.contains(" twice ") && !twice_is_activation_limit) // allow-noncombinator: swallow detector marker scan on classified text
+        || OTHER_DYNAMIC_MARKERS.iter().any(|m| cleaned.contains(m));
     if !has_marker {
         return;
     }
@@ -2227,6 +2235,26 @@ fn detect_dynamic_qty(
     // When "twice" is the SOLE dynamic marker and the AST carries a `repeat_for`,
     // the quantity IS represented; the warning is a false positive.
     if cleaned_twice_is_only_dynamic_marker(cleaned) && evidence.has_slot("repeat_for") {
+        return;
+    }
+    // CR 614.1a + CR 701.10g: "...it deals twice that much damage instead"
+    // (Neriv, Heart of the Storm) is a damage-doubling value-modifier
+    // replacement whose ×2 is carried by `ReplacementDefinition.damage_modification`
+    // (`Double`/`Triple`), NOT a `QuantityExpr` node — the sibling of the
+    // `quantity_modification` slot ("twice that many", Doubling Season) and the
+    // `repeat_for` clause above. `Double` is a UNIT variant with no `QuantityExpr`
+    // field, so it also escapes the `any_quantity_expr` carrier. When
+    // "twice that much damage" is the SOLE dynamic marker and the AST carries such
+    // a modification, the multiplier IS represented — runtime resolves it
+    // end-to-end via the `damage_done_applier` Double/Triple arm. Distinct from
+    // the `repeat_for` guard above (repeat-count "twice", which deliberately
+    // rejects the "twice that" multiplier form): here that multiplier IS the
+    // carried modification, so it is the accepted marker.
+    if cleaned_twice_damage_double_is_only_dynamic_marker(cleaned)
+        && evidence.any_at::<DamageModification>(&["damage_modification"], |m| {
+            matches!(m, DamageModification::Double | DamageModification::Triple)
+        })
+    {
         return;
     }
     // CR 608.2e + CR 109.5: "For each opponent who doesn't, <body>" is a
@@ -2535,19 +2563,30 @@ fn cleaned_twice_is_only_dynamic_marker(cleaned: &str) -> bool {
         return false;
     }
     // No OTHER dynamic marker may be present.
-    ![
-        " equal to ",
-        "for each ",
-        "where x is ",
-        "the number of ",
-        "half your ",
-        "half their ",
-        "half its ",
-        "half the ",
-    ]
-    .iter()
     // allow-noncombinator: swallow detector marker scan on classified text
-    .any(|marker| cleaned.contains(marker))
+    !OTHER_DYNAMIC_MARKERS.iter().any(|m| cleaned.contains(m))
+}
+
+/// True when the sole dynamic-quantity marker in `cleaned` is the
+/// damage-doubling phrase "twice that much damage" — the surface form Neriv,
+/// Heart of the Storm lowers to `DamageModification::Double`. Sibling of
+/// `cleaned_twice_is_only_dynamic_marker` (repeat-count "twice") for the
+/// damage-modification carrier: that helper deliberately REJECTS "twice that" (a
+/// multiplier needing a real `QuantityExpr`), but here the ×2 IS the
+/// "twice that much damage" phrase, already carried by `DamageModification`, so
+/// it is the accepted marker. Every OTHER dynamic marker — a second, independent
+/// "twice", "for each", "equal to", "the number of", "where x is", "half …" —
+/// keeps the warning, so a genuinely-swallowed second clause is never masked.
+fn cleaned_twice_damage_double_is_only_dynamic_marker(cleaned: &str) -> bool {
+    // allow-noncombinator: swallow detector phrase scan on classified text
+    if !cleaned.contains("twice that much damage") {
+        return false;
+    }
+    // Strip the accepted doubling phrase, then require no dynamic marker to
+    // remain — a residual " twice " catches a second, independent doubling.
+    let residual = cleaned.replace("twice that much damage", " ");
+    // allow-noncombinator: swallow detector marker scan on classified text
+    !(residual.contains(" twice ") || OTHER_DYNAMIC_MARKERS.iter().any(|m| residual.contains(m)))
 }
 
 /// CR 702.170c + CR 608.2c: "[you may] exile a card. If you do, it becomes
@@ -4423,7 +4462,9 @@ mod tests {
     };
     use crate::parser::oracle::parse_oracle_text;
     use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
-    use crate::types::ability::{AbilityDefinition, Effect, OutsideGameSourcePool, TargetFilter};
+    use crate::types::ability::{
+        AbilityDefinition, DamageModification, Effect, OutsideGameSourcePool, TargetFilter,
+    };
     use crate::types::identifiers::TrackedSetId;
     use crate::types::keywords::Keyword;
     use crate::types::mana::ManaCost;
@@ -7203,6 +7244,91 @@ this spell's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
         // No "twice" at all.
         assert!(!super::cleaned_twice_is_only_dynamic_marker(
             "draw a card for each creature you control."
+        ));
+    }
+
+    /// CR 614.1a + CR 701.10g: Neriv, Heart of the Storm — "it deals twice that
+    /// much damage instead" is a `DamageModification::Double` replacement. The ×2
+    /// is carried by the modification (a unit variant with no `QuantityExpr`), so
+    /// the "twice" marker must not flag DynamicQty.
+    ///
+    /// Non-vacuous: the two reach-guards prove the parse reached the real Double
+    /// carrier and admitted zero `Effect::Unimplemented` (an Unimplemented would
+    /// early-return `check_swallowed_clauses` and make the negative pass for the
+    /// wrong reason — card-test foot-gun #6). Revert surface: remove the
+    /// `damage_modification` suppression clause in `detect_dynamic_qty` and this
+    /// flips to a live DynamicQty warning.
+    #[test]
+    fn dynamic_qty_accepts_damage_double_carrier_neriv() {
+        // Verbatim Oracle text. "Flying" is supplied as an MTGJSON keyword — as
+        // the real card-data pipeline does — so it is recognized rather than left
+        // as an Unimplemented line; the doubling clause is the unit under test.
+        let types: Vec<String> = ["Legendary", "Creature", "Dragon"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let parsed = parse_oracle_text(
+            "Flying\n\
+             If a creature you control that entered this turn would deal damage, it deals twice \
+             that much damage instead.",
+            "Neriv, Heart of the Storm",
+            &["Flying".to_string()],
+            &types,
+            &["Dragon".to_string()],
+        );
+
+        // Reach-guard A: zero Unimplemented ⇒ the doubling unit's detector runs to
+        // completion (an Unimplemented would early-return `check_swallowed_clauses`
+        // — card-test foot-gun #6). Isolation was measured: the doubling clause
+        // ALONE parses to zero abilities + one Double replacement, so this
+        // negative is exercised on the doubling unit, not masked by the "Flying"
+        // keyword line.
+        assert!(
+            !any_ability_has_unimplemented(&parsed),
+            "reach-guard: Neriv must parse with zero Unimplemented (else the negative is vacuous)"
+        );
+        // Reach-guard B: the Double carrier the suppression keys on is present.
+        assert!(
+            parsed
+                .replacements
+                .iter()
+                .any(|r| r.damage_modification == Some(DamageModification::Double)),
+            "reach-guard: Neriv must parse to a Double damage-modification replacement"
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "DynamicQty"));
+    }
+
+    /// Helper-level narrowness gate for
+    /// `cleaned_twice_damage_double_is_only_dynamic_marker`: the damage-double
+    /// suppression fires ONLY when "twice that much damage" is the sole dynamic
+    /// marker, and — unlike `cleaned_twice_is_only_dynamic_marker` (repeat-count
+    /// "twice") — it accepts the "twice that" multiplier form because here the ×2
+    /// is carried by `DamageModification::Double`. Any second dynamic marker keeps
+    /// the warning, so a real second clause is never masked.
+    #[test]
+    fn dynamic_qty_damage_double_marker_gate() {
+        // Neriv's sole-marker case — suppression-eligible.
+        assert!(super::cleaned_twice_damage_double_is_only_dynamic_marker(
+            "if a creature you control that entered this turn would deal damage, it deals twice \
+             that much damage instead."
+        ));
+        // The OLD repeat-count helper REJECTS this exact phrase (it treats
+        // "twice that" as a multiplier needing a real QuantityExpr) — which is
+        // precisely why the damage-double helper is a separate sibling.
+        assert!(!super::cleaned_twice_is_only_dynamic_marker(
+            "it deals twice that much damage instead."
+        ));
+        // Non-masking: a genuine second dynamic marker keeps the warning live.
+        assert!(!super::cleaned_twice_damage_double_is_only_dynamic_marker(
+            "it deals twice that much damage. then draw cards equal to the number of counters on it."
+        ));
+        assert!(!super::cleaned_twice_damage_double_is_only_dynamic_marker(
+            "it deals twice that much damage, then create a token for each creature you control."
+        ));
+        // No damage-double phrase at all → not eligible.
+        assert!(!super::cleaned_twice_damage_double_is_only_dynamic_marker(
+            "investigate twice instead."
         ));
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -710,6 +710,7 @@ mod springheart_realdb_repro;
 mod squirrel_mob_dynamic_pump;
 mod stack_object_keyword_grants;
 mod std_counters_grammar_axes;
+mod std_dynqty_a_damage_mod_runtime;
 mod std_longtail_b_delayed_effects;
 mod std_s07_batch5a;
 mod std_s07_batch5b;

--- a/crates/engine/tests/integration/std_dynqty_a_damage_mod_runtime.rs
+++ b/crates/engine/tests/integration/std_dynqty_a_damage_mod_runtime.rs
@@ -1,0 +1,180 @@
+//! DynQty subgroup A — damage-modification replacement runtime guards
+//! (CR 614.1a). PERMANENT regression tests backing the coverage flip of two
+//! cards to `supported:True`.
+//!
+//! * Neriv, Heart of the Storm — "If a creature you control that entered this
+//!   turn would deal damage, it deals twice that much damage instead."
+//!   (`DamageModification::Double`, source filter carries `EnteredThisTurn`).
+//!   Proves BOTH the doubling AND the entered-this-turn gate: an
+//!   entered-this-turn source doubles (2 → 4); a prior-turn source does not
+//!   (stays 2). Reverting the "twice that much damage" → `Double` parser leaf
+//!   (oracle_replacement.rs) drops the replacement entirely, so the source no
+//!   longer doubles.
+//!
+//! * Fated Firepower — "...it deals that much damage plus an amount of damage
+//!   equal to the number of fire counters on this enchantment instead."
+//!   (`DamageModification::Plus { Ref(CountersOn fire) }`). Rules-correctness
+//!   regression: with 3 fire counters, a 2-damage source deals 5 (2 + 3), NOT 3
+//!   (the reverted `Plus{Fixed{1}}` "an" → 1 bug), NOT 2. Reverting the dynamic
+//!   "plus an amount of damage equal to <quantity>" parser arm regresses this to
+//!   3.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use engine::types::ability::{DamageModification, ReplacementDefinition};
+use engine::types::counter::CounterType;
+use engine::types::phase::Phase;
+
+use super::rules::run_combat;
+
+const NERIV_ORACLE: &str = "Flying\n\
+    If a creature you control that entered this turn would deal damage, it deals twice that much \
+    damage instead.";
+
+const FATED_FIREPOWER_ORACLE: &str = "Flash\n\
+    This enchantment enters with X fire counters on it.\n\
+    If a source you control would deal damage to an opponent or a permanent an opponent controls, \
+    it deals that much damage plus an amount of damage equal to the number of fire counters on \
+    this enchantment instead.";
+
+fn parse_card(oracle: &str, name: &str, types: &[&str]) -> ParsedAbilities {
+    let types: Vec<String> = types.iter().map(|s| (*s).to_string()).collect();
+    parse_oracle_text(oracle, name, &[], &types, &[])
+}
+
+/// The single damage-modification replacement on the card. `.expect` here is a
+/// reach-guard: reverting the parser arm under test drops the replacement, so
+/// this panics (the test fails) — the doubling/offset behavior below can only be
+/// asserted once the replacement is present.
+fn damage_modification_replacement(
+    oracle: &str,
+    name: &str,
+    types: &[&str],
+) -> ReplacementDefinition {
+    parse_card(oracle, name, types)
+        .replacements
+        .into_iter()
+        .find(|r| r.damage_modification.is_some())
+        .expect("expected a damage-modification replacement")
+}
+
+// ── Neriv, Heart of the Storm ───────────────────────────────────────────────
+
+/// Neriv (a): an entered-this-turn source you control deals 2 combat damage →
+/// DOUBLED to 4 via `DamageModification::Double`, gated on the `EnteredThisTurn`
+/// source filter. Revert surface: revert the "twice that much damage" → Double
+/// parser leaf and the replacement is dropped, so the source no longer doubles.
+#[test]
+fn neriv_entered_this_turn_source_doubles() {
+    let repl = damage_modification_replacement(
+        NERIV_ORACLE,
+        "Neriv, Heart of the Storm",
+        &["Legendary", "Creature", "Dragon"],
+    );
+    assert_eq!(repl.damage_modification, Some(DamageModification::Double));
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Attacker entered THIS turn (summoning-sick) but has haste so it can attack;
+    // `entered_battlefield_turn == turn_number` ⇒ EnteredThisTurn TRUE.
+    let fresh = scenario
+        .add_creature(P0, "Fresh Raider", 2, 2)
+        .with_summoning_sickness()
+        .haste()
+        .id();
+    let wall = scenario.add_creature(P1, "Stone Wall", 0, 10).id();
+    // Neriv holds the replacement but does not attack — the doubler must apply to
+    // ANY entered-this-turn creature you control, not only its own source.
+    scenario
+        .add_creature(P0, "Neriv, Heart of the Storm", 1, 1)
+        .with_replacement_definition(repl);
+
+    let mut runner = scenario.build();
+    run_combat(&mut runner, vec![fresh], vec![(wall, fresh)]);
+
+    let marked = runner.state().objects.get(&wall).unwrap().damage_marked;
+    assert_eq!(
+        marked, 4,
+        "CR 614.1a + CR 701.10g: an entered-this-turn source's 2 damage must double to 4"
+    );
+}
+
+/// Neriv (b): DISCRIMINATING for the `EnteredThisTurn` gate — a source that
+/// entered a PRIOR turn is NOT doubled; its 2 combat damage stays 2. Revert the
+/// gate (source filter loses `EnteredThisTurn`) and this doubles to 4, failing.
+#[test]
+fn neriv_prior_turn_source_not_doubled() {
+    let repl = damage_modification_replacement(
+        NERIV_ORACLE,
+        "Neriv, Heart of the Storm",
+        &["Legendary", "Creature", "Dragon"],
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Plain add_creature ⇒ entered_battlefield_turn = turn_number - 1 (prior
+    // turn), not summoning-sick ⇒ EnteredThisTurn FALSE.
+    let veteran = scenario.add_creature(P0, "Veteran Raider", 2, 2).id();
+    let wall = scenario.add_creature(P1, "Stone Wall", 0, 10).id();
+    scenario
+        .add_creature(P0, "Neriv, Heart of the Storm", 1, 1)
+        .with_replacement_definition(repl);
+
+    let mut runner = scenario.build();
+    run_combat(&mut runner, vec![veteran], vec![(wall, veteran)]);
+
+    let marked = runner.state().objects.get(&wall).unwrap().damage_marked;
+    assert_eq!(
+        marked, 2,
+        "a prior-turn source must not be doubled (EnteredThisTurn source filter)"
+    );
+}
+
+// ── Fated Firepower ─────────────────────────────────────────────────────────
+
+/// Fated Firepower: rules-correctness regression. With 3 fire counters on the
+/// enchantment, a 2-power source you control dealing combat damage to a permanent
+/// an opponent controls deals 2 + 3 = 5 — `Plus { Ref(CountersOn fire) }` resolved
+/// against the replacement source (the enchantment). Revert surface: revert the
+/// dynamic "plus an amount of damage equal to <quantity>" parser arm and the
+/// offset regresses to `Plus{Fixed{1}}` (2 + 1 = 3).
+#[test]
+fn fated_firepower_offset_scales_with_fire_counters() {
+    let repl = damage_modification_replacement(
+        FATED_FIREPOWER_ORACLE,
+        "Fated Firepower",
+        &["Enchantment"],
+    );
+    assert!(
+        matches!(
+            repl.damage_modification,
+            Some(DamageModification::Plus { .. })
+        ),
+        "FF must carry an additive Plus modification (revert → Plus{{Fixed{{1}}}} is still Plus, \
+         so the runtime magnitude below is the discriminator)"
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // 2-power source you control (prior turn ⇒ can attack).
+    let source = scenario.add_creature(P0, "Ember Striker", 2, 2).id();
+    // A permanent an opponent controls (matches FF's target filter).
+    let wall = scenario.add_creature(P1, "Stone Wall", 0, 10).id();
+    // Fated Firepower with 3 fire counters holds the replacement; CountersOn
+    // resolves against the replacement source = this enchantment.
+    let ff = scenario
+        .add_creature(P0, "Fated Firepower", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(repl)
+        .id();
+    scenario.with_counter(ff, CounterType::Generic("fire".to_string()), 3);
+
+    let mut runner = scenario.build();
+    run_combat(&mut runner, vec![source], vec![(wall, source)]);
+
+    let marked = runner.state().objects.get(&wall).unwrap().damage_marked;
+    assert_eq!(
+        marked, 5,
+        "CR 614.1a + CR 120: 2 base + 3 fire counters = 5 (revert → Plus{{Fixed{{1}}}} = 3)"
+    );
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds two composable **damage-modification replacement** parser arms (CR 614.1a — "instead" replacement effects) so damage-doubling and dynamic additive-offset cards parse to typed `DamageModification` values. Fixes a `DynamicQty` coverage-classifier false-positive that flagged damage-`Double`/`Triple` carriers as unsupported. Standard-legal cards unlocked: **Fated Firepower** and **Neriv, Heart of the Storm**; **Ojer Axonil, Deepest Might** (`SetToSourcePower`, already handled) gains an unchanged-behavior regression test.

DynQty subgroup A of the Standard rollout.

## Implementation method (required)

Method: /engine-implementer

## CR references

- `CR 614.1a` — a replacement effect that reads "instead" replaces the damage event with the modified amount.
- `CR 701.10g` — to double an amount of damage, the source instead deals twice that much damage.

## What changed

**`parser/oracle_replacement.rs`** — two arms, both composed from existing combinators (no verbatim Oracle-string match):

- `parse_that_much_damage_offset` — new arm (inserted before the numeric arm so `"an"`→1 does not shadow it):
  `preceded(tag("plus an amount of damage equal to "), terminated(take_until(" instead"), tag(" instead")))`
  → `map_opt` → `parse_cda_quantity(q)` → `DamageModification::Plus { value }`. Fail-closed: an unrecognized quantity makes `map_opt` fail and the arm yields.
- `parse_damage_modification_phrase` — new leaf `tag("twice that much damage")` added to the pre-existing Double `alt` (siblings `"double that damage"`, `"deals double that damage"`) → `DamageModification::Double`.

**Before → after AST (Fated Firepower):**

- Before: `it deals that much damage plus an amount of damage equal to the number of fire counters on ~ instead` → `ReplacementDefinition { damage_modification: None, .. }` (dropped / unsupported).
- After: `damage_modification: Some(DamageModification::Plus { value: <fire-counters-on-source ref> })`.

**`parser/swallow_check.rs`** — the `detect_dynamic_qty` coverage classifier was flagging `"twice that much damage"` (a static-typed `Double`, not a runtime `QuantityExpr`) as an unsupported dynamic clause. Added a suppression clause: when the only dynamic marker is the damage-double phrase and the parsed replacement carries `DamageModification::Double | Triple`, do not warn (CR 614.1a + CR 701.10g). Deduplicated the triplicated 8-phrase marker list into a single module-scope `OTHER_DYNAMIC_MARKERS` const.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

All commands run at the committed head `f62acde5f` (rebased onto upstream/main `b387f9c66`).

| check | command | result |
|---|---|---|
| parser combinator gate | `./scripts/check-parser-combinators.sh` | Gate G PASS + Gate A PASS |
| targeted lib tests (parser arms + swallow gates) | `cargo test -p engine --lib -- fated_firepower neriv ojer_axonil dynamic_qty_…_damage_double twice_is_only_dynamic_marker` | **8 passed; 0 failed** |
| runtime cast tests (doubling / offset scaling) | `cargo test -p engine --test integration -- neriv_entered_this_turn_source_doubles neriv_prior_turn_source_not_doubled fated_firepower_offset_scales_with_fire_counters` | **3 passed; 0 failed** |
| clippy | `cargo clippy -p engine --all-targets` | **0 warnings, 0 errors** |

**Runtime discriminators (the honesty arbiter):**

- `neriv_entered_this_turn_source_doubles` — source that entered this turn deals 2 → **4** marked damage (`Double` applied).
- `neriv_prior_turn_source_not_doubled` — source present since a prior turn deals 2 → **2** (replacement's `EnteredThisTurn` source filter correctly excludes it; CR 400.7).
- `fated_firepower_offset_scales_with_fire_counters` — base 2 + 3 fire counters → **5** (`Plus { value = fire-counters-on-source }` resolves dynamically).

**Coverage delta — isolated measurement.** Measured at base `d59d1c3e2` where base and tip differ **only** by this 4-file diff (perfect isolation of this change): exactly `{Fated Firepower, Neriv, Heart of the Storm}` `False→True`, `0` `True→False`, `0` appeared/disappeared. `supported_cards` 31394 → 31396.

**Rebase-invariance of that delta** (base advanced 10 commits to `b387f9c66`): established by measurement + causal orthogonality — (1) no upstream commit in the range touches `parser/oracle_replacement.rs` or `parser/swallow_check.rs` (this change's only production edits); (2) the one upstream commit that touches a dependency of this change, #6045 (`parse_cda_quantity`), is loyalty-counter-only (`~'s loyalty` → `CountersOn{Source, Loyalty}`), disjoint from Fated Firepower's fire-counter quantity — and the post-rebase lib test `fated_firepower_assembled_replacement` confirms FF still parses to `Plus{fire-counters}`. The card-data coverage-regression CI check runs the authoritative clean diff against upstream/main.

## Gate A

Gate A PASS head=f62acde5fbf46516f08db6cddea0e4387d480da2 base=be22e078bb1b05661d1ce34a21f3fbc07a136cab

## Anchored on

- `crates/engine/src/parser/oracle_replacement.rs` — `parse_damage_modification_phrase` already maps `"double that damage"` / `"deals double that damage"` → `DamageModification::Double`; the new `"twice that much damage"` leaf is a sibling in the same `alt`.
- `crates/engine/src/parser/oracle_replacement.rs` — `parse_that_much_damage_offset` already maps numeric offsets to `DamageModification::Plus`; the new dynamic arm mirrors it, delegating the quantity to `parse_cda_quantity`.

## Final review-impl

Final review-impl PASS head=f62acde5fbf46516f08db6cddea0e4387d480da2

## Claimed parse impact

- Fated Firepower
- Neriv, Heart of the Storm
