### PR TITLE
fix(engine): persist effect-resolution sacrifice batches across replacement pauses

### DIFF
--- a/crates/engine/src/game/effects/choose_and_sacrifice_rest.rs
+++ b/crates/engine/src/game/effects/choose_and_sacrifice_rest.rs
@@ -6,7 +6,7 @@ use crate::types::ability::{
 };
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{GameState, PendingPlayerScopeSacrificeCompletion, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 
@@ -145,10 +145,6 @@ pub fn resolve(
 
     // If all categories are empty for all players, skip directly to sacrifice.
     if eligible.iter().all(|e| e.is_empty()) && remaining_players.is_empty() {
-        // CR 603.10a: the permanents this sweep sacrifices left the battlefield
-        // together — stamp the sub-slice so a co-departing leaves-the-battlefield
-        // observer among them observes the rest.
-        let before = events.len();
         sacrifice_unchosen(
             state,
             &[],
@@ -157,13 +153,7 @@ pub fn resolve(
             ability.source_id,
             ability.controller,
             events,
-        );
-        crate::game::zones::stamp_simultaneous_from_slice(state, &mut events[before..]);
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::ChooseAndSacrificeRest,
-            source_id: ability.source_id,
-            subject: None,
-        });
+        )?;
         return Ok(());
     }
 
@@ -188,9 +178,6 @@ pub fn resolve(
     if let Some(auto_choices) = try_auto_resolve(&eligible) {
         let kept: Vec<ObjectId> = auto_choices.iter().filter_map(|&opt| opt).collect();
         if remaining_players.is_empty() {
-            // CR 603.10a: co-departing observer among the sacrificed group
-            // observes the rest — stamp the sweep's sub-slice.
-            let before = events.len();
             sacrifice_unchosen(
                 state,
                 &kept,
@@ -199,13 +186,7 @@ pub fn resolve(
                 ability.source_id,
                 ability.controller,
                 events,
-            );
-            crate::game::zones::stamp_simultaneous_from_slice(state, &mut events[before..]);
-            events.push(GameEvent::EffectResolved {
-                kind: EffectKind::ChooseAndSacrificeRest,
-                source_id: ability.source_id,
-                subject: None,
-            });
+            )?;
             return Ok(());
         }
         return advance_to_next_player(
@@ -324,9 +305,6 @@ pub(crate) fn step_total_power(
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
     let Some((&current_player, rest)) = players_remaining.split_first() else {
-        // CR 603.10a: all choices made — sacrifice the unchosen as one event so a
-        // co-departing leaves-the-battlefield observer among them sees the rest.
-        let before = events.len();
         sacrifice_unchosen(
             state,
             &all_kept,
@@ -335,13 +313,7 @@ pub(crate) fn step_total_power(
             source_id,
             source_controller,
             events,
-        );
-        crate::game::zones::stamp_simultaneous_from_slice(state, &mut events[before..]);
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::ChooseAndSacrificeRest,
-            source_id,
-            subject: None,
-        });
+        )?;
         return Ok(());
     };
 
@@ -420,30 +392,15 @@ pub(crate) fn step_exact_count(
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
     let Some((&target_player, rest)) = players_remaining.split_first() else {
-        let selections = unchosen_sacrifice_selections(
+        sacrifice_unchosen(
             state,
             &all_kept,
             scoped_players,
             sacrifice_filter,
             source_id,
             source_controller,
-        );
-        match super::perform_collected_player_scope_sacrifices(
-            state,
-            source_id,
-            source_controller,
-            selections,
             events,
-        )? {
-            super::PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice
-            | super::PendingPlayerScopeSacrificeOutcome::PausedForReplacement => {}
-            super::PendingPlayerScopeSacrificeOutcome::Completed { .. } => {}
-        }
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::ChooseAndSacrificeRest,
-            source_id,
-            subject: None,
-        });
+        )?;
         return Ok(());
     };
 
@@ -529,9 +486,6 @@ pub(crate) fn advance_to_next_player(
 ) -> Result<(), EffectError> {
     dedupe_object_ids(&mut all_kept);
     if remaining.is_empty() {
-        // CR 603.10a: terminal APNAP sweep — the sacrificed group left the
-        // battlefield together, so stamp this sub-slice for co-departing observers.
-        let before = events.len();
         sacrifice_unchosen(
             state,
             &all_kept,
@@ -540,13 +494,7 @@ pub(crate) fn advance_to_next_player(
             source_id,
             controller,
             events,
-        );
-        crate::game::zones::stamp_simultaneous_from_slice(state, &mut events[before..]);
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::ChooseAndSacrificeRest,
-            source_id,
-            subject: None,
-        });
+        )?;
         return Ok(());
     }
 
@@ -627,7 +575,7 @@ pub(crate) fn sacrifice_unchosen_from_handler(
     source_id: ObjectId,
     source_controller: PlayerId,
     events: &mut Vec<GameEvent>,
-) {
+) -> Result<(), EffectError> {
     sacrifice_unchosen(
         state,
         kept,
@@ -636,7 +584,7 @@ pub(crate) fn sacrifice_unchosen_from_handler(
         source_id,
         source_controller,
         events,
-    );
+    )
 }
 
 /// CR 701.21a: Sacrifice all permanents on the battlefield that were not chosen.
@@ -648,7 +596,7 @@ fn sacrifice_unchosen(
     source_id: ObjectId,
     source_controller: PlayerId,
     events: &mut Vec<GameEvent>,
-) {
+) -> Result<(), EffectError> {
     // CR 701.21a: Sacrifice each permanent NOT chosen, restricted to the
     // permanents controlled by the players within `player_scope`. A player
     // outside the effect's scope (e.g. Liliana's controller, scope = Opponent)
@@ -665,59 +613,27 @@ fn sacrifice_unchosen(
     } else {
         scoped_players.to_vec()
     };
-    // Collect all battlefield permanents not in the kept set, controlled by a
-    // player within scope.
-    for (controller, cards) in unchosen_sacrifice_selections_for_scope(
+    let selections = unchosen_sacrifice_selections_for_scope(
         state,
         kept,
         &effective_scope,
         sacrifice_filter,
         source_id,
         source_controller,
-    ) {
-        for obj_id in cards {
-            // Use the sacrifice primitive directly — single authority for sacrifice.
-            match crate::game::sacrifice::sacrifice_permanent(state, obj_id, controller, events) {
-                Ok(crate::game::sacrifice::SacrificeOutcome::Complete) => {}
-                Ok(crate::game::sacrifice::SacrificeOutcome::NeedsReplacementChoice(player)) => {
-                    state.waiting_for =
-                        crate::game::replacement::replacement_choice_waiting_for(player, state);
-                    // Replacement choice will resume; remaining sacrifices happen after.
-                    return;
-                }
-                Err(_) => {
-                    // Object may have left the battlefield; skip silently.
-                }
-            }
-        }
-    }
-}
-
-/// CR 701.21a: Build the exact per-controller sacrifice selections for the
-/// reusable APNAP/replacement-safe sacrifice executor. The selection is based
-/// on the post-choice battlefield snapshot, but the actual moves remain queued
-/// until every choosing player has committed their keep set.
-pub(crate) fn unchosen_sacrifice_selections(
-    state: &GameState,
-    kept: &[ObjectId],
-    scoped_players: &[PlayerId],
-    sacrifice_filter: &TargetFilter,
-    source_id: ObjectId,
-    source_controller: PlayerId,
-) -> Vec<(PlayerId, Vec<ObjectId>)> {
-    let effective_scope = if scoped_players.is_empty() {
-        players::apnap_order(state)
-    } else {
-        scoped_players.to_vec()
+    );
+    let completion = PendingPlayerScopeSacrificeCompletion {
+        effect_kind: Some(EffectKind::ChooseAndSacrificeRest),
+        ..Default::default()
     };
-    unchosen_sacrifice_selections_for_scope(
+    let _ = super::perform_collected_player_scope_sacrifices_with_completion(
         state,
-        kept,
-        &effective_scope,
-        sacrifice_filter,
         source_id,
         source_controller,
-    )
+        selections,
+        completion,
+        events,
+    )?;
+    Ok(())
 }
 
 fn unchosen_sacrifice_selections_for_scope(

--- a/crates/engine/src/game/effects/exploit.rs
+++ b/crates/engine/src/game/effects/exploit.rs
@@ -1,7 +1,8 @@
-use crate::game::sacrifice::{self, SacrificeOutcome};
 use crate::types::ability::{EffectError, EffectKind, ResolvedAbility, TargetRef};
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{
+    GameState, PendingPlayerScopeSacrificeCompletion, PendingPlayerScopeSacrificeFollowUp,
+};
 
 /// CR 702.110b: Exploit — sacrifice a creature the controller controls.
 /// On successful sacrifice, emits `CreatureExploited` for downstream trigger matchers.
@@ -10,32 +11,36 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    for target in &ability.targets {
-        if let TargetRef::Object(obj_id) = target {
-            let player_id = ability.controller;
-            match sacrifice::sacrifice_permanent(state, *obj_id, player_id, events) {
-                Ok(SacrificeOutcome::Complete) => {
-                    // CR 702.110: Emit exploit event after successful sacrifice
-                    events.push(GameEvent::CreatureExploited {
-                        exploiter: ability.source_id,
-                        sacrificed: *obj_id,
-                    });
-                }
-                Ok(SacrificeOutcome::NeedsReplacementChoice(player)) => {
-                    state.waiting_for =
-                        crate::game::replacement::replacement_choice_waiting_for(player, state);
-                    return Ok(());
-                }
-                Err(_) => continue,
-            }
-        }
-    }
-
-    events.push(GameEvent::EffectResolved {
-        kind: EffectKind::from(&ability.effect),
-        source_id: ability.source_id,
-        subject: None,
-    });
+    let selections = ability
+        .targets
+        .iter()
+        .filter_map(|target| match target {
+            TargetRef::Object(object_id) => state
+                .objects
+                .get(object_id)
+                .filter(|object| {
+                    object.zone == crate::types::zones::Zone::Battlefield
+                        && object.controller == ability.controller
+                })
+                .map(|_| (ability.controller, vec![*object_id])),
+            TargetRef::Player(_) => None,
+        })
+        .collect();
+    let completion = PendingPlayerScopeSacrificeCompletion {
+        effect_kind: Some(EffectKind::from(&ability.effect)),
+        follow_up: Some(PendingPlayerScopeSacrificeFollowUp::Exploit {
+            exploiter: ability.source_id,
+        }),
+        ..Default::default()
+    };
+    let _ = super::perform_collected_player_scope_sacrifices_with_completion(
+        state,
+        ability.source_id,
+        ability.controller,
+        selections,
+        completion,
+        events,
+    )?;
 
     Ok(())
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -23,8 +23,8 @@ use crate::types::game_state::{
     AutoMayChoice, CastOfferKind, ClauseMinimumSnapshot, DayNight, GameState, LKISnapshot,
     ManaAbilityResume, MayTriggerAutoChoiceKey, PendingContinuation, PendingCopyTokenBatch,
     PendingCostMoveResume, PendingPlayerScopeSacrificeChoice,
-    PendingPlayerScopeSacrificeCompletion, PendingRepeatedOptionalPayment, WaitingFor,
-    ZoneChangeRecord,
+    PendingPlayerScopeSacrificeCompletion, PendingPlayerScopeSacrificeFollowUp,
+    PendingRepeatedOptionalPayment, WaitingFor, ZoneChangeRecord,
 };
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::mana::ManaCost;
@@ -5888,7 +5888,8 @@ fn perform_player_scope_sacrifices(
     // A replacement choice resolves before this drain is reached. Preserve the
     // event outcome for its already-announced permanent before processing the
     // next selection, even when that pause had no queue tail.
-    record_sacrifice_batch_events(&mut completion, events);
+    let completed = record_sacrifice_batch_events(&mut completion, events);
+    emit_sacrifice_batch_follow_ups(&mut completion, completed, events);
 
     // CR 101.4: after every player has made the required APNAP choice, the
     // chosen permanents are moved as one simultaneous instruction.
@@ -5904,10 +5905,18 @@ fn perform_player_scope_sacrifices(
                 .map_err(|error| EffectError::InvalidParam(error.to_string()))?
             {
                 crate::game::sacrifice::SacrificeOutcome::Complete => {
-                    record_sacrifice_batch_events(&mut completion, &events[events_before_card..]);
+                    let completed = record_sacrifice_batch_events(
+                        &mut completion,
+                        &events[events_before_card..],
+                    );
+                    emit_sacrifice_batch_follow_ups(&mut completion, completed, events);
                 }
                 crate::game::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
-                    record_sacrifice_batch_events(&mut completion, &events[events_before_card..]);
+                    let completed = record_sacrifice_batch_events(
+                        &mut completion,
+                        &events[events_before_card..],
+                    );
+                    emit_sacrifice_batch_follow_ups(&mut completion, completed, events);
                     if !cards.is_empty() {
                         selections.insert(0, (player, cards));
                     }
@@ -5938,7 +5947,9 @@ fn perform_player_scope_sacrifices(
         }
     }
 
-    record_sacrifice_batch_events(&mut completion, &events[events_before_sacrifice..]);
+    let completed =
+        record_sacrifice_batch_events(&mut completion, &events[events_before_sacrifice..]);
+    emit_sacrifice_batch_follow_ups(&mut completion, completed, events);
     if !completion.deferred_events.is_empty() {
         let deferred_events = std::mem::take(&mut completion.deferred_events);
         events.splice(
@@ -5966,8 +5977,22 @@ fn perform_player_scope_sacrifices(
         i32::try_from(completion.sacrificed.len())
             .expect("a game cannot announce more sacrifices than i32 can represent"),
     );
+    if completion.publish_fresh_tracked_set {
+        publish_fresh_tracked_set(state, completion.sacrificed.clone());
+    }
+    if completion.propagate_parent_context {
+        if let Some(snapshot) =
+            parent_referent_context_from_events(state, &events[events_before_sacrifice..])
+        {
+            if let Some(cont) = state.pending_continuation.as_mut() {
+                cont.chain.set_effect_context_object_recursive(snapshot);
+            }
+        }
+    }
     events.push(GameEvent::EffectResolved {
-        kind: EffectKind::Sacrifice,
+        kind: completion
+            .effect_kind
+            .unwrap_or_else(|| EffectKind::from(&ability.effect)),
         source_id: ability.source_id,
         subject: None,
     });
@@ -6009,7 +6034,8 @@ fn record_announced_sacrifice(
 fn record_sacrifice_batch_events(
     completion: &mut PendingPlayerScopeSacrificeCompletion,
     events: &[GameEvent],
-) {
+) -> Vec<ObjectId> {
+    let mut completed = Vec::new();
     for event in events {
         match event {
             GameEvent::PermanentSacrificed { object_id, .. }
@@ -6017,6 +6043,7 @@ fn record_sacrifice_batch_events(
                     && !completion.sacrificed.contains(object_id) =>
             {
                 completion.sacrificed.push(*object_id);
+                completed.push(*object_id);
                 if !completion.zone_changed.contains(object_id) {
                     completion.zone_changed.push(*object_id);
                 }
@@ -6034,6 +6061,7 @@ fn record_sacrifice_batch_events(
                 // announced sacrifice's terminal result.
                 if !completion.sacrificed.contains(object_id) {
                     completion.sacrificed.push(*object_id);
+                    completed.push(*object_id);
                 }
                 if !completion.zone_changed.contains(object_id) {
                     completion.zone_changed.push(*object_id);
@@ -6050,18 +6078,68 @@ fn record_sacrifice_batch_events(
             _ => {}
         }
     }
+    completed
 }
 
-/// CR 101.4 + CR 701.21a + CR 616.1: Execute an already-collected set of
-/// player-owned sacrifice selections through the same replacement-safe queue
-/// used by ordinary scoped sacrifice effects. Keeper-choice effects collect the
-/// protected set first, then hand their unchosen set here so a replacement on
-/// one sacrifice cannot strand a later sacrifice or skip the original tail.
+/// CR 702.110b + CR 701.21a + CR 616.1: Emit each configured per-sacrifice
+/// follow-up only after the sacrifice event has completed. The completion ledger
+/// survives a replacement choice, so a resumed event is neither skipped nor
+/// emitted twice.
+fn emit_sacrifice_batch_follow_ups(
+    completion: &mut PendingPlayerScopeSacrificeCompletion,
+    completed: Vec<ObjectId>,
+    events: &mut Vec<GameEvent>,
+) {
+    let Some(follow_up) = completion.follow_up.clone() else {
+        return;
+    };
+
+    for sacrificed in completed {
+        if completion.followed_up_sacrifices.contains(&sacrificed) {
+            continue;
+        }
+        match follow_up {
+            PendingPlayerScopeSacrificeFollowUp::Exploit { exploiter } => {
+                events.push(GameEvent::CreatureExploited {
+                    exploiter,
+                    sacrificed,
+                });
+            }
+        }
+        completion.followed_up_sacrifices.push(sacrificed);
+    }
+}
+
+/// CR 101.4 + CR 701.21a + CR 616.1: Test-only default completion for the
+/// existing player-scope queue witnesses. Production callers provide their
+/// terminal work explicitly through the parameterized completion below.
+#[cfg(test)]
 pub(crate) fn perform_collected_player_scope_sacrifices(
     state: &mut GameState,
     source_id: ObjectId,
     source_controller: PlayerId,
     selections: Vec<(PlayerId, Vec<ObjectId>)>,
+    events: &mut Vec<GameEvent>,
+) -> Result<PendingPlayerScopeSacrificeOutcome, EffectError> {
+    perform_collected_player_scope_sacrifices_with_completion(
+        state,
+        source_id,
+        source_controller,
+        selections,
+        PendingPlayerScopeSacrificeCompletion::default(),
+        events,
+    )
+}
+
+/// CR 701.21a + CR 614.1 + CR 616.1: Run an already-collected sacrifice batch
+/// with its caller's exact terminal resolution work. `completion` is typed data,
+/// not a closure, so the same queue re-parks safely on every replacement choice.
+pub(crate) fn perform_collected_player_scope_sacrifices_with_completion(
+    state: &mut GameState,
+    source_id: ObjectId,
+    source_controller: PlayerId,
+    selections: Vec<(PlayerId, Vec<ObjectId>)>,
+    completion: PendingPlayerScopeSacrificeCompletion,
     events: &mut Vec<GameEvent>,
 ) -> Result<PendingPlayerScopeSacrificeOutcome, EffectError> {
     let ability = ResolvedAbility::new(
@@ -6074,7 +6152,7 @@ pub(crate) fn perform_collected_player_scope_sacrifices(
         source_id,
         source_controller,
     );
-    match perform_player_scope_sacrifices(state, &ability, selections, None, events)? {
+    match perform_player_scope_sacrifices(state, &ability, selections, Some(completion), events)? {
         PlayerScopeSacrificePerformOutcome::PausedForReplacement => {
             Ok(PendingPlayerScopeSacrificeOutcome::PausedForReplacement)
         }

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -1,11 +1,10 @@
 use crate::game::quantity::resolve_quantity_with_targets;
-use crate::game::sacrifice::{self, SacrificeOutcome};
 use crate::types::ability::{
     ControllerRef, Effect, EffectError, EffectKind, QuantityExpr, ResolvedAbility, TargetFilter,
     TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{GameState, PendingPlayerScopeSacrificeCompletion, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
@@ -291,33 +290,18 @@ pub fn resolve(
         // eligible permanent — the effect does as much as possible. Fast-path
         // this rather than round-tripping through EffectZoneChoice.
         if !up_to && eligible.len() <= count {
-            let mut sacrificed: i32 = 0;
-            for &obj_id in &eligible {
-                match sacrifice::sacrifice_permanent(state, obj_id, chooser, events) {
-                    Ok(SacrificeOutcome::Complete) => sacrificed += 1,
-                    Ok(SacrificeOutcome::NeedsReplacementChoice(player)) => {
-                        state.waiting_for =
-                            crate::game::replacement::replacement_choice_waiting_for(player, state);
-                        return Ok(());
-                    }
-                    Err(_) => {}
-                }
-            }
-            // CR 701.17a + CR 603.10a + CR 608.2f: every eligible permanent was
-            // sacrificed as part of the same resolution event, so co-departing
-            // sacrifice/LTB observers (Blood Artist) observe each other.
-            // `departed_subset` drops any permanent that didn't actually leave
-            // (e.g. CantBeSacrificed members excluded upstream).
-            crate::game::zones::mark_simultaneous_departures(
+            let completion = PendingPlayerScopeSacrificeCompletion {
+                effect_kind: Some(EffectKind::from(&ability.effect)),
+                ..Default::default()
+            };
+            let _ = super::perform_collected_player_scope_sacrifices_with_completion(
+                state,
+                ability.source_id,
+                ability.controller,
+                vec![(chooser, eligible)],
+                completion,
                 events,
-                &crate::game::zones::departed_subset(state, &eligible),
-            );
-            state.last_effect_count = Some(sacrificed);
-            events.push(GameEvent::EffectResolved {
-                kind: EffectKind::from(&ability.effect),
-                source_id: ability.source_id,
-                subject: None,
-            });
+            )?;
             return Ok(());
         }
 
@@ -356,6 +340,7 @@ pub fn resolve(
         return Ok(());
     }
 
+    let mut selections = Vec::new();
     for obj_id in targeted_objects {
         let obj = state
             .objects
@@ -401,26 +386,21 @@ pub fn resolve(
             continue;
         }
 
-        match sacrifice::sacrifice_permanent(state, obj_id, player_id, events) {
-            Ok(SacrificeOutcome::Complete) => {}
-            Ok(SacrificeOutcome::NeedsReplacementChoice(player)) => {
-                state.waiting_for =
-                    crate::game::replacement::replacement_choice_waiting_for(player, state);
-                return Ok(());
-            }
-            Err(_) => {
-                // Object may have left the battlefield between check and sacrifice;
-                // skip silently (same as the zone check above).
-                continue;
-            }
-        }
+        selections.push((player_id, vec![obj_id]));
     }
 
-    events.push(GameEvent::EffectResolved {
-        kind: EffectKind::from(&ability.effect),
-        source_id: ability.source_id,
-        subject: None,
-    });
+    let completion = PendingPlayerScopeSacrificeCompletion {
+        effect_kind: Some(EffectKind::from(&ability.effect)),
+        ..Default::default()
+    };
+    let _ = super::perform_collected_player_scope_sacrifices_with_completion(
+        state,
+        ability.source_id,
+        ability.controller,
+        selections,
+        completion,
+        events,
+    )?;
 
     Ok(())
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -8,7 +8,8 @@ use crate::types::actions::{GameAction, LearnOption, OutsideGameSelection};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
     ActionResult, CastOfferKind, ChosenDamageSource, CopyChosenSelection, GameState,
-    OutsideGameChoiceSource, PayableResource, PendingContinuation, WaitingFor,
+    OutsideGameChoiceSource, PayableResource, PendingContinuation,
+    PendingPlayerScopeSacrificeCompletion, WaitingFor,
 };
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::mana::ManaCost;
@@ -3871,26 +3872,47 @@ pub(super) fn handle_resolution_choice(
             let events_before_effect = events.len();
             match effect_kind {
                 EffectKind::Sacrifice => {
-                    for &card_id in &chosen {
-                        match super::sacrifice::sacrifice_permanent(state, card_id, player, events)
-                        {
-                            Ok(super::sacrifice::SacrificeOutcome::Complete) => {}
-                            Ok(super::sacrifice::SacrificeOutcome::NeedsReplacementChoice(
-                                choice_player,
-                            )) => {
-                                state.waiting_for =
-                                    super::replacement::replacement_choice_waiting_for(
-                                        choice_player,
-                                        state,
-                                    );
-                                return Ok(action_result_outcome(
-                                    events,
-                                    state.waiting_for.clone(),
-                                ));
+                    let completion = PendingPlayerScopeSacrificeCompletion {
+                        effect_kind: Some(EffectKind::Sacrifice),
+                        publish_fresh_tracked_set: state.pending_continuation.is_some(),
+                        propagate_parent_context: true,
+                        ..Default::default()
+                    };
+                    match effects::perform_collected_player_scope_sacrifices_with_completion(
+                        state,
+                        source_id,
+                        player,
+                        vec![(player, chosen.clone())],
+                        completion,
+                        events,
+                    )
+                    .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+                    {
+                        effects::PendingPlayerScopeSacrificeOutcome::WaitingForNextChoice => {
+                            unreachable!(
+                                "collected effect-zone sacrifices never prompt a new player"
+                            )
+                        }
+                        effects::PendingPlayerScopeSacrificeOutcome::PausedForReplacement => {
+                            return Ok(action_result_outcome(events, state.waiting_for.clone()));
+                        }
+                        effects::PendingPlayerScopeSacrificeOutcome::Completed {
+                            events_before_sacrifice,
+                            events_after_sacrifice,
+                        } => {
+                            set_priority(state, player);
+                            resume_with_error_propagation(state, events)?;
+                            if let Some(outcome) = batch_or_drain_observer_triggers(
+                                state,
+                                events,
+                                events_before_sacrifice,
+                                events_after_sacrifice,
+                            ) {
+                                return Ok(outcome);
                             }
-                            Err(error) => {
-                                return Err(EngineError::InvalidAction(error.to_string()));
-                            }
+                            return Ok(ResolutionChoiceOutcome::WaitingFor(
+                                state.waiting_for.clone(),
+                            ));
                         }
                     }
                 }
@@ -5088,7 +5110,8 @@ pub(super) fn handle_resolution_choice(
                     source_id,
                     source_controller,
                     events,
-                );
+                )
+                .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
             } else if let Err(e) = effects::choose_and_sacrifice_rest::advance_to_next_player(
                 state,
                 &categories,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1538,6 +1538,39 @@ pub struct PendingPlayerScopeSacrificeCompletion {
     /// buffer rather than only events produced by the tail drain.
     #[serde(default)]
     pub spans_replacement_pause: bool,
+    /// The resolution event emitted once the complete sacrifice batch settles.
+    /// Most callers inherit `EffectKind::Sacrifice` from their template; callers
+    /// that reuse this queue for a broader resolution instruction override it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effect_kind: Option<EffectKind>,
+    /// A per-permanent event that must follow every completed sacrifice, even
+    /// when delivery crossed a replacement-choice action boundary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub follow_up: Option<PendingPlayerScopeSacrificeFollowUp>,
+    /// Completed follow-up events, retained so a resumed event buffer can never
+    /// emit the same per-sacrifice event twice.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub followed_up_sacrifices: Vec<ObjectId>,
+    /// `EffectZoneChoice` starts a fresh selected-object set. Its replacement
+    /// pause must defer that publication until every selected sacrifice has
+    /// settled, so continuation consumers see the full actual set.
+    #[serde(default)]
+    pub publish_fresh_tracked_set: bool,
+    /// The interactive selection path normally snapshots the completed
+    /// sacrifice for a parent-referential continuation. Retain that suffix work
+    /// on the same typed batch when the selected sacrifice pauses.
+    #[serde(default)]
+    pub propagate_parent_context: bool,
+}
+
+/// CR 702.110b + CR 701.21a + CR 616.1: A per-sacrifice consequence carried
+/// by the replacement-safe simultaneous-sacrifice queue.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum PendingPlayerScopeSacrificeFollowUp {
+    /// Emit the exploit event only after the chosen creature's sacrifice has
+    /// actually completed, including after a graveyard-move replacement choice.
+    Exploit { exploiter: ObjectId },
 }
 
 /// CR 101.4 + CR 701.23i: APNAP state for a self-library search instruction

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -5,11 +5,12 @@ use engine::game::mana_abilities::activate_mana_ability;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, CastingPermission, ChoiceType,
-    Chooser, DigSource, DiscardSelfScope, Effect, ForEachCategoryAction, IterationCategory,
-    ManaContribution, ManaProduction, ModalChoice, QuantityExpr, QuantityRef,
-    ReplacementDefinition, ReplacementMode, ResolvedAbility, SacrificeCost, SpellCastingOption,
-    TargetFilter, TargetRef, TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, CastingPermission,
+    CategoryChooserScope, ChoiceType, Chooser, DigSource, DiscardSelfScope, Effect, EffectKind,
+    ForEachCategoryAction, IterationCategory, ManaContribution, ManaProduction, ModalChoice,
+    QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode, ResolvedAbility,
+    SacrificeCost, SpellCastingOption, TargetFilter, TargetRef, TargetSelectionMode,
+    TriggerDefinition, TypeFilter, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
@@ -8787,5 +8788,396 @@ fn drawn_this_turn_topdeck_preserves_selected_library_order() {
             .count(),
         1,
         "the synchronous payment tail emits one resolution event"
+    );
+}
+
+/// W-163-A (red first): a directly targeted sacrifice that pauses on the first
+/// replacement choice retains both the selected suffix and its terminal event.
+#[test]
+fn targeted_sacrifice_reparks_replacement_before_terminal_effect_resolved() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Targeted Sacrifice Resume Source", 1, 1)
+        .as_enchantment()
+        .id();
+    let first = scenario
+        .add_creature(P0, "Targeted Sacrifice First Redirect", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let second = scenario
+        .add_creature(P0, "Targeted Sacrifice Second Redirect", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let ability = ResolvedAbility::new(
+        Effect::Sacrifice {
+            target: TargetFilter::Any,
+            count: QuantityExpr::Fixed { value: 2 },
+            min_count: 0,
+        },
+        vec![TargetRef::Object(first), TargetRef::Object(second)],
+        source,
+        P0,
+    );
+    let mut runner = scenario.build();
+    let mut initial_events = Vec::new();
+
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("the first selected sacrifice reaches its replacement choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(
+        !initial_events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::Sacrifice,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "the terminal event must wait for the parked selected suffix"
+    );
+
+    let first_resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the first replacement delivers and re-parks the second sacrifice");
+    assert!(matches!(
+        first_resumed.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&first].zone, Zone::Exile);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Battlefield);
+    assert!(
+        !initial_events
+            .iter()
+            .chain(first_resumed.events.iter())
+            .any(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Sacrifice,
+                    source_id,
+                    ..
+                } if *source_id == source
+            )),
+        "the tail must remain parked across a second replacement choice"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the remaining selected sacrifice and terminal tail resolve");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().objects[&second].zone, Zone::Exile);
+    assert_eq!(runner.state().last_effect_count, Some(2));
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(first_resumed.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Sacrifice,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the directly targeted sacrifice finishes exactly once after both replacements"
+    );
+}
+
+/// W-163-B: the mandatory-all sacrifice fast path remains synchronous when no
+/// replacement decision is needed.
+#[test]
+fn mandatory_all_sacrifice_completes_synchronously() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Mandatory-All Sacrifice Source", 1, 1)
+        .as_enchantment()
+        .id();
+    let first = scenario
+        .add_creature(P0, "Mandatory-All Sacrifice First", 1, 1)
+        .id();
+    let second = scenario
+        .add_creature(P0, "Mandatory-All Sacrifice Second", 1, 1)
+        .id();
+    let ability = ResolvedAbility::new(
+        Effect::Sacrifice {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+            count: QuantityExpr::Fixed { value: 2 },
+            min_count: 0,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut runner = scenario.build();
+    let mut events = Vec::new();
+
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("mandatory-all sacrifice resolves inline");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert_eq!(runner.state().objects[&first].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Graveyard);
+    assert_eq!(runner.state().last_effect_count, Some(2));
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Sacrifice,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1
+    );
+}
+
+/// W-163-C: a sacrifice selected through `EffectZoneChoice` keeps its tracked
+/// set and chained tail behind the replacement boundary.
+#[test]
+fn effect_zone_sacrifice_replacement_preserves_tracked_set_and_tail() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Effect-Zone Sacrifice Source", 1, 1)
+        .as_enchantment()
+        .id();
+    let redirected = scenario
+        .add_creature(P0, "Effect-Zone Sacrifice Redirect", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    scenario.add_creature(P0, "Effect-Zone Sacrifice Unchosen", 1, 1);
+    let ability = ResolvedAbility::new(
+        Effect::Sacrifice {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+            count: QuantityExpr::Fixed { value: 1 },
+            min_count: 0,
+        },
+        vec![],
+        source,
+        P0,
+    )
+    .sub_ability(ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        source,
+        P0,
+    ));
+    let mut runner = scenario.build();
+    let mut initial_events = Vec::new();
+
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("sacrifice prompts for one creature");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::EffectZoneChoice {
+            effect_kind: EffectKind::Sacrifice,
+            ..
+        }
+    ));
+
+    let paused = runner
+        .act(GameAction::SelectCards {
+            cards: vec![redirected],
+        })
+        .expect("selected sacrifice reaches its replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(runner.state().chain_tracked_set_id.is_none());
+    assert_eq!(runner.state().players[P0.0 as usize].life, 20);
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("replacement delivery resumes the tracked-set publish and rider");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    let tracked = runner
+        .state()
+        .tracked_object_sets
+        .get(
+            &runner
+                .state()
+                .chain_tracked_set_id
+                .expect("selected sacrifice publishes a fresh tracked set after delivery"),
+        )
+        .expect("the published selected-sacrifice set exists");
+    assert_eq!(tracked, &vec![redirected]);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 21);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(paused.events.iter())
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Sacrifice,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the selected sacrifice emits one terminal event after its replacement settles"
+    );
+}
+
+/// W-163-D: Exploit emits its per-creature event and terminal event only after
+/// the replacement-delivered sacrifice has actually completed.
+#[test]
+fn exploit_replacement_preserves_creature_exploited_follow_up() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let exploiter = scenario
+        .add_creature(P0, "Exploit Replacement Source", 1, 1)
+        .id();
+    let victim = scenario
+        .add_creature(P0, "Exploit Replacement Victim", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let ability = ResolvedAbility::new(
+        Effect::Exploit {
+            target: TargetFilter::Any,
+        },
+        vec![TargetRef::Object(victim)],
+        exploiter,
+        P0,
+    );
+    let mut runner = scenario.build();
+    let mut initial_events = Vec::new();
+
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("exploit reaches the replacement choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(!initial_events
+        .iter()
+        .any(|event| matches!(event, GameEvent::CreatureExploited { .. })));
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("replacement delivery completes exploit");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::CreatureExploited {
+                    exploiter: event_exploiter,
+                    sacrificed,
+                } if *event_exploiter == exploiter && *sacrificed == victim
+            ))
+            .count(),
+        1,
+        "the exploit follow-up is emitted once after delivery"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Exploit,
+                    source_id,
+                    ..
+                } if *source_id == exploiter
+            ))
+            .count(),
+        1
+    );
+}
+
+/// W-163-E: the terminal sweep of choose-and-sacrifice-rest keeps its complete
+/// unchosen set and terminal event across a replacement choice.
+#[test]
+fn choose_and_sacrifice_rest_replacement_preserves_terminal_sweep() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Choose-and-Sacrifice-Rest Source", 1, 1)
+        .as_enchantment()
+        .id();
+    let victim = scenario
+        .add_creature(P0, "Choose-and-Sacrifice-Rest Victim", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let ability = ResolvedAbility::new(
+        Effect::ChooseAndSacrificeRest {
+            categories: vec![],
+            chooser_scope: CategoryChooserScope::EachPlayerSelf,
+            choose_filter: TargetFilter::Typed(TypedFilter::creature()),
+            sacrifice_filter: TargetFilter::Typed(TypedFilter::creature()),
+            total_power_cap: None,
+            keeper_constraint: None,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut runner = scenario.build();
+    let mut initial_events = Vec::new();
+
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("terminal unchosen sweep reaches its replacement choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(
+        !initial_events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::ChooseAndSacrificeRest,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "the terminal event must wait for the unchosen sacrifice delivery"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("replacement delivery finishes the unchosen sweep");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().objects[&victim].zone, Zone::Exile);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::ChooseAndSacrificeRest,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1
     );
 }


### PR DESCRIPTION
The p03s6 census found effect-resolution sites that match
SacrificeOutcome::NeedsReplacementChoice, surface the replacement prompt,
and then silently drop the remainder of their work — the rest of the
sacrifice loop, the tracked-set publish, per-sacrifice follow-ups, and the
terminal EffectResolved never run after the pause resolves.

Fix the five true match-but-forget sites by routing every collected
effect-resolution sacrifice batch through the existing replacement-safe
PendingPlayerScopeSacrificeChoice queue, parameterized by a typed
completion (CR 614.1 / CR 616.1):

- PendingPlayerScopeSacrificeCompletion gains effect_kind, a typed
  per-sacrifice follow_up (Exploit, CR 702.110b) with a delivered-ID
  ledger, publish_fresh_tracked_set, and propagate_parent_context — all
  serde-defaulted typed data, so the queue re-parks safely on nested
  pauses and the terminal tail (simultaneous-departure stamp per
  CR 603.10a, count, tracked set, EffectResolved) runs exactly once.
- effects/sacrifice.rs (mandatory-all fast path + targeted branch),
  effects/exploit.rs, effects/choose_and_sacrifice_rest.rs, and the
  EffectZoneChoice sacrifice arm in engine_resolution_choices.rs all
  delegate to perform_collected_player_scope_sacrifices_with_completion;
  the resolution-choice caller returns the live parked prompt on pause
  instead of clobbering it.
- step_exact_count's old unconditional EffectResolved push (which fired
  even when the batch paused) is eliminated — the completion owns the
  terminal event.

Sites verified NOT to need fixing: engine_debug.rs (the ordinary
post-action pipeline owns its suffix) and the cost/payment sites already
persisted via PendingCostMoveResume (#153/#162). No cost-resume variants
added — this is the effect-resolution layer's own continuation vocabulary.

Witnesses: replacement re-park with exactly-once terminal tail (targeted,
effect-zone tracked set, exploit follow-up, choose-and-sacrifice-rest
sweep) plus synchronous regressions, in cost_zone_pipeline.
