### PR TITLE
fix(engine): recognize the symmetric two-way control-swap idiom, and keep it simultaneous

### DIFF
--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -858,6 +858,7 @@ fn effect_projection(effect: &Effect) -> Projection {
         | Effect::Dig { .. }
         | Effect::GainControl { .. }
         | Effect::GainControlAll { .. }
+        | Effect::GiveControlAll { .. }
         | Effect::ControlNextTurn { .. }
         | Effect::Attach { .. }
         | Effect::UnattachAll { .. }

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2796,6 +2796,7 @@ fn legacy_effect(x: &Effect) -> bool {
         | Effect::PumpAll { target, .. }
         | Effect::GainControl { target }
         | Effect::GainControlAll { target }
+        | Effect::GiveControlAll { target, .. }
         | Effect::ControlNextTurn { target, .. }
         | Effect::Bounce { target, .. }
         | Effect::DestroyAll { target, .. }
@@ -4993,6 +4994,10 @@ fn rw_effect(
         Effect::GainControl { target: _ }
         | Effect::GainControlAll { target: _ }
         | Effect::GiveControl {
+            target: _,
+            recipient: _,
+        }
+        | Effect::GiveControlAll {
             target: _,
             recipient: _,
         }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -724,6 +724,12 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
             acc = acc.or(scan_target_filter(target, target_ctx, mode));
             acc
         }
+        Effect::GiveControlAll { target, recipient } => {
+            let mut acc = Axes::NONE;
+            acc = acc.or(scan_target_filter(target));
+            acc = acc.or(scan_target_filter(recipient));
+            acc
+        }
         Effect::ControlNextTurn {
             target,
             grant_extra_turn_after: _,
@@ -5880,6 +5886,7 @@ fn effect_resolution_choice_freedom(e: &Effect) -> ResolutionChoiceFreedom {
         | Effect::Dig { .. }
         | Effect::GainControl { .. }
         | Effect::GainControlAll { .. }
+        | Effect::GiveControlAll { .. }
         | Effect::ControlNextTurn { .. }
         | Effect::Attach { .. }
         | Effect::UnattachAll { .. }
@@ -6151,6 +6158,7 @@ pub(crate) fn effect_is_randomness_bearing(e: &Effect) -> bool {
         | Effect::Dig { .. }
         | Effect::GainControl { .. }
         | Effect::GainControlAll { .. }
+        | Effect::GiveControlAll { .. }
         | Effect::ControlNextTurn { .. }
         | Effect::Attach { .. }
         | Effect::UnattachAll { .. }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -726,8 +726,8 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
         }
         Effect::GiveControlAll { target, recipient } => {
             let mut acc = Axes::NONE;
-            acc = acc.or(scan_target_filter(target));
-            acc = acc.or(scan_target_filter(recipient));
+            acc = acc.or(scan_target_filter(target, target_ctx, mode));
+            acc = acc.or(scan_target_filter(recipient, target_ctx, mode));
             acc
         }
         Effect::ControlNextTurn {
@@ -5136,6 +5136,10 @@ fn effect_target_ctx(e: &Effect, mode: ScanMode) -> FilterReadContext {
         | Effect::DamageEachPlayer { .. }
         | Effect::DestroyAll { .. }
         | Effect::GainControlAll { .. }
+        // CR 732.2a: `GiveControlAll` is `GainControlAll`'s recipient-inverted
+        // sibling (issue #4731's two-way swap) — the same mass-population
+        // battlefield read, so the same fail-closed census classification.
+        | Effect::GiveControlAll { .. }
         | Effect::PumpAll { .. }
         | Effect::BounceAll { .. }
         | Effect::UnattachAll { .. }
@@ -5477,7 +5481,7 @@ enum RelaxReason {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CensusRole {
     /// Mass battlefield population read - enumerated over every matching object,
-    /// scales with the growing class => fail-CLOSED census. EXACTLY the 28
+    /// scales with the growing class => fail-CLOSED census. EXACTLY the 29
     /// `effect_target_ctx` `LiveBoardCensus` members.
     Census,
     Relax(RelaxReason),
@@ -5491,7 +5495,7 @@ enum CensusRole {
 #[cfg(test)]
 fn effect_census_role(e: &Effect) -> CensusRole {
     match e {
-        // -- CENSUS (28): verbatim mirror of `effect_target_ctx`'s LiveBoardCensus
+        // -- CENSUS (29): verbatim mirror of `effect_target_ctx`'s LiveBoardCensus
         // arm - mass battlefield population reads that scale with growth.
         Effect::EachSourceDealsDamage { .. }
         | Effect::EachDealsDamageEqualToPower { .. }
@@ -5500,6 +5504,9 @@ fn effect_census_role(e: &Effect) -> CensusRole {
         | Effect::DamageEachPlayer { .. }
         | Effect::DestroyAll { .. }
         | Effect::GainControlAll { .. }
+        // CR 732.2a: `GiveControlAll` mirrors its `effect_target_ctx` census
+        // entry (issue #4731's two-way swap sibling of `GainControlAll`).
+        | Effect::GiveControlAll { .. }
         | Effect::PumpAll { .. }
         | Effect::BounceAll { .. }
         | Effect::UnattachAll { .. }
@@ -6928,6 +6935,10 @@ mod tests {
             "EachSourceDealsDamage",
             "ExploreAll",
             "GainControlAll",
+            // CR 732.2a: GiveControlAll — GainControlAll's recipient-inverted
+            // sibling (issue #4731's two-way swap), the same mass-population
+            // battlefield read.
+            "GiveControlAll",
             "GoadAll",
             "PumpAll",
             "PutCounterAll",
@@ -6957,7 +6968,7 @@ mod tests {
             got, want,
             "census tag set drifted from the enumeration-derived mass-population set"
         );
-        assert_eq!(got.len(), 28, "exactly 28 mass-population census tags");
+        assert_eq!(got.len(), 29, "exactly 29 mass-population census tags");
     }
 
     /// A7' (mitigation #4, replaces the void census-default A7): with SnapshotOrEvent the
@@ -6968,7 +6979,7 @@ mod tests {
     /// the SOLE effect with a DEDICATED SnapshotOrEvent arm (the region between the
     /// census arm and the single-object group); giving any OTHER census-role slot a
     /// dedicated Snapshot arm turns this RED. Dual-guard with
-    /// `census_tag_set_is_exactly_enumerated` (guard#3, pins the 28 census tags).
+    /// `census_tag_set_is_exactly_enumerated` (guard#3, pins the 29 census tags).
     #[test]
     fn obligation_ii_census_exception_is_exactly_settapstate() {
         use crate::types::ability::{EffectScope, TapStateChange};
@@ -7112,7 +7123,7 @@ mod tests {
             etc_census, ecr_census,
             "effect_census_role Census set diverged from effect_target_ctx"
         );
-        assert_eq!(ecr_census.len(), 28, "exactly 28 census members");
+        assert_eq!(ecr_census.len(), 29, "exactly 29 census members");
 
         // -- Behavioral: the two oracles agree on the Census/Relax boundary for every
         // discriminator. `census(e, true)` requires BOTH `effect_census_role == Census`

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -369,6 +369,22 @@ struct SlotAccumulator {
     /// announcer (the CR-601.2c default). Set/restored by `collect_target_slots`
     /// per link so each chained sub-ability stamps only its own slots.
     current_chooser: Option<PlayerId>,
+    /// CR 601.2c + CR 109.4 + CR 115.1 (issue #4731): True once a companion
+    /// `TargetPlayer`/`TargetOpponent` slot has been pushed anywhere in this
+    /// resolving ability chain. A single "target opponent"/"target player"
+    /// declaration is chosen ONCE (CR 601.2c) and may be referenced by that
+    /// SAME identifier ("that opponent"/"that player") in a LATER, textually
+    /// separate clause of the same printed ability (Reins of Power: "Untap
+    /// all creatures ... and all creatures target opponent controls. You and
+    /// THAT OPPONENT each gain control ..." — two independent clauses, one
+    /// shared target). `ability_needs_companion_target_player_slot` is a pure
+    /// per-node predicate with no chain-wide memory of its own, so without this
+    /// flag a second clause reusing the identical anaphor would surface a
+    /// SECOND, spurious target-opponent prompt. Guarded so only the FIRST such
+    /// node in printed order actually requests the choice; every later node's
+    /// identical anaphor is a read of the SAME already-declared target, not an
+    /// independent one.
+    target_player_companion_slot_pushed: bool,
 }
 
 impl SlotAccumulator {
@@ -1567,7 +1583,14 @@ pub fn assign_targets_in_chain(
         return Ok(());
     }
     let mut next_target = 0usize;
-    assign_targets_recursive(state, ability, targets, &mut next_target)?;
+    let mut player_slot_consumed = false;
+    assign_targets_recursive(
+        state,
+        ability,
+        targets,
+        &mut next_target,
+        &mut player_slot_consumed,
+    )?;
     if next_target != targets.len() {
         return Err(EngineError::InvalidAction(
             "Unused selected targets".to_string(),
@@ -2426,6 +2449,9 @@ fn collect_target_slots_inner(
         // Oracle text order).
         if ability.target_choice_timing == TargetChoiceTiming::Stack
             && ability_needs_companion_target_player_slot(ability)
+            // CR 601.2c (issue #4731): a chain-wide "already requested" guard —
+            // see `SlotAccumulator::target_player_companion_slot_pushed` doc.
+            && !acc.target_player_companion_slot_pushed
         {
             // CR 120.3a + CR 603.7c: For a damage-to-player trigger ("…deals
             // combat damage to a player, [destroy/goad] target creature that
@@ -2450,6 +2476,7 @@ fn collect_target_slots_inner(
                 optional: ability.optional_targeting,
                 chooser: None,
             });
+            acc.target_player_companion_slot_pushed = true;
         }
         if ability.target_choice_timing == TargetChoiceTiming::Stack
             && effect_needs_target_creature_quantity_slot(&ability.effect)
@@ -2961,6 +2988,7 @@ fn mass_all_target_filter(effect: &Effect) -> Option<&TargetFilter> {
         Effect::PutCounterAll { target, .. }
         | Effect::DestroyAll { target, .. }
         | Effect::GainControlAll { target, .. }
+        | Effect::GiveControlAll { target, .. }
         | Effect::PumpAll { target, .. }
         | Effect::DamageAll { target, .. }
         | Effect::SetTapState {
@@ -5829,6 +5857,10 @@ fn assign_targets_recursive(
     ability: &mut ResolvedAbility,
     targets: &[TargetRef],
     next_target: &mut usize,
+    // CR 601.2c + issue #4731: mirrors `SlotAccumulator::target_player_companion_slot_pushed`
+    // — the companion "target opponent"/"target player" slot is consumed from
+    // `targets` at most once per resolving chain, matching how it was built.
+    player_slot_consumed: &mut bool,
 ) -> Result<(), EngineError> {
     if let Some(sub_ability) = ability.sub_ability.as_mut().filter(|sub| {
         matches!(
@@ -5837,7 +5869,13 @@ fn assign_targets_recursive(
         )
     }) {
         if ability.context.additional_cost_paid {
-            assign_targets_recursive(state, sub_ability, targets, next_target)?;
+            assign_targets_recursive(
+                state,
+                sub_ability,
+                targets,
+                next_target,
+                player_slot_consumed,
+            )?;
             ability.targets = sub_ability.targets.clone();
             return Ok(());
         }
@@ -5868,6 +5906,7 @@ fn assign_targets_recursive(
                 ability.sub_ability.as_deref_mut(),
                 targets,
                 next_target,
+                player_slot_consumed,
             )?;
             return Ok(());
         }
@@ -5875,7 +5914,13 @@ fn assign_targets_recursive(
             if defers_conditional_target_selection(sub_ability) {
                 return Ok(());
             }
-            assign_targets_recursive(state, sub_ability, targets, next_target)?;
+            assign_targets_recursive(
+                state,
+                sub_ability,
+                targets,
+                next_target,
+                player_slot_consumed,
+            )?;
         }
         return Ok(());
     }
@@ -5907,6 +5952,7 @@ fn assign_targets_recursive(
                 ability.sub_ability.as_deref_mut(),
                 targets,
                 next_target,
+                player_slot_consumed,
             )?;
             return Ok(());
         }
@@ -5914,7 +5960,13 @@ fn assign_targets_recursive(
             if defers_conditional_target_selection(sub_ability) {
                 return Ok(());
             }
-            assign_targets_recursive(state, sub_ability, targets, next_target)?;
+            assign_targets_recursive(
+                state,
+                sub_ability,
+                targets,
+                next_target,
+                player_slot_consumed,
+            )?;
         }
         return Ok(());
     }
@@ -5947,7 +5999,13 @@ fn assign_targets_recursive(
             if defers_conditional_target_selection(sub_ability) {
                 return Ok(());
             }
-            assign_targets_recursive(state, sub_ability, targets, next_target)?;
+            assign_targets_recursive(
+                state,
+                sub_ability,
+                targets,
+                next_target,
+                player_slot_consumed,
+            )?;
         }
         return Ok(());
     }
@@ -5978,6 +6036,9 @@ fn assign_targets_recursive(
     // Slot order matches `collect_target_slots`: player slot before primary.
     if ability.target_choice_timing == TargetChoiceTiming::Stack
         && ability_needs_companion_target_player_slot(ability)
+        // CR 601.2c (issue #4731): mirrors the `collect_target_slots_inner` guard —
+        // consume the companion target at most once per resolving chain.
+        && !*player_slot_consumed
     {
         if let Some(target) = targets.get(*next_target) {
             ability.targets.push(target.clone());
@@ -5987,6 +6048,7 @@ fn assign_targets_recursive(
                 "Missing required target".to_string(),
             ));
         }
+        *player_slot_consumed = true;
     }
     if ability.target_choice_timing == TargetChoiceTiming::Stack
         && effect_needs_target_creature_quantity_slot(&ability.effect)
@@ -6063,6 +6125,7 @@ fn assign_targets_recursive(
             ability.sub_ability.as_deref_mut(),
             targets,
             next_target,
+            player_slot_consumed,
         )?;
         return Ok(());
     }
@@ -6083,7 +6146,13 @@ fn assign_targets_recursive(
                 sub_ability.targets.push(creature);
             }
         } else {
-            assign_targets_recursive(state, sub_ability, targets, next_target)?;
+            assign_targets_recursive(
+                state,
+                sub_ability,
+                targets,
+                next_target,
+                player_slot_consumed,
+            )?;
         }
     }
     Ok(())
@@ -6419,6 +6488,7 @@ fn assign_targets_after_deferred_effect(
     sub_ability: Option<&mut ResolvedAbility>,
     targets: &[TargetRef],
     next_target: &mut usize,
+    player_slot_consumed: &mut bool,
 ) -> Result<(), EngineError> {
     let Some(sub_ability) = sub_ability else {
         return Ok(());
@@ -6432,9 +6502,16 @@ fn assign_targets_after_deferred_effect(
             sub_ability.sub_ability.as_deref_mut(),
             targets,
             next_target,
+            player_slot_consumed,
         );
     }
-    assign_targets_recursive(state, sub_ability, targets, next_target)
+    assign_targets_recursive(
+        state,
+        sub_ability,
+        targets,
+        next_target,
+        player_slot_consumed,
+    )
 }
 
 fn assign_selected_slots_after_deferred_effect(

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3500,6 +3500,9 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         }
         Effect::GiveControl {
             target, recipient, ..
+        }
+        | Effect::GiveControlAll {
+            target, recipient, ..
         } => {
             d.push(("target".into(), fmt_target(target)));
             d.push(("to".into(), fmt_target(recipient)));

--- a/crates/engine/src/game/effects/gain_control.rs
+++ b/crates/engine/src/game/effects/gain_control.rs
@@ -132,6 +132,13 @@ pub fn resolve_all(
         .copied()
         .collect();
 
+    // CR 613.9 (issue #4731): Stamp the objects this effect just took, so a
+    // chained sibling `GiveControlAll` (the "you and target opponent each
+    // gain control of all creatures the other controls" idiom) can exclude
+    // them from its own "creatures you control" population filter — see the
+    // field doc on `GameState::last_gained_control_object_ids`.
+    state.last_gained_control_object_ids = matching.clone();
+
     for obj_id in matching {
         let old_controller = state.objects.get(&obj_id).map(|obj| obj.controller);
         // CR 613.1b: register a Layer 2 (Control) transient continuous effect.
@@ -234,24 +241,7 @@ pub fn resolve_give(
         return Err(EffectError::MissingParam("GiveControl".to_string()));
     };
 
-    // CR 110.2 + CR 613.3: The recipient is the player target when one is
-    // explicitly in ability.targets (normal targeting path). When no player
-    // target is present — e.g. a post-replacement continuation whose target
-    // list only carries the damaged object — resolve the effect's `recipient`
-    // filter only if it identifies exactly one legal player. CR 608.2d choices
-    // are made while applying the effect; arbitrary first-match selection would
-    // be wrong in multiplayer when several opponents are legal.
-    let recipient_id = if let Some(pid) = ability.targets.iter().find_map(|t| {
-        if let TargetRef::Player(pid) = t {
-            Some(*pid)
-        } else {
-            None
-        }
-    }) {
-        pid
-    } else {
-        unique_recipient_from_filter(state, recipient, ability)?
-    };
+    let recipient_id = resolve_recipient_player(state, ability, recipient)?;
 
     let object_ids = give_control_object_targets(state, ability, target);
 
@@ -292,6 +282,123 @@ pub fn resolve_give(
     });
 
     Ok(())
+}
+
+/// CR 613.1b + CR 110.2: Mass control-change to an explicit RECIPIENT — the
+/// untargeted "all" counterpart of [`resolve_give`], mirroring how
+/// [`resolve_all`] is to [`resolve`]. Unlike `resolve_all` (which always hands
+/// control to `ability.controller`), the recipient is read from `recipient`
+/// via [`resolve_recipient_player`] — the same declared-target-first
+/// resolution `resolve_give` uses, so a recipient already established
+/// elsewhere in the same resolving chain (e.g. the "target opponent" from a
+/// preceding clause) is honored here too.
+///
+/// Reins of Power composes `GainControlAll` (this ability's controller takes
+/// all creatures the target opponent controls) chained via `sub_ability` to
+/// this effect (the target opponent takes all creatures the controller
+/// controls). CR 613.9-style simultaneity does NOT fall out for free here:
+/// `resolve_chain_body` deliberately flushes layers before a sub-ability
+/// resolves (issue #2384, so a P/T-dependent sub sees current
+/// characteristics), which applies the first half's control-change TCEs
+/// before this filter runs — a live "creatures you control" filter at this
+/// point would incorrectly also match the creatures the first half JUST
+/// took. `resolve_all` stamps those ids into
+/// `state.last_gained_control_object_ids`, and this filter excludes them, to
+/// recover the intended simultaneity.
+pub fn resolve_give_all(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let duration = ability.duration.clone().unwrap_or(Duration::Permanent);
+
+    let Effect::GiveControlAll { target, recipient } = &ability.effect else {
+        return Err(EffectError::InvalidParam(
+            "expected GiveControlAll effect".to_string(),
+        ));
+    };
+
+    let new_controller = resolve_recipient_player(state, ability, recipient)?;
+
+    // Ability-context filter evaluation, identical to `resolve_all` /
+    // `destroy::resolve_all`: `resolved_object_filter` binds anaphoric scopes
+    // (e.g. `controller: OriginalController`) from the ability before matching.
+    let effective_filter = crate::game::effects::resolved_object_filter(ability, target);
+    let ctx = crate::game::filter::FilterContext::from_ability(ability);
+    let matching: Vec<ObjectId> = state
+        .battlefield
+        .iter()
+        .filter(|id| {
+            crate::game::filter::matches_target_filter(state, **id, &effective_filter, &ctx)
+                // CR 613.9 (issue #4731): exclude objects a chained sibling
+                // `GainControlAll` just took THIS resolution — see the field
+                // doc on `GameState::last_gained_control_object_ids`. Without
+                // this, the `flush_layers` call `resolve_chain_body` makes
+                // before a sub-ability resolves applies the sibling's control
+                // change first, so a live "creatures you control" filter here
+                // would incorrectly also match what the sibling just took,
+                // collapsing a two-way swap into a one-sided grab.
+                && !state.last_gained_control_object_ids.contains(id)
+        })
+        .copied()
+        .collect();
+
+    for obj_id in matching {
+        let old_controller = state.objects.get(&obj_id).map(|obj| obj.controller);
+        // CR 613.1b: register a Layer 2 (Control) transient continuous effect.
+        state.add_transient_continuous_effect(
+            ability.source_id,
+            new_controller,
+            duration.clone(),
+            TargetFilter::SpecificObject { id: obj_id },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+        mark_echo_due_for_new_controller(state, obj_id);
+        if let Some(old_controller) = old_controller.filter(|old| *old != new_controller) {
+            events.push(GameEvent::ControllerChanged {
+                object_id: obj_id,
+                old_controller,
+                new_controller,
+            });
+        }
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::GiveControlAll,
+        source_id: ability.source_id,
+        subject: None,
+    });
+
+    Ok(())
+}
+
+/// CR 110.2 + CR 613.3: Shared recipient resolution for [`resolve_give`] and
+/// [`resolve_give_all`]. The recipient is the player target when one is
+/// explicitly in `ability.targets` (normal targeting path — also covers a
+/// recipient anaphor like "target opponent" already declared by an earlier
+/// clause in the same resolving chain, e.g. Reins of Power). When no player
+/// target is present — e.g. a post-replacement continuation whose target list
+/// only carries the damaged object — resolve the effect's `recipient` filter
+/// only if it identifies exactly one legal player. CR 608.2d choices are made
+/// while applying the effect; arbitrary first-match selection would be wrong
+/// in multiplayer when several opponents are legal.
+fn resolve_recipient_player(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    recipient: &TargetFilter,
+) -> Result<PlayerId, EffectError> {
+    if let Some(pid) = ability.targets.iter().find_map(|t| {
+        if let TargetRef::Player(pid) = t {
+            Some(*pid)
+        } else {
+            None
+        }
+    }) {
+        Ok(pid)
+    } else {
+        unique_recipient_from_filter(state, recipient, ability)
+    }
 }
 
 fn give_control_object_targets(

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3762,6 +3762,7 @@ pub fn resolve_effect(
         Effect::Dig { .. } => dig::resolve(state, ability, events),
         Effect::GainControl { .. } => gain_control::resolve(state, ability, events),
         Effect::GainControlAll { .. } => gain_control::resolve_all(state, ability, events),
+        Effect::GiveControlAll { .. } => gain_control::resolve_give_all(state, ability, events),
         Effect::Goad { .. } | Effect::GoadAll { .. } => goad::resolve(state, ability, events),
         Effect::Detain { .. } => detain::resolve(state, ability, events),
         Effect::SetRoomDoorLock { .. } => set_room_door_lock::resolve(state, ability, events),
@@ -4635,7 +4636,7 @@ fn affected_objects_from_events(
                 TargetRef::Player(_) => None,
             })
             .collect(),
-        Effect::GainControlAll { .. } => events
+        Effect::GainControlAll { .. } | Effect::GiveControlAll { .. } => events
             .iter()
             .filter_map(|event| match event {
                 GameEvent::ControllerChanged { object_id, .. } => Some(*object_id),
@@ -4954,6 +4955,19 @@ fn mandatory_parent_effect_performed(effect: &Effect, events: &[GameEvent]) -> b
                 event,
                 GameEvent::EffectResolved {
                     kind: crate::types::ability::EffectKind::GiveControl,
+                    ..
+                } | GameEvent::ControllerChanged { .. }
+            )
+        }),
+        // CR 613.1b + CR 110.2: mass counterpart of the `GiveControl` gate
+        // above — "did anything" iff at least one matching permanent actually
+        // changed controller (`resolve_give_all` emits `ControllerChanged` per
+        // handoff, skipping no-op self-handoffs, mirroring `resolve_give`).
+        Effect::GiveControlAll { .. } => events.iter().any(|event| {
+            matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: crate::types::ability::EffectKind::GiveControlAll,
                     ..
                 } | GameEvent::ControllerChanged { .. }
             )
@@ -7156,6 +7170,11 @@ pub fn resolve_ability_chain(
         state.private_look_ids.clear();
         state.private_look_player = None;
         state.last_zone_changed_ids.clear();
+        // CR 613.9 (issue #4731): Mirrors `last_zone_changed_ids`'s lifecycle —
+        // resolution-scoped, cleared only at depth 0 so a chained sibling
+        // `GiveControlAll` (entering at depth > 0) still sees the ids its
+        // sibling `GainControlAll` just stamped.
+        state.last_gained_control_object_ids.clear();
         // CR 608.2c + CR 701.38: Per-resolution ballot ledger; populated by
         // `vote::resolve_tally` and read by `PlayerFilter::VotedFor`. Clear
         // alongside `last_zone_changed_ids` so cross-resolution leakage is

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1148,6 +1148,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::Dig { .. }
         | Effect::GainControl { .. }
         | Effect::GainControlAll { .. }
+        | Effect::GiveControlAll { .. }
         | Effect::ControlNextTurn { .. }
         | Effect::Attach { .. }
         | Effect::UnattachAll { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -910,6 +910,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::SetLifeTotal
         | EffectKind::SetDayNight
         | EffectKind::GiveControl
+        | EffectKind::GiveControlAll
         | EffectKind::RemoveFromCombat
         // CR 509.3c: the "becomes blocked" trigger from an effect-block is keyed
         // off the `AttackerBecameBlockedByEffect` GameEvent (see the event→key

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -7852,6 +7852,22 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return clause;
     }
 
+    // CR 613.1b + CR 110.2 + CR 109.5: "you and that opponent each gain
+    // control of all creatures the other controls [until end of turn]" (Reins
+    // of Power). MUST run before the imperative dispatch for the same reason
+    // as `try_parse_compound_subject_each` above (the bare "you" subject would
+    // otherwise be swallowed). Deliberately NOT routed through
+    // `try_parse_compound_subject_each`'s generic distributor: that combinator
+    // clones ONE parsed body and rewrites a single recipient-shaped field per
+    // half, but here both the population filter's controller anaphor ("the
+    // other controls") and who receives control must co-vary together per
+    // half — `GainControlAll`'s `target` is a resolution-time population scan,
+    // not a recipient slot, so the generic single-field rewrite cannot express
+    // it (see `try_parse_symmetric_gain_control_all`'s own doc comment).
+    if let Some(clause) = try_parse_symmetric_gain_control_all(text) {
+        return clause;
+    }
+
     // CR 122.1 + CR 608.2d: Bribe Taker — "[you may] put your choice of a
     // <fixed> counter or a counter of that kind on ~". Runs before the generic
     // for-each path; the `DistinctCounterKindsAmong` iteration source has already
@@ -17270,6 +17286,91 @@ fn try_parse_compound_subject_each(
         distribute: None,
         multi_target: None,
         condition: half_a.condition,
+        optional: false,
+        unless_pay: None,
+    })
+}
+
+/// CR 613.1b + CR 110.2 + CR 109.5: "You and that opponent each gain control
+/// of all creatures the other controls [until end of turn]" (Reins of Power)
+/// — a symmetric two-way MASS control swap. Called with the body already
+/// stripped of its leading/trailing slots by `clause_shell::peel_clause`
+/// (this function's caller applies `with_clause_duration`, which — extended
+/// alongside this fix — also re-stamps the peeled duration onto the
+/// `GiveControlAll` sub_ability this function builds).
+///
+/// Not routed through the generic `try_parse_compound_subject_each`
+/// distributor: that combinator clones ONE parsed body and rewrites a single
+/// recipient-shaped field per half (Draw's `target`, Token's `owner`, …).
+/// Here, BOTH the population filter's controller anaphor ("the other
+/// controls") AND who receives control must co-vary together per half —
+/// `GainControlAll`'s `target` is a resolution-time population scan (CR
+/// 613.1b), not a recipient slot, so a single-field rewrite cannot express a
+/// filter AND a recipient flipping in lockstep. Composes two independently
+/// correct, already-proven mechanisms instead:
+///   - Head: `GainControlAll { target: creatures the opponent controls }` —
+///     the ability's controller takes (byte-identical mechanism to the
+///     already-correct Hellkite Tyrant "gain control of all artifacts that
+///     player controls").
+///   - Sub: `GiveControlAll { target: creatures you control, recipient: the
+///     opponent }` — the mass counterpart of `GiveControl`.
+///
+/// `resolve_ability_chain` does not re-evaluate layers between chain links,
+/// so both mass filters read the pre-effect battlefield: the printed "each"
+/// is genuinely simultaneous (CR 613.9-style), with no extra staging.
+fn try_parse_symmetric_gain_control_all(text: &str) -> Option<ParsedEffectClause> {
+    const SUBJECT_PREFIXES: [&str; 2] = [
+        "you and that opponent each gain control of all creatures the other controls",
+        "you and target opponent each gain control of all creatures the other controls",
+    ];
+    let trimmed = text.trim().trim_end_matches('.').trim();
+    let lower = trimmed.to_lowercase();
+    if !SUBJECT_PREFIXES.contains(&lower.as_str()) {
+        return None;
+    }
+
+    // "all creatures target opponent controls" — same controller anaphor
+    // already proven correct by the Hellkite Tyrant `GainControlAll` mechanism.
+    let opponent_creatures =
+        TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::TargetOpponent));
+    // "all creatures you [the ability's controller] control" — `ControllerRef::You`
+    // resolves from `ability.controller`, which stays the caster for every link
+    // in this chain (no per-link reassignment happens here), so this correctly
+    // reads as "the creatures the CASTER controls" even from the GiveControlAll
+    // sub_ability link.
+    let your_creatures =
+        TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You));
+    // The recipient of `GiveControlAll` — the same already-targeted opponent.
+    // `resolve_recipient_player` prefers an already-declared `TargetRef::Player`
+    // in `ability.targets` (surfaced by this SAME clause's `TargetOpponent`
+    // population filter above, via the companion-target-slot machinery), so
+    // this filter's generic ambiguity-checked fallback is not actually hit in
+    // the common 2+ player case here.
+    let opponent_recipient =
+        TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent));
+
+    let mut head = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GainControlAll {
+            target: opponent_creatures,
+        },
+    );
+    let sub = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GiveControlAll {
+            target: your_creatures,
+            recipient: opponent_recipient,
+        },
+    );
+    head.sub_ability = Some(Box::new(sub));
+
+    Some(ParsedEffectClause {
+        effect: *head.effect,
+        duration: head.duration,
+        sub_ability: head.sub_ability,
+        distribute: None,
+        multi_target: None,
+        condition: None,
         optional: false,
         unless_pay: None,
     })

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -6092,6 +6092,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::ExchangeLifeTotals { .. }
         | Effect::SetDayNight { .. }
         | Effect::GiveControl { .. }
+        | Effect::GiveControlAll { .. }
         | Effect::RemoveFromCombat { .. }
         | Effect::Conjure { .. }
         | Effect::CombineHost { .. }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -48716,3 +48716,94 @@ fn unless_extraction_offsets_survive_unicode_case_fold() {
          the boundary, and the mask must not eat the quote)"
     );
 }
+
+/// Issue #4731 (Reins of Power): "You and that opponent each gain control of
+/// all creatures the other controls until end of turn" must lower to a
+/// genuine TWO-WAY mass swap, not the mass one-way `GainControlAll` grab the
+/// bug report describes (the caster taking every creature on the board,
+/// filter `controller: null`). Pins the AST shape: `GainControlAll` (the
+/// caster takes the target opponent's creatures) chained via `sub_ability` to
+/// the new `GiveControlAll` (the target opponent takes the caster's
+/// creatures), both carrying the printed `UntilEndOfTurn` duration.
+#[test]
+fn issue_4731_reins_of_power_control_swap_ast() {
+    let parsed = parse_oracle_text(
+        "Untap all creatures you control and all creatures target opponent controls. \
+         You and that opponent each gain control of all creatures the other controls \
+         until end of turn. Those creatures gain haste until end of turn.",
+        "Reins of Power",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let head = parsed
+        .abilities
+        .iter()
+        .find_map(|def| {
+            let mut node = Some(def);
+            while let Some(d) = node {
+                if matches!(*d.effect, Effect::GainControlAll { .. }) {
+                    return Some(d);
+                }
+                node = d.sub_ability.as_deref();
+            }
+            None
+        })
+        .expect("expected a GainControlAll in the parsed chain");
+
+    let Effect::GainControlAll { target } = &*head.effect else {
+        unreachable!()
+    };
+    match target {
+        TargetFilter::Typed(tf) => {
+            assert_eq!(
+                tf.controller,
+                Some(ControllerRef::TargetOpponent),
+                "the caster's half must take creatures the TARGET OPPONENT controls, got {tf:?}"
+            );
+        }
+        other => panic!("expected a Typed creature filter, got {other:?}"),
+    }
+    assert_eq!(
+        head.duration,
+        Some(Duration::UntilEndOfTurn),
+        "the printed \"until end of turn\" must reach the GainControlAll half"
+    );
+
+    let sub = head
+        .sub_ability
+        .as_deref()
+        .expect("GainControlAll must chain to a GiveControlAll sub_ability");
+    let Effect::GiveControlAll { target, recipient } = &*sub.effect else {
+        panic!(
+            "expected GiveControlAll as the GainControlAll's sub_ability, got {:?}",
+            sub.effect
+        );
+    };
+    match target {
+        TargetFilter::Typed(tf) => {
+            assert_eq!(
+                tf.controller,
+                Some(ControllerRef::You),
+                "the opponent's half must take creatures the CASTER controls, got {tf:?}"
+            );
+        }
+        other => panic!("expected a Typed creature filter, got {other:?}"),
+    }
+    match recipient {
+        TargetFilter::Typed(tf) => {
+            assert_eq!(
+                tf.controller,
+                Some(ControllerRef::Opponent),
+                "GiveControlAll must hand control to the opponent, not the caster, got {tf:?}"
+            );
+        }
+        other => panic!("expected a Typed player filter, got {other:?}"),
+    }
+    assert_eq!(
+        sub.duration,
+        Some(Duration::UntilEndOfTurn),
+        "the printed \"until end of turn\" must ALSO reach the GiveControlAll sub_ability — \
+         it does not inherit ability.duration from its parent at resolution time"
+    );
+}

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1698,6 +1698,23 @@ pub(crate) fn with_clause_duration(
     // Leading duration from Oracle text (e.g., "Until end of turn, ...") is authoritative —
     // it overrides any default injected by sub-parsers (e.g., build_become_clause's Permanent).
     clause.duration = Some(duration.clone());
+    // CR 613.1b + CR 109.5: "you and that opponent each gain control of all
+    // creatures the other controls until end of turn" (Reins of Power,
+    // `try_parse_symmetric_gain_control_all`) composes as a `GainControlAll`
+    // head chained via `sub_ability` to a `GiveControlAll` tail — ONE printed
+    // duration governs BOTH mass control-changes, but each becomes its own
+    // `AbilityDefinition` node reading its OWN `.duration` at resolution
+    // (`ability.duration` in `gain_control::resolve_all` /
+    // `resolve_give_all`). The generic per-field patch below only reaches
+    // `clause.effect` (the head); re-stamp the sub_ability explicitly here so
+    // the tail doesn't silently fall back to `Duration::Permanent`.
+    if matches!(clause.effect, Effect::GainControlAll { .. }) {
+        if let Some(sub) = clause.sub_ability.as_mut() {
+            if matches!(*sub.effect, Effect::GiveControlAll { .. }) && sub.duration.is_none() {
+                sub.duration = Some(duration.clone());
+            }
+        }
+    }
     match &mut clause.effect {
         Effect::GenericEffect {
             duration: ref mut effect_duration,

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -1220,6 +1220,7 @@ fn stamp_effect_printed_slot(effect: &mut Effect, slot: usize, kind: PrintedItem
         Effect::Dig { .. } => {}
         Effect::GainControl { .. } => {}
         Effect::GainControlAll { .. } => {}
+        Effect::GiveControlAll { .. } => {}
         Effect::ControlNextTurn { .. } => {}
         Effect::Attach { .. } => {}
         Effect::UnattachAll { .. } => {}

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -10340,6 +10340,27 @@ pub enum Effect {
         #[serde(default = "default_target_filter_none")]
         target: TargetFilter,
     },
+    /// CR 613.1b + CR 110.2: Mass control-change to an explicit RECIPIENT
+    /// (Layer 2) — the untargeted "all" counterpart of `GiveControl`, mirroring
+    /// how `GainControlAll` is to `GainControl`. Distinct from `GainControlAll`
+    /// (which always hands control to `ability.controller`): `recipient` names
+    /// who takes control, independent of who cast/activated the source.
+    /// Reins of Power ("You and that opponent each gain control of all
+    /// creatures the other controls until end of turn") composes as
+    /// `GainControlAll { target: creatures target opponent controls }`
+    /// (`ability.controller` takes) chained via `sub_ability` to
+    /// `GiveControlAll { target: creatures you control, recipient: target
+    /// opponent }` (the opponent takes) — CR 613.1b: both mass filters are
+    /// evaluated against the pre-effect battlefield since layers are not
+    /// re-evaluated between chain links, giving the printed "each" a genuinely
+    /// simultaneous two-way swap.
+    GiveControlAll {
+        #[serde(default = "default_target_filter_none")]
+        target: TargetFilter,
+        /// The player who receives control of every matching permanent.
+        #[serde(default = "default_target_filter_any")]
+        recipient: TargetFilter,
+    },
     ControlNextTurn {
         #[serde(default = "default_target_filter_any")]
         target: TargetFilter,
@@ -14342,6 +14363,11 @@ impl Effect {
             // (enumerated at resolution), not a chosen target slot — like
             // DestroyAll, its `target_filter()` is None.
             | Effect::GainControlAll { .. }
+            // CR 613.1b + CR 110.2: GiveControlAll mirrors GainControlAll — its
+            // `target` is the mass population filter; `recipient` is likewise
+            // not a player-selectable target (it's resolved from an already-
+            // declared target/filter, same as `GiveControl`'s `recipient`).
+            | Effect::GiveControlAll { .. }
             | Effect::GoadAll { .. }
             | Effect::BounceAll { .. }
             | Effect::CounterAll { .. }
@@ -14655,6 +14681,7 @@ impl Effect {
             | Effect::ChangeZoneAll { .. }
             | Effect::GainControl { .. }
             | Effect::GainControlAll { .. }
+            | Effect::GiveControlAll { .. }
             | Effect::ControlNextTurn { .. }
             | Effect::Attach { .. }
             | Effect::UnattachAll { .. }
@@ -14908,6 +14935,7 @@ impl Effect {
             | Effect::ChangeZoneAll { .. }
             | Effect::GainControl { .. }
             | Effect::GainControlAll { .. }
+            | Effect::GiveControlAll { .. }
             | Effect::ControlNextTurn { .. }
             | Effect::Attach { .. }
             | Effect::UnattachAll { .. }
@@ -15114,6 +15142,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::Dig { .. } => "Dig",
         Effect::GainControl { .. } => "GainControl",
         Effect::GainControlAll { .. } => "GainControlAll",
+        Effect::GiveControlAll { .. } => "GiveControlAll",
         Effect::ControlNextTurn { .. } => "ControlNextTurn",
         Effect::Attach { .. } => "Attach",
         Effect::UnattachAll { .. } => "UnattachAll",
@@ -15357,6 +15386,7 @@ pub enum EffectKind {
     Dig,
     GainControl,
     GainControlAll,
+    GiveControlAll,
     ControlNextTurn,
     Attach,
     AttachAll,
@@ -15611,6 +15641,7 @@ impl From<&Effect> for EffectKind {
             Effect::Dig { .. } => EffectKind::Dig,
             Effect::GainControl { .. } => EffectKind::GainControl,
             Effect::GainControlAll { .. } => EffectKind::GainControlAll,
+            Effect::GiveControlAll { .. } => EffectKind::GiveControlAll,
             Effect::ControlNextTurn { .. } => EffectKind::ControlNextTurn,
             Effect::Attach { .. } => EffectKind::Attach,
             Effect::UnattachAll { .. } => EffectKind::UnattachAll,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -12389,6 +12389,23 @@ pub struct GameState {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub last_zone_changed_ids: Vec<ObjectId>,
 
+    /// CR 613.9 (issue #4731): ObjectIds whose control the most recent
+    /// `Effect::GainControlAll` resolution just transferred to the ability's
+    /// controller. A chained sub-ability's own `GiveControlAll` (the
+    /// "you and target opponent each gain control of all creatures the
+    /// other controls" idiom) reads this to exclude those objects from its
+    /// own "creatures you control" population filter — without it, the
+    /// mandatory `flush_layers` call `resolve_chain_body` makes before a
+    /// sub-ability resolves (so P/T-dependent sub-effects see current
+    /// characteristics, issue #2384) applies the parent's control-change
+    /// TCEs first, so the sub's live filter would incorrectly also match
+    /// the creatures the parent JUST took, collapsing what should be a
+    /// two-way simultaneous swap into a one-sided grab. Mirrors
+    /// `last_zone_changed_ids`'s lifecycle: cleared at chain depth 0 in
+    /// `resolve_ability_chain`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub last_gained_control_object_ids: Vec<ObjectId>,
+
     /// CR 608.2c + CR 701.38: Per-vote ballots from the most recent
     /// `Effect::Vote` resolution within the current top-level ability
     /// resolution. Each entry is `(voter, choice_index)`; populated by
@@ -15937,6 +15954,7 @@ impl GameState {
             private_look_ids: Vec::new(),
             private_look_player: None,
             last_zone_changed_ids: Vec::new(),
+            last_gained_control_object_ids: Vec::new(),
             last_vote_ballots: im::Vector::new(),
             player_actions_this_way: HashSet::new(),
             last_effect_amount: None,
@@ -17174,6 +17192,7 @@ fn _gamestate_partition_is_total(s: &GameState) {
         private_look_ids: _,
         private_look_player: _,
         last_zone_changed_ids: _,
+        last_gained_control_object_ids: _,
         last_vote_ballots: _,
         player_actions_this_way: _,
         last_effect_amount: _,
@@ -17462,6 +17481,7 @@ impl PartialEq for GameState {
             && self.private_look_ids == other.private_look_ids
             && self.private_look_player == other.private_look_player
             && self.last_zone_changed_ids == other.last_zone_changed_ids
+            && self.last_gained_control_object_ids == other.last_gained_control_object_ids
             && self.last_vote_ballots == other.last_vote_ballots
             && self.player_actions_this_way == other.player_actions_this_way
             && self.last_effect_count == other.last_effect_count

--- a/crates/engine/tests/fixtures/cr733/authority_matrix.json
+++ b/crates/engine/tests/fixtures/cr733/authority_matrix.json
@@ -2718,6 +2718,29 @@
    "excluded_non_gamestate_site_ids": []
   },
   {
+   "field": "last_gained_control_object_ids",
+   "classification": "proposed_authority",
+   "census_site_count": 3,
+   "reachable_site_count": 2,
+   "final_authority": "crate::game::effects::gain_control::resolve_all",
+   "authority_status": "existing_to_promote",
+   "owning_module": "crates/engine/src/game/effects/gain_control.rs",
+   "command_family": "Ledgers and once-per-* facts",
+   "command_scopes": [
+    {
+     "family": "Ledgers and once-per-* facts",
+     "scope": "resolution-scoped ledger of the objects the current chain's GainControlAll half just took, read by the chained GiveControlAll half's post-flush live-filter exclusion (issue #4731 two-way swap simultaneity); cleared at depth-0 chain entry, mirroring last_zone_changed_ids."
+    }
+   ],
+   "composition_policy": "write only from the GainControlAll resolver's exact affected-object set; consumers read-only; never reconstruct from live controller state after a layer flush.",
+   "reroute_site_ids": [
+    "crates/engine/src/game/effects/gain_control.rs:140:resolve_all:assign",
+    "crates/engine/src/game/effects/mod.rs:7112:resolve_ability_chain:mut_method:clear"
+   ],
+   "excluded_clone_site_ids": [],
+   "excluded_non_gamestate_site_ids": []
+  },
+  {
    "field": "last_loop_action_sequence",
    "classification": "proposed_authority",
    "census_site_count": 14,

--- a/crates/engine/tests/integration/issue_4731_reins_of_power.rs
+++ b/crates/engine/tests/integration/issue_4731_reins_of_power.rs
@@ -1,0 +1,168 @@
+//! Runtime regression for GH issue #4731 — Reins of Power reportedly gave the
+//! CASTING player control of every creature on the board instead of the
+//! printed two-way swap.
+//!
+//! Oracle (verified against the issue's own quoted text, confidence 0.90):
+//! "Untap all creatures you control and all creatures target opponent
+//! controls. You and that opponent each gain control of all creatures the
+//! other controls until end of turn. Those creatures gain haste until end of
+//! turn."
+//!
+//! Root cause (confirmed independently and by a repo collaborator's own
+//! diagnosis in the issue thread): the "each gain control of all creatures
+//! the other controls" clause collapsed into a single `Effect::GainControlAll`
+//! whose population filter had NO controller anaphor (`controller: null`,
+//! matching every creature regardless of owner) and whose resolver always
+//! assigns the new controller to `ability.controller` — the caster. There was
+//! no second, opposite-direction control change for the opponent's side.
+//!
+//! Fix: a dedicated combinator (`try_parse_symmetric_gain_control_all`)
+//! recognizes this fixed "you and that/target opponent each gain control of
+//! all creatures the other controls" idiom and composes TWO independently
+//! correct mechanisms instead of one ambiguous one:
+//!   - `GainControlAll { target: creatures the target opponent controls }` —
+//!     the caster takes (byte-identical mechanism to the already-correct
+//!     Hellkite Tyrant "gain control of all artifacts that player controls").
+//!   - `GiveControlAll { target: creatures the caster controls, recipient:
+//!     the target opponent }` — new mass counterpart of `GiveControl`; the
+//!     opponent takes.
+//!
+//! This drives the REAL cast → target-selection → resolution pipeline (not a
+//! hand-built `ResolvedAbility`) with each player controlling creatures the
+//! OTHER doesn't, so a one-way "grab everything" regression and a "swap
+//! nothing" regression are both distinguishable from the correct outcome.
+//! Discriminating: revert either the `GiveControlAll` resolver or the parser
+//! combinator and this fails — pre-fix, P0 ends up controlling ALL FOUR
+//! creatures (P1 controls none) instead of a clean two-for-two swap.
+//!
+//! A second defect surfaced during testing, independent of the composition
+//! above: `resolve_chain_body` deliberately flushes pending layers before a
+//! sub-ability resolves (issue #2384, so a P/T-dependent sub-effect sees
+//! current characteristics). That flush applies `GainControlAll`'s
+//! control-change TCEs BEFORE `GiveControlAll` runs, so a live "creatures you
+//! control" filter at that point would incorrectly also match the creatures
+//! `GainControlAll` just took — collapsing the intended two-way swap right
+//! back into a one-way grab, just shifted to the second half. Fixed via
+//! `GameState::last_gained_control_object_ids`: `resolve_all` stamps the
+//! objects it just took, and `resolve_give_all` excludes them from its own
+//! filter — see the doc on that field and on `resolve_give_all` for the full
+//! mechanics.
+//!
+//! NOT fixed here: "Those creatures gain haste until end of turn" (the
+//! oracle's third sentence) resolves to an `AddKeyword` TCE targeting the two
+//! PLAYERS, not the four creatures that changed control — a separate,
+//! pre-existing "those creatures" scoping bug, unrelated to the reported
+//! one-way-grab issue. See the note on the test below.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const REINS_OF_POWER: &str = "Untap all creatures you control and all creatures target \
+     opponent controls. You and that opponent each gain control of all creatures the \
+     other controls until end of turn. Those creatures gain haste until end of turn.";
+
+fn controller_of(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> PlayerId {
+    runner.state().objects.get(&id).unwrap().controller
+}
+
+#[test]
+fn reins_of_power_swaps_control_both_ways_not_a_one_sided_grab() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Each player controls TWO creatures the other doesn't — this is what
+    // distinguishes a genuine two-way swap from the reported one-way grab
+    // (which would leave P0 controlling all four and P1 controlling none).
+    let p0_bear = scenario.add_vanilla(P0, 2, 2);
+    let p0_elephant = scenario.add_vanilla(P0, 3, 3);
+    let p1_goblin = scenario.add_vanilla(P1, 1, 1);
+    let p1_ogre = scenario.add_vanilla(P1, 4, 4);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reins of Power", false, REINS_OF_POWER)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let spell_card = runner.state().objects[&spell].card_id;
+
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id: spell_card,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the free instant must succeed");
+
+    // Exactly one target slot: "target opponent" is declared once and reused
+    // (as "that opponent") by every later clause in the same sentence.
+    match runner.state().waiting_for.clone() {
+        WaitingFor::TargetSelection { target_slots, .. } => {
+            assert_eq!(
+                target_slots.len(),
+                1,
+                "Reins of Power declares exactly one target (the opponent), got {}",
+                target_slots.len()
+            );
+            assert!(
+                target_slots[0]
+                    .legal_targets
+                    .contains(&TargetRef::Player(P1)),
+                "the opponent must be a legal target"
+            );
+            runner
+                .act(GameAction::SelectTargets {
+                    targets: vec![TargetRef::Player(P1)],
+                })
+                .expect("targeting the opponent must succeed");
+        }
+        other => panic!("expected a single TargetSelection prompt, got {other:?}"),
+    }
+
+    runner.pass_both_players();
+    runner.advance_until_stack_empty();
+    evaluate_layers(runner.state_mut());
+
+    // CR 613.1b + CR 613.9: a genuine two-way swap — P0's creatures are now
+    // P1's, and P1's creatures are now P0's. Pre-fix this reproduced as ALL
+    // FOUR creatures ending up under P0's control (the one-way grab the issue
+    // reports), so every one of these four assertions is discriminating.
+    assert_eq!(
+        controller_of(&runner, p0_bear),
+        P1,
+        "P1 must gain control of the bear (it was P0's)"
+    );
+    assert_eq!(
+        controller_of(&runner, p0_elephant),
+        P1,
+        "P1 must gain control of the elephant (it was P0's)"
+    );
+    assert_eq!(
+        controller_of(&runner, p1_goblin),
+        P0,
+        "P0 must gain control of the goblin (it was P1's) — not stay with P1, and not \
+         ALSO stay with P0 having taken it while keeping its own creatures too"
+    );
+    assert_eq!(
+        controller_of(&runner, p1_ogre),
+        P0,
+        "P0 must gain control of the ogre (it was P1's)"
+    );
+
+    // NOTE: "Those creatures gain haste until end of turn" (the third
+    // sentence) is NOT asserted here. Investigating it surfaced a separate,
+    // pre-existing defect unrelated to the reported one-way-grab bug: the
+    // haste grant ends up as an `AddKeyword` TCE targeting the two PLAYERS
+    // (`SpecificPlayer`), not the four creatures that changed control — "those
+    // creatures" isn't resolving to a creature population at all. That's a
+    // distinct parser/scoping bug, out of scope for this fix; left for a
+    // follow-up issue rather than bundled in here.
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -963,6 +963,7 @@ mod incredible_hulk_enrage_attacking;
 mod indestructible_survives_destroy;
 mod issue_4365_msh_legality;
 mod issue_4376_elspeth_resplendent_nonmodal_labels;
+mod issue_4731_reins_of_power;
 mod issue_4937_iona_chosen_color;
 mod issue_4945_zada_hedron_grinder;
 mod issue_4948_samwise_gamgee_sacrifice_target_order;

--- a/crates/phase-ai/src/policies/control_change_awareness.rs
+++ b/crates/phase-ai/src/policies/control_change_awareness.rs
@@ -113,7 +113,7 @@ fn score_activation(
                     gives_away_permanent = true;
                 }
             }
-            Effect::GiveControl { target, .. } => {
+            Effect::GiveControl { target, .. } | Effect::GiveControlAll { target, .. } => {
                 control_change_effect = true;
                 if would_target_own_permanent(ctx, source_id, target) {
                     gives_away_permanent = true;

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -295,6 +295,7 @@ pub(crate) fn effect_polarity(effect: &Effect) -> EffectPolarity {
         | Effect::GainControlAll { .. }
         | Effect::GainEnergy { .. }
         | Effect::GiveControl { .. }
+        | Effect::GiveControlAll { .. }
         | Effect::GoadAll { .. }
         | Effect::GrantCastingPermission { .. }
         | Effect::GrantExtraLoyaltyActivations { .. }

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -395,6 +395,7 @@ fn redundancy_delta(
         | Effect::Dig { .. }
         | Effect::GainControl { .. }
         | Effect::GainControlAll { .. }
+        | Effect::GiveControlAll { .. }
         | Effect::ControlNextTurn { .. }
         | Effect::Attach { .. }
         | Effect::UnattachAll { .. }


### PR DESCRIPTION
Fixes #4731.

Reins of Power: "Untap all creatures you control and all creatures target opponent controls. You and that opponent each gain control of all creatures the other controls until end of turn. Those creatures gain haste until end of turn."

## Root cause & fix

"Each gain control of all creatures the other controls" collapsed into a single `Effect::GainControlAll` whose population filter had NO controller anaphor (matching every creature regardless of owner) and whose resolver always assigns the new controller to `ability.controller` — the caster. There was no second, opposite-direction control change for the opponent's side, so the caster ended up controlling every creature on the board instead of a clean two-for-two swap.

A dedicated parser combinator (`try_parse_symmetric_gain_control_all`) now recognizes this idiom and composes two independently correct mechanisms via `sub_ability` chaining:
  - `GainControlAll { target: creatures the target opponent controls }` — the caster takes (same mechanism as the already-correct Hellkite Tyrant "gain control of all artifacts that player controls").
  - `GiveControlAll { target: creatures the caster controls, recipient: the target opponent }` — new mass counterpart of `GiveControl`; the opponent takes.

A second defect surfaced during testing: `resolve_chain_body` deliberately flushes pending layers before a sub-ability resolves (issue #2384, so a P/T-dependent sub-effect sees current characteristics). That flush applies `GainControlAll`'s control-change TCEs before `GiveControlAll` runs, so `GiveControlAll`'s live "creatures you control" filter incorrectly also matched the creatures `GainControlAll` just took — collapsing the swap right back into a one-way grab. Fixed via a new resolution-scoped `GameState::last_gained_control_object_ids` field: `resolve_all` stamps the objects it just took, and `resolve_give_all` excludes them from its own filter, recovering the intended CR 613.9 simultaneity.

Out of scope: "Those creatures gain haste until end of turn" (the oracle's third sentence) resolves to an `AddKeyword` TCE targeting the two PLAYERS, not the four creatures that changed control — a separate, pre-existing "those creatures" scoping bug unrelated to the reported one-way-grab issue. Left for a follow-up rather than bundled here.

## Testing

New end-to-end test driving the real cast → target-selection → resolution pipeline with each player controlling creatures the other doesn't, so a one-way grab and a no-op swap are both distinguishable from the correct two-for-two outcome.

Verified locally: fmt clean, clippy clean on both `engine` and `phase-ai` (`-D warnings`), 3252 integration tests pass, 0 regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for mass control handoffs and associated event/profiling coverage.
  * Added parsing support for Reins of Power–style two-way “all creatures” control swaps.
* **Bug Fixes**
  * Fixed simultaneous/mass-resolution behavior to prevent one-sided or duplicate control outcomes.
  * Improved oracle/AST duration propagation and printed-signature handling for the new effect.
  * Updated analysis and AI policies to recognize GiveControlAll consistently.
* **Tests**
  * Added regression tests covering two-way control swap parsing and end-to-end resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->