### PR TITLE
Add regression tests: cost reductions apply to miracle costs

### DIFF
--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -2454,6 +2454,10 @@ fn miracle_sorcery_casts_during_draw_step() {
 fn miracle_cost_is_reduced_by_medallion_static() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
+    let miracle_cost = ManaCost::Cost {
+        shards: vec![ManaCostShard::Red],
+        generic: 1,
+    };
     // Ruby Medallion-class reducer on the battlefield (full parser path).
     scenario
         .add_creature(P0, "Ruby Medallion Stand-In", 2, 2)
@@ -2466,10 +2470,7 @@ fn miracle_cost_is_reduced_by_medallion_static() {
             shards: vec![ManaCostShard::Red],
             generic: 8,
         })
-        .with_keyword(Keyword::Miracle(ManaCost::Cost {
-            shards: vec![ManaCostShard::Red],
-            generic: 1,
-        }))
+        .with_keyword(Keyword::Miracle(miracle_cost.clone()))
         .with_ability(Effect::Draw {
             count: QuantityExpr::Fixed { value: 1 },
             target: TargetFilter::Controller,
@@ -2492,10 +2493,7 @@ fn miracle_cost_is_reduced_by_medallion_static() {
     runner.state_mut().waiting_for = WaitingFor::MiracleReveal {
         player: P0,
         object_id: miracle_obj,
-        cost: ManaCost::Cost {
-            shards: vec![ManaCostShard::Red],
-            generic: 1,
-        },
+        cost: miracle_cost,
     };
     runner
         .act(GameAction::CastSpellAsMiracle {
@@ -2556,6 +2554,10 @@ fn miracle_cost_is_reduced_by_medallion_static() {
 fn miracle_cost_fully_reduced_casts_for_zero() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
+    let miracle_cost = ManaCost::Cost {
+        shards: vec![],
+        generic: 2,
+    };
     scenario
         .add_creature(P0, "Ruby Medallion Stand-In", 2, 2)
         .from_oracle_text("Red spells you cast cost {1} less to cast.");
@@ -2569,10 +2571,7 @@ fn miracle_cost_fully_reduced_casts_for_zero() {
             shards: vec![ManaCostShard::Red, ManaCostShard::White],
             generic: 2,
         })
-        .with_keyword(Keyword::Miracle(ManaCost::Cost {
-            shards: vec![],
-            generic: 2,
-        }))
+        .with_keyword(Keyword::Miracle(miracle_cost.clone()))
         .with_ability(Effect::Draw {
             count: QuantityExpr::Fixed { value: 1 },
             target: TargetFilter::Controller,
@@ -2585,10 +2584,7 @@ fn miracle_cost_fully_reduced_casts_for_zero() {
     runner.state_mut().waiting_for = WaitingFor::MiracleReveal {
         player: P0,
         object_id: miracle_obj,
-        cost: ManaCost::Cost {
-            shards: vec![],
-            generic: 2,
-        },
+        cost: miracle_cost,
     };
     runner
         .act(GameAction::CastSpellAsMiracle {

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -2444,6 +2444,186 @@ fn miracle_sorcery_casts_during_draw_step() {
     );
 }
 
+/// CR 601.2f: The total cost of a miracle cast is the miracle ALTERNATIVE cost
+/// plus increases minus reductions — a Medallion-class battlefield static
+/// ("Red spells you cast cost {1} less to cast", Ruby Medallion) must discount
+/// the miracle cost, not just the printed cost. A red spell with miracle
+/// {1}{R} casts for {R} with the medallion out: the pool holds ONLY {R}, so if
+/// the reduction were dropped the Auto payment would demand {1}{R} and fail.
+#[test]
+fn miracle_cost_is_reduced_by_medallion_static() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Ruby Medallion-class reducer on the battlefield (full parser path).
+    scenario
+        .add_creature(P0, "Ruby Medallion Stand-In", 2, 2)
+        .from_oracle_text("Red spells you cast cost {1} less to cast.");
+
+    // A RED spell (color derived from the printed {8}{R}) with miracle {1}{R}.
+    let miracle_obj = scenario
+        .add_spell_to_hand(P0, "ReducedMiracle", false)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 8,
+        })
+        .with_keyword(Keyword::Miracle(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 1,
+        }))
+        .with_ability(Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    // EXACTLY {R} in pool: enough for the reduced {R}, not the unreduced {1}{R}.
+    runner.state_mut().players[0]
+        .mana_pool
+        .add(engine::types::mana::ManaUnit::new(
+            engine::types::mana::ManaType::Red,
+            ObjectId(0),
+            false,
+            Vec::new(),
+        ));
+    let card_id = runner.state().objects[&miracle_obj].card_id;
+
+    // Surface the reveal prompt directly (as the other miracle tests do).
+    runner.state_mut().waiting_for = WaitingFor::MiracleReveal {
+        player: P0,
+        object_id: miracle_obj,
+        cost: ManaCost::Cost {
+            shards: vec![ManaCostShard::Red],
+            generic: 1,
+        },
+    };
+    runner
+        .act(GameAction::CastSpellAsMiracle {
+            object_id: miracle_obj,
+            card_id,
+
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("Reveal should succeed");
+    runner.act(GameAction::PassPriority).expect("P0 pass");
+    runner.act(GameAction::PassPriority).expect("P1 pass");
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::CastOffer {
+                kind: CastOfferKind::Miracle { .. },
+                ..
+            }
+        ),
+        "should be MiracleCastOffer, got {:?}",
+        runner.state().waiting_for
+    );
+
+    // Revert-failing: with only {R} in pool this cast succeeds ONLY if the
+    // medallion reduced the miracle {1}{R} to {R} (CR 601.2f).
+    runner
+        .act(GameAction::CastSpellAsMiracle {
+            object_id: miracle_obj,
+            card_id,
+
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("miracle cast should succeed at the medallion-reduced cost {R}");
+
+    assert!(
+        matches!(
+            &runner.state().stack.last().unwrap().kind,
+            StackEntryKind::Spell {
+                casting_variant: CastingVariant::Miracle,
+                ..
+            }
+        ),
+        "spell should be on the stack via Miracle variant"
+    );
+    assert!(
+        runner.state().players[0].mana_pool.mana.is_empty(),
+        "the reduced miracle cost {{R}} should consume the single red mana, got {:?}",
+        runner.state().players[0].mana_pool.mana
+    );
+}
+
+/// CR 601.2f floor: reductions meeting or exceeding an ALL-GENERIC miracle cost
+/// take it to {0}. A gold R/W spell (color from its printed {2}{R}{W}) with
+/// miracle {2} under BOTH a Ruby and a Pearl Medallion-class static ({1} less
+/// each, both apply to a red-and-white spell) casts with an EMPTY mana pool —
+/// any unreduced residue would make the Auto payment fail.
+#[test]
+fn miracle_cost_fully_reduced_casts_for_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Ruby Medallion Stand-In", 2, 2)
+        .from_oracle_text("Red spells you cast cost {1} less to cast.");
+    scenario
+        .add_creature(P0, "Pearl Medallion Stand-In", 2, 2)
+        .from_oracle_text("White spells you cast cost {1} less to cast.");
+
+    let miracle_obj = scenario
+        .add_spell_to_hand(P0, "GoldMiracle", false)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Red, ManaCostShard::White],
+            generic: 2,
+        })
+        .with_keyword(Keyword::Miracle(ManaCost::Cost {
+            shards: vec![],
+            generic: 2,
+        }))
+        .with_ability(Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&miracle_obj].card_id;
+
+    runner.state_mut().waiting_for = WaitingFor::MiracleReveal {
+        player: P0,
+        object_id: miracle_obj,
+        cost: ManaCost::Cost {
+            shards: vec![],
+            generic: 2,
+        },
+    };
+    runner
+        .act(GameAction::CastSpellAsMiracle {
+            object_id: miracle_obj,
+            card_id,
+
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("Reveal should succeed");
+    runner.act(GameAction::PassPriority).expect("P0 pass");
+    runner.act(GameAction::PassPriority).expect("P1 pass");
+
+    // Revert-failing: the pool is EMPTY, so the cast succeeds only if the two
+    // {1}-less reductions floored the all-generic miracle {2} at {0} (CR 601.2f).
+    runner
+        .act(GameAction::CastSpellAsMiracle {
+            object_id: miracle_obj,
+            card_id,
+
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("miracle cast should succeed for {0} with both medallions out");
+
+    assert!(
+        matches!(
+            &runner.state().stack.last().unwrap().kind,
+            StackEntryKind::Spell {
+                casting_variant: CastingVariant::Miracle,
+                ..
+            }
+        ),
+        "spell should be on the stack via Miracle variant after the {{0}} cast"
+    );
+}
+
 /// CR 118.9: Rooftop Storm — "You may pay {0} rather than pay the mana cost for
 /// Zombie creature spells you cast." End-to-end: parse the Oracle text onto a
 /// battlefield permanent, then casting a Zombie creature offers the alternative


### PR DESCRIPTION
## Summary
Adds two engine-level regression tests proving cost-REDUCTION statics (Ruby/Pearl Medallion class) apply to the concretized miracle alternative cost per CR 601.2f (total cost = mana cost OR alternative cost, plus increases, minus reductions), including the fully-reduced {0} floor case for a gold R/W spell under both medallions (miracle {2} is entirely generic). Verified in ai-commander audit work that granted miracle functions; this closes the untested reducer×miracle interaction (CR 601.2f) with engine-level regression coverage.

- `miracle_cost_is_reduced_by_medallion_static` — a red spell with miracle {1}{R} under a parsed "Red spells you cast cost {1} less to cast." battlefield static casts with a pool of EXACTLY {R}; the Auto payment succeeds only if the reduction applied to the miracle cost.
- `miracle_cost_fully_reduced_casts_for_zero` — CR 601.2f floor: a gold R/W spell with an all-generic miracle {2} under both a Ruby- and a Pearl-Medallion-class static casts with an EMPTY mana pool ({2} − {1} − {1} floors at {0}).

Both drive the real engine pipeline (reveal accept → miracle trigger → `CastOfferKind::Miracle` → `CastSpellAsMiracle` with `CastPaymentMode::Auto`), mirroring the existing miracle section's style. Test-only change; no engine, parser, or card-data modifications.

## Files changed
- crates/engine/tests/integration/rules/casting.rs

## CR references
CR 601.2f, CR 702.94a, CR 603.11, CR 608.2g

## Implementation method (required)
Method: not-applicable — test-only addition (no engine/parser/card-data changes)

## Track
Developer

## LLM
Model: claude-fable-5
Thinking: high
Tier: Frontier

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean (no diff)
- `cargo clippy-strict` — `Finished 'dev' profile [unoptimized + debuginfo] target(s) in 6m 43s`, zero warnings
- `cargo test -p engine --test integration -- miracle` — `test result: ok. 16 passed; 0 failed; 0 ignored` (includes both new tests: `rules::casting::miracle_cost_is_reduced_by_medallion_static ... ok`, `rules::casting::miracle_cost_fully_reduced_casts_for_zero ... ok`)

## Gate A
Gate A PASS head=299c1f24f60354c9bf4673ff24e2a91c2d4bb511 base=4a0ffc9fe87dd4e0d5b4760936b313adafce50eb

## Anchored on
- crates/engine/tests/integration/rules/casting.rs:2227 — `miracle_accept_casts_for_miracle_cost`: the reveal-accept → trigger → `CastOfferKind::Miracle` → Auto-payment drive and pool-emptiness assertion pattern the new tests mirror
- crates/engine/tests/integration/granted_alt_cost_hand_keyword.rs:91 — `aminatou_miracle_cost_floors_at_zero`: the CR 601.2f {0}-floor regression phrasing the floor test anchors on

## Final review-impl
Final review-impl PASS head=299c1f24f60354c9bf4673ff24e2a91c2d4bb511

## Claimed parse impact
None.

## Validation Failures
None.

## CI Failures
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
