### PR TITLE
fix(engine): scan the Aura's own enchant-zone when choosing a host on non-cast entry

### DIFF
--- a/crates/engine/src/game/engine_exile_return_tests.rs
+++ b/crates/engine/src/game/engine_exile_return_tests.rs
@@ -1295,3 +1295,385 @@ fn exile_return_combines_normal_and_delayed_triggers_in_one_ordering_prompt() {
         .iter()
         .any(|summary| summary.source_id == delayed_source));
 }
+
+// ---------------------------------------------------------------------------
+// CR 303.4f/303.4g regression: a non-cast Aura re-entering the battlefield must
+// be able to find a legal host in a NON-battlefield zone (graveyard/hand) when
+// its Enchant ability points there (Animate Dead, Dance of the Dead, Spellweaver
+// Volute, Don't Worry About It). Before the `legal_aura_attachment_targets`
+// rewrite the candidate scan only looked at the battlefield, so such an Aura
+// could never find a host through this path and was stuck in exile forever.
+// ---------------------------------------------------------------------------
+
+/// Verbatim Animate Dead Oracle text (matches the repo's canonical corpus form
+/// in `crates/engine/tests/fixtures/integration_cards.json`, mirroring the
+/// `casting_tests.rs` reanimation fixtures).
+const ANIMATE_DEAD_ORACLE_FULL: &str = "Enchant creature card in a graveyard\nWhen this Aura enters, if it's on the battlefield, it loses \"enchant creature card in a graveyard\" and gains \"enchant creature put onto the battlefield with this Aura.\" Return enchanted creature card to the battlefield under your control and attach this Aura to it. When this Aura leaves the battlefield, that creature's controller sacrifices it.\nEnchanted creature gets -1/-0.";
+
+/// Builds a full Animate Dead-class reanimator Aura (real parser output for the
+/// ETB reanimation trigger + the graveyard-scoped Enchant keyword) in `zone`.
+fn build_reanimator_aura_in_zone(
+    state: &mut GameState,
+    card_id: CardId,
+    controller: PlayerId,
+    zone: Zone,
+) -> ObjectId {
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::card_type::CoreType;
+    use crate::types::keywords::Keyword;
+    use std::str::FromStr;
+    use std::sync::Arc;
+
+    let aura_id = create_object(state, card_id, controller, "Animate Dead".to_string(), zone);
+    let parsed = parse_oracle_text(
+        ANIMATE_DEAD_ORACLE_FULL,
+        "Animate Dead",
+        &[],
+        &["Enchantment".to_string()],
+        &["Aura".to_string()],
+    );
+    // Reach-guard: the live parser MUST attach the reanimator ETB trigger, else a
+    // downstream reanimation assertion could pass vacuously.
+    assert!(
+        !parsed.triggers.is_empty(),
+        "parser must produce the reanimator ETB trigger; got none"
+    );
+    let obj = state.objects.get_mut(&aura_id).unwrap();
+    obj.card_types.core_types.push(CoreType::Enchantment);
+    obj.card_types.subtypes.push("Aura".to_string());
+    obj.base_card_types = obj.card_types.clone();
+    let enchant = Keyword::from_str("Enchant:creature card in a graveyard").unwrap();
+    obj.base_keywords.push(enchant.clone());
+    obj.keywords.push(enchant);
+    obj.base_abilities = Arc::new(parsed.abilities.clone());
+    obj.abilities = Arc::new(parsed.abilities.clone());
+    obj.base_trigger_definitions = Arc::new(parsed.triggers.clone());
+    obj.trigger_definitions = parsed.triggers.clone().into();
+    obj.base_static_definitions = Arc::new(parsed.statics.clone());
+    obj.static_definitions = parsed.statics.clone().into();
+    aura_id
+}
+
+/// Builds a lightweight Aura (no ETB body) whose Enchant ability is `enchant_spec`
+/// (e.g. `"creature"` for a Pacifism-shaped battlefield Aura). Sets both live and
+/// base keywords so the ability survives any layer re-derivation during entry.
+fn build_simple_aura(
+    state: &mut GameState,
+    card_id: CardId,
+    controller: PlayerId,
+    zone: Zone,
+    enchant_spec: &str,
+) -> ObjectId {
+    use crate::types::card_type::CoreType;
+    use crate::types::keywords::Keyword;
+    use std::str::FromStr;
+
+    let aura_id = create_object(state, card_id, controller, "Test Aura".to_string(), zone);
+    let obj = state.objects.get_mut(&aura_id).unwrap();
+    obj.card_types.core_types.push(CoreType::Enchantment);
+    obj.card_types.subtypes.push("Aura".to_string());
+    obj.base_card_types = obj.card_types.clone();
+    let enchant = Keyword::from_str(&format!("Enchant:{enchant_spec}")).unwrap();
+    obj.base_keywords.push(enchant.clone());
+    obj.keywords.push(enchant);
+    aura_id
+}
+
+/// Creates a vanilla creature card in `zone` (owner `owner`) with a 2/2 body.
+fn build_creature_card(
+    state: &mut GameState,
+    card_id: CardId,
+    owner: PlayerId,
+    zone: Zone,
+) -> ObjectId {
+    use crate::types::card_type::CoreType;
+
+    let id = create_object(state, card_id, owner, "Grizzly Bears".to_string(), zone);
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.base_card_types = obj.card_types.clone();
+    obj.power = Some(2);
+    obj.toughness = Some(2);
+    obj.base_power = Some(2);
+    obj.base_toughness = Some(2);
+    id
+}
+
+fn source_leaves_battlefield_event(source_id: ObjectId) -> GameEvent {
+    GameEvent::ZoneChanged {
+        object_id: source_id,
+        from: Some(Zone::Battlefield),
+        to: Zone::Graveyard,
+        record: Box::new(ZoneChangeRecord {
+            name: "Aura Source".to_string(),
+            ..ZoneChangeRecord::test_minimal(source_id, Some(Zone::Battlefield), Zone::Graveyard)
+        }),
+    }
+}
+
+/// CR 303.4f + CR 610.3a: an Animate Dead-class Aura returning from exile (its
+/// source left the battlefield, firing its `UntilSourceLeaves` link) must find
+/// the legal creature card sitting in a graveyard, re-enter the battlefield, and
+/// attach to it — then its ETB reanimation trigger pulls that creature onto the
+/// battlefield. REVERT PROOF: with the `legal_aura_attachment_targets` rewrite
+/// reverted (battlefield-only scan) the graveyard host is invisible, the inline
+/// consult takes the `[] => Done` (CR 303.4g) arm, and both the "Aura on
+/// battlefield" and "attached_to == creature" assertions fail (Aura stays in
+/// exile).
+#[test]
+fn reanimator_aura_reenters_from_exile_and_attaches_to_graveyard_creature() {
+    use crate::game::game_object::AttachTarget;
+
+    let mut state = GameState::new_two_player(42);
+    state.turn_number = 2;
+    state.phase = Phase::PreCombatMain;
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+    state.waiting_for = WaitingFor::Priority {
+        player: PlayerId(0),
+    };
+
+    // The Aura currently sits in exile, linked to return when its source leaves.
+    let aura_id = build_reanimator_aura_in_zone(&mut state, CardId(601), PlayerId(0), Zone::Exile);
+    // Grizzly Bears in the OPPONENT's graveyard — a legal graveyard host and, once
+    // reanimated, a genuine control change to the Aura's controller.
+    let creature_id = build_creature_card(&mut state, CardId(602), PlayerId(1), Zone::Graveyard);
+
+    let source_id = create_object(
+        &mut state,
+        CardId(600),
+        PlayerId(0),
+        "Aura Source".to_string(),
+        Zone::Battlefield,
+    );
+    state.exile_links.push(ExileLink {
+        exiled_id: aura_id,
+        source_id,
+        kind: ExileLinkKind::UntilSourceLeaves {
+            return_zone: Zone::Battlefield,
+        },
+    });
+
+    // The source leaves → the Aura's implicit return fires and consults the host
+    // search on the way back onto the battlefield.
+    let mut events = vec![source_leaves_battlefield_event(source_id)];
+    check_exile_returns(&mut state, &mut events);
+
+    // (a) CR 303.4f: the Aura found the graveyard host and reached the battlefield
+    // instead of being stranded in exile by CR 303.4g.
+    assert!(
+        state.battlefield.contains(&aura_id),
+        "Aura must re-enter the battlefield via the graveyard host search; exile={:?}",
+        state.exile
+    );
+    assert!(
+        !state.exile.contains(&aura_id),
+        "Aura must no longer be in exile"
+    );
+    // (b) It attached to the specific graveyard creature.
+    assert_eq!(
+        state.objects[&aura_id].attached_to,
+        Some(AttachTarget::Object(creature_id)),
+        "Aura must be attached to the graveyard creature it enchanted"
+    );
+
+    // (c) The ETB reanimation chain fires through the real trigger pipeline and
+    // pulls the creature onto the battlefield under the Aura controller's control.
+    crate::game::triggers::process_triggers(&mut state, &events);
+    assert_eq!(
+        state.stack.len(),
+        1,
+        "the reanimator ETB trigger must be on the stack after process_triggers"
+    );
+    let mut etb_events = Vec::new();
+    crate::game::stack::resolve_top(&mut state, &mut etb_events);
+    crate::game::layers::evaluate_layers(&mut state);
+
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Battlefield,
+        "reanimated creature must be on the battlefield, not the graveyard"
+    );
+    assert_eq!(
+        state.objects[&creature_id].controller,
+        PlayerId(0),
+        "reanimated creature must be controlled by the Aura's controller"
+    );
+    assert_eq!(
+        state.objects[&aura_id].attached_to,
+        Some(AttachTarget::Object(creature_id)),
+        "Aura must stay attached to the reanimated creature"
+    );
+}
+
+/// CR 303.4g (negative) + CR 303.4f reach-guard: an ordinary battlefield-scoped
+/// Aura (Pacifism-shaped, `Enchant creature`) returning from exile finds a host
+/// ONLY when a legal creature is on the battlefield. Aura A returns to an empty
+/// board and correctly stays in exile (no spurious attach, no behavior change for
+/// the common case); Aura B — the positive reach-guard in the same state, proving
+/// the consult path is live — finds its battlefield creature and attaches. If the
+/// negative were vacuous (consult never ran), a non-Aura would simply re-enter
+/// unattached, which assertion A explicitly excludes.
+#[test]
+fn battlefield_scoped_aura_reenters_only_when_a_legal_host_exists() {
+    use crate::game::game_object::AttachTarget;
+
+    let mut state = GameState::new_two_player(42);
+    state.turn_number = 2;
+    state.phase = Phase::PreCombatMain;
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+    state.waiting_for = WaitingFor::Priority {
+        player: PlayerId(0),
+    };
+
+    // Aura A: battlefield-scoped, empty board — no legal host.
+    let aura_a = build_simple_aura(
+        &mut state,
+        CardId(701),
+        PlayerId(0),
+        Zone::Exile,
+        "creature",
+    );
+    let source_a = create_object(
+        &mut state,
+        CardId(700),
+        PlayerId(0),
+        "Aura Source".to_string(),
+        Zone::Battlefield,
+    );
+    state.exile_links.push(ExileLink {
+        exiled_id: aura_a,
+        source_id: source_a,
+        kind: ExileLinkKind::UntilSourceLeaves {
+            return_zone: Zone::Battlefield,
+        },
+    });
+
+    let mut events_a = vec![source_leaves_battlefield_event(source_a)];
+    check_exile_returns(&mut state, &mut events_a);
+
+    // CR 303.4g: no legal host on the battlefield → the Aura stays in its current
+    // zone (exile). (Non-vacuous: an unrecognized object would have re-entered the
+    // battlefield unattached — this assertion excludes that.)
+    assert!(
+        !state.battlefield.contains(&aura_a),
+        "battlefield-scoped Aura must NOT re-enter with no legal host"
+    );
+    assert!(
+        state.exile.contains(&aura_a),
+        "battlefield-scoped Aura with no host must stay in exile (CR 303.4g)"
+    );
+
+    // Positive reach-guard — Aura B: battlefield-scoped, with a legal battlefield
+    // creature present. Proves the same consult path DOES attach when a host
+    // exists (so assertion A above is a real "no host", not a skipped consult).
+    let aura_b = build_simple_aura(
+        &mut state,
+        CardId(711),
+        PlayerId(0),
+        Zone::Exile,
+        "creature",
+    );
+    let creature_b = build_creature_card(&mut state, CardId(712), PlayerId(0), Zone::Battlefield);
+    let source_b = create_object(
+        &mut state,
+        CardId(710),
+        PlayerId(0),
+        "Aura Source".to_string(),
+        Zone::Battlefield,
+    );
+    state.exile_links.push(ExileLink {
+        exiled_id: aura_b,
+        source_id: source_b,
+        kind: ExileLinkKind::UntilSourceLeaves {
+            return_zone: Zone::Battlefield,
+        },
+    });
+
+    let mut events_b = vec![source_leaves_battlefield_event(source_b)];
+    check_exile_returns(&mut state, &mut events_b);
+
+    assert!(
+        state.battlefield.contains(&aura_b),
+        "battlefield-scoped Aura must re-enter when a legal battlefield host exists"
+    );
+    assert_eq!(
+        state.objects[&aura_b].attached_to,
+        Some(AttachTarget::Object(creature_b)),
+        "Aura B must attach to the legal battlefield creature"
+    );
+}
+
+/// CR 303.4g (negative for the fixed path): a graveyard-scoped Aura returning from
+/// exile when the graveyard holds a card that does NOT satisfy its Enchant ability
+/// (an instant card, not a creature card) must still stay in exile — the fix must
+/// not spuriously attach to an illegal host. NON-VACUOUS: the graveyard is
+/// non-empty, so the new graveyard scan genuinely enumerates the instant card and
+/// `matches_target_filter` correctly rejects it; an unrecognized Aura would have
+/// re-entered the battlefield unattached, which this test excludes.
+#[test]
+fn graveyard_scoped_aura_stays_in_exile_when_no_legal_graveyard_creature() {
+    use crate::types::card_type::CoreType;
+
+    let mut state = GameState::new_two_player(42);
+    state.turn_number = 2;
+    state.phase = Phase::PreCombatMain;
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+    state.waiting_for = WaitingFor::Priority {
+        player: PlayerId(0),
+    };
+
+    let aura_id = build_reanimator_aura_in_zone(&mut state, CardId(801), PlayerId(0), Zone::Exile);
+    // A non-creature card sits in the graveyard: the scan reaches it, the filter
+    // rejects it (Enchant creature CARD in a graveyard requires a creature card).
+    let instant_id = create_object(
+        &mut state,
+        CardId(802),
+        PlayerId(1),
+        "Lightning Bolt".to_string(),
+        Zone::Graveyard,
+    );
+    {
+        let obj = state.objects.get_mut(&instant_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Instant);
+        obj.base_card_types = obj.card_types.clone();
+    }
+    // Sanity: the graveyard genuinely holds the candidate the scan will enumerate.
+    assert!(
+        state.players[1].graveyard.contains(&instant_id),
+        "reach-guard: graveyard must hold the non-matching candidate card"
+    );
+
+    let source_id = create_object(
+        &mut state,
+        CardId(800),
+        PlayerId(0),
+        "Aura Source".to_string(),
+        Zone::Battlefield,
+    );
+    state.exile_links.push(ExileLink {
+        exiled_id: aura_id,
+        source_id,
+        kind: ExileLinkKind::UntilSourceLeaves {
+            return_zone: Zone::Battlefield,
+        },
+    });
+
+    let mut events = vec![source_leaves_battlefield_event(source_id)];
+    check_exile_returns(&mut state, &mut events);
+
+    assert!(
+        !state.battlefield.contains(&aura_id),
+        "graveyard-scoped Aura must NOT re-enter when no legal graveyard creature exists"
+    );
+    assert!(
+        state.exile.contains(&aura_id),
+        "graveyard-scoped Aura with no legal host must stay in exile (CR 303.4g)"
+    );
+    assert!(
+        state.objects[&aura_id].attached_to.is_none(),
+        "Aura must not have spuriously attached to the illegal instant card"
+    );
+}

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -1413,11 +1413,31 @@ fn legal_aura_attachment_targets(
     enchant_filter: &TargetFilter,
 ) -> Vec<TargetRef> {
     let ctx = crate::game::filter::FilterContext::from_source_with_controller(aura_id, controller);
-    let mut targets: Vec<TargetRef> = state
-        .battlefield
-        .iter()
-        .copied()
+    // CR 303.4f: the controller chooses a legal object per the Aura's current
+    // enchant ability. Enumerate candidate hosts across whatever zone(s) that
+    // ability implies — an ordinary Aura (Pacifism) imposes no zone property and
+    // defaults to the battlefield, while a graveyard/hand-scoped enchant ability
+    // (Animate Dead, Dance of the Dead, Spellweaver Volute, Don't Worry About It)
+    // carries a `FilterProp::InZone`/`InAnyZone` that `extract_zones` surfaces.
+    // Mirrors `object_count_matching_ids` in `game/quantity.rs`. Using
+    // `zone_object_ids` for the battlefield case also (correctly) excludes
+    // phased-out permanents per CR 702.26b — they're treated as nonexistent and
+    // can never be a legal new host.
+    let zones = enchant_filter.extract_zones();
+    let zones = if zones.is_empty() {
+        vec![Zone::Battlefield]
+    } else {
+        zones
+    };
+    let mut targets: Vec<TargetRef> = zones
+        .into_iter()
+        .flat_map(|zone| crate::game::targeting::zone_object_ids(state, zone))
+        // CR 303.4d: an Aura can't enchant itself.
         .filter(|id| *id != aura_id)
+        // CR 115.1b + CR 303.4f: this consult is a controller CHOICE, not a
+        // targeting event (an Aura permanent doesn't target) — use
+        // `matches_target_filter`, never the `find_legal_targets` enumerator, so
+        // hexproof (CR 702.11) / shroud (CR 702.18) never remove a legal host.
         .filter(|id| crate::game::filter::matches_target_filter(state, *id, enchant_filter, &ctx))
         .filter(|id| crate::game::effects::attach::can_attach_to_object(state, aura_id, *id))
         .map(TargetRef::Object)


### PR DESCRIPTION
## Summary

CR 303.4f: when an Aura enters the battlefield by any means other than resolving as a spell (e.g. returning from exile) and the effect putting it there doesn't specify a host, the controller chooses a legal object per the Aura's current Enchant ability. `legal_aura_attachment_targets` computed that candidate list from `state.battlefield` only, unconditionally — even though both call sites already had the Aura's `enchant_filter` in hand, and that filter is the single source of truth for which zone(s) it can legally target.

An Enchant ability that targets "a creature card in a graveyard" (Animate Dead, Dance of the Dead), "an instant card in a graveyard" (Spellweaver Volute), or "a card in your hand" (Don't Worry About It) could therefore never find a legal host through this path, even when one genuinely existed — the consult always saw zero candidates and the Aura stayed stranded in its current zone (CR 303.4g).

**Fix**: rewrite `legal_aura_attachment_targets` to resolve the search zone(s) from `enchant_filter.extract_zones()` (defaulting to the battlefield when the filter imposes no zone constraint — the common case, unaffected), flat-map `zone_object_ids` over those zones, and filter with `matches_target_filter` — mirroring the existing `object_count_matching_ids` pattern in `game/quantity.rs`. Uses `matches_target_filter` rather than the spell-targeting enumerator: CR 115.1b says an Aura permanent doesn't target anything, so hexproof/shroud must never remove a candidate here, only an actual Enchant restriction can. Preserves the pre-existing "Enchant player" branch, the CR 303.4d self-enchant exclusion, and the `can_attach_to_object` legality gate unchanged.

Incidentally also now excludes phased-out permanents from the default battlefield case (CR 702.26b) via `zone_object_ids`'s existing filter — strictly more correct, not a behavior regression.

This is the fix that closes the final leg of the Worldgorger Dragon self-loop combo (mass-return mechanism fixed separately in #6055): the returning Animate Dead/Necromancy Aura can now find WGD sitting in the graveyard and re-attach to it, rather than staying stranded in exile.

## Test plan

- [x] New test: a reanimator-class Aura re-entering from exile with a legal graveyard host finds it, attaches, and its ETB reanimation chain fires end-to-end (creature reaches the battlefield under the correct controller)
- [x] New test: an ordinary battlefield-scoped Aura is unaffected — attaches iff a legal battlefield host exists (both a has-host positive and a no-host negative in one fixture)
- [x] New test: a graveyard-scoped Aura with NO legal graveyard creature correctly stays in exile (CR 303.4g) — non-vacuous, a non-matching card is present and enumerated/rejected by the scan
- [x] Zero regression: full `exile_return_tests` (16/16), `animate_dead`-filtered casting tests (9/9), `necromancy`-filtered casting tests (5/5)
- [x] Live-revert-and-rerun proof (done independently by two people): reverting just the scan-logic rewrite reproduces the exact failure (Aura stuck in exile); restoring is green
- [x] `cargo fmt --all`, `cargo clippy -p engine --all-targets -- -D warnings` clean
- [x] CR-annotation gate clean (115.1b, 303.4d, 303.4f, 303.4g, 610.3a, 702.11, 702.18, 702.26b all verified against the Comprehensive Rules)