### PR TITLE
fix(parser): honest coverage for 'double each kind of counter' class (CR 701.10e)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -17,7 +17,8 @@ use super::super::oracle_nom::bridge::nom_on_lower;
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_target::{
-    parse_target, parse_target_with_ctx, parse_type_phrase, parse_type_phrase_with_ctx,
+    parse_target, parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase,
+    parse_type_phrase_with_ctx, TargetSyntax,
 };
 use super::super::oracle_util::{parse_count_expr, parse_number};
 use super::lower::parse_for_each_multiplier_prefix;
@@ -974,22 +975,57 @@ fn resolve_remove_counter_from_target(text: &str, ctx: &mut ParseContext) -> Tar
     resolve_counter_target(text, ctx)
 }
 
-/// Resolve a counter target from text: self-ref, pronoun, or parse_target.
-/// Shared by put/remove/multiply counter parsers.
-fn resolve_counter_target(text: &str, ctx: &mut ParseContext) -> TargetFilter {
+/// Classification of a counter target phrase, distinguishing forms the runtime
+/// can resolve (`Supported`) from a non-targeted descriptor scope
+/// (`NonTargetedDescriptor`) that a targeted-only effect cannot enumerate.
+///
+/// Both arms carry a `TargetFilter`: `resolve_counter_target` unwraps them
+/// uniformly (put/remove/multiply counters resolve identically either way),
+/// while the counter-doubling arm of `try_parse_double_effect` consults the
+/// discriminant to gate the non-targeted mass form to an honest `Unimplemented`
+/// (CR 701.10e — see there).
+enum CounterTargetKind {
+    Supported(TargetFilter),
+    NonTargetedDescriptor(TargetFilter),
+}
+
+/// Classify a counter target from text: self-ref, pronoun, trigger anaphor, or a
+/// parsed target phrase. The anaphor guards run FIRST and in this exact order
+/// (order is load-bearing: `it`/`that creature` resolve against the parse
+/// context before any descriptor fallback), each yielding a single-object
+/// `Supported` filter. A parsed phrase is `Supported` only when it used the
+/// "target" keyword (CR 115.1 `TargetKeyword`); a bare descriptor scope is
+/// `NonTargetedDescriptor`.
+///
+/// The fallback parses with a fresh `ParseContext` so it stays byte-for-byte
+/// equivalent to the prior `parse_target(text)` call — the shared `ctx` is read
+/// only by the anaphor guards, exactly as before.
+fn classify_counter_target(text: &str, ctx: &mut ParseContext) -> CounterTargetKind {
     if is_self_ref(text) {
-        TargetFilter::SelfRef
+        CounterTargetKind::Supported(TargetFilter::SelfRef)
     } else if is_it_pronoun(text) {
         // CR 608.2k: Bare pronoun — context-dependent
-        resolve_it_pronoun(ctx)
+        CounterTargetKind::Supported(resolve_it_pronoun(ctx))
     } else if resolve_that_creature_in_trigger(text, ctx).is_some() {
         // CR 608.2k + CR 301.5a: Trigger-context "that creature" → triggering source.
-        TargetFilter::TriggeringSource
+        CounterTargetKind::Supported(TargetFilter::TriggeringSource)
     } else {
-        let (t, _rem) = parse_target(text);
+        let (t, _rem, syntax) = parse_target_with_syntax(text, &mut ParseContext::default());
         #[cfg(debug_assertions)]
         assert_no_compound_remainder(_rem, text);
-        t
+        match syntax {
+            TargetSyntax::TargetKeyword => CounterTargetKind::Supported(t),
+            TargetSyntax::Descriptor => CounterTargetKind::NonTargetedDescriptor(t),
+        }
+    }
+}
+
+/// Resolve a counter target from text: self-ref, pronoun, or parsed target.
+/// Shared by put/remove/multiply counter parsers, which resolve identically for
+/// both target classes — so the `CounterTargetKind` discriminant is unwrapped.
+fn resolve_counter_target(text: &str, ctx: &mut ParseContext) -> TargetFilter {
+    match classify_counter_target(text, ctx) {
+        CounterTargetKind::Supported(t) | CounterTargetKind::NonTargetedDescriptor(t) => t,
     }
 }
 
@@ -1229,15 +1265,30 @@ pub(super) fn try_parse_multiply_counter(lower: &str, ctx: &mut ParseContext) ->
 /// CR 701.10: Dispatch "double the ..." to counter-doubling, life-doubling,
 /// mana-doubling, or P/T-doubling.
 pub(super) fn try_parse_double_effect(lower: &str, ctx: &mut ParseContext) -> Option<Effect> {
-    // CR 701.10e: "double the number of each kind of counter on ..." → all counter types
+    // CR 701.10e: "double the number of each kind of counter on ..." → all counter
+    // kinds. The doubled amount is intrinsic to the resolver ("give as many of
+    // those counters as already present"), never a `QuantityExpr` carrier — the
+    // same reasoning as the `MultiplyCounter` escape hatch in swallow_check.
+    //
+    // `Effect::Double` is targeted-only (there is no battlefield-enumeration tier
+    // in `targeting::resolved_targets`), so a NON-targeted descriptor target such
+    // as "each creature you control" would double nothing at runtime. Gate that
+    // mass form to an honest `Unimplemented` until the DoubleCountersAll mass
+    // runtime exists; the targeted form resolves normally.
     if let Some(((), rest)) = nom_on_lower(lower, lower, |i| {
         value((), tag("double the number of each kind of counter on ")).parse(i)
     }) {
-        let target = resolve_counter_target(rest, ctx);
-        return Some(Effect::Double {
-            target_kind: DoubleTarget::Counters { counter_type: None },
-            target,
-        });
+        return match classify_counter_target(rest, ctx) {
+            CounterTargetKind::Supported(target) => Some(Effect::Double {
+                target_kind: DoubleTarget::Counters { counter_type: None },
+                target,
+            }),
+            // Fragment is the full lowercased clause (diagnostics-only); the
+            // parser receives no original-case copy at this dispatch depth.
+            CounterTargetKind::NonTargetedDescriptor(_) => {
+                Some(Effect::unimplemented("double_counters_nontargeted", lower))
+            }
+        };
     }
 
     // Counter doubling: "double the number of ..."
@@ -1476,6 +1527,116 @@ mod tests {
                 target: TargetFilter::ParentTargetController,
             })
         ));
+    }
+
+    /// §5 honest-red gate (CR 701.10e): `Effect::Double` is targeted-only, so a
+    /// NON-targeted descriptor population ("... on each creature you control")
+    /// has no runtime path and must lower to an honest `Effect::Unimplemented`;
+    /// the targeted form ("... on target creature") still lowers to
+    /// `Effect::Double`.
+    #[test]
+    fn double_each_kind_counter_gates_nontargeted_mass_form_to_unimplemented() {
+        let mass = try_parse_double_effect(
+            "double the number of each kind of counter on each creature you control",
+            &mut default_ctx(),
+        );
+        assert!(
+            matches!(mass, Some(Effect::Unimplemented { .. })),
+            "non-targeted mass form must be honest-red Unimplemented, got {mass:?}"
+        );
+
+        // The §5 gate keys on `Descriptor` ALONE (no plurality sub-condition), so a
+        // SINGULAR non-targeted descriptor must gate identically to the plural mass
+        // form — `Effect::Double` is targeted-only and would double nothing at
+        // runtime for either. Pins against a future plurality branch
+        // (`if plural { NonTargetedDescriptor } else { Supported }`) that would
+        // silently re-support the singular form as a non-functional `Effect::Double`.
+        let singular = try_parse_double_effect(
+            "double the number of each kind of counter on a creature you control",
+            &mut default_ctx(),
+        );
+        assert!(
+            matches!(singular, Some(Effect::Unimplemented { .. })),
+            "singular non-targeted descriptor form must gate identically to the mass \
+             form (honest-red Unimplemented), got {singular:?}"
+        );
+
+        let targeted = try_parse_double_effect(
+            "double the number of each kind of counter on target creature",
+            &mut default_ctx(),
+        );
+        assert!(
+            matches!(
+                targeted,
+                Some(Effect::Double {
+                    target_kind: DoubleTarget::Counters { counter_type: None },
+                    ..
+                })
+            ),
+            "targeted form must still resolve to Effect::Double, got {targeted:?}"
+        );
+    }
+
+    /// §5 F2 ordering (CR 608.2k): the anaphor guards run BEFORE the descriptor
+    /// fallback, so "... on it" inside a trigger whose subject is a non-self
+    /// creature filter resolves to the triggering object (`TriggeringSource`) as
+    /// a Supported single-object target — NOT an honest-red Unimplemented.
+    #[test]
+    fn double_each_kind_counter_on_it_binds_triggering_source_in_trigger_context() {
+        let mut ctx = default_ctx();
+        ctx.subject = Some(TargetFilter::Typed(TypedFilter::creature()));
+        let text = "double the number of each kind of counter on it";
+        let effect =
+            try_parse_double_effect(text, &mut ctx).expect("parse double-counter on-it anaphor");
+        assert!(
+            matches!(
+                effect,
+                Effect::Double {
+                    target_kind: DoubleTarget::Counters { counter_type: None },
+                    target: TargetFilter::TriggeringSource,
+                }
+            ),
+            "on-it anaphor in trigger context must bind TriggeringSource, got {effect:?}"
+        );
+    }
+
+    /// §5 real-card (CR 701.10e): Ultimate Spider-Man's back-face "Whenever you
+    /// attack, double the number of each kind of counter on each Spider and
+    /// legendary creature you control" is a NON-targeted descriptor population.
+    /// The YouAttack trigger's effect must be the honest-red Unimplemented from
+    /// the mass gate, not a silently non-functional `Effect::Double`.
+    #[test]
+    fn ultimate_spider_man_mass_double_counter_trigger_is_honest_unimplemented() {
+        use crate::parser::oracle::parse_oracle_text;
+
+        let parsed = parse_oracle_text(
+            "First strike, haste\n\
+             Camouflage — {2}: Put a +1/+1 counter on Ultimate Spider-Man. He gains hexproof and becomes colorless until end of turn.\n\
+             Whenever you attack, double the number of each kind of counter on each Spider and legendary creature you control.",
+            "Ultimate Spider-Man",
+            &[],
+            &["Legendary".to_string(), "Creature".to_string()],
+            &[],
+        );
+
+        let has_mass_double_unimplemented = parsed.triggers.iter().any(|t| {
+            t.execute.as_ref().is_some_and(|ability| {
+                matches!(
+                    &*ability.effect,
+                    // allow-noncombinator: test assertion on emitted Unimplemented category name
+                    Effect::Unimplemented { name, .. } if name == "double_counters_nontargeted"
+                )
+            })
+        });
+        assert!(
+            has_mass_double_unimplemented,
+            "USM's YouAttack mass counter-double must be an honest Unimplemented; triggers: {:?}",
+            parsed
+                .triggers
+                .iter()
+                .map(|t| t.execute.as_ref().map(|a| &a.effect))
+                .collect::<Vec<_>>()
+        );
     }
 
     /// CR 701.10a: "double target creature's power and toughness" → factor 2.

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -31,11 +31,11 @@ use super::oracle_ir::feature::{
 use super::swallow_evidence::UnitEvidence;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, CastingPermission, Comparator,
-    ContinuousModification, CopyRetargetPermission, DelayedTriggerCondition, Duration, Effect,
-    FilterProp, ManaProduction, ModalSelectionConstraint, OpponentMayScope, ParsedCondition,
-    PlayerFilter, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementMode,
-    RestrictionExpiry, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition,
-    TriggerConstraint, TriggerDefinition, UnlessPayScaling,
+    ContinuousModification, CopyRetargetPermission, DelayedTriggerCondition, DoubleTarget,
+    Duration, Effect, FilterProp, ManaProduction, ModalSelectionConstraint, OpponentMayScope,
+    ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef, ReplacementCondition,
+    ReplacementMode, RestrictionExpiry, StaticCondition, StaticDefinition, TargetFilter,
+    TriggerCondition, TriggerConstraint, TriggerDefinition, UnlessPayScaling,
 };
 use crate::types::game_state::RetargetScope;
 use crate::types::keywords::Keyword;
@@ -2214,8 +2214,24 @@ fn detect_dynamic_qty(
     {
         return;
     }
+    // CR 701.10e: The counter-multiplier escape hatch. Both `MultiplyCounter`
+    // ("double the number of +1/+1 counters") and the "each kind" form
+    // (`Effect::Double { target_kind: DoubleTarget::Counters, .. }`, counter.rs)
+    // carry the doubled amount intrinsically in the resolver ("give as many of
+    // those counters as already present"), never as a `QuantityExpr`. So the
+    // "the number of" dynamic marker IS represented by the effect itself — the
+    // DynamicQty warning would be a false positive.
     if cleaned_has_only_counter_multiplier_dynamic(cleaned)
-        && evidence.any_effect(|e| matches!(e, Effect::MultiplyCounter { .. }))
+        && evidence.any_effect(|e| {
+            matches!(
+                e,
+                Effect::MultiplyCounter { .. }
+                    | Effect::Double {
+                        target_kind: DoubleTarget::Counters { .. },
+                        ..
+                    }
+            )
+        })
     {
         return;
     }
@@ -2487,8 +2503,16 @@ fn decline_iteration_prefix(input: &str) -> bool {
 }
 
 fn cleaned_has_only_counter_multiplier_dynamic(cleaned: &str) -> bool {
+    // The counter multiplier phrase: either the "+1/+1 counters" form
+    // (`Effect::MultiplyCounter`) or the "each kind of counter" form
+    // (`Effect::Double { DoubleTarget::Counters }`, counter.rs).
+    let has_counter_multiplier = [
+        "double the number of +1/+1 counters",
+        "double the number of each kind of counter",
+    ]
+    .iter()
     // allow-noncombinator: swallow detector phrase scan on classified text
-    let has_counter_multiplier = cleaned.contains("double the number of +1/+1 counters");
+    .any(|phrase| cleaned.contains(phrase));
     if !has_counter_multiplier {
         return false;
     }
@@ -8371,6 +8395,77 @@ this spell's mana cost.\nAttacking creatures get -3/-0 until end of turn.",
             !has_swallowed_detector(&parsed, "ActivateOnlyDuring"),
             "a TYPED timing window must not be reported as swallowed"
         );
+    }
+
+    /// FIX1 recognizer (CR 701.10e): the counter-multiplier escape-hatch phrase
+    /// scan must ALSO accept the "each kind of counter" doubling form (which
+    /// emits `Effect::Double`, not `MultiplyCounter`), while staying
+    /// RED-conservative — a SECOND dynamic marker keeps the warning alive.
+    #[test]
+    fn counter_multiplier_recognizer_accepts_each_kind_form() {
+        // "each kind" doubling form — newly recognized.
+        assert!(super::cleaned_has_only_counter_multiplier_dynamic(
+            "double the number of each kind of counter on target creature"
+        ));
+        // Historical "+1/+1 counters" form — regression guard.
+        assert!(super::cleaned_has_only_counter_multiplier_dynamic(
+            "double the number of +1/+1 counters on target creature"
+        ));
+        // A SECOND dynamic marker ("for each") must keep the warning: a real
+        // uncaptured clause may hide behind it.
+        assert!(!super::cleaned_has_only_counter_multiplier_dynamic(
+            "double the number of each kind of counter on target creature for each card in your hand"
+        ));
+    }
+
+    /// FIX1 end-to-end (CR 701.10e): the "each kind of counter" doubling form no
+    /// longer produces a false-positive DynamicQty swallowed-clause warning — the
+    /// escape hatch now recognizes `Effect::Double { DoubleTarget::Counters }` as
+    /// the intrinsic carrier of the doubled count. Covers a synthetic targeted
+    /// instant AND Zimone, Paradox Sculptor's real activated line.
+    #[test]
+    fn double_each_kind_of_counter_is_not_a_dynamic_qty_swallow() {
+        use crate::parser::oracle_ir::feature::OracleSemanticFeature;
+
+        for (text, name, types) in [
+            (
+                "Double the number of each kind of counter on target creature.",
+                "Synthetic Counter Doubler",
+                &["Instant"][..],
+            ),
+            (
+                "{G}{U}, {T}: Double the number of each kind of counter on up to two target creatures and/or artifacts you control.",
+                "Zimone, Paradox Sculptor",
+                &["Legendary", "Creature"][..],
+            ),
+        ] {
+            let parsed = parse_named(text, name, types);
+
+            // REACH GUARDS (avoid vacuity): the line must actually parse and the
+            // detector's dynamic marker must be present, or the silence proves
+            // nothing about the escape-hatch arm.
+            assert!(
+                !parsed.abilities.is_empty(),
+                "{name}: the line must parse to at least one ability"
+            );
+            assert!(
+                !any_ability_has_unimplemented(&parsed),
+                "{name}: the targeted form must parse — a self-suppressing Unimplemented would make this vacuous"
+            );
+            assert!(
+                // allow-noncombinator: test reach-guard asserting the fixture text carries the marker
+                text.to_lowercase().contains("the number of"),
+                "{name}: the dynamic-qty marker must be present in the fixture"
+            );
+
+            assert!(
+                !has_swallowed_detector(
+                    &parsed,
+                    OracleSemanticFeature::DynamicQty.detector_label()
+                ),
+                "{name}: an intrinsic counter-doubler must not be flagged as a swallowed DynamicQty clause"
+            );
+        }
     }
 
     /// The OTHER half of the `ActivateOnlyDuring` input space, pinned to what the parser

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -32,11 +32,10 @@ use super::swallow_evidence::UnitEvidence;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, ActivationRestriction, CastingPermission, Comparator,
     ContinuousModification, CopyRetargetPermission, DamageModification, DelayedTriggerCondition,
-    DoubleTarget,
-    Duration, Effect, FilterProp, ManaProduction, ModalSelectionConstraint, OpponentMayScope,
-    ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef, ReplacementCondition,
-    ReplacementMode, RestrictionExpiry, StaticCondition, StaticDefinition, TargetFilter,
-    TriggerCondition, TriggerConstraint, TriggerDefinition, UnlessPayScaling,
+    DoubleTarget, Duration, Effect, FilterProp, ManaProduction, ModalSelectionConstraint,
+    OpponentMayScope, ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef,
+    ReplacementCondition, ReplacementMode, RestrictionExpiry, StaticCondition, StaticDefinition,
+    TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition, UnlessPayScaling,
 };
 use crate::types::game_state::RetargetScope;
 use crate::types::keywords::Keyword;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two parser-layer fixes for the "double the number of **each kind** of counter" class (CR 701.10e). **FIX 1** teaches the `DynamicQty` swallow detector that `Effect::Double{ DoubleTarget::Counters }` is the intrinsic dynamic carrier for this phrase (it previously recognized only `Effect::MultiplyCounter`), clearing a false-positive `SwallowedClause` that kept **7 correctly-parsed targeted cards red**. **§5** gates the *non-targeted mass* form of the phrase to an honest `Effect::unimplemented`, because `Effect::Double` is targeted-only (no battlefield-enumeration path) and would otherwise double **nothing** at runtime — keeping Ultimate Spider-Man honestly red rather than a silent false-green.

## Implementation method (required)

Method: /engine-implementer

## CR references

- `CR 701.10e` — doubling a kind of counter gives as many more as already present (amount is intrinsic to the resolver, never a `QuantityExpr` carrier).
- `CR 115.1` — the "target" keyword distinguishes a chosen target (`TargetKeyword`) from a mass descriptor.
- `CR 608.2k` — untargeted anaphor ("on it" / "that creature") binds to the cost/trigger object.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean
- `cargo clippy -p engine --lib -- -D warnings` — exit 0, no warnings
- `cargo test -p engine --lib` (counter + swallow_check modules) — 196 passed, 0 failed, 2 ignored; 6 new tests (5 original + 1 singular-descriptor hardening)
- `scripts/check-parser-combinators.sh` — exit 0
- **Coverage isolation** (warm `oracle-gen --filter` regen vs merge-base `card-data.json`; full-corpus `coverage_parse_diff` + `semantic-audit` run in CI):
  - **7 targeted cards flip False→True** (`[DynamicQty]`→`[]`, correct `Double{Counters}`): Arcade Cabinet, Deepglow Skate, Ferrafor Young Yew, Gilder Bairn, The First Tyrannic War, Vorel of the Hull Clade, Zimone Paradox Sculptor.
  - **Ultimate Spider-Man** — `[DynamicQty]`→`[]` **+ `Effect::Unimplemented("double_counters_nontargeted")`** → stays **honestly red**, does NOT flip (non-targeted mass; runtime deferred to the `DoubleCountersAll` epic).
  - **0 off-class drift** — all 26 Remove/Move/Multiply-counter cards (the complete non-double `resolve_counter_target` caller set) byte-identical `abilities`+`triggers` vs base.
  - Revert-probe: all 6 discriminating tests flip to FAILED under their targeted revert, restored.

## Gate A

Gate A PASS head=30585b9a7040dfa9ecb894a21335196e00471663 base=be22e078bb1b05661d1ce34a21f3fbc07a136cab

## Anchored on

- crates/engine/src/parser/swallow_check.rs (`detect_dynamic_qty` MultiplyCounter escape hatch) — analogous intrinsic-dynamic-carrier suppression extended to `Double{Counters}`.
- crates/engine/src/parser/oracle_effect/counter.rs:976 (`resolve_counter_target` anaphor precedence) — analogous SelfRef/it-pronoun/TriggeringSource guard order reused by `classify_counter_target`.

## Final review-impl

Final review-impl PASS head=30585b9a7040dfa9ecb894a21335196e00471663

_Head history: the review-impl loop ran clean on 03b6dce01. A maintainer then merged current `main` (incl. the already-merged dq-a PR #6066) into this branch via merge commit 3023f44d7, preserving this PR's parser logic byte-for-byte; a formatting-only rustfmt reflow of the swallow_check import block (30585b9a7) was applied on top. No parser logic changed after the reviewed head — Gate A above is re-run on the current head._

## Claimed parse impact

- Arcade Cabinet, Deepglow Skate, Ferrafor Young Yew, Gilder Bairn, The First Tyrannic War, Vorel of the Hull Clade, Zimone Paradox Sculptor — false-positive `SwallowedClause` cleared (now honestly supported).
- Ultimate Spider-Man — non-targeted mass form now honestly `Unimplemented` (was a silent false-green: parsed `Double{Counters}` that doubles nothing at runtime). Full support deferred (see below).

## Deferred follow-up (documented; not yet filed)

Making **Ultimate Spider-Man** (and any non-targeted mass "double each kind of counter on each X") an honest *green* requires an engine mass-runtime that does not exist yet:

- **`Effect::DoubleCountersAll { target, counter_type }`** — a mass sibling of the targeted `Effect::Double`, mirroring `PutCounterAll`/`DoublePTAll`: registered in `mass_all_target_filter`, resolver enumerates the battlefield via `matches_target_filter` with **CR 701.10e per-permanent dedupe** (a permanent that is both a Spider *and* legendary is doubled once), plus the ~17 exhaustive `Effect` match sites across the 5 crates. Full `/add-engine-effect` + `/add-engine-variant` lifecycle.
- **General "each A and B you control" compound-population grammar** — the supertype-led disjunct parser (`starts_with_type_word` supertype branch) that makes "each Spider and legendary creature you control" assemble the correct `Or`, travelling with the runtime above so USM's grammar + runtime land as one tested unit.

This PR intentionally keeps that scope **out** and USM **honestly red**, per the honesty gate.
