### PR TITLE
Fix Windows jq CRLF corrupting MTGJSON set downloads

### DIFF
--- a/scripts/fetch-draft-sets.sh
+++ b/scripts/fetch-draft-sets.sh
@@ -50,9 +50,11 @@ else
     # producing short packs. `extract_set_pool` skips any set without a
     # `booster.play` config, so an over-broad type here only costs download size.
     if command -v jq &>/dev/null; then
+        # tr strips Windows jq's trailing \r, which otherwise malforms every
+        # per-set download URL (see fetch-token-sets.sh).
         mapfile -t CODES < <(jq -r '.data[]
             | select(.type | IN("core", "expansion", "draft_innovation", "masters", "masterpiece", "eternal", "funny"))
-            | .code' "$SET_LIST" 2>/dev/null)
+            | .code' "$SET_LIST" 2>/dev/null | tr -d '\r')
     else
         # Fallback (jq absent — local dev only): grep/sed can't filter by type,
         # so this downloads more than needed. `booster.play` is still the gate.

--- a/scripts/fetch-token-sets.sh
+++ b/scripts/fetch-token-sets.sh
@@ -23,10 +23,13 @@ fi
 mapfile -t CODES < <(
   # tokenSetCode can name a legacy token pseudo-set that MTGJSON no longer
   # publishes as its own file; the parent set file already carries data.tokens.
+  # tr strips the \r that Windows jq appends to every line — a code with a
+  # trailing \r malforms the download URL (curl exit 3: "URL rejected") for
+  # every set, and the resulting .missing markers then mask the retries.
   jq -r '(reduce .data[].code as $code ({}; .[$code] = true)) as $known_codes
     | .data[]
     | select(.tokenSetCode != null and .tokenSetCode != "")
-    | .code, (.tokenSetCode | select($known_codes[.]))' "$SET_LIST" | sort -u
+    | .code, (.tokenSetCode | select($known_codes[.]))' "$SET_LIST" | tr -d '\r' | sort -u
 )
 
 if [ "${#CODES[@]}" -eq 0 ]; then

--- a/scripts/gen-card-data.sh
+++ b/scripts/gen-card-data.sh
@@ -319,8 +319,10 @@ GEN_COMMIT_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 MTGJSON_VERSION="unknown"
 MTGJSON_DATE="unknown"
 if [ -s "$MTGJSON_META_FILE" ]; then
-  MTGJSON_VERSION=$(jq -r '.meta.version // "unknown"' "$MTGJSON_META_FILE")
-  MTGJSON_DATE=$(jq -r '.meta.date // "unknown"' "$MTGJSON_META_FILE")
+  # tr strips Windows jq's trailing \r, which would otherwise embed a raw
+  # control character inside the JSON string values written to META_OUTPUT.
+  MTGJSON_VERSION=$(jq -r '.meta.version // "unknown"' "$MTGJSON_META_FILE" | tr -d '\r')
+  MTGJSON_DATE=$(jq -r '.meta.date // "unknown"' "$MTGJSON_META_FILE" | tr -d '\r')
 fi
 track_tmp "$META_OUTPUT_TMP"
 cat > "$META_OUTPUT_TMP" <<METAEOF

--- a/scripts/gen-card-data.sh
+++ b/scripts/gen-card-data.sh
@@ -367,6 +367,7 @@ FILE_SIZE=$(du -h "$OUTPUT" | cut -f1)
 NAMES_SIZE=$(du -h "$NAMES_OUTPUT" | cut -f1)
 # Count entries in the small names array (648K) rather than grepping the 90MB
 # card-data for `"name"` — the latter is slower and overcounts nested keys.
-CARD_COUNT=$(jq 'length' "$NAMES_OUTPUT")
+# tr strips Windows jq's trailing \r, which would otherwise corrupt this summary line.
+CARD_COUNT=$(jq 'length' "$NAMES_OUTPUT" | tr -d '\r')
 echo "Generated $OUTPUT ($FILE_SIZE, ~$CARD_COUNT cards)"
 echo "Generated $NAMES_OUTPUT ($NAMES_SIZE)"


### PR DESCRIPTION
## Summary
Fixes the MTGJSON per-set download sweep on Windows: Windows builds of jq terminate every line with `\r\n`, so the set codes read via `mapfile` in `fetch-token-sets.sh` / `fetch-draft-sets.sh` carry a trailing `\r` that malforms every download URL — curl rejects each request with exit 3 (`URL rejected: Malformed input to a URL function`), every set "fails", and the `.missing` markers written on failure then mask retries on the next run. Because `gen-card-data.sh` regenerates `crates/engine/data/known-tokens.toml` from whatever set files exist, a second run on a fresh Windows clone can silently regenerate an EMPTY token catalog. The same `\r` also lands inside `card-data-meta.json` string values (`mtgjson_version` / `mtgjson_date`) as a raw control character.

Fix: `| tr -d '\r'` on the jq outputs in the three affected spots — a no-op on Unix jq output.

Reproduced on Windows 11 / Git Bash / jq 1.8.2:
```
$ jq -r '.data[0].code' data/mtgjson/SetList.json | od -c
0000000   1   0   E  \r  \n
```

## Files changed
- scripts/fetch-token-sets.sh
- scripts/fetch-draft-sets.sh
- scripts/gen-card-data.sh

## Implementation method (required)
Method: not-applicable — build-script portability fix, no engine/parser/card logic touched.

## Track
Developer

## LLM
Model: claude-fable-5
Thinking: high
Tier: Frontier

## Verification
- `bash -n` on all three scripts — clean
- Full `gen-card-data.sh` run on Windows with the fix behavior (via an equivalent CRLF-stripping wrapper): 866 sets fetched, token catalog generated non-empty, card-data.json 93 MB / ~35,394 cards, `card-data-validate` schema gate passed
- Pre-commit and pre-push hooks passed locally (Gate A `head=fa0ed685...`)

## Gate A
Not applicable — no parser code touched; pre-commit combinator gate passed on commit.

## Anchored on
- scripts/lib/mtgjson-fetch.sh:51-60 — existing hardening layer for these same downloads (retry/atomic-rename); this fix extends the same robustness posture to the URL inputs
- scripts/gen-card-data.sh:193-205 — existing guard against regenerating/overwriting the token catalog spuriously; this fix closes the Windows path that defeats it
