### PR TITLE
ship/t168 cloak exile pipeline

### DIFF
--- a/crates/engine/src/game/effects/cloak.rs
+++ b/crates/engine/src/game/effects/cloak.rs
@@ -1,7 +1,9 @@
 use crate::game::quantity::resolve_quantity_with_targets;
+use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter};
 use crate::types::events::GameEvent;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{BatchCompletion, CloakExileMember, GameState};
+use crate::types::zones::Zone;
 
 /// CR 701.58a: Cloak — put the top card of a player's library onto the
 /// battlefield face down as a 2/2 creature **with ward {2}**. Like manifest
@@ -55,7 +57,7 @@ pub fn resolve(
         Some(TargetFilter::TrackedSet { .. }) => {
             // CR 608.2c: bind the `TrackedSetId(0)` sentinel to the chain's
             // published pile (the same set `Effect::Shuffle` just reordered).
-            let members: Vec<crate::types::identifiers::ObjectId> =
+            let member_ids: Vec<crate::types::identifiers::ObjectId> =
                 match crate::game::targeting::resolve_tracked_set_sentinel(
                     state,
                     TargetFilter::TrackedSet {
@@ -70,60 +72,50 @@ pub fn resolve(
                     _ => Vec::new(),
                 };
 
-            // CR 701.58e: cloak the pile one card at a time, in the shuffled order.
-            for object_id in members {
-                // Capture the departing creature's attachments BEFORE the exile —
-                // `sever_battlefield_attachment_graph_on_exit` clears this list as
-                // part of the zone change.
-                let attachments = state
-                    .objects
-                    .get(&object_id)
-                    .map(|obj| obj.attachments.clone())
-                    .unwrap_or_default();
-
-                // CR 603.6c + CR 122.2: a real Battlefield→Exile move — clears
-                // counters, fires leaves-the-battlefield triggers, and detaches
-                // the creature from any Aura/Equipment (host side).
-                crate::game::zones::move_to_zone(
-                    state,
+            // CR 603.10a: capture attachment identities while the departing
+            // creatures still exist on the battlefield. Zone delivery severs the
+            // live host edge before LTB trigger collection, so the typed tail
+            // needs this pre-event snapshot to clear the former attachment
+            // back-edges after the whole departure batch settles.
+            let members = member_ids
+                .into_iter()
+                .map(|object_id| CloakExileMember {
                     object_id,
-                    crate::types::zones::Zone::Exile,
-                    events,
-                );
+                    attachments: state
+                        .objects
+                        .get(&object_id)
+                        .map(|object| object.attachments.clone())
+                        .unwrap_or_default(),
+                })
+                .collect::<Vec<_>>();
+            let requests = members
+                .iter()
+                .map(|member| {
+                    ZoneMoveRequest::effect(member.object_id, Zone::Exile, ability.source_id)
+                })
+                .collect();
 
-                // CR 400.7 + CR 704.5m/704.5n: the exiled creature became a new
-                // object, and the cloaked card it returns as is yet another new
-                // object. The engine reuses `ObjectId` across zones, so the
-                // attachment side of the graph still points at that reused id —
-                // null each former attachment's back-edge to model "the object I
-                // was attached to ceased to exist" (CR 400.7). Without this, the
-                // reused-id face-down 2/2 that returns below would spuriously
-                // satisfy the attachment-legality re-check and the Aura/Equipment
-                // would never fall off. The post-resolution CR 704.5m SBA then
-                // sends orphaned Auras to the graveyard and unattaches Equipment.
-                for attachment_id in attachments {
-                    if let Some(attachment) = state.objects.get_mut(&attachment_id) {
-                        attachment.attached_to = None;
-                    }
-                }
-
-                // CR 701.58a: manifest the now-exiled card back onto the
-                // battlefield face down as a 2/2 with ward {2}.
-                crate::game::morph::manifest_card(
-                    state,
+            // CR 614.1 + CR 616.1: this is a real effect-owned
+            // Battlefield→Exile batch. Its detach/manifest tail belongs to the
+            // typed completion so it cannot run before a replacement choice, and
+            // it can re-park if an individual face-down entry later needs one.
+            let result = zone_pipeline::move_objects_simultaneously_then(
+                state,
+                requests,
+                Some(BatchCompletion::CloakExileDeliveryComplete {
                     player,
-                    object_id,
-                    ability.source_id,
-                    crate::types::ability::FaceDownProfile::cloaked_2_2(),
-                    None,
-                    events,
-                )
-                .map_err(|e| EffectError::MissingParam(format!("{e}")))?;
+                    source_id: ability.source_id,
+                    members,
+                }),
+                events,
+            );
+            if matches!(result, BatchMoveResult::NeedsChoice) {
+                return Ok(());
             }
-            // The detach/exile/return churn changed the attachment graph and P/T;
-            // force a layer recompute so downstream reads settle (mirrors
-            // `sever_battlefield_attachment_graph_on_exit`).
-            crate::game::layers::mark_layers_full(state);
+
+            // The synchronous completion already performed the manifest tail and
+            // emitted `EffectResolved`; do not let the common epilogue duplicate it.
+            return Ok(());
         }
         // (B) An explicit object set forwarded onto `ability.targets` by a parent
         //     `ChooseFromZone` (Vannifar's "cloak a card from your hand"). Those
@@ -173,6 +165,89 @@ pub fn resolve(
     });
 
     Ok(())
+}
+
+/// CR 701.58a + CR 603.10a + CR 614.1 + CR 616.1: Finish the tracked-pile
+/// cloak only after every proposed Battlefield→Exile move settles. A redirect
+/// that leaves a member on the battlefield did not make it leave, so its
+/// attachment edges stay intact. A redirect to any other zone did make it
+/// leave, so the captured attachment back-edges are cleared, but only a member
+/// that actually settled in Exile is manifested face down. This is the engine's
+/// ruling for Expose-style "exile ... then cloak them": a card redirected away
+/// from the exile pile is not re-manifested from a zone it never reached.
+pub(crate) fn complete_tracked_set_exile_delivery(
+    state: &mut GameState,
+    player: crate::types::player::PlayerId,
+    source_id: crate::types::identifiers::ObjectId,
+    members: Vec<CloakExileMember>,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    for (index, member) in members.iter().enumerate() {
+        let Some(zone) = state
+            .objects
+            .get(&member.object_id)
+            .map(|object| object.zone)
+        else {
+            continue;
+        };
+        if zone == Zone::Battlefield {
+            continue;
+        }
+
+        // CR 400.7 + CR 704.5m/704.5n: preserve the former attachment handling
+        // after the whole departure batch settled. `ObjectId` is reused across
+        // zones, so its former attachments must not point at a new incarnation.
+        for &attachment_id in &member.attachments {
+            if let Some(attachment) = state.objects.get_mut(&attachment_id) {
+                attachment.attached_to = None;
+            }
+        }
+
+        if zone != Zone::Exile {
+            continue;
+        }
+
+        // `manifest_card` is itself the single replacement-aware authority for
+        // the face-down battlefield entry (CR 701.58a); do not consult the zone
+        // pipeline a second time here.
+        let waiting_for_before_entry = state.waiting_for.clone();
+        crate::game::morph::manifest_card(
+            state,
+            player,
+            member.object_id,
+            source_id,
+            crate::types::ability::FaceDownProfile::cloaked_2_2(),
+            None,
+            events,
+        )
+        .expect("a settled Cloak batch member exists for face-down entry");
+
+        if state.waiting_for != waiting_for_before_entry {
+            // CR 614.1 + CR 616.1: An individual manifest entry can park on a
+            // replacement choice. Keep only the unstarted tail in this typed
+            // completion; the current entry is already parked by `manifest_card`.
+            crate::game::zone_pipeline::defer_completion_on_pause(
+                state,
+                BatchCompletion::CloakExileDeliveryComplete {
+                    player,
+                    source_id,
+                    members: members[index + 1..].to_vec(),
+                },
+            );
+            crate::game::layers::mark_layers_full(state);
+            return BatchMoveResult::NeedsChoice;
+        }
+    }
+
+    // The detach/exile/return churn changed the attachment graph and P/T; force
+    // a layer recompute so downstream reads settle (mirrors exit severing).
+    crate::game::layers::mark_layers_full(state);
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::Cloak,
+        source_id,
+        subject: None,
+    });
+    BatchMoveResult::Done
 }
 
 #[cfg(test)]

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -5953,6 +5953,13 @@ pub(crate) fn run_batch_completion(
 ) -> crate::game::zone_pipeline::BatchMoveResult {
     use crate::types::game_state::BatchCompletion;
     match completion {
+        BatchCompletion::CloakExileDeliveryComplete {
+            player,
+            source_id,
+            members,
+        } => effects::cloak::complete_tracked_set_exile_delivery(
+            state, player, source_id, members, events,
+        ),
         BatchCompletion::CastFromZoneExileDeliveryComplete {
             ability,
             in_place_ids,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1847,7 +1847,26 @@ pub struct PendingBatchDeliveries {
 /// on true completion, mirroring the `PendingCounterPostAction` continuation
 /// pattern.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloakExileMember {
+    /// The tracked pile member that was proposed to leave the battlefield.
+    pub object_id: ObjectId,
+    /// CR 603.10a: the host's pre-departure attachments. Delivery clears the
+    /// live host list before LTB collection, so the cloak tail uses this list to
+    /// sever the former attachments' back-edges after the batch settles.
+    pub attachments: Vec<ObjectId>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BatchCompletion {
+    /// CR 701.58a + CR 603.10a + CR 614.1 + CR 616.1: A tracked cloak pile's
+    /// Battlefield→Exile batch settled. Keep its pre-departure attachment
+    /// snapshots so the tail can detach every actual departure and manifest
+    /// only cards that actually reached Exile.
+    CloakExileDeliveryComplete {
+        player: PlayerId,
+        source_id: ObjectId,
+        members: Vec<CloakExileMember>,
+    },
     /// CR 614.1 + CR 616.1 + CR 611.2a: A `CastFromZone` current-zone-to-Exile
     /// batch settled. Keep the resolved ability and its two target partitions
     /// so the permission is recorded only after the exile delivery, while

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -9727,3 +9727,222 @@ fn effect_zone_put_at_library_position_mixed_sources_preserves_legacy_library_or
         );
     }
 }
+
+/// W-168 (red first): a tracked-pile cloak must park before its detach/manifest
+/// tail or `EffectResolved` when CR 616.1 requires an exile-redirect choice.
+/// After the selected redirect settles, only the member that actually reached
+/// exile may enter face down under the CR 701.58a cloak profile.
+#[test]
+fn cloak_tracked_exile_redirect_pauses_before_manifest_tail() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Cloak Redirect Source", 1, 1)
+        .id();
+    let redirected = scenario
+        .add_creature(P0, "Redirected Cloak Member", 2, 2)
+        .id();
+    let exiled = scenario.add_creature(P0, "Exiled Cloak Member", 3, 3).id();
+    let redirect_sources = [
+        scenario
+            .add_creature(P0, "Cloak Exile To Hand", 0, 0)
+            .as_enchantment()
+            .id(),
+        scenario
+            .add_creature(P0, "Cloak Exile To Graveyard", 0, 0)
+            .as_enchantment()
+            .id(),
+    ];
+
+    let mut runner = scenario.build();
+    for (redirect_source, redirected_to) in [
+        (redirect_sources[0], Zone::Hand),
+        (redirect_sources[1], Zone::Graveyard),
+    ] {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&redirect_source)
+            .expect("synthetic redirect source remains on the battlefield")
+            .replacement_definitions = vec![redirect_moved_to(Zone::Exile, redirected_to)
+            .valid_card(TargetFilter::SpecificObject { id: redirected })]
+        .into();
+    }
+    let tracked_set = engine::types::identifiers::TrackedSetId(0);
+    runner
+        .state_mut()
+        .tracked_object_sets
+        .insert(tracked_set, vec![redirected, exiled]);
+    runner.state_mut().chain_tracked_set_id = Some(tracked_set);
+    let ability = ResolvedAbility::new(
+        Effect::Cloak {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 0 },
+            object_source: Some(TargetFilter::TrackedSet { id: tracked_set }),
+        },
+        vec![],
+        source,
+        P0,
+    );
+
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("cloak reaches its replacement-safe exile batch");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&redirected].zone, Zone::Battlefield);
+    assert_eq!(runner.state().objects[&exiled].zone, Zone::Battlefield);
+    assert!(
+        !runner.state().objects[&redirected].face_down
+            && !runner.state().objects[&exiled].face_down,
+        "the manifest tail must not run before the redirect choice"
+    );
+    assert!(
+        !initial_events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::Cloak,
+                source_id,
+                ..
+            } if *source_id == source
+        )),
+        "Cloak must not resolve before the exile batch settles"
+    );
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the selected exile redirect settles the tracked cloak batch");
+    assert!(matches!(resumed.waiting_for, WaitingFor::Priority { .. }));
+    assert!(matches!(
+        runner.state().objects[&redirected].zone,
+        Zone::Hand | Zone::Graveyard
+    ));
+    assert!(
+        !runner.state().objects[&redirected].face_down,
+        "a card redirected away from exile must not be re-manifested"
+    );
+    assert_eq!(runner.state().objects[&exiled].zone, Zone::Battlefield);
+    assert!(
+        runner.state().objects[&exiled].face_down,
+        "the unredirected member must cloak from exile"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(resumed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Cloak,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the settled cloak tail resolves exactly once"
+    );
+}
+
+/// W-168-REG: an unredirected tracked-pile cloak remains synchronous and keeps
+/// the prior two zone changes per member plus the face-down ward-{2} outcome.
+#[test]
+fn cloak_tracked_exile_delivery_stays_synchronous_and_cloaks_every_member() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Synchronous Cloak Source", 1, 1)
+        .id();
+    let first = scenario
+        .add_creature(P0, "First Synchronous Cloak Member", 2, 2)
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second Synchronous Cloak Member", 3, 3)
+        .id();
+
+    let mut runner = scenario.build();
+    let tracked_set = engine::types::identifiers::TrackedSetId(0);
+    runner
+        .state_mut()
+        .tracked_object_sets
+        .insert(tracked_set, vec![first, second]);
+    runner.state_mut().chain_tracked_set_id = Some(tracked_set);
+    let ability = ResolvedAbility::new(
+        Effect::Cloak {
+            target: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 0 },
+            object_source: Some(TargetFilter::TrackedSet { id: tracked_set }),
+        },
+        vec![],
+        source,
+        P0,
+    );
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("unredirected tracked cloak resolves synchronously");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    for member in [first, second] {
+        let object = &runner.state().objects[&member];
+        assert_eq!(object.zone, Zone::Battlefield);
+        assert!(object.face_down);
+        assert_eq!(object.power, Some(2));
+        assert_eq!(object.toughness, Some(2));
+        assert!(object.keywords.iter().any(|keyword| matches!(
+            keyword,
+            Keyword::Ward(cost) if *cost == engine::types::keywords::WardCost::Mana(ManaCost::generic(2))
+        )));
+    }
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::ZoneChanged {
+                    object_id,
+                    to: Zone::Exile,
+                    ..
+                } if [first, second].contains(object_id)
+            ))
+            .count(),
+        2,
+        "every tracked member has one battlefield-to-exile event"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::ZoneChanged {
+                    object_id,
+                    to: Zone::Battlefield,
+                    ..
+                } if [first, second].contains(object_id)
+            ))
+            .count(),
+        2,
+        "every settled exile member has one face-down battlefield entry"
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Cloak,
+                    source_id,
+                    ..
+                } if *source_id == source
+            ))
+            .count(),
+        1,
+        "the synchronous cloak tail resolves exactly once"
+    );
+}

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -26,7 +26,6 @@ crates/engine/src/game/deck_loading.rs	create_contraption_deck_card	exempt	1
 crates/engine/src/game/deck_loading.rs	create_planar_deck_card	exempt	1
 crates/engine/src/game/deck_loading.rs	create_scheme_deck_card	exempt	1
 crates/engine/src/game/effects/cast_copy_of_card.rs	cast_one_copy	exempt	1
-crates/engine/src/game/effects/cloak.rs	resolve	mover	1
 crates/engine/src/game/effects/copy_spell.rs	resolve	exempt	1
 crates/engine/src/game/effects/epic.rs	resolve	exempt	1
 crates/engine/src/game/effects/explore.rs	resolve_explore_effect	mover	1


### PR DESCRIPTION
- **fix(engine): route cloak's battlefield exile through the replacement-safe zone pipeline**
- **chore(engine): refresh zone-authority baseline after cloak migration (40 hits / 26 rows)**
