### PR TITLE
fix(game): unblock optional choices after state restore

### DIFF
--- a/client/src/game/__tests__/restoreGameState.test.ts
+++ b/client/src/game/__tests__/restoreGameState.test.ts
@@ -1,12 +1,17 @@
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { EngineAdapter, GameEvent, GameState } from "../../adapter/types";
+import type { EngineAdapter, EngineSnapshot, GameAction, GameEvent, GameState, SubmitResult } from "../../adapter/types";
+import { nextSnapshotSeq } from "../../adapter/types";
 import { GAME_CHECKPOINTS_PREFIX, GAME_KEY_PREFIX } from "../../constants/storage";
 import { useGameStore } from "../../stores/gameStore";
 import { buildEngineAdapterMock } from "../../test/factories/engineAdapterFactory";
-import { buildGameState, buildPriorityWaitingFor } from "../../test/factories/gameStateFactory";
-import { restoreGameState } from "../dispatch";
+import {
+  buildGameState,
+  buildLegalActionsResult,
+  buildPriorityWaitingFor,
+} from "../../test/factories/gameStateFactory";
+import { dispatchAction, restoreGameState } from "../dispatch";
 
 vi.mock("idb-keyval", () => ({
   createStore: vi.fn(() => ({})),
@@ -139,5 +144,63 @@ describe("restoreGameState", () => {
       [checkpoint],
       expect.anything(),
     );
+  });
+
+  it("releases the dispatch mutex before accepting actions for the restored state", async () => {
+    const oldState = createMockState({ turn_number: 3 });
+    const restoredState = createMockState({ turn_number: 9 });
+    let currentState = oldState;
+    let releaseOldAction!: (result: SubmitResult) => void;
+    const submitAction = vi
+      .fn<EngineAdapter["submitAction"]>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<SubmitResult>((resolve) => {
+            releaseOldAction = resolve;
+          }),
+      )
+      .mockResolvedValue({ events: [], log_entries: [] } as SubmitResult);
+    const getSnapshot = vi
+      .fn<EngineAdapter["getSnapshot"]>()
+      .mockImplementation(async (): Promise<EngineSnapshot> => ({
+        state: currentState,
+        legalResult: buildLegalActionsResult(),
+        seq: nextSnapshotSeq(),
+      }));
+    const adapter = buildEngineAdapterMock(oldState, {
+      submitAction,
+      getSnapshot,
+      restoreState: vi.fn(async (state: GameState) => {
+        currentState = state;
+      }),
+    });
+
+    useGameStore.setState({
+      adapter,
+      gameMode: "ai",
+      gameState: oldState,
+      waitingFor: oldState.waiting_for,
+    });
+
+    const oldDispatch = dispatchAction({ type: "PassPriority" } as GameAction, 0);
+    expect(submitAction).toHaveBeenCalledTimes(1);
+
+    await expect(restoreGameState(restoredState)).resolves.toBeNull();
+
+    // The old action is still awaiting the adapter, but it must not keep the
+    // restored game's response queued behind the old dispatch generation.
+    const restoredDispatch = dispatchAction(
+      { type: "DecideOptionalEffect", data: { accept: true } } as GameAction,
+      0,
+    );
+    expect(submitAction).toHaveBeenCalledTimes(2);
+    await expect(restoredDispatch).resolves.toBeUndefined();
+
+    releaseOldAction({ events: [], log_entries: [] } as SubmitResult);
+    await expect(oldDispatch).resolves.toBeUndefined();
+
+    // The stale action cannot fetch or commit a snapshot after the restore.
+    expect(getSnapshot).toHaveBeenCalledTimes(2);
+    expect(useGameStore.getState().gameState).toEqual(restoredState);
   });
 });

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -82,6 +82,13 @@ let isAnimating = false;
 const pendingQueue: PendingWork[] = [];
 
 /**
+ * Identifies the game state for which the current dispatch pipeline is valid.
+ * Restoring a saved game replaces the engine state wholesale, so work queued
+ * for the old state must neither run nor release a newer dispatch's mutex.
+ */
+let dispatchGeneration = 0;
+
+/**
  * The local action currently being processed (set while inside processAction),
  * paired with the seat and WaitingFor object it was issued against. Used with
  * pendingQueue to deduplicate rapid double-clicks.
@@ -95,6 +102,32 @@ let inFlightLocalAction: {
   actor: number;
   waitingFor: WaitingFor | null;
 } | null = null;
+
+function isCurrentDispatchGeneration(generation: number): boolean {
+  return generation === dispatchGeneration;
+}
+
+/** Discard dispatch work that belongs to the game state being replaced. */
+function abandonDispatchesForStateRestore(): void {
+  dispatchGeneration += 1;
+  inFlightLocalAction = null;
+  isAnimating = false;
+  while (pendingQueue.length > 0) {
+    pendingQueue.shift()!.resolve();
+  }
+}
+
+function releaseDispatchMutex(generation: number): void {
+  if (!isCurrentDispatchGeneration(generation)) return;
+
+  if (pendingQueue.length > 0) {
+    processQueue(generation).catch(() => {
+      if (isCurrentDispatchGeneration(generation)) isAnimating = false;
+    });
+  } else {
+    isAnimating = false;
+  }
+}
 
 /** Structural equality for GameAction — action objects are small plain JSON. */
 function actionsEqual(a: GameAction, b: GameAction): boolean {
@@ -189,7 +222,11 @@ function showActionError(action: GameAction, err: unknown): void {
   });
 }
 
-async function processAction(action: GameAction, actor: number): Promise<void> {
+async function processAction(
+  action: GameAction,
+  actor: number,
+  generation: number,
+): Promise<void> {
   const { adapter, gameState } = useGameStore.getState();
   if (!adapter || !gameState) {
     debugLog("processAction called with no adapter or gameState");
@@ -226,6 +263,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   try {
     result = await adapter.submitAction(action, actor);
   } catch (err) {
+    if (!isCurrentDispatchGeneration(generation)) return;
     // Stale click after a priority/turn shift: the engine's actor-auth guard
     // correctly rejected it. Nothing changed engine-side, so drop it as a
     // no-op instead of letting a benign race escape as an unhandled rejection.
@@ -254,6 +292,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
     if (!isStateLost(err)) throw err;
     debugLog(`processAction: STATE_LOST on ${action.type}; attempting rehydrate`, "warn");
     const recovered = await attemptStateRehydrate();
+    if (!isCurrentDispatchGeneration(generation)) return;
     if (!recovered) {
       notifyEngineLost("submitAction");
       throw err;
@@ -267,6 +306,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
     try {
       result = await adapter.submitAction(action, actor);
     } catch (retryErr) {
+      if (!isCurrentDispatchGeneration(generation)) return;
       // Prefer the captured panic message over the bare retry tag — that's
       // the "diagnostic: submitAction-retry" the user reported, which told
       // them nothing actionable.
@@ -278,6 +318,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
       throw retryErr;
     }
   }
+  if (!isCurrentDispatchGeneration(generation)) return;
   const events: GameEvent[] = result.events;
 
   // 3b. Fetch the state AND its legal actions as ONE atomic snapshot, and persist
@@ -300,6 +341,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   try {
     snapshotResult = await adapter.getSnapshot();
   } catch (err) {
+    if (!isCurrentDispatchGeneration(generation)) return;
     if (isEnginePanic(err)) {
       await routePanic("getSnapshot-panic", err.panic);
       throw err;
@@ -311,6 +353,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
     if (!isStateLost(err)) throw err;
     debugLog("processAction: STATE_LOST on getSnapshot; attempting rehydrate", "warn");
     const recovered = await attemptStateRehydrate();
+    if (!isCurrentDispatchGeneration(generation)) return;
     if (!recovered) {
       notifyEngineLost("getSnapshot");
       throw err;
@@ -318,6 +361,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
     try {
       snapshotResult = await adapter.getSnapshot();
     } catch (retryErr) {
+      if (!isCurrentDispatchGeneration(generation)) return;
       if (isEnginePanic(retryErr)) {
         notifyEngineLost("getSnapshot-retry-panic", retryErr.panic);
       } else {
@@ -326,6 +370,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
       throw retryErr;
     }
   }
+  if (!isCurrentDispatchGeneration(generation)) return;
   const newState = snapshotResult.state;
   const { gameId } = useGameStore.getState();
   if (gameId) void saveAuthoritativeGame(gameId, adapter, newState);
@@ -418,6 +463,7 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   // The commit is revision-gated, so if a newer commit landed mid-animation
   // (a `gameStore.dispatch` from a modal, a remote update, an AI-loop advance),
   // THIS older pair is dropped rather than clobbering it.
+  if (!isCurrentDispatchGeneration(generation)) return;
   const store = useGameStore.getState();
   const stateHistory = shouldSaveHistory
     ? [...store.stateHistory, gameState].slice(-MAX_UNDO_HISTORY)
@@ -442,8 +488,8 @@ async function processAction(action: GameAction, actor: number): Promise<void> {
   }
 }
 
-async function processQueue(): Promise<void> {
-  while (pendingQueue.length > 0) {
+async function processQueue(generation: number): Promise<void> {
+  while (isCurrentDispatchGeneration(generation) && pendingQueue.length > 0) {
     const next = pendingQueue.shift()!;
     try {
       if (next.kind === "local") {
@@ -454,15 +500,19 @@ async function processQueue(): Promise<void> {
         }
         inFlightLocalAction = { action: next.action, actor: next.actor, waitingFor: next.waitingFor };
         try {
-          await processAction(next.action, next.actor);
+          await processAction(next.action, next.actor, generation);
         } finally {
-          inFlightLocalAction = null;
+          if (isCurrentDispatchGeneration(generation)) inFlightLocalAction = null;
         }
       } else {
-        await processRemoteUpdateInner(next.snapshot, next.events, next.logEntries);
+        await processRemoteUpdateInner(next.snapshot, next.events, next.logEntries, generation);
       }
       next.resolve();
     } catch (err) {
+      if (!isCurrentDispatchGeneration(generation)) {
+        next.resolve();
+        return;
+      }
       debugLog(`processQueue error (${next.kind}): ${err instanceof Error ? err.message : String(err)}`);
       if (next.kind === "local") {
         showActionError(next.action, err);
@@ -489,7 +539,7 @@ async function processQueue(): Promise<void> {
       }
     }
   }
-  isAnimating = false;
+  if (isCurrentDispatchGeneration(generation)) isAnimating = false;
 }
 
 /**
@@ -562,21 +612,19 @@ export async function dispatchAction(
     });
   }
 
+  const generation = dispatchGeneration;
   isAnimating = true;
   inFlightLocalAction = { action: submittedAction, actor, waitingFor: currentWaitingFor };
   try {
-    await processAction(submittedAction, actor);
+    await processAction(submittedAction, actor, generation);
   } catch (e) {
+    if (!isCurrentDispatchGeneration(generation)) return;
     debugLog(`dispatch error for ${submittedAction.type}: ${e instanceof Error ? e.message : String(e)}`);
     showActionError(submittedAction, e);
     throw e;
   } finally {
-    inFlightLocalAction = null;
-    if (pendingQueue.length > 0) {
-      processQueue().catch(() => { isAnimating = false; });
-    } else {
-      isAnimating = false;
-    }
+    if (isCurrentDispatchGeneration(generation)) inFlightLocalAction = null;
+    releaseDispatchMutex(generation);
   }
 }
 
@@ -587,7 +635,9 @@ async function processRemoteUpdateInner(
   snapshot: EngineSnapshot,
   events: GameEvent[],
   logEntries: GameLogEntry[] = [],
+  generation: number,
 ): Promise<void> {
+  if (!isCurrentDispatchGeneration(generation)) return;
   const state = snapshot.state;
 
   // 1. Capture positions before updating state (for lookups during animation)
@@ -636,6 +686,7 @@ async function processRemoteUpdateInner(
   // 5. Commit the pair after animations complete — revision-gated, so a remote
   //    update that was superseded while its animation played is dropped rather
   //    than clobbering the newer state.
+  if (!isCurrentDispatchGeneration(generation)) return;
   useGameStore.getState().commitEngineSnapshot(snapshot, { events, logEntries });
 
   // 6. Play victory/defeat stinger on GameOver
@@ -667,15 +718,12 @@ export async function processRemoteUpdate(
     });
   }
 
+  const generation = dispatchGeneration;
   isAnimating = true;
   try {
-    await processRemoteUpdateInner(snapshot, events, logEntries);
+    await processRemoteUpdateInner(snapshot, events, logEntries, generation);
   } finally {
-    if (pendingQueue.length > 0) {
-      processQueue().catch(() => { isAnimating = false; });
-    } else {
-      isAnimating = false;
-    }
+    releaseDispatchMutex(generation);
   }
 }
 
@@ -690,6 +738,7 @@ export async function restoreGameState(
   const { adapter, gameId } = useGameStore.getState();
   if (!adapter) return "No adapter available";
 
+  abandonDispatchesForStateRestore();
   try {
     await adapter.restoreState(state);
   } catch (err) {

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -19,7 +19,8 @@ use crate::types::actions::GameAction;
 use crate::types::card_type::CoreType;
 use crate::types::events::{GameEvent, ManaTapState};
 use crate::types::game_state::{
-    CastOfferKind, GameState, MulliganDecisionPhase, PayCostKind, PendingMulliganAction, WaitingFor,
+    AutoMayChoice, CastOfferKind, GameState, MulliganDecisionPhase, PayCostKind,
+    PendingMulliganAction, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaCost;
@@ -1586,8 +1587,29 @@ pub fn legal_actions_full(state: &GameState) -> LegalActionsFull {
         _ => (state, None),
     };
 
-    let actions: Vec<GameAction> = target_selection_actions_without_simulation(state)
+    let mut actions: Vec<GameAction> = target_selection_actions_without_simulation(state)
         .unwrap_or_else(|| flat_priority_actions_with_probe(state, priority_probe));
+
+    // This preference-setting action is intentionally excluded from AI candidate
+    // generation: it changes future prompt behavior rather than making a tactical
+    // game decision. It remains a legal player action, however, and must be present
+    // in the engine snapshot so a queued UI choice is not discarded as stale.
+    if matches!(
+        &state.waiting_for,
+        WaitingFor::OptionalEffectChoice {
+            may_trigger_key: Some(_),
+            ..
+        }
+    ) {
+        actions.extend([
+            GameAction::DecideOptionalEffectAndRemember {
+                choice: AutoMayChoice::Accept,
+            },
+            GameAction::DecideOptionalEffectAndRemember {
+                choice: AutoMayChoice::Decline,
+            },
+        ]);
+    }
 
     // Build spell costs map. The frontend display layer needs the
     // engine-effective cost (after Affinity / ReduceCost / commander tax / etc.)

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -918,6 +918,7 @@ mod oblivions_hunger_conditional_draw;
 mod omenpath_journey_random_exiled_with;
 mod omnath_unspent_green_mana_2887;
 mod one_ring_burden_upkeep_lethal;
+mod optional_effect_remember_legal_actions;
 mod otherwise_conditional_effects;
 mod outrageous_robbery_look_and_play;
 mod overlord_impending_offer_2859;

--- a/crates/engine/tests/integration/optional_effect_remember_legal_actions.rs
+++ b/crates/engine/tests/integration/optional_effect_remember_legal_actions.rs
@@ -1,0 +1,83 @@
+//! Regression: a keyed optional trigger's “don't ask again” choices must be
+//! surfaced in the engine legal-action snapshot so the client can safely queue
+//! the selected answer while animations settle.
+
+use engine::ai_support::legal_actions;
+use engine::game::engine::apply_as_current;
+use engine::game::zones::create_object;
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{
+    AutoMayChoice, GameState, MayTriggerAutoChoiceKey, MayTriggerOrigin, WaitingFor,
+};
+use engine::types::identifiers::CardId;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+#[test]
+fn keyed_optional_effect_exposes_and_resolves_remember_choices() {
+    let mut state = GameState::new_two_player(42);
+    let source_id = create_object(
+        &mut state,
+        CardId(903),
+        PlayerId(0),
+        "Optional source".to_string(),
+        Zone::Battlefield,
+    );
+    let key = MayTriggerAutoChoiceKey {
+        player: PlayerId(0),
+        source_id,
+        origin: MayTriggerOrigin::Printed { trigger_index: 0 },
+    };
+    state.waiting_for = WaitingFor::OptionalEffectChoice {
+        player: PlayerId(0),
+        source_id,
+        description: None,
+        may_trigger_key: Some(key),
+    };
+    let mut ability = ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        Vec::new(),
+        source_id,
+        PlayerId(0),
+    );
+    ability.optional = true;
+    state.pending_optional_effect = Some(Box::new(ability));
+
+    let accept = GameAction::DecideOptionalEffectAndRemember {
+        choice: AutoMayChoice::Accept,
+    };
+    let decline = GameAction::DecideOptionalEffectAndRemember {
+        choice: AutoMayChoice::Decline,
+    };
+    let actions = legal_actions(&state);
+    assert!(
+        actions.contains(&accept) && actions.contains(&decline),
+        "a keyed optional prompt must expose both remember actions: {actions:?}"
+    );
+
+    let mut unkeyed = state.clone();
+    let WaitingFor::OptionalEffectChoice {
+        may_trigger_key, ..
+    } = &mut unkeyed.waiting_for
+    else {
+        unreachable!("fixture must remain an optional-effect choice");
+    };
+    *may_trigger_key = None;
+    assert!(
+        !legal_actions(&unkeyed)
+            .iter()
+            .any(|action| matches!(action, GameAction::DecideOptionalEffectAndRemember { .. })),
+        "unkeyed optional prompts must not offer the remember action"
+    );
+
+    apply_as_current(&mut state, accept).expect("remembered accept must be legal");
+    assert_eq!(state.players[0].life, 21);
+    assert!(state
+        .may_trigger_auto_choices
+        .iter()
+        .any(|record| record.key == key && record.choice == AutoMayChoice::Accept));
+}


### PR DESCRIPTION
## Summary
- Reset the client dispatch generation when restoring a saved game so stale work cannot hold the queue mutex.
- Ignore stale in-flight work after a restore and expose keyed optional preference actions in the engine snapshot.

## Validation
- `cargo fmt --all`
- Tilt: frontend tests and frontend check passed.
- Engine Tilt is queued behind unrelated in-progress changes; CI will run the full engine suite.