### PR TITLE
Add opt-in game-log and action dumps to ai-commander

### DIFF
--- a/crates/phase-ai/src/bin/ai_commander.rs
+++ b/crates/phase-ai/src/bin/ai_commander.rs
@@ -171,9 +171,9 @@ fn main() {
     }
 
     let start = Instant::now();
-    let dump_log = std::env::var("PHASE_DUMP_LOG").is_ok();
+    let dump_log_path = read_dump_env("PHASE_DUMP_LOG");
     let mut game_log: Vec<engine::types::log::GameLogEntry> = Vec::new();
-    let dump_actions = std::env::var("PHASE_DUMP_ACTIONS").is_ok();
+    let dump_actions_path = read_dump_env("PHASE_DUMP_ACTIONS");
     let mut actions_log: Vec<String> = Vec::new();
     let mut total_actions: usize = 0;
     let mut last_turn_reported: u32 = 0;
@@ -182,7 +182,7 @@ fn main() {
     let ai_session = phase_ai::session::AiSession::arc_from_game(&state);
 
     loop {
-        let results = run_ai_actions(
+        let mut results = run_ai_actions(
             &mut state,
             &ai_players,
             &ai_configs,
@@ -192,12 +192,12 @@ fn main() {
         if results.is_empty() {
             break;
         }
-        if dump_log {
-            for r in &results {
-                game_log.extend(r.log_entries.iter().cloned());
+        if dump_log_path.is_some() {
+            for r in &mut results {
+                game_log.extend(std::mem::take(&mut r.log_entries));
             }
         }
-        if dump_actions {
+        if dump_actions_path.is_some() {
             for r in &results {
                 actions_log.push(format!("{:?}", r.action));
             }
@@ -273,19 +273,32 @@ fn main() {
         );
     }
 
-    if let Ok(path) = std::env::var("PHASE_DUMP_ACTIONS") {
-        std::fs::write(&path, actions_log.join("\n")).expect("write actions dump");
+    if let Some(path) = &dump_actions_path {
+        std::fs::write(path, actions_log.join("\n")).expect("write actions dump");
         println!("Dumped {} actions to {path}", actions_log.len());
     }
-    if let Ok(path) = std::env::var("PHASE_DUMP_LOG") {
+    if let Some(path) = &dump_log_path {
         let json = serde_json::to_string(&game_log).expect("serialize game log");
-        std::fs::write(&path, json).expect("write game log dump");
+        std::fs::write(path, json).expect("write game log dump");
         println!("Dumped {} game-log entries to {path}", game_log.len());
     }
 
     if aborted {
         std::process::exit(2);
     }
+}
+
+/// Reads an opt-in dump-destination env var once at startup. Absence is a
+/// valid "not capturing" state; any other error (e.g. invalid Unicode) is a
+/// misconfiguration and must not silently disable capture.
+fn read_dump_env(key: &str) -> Option<String> {
+    std::env::var(key)
+        .map(Some)
+        .or_else(|e| match e {
+            std::env::VarError::NotPresent => Ok(None),
+            e => Err(e),
+        })
+        .expect("invalid Unicode in dump-destination env var")
 }
 
 fn parse_difficulty(s: &str) -> AiDifficulty {

--- a/crates/phase-ai/src/bin/ai_commander.rs
+++ b/crates/phase-ai/src/bin/ai_commander.rs
@@ -171,6 +171,10 @@ fn main() {
     }
 
     let start = Instant::now();
+    let dump_log = std::env::var("PHASE_DUMP_LOG").is_ok();
+    let mut game_log: Vec<engine::types::log::GameLogEntry> = Vec::new();
+    let dump_actions = std::env::var("PHASE_DUMP_ACTIONS").is_ok();
+    let mut actions_log: Vec<String> = Vec::new();
     let mut total_actions: usize = 0;
     let mut last_turn_reported: u32 = 0;
     let mut aborted = false;
@@ -187,6 +191,16 @@ fn main() {
         );
         if results.is_empty() {
             break;
+        }
+        if dump_log {
+            for r in &results {
+                game_log.extend(r.log_entries.iter().cloned());
+            }
+        }
+        if dump_actions {
+            for r in &results {
+                actions_log.push(format!("{:?}", r.action));
+            }
         }
         total_actions += results.len();
 
@@ -257,6 +271,16 @@ fn main() {
             p.graveyard.len(),
             bf_count
         );
+    }
+
+    if let Ok(path) = std::env::var("PHASE_DUMP_ACTIONS") {
+        std::fs::write(&path, actions_log.join("\n")).expect("write actions dump");
+        println!("Dumped {} actions to {path}", actions_log.len());
+    }
+    if let Ok(path) = std::env::var("PHASE_DUMP_LOG") {
+        let json = serde_json::to_string(&game_log).expect("serialize game log");
+        std::fs::write(&path, json).expect("write game log dump");
+        println!("Dumped {} game-log entries to {path}", game_log.len());
     }
 
     if aborted {


### PR DESCRIPTION
## Summary
Adds two opt-in env-var dumps to the `ai-commander` sanity runner, for headless audit workflows:
- `PHASE_DUMP_LOG=<path>` — writes the accumulated structured `GameLogEntry` stream (JSON) at game end.
- `PHASE_DUMP_ACTIONS=<path>` — writes each chosen `GameAction` (debug format, one per line).

Zero behavior change when the vars are unset. Motivation: line-by-line rules auditing of headless games (we used this to audit granted-miracle behavior across 9 seeded 4-player games — the existing stdout reports per-turn life totals only, and declined optional offers such as `MiracleReveal` leave no observable trace). Related observation for a possible follow-up: `GameLogEntry` never records that a cast was a miracle cast, so miracle casts are indistinguishable from retail casts in the log; the actions dump is currently the only way to see them.

## Files changed
- crates/phase-ai/src/bin/ai_commander.rs

## Implementation method (required)
Method: not-applicable — dev-binary instrumentation, no engine/parser/card logic touched.

## Track
Developer

## LLM
Model: claude-fable-5
Thinking: high
Tier: Frontier

## Verification
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p phase-ai --release` — clean, finished in 2m35s
- `cargo build --release -p phase-ai` — builds; binary exercised across 9 seeded 4-player games with both vars set (dumps written, parsed downstream) and without (unchanged behavior).

## Gate A
Not applicable — no parser code touched; pre-commit combinator gate passed on commit.

## Anchored on
- crates/phase-ai/src/bin/ai_commander.rs:41-66 — existing env/arg-driven opt-in configuration in the same binary
- crates/phase-ai/src/duel_suite/attribution.rs:61 — existing precedent for capturing per-action streams for offline analysis
