### PR TITLE
ship/t166 cascade exile pipeline

### DIFF
--- a/crates/engine/src/game/effects/cascade.rs
+++ b/crates/engine/src/game/effects/cascade.rs
@@ -1,5 +1,4 @@
 use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
-use crate::game::zones;
 use crate::types::ability::{Effect, EffectError, EffectKind, LibraryPosition, ResolvedAbility};
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
@@ -60,100 +59,169 @@ pub fn resolve(
         return Err(EffectError::PlayerNotFound);
     }
 
-    let mut exiled_misses: Vec<ObjectId> = Vec::new();
-    let mut hit_card: Option<ObjectId> = None;
-
-    // CR 702.85a: Exile one at a time until a nonland with MV < source_mv is
-    // exiled, or the library is exhausted. Each iteration reads `library[0]`
-    // off the live player record so any replacement effect that mutated the
-    // library mid-loop is observed.
-    while let Some(card_id) = state
-        .players
-        .iter()
-        .find(|p| p.id == controller)
-        .and_then(|p| p.library.front().copied())
-    {
-        zones::move_to_zone(state, card_id, Zone::Exile, events);
-
-        // CR 614.1: A replacement effect may have moved the card to a zone
-        // other than Exile, or removed it entirely. Only count it as exiled
-        // (a hit or a miss) if it actually landed in Exile.
-        let zone_after = state.objects.get(&card_id).map(|o| o.zone);
-        if zone_after != Some(Zone::Exile) {
-            // Replacement redirected or removed; do not loop on the same card.
-            // Re-read the next library top on the next iteration.
-            if state
-                .players
-                .iter()
-                .find(|p| p.id == controller)
-                .is_some_and(|p| p.library.front().copied() == Some(card_id))
-            {
-                // Defensive: if the card is somehow still on top, break to
-                // avoid an infinite loop.
-                break;
-            }
-            continue;
-        }
-
-        let is_hit = state.objects.get(&card_id).is_some_and(|obj| {
-            let is_land = obj.card_types.core_types.contains(&CoreType::Land);
-            // CR 202.3d + CR 709.4b: the exiled card is off the stack, so a split
-            // card's mana value is its combined halves (front-only would misjudge
-            // the < source_mv hit test). No-ops for single-face cards.
-            let mv = obj.effective_mana_value();
-            !is_land && mv < source_mv
-        });
-
-        if is_hit {
-            hit_card = Some(card_id);
-            break;
-        } else {
-            exiled_misses.push(card_id);
-        }
-    }
-
-    match hit_card {
-        Some(hit) => {
-            events.push(GameEvent::EffectResolved {
-                kind: EffectKind::from(&ability.effect),
-                source_id: ability.source_id,
-                subject: None,
-            });
-            // CR 702.85a: Offer the cast. The caster's response is handled in
-            // `engine_resolution_choices` — we do not bottom-shuffle misses
-            // here because a rejection at cast time (X makes resulting MV
-            // ineligible) must still bottom-shuffle them together with the
-            // hit, and that path runs from `casting_costs`.
-            state.waiting_for = WaitingFor::CastOffer {
-                player: controller,
-                kind: CastOfferKind::Cascade {
-                    hit_card: hit,
-                    exiled_misses,
-                    source_mv,
-                    source_id: ability.source_id,
-                },
-            };
-        }
-        None => {
-            // CR 702.85a + CR 616.1: Library exhausted with no eligible hit.
-            // The completion marker rides the batch so CascadeMissed and
-            // EffectResolved fire only after every randomized bottom placement
-            // (including any redirected placements) has settled.
-            shuffle_to_bottom(
-                state,
-                &exiled_misses,
-                ability.source_id,
-                Some(BatchCompletion::CascadeBottomComplete {
-                    controller,
-                    source_id: ability.source_id,
-                    exiled_count: exiled_misses.len() as u32,
-                }),
-                events,
-            );
-        }
-    }
+    let _ = continue_exile_loop(
+        state,
+        controller,
+        ability.source_id,
+        source_mv,
+        Vec::new(),
+        events,
+    );
 
     Ok(())
+}
+
+/// CR 702.85a + CR 614.1 + CR 616.1: Propose one Library-to-Exile event at a
+/// time. The typed completion carries the loop cursor across a replacement
+/// choice, so the next top card and the cascade tail cannot run early.
+pub(crate) fn continue_exile_loop(
+    state: &mut GameState,
+    controller: crate::types::player::PlayerId,
+    source_id: ObjectId,
+    source_mv: u32,
+    exiled_misses: Vec<ObjectId>,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    let Some(current_card) = state
+        .players
+        .iter()
+        .find(|player| player.id == controller)
+        .and_then(|player| player.library.front().copied())
+    else {
+        return finish_without_hit(state, controller, source_id, exiled_misses, events);
+    };
+
+    zone_pipeline::move_objects_simultaneously_then(
+        state,
+        vec![ZoneMoveRequest::effect(
+            current_card,
+            Zone::Exile,
+            source_id,
+        )],
+        Some(BatchCompletion::CascadeExileLoopComplete {
+            controller,
+            source_id,
+            source_mv,
+            exiled_misses,
+            current_card,
+        }),
+        events,
+    )
+}
+
+/// CR 702.85a + CR 614.1 + CR 616.1: Classify one settled cascade exile after
+/// its replacement-safe delivery. A redirected card is not a hit or miss; a
+/// card still on top ends the loop defensively just as the former raw loop did.
+pub(crate) fn complete_exile_loop_step(
+    state: &mut GameState,
+    controller: crate::types::player::PlayerId,
+    source_id: ObjectId,
+    source_mv: u32,
+    mut exiled_misses: Vec<ObjectId>,
+    current_card: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    if state.objects.get(&current_card).map(|object| object.zone) != Some(Zone::Exile) {
+        let current_card_is_still_top = state
+            .players
+            .iter()
+            .find(|player| player.id == controller)
+            .is_some_and(|player| player.library.front().copied() == Some(current_card));
+        return if current_card_is_still_top {
+            finish_without_hit(state, controller, source_id, exiled_misses, events)
+        } else {
+            continue_exile_loop(
+                state,
+                controller,
+                source_id,
+                source_mv,
+                exiled_misses,
+                events,
+            )
+        };
+    }
+
+    let is_hit = state.objects.get(&current_card).is_some_and(|object| {
+        let is_land = object.card_types.core_types.contains(&CoreType::Land);
+        // CR 202.3d + CR 709.4b: the exiled card is off the stack, so a split
+        // card's mana value is its combined halves (front-only would misjudge
+        // the < source_mv hit test). No-ops for single-face cards.
+        let mana_value = object.effective_mana_value();
+        !is_land && mana_value < source_mv
+    });
+    if is_hit {
+        return finish_with_hit(
+            state,
+            controller,
+            source_id,
+            source_mv,
+            exiled_misses,
+            current_card,
+            events,
+        );
+    }
+
+    exiled_misses.push(current_card);
+    continue_exile_loop(
+        state,
+        controller,
+        source_id,
+        source_mv,
+        exiled_misses,
+        events,
+    )
+}
+
+/// CR 702.85a: After the first eligible card is delivered to exile, expose the
+/// cast offer exactly once. Declined or rejected casts bottom this hit together
+/// with the carried miss pile in `engine_resolution_choices`/`casting_costs`.
+fn finish_with_hit(
+    state: &mut GameState,
+    controller: crate::types::player::PlayerId,
+    source_id: ObjectId,
+    source_mv: u32,
+    exiled_misses: Vec<ObjectId>,
+    hit_card: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::Cascade,
+        source_id,
+        subject: None,
+    });
+    state.waiting_for = WaitingFor::CastOffer {
+        player: controller,
+        kind: CastOfferKind::Cascade {
+            hit_card,
+            exiled_misses,
+            source_mv,
+            source_id,
+        },
+    };
+    BatchMoveResult::Done
+}
+
+/// CR 702.85a + CR 616.1: With no eligible card, finish only after every miss
+/// settles into the randomly ordered Library-bottom batch.
+fn finish_without_hit(
+    state: &mut GameState,
+    controller: crate::types::player::PlayerId,
+    source_id: ObjectId,
+    exiled_misses: Vec<ObjectId>,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    let exiled_count = exiled_misses.len() as u32;
+    shuffle_to_bottom(
+        state,
+        &exiled_misses,
+        source_id,
+        Some(BatchCompletion::CascadeBottomComplete {
+            controller,
+            source_id,
+            exiled_count,
+        }),
+        events,
+    )
 }
 
 /// CR 702.85a + CR 401.4: Put cards on the bottom of the player's library in

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -5944,6 +5944,21 @@ pub(crate) fn run_batch_completion(
 ) -> crate::game::zone_pipeline::BatchMoveResult {
     use crate::types::game_state::BatchCompletion;
     match completion {
+        BatchCompletion::CascadeExileLoopComplete {
+            controller,
+            source_id,
+            source_mv,
+            exiled_misses,
+            current_card,
+        } => effects::cascade::complete_exile_loop_step(
+            state,
+            controller,
+            source_id,
+            source_mv,
+            exiled_misses,
+            current_card,
+            events,
+        ),
         BatchCompletion::CascadeBottomComplete {
             controller,
             source_id,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1848,6 +1848,16 @@ pub struct PendingBatchDeliveries {
 /// pattern.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BatchCompletion {
+    /// CR 702.85a + CR 614.1 + CR 616.1: One proposed cascade exile settled.
+    /// Keep the current card, source threshold, controller, and already-exiled
+    /// misses with the batch so a replacement choice resumes the loop correctly.
+    CascadeExileLoopComplete {
+        controller: PlayerId,
+        source_id: ObjectId,
+        source_mv: u32,
+        exiled_misses: Vec<ObjectId>,
+        current_card: ObjectId,
+    },
     /// CR 702.85a + CR 616.1: A no-hit Cascade's randomized bottom batch has
     /// settled (including any redirected cards), so its completion events may
     /// fire exactly once.

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -7217,6 +7217,176 @@ fn cascade_bottom_batch_pauses_for_library_redirect_before_completion() {
     );
 }
 
+/// W-166 (red first): Cascade's one-card Library-to-Exile delivery must park
+/// the loop before its hit offer or miss-tail runs when CR 616.1 requires a
+/// replacement choice.
+#[test]
+fn cascade_library_exile_redirect_pauses_before_hit_tail() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Cascade Exile Redirect Source", 1, 1)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let miss = scenario
+        .add_spell_to_library_top(P0, "Cascade Redirect Miss", true)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let hit = scenario
+        .add_spell_to_library_top(P0, "Cascade Redirect Hit", false)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    scenario
+        .add_creature(P0, "Cascade Exile To Hand Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(
+            redirect_moved_to(Zone::Exile, Zone::Hand)
+                .valid_card(TargetFilter::Typed(TypedFilter::new(TypeFilter::Instant))),
+        );
+    scenario
+        .add_creature(P0, "Cascade Exile To Graveyard Redirect", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(
+            redirect_moved_to(Zone::Exile, Zone::Graveyard)
+                .valid_card(TargetFilter::Typed(TypedFilter::new(TypeFilter::Instant))),
+        );
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![miss, hit];
+    let ability = ResolvedAbility::new(Effect::Cascade, vec![], source, P0);
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("cascade reaches its first replacement-safe exile");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&miss].zone, Zone::Library);
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Library);
+    assert!(
+        !initial_events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::Cascade,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "the hit offer tail must not precede the replacement choice"
+    );
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the settled first exile resumes the cascade loop");
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::CastOffer {
+            player: P0,
+            kind:
+                engine::types::game_state::CastOfferKind::Cascade {
+                    hit_card,
+                    exiled_misses,
+                    source_mv: 4,
+                    source_id,
+                },
+        } if hit_card == hit && exiled_misses.is_empty() && source_id == source
+    ));
+    assert_eq!(runner.state().objects[&miss].zone, Zone::Hand);
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Exile);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Cascade,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the settled loop exposes the cascade tail exactly once"
+    );
+}
+
+/// W-166-REG: Without replacements Cascade still finds its first eligible hit,
+/// carries every prior miss, and puts both cards on the library bottom when the
+/// controller declines the cast offer.
+#[test]
+fn cascade_exile_loop_stays_synchronous_without_replacements() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Synchronous Cascade Exile Source", 1, 1)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let miss = scenario
+        .add_spell_to_library_top(P0, "Synchronous Cascade Miss", true)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let hit = scenario
+        .add_spell_to_library_top(P0, "Synchronous Cascade Hit", true)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![miss, hit];
+    let mut events = Vec::new();
+    resolve_ability_chain(
+        runner.state_mut(),
+        &ResolvedAbility::new(Effect::Cascade, vec![], source, P0),
+        &mut events,
+        0,
+    )
+    .expect("unredirected cascade resolves synchronously to its offer");
+    assert!(matches!(
+        &runner.state().waiting_for,
+        WaitingFor::CastOffer {
+            kind:
+                engine::types::game_state::CastOfferKind::Cascade {
+                    hit_card,
+                    exiled_misses,
+                    source_mv: 4,
+                    source_id,
+                },
+            ..
+        } if *hit_card == hit && exiled_misses == &vec![miss] && *source_id == source
+    ));
+    assert_eq!(runner.state().objects[&miss].zone, Zone::Exile);
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Exile);
+
+    let declined = runner
+        .act(GameAction::CascadeChoice {
+            choice: engine::types::actions::CastChoice::Decline,
+        })
+        .expect("declined cascade puts its hit and miss on the library bottom");
+    assert!(matches!(
+        declined.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().players[P0.0 as usize].library.len(), 2);
+    assert_eq!(runner.state().objects[&miss].zone, Zone::Library);
+    assert_eq!(runner.state().objects[&hit].zone, Zone::Library);
+    assert_eq!(
+        events
+            .iter()
+            .chain(declined.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Cascade,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the synchronous cascade tail resolves exactly once"
+    );
+}
+
 /// W-L3 (red first): PutAtLibraryPosition must keep its requested top ordering
 /// while routing every placement through the Library replacement consult.
 #[test]

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -25,7 +25,6 @@ crates/engine/src/game/deck_loading.rs	create_attraction_deck_card	exempt	1
 crates/engine/src/game/deck_loading.rs	create_contraption_deck_card	exempt	1
 crates/engine/src/game/deck_loading.rs	create_planar_deck_card	exempt	1
 crates/engine/src/game/deck_loading.rs	create_scheme_deck_card	exempt	1
-crates/engine/src/game/effects/cascade.rs	resolve	mover	1
 crates/engine/src/game/effects/cast_copy_of_card.rs	cast_one_copy	exempt	1
 crates/engine/src/game/effects/cast_from_zone.rs	grant_lingering_permissions	mover	1
 crates/engine/src/game/effects/cloak.rs	resolve	mover	1


### PR DESCRIPTION
- **fix(engine): route cascade's exile loop through the replacement-safe zone pipeline**
- **chore(engine): refresh zone-authority baseline after cascade migration (42 hits / 28 rows)**
