### PR TITLE
ship/t167 impulse exile pipeline

### DIFF
--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -1,10 +1,10 @@
-use crate::game::zones;
+use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
 use crate::types::ability::{
     AbilityCost, CastingPermission, Duration, Effect, EffectError, EffectKind, ResolvedAbility,
     SpellStackToGraveyardReplacement, TargetFilter, TargetRef,
 };
 use crate::types::events::GameEvent;
-use crate::types::game_state::{CastingVariant, GameState, WaitingFor};
+use crate::types::game_state::{BatchCompletion, CastingVariant, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::ManaCost;
 use crate::types::zones::Zone;
@@ -399,13 +399,23 @@ pub fn resolve(
         );
     }
 
-    grant_lingering_permissions(state, ability, &target_ids, events)?;
-
-    events.push(GameEvent::EffectResolved {
-        kind: EffectKind::CastFromZone,
-        source_id: ability.source_id,
-        subject: None,
-    });
+    match grant_lingering_permissions(state, ability, &target_ids, events)? {
+        LingeringPermissionGrantResult::Immediate => {
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::CastFromZone,
+                source_id: ability.source_id,
+                subject: None,
+            });
+        }
+        LingeringPermissionGrantResult::ExileDeliveryComplete => {}
+        // CR 614.1 + CR 616.1: A current-zone-to-Exile delivery may park for
+        // replacement ordering. Its typed batch completion records the
+        // permission and emits `EffectResolved` only after the delivery settles,
+        // so this resolver must not run either tail early.
+        LingeringPermissionGrantResult::NeedsChoice => {
+            return Ok(());
+        }
+    }
 
     Ok(())
 }
@@ -488,8 +498,10 @@ pub(crate) fn complete_hand_pick_cast_from_zone(
         return Ok(true);
     }
 
-    grant_lingering_permissions(state, ability, std::slice::from_ref(&card), events)?;
-    Ok(false)
+    Ok(matches!(
+        grant_lingering_permissions(state, ability, std::slice::from_ref(&card), events)?,
+        LingeringPermissionGrantResult::NeedsChoice
+    ))
 }
 
 fn effective_cast_from_zone_constraint(
@@ -740,6 +752,20 @@ fn cast_from_zone_enters_with_modifications(
     Vec::new()
 }
 
+/// Result of a lingering cast permission grant. An exile-delivery batch owns
+/// `EffectResolved` so its tail cannot run before a parked replacement choice.
+pub(crate) enum LingeringPermissionGrantResult {
+    /// Every resolved target already occupies an in-place supported zone.
+    Immediate,
+    /// One batch delivered every current-zone-to-Exile target through the
+    /// replacement pipeline synchronously; its completion recorded only
+    /// settled exile cards and emitted the resolution tail.
+    ExileDeliveryComplete,
+    /// The replacement pipeline parked at CR 616.1; its completion owns the
+    /// permission and resolution tail once the choice settles.
+    NeedsChoice,
+}
+
 /// CR 118.9: Stamp `ExileWithAltCost` / `ExileWithAltAbilityCost` on resolved
 /// targets. Shared by the direct resolve path and the `EffectZoneChoice` resume
 /// path (Electrodominance hand pick).
@@ -748,6 +774,55 @@ pub(crate) fn grant_lingering_permissions(
     ability: &ResolvedAbility,
     target_ids: &[ObjectId],
     events: &mut Vec<GameEvent>,
+) -> Result<LingeringPermissionGrantResult, EffectError> {
+    let mut in_place_ids = Vec::new();
+    let mut exile_delivery_ids = Vec::new();
+    for &obj_id in target_ids {
+        let Some(current_zone) = state.objects.get(&obj_id).map(|object| object.zone) else {
+            continue;
+        };
+        if matches!(current_zone, Zone::Exile | Zone::Graveyard | Zone::Hand) {
+            in_place_ids.push(obj_id);
+        } else {
+            exile_delivery_ids.push(obj_id);
+        }
+    }
+
+    if exile_delivery_ids.is_empty() {
+        record_lingering_permissions(state, ability, &in_place_ids)?;
+        return Ok(LingeringPermissionGrantResult::Immediate);
+    }
+
+    // CR 614.1 + CR 616.1: The impulse-draw-class current-zone-to-Exile
+    // instruction is a replaceable effect-owned event. Keep the permission
+    // recording and resolution event in the typed completion so a replacement
+    // choice cannot expose either tail before the whole batch settles.
+    let requests = exile_delivery_ids
+        .iter()
+        .map(|&obj_id| ZoneMoveRequest::effect(obj_id, Zone::Exile, ability.source_id))
+        .collect();
+    let result = zone_pipeline::move_objects_simultaneously_then(
+        state,
+        requests,
+        Some(BatchCompletion::CastFromZoneExileDeliveryComplete {
+            ability: Box::new(ability.clone()),
+            in_place_ids,
+            exile_delivery_ids,
+        }),
+        events,
+    );
+    Ok(match result {
+        BatchMoveResult::Done => LingeringPermissionGrantResult::ExileDeliveryComplete,
+        BatchMoveResult::NeedsChoice => LingeringPermissionGrantResult::NeedsChoice,
+    })
+}
+
+/// CR 118.9: Construct the object-local casting permissions after the caller
+/// established that each target is in a zone the permission can authorize.
+fn record_lingering_permissions(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    target_ids: &[ObjectId],
 ) -> Result<(), EffectError> {
     let (
         without_paying,
@@ -788,17 +863,12 @@ pub(crate) fn grant_lingering_permissions(
     let enters_with_modifications = cast_from_zone_enters_with_modifications(ability);
 
     for &obj_id in target_ids {
-        // CR 601.2a: Impulse-draw and similar grants move non-exile cards to
-        // exile before attaching `ExileWithAltCost`. Targeted graveyard grants
-        // (Emry, Lurker in the Loch) and resolution-time hand picks
-        // (Electrodominance) keep the card in its source zone and grant a
-        // permission the casting pipeline consumes in place.
+        // CR 601.2a: Targeted graveyard grants (Emry, Lurker in the Loch) and
+        // resolution-time hand picks (Electrodominance) keep the card in its
+        // source zone and grant a permission the casting pipeline consumes in
+        // place. Current-zone-to-Exile targets arrive here only after their
+        // replacement-safe delivery settled in exile.
         let current_zone = state.objects.get(&obj_id).map(|o| o.zone);
-        if current_zone.is_some_and(|z| z != Zone::Exile && z != Zone::Graveyard && z != Zone::Hand)
-        {
-            zones::move_to_zone(state, obj_id, Zone::Exile, events);
-        }
-
         // CR 118.9: Grant casting permission. Three cases:
         //   - `alt_ability_cost: Some(_)` → `ExileWithAltAbilityCost` (Nashi:
         //     "pay life equal to its mana value rather than paying its mana
@@ -877,10 +947,39 @@ pub(crate) fn grant_lingering_permissions(
     Ok(())
 }
 
+/// CR 614.1 + CR 616.1 + CR 611.2a: Complete an impulse-draw-class exile
+/// delivery only after every proposed move settles. A redirected card receives
+/// no exile permission; existing Hand/Graveyard/Exile targets retain their
+/// established in-place grant behavior.
+pub(crate) fn complete_lingering_permissions_after_exile_delivery(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    in_place_ids: &[ObjectId],
+    exile_delivery_ids: &[ObjectId],
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    let mut permission_ids = in_place_ids.to_vec();
+    permission_ids.extend(exile_delivery_ids.iter().copied().filter(|obj_id| {
+        state
+            .objects
+            .get(obj_id)
+            .is_some_and(|object| object.zone == Zone::Exile)
+    }));
+    record_lingering_permissions(state, ability, &permission_ids)
+        .expect("CastFromZone batch completion carries a CastFromZone ability");
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::CastFromZone,
+        source_id: ability.source_id,
+        subject: None,
+    });
+    BatchMoveResult::Done
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::game::engine::apply_as_current;
+    use crate::game::zones;
     use crate::game::zones::create_object;
     use crate::types::ability::{
         CardPlayMode, CastFromZoneDriver, CastPermissionConstraint, Comparator, ControllerRef,

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -4268,13 +4268,22 @@ pub(super) fn handle_resolution_choice(
                             ));
                         }
                     } else {
-                        effects::cast_from_zone::grant_lingering_permissions(
-                            &mut *state,
-                            &ability,
-                            &chosen,
-                            events,
-                        )
-                        .map_err(|e| EngineError::InvalidAction(e.to_string()))?;
+                        let permission_grant =
+                            effects::cast_from_zone::grant_lingering_permissions(
+                                &mut *state,
+                                &ability,
+                                &chosen,
+                                events,
+                            )
+                            .map_err(|e| EngineError::InvalidAction(e.to_string()))?;
+                        if matches!(
+                            permission_grant,
+                            effects::cast_from_zone::LingeringPermissionGrantResult::NeedsChoice
+                        ) {
+                            return Ok(ResolutionChoiceOutcome::WaitingFor(
+                                state.waiting_for.clone(),
+                            ));
+                        }
                     }
                 }
                 // CR 701.68a: Place `count_param` -1/-1 counters on the creature
@@ -5944,6 +5953,17 @@ pub(crate) fn run_batch_completion(
 ) -> crate::game::zone_pipeline::BatchMoveResult {
     use crate::types::game_state::BatchCompletion;
     match completion {
+        BatchCompletion::CastFromZoneExileDeliveryComplete {
+            ability,
+            in_place_ids,
+            exile_delivery_ids,
+        } => effects::cast_from_zone::complete_lingering_permissions_after_exile_delivery(
+            state,
+            &ability,
+            &in_place_ids,
+            &exile_delivery_ids,
+            events,
+        ),
         BatchCompletion::CascadeExileLoopComplete {
             controller,
             source_id,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1848,6 +1848,15 @@ pub struct PendingBatchDeliveries {
 /// pattern.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BatchCompletion {
+    /// CR 614.1 + CR 616.1 + CR 611.2a: A `CastFromZone` current-zone-to-Exile
+    /// batch settled. Keep the resolved ability and its two target partitions
+    /// so the permission is recorded only after the exile delivery, while
+    /// established in-place Hand/Graveyard/Exile grants remain unchanged.
+    CastFromZoneExileDeliveryComplete {
+        ability: Box<ResolvedAbility>,
+        in_place_ids: Vec<ObjectId>,
+        exile_delivery_ids: Vec<ObjectId>,
+    },
     /// CR 702.85a + CR 614.1 + CR 616.1: One proposed cascade exile settled.
     /// Keep the current card, source threshold, controller, and already-exiled
     /// misses with the batch so a replacement choice resumes the loop correctly.

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -5,12 +5,12 @@ use engine::game::mana_abilities::activate_mana_ability;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, CastingPermission,
-    CategoryChooserScope, ChoiceType, Chooser, DigSource, DiscardSelfScope, Effect, EffectKind,
-    FilterProp, ForEachCategoryAction, IterationCategory, ManaContribution, ManaProduction,
-    ModalChoice, QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode,
-    ResolvedAbility, SacrificeCost, SpellCastingOption, TargetFilter, TargetRef,
-    TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, CardPlayMode, CardSelectionMode,
+    CastFromZoneDriver, CastingPermission, CategoryChooserScope, ChoiceType, Chooser, DigSource,
+    DiscardSelfScope, Effect, EffectKind, FilterProp, ForEachCategoryAction, IterationCategory,
+    ManaContribution, ManaProduction, ModalChoice, QuantityExpr, QuantityRef,
+    ReplacementDefinition, ReplacementMode, ResolvedAbility, SacrificeCost, SpellCastingOption,
+    TargetFilter, TargetRef, TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
@@ -7384,6 +7384,164 @@ fn cascade_exile_loop_stays_synchronous_without_replacements() {
             .count(),
         1,
         "the synchronous cascade tail resolves exactly once"
+    );
+}
+
+/// W-167 (red first): a cast-from-zone exile delivery must park before it grants
+/// the lingering permission or emits its resolution event when CR 616.1 requires
+/// the affected card's controller to choose a replacement.
+#[test]
+fn cast_from_zone_exile_redirect_pauses_before_lingering_permission_tail() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Cast-From-Zone Redirect Source", 1, 1)
+        .id();
+    let card = scenario
+        .add_spell_to_library_top(P0, "Cast-From-Zone Redirect Card", true)
+        .id();
+    scenario
+        .add_creature(P0, "Cast-From-Zone Exile To Hand", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Hand));
+    scenario
+        .add_creature(P0, "Cast-From-Zone Exile To Graveyard", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Exile, Zone::Graveyard));
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![card];
+    let ability = ResolvedAbility::new(
+        Effect::CastFromZone {
+            target: TargetFilter::ParentTarget,
+            without_paying_mana_cost: true,
+            mode: CardPlayMode::Cast,
+            cast_transformed: false,
+            alt_ability_cost: None,
+            constraint: None,
+            duration: None,
+            driver: CastFromZoneDriver::LingeringPermission,
+            mana_spend_permission: None,
+        },
+        vec![TargetRef::Object(card)],
+        source,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("CastFromZone reaches its replacement-safe exile delivery");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&card].zone, Zone::Library);
+    assert!(runner.state().objects[&card].casting_permissions.is_empty());
+    assert!(
+        !initial_events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::CastFromZone,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "the lingering-permission tail must not precede the replacement choice"
+    );
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the selected exile redirect settles the CastFromZone delivery");
+    assert!(matches!(
+        resumed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&card].zone, Zone::Hand);
+    assert!(
+        runner.state().objects[&card].casting_permissions.is_empty(),
+        "an exile permission must not attach when the card did not reach exile"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::CastFromZone,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the settled CastFromZone tail resolves exactly once"
+    );
+}
+
+/// W-167-REG: an unredirected CastFromZone exile delivery remains synchronous
+/// and grants exactly the same permission as the prior raw mover.
+#[test]
+fn cast_from_zone_exile_delivery_stays_synchronous_and_grants_permission() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Synchronous Cast-From-Zone Source", 1, 1)
+        .id();
+    let card = scenario
+        .add_spell_to_library_top(P0, "Synchronous Cast-From-Zone Card", true)
+        .id();
+    let second_card = scenario
+        .add_spell_to_library_top(P0, "Second Synchronous Cast-From-Zone Card", true)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![card, second_card];
+    let ability = ResolvedAbility::new(
+        Effect::CastFromZone {
+            target: TargetFilter::ParentTarget,
+            without_paying_mana_cost: true,
+            mode: CardPlayMode::Cast,
+            cast_transformed: false,
+            alt_ability_cost: None,
+            constraint: None,
+            duration: None,
+            driver: CastFromZoneDriver::LingeringPermission,
+            mana_spend_permission: None,
+        },
+        vec![TargetRef::Object(card), TargetRef::Object(second_card)],
+        source,
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("unredirected CastFromZone resolves synchronously");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    for card in [card, second_card] {
+        assert_eq!(runner.state().objects[&card].zone, Zone::Exile);
+        assert!(runner.state().objects[&card]
+            .casting_permissions
+            .iter()
+            .any(|permission| matches!(permission, CastingPermission::ExileWithAltCost { .. })));
+    }
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::CastFromZone,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the synchronous CastFromZone path resolves exactly once"
     );
 }
 

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -26,7 +26,6 @@ crates/engine/src/game/deck_loading.rs	create_contraption_deck_card	exempt	1
 crates/engine/src/game/deck_loading.rs	create_planar_deck_card	exempt	1
 crates/engine/src/game/deck_loading.rs	create_scheme_deck_card	exempt	1
 crates/engine/src/game/effects/cast_copy_of_card.rs	cast_one_copy	exempt	1
-crates/engine/src/game/effects/cast_from_zone.rs	grant_lingering_permissions	mover	1
 crates/engine/src/game/effects/cloak.rs	resolve	mover	1
 crates/engine/src/game/effects/copy_spell.rs	resolve	exempt	1
 crates/engine/src/game/effects/epic.rs	resolve	exempt	1


### PR DESCRIPTION
- **fix(engine): record impulse cast permissions only after replacement-safe exile delivery**
- **chore(engine): refresh zone-authority baseline after impulse-exile migration (41 hits / 27 rows)**
