### PR TITLE
ship/t169 explore hand pipeline

### DIFF
--- a/crates/engine/src/game/effects/explore.rs
+++ b/crates/engine/src/game/effects/explore.rs
@@ -2,14 +2,14 @@ use std::collections::HashSet;
 
 use crate::game::filter;
 use crate::game::replacement::{self, ReplacementResult};
-use crate::game::zones;
+use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
 use crate::types::ability::{
     Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{BatchCompletion, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
@@ -314,14 +314,24 @@ pub(crate) fn resolve_explore_effect(
         .unwrap_or(false);
 
     if is_land {
-        // CR 701.44a: Land revealed — put the card into the player's hand. No counter.
-        zones::move_to_zone(state, top_card_id, crate::types::zones::Zone::Hand, events);
-
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::from(&ability.effect),
-            source_id: explorer_id,
-            subject: None,
-        });
+        // CR 701.44a + CR 614.1 + CR 616.1: The revealed land's Library→Hand
+        // instruction is a replaceable zone-change event. Keep Explore's
+        // completion event on the typed batch tail so a replacement-ordering
+        // choice settles the move before "whenever [a creature] explores"
+        // triggers or a chained continuation can run.
+        let result = zone_pipeline::move_objects_simultaneously_then(
+            state,
+            vec![ZoneMoveRequest::effect(
+                top_card_id,
+                crate::types::zones::Zone::Hand,
+                ability.source_id,
+            )],
+            Some(BatchCompletion::ExploreLandDeliveryComplete { explorer_id }),
+            events,
+        );
+        if matches!(result, BatchMoveResult::NeedsChoice) {
+            return Ok(());
+        }
     } else {
         // CR 701.44a: Nonland revealed — put a +1/+1 counter on the creature,
         // then player chooses to put the card back on top or into graveyard.
@@ -354,6 +364,22 @@ pub(crate) fn resolve_explore_effect(
     }
 
     Ok(())
+}
+
+/// CR 701.44a + CR 701.44b + CR 614.1 + CR 616.1: A revealed land's proposed
+/// hand delivery has settled. The permanent explored even when a replacement
+/// redirected the land elsewhere, so emit its completion event exactly once;
+/// the replacement-resume boundary then drains any already-parked continuation.
+pub(crate) fn complete_land_delivery(
+    explorer_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::Explore,
+        source_id: explorer_id,
+        subject: None,
+    });
+    BatchMoveResult::Done
 }
 
 /// CR 701.44d: If multiple permanents explore simultaneously, controllers choose

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -6131,6 +6131,9 @@ pub(crate) fn run_batch_completion(
 ) -> crate::game::zone_pipeline::BatchMoveResult {
     use crate::types::game_state::BatchCompletion;
     match completion {
+        BatchCompletion::ExploreLandDeliveryComplete { explorer_id } => {
+            effects::explore::complete_land_delivery(explorer_id, events)
+        }
         BatchCompletion::CloakExileDeliveryComplete {
             player,
             source_id,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2421,6 +2421,10 @@ pub struct CloakExileMember {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BatchCompletion {
+    /// CR 701.44a + CR 701.44b + CR 614.1 + CR 616.1: A revealed explore land's
+    /// proposed Library→Hand delivery settled. The explore completion event is
+    /// deferred so its trigger boundary cannot precede a replacement choice.
+    ExploreLandDeliveryComplete { explorer_id: ObjectId },
     /// CR 701.58a + CR 603.10a + CR 614.1 + CR 616.1: A tracked cloak pile's
     /// Battlefield→Exile batch settled. Keep its pre-departure attachment
     /// snapshots so the tail can detach every actual departure and manifest

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -9946,3 +9946,172 @@ fn cloak_tracked_exile_delivery_stays_synchronous_and_cloaks_every_member() {
         "the synchronous cloak tail resolves exactly once"
     );
 }
+
+/// W-169 (red first): a revealed explore land's replaceable Library→Hand move
+/// must settle before the Explore trigger event or a chained continuation runs.
+#[test]
+fn explore_land_redirect_pauses_before_explore_tail() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let explorer = scenario
+        .add_creature(P0, "Explore Redirect Source", 1, 1)
+        .id();
+    let land = scenario.add_card_to_library_top(P0, "Explore Redirect Land");
+    for (name, destination) in [
+        ("Explore Hand To Graveyard", Zone::Graveyard),
+        ("Explore Hand To Exile", Zone::Exile),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Hand, destination));
+    }
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&land)
+        .expect("revealed land exists")
+        .card_types
+        .core_types
+        .push(CoreType::Land);
+    let mut ability = ResolvedAbility::new(Effect::Explore, vec![], explorer, P0);
+    ability.sub_ability = Some(Box::new(ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        vec![],
+        explorer,
+        P0,
+    )));
+    let mut initial_events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("explore reaches its replacement-safe land delivery");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&land].zone, Zone::Library);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 20);
+    assert!(
+        !initial_events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::Explore,
+                source_id,
+                ..
+            } if *source_id == explorer
+        )),
+        "the explore tail must not precede the replacement choice"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the selected redirect settles the explore land delivery");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&land].zone, Zone::Graveyard);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 21);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Explore,
+                    source_id,
+                    ..
+                } if *source_id == explorer
+            ))
+            .count(),
+        1,
+        "a redirected land still completes exactly one explore"
+    );
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::GainLife,
+                    source_id,
+                    ..
+                } if *source_id == explorer
+            ))
+            .count(),
+        1,
+        "the chained continuation runs exactly once after the explore tail"
+    );
+}
+
+/// W-169-REG: without a redirect, an explore land remains synchronous while the
+/// nonland branch keeps its existing counter-then-choice behavior.
+#[test]
+fn explore_land_delivery_stays_synchronous_and_nonland_path_is_unchanged() {
+    let mut land_scenario = GameScenario::new();
+    land_scenario.at_phase(Phase::PreCombatMain);
+    let land_explorer = land_scenario
+        .add_creature(P0, "Synchronous Explore Land Source", 1, 1)
+        .id();
+    let land = land_scenario.add_card_to_library_top(P0, "Synchronous Explore Land");
+    let mut land_runner = land_scenario.build();
+    land_runner
+        .state_mut()
+        .objects
+        .get_mut(&land)
+        .expect("revealed land exists")
+        .card_types
+        .core_types
+        .push(CoreType::Land);
+    let land_ability = ResolvedAbility::new(Effect::Explore, vec![], land_explorer, P0);
+    let mut land_events = Vec::new();
+    resolve_ability_chain(land_runner.state_mut(), &land_ability, &mut land_events, 0)
+        .expect("unredirected land explore resolves synchronously");
+
+    assert!(matches!(
+        land_runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(land_runner.state().objects[&land].zone, Zone::Hand);
+    assert!(
+        !land_runner.state().objects[&land_explorer]
+            .counters
+            .contains_key(&CounterType::Plus1Plus1),
+        "a land explore does not add a +1/+1 counter"
+    );
+
+    let mut nonland_scenario = GameScenario::new();
+    nonland_scenario.at_phase(Phase::PreCombatMain);
+    let nonland_explorer = nonland_scenario
+        .add_creature(P0, "Synchronous Explore Nonland Source", 1, 1)
+        .id();
+    let nonland = nonland_scenario
+        .add_spell_to_library_top(P0, "Synchronous Explore Nonland", true)
+        .id();
+    let mut nonland_runner = nonland_scenario.build();
+    let nonland_ability = ResolvedAbility::new(Effect::Explore, vec![], nonland_explorer, P0);
+    let mut nonland_events = Vec::new();
+    resolve_ability_chain(
+        nonland_runner.state_mut(),
+        &nonland_ability,
+        &mut nonland_events,
+        0,
+    )
+    .expect("nonland explore keeps its counter-then-choice path");
+
+    assert_eq!(
+        nonland_runner.state().objects[&nonland_explorer].counters[&CounterType::Plus1Plus1],
+        1
+    );
+    assert!(matches!(
+        nonland_runner.state().waiting_for,
+        WaitingFor::DigChoice { ref cards, .. } if cards == &vec![nonland]
+    ));
+}

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -28,7 +28,6 @@ crates/engine/src/game/deck_loading.rs	create_scheme_deck_card	exempt	1
 crates/engine/src/game/effects/cast_copy_of_card.rs	cast_one_copy	exempt	1
 crates/engine/src/game/effects/copy_spell.rs	resolve	exempt	1
 crates/engine/src/game/effects/epic.rs	resolve	exempt	1
-crates/engine/src/game/effects/explore.rs	resolve_explore_effect	mover	1
 crates/engine/src/game/effects/paradigm.rs	cast_paradigm_copy	exempt	1
 crates/engine/src/game/effects/prepare.rs	synthesize_prepared_copy_object	exempt	1
 crates/engine/src/game/effects/return_as_aura.rs	resolve	mover	1


### PR DESCRIPTION
- **fix(engine): route explore's land library-to-hand delivery through the replacement-safe zone pipeline**
- **chore(census): tighten zone-authority baseline to 39 hits / 25 rows after explore migration**
