### PR TITLE
feat(parser): Ward of Bones per-player quantity cast prohibition + same-is-true spell widening

### DIFF
--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -968,10 +968,10 @@ pub(crate) fn parse_per_turn_cast_limit(tp: &str, text: &str) -> Option<StaticDe
 }
 
 /// CR 101.2 + CR 109.5 + CR 508.1 + CR 601.3a: "Each [scope] who [did X] this turn
-/// can't [Y]" — a static prohibition gated on a PER-AFFECTED-PLAYER turn-activity
-/// predicate (Angelic Arbiter).
+/// can't [Y]" — a static prohibition gated on a PER-AFFECTED-PLAYER predicate
+/// (Angelic Arbiter, Ward of Bones).
 ///
-/// The two clauses are:
+/// The clauses are:
 /// - "Each opponent who attacked with a creature this turn can't cast spells."
 ///   → `CantBeCast { who: Opponents }` + `per_player_condition: YouAttackedThisTurn`
 ///   (CR 601.3a cast prohibition).
@@ -979,11 +979,23 @@ pub(crate) fn parse_per_turn_cast_limit(tp: &str, text: &str) -> Option<StaticDe
 ///   → `CantAttack` with `affected = opponents' creatures` +
 ///   `per_player_condition: YouCastSpellThisTurn { filter: None }` (CR 508.1
 ///   declare-attackers prohibition).
+/// - "Each opponent who controls more lands than you can't play lands." (Ward
+///   of Bones, line 2) → `StaticMode::Other("CantPlayLand")`, `affected` =
+///   opponents' player scope, `per_player_condition: QuantityComparison`
+///   (`controls_more_than_you_condition` — a relative permanent-count gate,
+///   CR 109.4, rather than a turn-activity predicate).
 ///
-/// The turn-activity predicate is stored in `per_player_condition` (CR 109.5:
-/// evaluated against the AFFECTED player — the caster, or the attacking creature's
-/// controller), NEVER in `condition` (which is the source-relative functioning
-/// gate). `condition` stays `None` so the prohibition is not globally gated.
+/// Ward of Bones's OTHER clause ("controls more creatures than you can't cast
+/// creature spells. The same is true for artifacts and enchantments.") is NOT
+/// handled here — each named type is an independent per-type prohibition, so
+/// it needs a multi-def result and is owned by the sibling
+/// `parse_relative_count_typed_cast_prohibitions` on the multi-static path.
+///
+/// The per-affected-player predicate is stored in `per_player_condition` (CR
+/// 109.5: evaluated against the AFFECTED player — the caster, or the attacking
+/// creature's controller), NEVER in `condition` (which is the source-relative
+/// functioning gate). `condition` stays `None` so the prohibition is not
+/// globally gated.
 ///
 /// Composed from the shared `strip_casting_prohibition_subject` building block plus
 /// nom `tag`/`alt`/`value` — no string-matching dispatch.

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -982,8 +982,8 @@ pub(crate) fn parse_per_turn_cast_limit(tp: &str, text: &str) -> Option<StaticDe
 /// - "Each opponent who controls more lands than you can't play lands." (Ward
 ///   of Bones, line 2) → `StaticMode::Other("CantPlayLand")`, `affected` =
 ///   opponents' player scope, `per_player_condition: QuantityComparison`
-///   (`controls_more_than_you_condition` — a relative permanent-count gate,
-///   CR 109.4, rather than a turn-activity predicate).
+///   (`controls_more_than_you_condition` — a relative permanent-count gate
+///   rather than a turn-activity predicate).
 ///
 /// Ward of Bones's OTHER clause ("controls more creatures than you can't cast
 /// creature spells. The same is true for artifacts and enchantments.") is NOT

--- a/crates/engine/tests/integration/ward_of_bones_relative_count_cast_prohibition.rs
+++ b/crates/engine/tests/integration/ward_of_bones_relative_count_cast_prohibition.rs
@@ -208,6 +208,43 @@ fn more_enchantments_blocks_only_enchantment_spells() {
     );
 }
 
+/// Boundary case: P1 controls the SAME number of creatures as P0 (1 vs 1), not
+/// STRICTLY more. CR 109.4's "more than" is a strict inequality
+/// (`Comparator::GT`); the prohibition must not fire on a tie. This is the one
+/// case the per-type tests above never probe (they only ever use a strict
+/// count difference), so it's the discriminating regression guard against the
+/// comparator silently regressing to `GE` (which would wrongly block casts
+/// whenever the counts are merely equal).
+#[test]
+fn equal_creature_count_does_not_block_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    scenario
+        .add_creature(P0, "Ward of Bones", 0, 0)
+        .as_artifact()
+        .from_oracle_text(WARD_OF_BONES_CAST_LINE);
+    // P0 controls one creature — the threshold P1 must EXCEED, not merely meet.
+    scenario.add_creature(P0, "P0 Bear", 2, 2);
+    // P1 controls exactly one creature: equal to P0's count, not more.
+    scenario.add_creature(P1, "P1 Bear", 2, 2);
+
+    let creature_spell = zero_creature_spell(&mut scenario, P1);
+
+    let mut runner = scenario.build();
+    runner.state_mut().active_player = P1;
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    // CR 109.4: equal counts are not "more than" → the prohibition must not
+    // apply. FAILS if `Comparator::GT` ever regresses to `GE`.
+    assert!(
+        can_cast_object_now(runner.state(), P1, creature_spell),
+        "P1 controls the SAME number of creatures as you (1 vs 1), not more → \
+         the creature spell must stay castable (regression guard for GT vs GE)"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Two-Headed Giant: "each opponent" must not treat a TEAMMATE as an opponent
 // on the CAST seam (sibling of the land-play fix).

--- a/crates/engine/tests/integration/ward_of_bones_relative_count_cast_prohibition.rs
+++ b/crates/engine/tests/integration/ward_of_bones_relative_count_cast_prohibition.rs
@@ -209,12 +209,11 @@ fn more_enchantments_blocks_only_enchantment_spells() {
 }
 
 /// Boundary case: P1 controls the SAME number of creatures as P0 (1 vs 1), not
-/// STRICTLY more. CR 109.4's "more than" is a strict inequality
-/// (`Comparator::GT`); the prohibition must not fire on a tie. This is the one
-/// case the per-type tests above never probe (they only ever use a strict
-/// count difference), so it's the discriminating regression guard against the
-/// comparator silently regressing to `GE` (which would wrongly block casts
-/// whenever the counts are merely equal).
+/// STRICTLY more. "More than" is a strict inequality (`Comparator::GT`); the
+/// prohibition must not fire on a tie. This is the one case the per-type tests
+/// above never probe (they only ever use a strict count difference), so it's the
+/// discriminating regression guard against the comparator silently regressing to
+/// `GE` (which would wrongly block casts whenever the counts are merely equal).
 #[test]
 fn equal_creature_count_does_not_block_cast() {
     let mut scenario = GameScenario::new();
@@ -236,8 +235,8 @@ fn equal_creature_count_does_not_block_cast() {
     runner.state_mut().layers_dirty.mark_full();
     evaluate_layers(runner.state_mut());
 
-    // CR 109.4: equal counts are not "more than" → the prohibition must not
-    // apply. FAILS if `Comparator::GT` ever regresses to `GE`.
+    // Equal counts are not "more than" → the prohibition must not apply. FAILS
+    // if `Comparator::GT` ever regresses to `GE`.
     assert!(
         can_cast_object_now(runner.state(), P1, creature_spell),
         "P1 controls the SAME number of creatures as you (1 vs 1), not more → \


### PR DESCRIPTION
## Update

While rebasing this branch, `restriction.rs` conflicted with an already-merged fix on `main` that implements this exact card — more completely and more correctly than this PR's original approach:

- It also covers the land-play clause ("Each opponent who controls more lands than you can't play lands"), which this PR had explicitly deferred.
- Critically, it fixes a **rules bug in my original approach**: this PR had modeled the cast restriction as ONE static with a single `Or[Creature, Artifact, Enchantment]` filter gated on a single (creature) count comparison. Per the card's 2008-08-01 ruling, each type is an **independent** prohibition — an opponent with more artifacts but not more creatures must still be barred from casting artifact spells specifically. The upstream fix (`parse_relative_count_typed_cast_prohibitions`) correctly emits one `CantBeCast` static per type, each gated on its own count comparison, and ships with real game-scenario integration tests (`crates/engine/tests/integration/ward_of_bones_relative_count_cast_prohibition.rs`, `ward_of_bones_relative_count_land_prohibition.rs`) proving the per-type independence.

I resolved the conflict by taking the upstream implementation as-is and dropping this PR's now-superseded/incorrect functions and shape-tests (they asserted the collapsed-`Or` model, which upstream's own tests demonstrate is wrong). What's left is a small doc-comment correction to `parse_per_player_conditional_prohibition`'s header, clarifying which clause it owns now that the cast-restriction clause moved to the sibling multi-def parser.

Given the underlying issue (#6077) is already fixed on `main`, this PR no longer adds new capability — it's a documentation-accuracy fix only. Deferring to the maintainers on whether to take it or close it as moot.

---

## Original summary (superseded, kept for history)

Fixes #6077. `Ward of Bones`'s per-player cast prohibition — "Each opponent who controls more creatures than you can't cast creature spells. The same is true for artifacts and enchantments." (Scryfall-verified, `oracle_id: c3ea1497-63ac-46bb-95e9-d98b93a880b3`) — was unhandled at the time this PR was opened. The original approach added a `QuantityComparison`-based per-player condition arm and a typed "cast `<type>` spells[. The same is true for X and Y]" verb producing a single widened `Or` filter. That approach is now superseded per the note above.


---

## Update 2 (review response)

@matthewevans's review requesting runtime proof was attached to `fb19028a4` — the pre-conflict-resolution commit described above, which no longer exists on this branch. #6095 (the concurrently-merged fix, referenced above) already ships exactly that proof in `crates/engine/tests/integration/ward_of_bones_relative_count_cast_prohibition.rs` (per-type block/allow assertions through `can_cast_object_now`, plus a Two-Headed Giant variant). One gap remained — no test pinned the `Comparator::GT` (strict) semantics against an equal-count tie — closed in `406dc391c` (`equal_creature_count_does_not_block_cast`).
