### PR TITLE
ship/t161 r3r4 category topdeck

### DIFF
--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -283,9 +283,9 @@ pub(crate) fn drain_pending_per_category_zone_choice(
     state: &mut GameState,
     chosen: &[ObjectId],
     events: &mut Vec<GameEvent>,
-) {
+) -> crate::game::zone_pipeline::BatchMoveResult {
     let Some(pending) = state.pending_per_category_zone_choice.take() else {
-        return;
+        return crate::game::zone_pipeline::BatchMoveResult::Done;
     };
     let crate::types::game_state::PendingPerCategoryZoneChoice {
         ability,
@@ -293,47 +293,87 @@ pub(crate) fn drain_pending_per_category_zone_choice(
         remaining_member_filters,
     } = pending;
 
-    match &ability.effect {
+    if matches!(
+        &ability.effect,
         Effect::ForEachCategory {
             action: ForEachCategoryAction::ExileFromPool { .. },
             ..
-        } => {
-            for &card_id in chosen {
-                crate::game::zones::move_to_zone(state, card_id, Zone::Exile, events);
-            }
-            if !chosen.is_empty() {
-                super::publish_tracked_set(state, chosen.to_vec());
-            }
         }
-        Effect::ForEachCategory {
-            action:
-                ForEachCategoryAction::PutCounter {
-                    counter_type,
-                    count,
-                    ..
-                },
-            ..
-        } => {
-            let count_val =
-                crate::game::quantity::resolve_quantity_with_targets(state, count, &ability).max(0)
-                    as u32;
-            for &card_id in chosen {
-                crate::game::effects::counters::apply_counter_addition(
-                    state,
-                    ability.controller,
+    ) {
+        // CR 701.13a + CR 614.1 + CR 616.1: Each chosen card's exile is an
+        // effect-owned zone-change event. Keep the tracked-set extension and
+        // next-member prompt on the batch tail so neither can run before a
+        // replacement choice settles the exile.
+        let requests = chosen
+            .iter()
+            .map(|&card_id| {
+                crate::game::zone_pipeline::ZoneMoveRequest::effect(
                     card_id,
-                    counter_type.clone(),
-                    count_val,
-                    events,
-                );
-            }
-            if !chosen.is_empty() {
-                publish_tracked_set_unique(state, chosen);
-            }
-        }
-        _ => {}
+                    Zone::Exile,
+                    ability.source_id,
+                )
+            })
+            .collect();
+        return crate::game::zone_pipeline::move_objects_simultaneously_then(
+            state,
+            requests,
+            Some(
+                crate::types::game_state::BatchCompletion::ForEachCategoryExileComplete {
+                    ability,
+                    pool,
+                    remaining_member_filters,
+                    chosen: chosen.to_vec(),
+                },
+            ),
+            events,
+        );
     }
 
+    if let Effect::ForEachCategory {
+        action:
+            ForEachCategoryAction::PutCounter {
+                counter_type,
+                count,
+                ..
+            },
+        ..
+    } = &ability.effect
+    {
+        let count_val = crate::game::quantity::resolve_quantity_with_targets(state, count, &ability)
+            .max(0) as u32;
+        for &card_id in chosen {
+            crate::game::effects::counters::apply_counter_addition(
+                state,
+                ability.controller,
+                card_id,
+                counter_type.clone(),
+                count_val,
+                events,
+            );
+        }
+        if !chosen.is_empty() {
+            publish_tracked_set_unique(state, chosen);
+        }
+    }
+
+    let _ = prompt_next_category_member(state, &ability, &pool, remaining_member_filters, events);
+    crate::game::zone_pipeline::BatchMoveResult::Done
+}
+
+/// CR 608.2c: Complete one settled `ForEachCategoryExile` member. The typed
+/// batch tail owns both the tracked-set extension and the next-member prompt so
+/// a CR 616.1 replacement choice resolves before the iteration advances.
+pub(crate) fn complete_per_category_exile(
+    state: &mut GameState,
+    ability: Box<ResolvedAbility>,
+    pool: Vec<ObjectId>,
+    remaining_member_filters: Vec<TargetFilter>,
+    chosen: Vec<ObjectId>,
+    events: &mut Vec<GameEvent>,
+) {
+    if !chosen.is_empty() {
+        super::publish_tracked_set(state, chosen);
+    }
     let _ = prompt_next_category_member(state, &ability, &pool, remaining_member_filters, events);
 }
 

--- a/crates/engine/src/game/effects/drawn_this_turn_choice.rs
+++ b/crates/engine/src/game/effects/drawn_this_turn_choice.rs
@@ -3,10 +3,10 @@ use std::collections::HashSet;
 use crate::game::life_costs::{can_pay_life_cost, pay_life_as_cost};
 use crate::game::quantity::resolve_quantity;
 use crate::game::targeting::resolve_effect_player_ref;
-use crate::game::zones;
-use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
+use crate::types::ability::{Effect, EffectError, EffectKind, LibraryPosition, ResolvedAbility};
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{BatchCompletion, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
@@ -76,11 +76,11 @@ pub struct TopdeckChoice<'a> {
     pub chosen_to_topdeck: &'a [ObjectId],
 }
 
-pub fn handle_topdeck_choice(
+pub(crate) fn handle_topdeck_choice(
     state: &mut GameState,
     choice: TopdeckChoice<'_>,
     events: &mut Vec<GameEvent>,
-) -> Result<(), EffectError> {
+) -> Result<BatchMoveResult, EffectError> {
     if choice.chosen_to_topdeck.len() > choice.count {
         return Err(EffectError::InvalidParam(
             "too many cards selected".to_string(),
@@ -111,21 +111,59 @@ pub fn handle_topdeck_choice(
         ));
     }
 
-    for object_id in choice.chosen_to_topdeck.iter().rev() {
-        zones::move_to_library_at_index(state, *object_id, Some(0), events);
-    }
-    for _ in 0..payment_count {
-        if pay_life_as_cost(state, choice.player, choice.life_payment, events).is_unpayable() {
-            return Err(EffectError::InvalidParam("life payment failed".to_string()));
-        }
+    let requests = choice
+        .chosen_to_topdeck
+        .iter()
+        .rev()
+        .map(|&object_id| {
+            ZoneMoveRequest::effect(object_id, Zone::Library, choice.source_id)
+                .at_library_position(LibraryPosition::Top)
+        })
+        .collect();
+    Ok(zone_pipeline::move_objects_simultaneously_then(
+        state,
+        requests,
+        Some(BatchCompletion::DrawnThisTurnTopdeckComplete {
+            player: choice.player,
+            life_payment: choice.life_payment,
+            payment_count,
+            topdecked_count: choice.chosen_to_topdeck.len(),
+            source_id: choice.source_id,
+        }),
+        events,
+    ))
+}
+
+/// CR 608.2c + CR 614.1 + CR 616.1: Complete the pay-or-topdeck instruction
+/// only after every selected Library placement has settled. The pre-batch
+/// affordability check makes an unpayable payment here an internal
+/// inconsistency; preserve the legacy event-free failure shape in release
+/// builds while asserting it in debug builds.
+pub(crate) fn complete_topdeck_choice(
+    state: &mut GameState,
+    player: PlayerId,
+    life_payment: u32,
+    payment_count: usize,
+    topdecked_count: usize,
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) {
+    let payment_failed = (0..payment_count)
+        .any(|_| pay_life_as_cost(state, player, life_payment, events).is_unpayable());
+    debug_assert!(
+        !payment_failed,
+        "pre-validated drawn-this-turn life payment became unpayable after Library delivery"
+    );
+    if payment_failed {
+        return;
     }
 
+    state.last_effect_count = Some(topdecked_count as i32);
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::ChooseDrawnThisTurnPayOrTopdeck,
-        source_id: choice.source_id,
+        source_id,
         subject: None,
     });
-    Ok(())
 }
 
 fn eligible_drawn_hand_cards(state: &GameState, player: PlayerId) -> Vec<ObjectId> {

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3217,9 +3217,16 @@ pub(super) fn handle_resolution_choice(
             // the per-player path (Sanar, Portent of Calamity). The continuation
             // ("from among them" / "put the rest …") reads that tracked set.
             if state.pending_per_category_zone_choice.is_some() {
-                effects::choose_from_zone::drain_pending_per_category_zone_choice(
+                match effects::choose_from_zone::drain_pending_per_category_zone_choice(
                     state, &chosen, events,
-                );
+                ) {
+                    crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                    crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                        return Ok(ResolutionChoiceOutcome::WaitingFor(
+                            state.waiting_for.clone(),
+                        ));
+                    }
+                }
                 super::engine::resume_pending_continuation_if_priority(state, events)
                     .expect("a settled zone choice must resume its continuation");
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
@@ -4447,7 +4454,7 @@ pub(super) fn handle_resolution_choice(
             },
             GameAction::SelectCards { cards: chosen },
         ) => {
-            effects::drawn_this_turn_choice::handle_topdeck_choice(
+            match effects::drawn_this_turn_choice::handle_topdeck_choice(
                 state,
                 effects::drawn_this_turn_choice::TopdeckChoice {
                     player,
@@ -4460,11 +4467,18 @@ pub(super) fn handle_resolution_choice(
                 },
                 events,
             )
-            .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
+            .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+            {
+                crate::game::zone_pipeline::BatchMoveResult::Done => {}
+                crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
+                    return Ok(ResolutionChoiceOutcome::WaitingFor(
+                        state.waiting_for.clone(),
+                    ));
+                }
+            }
             // Issue #423 audit: `handle_topdeck_choice` moves cards between the
             // hand and the top of the library — never off the battlefield — so
             // it produces no dies-triggers and needs no collection here.
-            state.last_effect_count = Some(chosen.len() as i32);
             set_priority(state, player);
             resume_with_error_propagation(state, events)?;
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
@@ -5723,6 +5737,40 @@ pub(crate) fn run_batch_completion(
                 cont.chain.context.optional_effect_performed = !continuation_targets.is_empty();
             }
             finish_with_continuation(state, player, events);
+            crate::game::zone_pipeline::BatchMoveResult::Done
+        }
+        BatchCompletion::ForEachCategoryExileComplete {
+            ability,
+            pool,
+            remaining_member_filters,
+            chosen,
+        } => {
+            effects::choose_from_zone::complete_per_category_exile(
+                state,
+                ability,
+                pool,
+                remaining_member_filters,
+                chosen,
+                events,
+            );
+            crate::game::zone_pipeline::BatchMoveResult::Done
+        }
+        BatchCompletion::DrawnThisTurnTopdeckComplete {
+            player,
+            life_payment,
+            payment_count,
+            topdecked_count,
+            source_id,
+        } => {
+            effects::drawn_this_turn_choice::complete_topdeck_choice(
+                state,
+                player,
+                life_payment,
+                payment_count,
+                topdecked_count,
+                source_id,
+                events,
+            );
             crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::SurveilKeepOnTop { player, top_cards } => {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1882,6 +1882,24 @@ pub enum BatchCompletion {
         publish_tracked_set: Vec<ObjectId>,
         continuation_targets: Vec<ObjectId>,
     },
+    /// CR 701.13a + CR 614.1 + CR 616.1: A per-category exile member has
+    /// settled, so its tracked-set extension and next-member prompt can run.
+    ForEachCategoryExileComplete {
+        ability: Box<ResolvedAbility>,
+        pool: Vec<ObjectId>,
+        remaining_member_filters: Vec<crate::types::ability::TargetFilter>,
+        chosen: Vec<ObjectId>,
+    },
+    /// CR 401.4 + CR 614.1 + CR 616.1 + CR 608.2c: A drawn-this-turn
+    /// topdeck batch has settled, so its life-payment and resolution tail can
+    /// run exactly once after the selected cards' ordered Library delivery.
+    DrawnThisTurnTopdeckComplete {
+        player: PlayerId,
+        life_payment: u32,
+        payment_count: usize,
+        topdecked_count: usize,
+        source_id: ObjectId,
+    },
     /// CR 701.25a: After the surveil rest pile reaches the graveyard, the kept
     /// cards rest on top of the player's library in the chosen order
     /// (`top_cards[0]` becomes the topmost card).

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -6,10 +6,10 @@ use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, CastingPermission, ChoiceType,
-    DigSource, DiscardSelfScope, Effect, ManaContribution, ManaProduction, ModalChoice,
-    QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode, ResolvedAbility,
-    SacrificeCost, SpellCastingOption, TargetFilter, TargetRef, TargetSelectionMode,
-    TriggerDefinition, TypeFilter, TypedFilter,
+    Chooser, DigSource, DiscardSelfScope, Effect, ForEachCategoryAction, IterationCategory,
+    ManaContribution, ManaProduction, ModalChoice, QuantityExpr, QuantityRef,
+    ReplacementDefinition, ReplacementMode, ResolvedAbility, SacrificeCost, SpellCastingOption,
+    TargetFilter, TargetRef, TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
@@ -8086,4 +8086,362 @@ fn r2_effect_zone_moves_stay_synchronous_without_redirects() {
     assert_eq!(dig_runner.state().objects[&kept].zone, Zone::Hand);
     assert_eq!(dig_runner.state().objects[&rest].zone, Zone::Graveyard);
     assert_eq!(dig_runner.state().players[P0.0 as usize].life, 21);
+}
+
+fn per_color_exile_ability(
+    source_id: engine::types::identifiers::ObjectId,
+    pool: Vec<engine::types::identifiers::ObjectId>,
+) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::ForEachCategory {
+            category: IterationCategory::Color,
+            chooser: Chooser::Controller,
+            action: ForEachCategoryAction::ExileFromPool {
+                zone: Zone::Library,
+                up_to: true,
+            },
+        },
+        pool.into_iter().map(TargetRef::Object).collect(),
+        source_id,
+        P0,
+    )
+}
+
+/// W-R3 (red first): a per-category exile's tracked-set extension and next
+/// member prompt must wait for its replacement-aware exile delivery.
+#[test]
+fn per_category_exile_redirect_pauses_before_next_member() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Per-Category Exile Redirect Source", 1, 1)
+        .id();
+    let white = scenario.add_card_to_library_top(P0, "Per-Category White Card");
+    let blue = scenario.add_card_to_library_top(P0, "Per-Category Blue Card");
+    for (name, destination) in [
+        ("Per-Category Exile To Graveyard", Zone::Graveyard),
+        ("Per-Category Exile To Hand", Zone::Hand),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Exile, destination));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().objects.get_mut(&white).unwrap().color = vec![ManaColor::White];
+    runner.state_mut().objects.get_mut(&blue).unwrap().color = vec![ManaColor::Blue];
+    let ability = per_color_exile_ability(source, vec![white, blue]);
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("the first color member reaches its choice");
+
+    let paused = runner
+        .act(GameAction::SelectCards { cards: vec![white] })
+        .expect("the selected exile reaches a replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&white].zone, Zone::Library);
+    let tracked = runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &runner
+                .state()
+                .chain_tracked_set_id
+                .expect("per-category resolution starts a tracked set"),
+        )
+        .expect("per-category tracked set exists");
+    assert!(
+        tracked.is_empty(),
+        "the batch tail has not published the exile"
+    );
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the redirected exile resumes the iteration tail");
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::ChooseFromZoneChoice { ref cards, .. } if cards == &vec![blue]
+    ));
+    assert_eq!(runner.state().objects[&white].zone, Zone::Graveyard);
+    let tracked = runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &runner
+                .state()
+                .chain_tracked_set_id
+                .expect("the settled exile publishes to the tracked set"),
+        )
+        .expect("the tracked set exists after the batch settles");
+    assert_eq!(tracked, &vec![white]);
+
+    let completed = runner
+        .act(GameAction::SelectCards { cards: vec![] })
+        .expect("declining the final category member completes the iteration");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+    assert_eq!(runner.state().objects[&blue].zone, Zone::Library);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(paused.events.iter())
+            .chain(resumed.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::ChooseFromZone,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the per-category iteration tail resolves exactly once"
+    );
+}
+
+/// W-R3-REG: without a redirect, per-category exiles settle inline and advance
+/// to the next category member before finishing the iteration.
+#[test]
+fn per_category_exile_stays_synchronous_without_redirects() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Synchronous Per-Category Exile Source", 1, 1)
+        .id();
+    let white = scenario.add_card_to_library_top(P0, "Synchronous Per-Category White");
+    let blue = scenario.add_card_to_library_top(P0, "Synchronous Per-Category Blue");
+    let mut runner = scenario.build();
+    runner.state_mut().objects.get_mut(&white).unwrap().color = vec![ManaColor::White];
+    runner.state_mut().objects.get_mut(&blue).unwrap().color = vec![ManaColor::Blue];
+    let ability = per_color_exile_ability(source, vec![white, blue]);
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("the first color member reaches its choice");
+
+    let first = runner
+        .act(GameAction::SelectCards { cards: vec![white] })
+        .expect("the white exile settles inline");
+    assert!(matches!(
+        first.waiting_for,
+        WaitingFor::ChooseFromZoneChoice { ref cards, .. } if cards == &vec![blue]
+    ));
+    assert_eq!(runner.state().objects[&white].zone, Zone::Exile);
+
+    let completed = runner
+        .act(GameAction::SelectCards { cards: vec![blue] })
+        .expect("the blue exile completes the iteration");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+    assert_eq!(runner.state().objects[&blue].zone, Zone::Exile);
+    let tracked = runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &runner
+                .state()
+                .chain_tracked_set_id
+                .expect("per-category exiles publish one shared tracked set"),
+        )
+        .expect("the shared tracked set exists");
+    assert_eq!(tracked, &vec![white, blue]);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(first.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::ChooseFromZone,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the synchronous per-category iteration resolves exactly once"
+    );
+}
+
+/// W-R4 (red first): selected drawn cards must settle their replacement-aware
+/// Library delivery before the remaining cards' life payment or resolution event.
+#[test]
+fn drawn_this_turn_topdeck_redirect_pauses_before_payment() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Drawn-This-Turn Redirect Source", 1, 1)
+        .id();
+    let topdecked = scenario.add_card_to_hand(P0, "Drawn-This-Turn Topdecked");
+    let kept = scenario.add_card_to_hand(P0, "Drawn-This-Turn Kept");
+    for (name, destination) in [
+        ("Drawn-This-Turn Library To Graveyard", Zone::Graveyard),
+        ("Drawn-This-Turn Library To Exile", Zone::Exile),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Library, destination));
+    }
+
+    let mut runner = scenario.build();
+    engine::game::effects::drawn_this_turn_choice::record_drawn_card(
+        runner.state_mut(),
+        P0,
+        topdecked,
+    );
+    engine::game::effects::drawn_this_turn_choice::record_drawn_card(runner.state_mut(), P0, kept);
+    let ability = ResolvedAbility::new(
+        Effect::ChooseDrawnThisTurnPayOrTopdeck {
+            count: QuantityExpr::Fixed { value: 2 },
+            life_payment: QuantityExpr::Fixed { value: 4 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("drawn-this-turn effect reaches its selection");
+
+    let paused = runner
+        .act(GameAction::SelectCards {
+            cards: vec![topdecked],
+        })
+        .expect("the Library delivery reaches its replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&topdecked].zone, Zone::Hand);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 20);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(paused.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::ChooseDrawnThisTurnPayOrTopdeck,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        0,
+        "the resolution event waits behind the replacement choice"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the redirected Library delivery runs the payment tail");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+    assert_eq!(runner.state().objects[&topdecked].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&kept].zone, Zone::Hand);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 16);
+    assert_eq!(runner.state().last_effect_count, Some(1));
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(paused.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::ChooseDrawnThisTurnPayOrTopdeck,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the payment tail emits one resolution event after the replacement settles"
+    );
+}
+
+/// W-R4-REG: reverse request construction preserves the selected order when
+/// each ordered Library placement inserts at the top.
+#[test]
+fn drawn_this_turn_topdeck_preserves_selected_library_order() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Synchronous Drawn-This-Turn Source", 1, 1)
+        .id();
+    let prior_top = scenario.add_card_to_library_top(P0, "Drawn-This-Turn Prior Top");
+    let first = scenario.add_card_to_hand(P0, "Drawn-This-Turn First");
+    let second = scenario.add_card_to_hand(P0, "Drawn-This-Turn Second");
+    let kept = scenario.add_card_to_hand(P0, "Drawn-This-Turn Kept");
+    let mut runner = scenario.build();
+    for object_id in [first, second, kept] {
+        engine::game::effects::drawn_this_turn_choice::record_drawn_card(
+            runner.state_mut(),
+            P0,
+            object_id,
+        );
+    }
+    let ability = ResolvedAbility::new(
+        Effect::ChooseDrawnThisTurnPayOrTopdeck {
+            count: QuantityExpr::Fixed { value: 3 },
+            life_payment: QuantityExpr::Fixed { value: 4 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("drawn-this-turn effect reaches its selection");
+
+    let completed = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("the unredirected Library placements settle inline");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player } if player == P0
+    ));
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .library
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![first, second, prior_top],
+        "first-selected remains topmost after reverse index-zero placements"
+    );
+    assert_eq!(runner.state().players[P0.0 as usize].life, 16);
+    assert_eq!(runner.state().last_effect_count, Some(2));
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: engine::types::ability::EffectKind::ChooseDrawnThisTurnPayOrTopdeck,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the synchronous payment tail emits one resolution event"
+    );
 }

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -29,10 +29,8 @@ crates/engine/src/game/deck_loading.rs	create_scheme_deck_card	container	1
 crates/engine/src/game/effects/cascade.rs	resolve	mover	1
 crates/engine/src/game/effects/cast_copy_of_card.rs	cast_one_copy	zone-assign	1
 crates/engine/src/game/effects/cast_from_zone.rs	grant_lingering_permissions	mover	1
-crates/engine/src/game/effects/choose_from_zone.rs	drain_pending_per_category_zone_choice	mover	1
 crates/engine/src/game/effects/cloak.rs	resolve	mover	1
 crates/engine/src/game/effects/copy_spell.rs	resolve	zone-assign	1
-crates/engine/src/game/effects/drawn_this_turn_choice.rs	handle_topdeck_choice	mover	1
 crates/engine/src/game/effects/epic.rs	resolve	zone-assign	1
 crates/engine/src/game/effects/explore.rs	resolve_explore_effect	mover	1
 crates/engine/src/game/effects/paradigm.rs	cast_paradigm_copy	zone-assign	1


### PR DESCRIPTION
- **refactor(engine): route per-category exile and drawn-topdeck moves through the pipeline (R3+R4)**
- **chore: tighten zone-authority baseline after R3+R4 migration**
