### PR TITLE
fix(engine): persist ward sacrifice payments across replacement pauses

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -2199,6 +2199,7 @@ pub(crate) fn drain_pending_cost_move_resume(
             Some(
                 PendingCostMoveResume::Cast { .. }
                     | PendingCostMoveResume::SacrificeForCost { .. }
+                    | PendingCostMoveResume::WardSacrificePayment { .. }
                     | PendingCostMoveResume::ReplacementMayCost { .. }
                     | PendingCostMoveResume::CollectEvidencePayment { .. }
                     | PendingCostMoveResume::UnlessBouncePayment { .. }
@@ -2211,6 +2212,7 @@ pub(crate) fn drain_pending_cost_move_resume(
             Some(
                 PendingCostMoveResume::Cast { .. }
                     | PendingCostMoveResume::SacrificeForCost { .. }
+                    | PendingCostMoveResume::WardSacrificePayment { .. }
                     | PendingCostMoveResume::ReplacementMayCost { .. }
                     | PendingCostMoveResume::Foretell { .. }
                     | PendingCostMoveResume::CollectEvidencePayment { .. }
@@ -2243,6 +2245,11 @@ pub(crate) fn drain_pending_cost_move_resume(
         Some(PendingCostMoveResume::Cast { .. } | PendingCostMoveResume::SacrificeForCost { .. })
     ) {
         casting_costs::resume_interrupted_cost_payment(state, events, action_event_start)?
+    } else if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::WardSacrificePayment { .. })
+    ) {
+        engine_payment_choices::resume_ward_sacrifice_payment(state, events)?
     } else if matches!(
         state.pending_cost_move_resume,
         Some(PendingCostMoveResume::ReplacementMayCost { .. })

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -7,6 +7,7 @@ use crate::types::ability::{
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
     ActionResult, AutoMayChoice, GameState, PendingContinuation, PendingCostMoveResume, WaitingFor,
+    WardSacrificePaymentResume,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -1595,6 +1596,109 @@ fn selected_sacrifice_total_power(state: &GameState, chosen: &[ObjectId]) -> i32
         .sum()
 }
 
+/// CR 702.21a + CR 701.21 + CR 616.1: Persist the exact unpaid ward payment
+/// work while the current sacrifice waits for a replacement choice. Preserve a
+/// delivery-tail prompt when it owns the action; otherwise expose the live
+/// replacement ordering choice.
+fn pause_ward_sacrifice_payment(
+    state: &mut GameState,
+    player: PlayerId,
+    pending_effect: Box<ResolvedAbility>,
+    resume: WardSacrificePaymentResume,
+    choice_player: PlayerId,
+) -> WaitingFor {
+    state.pending_cost_move_resume = Some(PendingCostMoveResume::WardSacrificePayment {
+        player,
+        pending_effect,
+        resume,
+    });
+    if state.pending_replacement.is_some() {
+        costs::pause_cost_payment_for_replacement_choice(state, choice_player);
+    }
+    state.waiting_for.clone()
+}
+
+/// CR 702.21a: Finish the ward payment only after every required sacrifice has
+/// settled, then allow the normal resolution-continuation tail to advance once.
+fn finish_ward_sacrifice_payment(
+    state: &mut GameState,
+    pending_effect: ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::from(&pending_effect.effect),
+        source_id: pending_effect.source_id,
+        subject: None,
+    });
+
+    set_active_priority(state);
+    resume_pending_continuation_if_priority(state, events)?;
+    Ok(state.waiting_for.clone())
+}
+
+/// CR 702.21a + CR 701.21 + CR 614.1 + CR 616.1: Resume only the ward
+/// sacrifice work that followed the sacrifice completed by the replacement
+/// action. This is reached exclusively through the typed cost-move dispatcher.
+pub(super) fn resume_ward_sacrifice_payment(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let Some(PendingCostMoveResume::WardSacrificePayment {
+        player,
+        pending_effect,
+        resume,
+    }) = state.pending_cost_move_resume.take()
+    else {
+        unreachable!("ward sacrifice payment resume requires its typed continuation")
+    };
+
+    match resume {
+        WardSacrificePaymentResume::MultiSacrifice { remaining } => {
+            for (index, id) in remaining.iter().enumerate() {
+                match crate::game::sacrifice::sacrifice_permanent(state, *id, player, events)? {
+                    crate::game::sacrifice::SacrificeOutcome::Complete => {}
+                    crate::game::sacrifice::SacrificeOutcome::NeedsReplacementChoice(
+                        choice_player,
+                    ) => {
+                        return Ok(pause_ward_sacrifice_payment(
+                            state,
+                            player,
+                            pending_effect,
+                            WardSacrificePaymentResume::MultiSacrifice {
+                                remaining: remaining[index + 1..].to_vec(),
+                            },
+                            choice_player,
+                        ));
+                    }
+                }
+            }
+            finish_ward_sacrifice_payment(state, *pending_effect, events)
+        }
+        WardSacrificePaymentResume::Sequential {
+            permanents,
+            sacrificed,
+            remaining,
+        } => {
+            if remaining > 1 {
+                let eligible = permanents
+                    .into_iter()
+                    .filter(|&id| id != sacrificed && state.objects.contains_key(&id))
+                    .collect();
+                state.waiting_for = WaitingFor::WardSacrificeChoice {
+                    player,
+                    permanents: eligible,
+                    pending_effect,
+                    remaining: remaining - 1,
+                    min_total_power: None,
+                };
+                Ok(state.waiting_for.clone())
+            } else {
+                finish_ward_sacrifice_payment(state, *pending_effect, events)
+            }
+        }
+    }
+}
+
 pub(super) fn handle_ward_sacrifice_choice(
     state: &mut GameState,
     waiting_for: WaitingFor,
@@ -1636,8 +1740,21 @@ pub(super) fn handle_ward_sacrifice_choice(
                 "Selected permanents' total power must be at least {threshold}"
             )));
         }
-        for id in &chosen {
-            crate::game::sacrifice::sacrifice_permanent(state, *id, player, events)?;
+        for (index, id) in chosen.iter().enumerate() {
+            match crate::game::sacrifice::sacrifice_permanent(state, *id, player, events)? {
+                crate::game::sacrifice::SacrificeOutcome::Complete => {}
+                crate::game::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                    return Ok(pause_ward_sacrifice_payment(
+                        state,
+                        player,
+                        pending_effect,
+                        WardSacrificePaymentResume::MultiSacrifice {
+                            remaining: chosen[index + 1..].to_vec(),
+                        },
+                        choice_player,
+                    ));
+                }
+            }
         }
     } else {
         if chosen.len() != 1 || !permanents.contains(&chosen[0]) {
@@ -1653,7 +1770,22 @@ pub(super) fn handle_ward_sacrifice_choice(
         // group; the `handle_sacrifice_for_cost` co-departed stamp does not apply here.
         // A co-departing observer therefore under-observes. Closing this would batch all
         // Ward sacrifices into one action (like `handle_sacrifice_for_cost`) — out of scope.
-        crate::game::sacrifice::sacrifice_permanent(state, chosen[0], player, events)?;
+        match crate::game::sacrifice::sacrifice_permanent(state, chosen[0], player, events)? {
+            crate::game::sacrifice::SacrificeOutcome::Complete => {}
+            crate::game::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                return Ok(pause_ward_sacrifice_payment(
+                    state,
+                    player,
+                    pending_effect,
+                    WardSacrificePaymentResume::Sequential {
+                        permanents,
+                        sacrificed: chosen[0],
+                        remaining,
+                    },
+                    choice_player,
+                ));
+            }
+        }
 
         // If more sacrifices remain, re-prompt with updated eligible permanents
         if remaining > 1 {
@@ -1672,15 +1804,7 @@ pub(super) fn handle_ward_sacrifice_choice(
         }
     }
 
-    events.push(GameEvent::EffectResolved {
-        kind: EffectKind::from(&pending_effect.effect),
-        source_id: pending_effect.source_id,
-        subject: None,
-    });
-
-    set_active_priority(state);
-    resume_pending_continuation_if_priority(state, events)?;
-    Ok(state.waiting_for.clone())
+    finish_ward_sacrifice_payment(state, *pending_effect, events)
 }
 
 /// CR 118.12: Handle player's selection of a permanent to return to hand as unless cost.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2817,6 +2817,25 @@ pub enum PendingSacrificeCostCompletion {
     SelfRef,
 }
 
+/// CR 702.21a + CR 701.21 + CR 616.1: The unpaid work after one ward sacrifice
+/// pauses on a replacement choice. Aggregate ward costs retain their already
+/// selected ordered suffix; sequential ward costs retain the live eligibility
+/// basis needed to reconstruct the next one-per-round-trip choice.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum WardSacrificePaymentResume {
+    /// The selected aggregate sacrifice suffix, in the order the player chose.
+    MultiSacrifice { remaining: Vec<ObjectId> },
+    /// The selected sequential sacrifice settled through the replacement
+    /// action. `remaining` includes that sacrifice, matching
+    /// `WaitingFor::WardSacrificeChoice` before its ordinary re-prompt tail.
+    Sequential {
+        permanents: Vec<ObjectId>,
+        sacrificed: ObjectId,
+        remaining: u32,
+    },
+}
+
 /// CR 601.2h + CR 614.1 + CR 616.1: A cost move paused for a replacement
 /// choice. `Cast` resumes a cast or activation after its next object is
 /// delivered. `ReplacementMayCost` keeps the outer optional replacement parked
@@ -2830,6 +2849,9 @@ pub enum PendingSacrificeCostCompletion {
 /// more replacement-choice action boundaries, including its event span and
 /// LKI record identities. `CollectEvidencePayment` and `UnlessBouncePayment`
 /// retain their selected-object program counters and exact completion tails.
+/// `WardSacrificePayment` retains either the ordered aggregate suffix or the
+/// sequential re-prompt basis until the current sacrifice's replacement choice
+/// has settled.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum PendingCostMoveResume {
     Cast {
@@ -2859,6 +2881,14 @@ pub enum PendingCostMoveResume {
         /// sacrifices before a replacement-choice boundary.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         departure_record_indices: Vec<usize>,
+    },
+    /// CR 702.21a + CR 701.21 + CR 614.1 + CR 616.1: A ward sacrifice payment
+    /// that must wait for a competing replacement choice before its unpaid
+    /// suffix or terminal effect-resolution tail can proceed.
+    WardSacrificePayment {
+        player: PlayerId,
+        pending_effect: Box<ResolvedAbility>,
+        resume: WardSacrificePaymentResume,
     },
     ReplacementMayCost {
         source_id: ObjectId,

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -1148,6 +1148,350 @@ fn collect_evidence_and_unless_bounce_costs_complete_synchronously_without_repla
     assert!(bounce_runner.state().pending_cost_move_resume.is_none());
 }
 
+/// CR 702.21a + CR 701.21 + CR 616.1: A ward payment selecting multiple
+/// permanents must leave its unsacrificed suffix parked while each selected
+/// sacrifice waits on a competing graveyard replacement choice.
+#[test]
+fn ward_multi_sacrifice_payment_reparks_each_replacement_before_effect_resolved() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Ward Multi-Sacrifice Effect Source", 1, 1)
+        .id();
+    let first = scenario
+        .add_creature(P0, "First Ward Multi-Sacrifice Redirect", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second Ward Multi-Sacrifice Redirect", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().waiting_for = WaitingFor::WardSacrificeChoice {
+        player: P0,
+        permanents: vec![first, second],
+        pending_effect: Box::new(ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            source,
+            P0,
+        )),
+        remaining: 1,
+        min_total_power: Some(2),
+    };
+
+    let initial = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("the first selected ward sacrifice reaches its replacement choice");
+    assert!(matches!(
+        initial.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&first].zone, Zone::Battlefield);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Battlefield);
+    assert!(
+        !initial.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved { source_id, .. } if *source_id == source
+        )),
+        "the ward tail must not resolve before the first replacement choice"
+    );
+
+    let after_first = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the first replacement resumes only the second selected ward sacrifice");
+    assert!(matches!(
+        after_first.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_ne!(runner.state().objects[&first].zone, Zone::Battlefield);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Battlefield);
+    assert!(
+        !after_first.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved { source_id, .. } if *source_id == source
+        )),
+        "the tail remains parked when the resumed suffix pauses again"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the second replacement completes the parked ward suffix");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    assert_ne!(runner.state().objects[&second].zone, Zone::Battlefield);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+
+    let events = initial
+        .events
+        .iter()
+        .chain(after_first.events.iter())
+        .chain(completed.events.iter());
+    for object_id in [first, second] {
+        assert_eq!(
+            events
+                .clone()
+                .filter(|event| matches!(
+                    event,
+                    GameEvent::PermanentSacrificed { object_id: sacrificed, .. }
+                        if *sacrificed == object_id
+                ))
+                .count(),
+            1,
+            "each selected permanent is sacrificed exactly once"
+        );
+    }
+    assert_eq!(
+        events
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved { source_id, .. } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the ward payment tail resolves exactly once after every selected sacrifice settles"
+    );
+}
+
+/// CR 702.21a + CR 701.21 + CR 616.1: A sequential ward payment must not
+/// surface its next sacrifice prompt until the current replacement choice has
+/// settled.
+#[test]
+fn ward_sequential_sacrifice_payment_reprompts_only_after_replacement_resolves() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Ward Sequential Effect Source", 1, 1)
+        .id();
+    let first = scenario
+        .add_creature(P0, "First Ward Sequential Redirect", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second Ward Sequential Sacrifice", 1, 1)
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().waiting_for = WaitingFor::WardSacrificeChoice {
+        player: P0,
+        permanents: vec![first, second],
+        pending_effect: Box::new(ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            source,
+            P0,
+        )),
+        remaining: 2,
+        min_total_power: None,
+    };
+
+    let initial = runner
+        .act(GameAction::SelectCards { cards: vec![first] })
+        .expect("the first sequential ward sacrifice reaches its replacement choice");
+    assert!(matches!(
+        initial.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(
+        !initial.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved { source_id, .. } if *source_id == source
+        )),
+        "neither the next ward prompt nor the tail may overwrite the replacement pause"
+    );
+
+    let reprompt = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the completed first sacrifice reconstructs the next ward choice");
+    let WaitingFor::WardSacrificeChoice {
+        player,
+        permanents,
+        remaining,
+        ..
+    } = &reprompt.waiting_for
+    else {
+        panic!(
+            "the sequential ward suffix must prompt only after replacement resolution, got {:?}",
+            reprompt.waiting_for
+        );
+    };
+    assert_eq!(*player, P0);
+    assert_eq!(*remaining, 1);
+    assert_eq!(permanents, &vec![second]);
+    assert!(
+        !reprompt.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved { source_id, .. } if *source_id == source
+        )),
+        "the tail waits for the final sequential sacrifice"
+    );
+
+    let completed = runner
+        .act(GameAction::SelectCards {
+            cards: vec![second],
+        })
+        .expect("the final ward sacrifice resolves synchronously");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    let events = initial
+        .events
+        .iter()
+        .chain(reprompt.events.iter())
+        .chain(completed.events.iter());
+    for object_id in [first, second] {
+        assert_eq!(
+            events
+                .clone()
+                .filter(|event| matches!(
+                    event,
+                    GameEvent::PermanentSacrificed { object_id: sacrificed, .. }
+                        if *sacrificed == object_id
+                ))
+                .count(),
+            1,
+            "each sequential ward sacrifice occurs exactly once"
+        );
+    }
+    assert_eq!(
+        events
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved { source_id, .. } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the final sequential sacrifice reaches the ward tail exactly once"
+    );
+}
+
+/// CR 702.21a + CR 701.21: Ward sacrifice payments without a replacement
+/// choice retain the existing synchronous aggregate and sequential behavior.
+#[test]
+fn ward_sacrifice_payment_completes_synchronously_without_replacements() {
+    let mut aggregate_scenario = GameScenario::new();
+    aggregate_scenario.at_phase(Phase::PreCombatMain);
+    let aggregate_source = aggregate_scenario
+        .add_creature(P0, "Synchronous Aggregate Ward Source", 1, 1)
+        .id();
+    let aggregate_first = aggregate_scenario
+        .add_creature(P0, "Synchronous Aggregate Ward First", 1, 1)
+        .id();
+    let aggregate_second = aggregate_scenario
+        .add_creature(P0, "Synchronous Aggregate Ward Second", 1, 1)
+        .id();
+    let mut aggregate_runner = aggregate_scenario.build();
+    aggregate_runner.state_mut().waiting_for = WaitingFor::WardSacrificeChoice {
+        player: P0,
+        permanents: vec![aggregate_first, aggregate_second],
+        pending_effect: Box::new(ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            aggregate_source,
+            P0,
+        )),
+        remaining: 1,
+        min_total_power: Some(2),
+    };
+    let aggregate = aggregate_runner
+        .act(GameAction::SelectCards {
+            cards: vec![aggregate_first, aggregate_second],
+        })
+        .expect("aggregate ward payment completes synchronously");
+    assert!(matches!(aggregate.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(
+        aggregate
+            .events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved { source_id, .. } if *source_id == aggregate_source
+            ))
+            .count(),
+        1
+    );
+
+    let mut sequential_scenario = GameScenario::new();
+    sequential_scenario.at_phase(Phase::PreCombatMain);
+    let sequential_source = sequential_scenario
+        .add_creature(P0, "Synchronous Sequential Ward Source", 1, 1)
+        .id();
+    let sequential_first = sequential_scenario
+        .add_creature(P0, "Synchronous Sequential Ward First", 1, 1)
+        .id();
+    let sequential_second = sequential_scenario
+        .add_creature(P0, "Synchronous Sequential Ward Second", 1, 1)
+        .id();
+    let mut sequential_runner = sequential_scenario.build();
+    sequential_runner.state_mut().waiting_for = WaitingFor::WardSacrificeChoice {
+        player: P0,
+        permanents: vec![sequential_first, sequential_second],
+        pending_effect: Box::new(ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            sequential_source,
+            P0,
+        )),
+        remaining: 2,
+        min_total_power: None,
+    };
+    let first = sequential_runner
+        .act(GameAction::SelectCards {
+            cards: vec![sequential_first],
+        })
+        .expect("first sequential ward payment completes synchronously");
+    assert!(matches!(
+        first.waiting_for,
+        WaitingFor::WardSacrificeChoice {
+            remaining: 1,
+            ref permanents,
+            ..
+        } if permanents == &vec![sequential_second]
+    ));
+    assert!(
+        !first.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved { source_id, .. } if *source_id == sequential_source
+        )),
+        "the sequential branch keeps the final ward tail behind its second prompt"
+    );
+    let final_payment = sequential_runner
+        .act(GameAction::SelectCards {
+            cards: vec![sequential_second],
+        })
+        .expect("second sequential ward payment completes the tail");
+    assert!(matches!(
+        final_payment.waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert_eq!(
+        first
+            .events
+            .iter()
+            .chain(final_payment.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved { source_id, .. } if *source_id == sequential_source
+            ))
+            .count(),
+        1
+    );
+}
+
 #[test]
 fn village_rites_sacrifice_cost_pauses_for_competing_graveyard_replacements() {
     const VILLAGE_RITES: &str =


### PR DESCRIPTION
Both WardSacrificeChoice call sites discarded the SacrificeOutcome returned by
sacrifice_permanent, so a mid-payment NeedsReplacementChoice was silently
dropped and the handler ran its re-prompt / EffectResolved tail anyway.

Park the unpaid work as PendingCostMoveResume::WardSacrificePayment (CR 702.21a
+ CR 701.21 + CR 614.1 + CR 616.1), drained by the existing cost-move boundary
dispatcher — no second resume mechanism. A typed WardSacrificePaymentResume
program counter separates the two payment shapes: MultiSacrifice retains the
ordered unsacrificed suffix (re-parking on repeated pauses), Sequential retains
the live-eligibility re-prompt basis so the remaining-1 ward prompt appears only
after the replacement settles. The EffectResolved + priority tail is extracted
into one finish_ward_sacrifice_payment authority shared by the synchronous path
and both resume legs, so it runs exactly once.

The sequential co-departed-gap note (CR 603.10a + CR 118.8) is preserved
unchanged; no ward batching attempted.

Witnesses (watched red against the discarded-outcome originals):
ward_multi_sacrifice_payment_reparks_each_replacement_before_effect_resolved,
ward_sequential_sacrifice_payment_reprompts_only_after_replacement_resolves,
ward_sacrifice_payment_completes_synchronously_without_replacements.
