### PR TITLE
Fix parser misparse: Dropped intervening-if / gating condition (condition: null)

### DIFF
--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -5028,7 +5028,7 @@ mod tests {
         ));
         assert!(!replacement_condition_reads_projected_resource(
             &ReplacementCondition::CastFromZone {
-                zone: crate::types::zones::Zone::Graveyard
+                zone: Some(crate::types::zones::Zone::Graveyard)
             }
         ));
         assert!(!duration_reads_projected_resource(

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -4807,13 +4807,17 @@ fn evaluate_replacement_condition(
             .objects
             .get(&source_id)
             .is_some_and(|o| o.cast_variant_paid == Some((*variant, state.turn_number))),
-        // CR 603.4: "if you cast it from [zone]" — applies only when the source
-        // permanent was cast from the gated zone. Equivalent to CastViaEscape
-        // for arbitrary zones (Hand for Myojin, Exile for foretell-style, etc.).
-        ReplacementCondition::CastFromZone { zone } => state
-            .objects
-            .get(&source_id)
-            .is_some_and(|o| o.cast_from_zone == Some(*zone)),
+        // CR 601.2 + CR 603.4: "if you cast it [from [zone]]" — applies only when
+        // the source permanent was cast. `Some(zone)` narrows to the gated origin
+        // (Hand for Myojin, Exile for foretell-style, etc.); `None` is the
+        // zoneless form (Nine-Lives Familiar) satisfied by a cast from ANY zone,
+        // i.e. `cast_from_zone.is_some()`.
+        ReplacementCondition::CastFromZone { zone } => {
+            state.objects.get(&source_id).is_some_and(|o| match zone {
+                Some(z) => o.cast_from_zone == Some(*z),
+                None => o.cast_from_zone.is_some(),
+            })
+        }
         // CR 614.1d + CR 601: entry-origin gate on the ENTERING object
         // (`affected_object_id`), NOT the replacement source. The physical half
         // delegates to the shared `OriginConstraint::matches_from` predicate.

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -17,7 +17,9 @@ use super::super::oracle_nom::condition::{
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
 use super::super::oracle_quantity::{canonicalize_quantity_ref, parse_cda_quantity};
-use super::super::oracle_target::{parse_target, parse_type_phrase, parse_zone_word};
+use super::super::oracle_target::{
+    parse_cost_paid_mana_value_reference, parse_target, parse_type_phrase, parse_zone_word,
+};
 use super::super::oracle_util::{parse_comparison_suffix, parse_subtype, TextPair};
 use super::sequence::parse_dig_from_among;
 use super::{parse_effect_chain, scan_contains_phrase, ParseContext};
@@ -2665,6 +2667,37 @@ pub(super) fn strip_mana_value_conditional(text: &str) -> (Option<AbilityConditi
     let lower = text.to_lowercase();
     let tp = TextPair::new(text, &lower);
 
+    // NOTE (honest coverage): the LEADING dynamic-RHS surface — "if it has [the
+    // same] mana value [...] the <verb>ed <noun>['s mana value], <body>" (Anchor
+    // to Reality: "...put that card onto the battlefield, then shuffle. If it has
+    // mana value less than the sacrificed permanent's mana value, scry 2.") — is
+    // deliberately NOT wired here. In that surface "it" is the just-searched /
+    // placed card (an object introduced by an earlier instruction, CR 608.2c
+    // Demonstrative), NOT an object target: Anchor declares no object target and
+    // the searched card is never bound to any runtime object scope (search /
+    // change-zone do not populate `effect_context_object`). Binding "it" to
+    // `ObjectScope::Target` here would resolve to nothing (0) and make the scry
+    // gate fire on the wrong comparison, so this class stays honestly RED
+    // (swallowed) until the searched-object runtime binding exists. The suffix
+    // (target-anaphor) surface below is the only one wired.
+
+    // CR 202.3 + CR 608.2k: suffix dynamic RHS — "<effect> if it has [the same]
+    // mana value [...] the <verb>ed <noun>['s mana value]" (Hisoka, Minamo
+    // Sensei: "Counter target spell if it has the same mana value as the
+    // discarded card.").
+    if let Some((before, after)) = tp.rsplit_around(" if ") {
+        if let Ok((rest, condition)) =
+            parse_it_mana_value_vs_cost_paid_object(after.lower.trim_end_matches('.'))
+        {
+            if rest.trim().is_empty() {
+                return (
+                    Some(condition),
+                    before.original.trim_end_matches('.').trim().to_string(),
+                );
+            }
+        }
+    }
+
     // Leading position, past tense: "If its mana value was N or less/greater, [effect]."
     // CR 400.7: past-tense check → use_lki: true (LKI snapshot).
     if let Ok((rest, _)) =
@@ -2844,6 +2877,60 @@ fn parse_dynamic_mana_value_threshold(text: &str) -> Option<(Comparator, Quantit
     ))
 }
 
+/// CR 202.3 + CR 608.2k: "it has [the same] mana value [as | less than | greater
+/// than] the <verb>ed <noun>['s mana value]" — compares the ability's first
+/// object target's mana value (CR 115.1: "it") to the mana value of the object
+/// paid as a cost / previously referenced (CR 608.2k: `CostPaidObject`). Hisoka,
+/// Minamo Sensei ("Counter target spell if it has the same mana value as the
+/// discarded card") — here "it" anaphors to the countered target spell, so the
+/// LHS is `ObjectScope::Target`. Both operands are typed
+/// `QuantityRef::ObjectManaValue` — no fixed threshold — so a mana-value change
+/// to either object after cost payment is read at resolution.
+///
+/// Only wired for the SUFFIX (target-anaphor) surface. The leading surface where
+/// "it" denotes a just-searched/placed card (Anchor to Reality) is intentionally
+/// left unwired — see the note in `strip_mana_value_conditional` — because that
+/// object has no runtime scope binding and `Target` would be wrong.
+fn parse_it_mana_value_vs_cost_paid_object(input: &str) -> OracleResult<'_, AbilityCondition> {
+    let (rest, _) = tag("it has ").parse(input)?;
+    let (rest, comparator) = alt((
+        // "the same mana value as <referent>" — equality surface.
+        value(Comparator::EQ, tag("the same mana value as ")),
+        // "mana value <comparator> <referent>".
+        preceded(
+            tag("mana value "),
+            alt((
+                value(Comparator::LE, tag("less than or equal to ")),
+                value(Comparator::LT, tag("less than ")),
+                value(Comparator::GE, tag("greater than or equal to ")),
+                value(Comparator::GT, tag("greater than ")),
+                value(Comparator::EQ, tag("equal to ")),
+            )),
+        ),
+    ))
+    .parse(rest)?;
+    // CR 608.2k: the RHS referent ("the discarded/sacrificed <noun>") and its
+    // CostPaidObject → QuantityRef mapping come from the single shared authority
+    // `parse_cost_paid_mana_value_reference` (oracle_target). The optional
+    // possessive suffix "'s mana value" (Anchor to Reality: "the sacrificed
+    // permanent's mana value") is consumed locally here — it is a consumption
+    // detail of this surface, not part of the referent→scope mapping.
+    let (rest, rhs_qty) = parse_cost_paid_mana_value_reference(rest)?;
+    let (rest, _) = opt(tag("'s mana value")).parse(rest)?;
+    Ok((
+        rest,
+        AbilityCondition::QuantityCheck {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::ObjectManaValue {
+                    scope: ObjectScope::Target,
+                },
+            },
+            comparator,
+            rhs: QuantityExpr::Ref { qty: rhs_qty },
+        },
+    ))
+}
+
 pub(super) fn strip_target_supertype_conditional(text: &str) -> (Option<AbilityCondition>, String) {
     let lower = text.to_lowercase();
     let tp = TextPair::new(text, &lower);
@@ -2856,6 +2943,30 @@ pub(super) fn strip_target_supertype_conditional(text: &str) -> (Option<AbilityC
             Some(nonbasic_land_lki_condition()),
             text[body_start..].to_string(),
         );
+    }
+
+    // CR 205.4a + CR 400.7: leading past-tense LKI supertype gate on the prior
+    // target — "if that land was <supertype>, <body>" (Feast of Worms: "if that
+    // land was legendary, its controller sacrifices another land of their
+    // choice"). Generalizes the nonbasic arm above to the CR 205.4a supertype
+    // set; `use_lki: true` because the destroyed land is read at last-known
+    // information (CR 400.7 — it is already in the graveyard when the second
+    // sentence resolves).
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("if that land was ").parse(lower.as_str()) {
+        if let Ok((after_super, supertype)) = parse_supertype_word(rest) {
+            if let Ok((_, _)) = tag::<_, _, OracleError<'_>>(", ").parse(after_super) {
+                let body_start = text.len() - after_super.len() + ", ".len();
+                let condition = AbilityCondition::TargetMatchesFilter {
+                    filter: TargetFilter::Typed(
+                        TypedFilter::default()
+                            .properties(vec![FilterProp::HasSupertype { value: supertype }]),
+                    ),
+                    use_lki: true,
+                    subject_slot: None,
+                };
+                return (Some(condition), text[body_start..].to_string());
+            }
+        }
     }
 
     if let Some((before, after)) = tp.rsplit_around(" if that land was ") {

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -17,6 +17,7 @@ use super::primitives::{
     parse_article, parse_color, parse_keyword_name, parse_mana_cost, parse_number,
 };
 use super::quantity as nom_quantity;
+use super::target::parse_self_reference;
 use crate::parser::oracle_target::{
     cast_capable_zones_except, parse_type_phrase, parse_zone_suffix, parse_zone_word,
     peek_zone_boundary,
@@ -345,7 +346,10 @@ fn parse_was_cast_condition(input: &str) -> OracleResult<'_, StaticCondition> {
             |(_, zone)| StaticCondition::WasCast { zone: Some(zone) },
         ),
         // CR 601.2a + CR 400.7: zoneless "was cast" gate (Anti-Venom "if he was
-        // cast"). "they" takes the plural verb "were cast".
+        // cast"). "they" takes the plural verb "were cast". The active-voice
+        // "you cast it"/"you cast them" (Nine-Lives Familiar: "enters with eight
+        // revival counters on it if you cast it") is the same zoneless
+        // cast-provenance gate — the object was cast from anywhere.
         value(
             StaticCondition::WasCast { zone: None },
             alt((
@@ -356,6 +360,8 @@ fn parse_was_cast_condition(input: &str) -> OracleResult<'_, StaticCondition> {
                 tag("he was cast"),
                 tag("she was cast"),
                 tag("they were cast"),
+                tag("you cast it"),
+                tag("you cast them"),
             )),
         ),
     ))
@@ -368,12 +374,58 @@ fn parse_damage_dealt_this_turn_conditions(input: &str) -> OracleResult<'_, Stat
         // "was dealt excess damage this turn" wins over the shorter "was dealt
         // damage this turn" prefix in `parse_source_was_dealt_damage_this_turn`.
         parse_subject_was_dealt_excess_damage_this_turn,
+        // CR 120.1 + CR 603.4: amount-first passive form "N or more damage was
+        // dealt to <recipient> this turn" (Burning-Eye Zubera cycle). Prefix is a
+        // number, disjoint from the subject-first arms below.
+        parse_amount_damage_dealt_to_recipient_this_turn,
         parse_player_was_dealt_damage_threshold_this_turn,
         parse_player_dealt_combat_damage_by_source_this_turn,
         parse_source_dealt_damage_this_turn,
         parse_source_was_dealt_damage_this_turn,
     ))
     .parse(input)
+}
+
+/// CR 120.1 + CR 603.4 + CR 603.10a: "N or more [combat] damage was dealt to
+/// <recipient> this turn" — the amount-first passive form gating a dies trigger
+/// on accumulated damage to the triggering object (Burning-Eye Zubera cycle:
+/// "When this creature dies, if 4 or more damage was dealt to it this turn,
+/// ..."). The recipient anaphors ("it"/"~"/"this creature"/"this permanent") all
+/// denote the source that died, so they bind `TargetFilter::SelfRef`; the source
+/// axis is `Any` (damage from any object counts). Distinct word order from
+/// `parse_player_was_dealt_damage_threshold_this_turn` (subject-first), so it is
+/// its own combinator rather than a shared one.
+fn parse_amount_damage_dealt_to_recipient_this_turn(
+    input: &str,
+) -> OracleResult<'_, StaticCondition> {
+    let (rest, amount) = parse_number(input)?;
+    let (rest, _) = tag(" or more ").parse(rest)?;
+    let (rest, combat) = opt(tag("combat ")).parse(rest)?;
+    let (rest, _) = tag("damage was dealt to ").parse(rest)?;
+    // The recipient anaphor ("it" / "~" / "this creature" / "this permanent" / …)
+    // routes through the shared self-reference authority rather than re-enumerating
+    // a subset inline. CR 201.5: each denotes the ability's own object (`SelfRef`).
+    let (rest, target) = parse_self_reference(rest)?;
+    let (rest, _) = tag(" this turn").parse(rest)?;
+    let damage_kind = if combat.is_some() {
+        DamageKindFilter::CombatOnly
+    } else {
+        DamageKindFilter::Any
+    };
+    Ok((
+        rest,
+        make_quantity_ge(
+            QuantityRef::DamageDealtThisTurn {
+                source: Box::new(TargetFilter::Any),
+                target: Box::new(target),
+                aggregate: AggregateFunction::Sum,
+                group_by: None,
+                damage_kind,
+                channel: DamageChannel::Total,
+            },
+            amount,
+        ),
+    ))
 }
 
 /// Wrapper around `parse_type_phrase` that fails (nom error) when the result is
@@ -584,6 +636,19 @@ fn parse_source_dealt_damage_this_turn(input: &str) -> OracleResult<'_, StaticCo
             TargetFilter::Typed(TypedFilter::creature()),
             alt((tag("a creature"), tag("creature"))),
         ),
+        // NOTE: no "it" (dying-object anaphor) arm here. "if <source> dealt damage
+        // to it this turn" on a *dies* trigger (Hawkeye, Avenging Archer) names the
+        // creature that died, which is the trigger event's SOURCE object
+        // (`extract_source_from_event(ZoneChanged)`), NOT its `EventTarget`
+        // (`extract_target_object_from_event`, which yields `Some` only for a
+        // `DamageDealt` event — CR 120.1). Binding "it" to `TargetFilter::EventTarget`
+        // here made the intervening-if silently always-false at runtime (the
+        // ZoneChanged event has no EventTarget, so the damage-record match found
+        // nothing and the gate could never hold). No object-matching `TargetFilter`
+        // resolves the trigger *source* object today (`TriggeringSource` is inert in
+        // `matches_target_filter`), so this dies-object damage look-back stays an
+        // honest RED (swallowed `Condition_If`) until that dying-object recipient
+        // filter is built. See the pinned `hawkeye_*_is_honest_red` tripwire.
     ))
     .parse(rest)?;
     let (rest, _) = tag(" this turn").parse(rest)?;
@@ -5359,6 +5424,11 @@ fn parse_zone_history_condition(input: &str) -> OracleResult<'_, StaticCondition
         parse_card_left_your_graveyard_this_turn,
         parse_permanent_put_into_your_hand_from_battlefield_this_turn,
         parse_card_put_into_your_graveyard_from_anywhere_this_turn,
+        // CR 404.1: owner-scoped "your graveyard" form — must precede the
+        // any-graveyard form so "your graveyard" is not left for the
+        // unscoped combinator (their suffixes are disjoint, but keep the
+        // owner-scoped, more-specific one first for clarity).
+        parse_object_put_into_your_graveyard_from_battlefield_this_turn,
         parse_object_put_into_graveyard_from_battlefield_this_turn,
         parse_creature_died_this_turn_conditions,
         // "a nonland permanent left the battlefield this turn" (Revolt variant)
@@ -5628,6 +5698,42 @@ fn parse_your_card_put_into_your_graveyard_from_anywhere_this_turn(
                 from: None,
                 to: Some(Zone::Graveyard),
                 filter: add_owned_with_props(filter, ControllerRef::You, &[FilterProp::NonToken]),
+            },
+            1,
+        ),
+    ))
+}
+
+/// CR 404.1 + CR 400.7 + CR 603.4: "a <type> was put into your graveyard from
+/// the battlefield this turn" — the owner-scoped variant of the any-graveyard
+/// form. A permanent is put into its OWNER's graveyard (CR 404.1), so "your
+/// graveyard" is an OWNERSHIP scope, encoded as `FilterProp::Owned { You }` on
+/// the filter (reads `obj.owner`), never as a controller filter and never on the
+/// zoneless `to` field. Kami of Transience's each-end-step return gate: "if an
+/// enchantment was put into your graveyard from the battlefield this turn".
+/// Mirrors `parse_permanent_put_into_your_hand_from_battlefield_this_turn`.
+fn parse_object_put_into_your_graveyard_from_battlefield_this_turn(
+    input: &str,
+) -> OracleResult<'_, StaticCondition> {
+    let (rest, _) = parse_article(input)?;
+    let suffix = " was put into your graveyard from the battlefield this turn";
+    let (rest, type_text) = take_until(suffix).parse(rest)?;
+    let (rest, _) = tag(suffix).parse(rest)?;
+    let (filter, leftover) = parse_type_phrase(type_text.trim());
+    if !leftover.trim().is_empty() || filter == TargetFilter::Any {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+
+    Ok((
+        rest,
+        make_quantity_ge(
+            QuantityRef::ZoneChangeCountThisTurn {
+                from: Some(Zone::Battlefield),
+                to: Some(Zone::Graveyard),
+                filter: add_owned_with_props(filter, ControllerRef::You, &[]),
             },
             1,
         ),

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3701,7 +3701,7 @@ fn parse_enters_with_counters(
             } else if let Some(cond) = kicker_condition {
                 def = def.condition(cond);
             } else if let Some(zone) = extract_cast_from_zone_suffix(work_text) {
-                def = def.condition(ReplacementCondition::CastFromZone { zone });
+                def = def.condition(ReplacementCondition::CastFromZone { zone: Some(zone) });
             } else if extract_you_attacked_this_turn_suffix(work_text) {
                 def = def.condition(ReplacementCondition::YouAttackedThisTurn);
             } else if extract_cast_using_web_slinging_suffix(work_text) {
@@ -3895,7 +3895,7 @@ fn parse_enters_with_counters(
     } else if let Some(cond) = kicker_condition {
         def = def.condition(cond);
     } else if let Some(zone) = extract_cast_from_zone_suffix(work_text) {
-        def = def.condition(ReplacementCondition::CastFromZone { zone });
+        def = def.condition(ReplacementCondition::CastFromZone { zone: Some(zone) });
     } else if extract_you_attacked_this_turn_suffix(work_text) {
         // CR 207.2c (Raid): "Raid — ~ enters with [counter] on it if you
         // attacked this turn." (Cruel Administrator, Goblin Boarders, etc.)
@@ -4531,6 +4531,25 @@ fn replacement_condition_from_static(condition: StaticCondition) -> Option<Repla
             Some(ReplacementCondition::SourceTappedState { tapped: false })
         }
         StaticCondition::HasMaxSpeed => Some(ReplacementCondition::HasMaxSpeed),
+        // CR 601.2 + CR 614.1c: cast-provenance enters-with gate. "if you cast
+        // it" (zoneless, `zone: None` = cast from anywhere; Nine-Lives Familiar)
+        // and "if it was cast from <zone>" (`zone: Some(z)`; Myojin cycle) share
+        // the one `CastFromZone` `Option<Zone>` parameterization on the CR 601.2
+        // axis.
+        StaticCondition::WasCast { zone } => Some(ReplacementCondition::CastFromZone { zone }),
+        // CR 614.1d + CR 700.9: presence-gated enters-with replacement — "enters
+        // with ... if you control a modified creature" (Heir of the Ancient
+        // Fang). `parse_you_control_a` already injects the controller scope
+        // (`controller: You`) into the filter, which is exactly the shape
+        // `IfControlsMatching` evaluates against its source controller. A filter
+        // with no controller restriction (`None`) maps to a "any player controls"
+        // presence gate, which is still expressible as `IfControlsMatching`.
+        StaticCondition::IsPresent { filter: Some(f) } => {
+            Some(ReplacementCondition::IfControlsMatching {
+                minimum: 1,
+                filter: f,
+            })
+        }
         _ => None,
     }
 }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5210,7 +5210,18 @@ fn parse_mana_value_reference_qty(
     .parse(input)
 }
 
-fn parse_cost_paid_mana_value_reference(
+/// CR 608.2k: single authority mapping the untargeted cost-paid-object referent
+/// "the [discarded|sacrificed] <noun>" to
+/// `QuantityRef::ObjectManaValue { scope: CostPaidObject }`. Shared by the
+/// mana-value referent quantity path (`parse_mana_value_reference_qty`) and the
+/// "it has ... mana value ... the <verb>ed <noun>" condition surface
+/// (`oracle_effect::conditions::parse_it_mana_value_vs_cost_paid_object`), so the
+/// verb/noun enumeration and the CostPaidObject mapping live in one place rather
+/// than being re-hand-rolled per call site. "exiled" is intentionally excluded
+/// here: in the quantity path "the exiled card" already binds effect-exile
+/// (`TrackedSet`) semantics, so exiled is context-dependent and handled by the
+/// context-gated `parse_cost_paid_object_reference` instead.
+pub(crate) fn parse_cost_paid_mana_value_reference(
     input: &str,
 ) -> super::oracle_nom::error::OracleResult<'_, QuantityRef> {
     let (rest, _) = opt(tag("the ")).parse(input)?;

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4637,6 +4637,44 @@ fn parse_cast_from_zone_intervening_if(input: &str) -> OracleResult<'_, TriggerC
     Ok((rest, scoped_you_cast_from_zone(zone)))
 }
 
+/// CR 601.2 + CR 603.4: "if you cast it from anywhere other than <zone>" —
+/// cast-provenance intervening-if requiring the entering permanent to have been
+/// cast (CR 601.2) but from a zone OTHER than the named one (Alex Wilder,
+/// Runaway: "if you cast it from anywhere other than your hand"). Lowers to the
+/// conjunction of a positive `WasCast` (it was cast at all — a token or
+/// put-onto-battlefield entry fails this conjunct) and the negation of the
+/// zone-scoped cast (`scoped_you_cast_from_zone`), so a hand-cast fails the
+/// second conjunct. Both axes stay separately resolvable rather than collapsing
+/// into a `from_hand: bool`. MUST be registered before the bare "if you cast it"
+/// handler, whose `" from"` guard already declines this phrase but which would
+/// otherwise be a latent shadowing hazard.
+fn parse_cast_from_anywhere_other_than_intervening_if(
+    input: &str,
+) -> OracleResult<'_, TriggerCondition> {
+    let (rest, _) = tag("if you cast it from anywhere other than ").parse(input)?;
+    let (rest, zone) = alt((
+        value(Zone::Hand, tag("your hand")),
+        value(Zone::Graveyard, tag("your graveyard")),
+        value(Zone::Exile, tag("exile")),
+    ))
+    .parse(rest)?;
+    Ok((
+        rest,
+        TriggerCondition::And {
+            conditions: vec![
+                TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                TriggerCondition::Not {
+                    condition: Box::new(scoped_you_cast_from_zone(zone)),
+                },
+            ],
+        },
+    ))
+}
+
 /// CR 603.4 + CR 404.1 + CR 205.3: "if you cast it/them and <game-state condition>"
 /// — cast-provenance AND a second conjunct (Ran and Shaw: "if you cast them and
 /// there are three or more Dragon and/or Lesson cards in your graveyard"). The
@@ -4771,6 +4809,21 @@ fn extract_if_condition_with_card_name(
     // from the named zone. MUST precede the zoneless "if you cast it" arm.
     if let Some((before, condition, rest)) =
         scan_preceded(&lower, parse_cast_from_zone_intervening_if)
+    {
+        let pos = before.len();
+        let clause_len = lower.len() - before.len() - rest.len();
+        return (
+            strip_condition_clause(text, pos, clause_len),
+            Some(condition),
+        );
+    }
+
+    // CR 601.2 + CR 603.4: "if you cast it from anywhere other than <zone>" —
+    // cast-provenance requiring a non-<zone> cast origin (Alex Wilder, Runaway).
+    // Ordered here alongside the other zone-specific cast-provenance arms and
+    // before the bare "if you cast it" handler.
+    if let Some((before, condition, rest)) =
+        scan_preceded(&lower, parse_cast_from_anywhere_other_than_intervening_if)
     {
         let pos = before.len();
         let clause_len = lower.len() - before.len() - rest.len();
@@ -5267,6 +5320,21 @@ fn extract_if_condition_with_card_name(
                 Some(TriggerCondition::WasType { card_type }),
             );
         }
+    }
+
+    // CR 603.2 + CR 400.7 + CR 303.4: "if an <attachment> you controlled was
+    // attached to it" — attachment-first look-back on the dying object (Dawn
+    // Evangel). Ordered before the subject-first zone-change-object filter
+    // condition ("if it was enchanted") since the two phrasings are disjoint.
+    if let Some((before, condition, rest)) =
+        scan_preceded(&lower, parse_attached_object_died_intervening_if)
+    {
+        let pos = before.len();
+        let clause_len = lower.len() - before.len() - rest.len();
+        return (
+            strip_condition_clause(text, pos, clause_len),
+            Some(condition),
+        );
     }
 
     if let Some(result) =
@@ -5906,6 +5974,44 @@ fn parse_zone_change_object_token_predicate(input: &str) -> OracleResult<'_, Tri
 fn map_attachment_kind_filter_prop(input: &str) -> OracleResult<'_, FilterProp> {
     let (rest, kinds) = parse_attachment_kind_disjunction(input)?;
     Ok((rest, attachment_kinds_filter_prop(kinds, None)))
+}
+
+/// CR 603.2 + CR 400.7 + CR 303.4: "if an <attachment> [you controlled] was
+/// attached to it" — the attachment-first look-back on the dying object (Dawn
+/// Evangel: "if an Aura you controlled was attached to it"). "it" is the
+/// triggering creature that died; the predicate asks whether that object had an
+/// attachment of the named kind — controlled by you when the possessive scope is
+/// present — at last-known information (CR 603.10a). Reduces to the SAME
+/// `ZoneChangeObjectMatchesFilter` + `HasAttachment` condition the subject-first
+/// "if it was enchanted" look-back produces (via
+/// `map_attachment_kind_filter_prop`), so no new runtime variant is needed — only
+/// the controller scope and the surface word order differ.
+fn parse_attached_object_died_intervening_if(input: &str) -> OracleResult<'_, TriggerCondition> {
+    let (rest, _) = alt((tag("if an "), tag("if a "))).parse(input)?;
+    let (rest, kind) = alt((
+        value(AttachmentKind::Aura, tag("aura")),
+        value(AttachmentKind::Equipment, tag("equipment")),
+    ))
+    .parse(rest)?;
+    let (rest, controller) = alt((
+        value(Some(ControllerRef::You), tag(" you controlled")),
+        value(
+            Some(ControllerRef::Opponent),
+            tag(" an opponent controlled"),
+        ),
+        value(None, tag("")),
+    ))
+    .parse(rest)?;
+    let (rest, _) = tag(" was attached to it").parse(rest)?;
+    let prop = attachment_kinds_filter_prop(vec![kind], controller);
+    Ok((
+        rest,
+        TriggerCondition::ZoneChangeObjectMatchesFilter {
+            origin: Some(Zone::Battlefield),
+            destination: Zone::Graveyard,
+            filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![prop])),
+        },
+    ))
 }
 
 fn try_extract_no_mana_spent_condition(

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -4917,7 +4917,7 @@ mod tests {
     /// (issue #2234).
     #[test]
     fn condition_as_long_as_bronze_horse_reports_known_gap_champions_helm_accepted() {
-        use crate::types::ability::{FilterProp, ShieldKind, TypedFilter};
+        use crate::types::ability::{FilterProp, ReplacementCondition, ShieldKind, TypedFilter};
         use crate::types::keywords::Keyword;
         use crate::types::replacements::ReplacementEvent;
         use crate::types::ContinuousModification;
@@ -4947,28 +4947,39 @@ mod tests {
             "expected gated damage-prevention replacement, got {:#?}",
             bronze.replacements
         );
-        // KNOWN GAP, pinned deliberately. Bronze Horse DOES report a swallowed
-        // `Condition_AsLongAs` — and did so in the shipped card data long before this
-        // change (verified against the pre-cutover full-pool export). The assertions
-        // above are why: the "as long as you control another creature" gate survives
-        // only inside `description` (a String), and is never lifted into a typed
-        // condition on the replacement. So the condition really is swallowed and the
-        // detector is right.
-        //
-        // This test previously asserted the OPPOSITE and passed — vacuously. It parses
-        // with an empty MTGJSON keyword list, so the "Trample" line fell through to an
-        // `Effect::Unimplemented`, which tripped the CARD-WIDE Unimplemented gate and
-        // silenced all fourteen detectors on the whole card. The green was the gate,
-        // not the parse. Per-unit suppression scopes that gate to the "Trample" line
-        // alone, so line 1 is now audited and the pre-existing gap is visible.
-        //
-        // Flip this assertion when the "as long as" gate is lifted into a typed
-        // replacement condition; until then it is a tripwire, not an endorsement.
+        // CR 611.3 + CR 614.1d: The "as long as you control another creature" gate is
+        // now LIFTED into a typed replacement condition. The shared
+        // `parse_inner_condition` reads "you control another creature" as
+        // `StaticCondition::IsPresent { Some(creature ∧ Another ∧ You) }`, and the
+        // `replacement_condition_from_static` bridge maps that presence check to
+        // `ReplacementCondition::IfControlsMatching { minimum: 1, .. }` — evaluated
+        // dynamically at each damage event, which is exactly the "as long as"
+        // continuous semantics. The detector therefore no longer reports a swallow.
+        // (This flips the prior deliberate tripwire, per its own instruction: the gate
+        // is no longer description-only.)
         assert!(
-            has_swallowed_detector(&bronze, "Condition_AsLongAs"),
-            "Bronze Horse's as-long-as gate is description-only, never typed: the swallow \
-             is real. Warnings: {:?}",
+            !has_swallowed_detector(&bronze, "Condition_AsLongAs"),
+            "Bronze Horse's as-long-as gate is now typed via IfControlsMatching; the \
+             Condition_AsLongAs swallow must clear. Warnings: {:?}",
             bronze.parse_warnings
+        );
+        assert!(
+            bronze.replacements.iter().any(|r| {
+                r.event == ReplacementEvent::DamageDone
+                    && matches!(
+                        &r.condition,
+                        Some(ReplacementCondition::IfControlsMatching { minimum, filter })
+                            if *minimum == 1
+                                && matches!(
+                                    filter,
+                                    TargetFilter::Typed(TypedFilter { properties, .. })
+                                        if properties.contains(&FilterProp::Another)
+                                )
+                    )
+            }),
+            "expected the prevention replacement to carry a typed IfControlsMatching gate \
+             over 'another creature you control', got {:#?}",
+            bronze.replacements
         );
 
         let helm = parse_named(

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -17948,11 +17948,19 @@ pub enum ReplacementCondition {
     /// `AbilityCondition::CastVariantPaid`. Evaluated against
     /// `GameObject.cast_variant_paid`. Used by Scarlet Spider (web-slinging).
     CastVariantPaid { variant: CastVariantPaid },
-    /// CR 603.4: "if you cast it from [zone]" — replacement applies only when
-    /// the source object was cast from the specified zone (e.g., Myojin's
-    /// "enters with an indestructible counter on it if you cast it from your
-    /// hand"). Evaluated against `GameObject.cast_from_zone`.
-    CastFromZone { zone: Zone },
+    /// CR 601.2 + CR 603.4: "if you cast it [from [zone]]" — replacement applies
+    /// only when the source object was cast. `zone: Some(z)` narrows to a specific
+    /// origin (e.g., Myojin's "enters with an indestructible counter on it if you
+    /// cast it from your hand"); `zone: None` is the zoneless "if you cast it"
+    /// (Nine-Lives Familiar) — cast from ANY zone, i.e. the object was cast at all
+    /// (a token or put-onto-battlefield entry is NOT cast and fails this gate).
+    /// One `Option<Zone>` parameterization on the CR 601.2 cast-provenance axis
+    /// rather than a separate zoneless-`WasCast` sibling. Evaluated against
+    /// `GameObject.cast_from_zone`.
+    CastFromZone {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        zone: Option<Zone>,
+    },
     /// CR 614.1d + CR 601: Gates a replacement on how the *entering* object
     /// (the event's `affected_object_id`) arrived — NOT the replacement source.
     /// Both halves reference the entering object, which distinguishes this from

--- a/crates/engine/tests/integration/dropped_intervening_if_gating_condition.rs
+++ b/crates/engine/tests/integration/dropped_intervening_if_gating_condition.rs
@@ -1,0 +1,607 @@
+//! "Dropped intervening-if / gating condition (condition: null)" — build-for-the-class.
+//!
+//! Each card below previously emitted its condition-bearing trigger / replacement
+//! / effect-clause with `condition: null` and a `SwallowedClause { Condition_If }`
+//! warning. The fixes route every game-state gate through the single
+//! `parse_inner_condition` authority (and its trigger/replacement/effect bridges),
+//! or through a source/event-referential seam mirroring the existing
+//! `parse_*_intervening_if` combinators.
+//!
+//! Oracle text is verbatim vs `data/card-data.json` / Scryfall. Each parse test
+//! names the assertion that flips when the fix is reverted (the condition returns
+//! to `None` AND the `Condition_If` swallow reappears). Runtime tests drive the
+//! real cast pipeline for the two most novel runtime-touching changes: Heir's
+//! `IfControlsMatching` presence gate and Nine-Lives' `CastFromZone { zone: None }`
+//! (the `Option<Zone>` widening's `cast_from_zone.is_some()` arm).
+//!
+//! THREE cards are DELIBERATELY out of scope and pinned as honest RED
+//! (swallowed) — `anchor_to_reality_*` and `heroic_return_*` at the bottom of
+//! this file, and `hawkeye_*_is_honest_red` in the A-series. Their gates are not
+//! resolvable intervening-if game-state conditions with the seams built today:
+//! Anchor compares a just-searched card's mana value (no runtime object-scope
+//! binding yet), Heroic Return uses a reflexive "enters this way" replacement
+//! (CR 614.1c), and Hawkeye's "if Hawkeye dealt damage to it this turn" names the
+//! DYING object (the trigger event's SOURCE, CR 400.7) for which no object-matching
+//! `TargetFilter` recipient exists yet (`EventTarget` resolves only a `DamageDealt`
+//! recipient, not a `ZoneChanged` source — CR 120.1). They are pinned so this
+//! change cannot silently mis-count them as fixed, and so any future half-fix
+//! trips a failing test.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle::{parse_oracle_text, ParsedAbilities};
+use engine::types::counter::CounterType;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+// ── Verbatim Oracle text ─────────────────────────────────────────────────────
+
+const BURNING_EYE_ZUBERA: &str = "When this creature dies, if 4 or more damage was dealt to it this turn, this creature deals 3 damage to any target.";
+const KAMI_OF_TRANSIENCE: &str = "Trample\nWhenever you cast an enchantment spell, put a +1/+1 counter on this creature.\nAt the beginning of each end step, if an enchantment was put into your graveyard from the battlefield this turn, you may return this card from your graveyard to your hand.";
+const NINE_LIVES_FAMILIAR: &str = "This creature enters with eight revival counters on it if you cast it.\nWhen this creature dies, if it had a revival counter on it, return it to the battlefield with one fewer revival counter on it at the beginning of the next end step.";
+const HAWKEYE: &str = "Reach\nWhenever a creature an opponent controls dies, if Hawkeye dealt damage to it this turn, draw a card.\n{T}: Hawkeye deals 1 damage to any target.";
+const ALEX_WILDER: &str = "Whenever Alex Wilder or another creature you control enters, if you cast it from anywhere other than your hand, it gets +2/+0 and gains haste until end of turn.\nEscape—{2}{R}, Exile three other cards from your graveyard. (You may cast this card from your graveyard for its escape cost.)";
+const DAWN_EVANGEL: &str = "Whenever a creature dies, if an Aura you controlled was attached to it, return target creature card with mana value 2 or less from your graveyard to your hand.";
+const HEIR_OF_THE_ANCIENT_FANG: &str = "This creature enters with a +1/+1 counter on it if you control a modified creature. (Equipment, Auras you control, and counters are modifications.)";
+const FEAST_OF_WORMS: &str = "Destroy target land. If that land was legendary, its controller sacrifices another land of their choice.";
+const HISOKA: &str =
+    "{2}{U}, Discard a card: Counter target spell if it has the same mana value as the discarded card.";
+const VANILLA: &str = "";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn has_condition_if_swallow(parsed: &ParsedAbilities) -> bool {
+    parsed.parse_warnings.iter().any(|w| {
+        format!("{w:?}").contains("SwallowedClause") && format!("{w:?}").contains("Condition_If")
+    })
+}
+
+fn parse(name: &str, oracle: &str, types: &[&str], subtypes: &[&str]) -> ParsedAbilities {
+    let ts: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+    let sts: Vec<String> = subtypes.iter().map(|s| s.to_string()).collect();
+    parse_oracle_text(oracle, name, &[], &ts, &sts)
+}
+
+// ══ A1 — Burning-Eye Zubera: amount-first passive damage-to-self this-turn ═════
+
+#[test]
+fn burning_eye_zubera_threshold_damage_dies_gate() {
+    let p = parse(
+        "Burning-Eye Zubera",
+        BURNING_EYE_ZUBERA,
+        &["Creature"],
+        &["Spirit"],
+    );
+    let cond = format!("{:?}", p.triggers[0].condition);
+    // Revert-failing: dropping the amount-first arm returns condition -> None.
+    assert!(
+        cond.contains("DamageDealtThisTurn")
+            && cond.contains("target: SelfRef")
+            && cond.contains("comparator: GE")
+            && cond.contains("Fixed { value: 4 }"),
+        "expected DamageDealtThisTurn>=4 to SelfRef, got {cond}"
+    );
+    assert!(
+        !has_condition_if_swallow(&p),
+        "Condition_If swallow must clear"
+    );
+}
+
+// ══ A2 — Kami of Transience: owner-scoped this-turn zone-transfer tally ════════
+
+#[test]
+fn kami_of_transience_owner_scoped_graveyard_tally() {
+    let p = parse(
+        "Kami of Transience",
+        KAMI_OF_TRANSIENCE,
+        &["Creature"],
+        &["Spirit"],
+    );
+    // The end-step trigger is the second one; the cast-enchantment trigger has no gate.
+    let cond = format!("{:?}", p.triggers[1].condition);
+    // Revert-failing: the owner axis must be Owned{You} (CR 404.1), not a controller
+    // filter — a control-changed enchantment you control but an opponent OWNS goes to
+    // the opponent's graveyard and must NOT satisfy this gate.
+    assert!(
+        cond.contains("ZoneChangeCountThisTurn")
+            && cond.contains("from: Some(Battlefield)")
+            && cond.contains("to: Some(Graveyard)")
+            && cond.contains("Enchantment")
+            && cond.contains("Owned { controller: You }"),
+        "expected owner-scoped Enchantment battlefield->graveyard tally, got {cond}"
+    );
+    assert!(
+        !has_condition_if_swallow(&p),
+        "Condition_If swallow must clear"
+    );
+}
+
+// ══ A3 — Nine-Lives dies: HadCounters (LKI) regression guard, no code change ═══
+
+#[test]
+fn nine_lives_dies_trigger_uses_lki_had_counters() {
+    let p = parse(
+        "Nine-Lives Familiar",
+        NINE_LIVES_FAMILIAR,
+        &["Creature"],
+        &["Cat"],
+    );
+    let cond = format!("{:?}", p.triggers[0].condition);
+    // Guards the LKI seam: a future refactor swapping `try_extract_had_counter_condition`
+    // for the live-read `try_extract_has_counter_condition` would flip HadCounters->HasCounters.
+    assert!(
+        cond.contains("HadCounters") && cond.contains("Generic(\"revival\")"),
+        "dies trigger must read last-known revival counters (HadCounters), got {cond}"
+    );
+}
+
+// ══ A4 — Hawkeye: dying-object damage look-back is honest RED (pinned) ═════════
+
+/// Hawkeye, Avenging Archer — honest RED. "Whenever a creature an opponent
+/// controls dies, if Hawkeye dealt damage to it this turn, draw a card": the "it"
+/// names the creature that DIED, which is the trigger event's SOURCE object
+/// (`extract_source_from_event(ZoneChanged)` — CR 400.7: it is a new object in
+/// the graveyard, referenced by LKI), NOT its `EventTarget`
+/// (`extract_target_object_from_event`, which yields `Some` only for a
+/// `DamageDealt` event — CR 120.1).
+///
+/// An earlier fix bound "it" to `TargetFilter::EventTarget`, which cleared the
+/// swallow but made the intervening-if silently ALWAYS-FALSE at runtime: a dies
+/// trigger carries a `ZoneChanged` event with no EventTarget, so the
+/// `DamageDealtThisTurn` look-back matched zero records and the gate could never
+/// hold — Hawkeye would never draw even after dealing the lethal damage. No
+/// object-matching `TargetFilter` resolves the trigger *source* object today
+/// (`TriggeringSource` is inert in `matches_target_filter`), so the dying-object
+/// recipient filter this gate needs does not exist yet.
+///
+/// Pin: this stays honest RED (swallowed `Condition_If`, no leaked always-false
+/// gate) until a dying-object recipient filter is built. Flip the assertions when
+/// that seam exists.
+#[test]
+fn hawkeye_dealt_damage_to_dying_object_is_honest_red() {
+    let p = parse(
+        "Hawkeye, Avenging Archer",
+        HAWKEYE,
+        &["Creature"],
+        &["Human", "Archer"],
+    );
+    let cond = format!("{:?}", p.triggers[0].condition);
+    // No broken always-false damage look-back leaked onto the dies trigger. The
+    // dying object is unresolvable as an EventTarget here, so the gate must NOT be
+    // wired to `DamageDealtThisTurn { target: EventTarget }` (which resolves to
+    // nothing on a ZoneChanged event). The condition stays dropped (`None`).
+    assert!(
+        !cond.contains("EventTarget") && !cond.contains("DamageDealtThisTurn"),
+        "Hawkeye's dies-trigger damage gate must NOT be wired to an unresolvable \
+         EventTarget look-back; condition must stay dropped, got {cond}"
+    );
+    assert!(
+        p.triggers[0].condition.is_none(),
+        "the dropped intervening-if leaves condition None (Mandatory shape), got {cond}"
+    );
+    // Reach-guard: the dies trigger + draw-a-card effect actually parsed, so the
+    // swallow below is a real dropped gate — not a card-wide Unimplemented
+    // short-circuit that would silence the detector for unrelated reasons.
+    let execute = format!("{:?}", p.triggers[0].execute);
+    assert!(
+        execute.contains("Draw"),
+        "the dies trigger's draw-a-card effect must parse, got {execute}"
+    );
+    // Honest RED: the dropped "if Hawkeye dealt damage to it this turn" gate is
+    // flagged as a swallowed condition, not silently ignored.
+    assert!(
+        has_condition_if_swallow(&p),
+        "Hawkeye's dying-object damage look-back must remain a flagged (RED) swallow \
+         until the dying-object recipient filter exists. Warnings: {:?}",
+        p.parse_warnings
+    );
+}
+
+// ══ B — Alex Wilder: cast from anywhere OTHER than a named zone ════════════════
+
+#[test]
+fn alex_wilder_cast_from_non_hand_zone() {
+    let p = parse(
+        "Alex Wilder, Runaway",
+        ALEX_WILDER,
+        &["Creature"],
+        &["Human"],
+    );
+    let cond = format!("{:?}", p.triggers[0].condition);
+    // Revert-failing: the And[WasCast, Not(WasCast{Hand})] carries both conjuncts.
+    // The positive WasCast excludes a never-cast token; the Not(Hand) excludes hand-casts.
+    assert!(
+        cond.contains("And")
+            && cond.contains("WasCast { zone: None")
+            && cond.contains("Not")
+            && cond.contains("zone: Some(Hand)"),
+        "expected And[WasCast, Not(WasCast{{Hand}})], got {cond}"
+    );
+    assert!(
+        !has_condition_if_swallow(&p),
+        "Condition_If swallow must clear"
+    );
+}
+
+// ══ C — Dawn Evangel: Aura you controlled attached to the dead object (LKI) ════
+
+#[test]
+fn dawn_evangel_your_aura_attached_lki() {
+    let p = parse(
+        "Dawn Evangel",
+        DAWN_EVANGEL,
+        &["Creature"],
+        &["Human", "Cleric"],
+    );
+    let cond = format!("{:?}", p.triggers[0].condition);
+    // Revert-failing: dropping the attachment-first seam returns condition -> None.
+    // HasAttachment{Aura, Some(You)} over the dying creature's battlefield->graveyard
+    // LKI is the same runtime shape the "if it was enchanted" look-back produces.
+    assert!(
+        cond.contains("ZoneChangeObjectMatchesFilter")
+            && cond.contains("destination: Graveyard")
+            && cond.contains("HasAttachment")
+            && cond.contains("kind: Aura")
+            && cond.contains("controller: Some(You)"),
+        "expected ZoneChangeObjectMatchesFilter HasAttachment{{Aura,You}}, got {cond}"
+    );
+    assert!(
+        !has_condition_if_swallow(&p),
+        "Condition_If swallow must clear"
+    );
+}
+
+// ══ D1 — Heir of the Ancient Fang: enters-with gated by control presence ══════
+
+#[test]
+fn heir_of_the_ancient_fang_controls_modified_gate() {
+    let p = parse(
+        "Heir of the Ancient Fang",
+        HEIR_OF_THE_ANCIENT_FANG,
+        &["Creature"],
+        &["Snake"],
+    );
+    let cond = format!("{:?}", p.replacements[0].condition);
+    // Revert-failing: dropping the IsPresent -> IfControlsMatching bridge arm returns
+    // condition -> None (Mandatory) so Heir would ALWAYS enter with the counter.
+    assert!(
+        cond.contains("IfControlsMatching")
+            && cond.contains("Modified")
+            && cond.contains("controller: Some(You)"),
+        "expected IfControlsMatching over a modified creature you control, got {cond}"
+    );
+    assert!(
+        !has_condition_if_swallow(&p),
+        "Condition_If swallow must clear"
+    );
+}
+
+// ══ D2 — Nine-Lives enters: zoneless "if you cast it" -> CastFromZone{None} ════
+
+#[test]
+fn nine_lives_enters_gated_on_cast() {
+    let p = parse(
+        "Nine-Lives Familiar",
+        NINE_LIVES_FAMILIAR,
+        &["Creature"],
+        &["Cat"],
+    );
+    let repl = p
+        .replacements
+        .iter()
+        .find(|r| {
+            r.execute.as_ref().is_some_and(|e| {
+                matches!(
+                    &*e.effect,
+                    engine::types::ability::Effect::PutCounter { .. }
+                )
+            })
+        })
+        .expect("enters-with-counters replacement must exist");
+    let cond = format!("{:?}", repl.condition);
+    // Revert-failing: without the "you cast it" -> WasCast{None} -> CastFromZone{None}
+    // wiring the condition returns to None (Mandatory), so a non-cast entry would
+    // wrongly gain the 8 counters.
+    assert!(
+        cond.contains("CastFromZone { zone: None }"),
+        "expected CastFromZone{{zone:None}} (cast from anywhere), got {cond}"
+    );
+    assert!(
+        !has_condition_if_swallow(&p),
+        "Condition_If swallow must clear"
+    );
+}
+
+// ══ E1 — Feast of Worms: leading LKI supertype gate on the destroyed land ═════
+
+#[test]
+fn feast_of_worms_legendary_lki_gate() {
+    let p = parse("Feast of Worms", FEAST_OF_WORMS, &["Sorcery"], &[]);
+    let sub = p.abilities[0]
+        .sub_ability
+        .as_ref()
+        .expect("second-clause sub-ability must exist");
+    let cond = format!("{:?}", sub.condition);
+    // Revert-failing: dropping the "if that land was <supertype>" arm returns the
+    // sub-ability condition -> None. use_lki:true reads the land at last-known info.
+    assert!(
+        cond.contains("TargetMatchesFilter")
+            && cond.contains("HasSupertype")
+            && cond.contains("Legendary")
+            && cond.contains("use_lki: true"),
+        "expected LKI Legendary supertype gate on the sacrifice sub, got {cond}"
+    );
+    // The gated effect itself parses (controller sacrifices another land).
+    assert!(
+        format!("{:?}", sub.effect).contains("Sacrifice"),
+        "the gated sub-effect must be a Sacrifice, got {:?}",
+        sub.effect
+    );
+    assert!(
+        !has_condition_if_swallow(&p),
+        "Condition_If swallow must clear"
+    );
+}
+
+// ══ E2 — Hisoka: target MV == cost-paid (discarded) object MV ═════════════════
+
+#[test]
+fn hisoka_target_mv_equals_discarded_mv() {
+    let p = parse(
+        "Hisoka, Minamo Sensei",
+        HISOKA,
+        &["Creature", "Legendary"],
+        &["Human", "Wizard"],
+    );
+    let cond = format!("{:?}", p.abilities[0].condition);
+    // Revert-failing: dropping the "it has the same mana value as the discarded card"
+    // combinator returns condition -> None. Both operands are ObjectManaValue refs
+    // (Target vs CostPaidObject), no fixed threshold.
+    assert!(
+        cond.contains("QuantityCheck")
+            && cond.contains("ObjectManaValue { scope: Target }")
+            && cond.contains("comparator: EQ")
+            && cond.contains("ObjectManaValue { scope: CostPaidObject }"),
+        "expected QuantityCheck ManaValue(Target) EQ ManaValue(CostPaidObject), got {cond}"
+    );
+    assert!(
+        !has_condition_if_swallow(&p),
+        "Condition_If swallow must clear"
+    );
+}
+
+// ══ D1 runtime — presence gate flips the enters-with counter ══════════════════
+
+/// Positive reach-guard: Heir cast while controlling a modified creature (a
+/// creature bearing a +1/+1 counter, CR 700.9) enters WITH its +1/+1 counter.
+#[test]
+fn heir_runtime_modified_present_gains_counter() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain).with_life(P0, 20);
+    // A modified creature you control: a vanilla bear carrying a +1/+1 counter.
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    scenario.with_counter(bear, CounterType::Plus1Plus1, 1);
+    let heir = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Heir of the Ancient Fang",
+            1,
+            1,
+            HEIR_OF_THE_ANCIENT_FANG,
+        )
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 0,
+        })
+        .id();
+    let mut runner = scenario.build();
+    let outcome = runner.cast(heir).resolve();
+    assert_eq!(
+        outcome.zone_of(heir),
+        Zone::Battlefield,
+        "Heir must resolve to the battlefield"
+    );
+    assert_eq!(
+        outcome.counters(heir, CounterType::Plus1Plus1),
+        1,
+        "with a modified creature present, Heir must enter with a +1/+1 counter"
+    );
+}
+
+/// Revert-failing veto: Heir cast while controlling NO modified creature enters
+/// with ZERO counters. Reverting the `IsPresent -> IfControlsMatching` bridge makes
+/// the replacement Mandatory, so this cast would wrongly gain the counter. Paired
+/// with the positive above (a real placement), this is not a vacuous negative.
+#[test]
+fn heir_runtime_no_modified_no_counter() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain).with_life(P0, 20);
+    // An UNmodified creature you control (no counters, not equipped/enchanted).
+    scenario.add_creature(P0, "Grizzly Bears", 2, 2);
+    let heir = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Heir of the Ancient Fang",
+            1,
+            1,
+            HEIR_OF_THE_ANCIENT_FANG,
+        )
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 0,
+        })
+        .id();
+    let mut runner = scenario.build();
+    let outcome = runner.cast(heir).resolve();
+    assert_eq!(
+        outcome.zone_of(heir),
+        Zone::Battlefield,
+        "Heir must resolve to the battlefield"
+    );
+    assert_eq!(
+        outcome.counters(heir, CounterType::Plus1Plus1),
+        0,
+        "with no modified creature, Heir must enter with no +1/+1 counter"
+    );
+}
+
+// ══ D2 runtime — cast entry satisfies CastFromZone{None} and places counters ══
+
+/// Positive reach-guard exercising the `CastFromZone { zone: None }` runtime arm
+/// (`cast_from_zone.is_some()`): a hard cast of Nine-Lives from hand sets
+/// `cast_from_zone = Some(Hand)`, so the zoneless gate holds and the 8 revival
+/// counters are placed. Proves the widened `Option<Zone>` evaluator's `None` arm
+/// returns true for a real cast (a bug that returned false would place 0).
+#[test]
+fn nine_lives_runtime_cast_gains_revival_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain).with_life(P0, 20);
+    let familiar = scenario
+        .add_creature_to_hand_from_oracle(P0, "Nine-Lives Familiar", 0, 3, NINE_LIVES_FAMILIAR)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 0,
+        })
+        .id();
+    let mut runner = scenario.build();
+    let outcome = runner.cast(familiar).resolve();
+    assert_eq!(
+        outcome.zone_of(familiar),
+        Zone::Battlefield,
+        "the cast Nine-Lives must resolve onto the battlefield"
+    );
+    assert_eq!(
+        outcome.counters(familiar, CounterType::Generic("revival".to_string())),
+        8,
+        "a cast Nine-Lives (cast_from_zone = Some) must enter with eight revival counters"
+    );
+}
+
+/// Control (NOT a gate discriminator): `add_creature_from_oracle` seeds a permanent
+/// directly onto the battlefield, bypassing the ETB replacement pipeline, so it
+/// carries no revival counters regardless of the gate. Paired with the cast
+/// positive above, it proves the 8 counters in that test come from the cast
+/// pipeline + replacement (not from seeding). The condition-gate discrimination for
+/// D2 lives in the PARSE test `nine_lives_enters_gated_on_cast` (revert → the
+/// condition returns to `None`/Mandatory); a true runtime negative would require
+/// reanimating a fresh non-cast object through the pipeline, which the harness does
+/// not offer cleanly.
+#[test]
+fn nine_lives_runtime_noncast_entry_has_no_revival_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain).with_life(P0, 20);
+    let familiar = scenario
+        .add_creature_from_oracle(P0, "Nine-Lives Familiar", 0, 3, NINE_LIVES_FAMILIAR)
+        .id();
+    let runner = scenario.build();
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&familiar)
+            .unwrap()
+            .counters
+            .get(&CounterType::Generic("revival".to_string()))
+            .copied()
+            .unwrap_or(0),
+        0,
+        "a directly-seeded (non-cast) Nine-Lives must carry no revival counters"
+    );
+}
+
+// ══ Vanilla sanity for the runtime harness (self-check) ═══════════════════════
+
+#[test]
+fn vanilla_control_creature_is_not_modified() {
+    // Guards the D1 negative fixture: a bare creature must not be "modified", else
+    // heir_runtime_no_modified_no_counter would be vacuous.
+    let p = parse("Grizzly Bears", VANILLA, &["Creature"], &["Bear"]);
+    assert!(p.replacements.is_empty() && p.triggers.is_empty());
+}
+
+// ══ Pinned KNOWN GAPS — honest-RED cards in this backlog category ═════════════
+//
+// Two cards from the 605-card "Dropped intervening-if / gating condition"
+// backlog are DELIBERATELY left unsupported (swallowed / RED), because their
+// gates are NOT intervening-if game-state conditions and belong to separate,
+// unbuilt seams. Pinning them here keeps them from being silently mis-counted as
+// "fixed" by this change and turns any accidental future half-fix into a failing
+// tripwire (flip the assertion when the real seam is built).
+
+const ANCHOR_TO_REALITY: &str = "As an additional cost to cast this spell, sacrifice an artifact or creature.\nSearch your library for an Equipment or Vehicle card, put that card onto the battlefield, then shuffle. If it has mana value less than the sacrificed permanent's mana value, scry 2.";
+const HEROIC_RETURN: &str = "This spell costs {2} less to cast if a creature is attacking you.\nReturn target creature card from your graveyard to the battlefield. If a Hero enters this way, it enters with two additional +1/+1 counters on it.";
+
+/// Anchor to Reality — honest RED. "If it has mana value less than the sacrificed
+/// permanent's mana value, scry 2" compares the just-SEARCHED/placed card's mana
+/// value (CR 608.2c anaphor, not a target) to the cost-paid permanent's. Anchor
+/// declares no object target and the searched card has no runtime object-scope
+/// binding (search / change-zone never populate `effect_context_object`), so the
+/// shared `parse_it_mana_value_vs_cost_paid_object` combinator is intentionally
+/// NOT wired for this leading surface (only the Hisoka target-anaphor suffix is).
+///
+/// Revert-failing: re-adding the leading-`if` arm would parse Anchor "clean" (no
+/// swallow) with a `QuantityCheck` whose LHS is `ObjectManaValue { Target }` — a
+/// scope that resolves to nothing here — flipping this pin. Honest RED (swallowed,
+/// with no leaked mana-value gate) is correct until the searched-object binding
+/// exists.
+#[test]
+fn anchor_to_reality_dynamic_mv_gate_is_honest_red() {
+    let p = parse("Anchor to Reality", ANCHOR_TO_REALITY, &["Artifact"], &[]);
+    let abilities = format!("{:?}", p.abilities);
+    // No broken dynamic-MV gate leaked into the ability tree.
+    assert!(
+        !abilities.contains("ObjectManaValue") && !abilities.contains("QuantityCheck"),
+        "Anchor's scry gate must NOT be wired to a target-scoped ObjectManaValue \
+         (unresolvable here); got {abilities}"
+    );
+    // Reach-guard: the search + scry pipeline actually parsed (so the swallow below
+    // is a real dropped gate, not a card-wide Unimplemented short-circuit).
+    assert!(
+        abilities.contains("SearchLibrary") && abilities.contains("Scry"),
+        "the search->scry effect chain must parse, got {abilities}"
+    );
+    // Honest RED: the dropped mana-value gate is flagged, not silently ignored.
+    assert!(
+        has_condition_if_swallow(&p),
+        "Anchor's dynamic-MV scry gate must remain a flagged (RED) swallow until the \
+         searched-object runtime binding exists. Warnings: {:?}",
+        p.parse_warnings
+    );
+}
+
+/// Heroic Return — honest RED. "If a Hero enters this way, it enters with two
+/// additional +1/+1 counters" is a REFLEXIVE replacement created during the
+/// spell's resolution (CR 614.1c), gating a bonus on the entering RETURNED
+/// creature being a Hero — not a game-state intervening-if on the spell. The
+/// intervening-if seam this change targets does not model reflexive
+/// enters-this-way replacements (the enters-with-counters parser mis-attaches an
+/// ungated rider to the spell's own `SelfRef`, which never enters), so this card
+/// is explicitly out of scope and left RED.
+///
+/// Pin: flip this when a real "if a <type> enters this way" reflexive-replacement
+/// seam is built. Until then, asserting the swallow persists prevents mis-marking
+/// Heroic Return as fixed by this change.
+#[test]
+fn heroic_return_enters_this_way_is_honest_red() {
+    let p = parse("Heroic Return", HEROIC_RETURN, &["Sorcery"], &[]);
+    // Honest RED: the "if a Hero enters this way" rider is flagged as a dropped
+    // condition, not modeled as a working typed gate.
+    assert!(
+        has_condition_if_swallow(&p),
+        "Heroic Return's 'if a Hero enters this way' reflexive rider must remain a \
+         flagged (RED) swallow — it is out of scope for the intervening-if seam. \
+         Warnings: {:?}",
+        p.parse_warnings
+    );
+    // The reflexive gate was NOT lifted into a typed condition: every replacement
+    // the enters-with-counters parser produced here is still ungated
+    // (`condition: None`, Mandatory) — the "if a Hero enters this way" gate is
+    // dropped, matching the swallow above. (If a future seam models it, this
+    // `condition` becomes `Some(..)` and the assertion flips, per the pin.)
+    assert!(
+        p.replacements.iter().all(|r| r.condition.is_none()),
+        "no typed enters-this-way gate should exist yet; every rider stays ungated, \
+         got {:?}",
+        p.replacements
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -111,6 +111,7 @@ mod dragonstorm_forecaster_named_or_tutor;
 mod draw_from_general_post_replacement;
 mod dream_salvage_target_opponent_discards;
 mod dredgers_insight_mill_from_among;
+mod dropped_intervening_if_gating_condition;
 mod druid_of_purification_destroy_chosen_4780;
 mod duskmantle_seer_each_player_reveal;
 mod elemental_spectacle_regression;

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4760
-- **Total card appearances across root causes:** 4794 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4752
+- **Total card appearances across root causes:** 4786 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -13,7 +13,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
 | 1 | Relative-clause / filter restriction on target dropped | 748 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
-| 2 | Dropped intervening-if / gating condition (condition: null) | 606 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
+| 2 | Dropped intervening-if / gating condition (condition: null) | 598 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
 | 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 330 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
@@ -807,7 +807,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 2. Dropped intervening-if / gating condition (condition: null)  (605 cards)
+### 2. Dropped intervening-if / gating condition (condition: null)  (597 cards)
 
 **Signature.** Trigger/static/replacement/spell condition left null though Oracle has an 'if/while/as long as/unless' game-state gate; the effect resolves unconditionally (CR 603.4 / 608.2c).
 
@@ -826,7 +826,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Ajani, Nacatl Avenger
 - Akuta, Born of Ash
 - Alacrian Jaguar
-- Alex Wilder, Runaway
 - Amalia Benavides Aguirre
 - Anax, Hardened in the Forge
 - Anchor to Reality
@@ -887,7 +886,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Bronze Horse
 - Bull-Rush Bruiser
 - Bulwark Ox
-- Burning-Eye Zubera
 - Cache Grab
 - Calamity of the Titans
 - Call to Arms
@@ -925,7 +923,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Cursed Scroll
 - Daredevil Dragster
 - Daredevil, Man Without Fear
-- Dawn Evangel
 - Dead Ringers
 - Death of a Thousand Stings
 - Death's Caress
@@ -983,7 +980,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Fated Clash
 - Fear of Immobility
 - Feast of Blood
-- Feast of Worms
 - Feast on the Fallen
 - Feed the Infection
 - Festival
@@ -1046,7 +1042,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Hawkeye, Avenging Archer
 - Head to Head
 - Hedron-Field Purists
-- Heir of the Ancient Fang
 - Helicarrier Strike
 - Hellkite Hatchling
 - Henge Walker
@@ -1058,7 +1053,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Heroic Teamwork
 - Hidetsugu's Second Rite
 - Hidetsugu, Devouring Chaos
-- Hisoka, Minamo Sensei
 - Hixus, Prison Warden
 - Hobgoblin Captain
 - Holistic Wisdom
@@ -1097,7 +1091,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Kaervek's Purge
 - Kaervek's Torch
 - Kaito Shizuki
-- Kami of Transience
 - Kavu Runner
 - Kezzerdrix
 - Kjeldoran Guard
@@ -1174,7 +1167,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Nightshade Assassin
 - Nikara, Lair Scavenger
 - Nimbus Champion
-- Nine-Lives Familiar
 - No Quarter
 - Norn's Decree
 - Norn's Fetchling


### PR DESCRIPTION
## Summary
Fixes the "Dropped intervening-if / gating condition (condition: null)" misparse (backlog RC2) for the class; verified 11 sample card(s) from the 9 focus sets. Removed the fixed cards from docs/parser-misparse-backlog.md.

## Files changed
- crates/engine/src/parser/oracle_nom/condition.rs
- crates/engine/src/parser/oracle_trigger.rs
- crates/engine/src/parser/oracle_replacement.rs
- crates/engine/src/parser/oracle_effect/conditions.rs
- crates/engine/src/parser/oracle_target.rs
- crates/engine/src/types/ability.rs
- crates/engine/src/game/replacement.rs
- crates/engine/src/game/ability_scan.rs
- crates/engine/src/parser/swallow_check.rs
- crates/engine/tests/integration/dropped_intervening_if_gating_condition.rs
- crates/engine/tests/integration/main.rs
- docs/parser-misparse-backlog.md

Note: `crates/engine/src/parser/oracle_target.rs` is included because `oracle_effect/conditions.rs` imports `parse_cost_paid_mana_value_reference` from it, which is `pub(crate)` only after this change; the file is a required, compile-load-bearing part of the fix.

## CR references
- CR 120.1
- CR 120.2a
- CR 202.3
- CR 205.3
- CR 205.4a
- CR 303.4
- CR 400.7
- CR 404.1
- CR 601.2
- CR 603.2
- CR 603.4
- CR 603.10a
- CR 608.2k
- CR 611.3
- CR 614.1c
- CR 614.1d
- CR 700.9

## Implementation method (required)
Method: /engine-implementer

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

Tier: Frontier

## Verification
- `cargo fmt --all` — clean (exit 0)
- `./scripts/check-parser-combinators.sh` — PASS (Gate A + Gate G, exit 0)
- `cargo clippy --all-targets -- -D warnings` — clean (exit 0)
- `cargo test -p engine` — 3282 passed, 0 failed, 2 ignored (exit 0); new dropped_intervening_if_gating_condition module 17/17 pass
- `./scripts/gen-card-data.sh` — regenerated card-data.json (~35367 cards, standard 97.1%) (exit 0)
- `cargo coverage` — 8 wired cards supported:true gap:0 with correct typed AST; 3 deferred cards honest-RED (exit 0)
- `cargo semantic-audit data` — all 8 wired cards clean; only deferred Hawkeye carries the intended honest-RED DroppedCondition (exit 0)

## Gate A
Gate A PASS head=ffc0ebc407f75e891bd07dc639a868889d1281e3 base=2f4608051c4d694d3ec3fd59c3e68c26d3746559

## Anchored on
- crates/engine/src/parser/oracle_trigger.rs:4629 — existing `parse_cast_from_zone_intervening_if`; the new "cast from anywhere other than <zone>" arm is a sibling combinator registered beside it.
- crates/engine/src/parser/oracle_nom/condition.rs:5562 — existing `parse_permanent_put_into_your_hand_from_battlefield_this_turn`; the new owner-scoped battlefield→graveyard combinator mirrors it (CR 404.1 `Owned{You}`).
- crates/engine/src/game/replacement.rs:4815 — existing `ReplacementCondition::CastFromZone` eval arm, parameterized on the CR 601.2 cast-provenance axis to `Option<Zone>` (Some=narrowed origin, None=cast from anywhere).

## Final review-impl
Final review-impl PASS head=ffc0ebc407f75e891bd07dc639a868889d1281e3

## Claimed parse impact
- Alex Wilder, Runaway
- Burning-Eye Zubera
- Dawn Evangel
- Feast of Worms
- Heir of the Ancient Fang
- Hisoka, Minamo Sensei
- Kami of Transience
- Nine-Lives Familiar

## Validation Failures
None.

## CI Failures
None.
