### PR TITLE
review: narrow decline-tail verb to discard, add 3-player fan-out test

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2706,6 +2706,19 @@ fn detach_after_player_scope_local_chain(
         .condition
         .as_ref()
         .is_some_and(condition_depends_on_effect_performed);
+    // CR 608.2c + CR 109.5: a decline-branch sub-ability gated on
+    // `ZoneChangedThisWay` (Kroxa, Titan of Death's Hunger: "each opponent who
+    // didn't discard a nonland card this way") reads `last_zone_changed_ids`
+    // stamped by THIS iteration's own scoped zone change — it is per-opponent
+    // by construction exactly like the performed-gate class above, just keyed
+    // on WHAT moved rather than WHETHER the parent action happened. Detaching
+    // it as the unscoped tail would evaluate it once, after every opponent's
+    // discard has already overwritten the ledger, against the wrong (or a
+    // stale aggregate) zone-change set.
+    let next_is_zone_change_this_way_gated = next
+        .condition
+        .as_ref()
+        .is_some_and(condition_depends_on_zone_change_this_way);
     // CR 608.2c: When the parser distributes "each player reveals the top card
     // of their library, loses life equal to that card's mana value, then puts
     // it into their hand" it stamps the SAME `player_scope` onto every clause.
@@ -2753,6 +2766,7 @@ fn detach_after_player_scope_local_chain(
         Some(PlayerFilter::PerformedActionThisWay { .. })
     );
     if next_is_performed_gated
+        || next_is_zone_change_this_way_gated
         || next_is_co_scoped_anaphoric_consumer
         || next_is_optional_clause_continuation
         || (is_player_scope_local_continuation(&node.effect, &next.effect)

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3626,6 +3626,15 @@ fn parse_excluded_player_anchor(i: &str) -> OracleResult<'_, PlayerFilter> {
 }
 
 pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, String) {
+    // CR 701.9a + CR 608.2c: Reserve only the exact Kroxa/Strongarm
+    // mandatory-FILTERED decline-tail grammar for its dedicated dispatcher.
+    // A broad `who didn't` reservation also captures unrelated relative clauses
+    // (for example, sacrifice and choose), changing their parser routes even
+    // though this dispatcher intentionally supports discard only.
+    if strip_each_scope_who_didnt_verb_filter_this_way_subject(text).is_some() {
+        return (None, text.to_string());
+    }
+
     let lower = text.to_lowercase();
     let scope_rest = nom_on_lower(text, &lower, |i| {
         alt((
@@ -3804,17 +3813,6 @@ pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, St
         // for readability, not correctness — but `who does` is listed AFTER the
         // longer `who doesn't`/`who does not` tags to mirror the grammar.
         tag("who does"),
-        // CR 701.9a + CR 608.2c: Reserve the relative-clause shape "who
-        // didn't" / "who did not" for the Kroxa-class subject-only
-        // mandatory-FILTERED decline-tail dispatcher
-        // (`strip_each_scope_who_didnt_verb_filter_this_way_subject` in
-        // `parse_effect_clause_inner`). Without this guard, `each opponent `
-        // would strip here and leave `who didn't discard a nonland card this
-        // way loses 3 life` orphaned — misparsed as an ordinary imperative
-        // clause with no gate, so every opponent loses the life regardless of
-        // what they discarded (issue #6007).
-        tag("who didn't"),
-        tag("who did not"),
         // CR 119.3 + CR 701.55a: "each opponent who lost N or more life this
         // turn faces a villainous choice" is a restricted chooser phrase, not
         // a normal per-player imperative. Preserve the full subject so the

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3968,10 +3968,13 @@ pub(super) fn strip_each_scope_who_does_subject(text: &str) -> Option<(PlayerFil
 /// nonland card", matching the official ruling that Kroxa's life loss still
 /// applies to an opponent with no cards in hand.
 ///
-/// Verb is a small closed set of "this way" cost-payment actions (discard,
-/// sacrifice, exile) — `ZoneChangedThisWay` reads `last_zone_changed_ids`
-/// which every one of them populates identically, so the matched verb itself
-/// carries no separate semantics; it only anchors the grammar.
+/// Verb is scoped to "discard" — the only verb this exact "who didn't <verb>
+/// a [filter] this way" relative-clause construction is verified against
+/// (Kroxa). `ZoneChangedThisWay` itself is verb-agnostic (it reads
+/// `last_zone_changed_ids`, which sacrifice/exile populate identically to
+/// discard), so widening the `alt()` to those verbs is a one-line change
+/// once a card actually prints that construction — deferred rather than
+/// speculatively added ahead of a verified card.
 pub(super) fn strip_each_scope_who_didnt_verb_filter_this_way_subject(
     text: &str,
 ) -> Option<(PlayerFilter, TargetFilter, String)> {
@@ -3984,7 +3987,7 @@ pub(super) fn strip_each_scope_who_didnt_verb_filter_this_way_subject(
         ))
         .parse(i)?;
         let (i, _) = alt((tag("didn't "), tag("did not "))).parse(i)?;
-        let (i, _) = alt((tag("discard "), tag("sacrifice "), tag("exile "))).parse(i)?;
+        let (i, _) = tag("discard ").parse(i)?;
         let (i, _) = alt((tag("a "), tag("an "))).parse(i)?;
         let (filter, after_filter) = parse_type_phrase(i);
         if matches!(filter, TargetFilter::Any) {

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -9,7 +9,7 @@ use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower, split_once
 use super::super::oracle_nom::duration::{
     parse_duration, parse_for_as_long_as_condition, parse_until_source_exiles_another_card_body,
 };
-use super::super::oracle_nom::error::{OracleError, OracleResult};
+use super::super::oracle_nom::error::{oracle_err, OracleError, OracleResult};
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_quantity::{
@@ -19,7 +19,7 @@ use super::super::oracle_quantity::{
 };
 use super::super::oracle_target::{
     parse_anaphoric_target_ref, parse_target, parse_target_with_ctx, parse_that_clause_suffix,
-    parse_type_phrase_with_ctx,
+    parse_type_phrase, parse_type_phrase_with_ctx,
 };
 use super::super::oracle_util::{parse_comparator_prefix, parse_count_expr, strip_after, TextPair};
 use crate::parser::oracle_ir::ast::*;
@@ -3804,6 +3804,17 @@ pub(super) fn strip_each_player_subject(text: &str) -> (Option<PlayerFilter>, St
         // for readability, not correctness — but `who does` is listed AFTER the
         // longer `who doesn't`/`who does not` tags to mirror the grammar.
         tag("who does"),
+        // CR 701.9a + CR 608.2c: Reserve the relative-clause shape "who
+        // didn't" / "who did not" for the Kroxa-class subject-only
+        // mandatory-FILTERED decline-tail dispatcher
+        // (`strip_each_scope_who_didnt_verb_filter_this_way_subject` in
+        // `parse_effect_clause_inner`). Without this guard, `each opponent `
+        // would strip here and leave `who didn't discard a nonland card this
+        // way loses 3 life` orphaned — misparsed as an ordinary imperative
+        // clause with no gate, so every opponent loses the life regardless of
+        // what they discarded (issue #6007).
+        tag("who didn't"),
+        tag("who did not"),
         // CR 119.3 + CR 701.55a: "each opponent who lost N or more life this
         // turn faces a villainous choice" is a restricted chooser phrase, not
         // a normal per-player imperative. Preserve the full subject so the
@@ -3938,6 +3949,52 @@ pub(super) fn strip_each_scope_who_does_subject(text: &str) -> Option<(PlayerFil
         Ok((i, scope))
     })
     .map(|(scope, rest)| (scope, rest.to_string()))
+}
+
+/// CR 701.9a + CR 608.2c + CR 109.5: Strip a leading "each <scope> who
+/// didn't / did not <verb> a [filter] this way, <body>" subject-only
+/// mandatory-FILTERED decline-tail. Returns the player scope, the filter the
+/// scoped player's own zone change failed to match, and the body text.
+///
+/// Sibling of `strip_each_scope_who_cant_subject` (mandatory-IMPOSSIBLE: the
+/// action couldn't happen at all) and `strip_each_scope_who_doesnt_subject`
+/// (OPTIONAL-decline): this fills the mandatory-FILTERED cell, where the
+/// scoped player's mandatory action always happens but the body only cares
+/// whether the moved object matched a filter (Kroxa, Titan of Death's Hunger:
+/// "each opponent discards a card, then each opponent who didn't discard a
+/// nonland card this way loses 3 life"). The gate reads
+/// `ZoneChangedThisWay { filter }` (CR 608.2c) rather than a pass/fail signal
+/// — an opponent who discarded nothing (empty hand) still "didn't discard a
+/// nonland card", matching the official ruling that Kroxa's life loss still
+/// applies to an opponent with no cards in hand.
+///
+/// Verb is a small closed set of "this way" cost-payment actions (discard,
+/// sacrifice, exile) — `ZoneChangedThisWay` reads `last_zone_changed_ids`
+/// which every one of them populates identically, so the matched verb itself
+/// carries no separate semantics; it only anchors the grammar.
+pub(super) fn strip_each_scope_who_didnt_verb_filter_this_way_subject(
+    text: &str,
+) -> Option<(PlayerFilter, TargetFilter, String)> {
+    let lower = text.to_lowercase();
+    nom_on_lower(text, &lower, |i| {
+        let (i, scope) = alt((
+            value(PlayerFilter::Opponent, tag("each other player who ")),
+            value(PlayerFilter::Opponent, tag("each opponent who ")),
+            value(PlayerFilter::All, tag("each player who ")),
+        ))
+        .parse(i)?;
+        let (i, _) = alt((tag("didn't "), tag("did not "))).parse(i)?;
+        let (i, _) = alt((tag("discard "), tag("sacrifice "), tag("exile "))).parse(i)?;
+        let (i, _) = alt((tag("a "), tag("an "))).parse(i)?;
+        let (filter, after_filter) = parse_type_phrase(i);
+        if matches!(filter, TargetFilter::Any) {
+            return Err(oracle_err(i));
+        }
+        let (i, _) = tag("this way").parse(after_filter.trim_start())?;
+        let (i, _) = preceded(opt(tag(",")), opt(multispace1)).parse(i)?;
+        Ok((i, (scope, filter)))
+    })
+    .map(|((scope, filter), rest)| (scope, filter, rest.to_string()))
 }
 
 /// CR 608.2e + CR 608.2c + CR 101.3: Strip a leading "For each opponent who

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -3968,11 +3968,14 @@ pub(super) fn strip_each_scope_who_does_subject(text: &str) -> Option<(PlayerFil
 ///
 /// Verb is scoped to "discard" — the only verb this exact "who didn't <verb>
 /// a [filter] this way" relative-clause construction is verified against
-/// (Kroxa). `ZoneChangedThisWay` itself is verb-agnostic (it reads
-/// `last_zone_changed_ids`, which sacrifice/exile populate identically to
-/// discard), so widening the `alt()` to those verbs is a one-line change
-/// once a card actually prints that construction — deferred rather than
-/// speculatively added ahead of a verified card.
+/// (Kroxa, Titan of Death's Hunger — opponent scope, nonland filter; and
+/// Strongarm Tactics — all-players scope, creature filter: "Each player
+/// discards a card. Then each player who didn't discard a creature card
+/// this way loses 4 life."). `ZoneChangedThisWay` itself is verb-agnostic
+/// (it reads `last_zone_changed_ids`, which sacrifice/exile populate
+/// identically to discard), so widening the `alt()` to those verbs is a
+/// one-line change once a card actually prints that construction —
+/// deferred rather than speculatively added ahead of a verified card.
 pub(super) fn strip_each_scope_who_didnt_verb_filter_this_way_subject(
     text: &str,
 ) -> Option<(PlayerFilter, TargetFilter, String)> {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -47,14 +47,14 @@ use lower::{
     rebind_decline_body_recipient, rebind_subject_only_body_recipient,
     scan_until_next_same_source_exile_invalidation, split_difference_repeat_suffix,
     strip_any_number_quantifier, strip_each_player_subject, strip_each_scope_who_cant_subject,
-    strip_each_scope_who_does_subject, strip_each_scope_who_doesnt_subject,
-    strip_for_each_opponent_who_doesnt, strip_for_each_prefix, strip_for_each_repeat_suffix,
-    strip_leading_duration, strip_leading_quantifier, strip_leading_return_destination_ext,
-    strip_leading_sequence_connector, strip_optional_effect_prefix, strip_player_scope_subject,
-    strip_repeat_count_suffix, strip_return_destination_ext,
-    strip_return_destination_ext_with_remainder, strip_temporal_prefix, strip_temporal_suffix,
-    trim_dangling_target_word, try_parse_damage, try_parse_damage_with_remainder,
-    try_parse_distribute_counters, try_parse_distribute_damage,
+    strip_each_scope_who_didnt_verb_filter_this_way_subject, strip_each_scope_who_does_subject,
+    strip_each_scope_who_doesnt_subject, strip_for_each_opponent_who_doesnt, strip_for_each_prefix,
+    strip_for_each_repeat_suffix, strip_leading_duration, strip_leading_quantifier,
+    strip_leading_return_destination_ext, strip_leading_sequence_connector,
+    strip_optional_effect_prefix, strip_player_scope_subject, strip_repeat_count_suffix,
+    strip_return_destination_ext, strip_return_destination_ext_with_remainder,
+    strip_temporal_prefix, strip_temporal_suffix, trim_dangling_target_word, try_parse_damage,
+    try_parse_damage_with_remainder, try_parse_distribute_counters, try_parse_distribute_damage,
 };
 
 pub(crate) use self::token::parse_token_description;
@@ -27139,6 +27139,41 @@ pub(crate) fn parse_effect_chain_ir(
                 let condition = AbilityCondition::And {
                     conditions: vec![
                         AbilityCondition::effect_performed(),
+                        AbilityCondition::ScopedPlayerMatches { filter: scope },
+                    ],
+                };
+                (body, Some(condition), DeclineDispatch::SubjectOnly)
+            } else if let Some((scope, filter, body)) =
+                strip_each_scope_who_didnt_verb_filter_this_way_subject(&text)
+            {
+                // CR 701.9a + CR 608.2c + CR 109.5: subject-only mandatory-FILTERED
+                // decline-tail (Kroxa, Titan of Death's Hunger: "each opponent
+                // discards a card, then each opponent who didn't discard a nonland
+                // card this way loses 3 life."). Unlike the `who can't` arm (whether
+                // the action happened at all), this gates on WHAT moved:
+                // `Not { ZoneChangedThisWay { filter } }` reads `last_zone_changed_ids`
+                // from the just-completed per-iteration discard/sacrifice/exile, so an
+                // opponent with an empty hand (who discarded nothing) still satisfies
+                // "didn't discard a nonland card" — matching the printed ruling.
+                //
+                // The `ScopedPlayerMatches { filter: scope }` conjunct mirrors the
+                // `who can't` / `who does` arms' cross-scope fix; a no-op for Kroxa
+                // (both clauses scope `Opponent`) but uniformly safe for the class.
+                //
+                // Do NOT stamp `player_scope`: the body inherits the parent's
+                // per-player iteration via `sub_ability` attachment, so
+                // `ZoneChangedThisWay` reads THIS iteration's own zone change, not a
+                // detached whole-chain aggregate.
+                if let Some(prev) = builder.last_mut() {
+                    if prev.boundary == Some(ClauseBoundary::Sentence) {
+                        prev.boundary = Some(ClauseBoundary::Then);
+                    }
+                }
+                let condition = AbilityCondition::And {
+                    conditions: vec![
+                        AbilityCondition::Not {
+                            condition: Box::new(AbilityCondition::ZoneChangedThisWay { filter }),
+                        },
                         AbilityCondition::ScopedPlayerMatches { filter: scope },
                     ],
                 };

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -25290,6 +25290,28 @@ fn strip_each_scope_who_cant_subject_rejects_non_matches() {
     );
 }
 
+#[test]
+fn strip_each_scope_who_didnt_discard_filter_this_way_is_exact() {
+    let (scope, filter, body) = strip_each_scope_who_didnt_verb_filter_this_way_subject(
+        "each opponent who didn't discard a nonland card this way loses 3 life",
+    )
+    .expect("Kroxa-class decline tail");
+    assert_eq!(scope, PlayerFilter::Opponent);
+    assert!(matches!(filter, TargetFilter::Typed(_)));
+    assert_eq!(body, "loses 3 life");
+
+    for unrelated in [
+        "each player who didn't sacrifice a creature loses 3 life",
+        "each player who didn't choose the lowest number discards their hand",
+        "each opponent who didn't draws a card",
+    ] {
+        assert!(
+            strip_each_scope_who_didnt_verb_filter_this_way_subject(unrelated).is_none(),
+            "only the supported discard-a/an-filter-this-way grammar may reserve: {unrelated}",
+        );
+    }
+}
+
 /// CR 118.12 + CR 608.2d + CR 109.5: `strip_each_scope_who_does_subject`
 /// covers the full subject-only × scope × positive-"does" matrix (The Second
 /// Doctor: "each opponent who does can't attack you …"; Step Between Worlds:

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
@@ -113,6 +113,9 @@ expression: "&ir"
                 "amount": {
                   "type": "Fixed",
                   "value": 3
+                },
+                "target": {
+                  "type": "ScopedPlayer"
                 }
               },
               "cost": null,
@@ -120,13 +123,37 @@ expression: "&ir"
               "duration": null,
               "description": null,
               "target_prompt": null,
-              "condition": null,
+              "condition": {
+                "type": "And",
+                "conditions": [
+                  {
+                    "type": "Not",
+                    "condition": {
+                      "type": "ZoneChangedThisWay",
+                      "filter": {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Card",
+                          {
+                            "Non": "Land"
+                          }
+                        ],
+                        "controller": null,
+                        "properties": []
+                      }
+                    }
+                  },
+                  {
+                    "type": "ScopedPlayerMatches",
+                    "filter": {
+                      "type": "Opponent"
+                    }
+                  }
+                ]
+              },
               "optional_targeting": false,
               "optional": false,
-              "forward_result": false,
-              "player_scope": {
-                "type": "Opponent"
-              }
+              "forward_result": false
             },
             "duration": null,
             "description": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_lowered.snap
@@ -76,6 +76,9 @@ expression: "&lowered"
             "amount": {
               "type": "Fixed",
               "value": 3
+            },
+            "target": {
+              "type": "ScopedPlayer"
             }
           },
           "cost": null,
@@ -83,13 +86,37 @@ expression: "&lowered"
           "duration": null,
           "description": null,
           "target_prompt": null,
-          "condition": null,
+          "condition": {
+            "type": "And",
+            "conditions": [
+              {
+                "type": "Not",
+                "condition": {
+                  "type": "ZoneChangedThisWay",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Card",
+                      {
+                        "Non": "Land"
+                      }
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                }
+              },
+              {
+                "type": "ScopedPlayerMatches",
+                "filter": {
+                  "type": "Opponent"
+                }
+              }
+            ]
+          },
           "optional_targeting": false,
           "optional": false,
-          "forward_result": false,
-          "player_scope": {
-            "type": "Opponent"
-          }
+          "forward_result": false
         },
         "duration": null,
         "description": null,

--- a/crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
+++ b/crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
@@ -1,0 +1,157 @@
+//! Kroxa, Titan of Death's Hunger — subject-only mandatory-FILTERED
+//! decline-tail (issue #6007).
+//!
+//! Oracle (ETB/attack trigger body):
+//!   "Whenever Kroxa enters or attacks, each opponent discards a card, then
+//!    each opponent who didn't discard a nonland card this way loses 3
+//!    life."
+//!
+//! Before this fix, the "then each opponent who didn't discard a nonland
+//! card this way" clause was parsed as an ordinary, unconditional per-player
+//! imperative (no gate at all), so every opponent lost 3 life regardless of
+//! what — or whether anything — they discarded.
+//!
+//! CR anchors:
+//!   - CR 608.2c: "each opponent who didn't discard a nonland card this way"
+//!     gates the life-loss sub-ability on `Not { ZoneChangedThisWay {
+//!     filter: nonland } }` — a property of WHAT moved via `last_zone_changed_ids`
+//!     during THIS iteration's discard, not whether the discard happened at
+//!     all (distinguishing this from the plain "who can't" mandatory-
+//!     impossible class).
+//!   - CR 701.9a: To discard, move a card from hand to graveyard — the
+//!     Discard sub-resolution stamps `last_zone_changed_ids` with the
+//!     discarded object so the filter check reads the correct card.
+//!   - Ruling: a player with no cards in hand discards no card this way, so
+//!     they haven't discarded a nonland card — the life loss still applies.
+//!   - CR 109.5: the body's implicit recipient ("loses 3 life" with no
+//!     stated subject) binds to the per-iteration scoped player via the
+//!     shared `rebind_clause_recipients_with(_,
+//!     rebind_subject_only_body_recipient)` walker (`LoseLife.target`:
+//!     `None` → `Some(ScopedPlayer)`).
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, ResolvedAbility};
+use engine::types::card_type::CoreType;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const TRIGGER_BODY: &str = "each opponent discards a card, then each opponent \
+     who didn't discard a nonland card this way loses 3 life.";
+
+fn kroxa_trigger(controller: PlayerId, source_id: ObjectId) -> ResolvedAbility {
+    let def = parse_effect_chain(TRIGGER_BODY, AbilityKind::Spell);
+    build_resolved_from_def(&def, source_id, controller)
+}
+
+fn add_hand_card(state: &mut GameState, card_id: u64, player: PlayerId, is_land: bool) -> ObjectId {
+    let oid = create_object(
+        state,
+        CardId(card_id),
+        player,
+        "Card".to_string(),
+        Zone::Hand,
+    );
+    if is_land {
+        let obj = state
+            .objects
+            .get_mut(&oid)
+            .expect("just-created hand object");
+        obj.card_types.core_types.push(CoreType::Land);
+        obj.base_card_types = obj.card_types.clone();
+    }
+    oid
+}
+
+fn life(state: &GameState, player: PlayerId) -> i32 {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .life
+}
+
+/// An opponent who discards a LAND card "didn't discard a nonland card this
+/// way" — the life loss must fire.
+#[test]
+fn kroxa_opponent_discards_land_loses_three_life() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Kroxa".to_string(),
+        Zone::Battlefield,
+    );
+    add_hand_card(&mut state, 100, PlayerId(1), true);
+
+    let opponent_life_before = life(&state, PlayerId(1));
+    let ability = kroxa_trigger(PlayerId(0), source);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        life(&state, PlayerId(1)),
+        opponent_life_before - 3,
+        "opponent discarded a land card (not a nonland card), so the life loss must fire"
+    );
+}
+
+/// An opponent who discards a NONLAND card DID "discard a nonland card this
+/// way" — the life loss must NOT fire.
+#[test]
+fn kroxa_opponent_discards_nonland_avoids_life_loss() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Kroxa".to_string(),
+        Zone::Battlefield,
+    );
+    add_hand_card(&mut state, 100, PlayerId(1), false);
+
+    let opponent_life_before = life(&state, PlayerId(1));
+    let ability = kroxa_trigger(PlayerId(0), source);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        life(&state, PlayerId(1)),
+        opponent_life_before,
+        "opponent discarded a nonland card this way, so the life loss must not fire"
+    );
+}
+
+/// An opponent with an empty hand discards no card at all — they still
+/// haven't discarded a nonland card, so the life loss must fire per the
+/// printed ruling.
+#[test]
+fn kroxa_opponent_with_empty_hand_still_loses_three_life() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Kroxa".to_string(),
+        Zone::Battlefield,
+    );
+    // PlayerId(1) has no cards in hand.
+
+    let opponent_life_before = life(&state, PlayerId(1));
+    let ability = kroxa_trigger(PlayerId(0), source);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        life(&state, PlayerId(1)),
+        opponent_life_before - 3,
+        "opponent had no cards to discard, so they didn't discard a nonland card either — life loss must still fire"
+    );
+}

--- a/crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
+++ b/crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
@@ -223,6 +223,83 @@ fn hand_size(state: &GameState, player: PlayerId) -> usize {
         .count()
 }
 
+/// Strongarm Tactics — the sibling all-players (`PlayerFilter::All`) scope
+/// of the same mandatory-FILTERED decline-tail construction, with a
+/// "creature" filter instead of Kroxa's "nonland" filter:
+///   "Each player discards a card. Then each player who didn't discard a
+///    creature card this way loses 4 life."
+///
+/// Unlike Kroxa's opponent-only fan-out, "each player" includes the
+/// ability's own controller — this pins that the controller-inclusive scope
+/// and its per-player `ZoneChangedThisWay` gate both resolve correctly.
+const STRONGARM_TACTICS_BODY: &str = "each player discards a card, then each \
+     player who didn't discard a creature card this way loses 4 life.";
+
+fn strongarm_tactics_effect(controller: PlayerId, source_id: ObjectId) -> ResolvedAbility {
+    let def = parse_effect_chain(STRONGARM_TACTICS_BODY, AbilityKind::Spell);
+    build_resolved_from_def(&def, source_id, controller)
+}
+
+fn add_creature_hand_card(state: &mut GameState, card_id: u64, player: PlayerId) -> ObjectId {
+    let oid = create_object(
+        state,
+        CardId(card_id),
+        player,
+        "Card".to_string(),
+        Zone::Hand,
+    );
+    let obj = state
+        .objects
+        .get_mut(&oid)
+        .expect("just-created hand object");
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.base_card_types = obj.card_types.clone();
+    oid
+}
+
+/// Three players, all in the "each player" scope (including the caster):
+/// one discards a creature card (avoids life loss), one discards a
+/// noncreature card (loses life), one has an empty hand (still loses life
+/// per the same "didn't discard" ruling Kroxa relies on).
+#[test]
+fn strongarm_tactics_all_players_gated_by_own_discard() {
+    let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Strongarm Tactics".to_string(),
+        Zone::Battlefield,
+    );
+    // PlayerId(0) is the caster and is still in the "each player" scope.
+    add_creature_hand_card(&mut state, 100, PlayerId(0));
+    add_hand_card(&mut state, 200, PlayerId(1), false);
+    // PlayerId(2) has no cards in hand.
+
+    let p0_life_before = life(&state, PlayerId(0));
+    let p1_life_before = life(&state, PlayerId(1));
+    let p2_life_before = life(&state, PlayerId(2));
+    let ability = strongarm_tactics_effect(PlayerId(0), source);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        life(&state, PlayerId(0)),
+        p0_life_before,
+        "caster discarded a creature card, so the life loss must not fire for the caster"
+    );
+    assert_eq!(
+        life(&state, PlayerId(1)),
+        p1_life_before - 4,
+        "P1 discarded a noncreature card, so the life loss must fire for P1"
+    );
+    assert_eq!(
+        life(&state, PlayerId(2)),
+        p2_life_before - 4,
+        "P2 had no cards to discard, so they didn't discard a creature card either — life loss must still fire"
+    );
+}
+
 #[test]
 fn non_discard_who_didnt_clause_still_draws_a_card() {
     let mut state = GameState::new(FormatConfig::standard(), 2, 42);

--- a/crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
+++ b/crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
@@ -155,3 +155,41 @@ fn kroxa_opponent_with_empty_hand_still_loses_three_life() {
         "opponent had no cards to discard, so they didn't discard a nonland card either — life loss must still fire"
     );
 }
+
+/// Three players: two opponents in the same per-opponent fan-out, one
+/// discarding a land and the other a nonland card. Each opponent's own
+/// discard must gate their own life loss independently — a structural
+/// regression guard for `detach_after_player_scope_local_chain` keeping the
+/// `ZoneChangedThisWay`-gated sub-ability attached to its own iteration
+/// instead of a once-after-all-iterations tail (which would read only the
+/// last-processed opponent's discard for every opponent).
+#[test]
+fn kroxa_three_player_each_opponent_gated_by_their_own_discard() {
+    let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Kroxa".to_string(),
+        Zone::Battlefield,
+    );
+    add_hand_card(&mut state, 100, PlayerId(1), true);
+    add_hand_card(&mut state, 200, PlayerId(2), false);
+
+    let p1_life_before = life(&state, PlayerId(1));
+    let p2_life_before = life(&state, PlayerId(2));
+    let ability = kroxa_trigger(PlayerId(0), source);
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        life(&state, PlayerId(1)),
+        p1_life_before - 3,
+        "P1 discarded a land — life loss must fire for P1"
+    );
+    assert_eq!(
+        life(&state, PlayerId(2)),
+        p2_life_before,
+        "P2 discarded a nonland card — life loss must NOT fire for P2"
+    );
+}

--- a/crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
+++ b/crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
@@ -193,3 +193,61 @@ fn kroxa_three_player_each_opponent_gated_by_their_own_discard() {
         "P2 discarded a nonland card — life loss must NOT fire for P2"
     );
 }
+
+/// Regression guard for the guard-scoping fix at `strip_each_player_subject`'s
+/// "who didn't"/"who did not" reservation: that reservation must only claim
+/// the "discard" verb the Kroxa dispatcher understands, not every verb.
+///
+/// Before the fix, reserving bare "who didn't"/"who did not" (any verb) left
+/// non-discard "who didn't <verb> ... this way, <body>" clauses — e.g. Kynaios
+/// and Tiro of Meletis: "each other player who didn't put a card onto the
+/// battlefield this way draws a card" — with no dispatcher able to claim
+/// them. They fell through to the ordinary imperative parser, which matched
+/// the leftover "put a card onto the battlefield" fragment as a `ChangeZone`
+/// effect and silently dropped the actual "draws a card" action entirely.
+fn add_library_card(state: &mut GameState, card_id: u64, player: PlayerId) -> ObjectId {
+    create_object(
+        state,
+        CardId(card_id),
+        player,
+        "Card".to_string(),
+        Zone::Library,
+    )
+}
+
+fn hand_size(state: &GameState, player: PlayerId) -> usize {
+    state
+        .objects
+        .values()
+        .filter(|obj| obj.zone == Zone::Hand && obj.owner == player)
+        .count()
+}
+
+#[test]
+fn non_discard_who_didnt_clause_still_draws_a_card() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Kynaios and Tiro of Meletis".to_string(),
+        Zone::Battlefield,
+    );
+    add_library_card(&mut state, 100, PlayerId(1));
+
+    let text = "each other player who didn't put a card onto the battlefield \
+        this way draws a card.";
+    let def = parse_effect_chain(text, AbilityKind::Spell);
+    let ability = build_resolved_from_def(&def, source, PlayerId(0));
+
+    let hand_before = hand_size(&state, PlayerId(1));
+    let mut events = Vec::new();
+    resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+    assert_eq!(
+        hand_size(&state, PlayerId(1)),
+        hand_before + 1,
+        "the non-discard decline-tail clause must still resolve as a Draw, \
+         not be misparsed into a dropped ChangeZone effect"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -563,6 +563,7 @@ mod knollspine_dragon_target_damage_draw;
 mod kodama_anti_recursion_intervening_if;
 mod krark_clan_ironworks_castability;
 mod krark_thumb_coin_flip;
+mod kroxa_titan_nonland_discard_life_loss;
 mod kutzils_flanker_mode_one_counter;
 mod l02_bb1_activation_conditions;
 mod l02_bb2_cast_origin;


### PR DESCRIPTION
## Summary
Fixes the "each opponent who didn't discard a nonland card this way" misparse for Kroxa, Titan of Death's Hunger. Closes #6007

The clause was parsed as an ordinary, unconditional per-player imperative with no gate at all, so every opponent lost 3 life whenever Kroxa entered or attacked, regardless of what — or whether anything — they discarded.

## Files changed
- crates/engine/src/parser/oracle_effect/lower.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/game/effects/mod.rs
- crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
- crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_lowered.snap
- crates/engine/tests/integration/kroxa_titan_nonland_discard_life_loss.rs
- crates/engine/tests/integration/main.rs

## CR references
- CR 608.2c — general condition-gating on a sub-ability
- CR 701.9a — discard definition (hand → graveyard), and "discarded this way" reads `last_zone_changed_ids`
- CR 109.5 — per-iteration recipient/scope binding inside a `player_scope` fan-out

## Implementation method (required)
Method: manual (parser dispatch + engine iteration-attachment fix), verified against the existing `strip_each_scope_who_cant_subject` / `strip_each_scope_who_doesnt_subject` / `strip_each_scope_who_does_subject` decline-tail family

## Track
Developer

## Verification
- [x] Required checks ran clean locally (Tilt unavailable in this environment; ran cargo directly).
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p engine --lib` — 16840 passed; 0 failed; 7 ignored
- `cargo test -p engine --test integration` — 3277 passed; 0 failed; 2 ignored (includes the 4 new Kroxa regression tests)
- `cargo clippy -p engine --lib --tests -- -D warnings` — clean, no warnings
- `cargo fmt --all` — applied, no diff
- `./scripts/check-parser-combinators.sh` — Gate A PASS (see below)

## Gate A
Gate A PASS head=e73c70c1762aa268434efc09452ffa33955415db base=2f4608051c4d694d3ec3fd59c3e68c26d3746559

## Anchored on
- crates/engine/src/parser/oracle_effect/lower.rs:3868 — `strip_each_scope_who_cant_subject`, the mandatory-impossible decline-tail sibling this new dispatcher parallels (subject-only "each `<scope>` who ..." head, `PlayerFilter` scope detection, comma-optional body split)
- crates/engine/src/game/effects/mod.rs:2216 — `condition_depends_on_effect_performed`, whose sibling `condition_depends_on_zone_change_this_way` (already defined, used elsewhere for interactive-choice deferral) is now also consulted by `detach_after_player_scope_local_chain` so a `ZoneChangedThisWay`-gated sub-ability stays attached to its own per-player iteration instead of detaching as a once-after-all-iterations tail

## Final review-impl
Self-reviewed inline against the universal lenses (correct seam, class vs single case, sibling coverage, vacuous-negative guard, edge cases): narrowed the new dispatcher's verb set from a speculative {discard, sacrifice, exile} to `discard` only, since sacrifice/exile are unverified against any real card printing this construction — widening is a one-line change once one exists. Added a 3-player regression test to pin the per-opponent iteration-attachment fix (the second, less obvious half of the bug: without it, the life-loss sub-ability detaches from the per-opponent Discard iteration and evaluates once against a stale/aggregate zone-change ledger instead of each opponent's own discard).

## Claimed parse impact
- Kroxa, Titan of Death's Hunger

## Validation Failures
None.

## CI Failures
None.


Closes #6007
