### PR TITLE
Add Angel's Grace

### DIFF
--- a/crates/engine/src/game/effects/win_lose.rs
+++ b/crates/engine/src/game/effects/win_lose.rs
@@ -64,6 +64,18 @@ pub fn resolve_lose(
     };
 
     for pid in players_to_eliminate {
+        // CR 104.3e + CR 810.8a: An effect-stated loss is still a loss, so a
+        // "can't lose the game" continuous effect precludes it (CR 810.8a's
+        // Platinum Angel example: "Neither that player nor their teammate can
+        // lose the game" — the same clause Angel's Grace and Gideon of the
+        // Trials' emblem grant). Mirrors the `player_has_cant_win` gate on the
+        // sibling `resolve_win` path (CR 104.2b). The concede (CR 104.3a) and
+        // SBA (CR 104.3b-d) paths do not route through here: concede must
+        // never be blocked, and the SBA loop pre-filters via the same
+        // `player_has_cant_lose` predicate.
+        if crate::game::sba::player_has_cant_lose(state, pid) {
+            continue;
+        }
         // CR 104.3e: A player who loses the game leaves the game.
         eliminate_player(state, pid, events);
     }
@@ -366,6 +378,56 @@ mod tests {
                 winner: Some(PlayerId(0))
             }
         ));
+    }
+
+    /// CR 104.3e + CR 810.8a: An effect-stated loss ("you lose the game",
+    /// Pact triggers, Door to Nothingness) is precluded by a `CantLoseTheGame`
+    /// static on the affected player — the "can't lose" half of the Platinum
+    /// Angel / Angel's Grace / Gideon-emblem clause. RED if `resolve_lose`
+    /// eliminates unconditionally. The untargeted elimination test above is
+    /// the live-path sibling proving the loss path executes without the
+    /// static (reach guard).
+    #[test]
+    fn lose_effect_blocked_by_cant_lose_static() {
+        let mut state = GameState::new_two_player(42);
+        let angel = create_object(
+            &mut state,
+            CardId(201),
+            PlayerId(0),
+            "Platinum Angel".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&angel)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantLoseTheGame).affected(
+                TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::You)),
+            ));
+
+        // PlayerId(0)'s own "you lose the game" effect resolves but the loss
+        // is precluded (CR 810.8a's Platinum Angel example).
+        let ability = ResolvedAbility::new(
+            Effect::LoseTheGame { target: None },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+
+        resolve_lose(&mut state, &ability, &mut events).unwrap();
+
+        assert!(!state.players[0].is_eliminated);
+        assert!(!state.players[1].is_eliminated);
+        assert!(!matches!(state.waiting_for, WaitingFor::GameOver { .. }));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            GameEvent::EffectResolved {
+                kind: EffectKind::LoseTheGame,
+                ..
+            }
+        )));
     }
 
     /// CR 104.2b: Platinum Angel's full clause — the permanent's controller

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -6111,10 +6111,18 @@ pub fn find_applicable_replacements(
                     }
                     if let Some(ref tf) = repl_def.damage_target_filter {
                         if let ProposedEvent::Damage { target, .. } = event {
+                            // CR 109.4 + CR 614.1a: `Controller`/`Opponent` target
+                            // scopes resolve against the installing player anchored
+                            // at install time (`source_controller`, computed above) —
+                            // the sentinel host `ObjectId(0)` has no controller of
+                            // its own (Angel's Grace's "your life total" floor binds
+                            // to its caster). `Any`/`Specific` ignore the controller,
+                            // and `SourceChosenPlayer` consults the source object,
+                            // so only the two player-relative scopes read it.
                             if !matches_damage_target_filter(
                                 tf,
                                 target,
-                                PlayerId(0),
+                                source_controller,
                                 ObjectId(0),
                                 state,
                             ) {

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -433,10 +433,30 @@ fn ascend_status_in(
 /// emblems function in the command zone — Gideon of the Trials' emblem),
 /// mirroring `player_has_cant_win` → `check_static_ability`'s CR 114.4 scope.
 ///
+/// CR 810.8a: "If an effect says that a player can't lose the game, that
+/// player's team can't lose the game" (Platinum Angel example: "Neither that
+/// player nor their teammate can lose the game"). So in 2HG, this is true for
+/// `player_id` if EITHER `player_id` itself or their teammate has the grant —
+/// mirrors the `player_has_cant_gain_life` / `player_has_cant_lose_life`
+/// teammate fold in `static_abilities.rs` (CR 810.9g/810.9h siblings).
+///
 /// `pub(crate)` so the live loop-shortcut firewall
 /// (`analysis::loop_check::live_mandatory_loop_winner`, CR 101.2) can reuse the same
 /// SBA-layer predicate rather than re-deriving the can't-lose check.
 pub(crate) fn player_has_cant_lose(state: &GameState, player_id: PlayerId) -> bool {
+    cant_lose_active_for(state, player_id)
+        || (super::topology::has_two_headed_giant_shared_resources(state)
+            && super::players::teammates(state, player_id)
+                .into_iter()
+                .any(|teammate| cant_lose_active_for(state, teammate)))
+}
+
+/// Single-player check underlying `player_has_cant_lose`: does `player_id`
+/// itself (battlefield permanent, command-zone emblem, or spell-applied
+/// transient effect) have an active `CantLoseTheGame` grant? Does NOT fold in
+/// teammates — callers needing the CR 810.8a team-wide answer must go through
+/// `player_has_cant_lose`.
+fn cant_lose_active_for(state: &GameState, player_id: PlayerId) -> bool {
     // CR 604.1: O(1) presence gate on the printed-static authority only (the
     // index is built over `game_functioning_statics`, so it has identical
     // battlefield + command-zone scoping). The transient-continuous-effect path

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -427,20 +427,26 @@ fn ascend_status_in(
 /// Mirrors `player_has_protection_from_everything` in `static_abilities.rs`:
 /// for transient effects scoped to players, we scan `transient_continuous_effects`
 /// for entries pinned to this player via `SpecificPlayer { id }` whose
-/// modifications grant `StaticMode::CantLoseTheGame`. The battlefield scan
-/// handles the permanent-source path (Platinum Angel and friends).
+/// modifications grant `StaticMode::CantLoseTheGame`. The game-scope static
+/// scan handles the printed-source path: battlefield permanents (Platinum
+/// Angel and friends) plus command-zone emblems (CR 114.4: abilities of
+/// emblems function in the command zone — Gideon of the Trials' emblem),
+/// mirroring `player_has_cant_win` → `check_static_ability`'s CR 114.4 scope.
 ///
 /// `pub(crate)` so the live loop-shortcut firewall
 /// (`analysis::loop_check::live_mandatory_loop_winner`, CR 101.2) can reuse the same
 /// SBA-layer predicate rather than re-deriving the can't-lose check.
 pub(crate) fn player_has_cant_lose(state: &GameState, player_id: PlayerId) -> bool {
-    // CR 604.1: O(1) presence gate on the battlefield-static authority only. The
-    // transient-continuous-effect path below is a separate authority the index does
-    // NOT fold, so gate the `.any()` with a short-circuit conjunction rather than an
-    // early return.
+    // CR 604.1: O(1) presence gate on the printed-static authority only (the
+    // index is built over `game_functioning_statics`, so it has identical
+    // battlefield + command-zone scoping). The transient-continuous-effect path
+    // below is a separate authority the index does NOT fold, so gate the
+    // `.any()` with a short-circuit conjunction rather than an early return.
+    // CR 114.4: `game_active_statics` includes command-zone emblems, so an
+    // emblem's "you can't lose the game" (Gideon of the Trials) is honored.
     let from_permanent = static_kind_present(state, StaticModeKind::CantLoseTheGame) && {
         crate::game::perf_counters::record_static_full_scan();
-        super::functioning_abilities::battlefield_active_statics(state).any(|(obj, def)| {
+        super::functioning_abilities::game_active_statics(state).any(|(obj, def)| {
             def.mode == StaticMode::CantLoseTheGame
                 && static_affects_player(obj.controller, &def.affected, player_id)
         })
@@ -4747,6 +4753,46 @@ mod tests {
             "Player with CantLoseTheGame at 0 life should not be eliminated"
         );
         assert!(!state.eliminated_players.contains(&PlayerId(0)));
+    }
+
+    /// CR 104.3b + CR 114.4: `CantLoseTheGame` printed on a command-zone
+    /// emblem (Gideon of the Trials' emblem: "… you can't lose the game …")
+    /// functions from the command zone, so the loss-SBA skip honors it. RED
+    /// when `player_has_cant_lose` scans only the battlefield. The unprotected
+    /// opponent at 0 life IS eliminated — the live sibling proves the loss SBA
+    /// executed (reach guard), and that the emblem's `You`-scoped `affected`
+    /// filter protects only its controller.
+    #[test]
+    fn sba_cant_lose_from_command_zone_emblem() {
+        use crate::types::ability::StaticDefinition;
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(101),
+            PlayerId(0),
+            "Gideon of the Trials Emblem".to_string(),
+            Zone::Command,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.is_emblem = true;
+        obj.static_definitions
+            .push(StaticDefinition::new(StaticMode::CantLoseTheGame).affected(
+                TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::You)),
+            ));
+        state.players[0].life = 0;
+        state.players[1].life = 0;
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            !state.players[0].is_eliminated,
+            "emblem-granted CantLoseTheGame must function from the command zone (CR 114.4)"
+        );
+        assert!(
+            state.players[1].is_eliminated,
+            "opponent of the emblem's controller is not protected (reach guard)"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -1112,7 +1112,29 @@ pub fn build_cost_permission_context(
 ///
 /// Checks both battlefield permanents and spell-applied transient effects
 /// (e.g., a sorcery that grants all players CantWinTheGame this turn).
+///
+/// CR 810.8a: "If an effect says that a player can't win the game, that
+/// player's team can't win the game" (the Platinum Angel / Angel's Grace
+/// example: neither player on the opposing team can win while the clause
+/// affects one of them). So in 2HG this is true for `player_id` if EITHER
+/// `player_id` itself or their teammate has the grant — mirrors the
+/// `player_has_cant_gain_life` / `player_has_cant_lose_life` teammate fold
+/// below (CR 810.9g/810.9h siblings) and `sba::player_has_cant_lose`'s
+/// identical CR 810.8a fold on the can't-lose side.
 pub fn player_has_cant_win(state: &GameState, player_id: PlayerId) -> bool {
+    cant_win_active_for(state, player_id)
+        || (super::topology::has_two_headed_giant_shared_resources(state)
+            && super::players::teammates(state, player_id)
+                .into_iter()
+                .any(|teammate| cant_win_active_for(state, teammate)))
+}
+
+/// Single-player check underlying `player_has_cant_win`: does `player_id`
+/// itself (battlefield permanent, command-zone emblem, or spell-applied
+/// transient effect) have an active `CantWinTheGame` grant? Does NOT fold in
+/// teammates — callers needing the CR 810.8a team-wide answer must go through
+/// `player_has_cant_win`.
+fn cant_win_active_for(state: &GameState, player_id: PlayerId) -> bool {
     check_static_ability(
         state,
         StaticMode::CantWinTheGame,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1957,6 +1957,53 @@ fn try_parse_global_damage_modification_replacement(text: &str) -> Option<Effect
     })
 }
 
+/// CR 614.1a + CR 514.2 + CR 611.2c: Recognize the one-shot spell/trigger form
+/// of the life-floor damage replacement — "damage that would reduce your life
+/// total to less than N reduces it to N instead" (Angel's Grace, Angel of
+/// Grace's ETB trigger) — and lift it to an
+/// `Effect::AddTargetReplacement { target: None }` that installs a floating
+/// turn-bound replacement in `pending_damage_replacements`. Unlike the
+/// one-shot "the next time …" shields (`CreateDamageReplacement`), the
+/// installed definition keeps `ShieldKind::None`, so it re-applies to every
+/// damage event until it expires (the floor is continuous for the turn). The
+/// permanent-static form of the same sentence (Worship, Fortune Thief, Ali
+/// from Cairo, Sustaining Spirit) routes at document level through the
+/// replacement parser and never reaches this dispatch.
+///
+/// `lower` is the already-lowercased, duration-stripped clause text — the
+/// leading "until end of turn," is consumed upstream by
+/// `strip_leading_duration` and re-attached via `with_clause_duration`, so
+/// `expiry` is left `None` on the produced definition; the install resolver
+/// derives it from `ability.duration` via `expiry_from_duration` (mirrors
+/// `parse_enter_from_zone_redirect_replacement` below).
+///
+/// Parsing is delegated to `parse_replacement_line` — the single authority
+/// for replacement sentences (it reaches the all-consuming
+/// `parse_unconditional_life_floor_damage_replacement`). The typed acceptance
+/// check keeps the lift scoped to the life-floor family; the
+/// "if [source] would deal … instead" family is owned by
+/// `try_parse_global_damage_modification_replacement`.
+fn try_parse_global_life_floor_replacement(text: &str, lower: &str) -> Option<Effect> {
+    use super::oracle_replacement::parse_replacement_line;
+    // Structural nom prefix gate; the parse itself is delegated below.
+    tag::<_, _, OracleError<'_>>("damage that would reduce ")
+        .parse(lower)
+        .ok()?;
+    let replacement = parse_replacement_line(text, "")?;
+    if !matches!(replacement.event, ReplacementEvent::DamageDone)
+        || !matches!(
+            replacement.damage_modification,
+            Some(DamageModification::LifeFloor { .. })
+        )
+    {
+        return None;
+    }
+    Some(Effect::AddTargetReplacement {
+        replacement: Box::new(replacement),
+        target: TargetFilter::None,
+    })
+}
+
 /// CR 614.1a + CR 614.1d + CR 601: Recognize a floating zone-change redirect
 /// replacement of the shape
 /// "if one or more <creatures/permanents> would enter [from <zone>]
@@ -7799,6 +7846,17 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // "shuffle them into their libraries" never collapses into a bare
     // `Effect::Shuffle`.
     if let Some(effect) = parse_enter_from_zone_redirect_replacement(&lower) {
+        return parsed_clause(effect);
+    }
+
+    // CR 614.1a + CR 514.2: floating turn-bound life-floor replacement
+    // ("Until end of turn, damage that would reduce your life total to less
+    // than 1 reduces it to 1 instead." — Angel's Grace; Angel of Grace's ETB
+    // trigger). Dispatched after `strip_leading_duration` for the same reason
+    // as the zone-redirect lift above: the recursive (duration-stripped) call
+    // reaches it, and `AbilityDefinition.duration == UntilEndOfTurn` reaches
+    // `expiry_from_duration` in the install resolver.
+    if let Some(effect) = try_parse_global_life_floor_replacement(text, &lower) {
         return parsed_clause(effect);
     }
 

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2685,16 +2685,26 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
         value((), alt((tag("it's "), tag("it’s ")))),
         value((), tag("this creature gets ")),
         value((), tag("~ gets ")),
-        // CR 104.3 + CR 119.7 + CR 119.8: Bare-plural-player subject + restriction
-        // predicate. Everybody Lives! prints "Players can't lose life this turn
-        // and players can't lose the game or win the game this turn." — the
-        // conjunction must split so each half parses as its own
-        // subject + predicate clause. Safe to split: "players can't" /
-        // "players cannot" can only begin a subject-predicate clause, never a
-        // noun-phrase continuation.
-        value((), tag("players can't ")),
-        value((), tag("players cannot ")),
     )))
+    // CR 104.2b + CR 104.3e + CR 119.7 + CR 119.8: Plural-player subject +
+    // restriction predicate. Everybody Lives! prints "Players can't lose life
+    // this turn and players can't lose the game or win the game this turn.";
+    // Angel's Grace prints "You can't lose the game this turn and your
+    // opponents can't win the game this turn." — the conjunction must split so
+    // each half parses as its own subject + predicate clause
+    // (`try_parse_subject_restriction_clause` → `parse_restriction_modes`).
+    // Safe to split: a plural-player subject followed by "can't"/"cannot" can
+    // only begin a subject-predicate clause, never a noun-phrase continuation.
+    // The subject axis is composed with the negation axis rather than
+    // enumerated per permutation (CLAUDE.md "compose, don't enumerate
+    // permutations").
+    .or(preceded(
+        alt((
+            tag::<_, _, OracleError<'_>>("players "),
+            tag("your opponents "),
+        )),
+        value((), alt((tag("can't "), tag("cannot ")))),
+    ))
     // CR 109.3 + CR 201.4b + CR 608.2k: gendered pronouns ("he"/"she") used as an
     // Oracle-text subject refer to the card itself (Machine Man, Model X-51:
     // "... put a +1/+1 counter on ~ and he gains flying until end of turn";

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -2690,14 +2690,34 @@ fn starts_bare_and_clause_lower(s: &str) -> bool {
     // restriction predicate. Everybody Lives! prints "Players can't lose life
     // this turn and players can't lose the game or win the game this turn.";
     // Angel's Grace prints "You can't lose the game this turn and your
-    // opponents can't win the game this turn." — the conjunction must split so
-    // each half parses as its own subject + predicate clause
+    // opponents can't win the game this turn." (same conjunct in Celestine
+    // Reef's chaos trigger and Courageous Resolve's fateful-hour list) — the
+    // conjunction must split so each half parses as its own
+    // subject + predicate clause
     // (`try_parse_subject_restriction_clause` → `parse_restriction_modes`).
     // Safe to split: a plural-player subject followed by "can't"/"cannot" can
     // only begin a subject-predicate clause, never a noun-phrase continuation.
     // The subject axis is composed with the negation axis rather than
     // enumerated per permutation (CLAUDE.md "compose, don't enumerate
     // permutations").
+    //
+    // Class boundary — the subject axis is deliberately closed over the two
+    // forms printed cards actually feed to THIS bare-and boundary ("players",
+    // "your opponents"; AtomicCards survey of `and <player-subject> can't`).
+    // Sibling player-subject forms are excluded, each for cause:
+    // - "opponents can't" (bare, The Bird Champion) and the static-line
+    //   compounds (Platinum Angel, Abyssal Persecutor, Herald of Eternal
+    //   Dawn, Cloudsteel Kirin's granted ability) never reach this splitter:
+    //   whole-line "can't win/lose" statics are owned by the
+    //   `is_cant_win_lose_compound` seam (`oracle.rs` B20), which splits at
+    //   " and " before effect-sequence chunking.
+    // - "your opponent can't" (singular) appears only inside reminder text
+    //   (Adventurer Beguiler), which is stripped before parsing.
+    // - "each opponent can't" / "an opponent can't" / "their opponents
+    //   can't" appear in no printed Oracle text as a bare-and conjunct;
+    //   admitting them here would be speculative grammar with no card able
+    //   to exercise the lowering. Widen this axis only with a real card AND
+    //   a verified `parse_subject_application` lowering for the new subject.
     .or(preceded(
         alt((
             tag::<_, _, OracleError<'_>>("players "),
@@ -3277,7 +3297,16 @@ pub(super) fn push_clause_chunk(
     raw_text: &str,
     boundary_after: Option<ClauseBoundary>,
 ) {
-    let text = raw_text.trim().trim_end_matches('.').trim();
+    // CR 119.7 + CR 119.8: an Oxford-comma list ("X, Y, and Z") peeled from the
+    // tail via the bare-and splitter leaves the second-to-last chunk ending in
+    // a dangling list comma ("Y,") — trim it here, not just the sentence-final
+    // period, or the comma survives into the clause text and breaks any
+    // all_consuming parse (e.g. `parse_restriction_modes`) downstream.
+    // Courageous Resolve's fateful-hour list ("you can't lose life this turn,
+    // you can't lose the game this turn, and your opponents can't win the game
+    // this turn") is the exemplar: without this trim, "can't lose the game
+    // this turn," fails all_consuming and falls to Unimplemented.
+    let text = raw_text.trim().trim_end_matches(['.', ',']).trim();
     if text.is_empty() {
         return;
     }
@@ -11619,6 +11648,51 @@ mod tests {
         // verb must NOT split (no false clause boundary).
         assert!(!starts_bare_and_clause("he attacks this turn"));
         assert!(!starts_bare_and_clause("she deals 2 damage to any target"));
+    }
+
+    /// CR 104.2b + CR 104.3e + CR 119.7 + CR 119.8: plural-player subject +
+    /// "can't"/"cannot" restriction boundary. Admitted subjects are exactly
+    /// the forms printed cards feed to this bare-and conjunct boundary:
+    /// "players" (Everybody Lives!) and "your opponents" (Angel's Grace,
+    /// Celestine Reef's chaos trigger, Courageous Resolve's fateful-hour
+    /// list). Sibling player-subject forms must NOT match — no printed card
+    /// reaches this boundary with them: bare "opponents can't" (The Bird
+    /// Champion) and the Platinum Angel-class compounds are whole-line
+    /// statics owned by the `is_cant_win_lose_compound` seam in `oracle.rs`;
+    /// singular "your opponent can't" occurs only in stripped reminder text
+    /// (Adventurer Beguiler); "each opponent"/"an opponent"/"their
+    /// opponents" + "can't" appear in no Oracle text at all.
+    #[test]
+    fn bare_and_clause_plural_player_restriction_boundary() {
+        // Admitted forms, verbatim from the cards that exercise them.
+        assert!(starts_bare_and_clause(
+            "players can't lose the game or win the game this turn"
+        ));
+        assert!(starts_bare_and_clause(
+            "your opponents can't win the game this turn"
+        ));
+        assert!(starts_bare_and_clause("your opponents can't win the game"));
+        // Excluded sibling subjects — must stay un-split at this boundary.
+        assert!(!starts_bare_and_clause("opponents can't win the game"));
+        assert!(!starts_bare_and_clause(
+            "your opponent can't win the game this turn"
+        ));
+        assert!(!starts_bare_and_clause(
+            "each opponent can't win the game this turn"
+        ));
+        assert!(!starts_bare_and_clause(
+            "an opponent can't win the game this turn"
+        ));
+        assert!(!starts_bare_and_clause(
+            "their opponents can't win the game this turn"
+        ));
+        // Possessive noun phrase is a continuation, not a player subject.
+        assert!(!starts_bare_and_clause(
+            "your opponents' creatures can't block this turn"
+        ));
+        // Admitted subject WITHOUT the restriction predicate must not split
+        // via this arm.
+        assert!(!starts_bare_and_clause("your opponents gain 2 life"));
     }
 
     /// CR 601.2c + CR 611.2c: A second `"target <noun>"` conjunct joined by a

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -16479,6 +16479,131 @@ fn everybody_lives_emits_cant_lose_life_lose_game_win_game_statics() {
     );
 }
 
+// CR 104.2b + CR 104.3e + CR 614.1a + CR 514.2: Angel's Grace prints a
+// two-subject restriction conjunction ("You can't lose the game this turn and
+// your opponents can't win the game this turn.") followed by the one-shot form
+// of the life-floor damage replacement ("Until end of turn, damage that would
+// reduce your life total to less than 1 reduces it to 1 instead."). SHAPE
+// test: the chain must emit a Controller-scoped `CantLoseTheGame`, an
+// Opponent-scoped `CantWinTheGame`, and an `AddTargetReplacement` carrying
+// `DamageDone` + `LifeFloor{1}` + `Player{Controller}` with duration
+// `UntilEndOfTurn` and `expiry: None` (derived from the ability duration at
+// install). Zero `Effect::Unimplemented` is the reach guard: before the fix,
+// the whole first sentence and the floor clause each routed to
+// `Effect::Unimplemented`. Runtime semantics are covered by
+// `tests/integration/angels_grace.rs`.
+#[test]
+fn angels_grace_emits_cant_lose_cant_win_and_life_floor() {
+    use crate::types::ability::{
+        DamageModification, DamageTargetFilter, DamageTargetPlayerScope, Duration,
+    };
+    use crate::types::replacements::ReplacementEvent;
+    use crate::types::statics::StaticMode;
+
+    let r = parse(
+        "Split second (As long as this spell is on the stack, players can't cast spells \
+         or activate abilities that aren't mana abilities.)\n\
+         You can't lose the game this turn and your opponents can't win the game this \
+         turn. Until end of turn, damage that would reduce your life total to less than \
+         1 reduces it to 1 instead.",
+        "Angel's Grace",
+        &[Keyword::SplitSecond],
+        &["Instant"],
+        &[],
+    );
+    assert_eq!(r.abilities.len(), 1, "single chained spell ability");
+
+    let mut cant_lose_affected = None;
+    let mut cant_win_affected = None;
+    let mut life_floor = None;
+    let mut node = Some(&r.abilities[0]);
+    while let Some(def) = node {
+        assert!(
+            !matches!(*def.effect, Effect::Unimplemented { .. }),
+            "no Unimplemented chunk should remain, got {:?}",
+            def.effect
+        );
+        match &*def.effect {
+            Effect::GenericEffect {
+                static_abilities, ..
+            } => {
+                for s in static_abilities {
+                    match s.mode {
+                        StaticMode::CantLoseTheGame => {
+                            cant_lose_affected = s.affected.clone();
+                        }
+                        StaticMode::CantWinTheGame => {
+                            cant_win_affected = s.affected.clone();
+                        }
+                        _ => continue,
+                    }
+                    // CR 514.2: "this turn" — both restriction statics must be
+                    // duration-scoped so the transient effects end at cleanup;
+                    // a dropped duration would make the locks permanent.
+                    assert_eq!(
+                        def.duration,
+                        Some(Duration::UntilEndOfTurn),
+                        "restriction statics must carry the this-turn duration"
+                    );
+                }
+            }
+            Effect::AddTargetReplacement {
+                replacement,
+                target,
+            } => {
+                assert_eq!(
+                    *target,
+                    TargetFilter::None,
+                    "self-contained floating replacement takes no per-target binding"
+                );
+                assert_eq!(
+                    def.duration,
+                    Some(Duration::UntilEndOfTurn),
+                    "the install resolver derives the EndOfTurn expiry from this duration"
+                );
+                life_floor = Some((**replacement).clone());
+            }
+            _ => {}
+        }
+        node = def.sub_ability.as_deref();
+    }
+
+    // CR 104.3b + CR 104.3e: "You can't lose the game" binds to the caster.
+    assert_eq!(
+        cant_lose_affected,
+        Some(TargetFilter::Controller),
+        "CantLoseTheGame must be Controller-scoped"
+    );
+    // CR 104.2b: "your opponents can't win the game" binds to the opponents.
+    assert!(
+        matches!(
+            cant_win_affected,
+            Some(TargetFilter::Typed(TypedFilter {
+                controller: Some(ControllerRef::Opponent),
+                ..
+            }))
+        ),
+        "CantWinTheGame must be Opponent-scoped, got {cant_win_affected:?}"
+    );
+    // CR 614.1a: the life floor is a DamageDone replacement on the caster.
+    let repl = life_floor.expect("chain must emit the AddTargetReplacement life floor");
+    assert!(matches!(repl.event, ReplacementEvent::DamageDone));
+    assert_eq!(
+        repl.damage_modification,
+        Some(DamageModification::LifeFloor { minimum: 1 })
+    );
+    assert_eq!(
+        repl.damage_target_filter,
+        Some(DamageTargetFilter::Player {
+            player: DamageTargetPlayerScope::Controller
+        })
+    );
+    assert!(
+        repl.expiry.is_none(),
+        "expiry is derived from the ability duration at install, not parse time"
+    );
+}
+
 #[test]
 fn avatars_wrath_parses_airbend_chain_cast_restriction_and_self_exile() {
     let r = parse(

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -16654,6 +16654,70 @@ fn angel_of_grace_trigger_lifts_life_floor_with_duration() {
     assert!(replacement.expiry.is_none());
 }
 
+// CR 104.2b + CR 104.3e + CR 119.7 + CR 119.8: Courageous Resolve's
+// fateful-hour tail is an Oxford-comma list of THREE restriction clauses
+// under one "you can't"-family subject axis, the last of which switches
+// subject to "your opponents" — the same tail Angel's Grace and Celestine
+// Reef print, but reached through a comma-list rather than a plain
+// bare-"and" pair. Regression for the class boundary this PR adds to
+// `starts_bare_and_clause_lower`: splitting "your opponents can't win the
+// game this turn" off the tail left the PRECEDING comma-list item ("you
+// can't lose the game this turn,") with its dangling list comma still
+// attached, which broke `parse_restriction_modes`'s `all_consuming` match
+// and silently regressed it to `Effect::Unimplemented`. Fixed at the shared
+// `push_clause_chunk` (trims a trailing list comma, not just the sentence-
+// final period) rather than in this one bare-and arm, since every chunk
+// boundary in the module routes through it. RED against the unfixed chunk
+// trim: the middle clause reverts to `Unimplemented { name: "can't", .. }`.
+#[test]
+fn courageous_resolve_fateful_hour_list_zero_unimplemented() {
+    let r = parse(
+        "Up to one target creature you control gains protection from each of your \
+         opponents until end of turn. Draw a card.\n\
+         Fateful hour — If you have 5 or less life, you can't lose life this turn, you \
+         can't lose the game this turn, and your opponents can't win the game this turn.",
+        "Courageous Resolve",
+        &[],
+        &["Instant"],
+        &[],
+    );
+    let fateful = r
+        .abilities
+        .iter()
+        .find(|a| {
+            a.description
+                .as_deref()
+                .is_some_and(|d| d.starts_with("Fateful hour"))
+        })
+        .expect("Fateful hour ability present");
+
+    let mut modes = Vec::new();
+    let mut node = Some(fateful);
+    while let Some(def) = node {
+        assert!(
+            !matches!(*def.effect, Effect::Unimplemented { .. }),
+            "no Unimplemented chunk should remain in the fateful-hour chain, got {:?}",
+            def.effect
+        );
+        if let Effect::GenericEffect {
+            static_abilities, ..
+        } = &*def.effect
+        {
+            modes.extend(static_abilities.iter().map(|s| s.mode.clone()));
+        }
+        node = def.sub_ability.as_deref();
+    }
+    assert_eq!(
+        modes,
+        vec![
+            StaticMode::CantLoseLife,
+            StaticMode::CantLoseTheGame,
+            StaticMode::CantWinTheGame,
+        ],
+        "all three fateful-hour restrictions must resolve in order, got {modes:?}"
+    );
+}
+
 #[test]
 fn avatars_wrath_parses_airbend_chain_cast_restriction_and_self_exile() {
     let r = parse(

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -16604,6 +16604,56 @@ fn angels_grace_emits_cant_lose_cant_win_and_life_floor() {
     );
 }
 
+// CR 614.1a + CR 514.2: Angel of Grace carries the same life-floor sentence in
+// TRIGGER context ("When this creature enters, until end of turn, damage that
+// would reduce your life total to less than 1 reduces it to 1 instead.") —
+// the divergent production entry for the lift. The trigger's execute body must
+// lower to `AddTargetReplacement` with `Duration::UntilEndOfTurn` threaded
+// onto the executing ability (the install resolver derives the EndOfTurn
+// expiry from it via `expiry_from_duration`); a dropped duration would make
+// the floor permanent.
+#[test]
+fn angel_of_grace_trigger_lifts_life_floor_with_duration() {
+    use crate::types::ability::{DamageModification, Duration};
+
+    let r = parse(
+        "Flash\nFlying\nWhen this creature enters, until end of turn, damage that would \
+         reduce your life total to less than 1 reduces it to 1 instead.\n{4}{W}{W}, Exile \
+         this card from your graveyard: Your life total becomes 10.",
+        "Angel of Grace",
+        &[Keyword::Flash, Keyword::Flying],
+        &["Creature"],
+        &["Angel"],
+    );
+    let execute = r
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_ref())
+        .expect("ETB trigger should have an execute body");
+    assert!(
+        !has_unimplemented(execute),
+        "ETB trigger body must not contain Unimplemented effects: {execute:#?}"
+    );
+    let Effect::AddTargetReplacement {
+        replacement,
+        target,
+    } = &*execute.effect
+    else {
+        panic!("trigger body must lift to AddTargetReplacement, got {execute:#?}");
+    };
+    assert_eq!(*target, TargetFilter::None);
+    assert_eq!(
+        replacement.damage_modification,
+        Some(DamageModification::LifeFloor { minimum: 1 })
+    );
+    assert_eq!(
+        execute.duration,
+        Some(Duration::UntilEndOfTurn),
+        "the trigger-context duration must ride on the executing ability"
+    );
+    assert!(replacement.expiry.is_none());
+}
+
 #[test]
 fn avatars_wrath_parses_airbend_chain_cast_restriction_and_self_exile() {
     let r = parse(

--- a/crates/engine/tests/integration/angels_grace.rs
+++ b/crates/engine/tests/integration/angels_grace.rs
@@ -1,0 +1,211 @@
+//! CR 104.2b + CR 104.3b + CR 104.3e + CR 614.1a + CR 514.2 — Angel's Grace.
+//!
+//! "Split second (…)\nYou can't lose the game this turn and your opponents
+//! can't win the game this turn. Until end of turn, damage that would reduce
+//! your life total to less than 1 reduces it to 1 instead."
+//!
+//! Three runtime seams, each with a revert-failing assertion:
+//! - the conjunct splitter arm ("… and your opponents can't …") that lets the
+//!   sentence lower to `CantLoseTheGame`/`CantWinTheGame` transient effects
+//!   (without it the whole sentence is `Effect::Unimplemented` and every
+//!   assertion here fails);
+//! - the life-floor lift to `Effect::AddTargetReplacement` installing a
+//!   floating, non-consumed, turn-bound `DamageModification::LifeFloor`
+//!   replacement (CR 614.1a);
+//! - the floating replacement's `DamageTargetPlayerScope::Controller`
+//!   authority: it must bind to the INSTALLING player (`source_controller`),
+//!   not a hardcoded `PlayerId(0)` — which is why every test here casts
+//!   Angel's Grace from **P1**. A P0-caster fixture would pass vacuously
+//!   against that hardcode.
+//!
+//! Oracle text is verbatim (per the `/card-test` recipe); the Split second
+//! keyword line is fed through the keyword path, mirroring the MTGJSON
+//! pipeline, so it never degrades to an inline-reminder `Unimplemented`.
+
+use engine::game::sba::check_state_based_actions;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+/// Verbatim Oracle text (MTGJSON), including the Split second keyword line.
+const ANGELS_GRACE: &str = "Split second (As long as this spell is on the stack, players can't cast spells or activate abilities that aren't mana abilities.)\nYou can't lose the game this turn and your opponents can't win the game this turn. Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead.";
+
+/// Add Angel's Grace to P1's hand with Split second fed via the keyword path.
+fn add_angels_grace(scenario: &mut GameScenario) -> ObjectId {
+    let mut builder = scenario.add_spell_to_hand(P1, "Angel's Grace", /* is_instant */ true);
+    builder.from_oracle_text_with_keywords(&["Split second"], ANGELS_GRACE);
+    builder.id()
+}
+
+/// CR 117.3d: P0 (the active player) passes priority so P1 can cast the
+/// instant, then drive the full cast pipeline to resolution.
+fn cast_angels_grace_as_p1(runner: &mut GameRunner, spell: ObjectId) {
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes priority so P1 can cast");
+    runner.cast(spell).resolve();
+}
+
+/// CR 104.3b: after Angel's Grace resolves, its caster (P1) is not eliminated
+/// by the 0-or-less-life SBA this turn, while the unprotected opponent (P0) at
+/// 0 life IS eliminated — the live sibling proves the loss SBA path executed
+/// (reach guard), so the P1 survival is not vacuous.
+#[test]
+fn angels_grace_controller_cannot_lose_this_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = add_angels_grace(&mut scenario);
+    let mut runner = scenario.build();
+
+    cast_angels_grace_as_p1(&mut runner, spell);
+
+    runner.state_mut().players[0].life = 0;
+    runner.state_mut().players[1].life = 0;
+    let mut events = Vec::new();
+    check_state_based_actions(runner.state_mut(), &mut events);
+
+    assert!(
+        !runner.state().players[1].is_eliminated,
+        "Angel's Grace caster at 0 life must not lose this turn (CR 104.3b skip)"
+    );
+    assert!(
+        runner.state().players[0].is_eliminated,
+        "unprotected opponent at 0 life must still be eliminated (reach guard)"
+    );
+}
+
+/// CR 104.2b: after Angel's Grace resolves, an opponent's "You win the game."
+/// effect does not end the game this turn.
+#[test]
+fn angels_grace_blocks_opponent_win_effect() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let grace = add_angels_grace(&mut scenario);
+    let win = scenario
+        .add_spell_to_hand_from_oracle(P0, "Test Win Spell", true, "You win the game.")
+        .id();
+    let mut runner = scenario.build();
+
+    cast_angels_grace_as_p1(&mut runner, grace);
+    // Priority returns to the active player (P0), who now tries to win.
+    runner.cast(win).resolve();
+
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
+        "opponent's win effect must be blocked by Angel's Grace (CR 104.2b), got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+/// Reach guard for [`angels_grace_blocks_opponent_win_effect`]: without Angel's
+/// Grace the identical win effect ends the game, proving the win path is live
+/// and the blocked outcome above is not vacuous.
+#[test]
+fn win_effect_ends_game_without_angels_grace() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let win = scenario
+        .add_spell_to_hand_from_oracle(P0, "Test Win Spell", true, "You win the game.")
+        .id();
+    let mut runner = scenario.build();
+
+    runner.cast(win).resolve();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::GameOver { winner: Some(P0) }
+        ),
+        "without Angel's Grace the win effect must end the game, got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+/// CR 614.1 + CR 614.3: replacement effects apply continuously as events
+/// happen and last until their duration expires — the life floor applies to
+/// EVERY damage event this turn (not a consumed one-shot shield), floors only
+/// the CASTER's life (P1), and does not floor the opponent's.
+///
+/// Both players start at 2 life so the scope assertions discriminate the
+/// controller authority: under the old hardcoded-`PlayerId(0)` floating
+/// target-filter check, P1's damage would NOT be floored (life -1) and P0's
+/// wrongly would — both assertions flip.
+#[test]
+fn angels_grace_life_floor_applies_to_each_damage_event() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P0, 2).with_life(P1, 2);
+    let grace = add_angels_grace(&mut scenario);
+    let bolt_a = scenario.add_bolt_to_hand(P0);
+    let bolt_b = scenario.add_bolt_to_hand(P0);
+    let bolt_c = scenario.add_bolt_to_hand(P0);
+    let mut runner = scenario.build();
+
+    cast_angels_grace_as_p1(&mut runner, grace);
+
+    // First damage event: 3 damage at 2 life is floored to 1 (CR 614.1a).
+    let outcome = runner.cast(bolt_a).target_player(P1).resolve();
+    outcome.assert_life_delta(P1, -1);
+
+    // Second damage event the same turn: still floored — the replacement is
+    // continuous for the turn, not consumed on first use.
+    let outcome = runner.cast(bolt_b).target_player(P1).resolve();
+    outcome.assert_life_delta(P1, 0);
+    assert_eq!(
+        runner.state().players[1].life,
+        1,
+        "every damage event this turn is floored at 1"
+    );
+
+    // Multi-authority scope: the floor binds to the caster (P1), never the
+    // opponent — P0's own damage is NOT floored, dropping P0 to -1 and losing
+    // the game to the SBA (which also re-proves the damage pipeline is live).
+    let outcome = runner.cast(bolt_c).target_player(P0).resolve();
+    outcome.assert_life_delta(P0, -3);
+    assert_eq!(
+        runner.state().players[0].life,
+        -1,
+        "the floor must not apply to the non-caster (Controller scope authority)"
+    );
+}
+
+/// CR 514.2: the floor (and the can't-lose lock) end at cleanup — next turn
+/// the same damage is not floored, so the caster's life drops below 1.
+#[test]
+fn angels_grace_life_floor_expires_at_cleanup() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_life(P1, 2);
+    let grace = add_angels_grace(&mut scenario);
+    let bolt = scenario.add_bolt_to_hand(P1);
+    let mut runner = scenario.build();
+
+    cast_angels_grace_as_p1(&mut runner, grace);
+
+    // Cross the cleanup step into P1's turn (CR 514.2 prunes the floor).
+    runner.advance_to_phase(Phase::Upkeep);
+    assert_eq!(
+        runner.state().active_player,
+        P1,
+        "scenario must have advanced into P1's turn"
+    );
+
+    // P1 (active, holding priority) bolts themself: 3 damage at 2 life with no
+    // floor drops them to -1. If the floor (or its expiry) leaked past
+    // cleanup, life would read 1 instead.
+    runner.cast(bolt).target_player(P1).resolve();
+    assert_eq!(
+        runner.state().players[1].life,
+        -1,
+        "the life floor must expire at cleanup (CR 514.2)"
+    );
+    // CR 514.2 + CR 104.3b: the can't-lose transient also ended at cleanup, so
+    // the loss SBA now eliminates P1 — proving BOTH halves of "this turn"
+    // expired, not just the replacement.
+    assert!(
+        runner.state().players[1].is_eliminated,
+        "the can't-lose effect must also expire at cleanup (CR 514.2)"
+    );
+}

--- a/crates/engine/tests/integration/angels_grace.rs
+++ b/crates/engine/tests/integration/angels_grace.rs
@@ -99,6 +99,56 @@ fn angels_grace_blocks_opponent_win_effect() {
     );
 }
 
+/// CR 104.3e + CR 810.8a: an effect-stated loss ("Target player loses the
+/// game" — Door to Nothingness wording) is precluded for the Angel's Grace
+/// caster this turn, while the same effect still eliminates the unprotected
+/// opponent (in-test reach guard proving the effect-loss path is live).
+#[test]
+fn angels_grace_blocks_loss_effects_against_caster() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let grace = add_angels_grace(&mut scenario);
+    let doom_a = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Test Loss Spell A",
+            true,
+            "Target player loses the game.",
+        )
+        .id();
+    let doom_b = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Test Loss Spell B",
+            true,
+            "Target player loses the game.",
+        )
+        .id();
+    let mut runner = scenario.build();
+
+    cast_angels_grace_as_p1(&mut runner, grace);
+
+    // P0 (active, holding priority post-resolution) aims the loss at the
+    // protected caster: the effect resolves but the loss is precluded.
+    runner.cast(doom_a).target_player(P1).resolve();
+    assert!(
+        !runner.state().players[1].is_eliminated,
+        "Angel's Grace caster must not lose to an effect-stated loss (CR 104.3e)"
+    );
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
+        "game must continue after the blocked loss"
+    );
+
+    // Reach guard: the identical effect against the unprotected P0 eliminates
+    // them, proving the effect-loss path is live this game.
+    runner.cast(doom_b).target_player(P0).resolve();
+    assert!(
+        runner.state().players[0].is_eliminated,
+        "unprotected player must still lose to the effect (reach guard)"
+    );
+}
+
 /// Reach guard for [`angels_grace_blocks_opponent_win_effect`]: without Angel's
 /// Grace the identical win effect ends the game, proving the win path is live
 /// and the blocked outcome above is not vacuous.

--- a/crates/engine/tests/integration/angels_grace_2hg.rs
+++ b/crates/engine/tests/integration/angels_grace_2hg.rs
@@ -1,0 +1,216 @@
+//! CR 810.8a — Two-Headed Giant team propagation for `CantLoseTheGame` /
+//! `CantWinTheGame`.
+//!
+//! CR 810.8a (verified against `docs/MagicCompRules.txt:6733`): "Players win
+//! and lose the game only as a team, not as individuals. ... If an effect
+//! says that a player can't win the game, that player's team can't win the
+//! game. If an effect says that a player can't lose the game, that player's
+//! team can't lose the game." The Platinum Angel example in the same rule
+//! ("Neither that player nor their teammate can lose the game ... neither
+//! player on the opposing team can win the game") is the exact clause Angel's
+//! Grace prints ("You can't lose the game this turn and your opponents can't
+//! win the game this turn").
+//!
+//! `angels_grace.rs` exercises only two-player fixtures, so it can't
+//! distinguish "protects the named player" from "protects the named player's
+//! team" — a 1v1 game has no teammate to leave unprotected. These fixtures
+//! install the grant on ONE 2HG teammate only (mirroring the transient,
+//! `SpecificPlayer`-scoped continuous effect Angel's Grace's resolution
+//! installs — see `effect.rs::register_transient_effect`'s player-target
+//! branch) and check the OTHER, non-granted teammate — both through the SBA
+//! path (`check_state_based_actions`) and the effect-stated path
+//! (`resolve_lose` / `resolve_win`), matching the two runtime authorities the
+//! review flagged: `sba.rs`'s `player_has_cant_lose` and
+//! `static_abilities.rs`'s `player_has_cant_win`.
+//!
+//! 2HG seating (`FormatConfig::two_headed_giant()`, 4 players): P0+P1 are one
+//! team, P2+P3 the other (see `game::topology::teammates`).
+
+use engine::game::effects::win_lose::{resolve_lose, resolve_win};
+use engine::game::sba::check_state_based_actions;
+use engine::types::ability::{
+    ContinuousModification, Duration, Effect, ResolvedAbility, TargetFilter, TargetRef,
+};
+use engine::types::format::FormatConfig;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+use engine::types::statics::StaticMode;
+
+const TEAM_A_0: PlayerId = PlayerId(0);
+const TEAM_A_1: PlayerId = PlayerId(1);
+const TEAM_B_0: PlayerId = PlayerId(2);
+const TEAM_B_1: PlayerId = PlayerId(3);
+
+/// Install a transient, turn-bound `CantLoseTheGame` grant scoped to exactly
+/// one player — mirrors the `SpecificPlayer`-targeted TCE Angel's Grace's
+/// resolution installs for its caster (`effect.rs::register_transient_effect`),
+/// without going through the full split-second cast pipeline.
+fn grant_transient_cant_lose(state: &mut GameState, player: PlayerId) {
+    state.add_transient_continuous_effect(
+        ObjectId(9001),
+        player,
+        Duration::UntilEndOfTurn,
+        TargetFilter::SpecificPlayer { id: player },
+        vec![ContinuousModification::AddStaticMode {
+            mode: StaticMode::CantLoseTheGame,
+        }],
+        None,
+    );
+}
+
+/// Install a transient, turn-bound `CantWinTheGame` grant scoped to exactly
+/// one player — the "your opponents can't win the game" half of Angel's
+/// Grace, installed per-opponent by the same TCE dispatch.
+fn grant_transient_cant_win(state: &mut GameState, player: PlayerId) {
+    state.add_transient_continuous_effect(
+        ObjectId(9002),
+        player,
+        Duration::UntilEndOfTurn,
+        TargetFilter::SpecificPlayer { id: player },
+        vec![ContinuousModification::AddStaticMode {
+            mode: StaticMode::CantWinTheGame,
+        }],
+        None,
+    );
+}
+
+/// (a) SBA loss: CR 810.8c team life total is <= 0 (P0 at -10, P1 at 5, team
+/// total -5 — the same shape as `sba::tests::sba_2hg_team_dies_together`,
+/// which proves this combined total would otherwise eliminate the team), but
+/// only P1 holds the transient `CantLoseTheGame` grant. CR 810.8a: the grant
+/// protects the whole team, so NEITHER member is eliminated by the life SBA,
+/// even though P0 (the one actually below the individual eyeball test)
+/// received no grant of its own.
+#[test]
+fn sba_loss_blocked_for_2hg_team_when_only_one_teammate_granted() {
+    let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+    state.players[0].life = -10;
+    state.players[1].life = 5;
+    grant_transient_cant_lose(&mut state, TEAM_A_1);
+    let mut events = Vec::new();
+
+    check_state_based_actions(&mut state, &mut events);
+
+    assert!(
+        !state.players[0].is_eliminated,
+        "CR 810.8a: P0 must survive the life SBA via teammate P1's can't-lose grant"
+    );
+    assert!(
+        !state.players[1].is_eliminated,
+        "the granted teammate must also survive"
+    );
+}
+
+/// (c) Negative control for (a): the opposing team holds no grant at all and
+/// has the identical <= 0 combined life total — the team loses normally.
+/// Proves the life-SBA elimination path is live this game, so (a)'s survival
+/// isn't vacuous.
+#[test]
+fn sba_loss_still_applies_to_ungranted_2hg_team() {
+    let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+    state.players[2].life = -10;
+    state.players[3].life = 5;
+    let mut events = Vec::new();
+
+    check_state_based_actions(&mut state, &mut events);
+
+    assert!(
+        state.players[2].is_eliminated,
+        "unprotected team must still lose to the life SBA (reach guard)"
+    );
+    assert!(
+        state.players[3].is_eliminated,
+        "CR 810.8a: the whole team is eliminated together, not just the individual"
+    );
+}
+
+/// (b) Effect-stated loss: only P1 holds the transient `CantLoseTheGame`
+/// grant; a "target player loses the game" effect (Door to Nothingness /
+/// Angel's-Grace-adjacent wording) is aimed at P0, the NON-granted teammate.
+/// CR 810.8a: the loss is precluded for the whole team, so P0 survives.
+#[test]
+fn effect_stated_loss_blocked_for_non_granted_2hg_teammate() {
+    let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+    grant_transient_cant_lose(&mut state, TEAM_A_1);
+
+    let doom = ResolvedAbility::new(
+        Effect::LoseTheGame { target: None },
+        vec![TargetRef::Player(TEAM_A_0)],
+        ObjectId(1),
+        TEAM_B_0,
+    );
+    let mut events = Vec::new();
+    resolve_lose(&mut state, &doom, &mut events).unwrap();
+
+    assert!(
+        !state.players[0].is_eliminated,
+        "CR 810.8a: P0 must not lose to an effect-stated loss via teammate P1's grant"
+    );
+    assert!(!state.players[1].is_eliminated);
+
+    // Reach guard: the identical effect aimed at the opposing (ungranted)
+    // team still eliminates it — proving the effect-loss path is live and
+    // team-cascading (CR 810.8a: the whole team goes down together).
+    let doom_reach = ResolvedAbility::new(
+        Effect::LoseTheGame { target: None },
+        vec![TargetRef::Player(TEAM_B_0)],
+        ObjectId(2),
+        TEAM_A_0,
+    );
+    resolve_lose(&mut state, &doom_reach, &mut events).unwrap();
+    assert!(
+        state.players[2].is_eliminated,
+        "unprotected team must still lose (reach guard)"
+    );
+    assert!(
+        state.players[3].is_eliminated,
+        "CR 810.8a: the whole opposing team is eliminated together"
+    );
+}
+
+/// (d) Can't-win discrimination: only P2 holds the transient `CantWinTheGame`
+/// grant (the "opponents can't win" half of Angel's Grace, installed on one
+/// member of the opposing team); an effect-stated win is attempted by P3,
+/// P2's NON-granted teammate. CR 810.8a: the restriction covers the whole
+/// team, so the win effect must resolve with no eliminations.
+#[test]
+fn effect_stated_win_blocked_for_non_granted_2hg_teammate() {
+    let mut state = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+    grant_transient_cant_win(&mut state, TEAM_B_0);
+
+    let win = ResolvedAbility::new(
+        Effect::WinTheGame { target: None },
+        vec![],
+        ObjectId(3),
+        TEAM_B_1,
+    );
+    let mut events = Vec::new();
+    resolve_win(&mut state, &win, &mut events).unwrap();
+
+    assert!(
+        !state.players[0].is_eliminated && !state.players[1].is_eliminated,
+        "CR 810.8a: P3's win must be a no-op — teammate P2's can't-win grant covers the whole team"
+    );
+    assert!(
+        !state.players[2].is_eliminated && !state.players[3].is_eliminated,
+        "a blocked win eliminates no one, including the (non-)winning team itself"
+    );
+
+    // Reach guard: without any grant, the identical effect-stated win by the
+    // opposing team's member DOES eliminate the other team, proving the win
+    // path is live and this isn't vacuous.
+    let mut state2 = GameState::new(FormatConfig::two_headed_giant(), 4, 42);
+    let win2 = ResolvedAbility::new(
+        Effect::WinTheGame { target: None },
+        vec![],
+        ObjectId(4),
+        TEAM_B_1,
+    );
+    let mut events2 = Vec::new();
+    resolve_win(&mut state2, &win2, &mut events2).unwrap();
+    assert!(
+        state2.players[0].is_eliminated && state2.players[1].is_eliminated,
+        "unprotected opposing team must still lose to the win effect (reach guard)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod anax_instead_branch_not_chain;
 mod ancient_brass_dragon_roll_d20;
 mod ancient_bronze_dragon_roll_d20;
 mod ancient_copper_dragon_roll_d20;
+mod angels_grace;
 mod announce_locked_x_runtime;
 mod another_round_repeat;
 mod archmage_ascension_gated_draw_replacement;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -13,6 +13,7 @@ mod ancient_brass_dragon_roll_d20;
 mod ancient_bronze_dragon_roll_d20;
 mod ancient_copper_dragon_roll_d20;
 mod angels_grace;
+mod angels_grace_2hg;
 mod announce_locked_x_runtime;
 mod another_round_repeat;
 mod archmage_ascension_gated_draw_replacement;


### PR DESCRIPTION
## Summary
Adds engine support for **Angel's Grace**.

Built for the class, not the card:
- The "You can't lose the game this turn and your opponents can't win the game this turn." conjunction now splits at the clause boundary via a composed subject × negation axis (`players `/`your opponents ` × `can't `/`cannot `) in the bare-and splitter — the same seam and shape as the existing Everybody Lives! arms — and each half lowers through the existing `parse_restriction_modes` → `CantLoseTheGame`/`CantWinTheGame` transient-continuous-effect machinery (no new effects, no new enum variants).
- "Until end of turn, damage that would reduce your life total to less than 1 reduces it to 1 instead." lifts to the existing `Effect::AddTargetReplacement { target: None }` (Rankle and Torbran / Don't Blink seam), delegating the sentence parse to `parse_replacement_line` (the Worship/Fortune Thief life-floor authority). **Angel of Grace** (same sentence in an ETB trigger) flips to supported by the same arm.
- Latent-bug fix found in plan review: the floating (pending-registry) damage-replacement scan hardcoded `PlayerId(0)` as the controller authority in its `damage_target_filter` check; it now threads the install-time `source_controller`, so `DamageTargetPlayerScope::Controller`/`Opponent` bind to the actual installing player for the whole floating-replacement class.
- Class parity for the shared primitive: `player_has_cant_lose` now scans `game_active_statics` (battlefield + command zone, CR 114.4) instead of battlefield-only, so a command-zone emblem's "you can't lose the game" (Gideon of the Trials' emblem) is honored — matching `player_has_cant_win`, which already had command-zone scope.
- Second review-found gap closed: `resolve_lose` (CR 104.3e effect-stated losses — Pacts, Door to Nothingness) now gates each loss through `player_has_cant_lose`, mirroring `resolve_win`'s existing `player_has_cant_win` gate; previously "can't lose the game" only blocked SBA losses. Concede (CR 104.3a) and the SBA loop are unaffected, and `resolve_win`'s opponent elimination deliberately stays ungated (CR 104.1: a win ends the game; opponents don't "lose" per CR 104.3 — which is why these cards print both halves).

Known remaining sibling gaps (distinct root causes, intentionally out of scope, coverage stays honest/red for them): Gideon of the Trials' emblem *parse* (single-def emblem static path + short-name normalization of the "Gideon planeswalker" subtype adjective), Serra the Benevolent's emblem (replacement text inside an emblem). ~~Courageous Resolve (comma-list conjunct form)~~ — **fixed in the review-response commit below**, see `## Review response` section.

## Review response (head `765c12b39`)

matthewevans requested changes on two points; both are addressed in `765c12b39`, appended on top of `c8c3572af` (not rebased — a sibling branch, `card/gideon-of-the-trials`, is based on this one).

**1. Coverage-parse-diff verification (4 cards / 8 signatures, not 2).** Re-verified against fresh Scryfall Oracle text (not memory) for all four cards. Full discrimination posted as PR comment (`<!-- coverage-parse-diff -->`). Summary:
- **Angel's Grace / Angel of Grace** — the two intended additions; unchanged from the original analysis.
- **Courageous Resolve** — the same bare-and boundary Angel's Grace exercises also fires on Courageous Resolve's fateful-hour Oxford-comma list (`"...you can't lose the game this turn, and your opponents can't win the game this turn"`), which is correct and in-scope. Discriminating it surfaced a real regression the widening exposed: peeling the opponents-clause off the list left the *preceding* item with a dangling list comma (`"can't lose the game this turn,"`), which broke `parse_restriction_modes`'s `all_consuming` match and silently fell to `Effect::Unimplemented`. Fixed at the shared `push_clause_chunk` (every chunk boundary in the module routes through it, so this is the root-cause fix, not a one-arm patch) — it now trims a trailing list comma the same way it already trims the sentence-final period. Courageous Resolve now parses fully: `supported=true, gap_count=0` (previously left partially `Unimplemented`; the "known remaining sibling gap" note above is stale and struck through).
- **Celestine Reef** — a partial, non-regressing improvement: the "your opponents can't win the game" clause now resolves to `CantWinTheGame` via the same arm. The "you can't lose the game" clause stays `Unimplemented` for an unrelated, pre-existing, out-of-scope reason: this engine has no support for "until a player planeswalks" as a recognized duration/until-clause (a Planechase-specific event duration). Not caused by this PR's diff and not fixed here — `supported=false, gap_count=1` (down from a fully-unparsed trigger body before this PR).

**2. Class boundary at `sequence.rs:2707`.** Reviewed the prior agent's uncommitted documentation/test diff critically rather than trusting it: independently re-verified every cited card (Platinum Angel, Abyssal Persecutor, Herald of Eternal Dawn, Cloudsteel Kirin, Gideon of the Trials' emblem, The Book of Exalted Deeds, The Bird Champion, Adventurer Beguiler) via fresh Scryfall lookups, and re-ran gemini's suggested determiner-generic widen (`each`/`an`/`their`/`your` + `opponent(s)`) against Scryfall oracle-text search for "and each/an/their/your opponent(s) can't" — zero matches for every sibling form. The static-line "can't win/lose" compounds are intercepted by `is_cant_win_lose_compound` (`oracle.rs`, gated behind `is_granted_static_line`) before ever reaching this splitter — confirmed by reading both call sites, not assumed. Verdict: kept the documentation and boundary test as committed (both positive and negative cases hold up), and declined gemini's widen — it has no card to exercise or test, matching CLAUDE.md's evidence bar.

## Review response 2 (head `0724b2a7b`) — 2HG team propagation, CR 810.8a

matthewevans's second CHANGES_REQUESTED review blocked on: `CantLoseTheGame` protected only the named player, not that player's Two-Headed Giant team.

**Rule verified fresh** against `docs/MagicCompRules.txt:6733` (CR 810.8a), quoted verbatim: "Players win and lose the game only as a team, not as individuals. If either player on a team loses the game, the team loses the game. If either player on a team wins the game, the entire team wins the game. **If an effect says that a player can't win the game, that player's team can't win the game. If an effect says that a player can't lose the game, that player's team can't lose the game.**" The rule's own Platinum Angel example is the exact clause Angel's Grace prints: "Neither that player nor their teammate can lose the game while Platinum Angel is on the battlefield, and neither player on the opposing team can win the game."

**Verdict on the can't-win side:** the CR text states the identical team-propagation requirement for can't-win as for can't-lose (same sentence, parallel construction — not something I inferred), and the code evidence showed `player_has_cant_win` (`static_abilities.rs`) had the identical single-player defect as `player_has_cant_lose`. So the can't-win side is fixed in this response too, not just documented as a gap — both sides of Angel's Grace's own clause needed it.

**Fix, single authority point.** `player_has_cant_lose` (`crates/engine/src/game/sba.rs`) and `player_has_cant_win` (`crates/engine/src/game/static_abilities.rs`) each now fold in the 2HG teammate's grant, mirroring the existing `player_has_cant_gain_life` / `player_has_cant_lose_life` teammate fold already in `static_abilities.rs` (CR 810.9g/810.9h siblings — the reviewer's "adjacent life-lock helpers" reference): true for `player_id` if EITHER `player_id` itself or their teammate (`topology::has_two_headed_giant_shared_resources` + `players::teammates`) has the grant. Each single-player check was extracted into a small helper (`cant_lose_active_for` / `cant_win_active_for`) that the team-aware public function wraps — no duplicated scanning logic.

Both `player_has_cant_lose` and `player_has_cant_win` are the single shared authority already consulted by every caller (the SBA loop's `collect_life_losers`/`collect_draw_from_empty_losers` in `sba.rs`, `win_lose.rs`'s `resolve_lose`/`resolve_win`, and the loop-shortcut firewall in `analysis/loop_check.rs`), so the fix applies at one seam and every caller inherits it — no other file needed to change.

**Tests added** (`crates/engine/tests/integration/angels_grace_2hg.rs`, registered in `tests/integration/main.rs`): install the transient `CantLoseTheGame`/`CantWinTheGame` grant (the same `SpecificPlayer`-scoped TCE shape Angel's Grace's own resolution installs) on only ONE 2HG teammate, then exercise the OTHER teammate through the real runtime entry points:
- `sba_loss_blocked_for_2hg_team_when_only_one_teammate_granted` — SBA path (`check_state_based_actions`), team life total ≤ 0, only one teammate granted → team survives.
- `sba_loss_still_applies_to_ungranted_2hg_team` — negative control: identical life shape, no grant anywhere → team is eliminated (reach guard proving the SBA path is live).
- `effect_stated_loss_blocked_for_non_granted_2hg_teammate` — effect-stated path (`resolve_lose`, "target player loses the game" aimed at the non-granted teammate) → team survives, with an in-test reach guard against the opposing (ungranted) team.
- `effect_stated_win_blocked_for_non_granted_2hg_teammate` — can't-win discrimination (`resolve_win`, effect-stated win attempted by the non-granted teammate of the `CantWinTheGame` holder) → no-op, with a reach guard proving an unprotected win still eliminates normally.

The parser/coverage reconciliation from the first review response is untouched — no changes to `sequence.rs`, `mod.rs`, or `oracle_tests.rs` in this commit.

## Files changed
- crates/engine/src/parser/oracle_effect/sequence.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/game/replacement.rs
- crates/engine/src/game/effects/win_lose.rs
- crates/engine/src/game/sba.rs
- crates/engine/src/game/static_abilities.rs
- crates/engine/src/parser/oracle_tests.rs
- crates/engine/tests/integration/angels_grace.rs (new)
- crates/engine/tests/integration/angels_grace_2hg.rs (new)
- crates/engine/tests/integration/main.rs

## CR references
CR 104.2b, CR 104.3a, CR 104.3b, CR 104.3e, CR 109.4, CR 114.4, CR 117.3d, CR 119.7, CR 119.8, CR 514.2, CR 604.1, CR 611.2c, CR 614.1, CR 614.1a, CR 614.3, CR 810.8a, CR 810.9g, CR 810.9h — all verified by grep against docs/MagicCompRules.txt (July 2026).

## Implementation method (required)
Method: /engine-implementer

## Track
Developer

## LLM
Model: claude-sonnet-5
Thinking: high
Tier: Frontier

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean, no changes
- `cargo clippy --all-targets -- -D warnings` (workspace) — Finished, zero warnings (exit 0)
- `cargo test -p engine --test integration -- angels_grace` — 10 passed; 0 failed (6 prior + 4 new 2HG tests)
- `cargo test -p engine` (full suite, at `0724b2a7b`) — lib: 16857 passed; 0 failed; 7 ignored. Integration: 3301 passed; 0 failed; 2 ignored (3297 baseline + 4 new).
- `cargo coverage` — Angel's Grace: `supported=true gap_count=0`; Angel of Grace: `supported=true gap_count=0`; Courageous Resolve: `supported=true gap_count=0`; Celestine Reef: `supported=false gap_count=1` (unrelated pre-existing gap, see Review response section) — no regression, this response touches no parser code.
- `cargo semantic-audit` — zero findings for Angel's Grace / Angel of Grace (`grep -i "angel's grace\|angel of grace" data/semantic-audit.md` — no match)
- `git status --short` / `git diff --stat 765c12b39...HEAD` — clean tree, exactly the 4 files this response touches

**Review-response-2 commit (`0724b2a7b`), re-run at that head:**
- `cargo fmt --all` — clean, no changes
- `cargo clippy --all-targets -- -D warnings` (workspace) — Finished, zero warnings (exit 0)
- `cargo test -p engine` (full suite) — lib: 16857 passed; 0 failed; 7 ignored. Integration: 3301 passed; 0 failed; 2 ignored.
- `cargo coverage` — Angel's Grace / Angel of Grace unregressed (`supported=true, gap_count=0` both); no card regressed (no parser files touched by this commit)
- `cargo semantic-audit` — zero findings for Angel's Grace / Angel of Grace

## Gate A
Gate A PASS head=0724b2a7b360e31e04c64344dcf25b6774a0c59f base=765c12b39b9c7e7149d9797296372e0588b29309

## Anchored on
- crates/engine/src/parser/oracle_effect/sequence.rs:2725 — existing composed subject × verb `preceded(alt(..), value((), alt(..)))` boundary axis (gendered-pronoun arm) in the same `starts_bare_and_clause_lower` function; the new plural-player × negation axis mirrors it and replaces the enumerated `players can't/cannot` tags
- crates/engine/src/parser/oracle_effect/mod.rs:2031 — `parse_enter_from_zone_redirect_replacement`, the existing duration-stripped floating-replacement lift to `Effect::AddTargetReplacement { target: None }` at the same dispatch slot after `strip_leading_duration`; `try_parse_global_life_floor_replacement` mirrors its contract (expiry left `None`, derived from ability duration at install) and its `parse_replacement_line` delegation follows `try_parse_global_damage_modification_replacement` (mod.rs:1923)
- crates/engine/src/game/static_abilities.rs:712 — `check_static_ability`'s CR 114.4 battlefield + command-zone scan (`game_functioning_statics`), the authority `player_has_cant_win` already uses; `player_has_cant_lose` now mirrors it via `game_active_statics`
- crates/engine/src/parser/oracle_effect/sequence.rs:3300 (review-response commit) — `push_clause_chunk`'s pre-existing `.trim_end_matches('.')` sentence-final-period trim is the anchor pattern; the fix extends it to a char-class trim (`['.', ','])`) at the same call site, not a new suppression arm
- crates/engine/src/game/static_abilities.rs:1174 and :1192 (review-response-2 commit) — `player_has_cant_gain_life` / `player_has_cant_lose_life`'s existing `has_two_headed_giant_shared_resources(state) && teammates(state, player_id).into_iter().any(...)` teammate fold (CR 810.9g/810.9h); `player_has_cant_lose` and `player_has_cant_win` now apply the identical fold for CR 810.8a

## Final review-impl
Final review-impl PASS head=0724b2a7b360e31e04c64344dcf25b6774a0c59f

Self-review against docs/AI-CONTRIBUTOR.md §5.3 checklist (no repo-local `/review-impl` skill available in this runtime; performed the checklist directly against `git diff 765c12b39..0724b2a7b`):
- (a) correct seam: fix lands exactly at the two authorities the review cited (`sba.rs::player_has_cant_lose`, `static_abilities.rs::player_has_cant_win`), not a symptom-patch at a caller.
- (b) idiomatic: reuses the established `player_has_cant_gain_life`/`player_has_cant_lose_life` teammate-fold shape verbatim (same helpers, same short-circuit structure).
- (c) nom-mandate: n/a — no parser changes in this commit.
- (d) CR-citation: CR 810.8a is itself the authorizing rule for this behavior (verified fresh against `docs/MagicCompRules.txt:6733`); no separate layering rule applies.
- (e) pattern coverage: fixes the shared authority every can't-lose/can't-win caller in the engine routes through (SBA loop, effect-stated loss/win, loop-shortcut firewall) — not an Angel's-Grace-only patch.
- (f) logic placement: engine-only; no frontend touched.
- (g) building-block reuse: reuses `topology::teammates` / `topology::has_two_headed_giant_shared_resources`, no duplicated scan logic.
- (h) bool-flag avoidance: no new bool fields/params introduced.
- (i) test discrimination: all four new tests drive real engine entry points (`check_state_based_actions`, `resolve_lose`, `resolve_win`) and each protected-team assertion is paired with an in-test or sibling reach guard proving the unprotected path still fires — no bare negative assertions.

## Claimed parse impact
- Angel's Grace
- Angel of Grace
- Courageous Resolve (incidental fix, review-response commit)

No new parse impact in review-response-2 — that commit touches only runtime authority functions and tests, not the parser.

## Validation Failures
None.

## CI Failures
None.
