### PR TITLE
ship/t170 return as aura pipeline

### DIFF
--- a/crates/engine/src/game/effects/return_as_aura.rs
+++ b/crates/engine/src/game/effects/return_as_aura.rs
@@ -34,17 +34,16 @@
 //! adds, so the grants depend on the removal and apply after it).
 
 use crate::game::filter::{matches_target_filter, FilterContext};
-use crate::game::replacement::{self, ReplacementResult};
+use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
 use crate::types::ability::{
     ContinuousModification, Duration, Effect, EffectError, EffectKind, ResolvedAbility,
     TargetFilter, TargetRef,
 };
 use crate::types::card_type::{CoreType, SubtypeSet};
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{BatchCompletion, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
-use crate::types::proposed_event::ProposedEvent;
 use crate::types::zones::Zone;
 
 /// CR 614.1 + CR 614.12: Resolve a `Effect::ReturnAsAura` sub-effect.
@@ -130,50 +129,26 @@ pub fn resolve(
             obj.trigger_definitions.clear();
         }
 
-        // CR 303.4g + CR 614.6 + CR 616.1: No legal object to enchant → owner's
-        // graveyard. Route the Battlefield → Graveyard move through the
-        // replacement pipeline so leaves-the-battlefield replacements
-        // (Rest in Peace → exile, Leyline of the Void → exile, regen shields,
-        // etc.) can intercept the zone change exactly as they would for any
-        // other LTB event.
-        let proposed = ProposedEvent::zone_change(
-            returned_id,
-            Zone::Battlefield,
-            Zone::Graveyard,
-            Some(ability.source_id),
+        // CR 303.4g + CR 614.1 + CR 616.1: No legal object to enchant proposes
+        // the owner's-graveyard move through the replacement-safe pipeline.
+        // Keep the sole resolution event in the typed completion: Rest in Peace
+        // / Leyline redirects, prevention, and a CR 616.1 choice all settle the
+        // proposed event before the ReturnAsAura tail runs exactly once.
+        let result = zone_pipeline::move_objects_simultaneously_then(
+            state,
+            vec![ZoneMoveRequest::effect(
+                returned_id,
+                Zone::Graveyard,
+                ability.source_id,
+            )],
+            Some(BatchCompletion::ReturnAsAuraNoTargetComplete {
+                source_id: ability.source_id,
+            }),
+            events,
         );
-        match replacement::replace_event(state, proposed, events) {
-            ReplacementResult::Execute(ProposedEvent::ZoneChange {
-                object_id,
-                to: dest,
-                ..
-            }) => {
-                crate::game::zones::move_to_zone(state, object_id, dest, events);
-                crate::game::layers::mark_layers_full(state);
-            }
-            ReplacementResult::Execute(_) => {
-                // Pipeline preserves the event variant; other variants are
-                // unreachable for a `zone_change`-seeded pipeline.
-            }
-            ReplacementResult::Prevented => {
-                // Move was prevented by a replacement (e.g., regen shield);
-                // CR 704.5n SBA will sweep any residual unattached Aura.
-            }
-            ReplacementResult::NeedsChoice(player) => {
-                // CR 616.1: Multi-replacement player choice — install the
-                // picker and defer EffectResolved. After the player picks,
-                // CR 704.5n SBA sweeps the still-orphaned Aura on the next
-                // pass, yielding the same end state for the rare contested
-                // case (no post-replacement continuation is stashed here).
-                state.waiting_for = replacement::replacement_choice_waiting_for(player, state);
-                return Ok(());
-            }
+        if matches!(result, BatchMoveResult::NeedsChoice) {
+            return Ok(());
         }
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::ReturnAsAura,
-            source_id: ability.source_id,
-            subject: None,
-        });
         return Ok(());
     }
 
@@ -205,6 +180,21 @@ pub fn resolve(
         subject: None,
     });
     Ok(())
+}
+
+/// CR 303.4g + CR 614.1 + CR 616.1: The no-host proposed graveyard move has
+/// settled. Its destination may have been replaced or the move prevented, but
+/// this ReturnAsAura instruction has completed and emits one resolution event.
+pub(crate) fn complete_no_target_delivery(
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::ReturnAsAura,
+        source_id,
+        subject: None,
+    });
+    BatchMoveResult::Done
 }
 
 /// CR 614.1d + CR 113.10 + CR 303.4a + CR 702.5a: Install the Aura's

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -6131,6 +6131,9 @@ pub(crate) fn run_batch_completion(
 ) -> crate::game::zone_pipeline::BatchMoveResult {
     use crate::types::game_state::BatchCompletion;
     match completion {
+        BatchCompletion::ReturnAsAuraNoTargetComplete { source_id } => {
+            effects::return_as_aura::complete_no_target_delivery(source_id, events)
+        }
         BatchCompletion::ExploreLandDeliveryComplete { explorer_id } => {
             effects::explore::complete_land_delivery(explorer_id, events)
         }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2421,6 +2421,11 @@ pub struct CloakExileMember {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BatchCompletion {
+    /// CR 303.4g + CR 614.1 + CR 616.1: A return-as-Aura host had no legal
+    /// object to enchant, and its proposed Battlefield→Graveyard move settled.
+    /// The completion event waits for any replacement choice without carrying
+    /// redundant move data.
+    ReturnAsAuraNoTargetComplete { source_id: ObjectId },
     /// CR 701.44a + CR 701.44b + CR 614.1 + CR 616.1: A revealed explore land's
     /// proposed Library→Hand delivery settled. The explore completion event is
     /// deferred so its trigger boundary cannot precede a replacement choice.

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -6,11 +6,12 @@ use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, CardPlayMode, CardSelectionMode,
-    CastFromZoneDriver, CastingPermission, CategoryChooserScope, ChoiceType, Chooser, DigSource,
-    DiscardSelfScope, Effect, EffectKind, FilterProp, ForEachCategoryAction, IterationCategory,
-    ManaContribution, ManaProduction, ModalChoice, QuantityExpr, QuantityRef,
-    ReplacementDefinition, ReplacementMode, ResolvedAbility, SacrificeCost, SpellCastingOption,
-    TargetFilter, TargetRef, TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
+    CastFromZoneDriver, CastingPermission, CategoryChooserScope, ChoiceType, Chooser,
+    ContinuousModification, DigSource, DiscardSelfScope, Effect, EffectKind, FilterProp,
+    ForEachCategoryAction, IterationCategory, ManaContribution, ManaProduction, ModalChoice,
+    QuantityExpr, QuantityRef, ReplacementDefinition, ReplacementMode, ResolvedAbility,
+    SacrificeCost, SpellCastingOption, TargetFilter, TargetRef, TargetSelectionMode,
+    TriggerDefinition, TypeFilter, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
@@ -10114,4 +10115,214 @@ fn explore_land_delivery_stays_synchronous_and_nonland_path_is_unchanged() {
         nonland_runner.state().waiting_for,
         WaitingFor::DigChoice { ref cards, .. } if cards == &vec![nonland]
     ));
+}
+
+/// W-170 (red first): the no-host ReturnAsAura graveyard instruction must park
+/// its resolution tail until CR 616.1 chooses and settles the replacement.
+#[test]
+fn return_as_aura_no_target_redirect_pauses_before_resolution_tail() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let host = scenario
+        .add_creature(P0, "Return-As-Aura Redirect Host", 2, 2)
+        .id();
+    for name in [
+        "Return-As-Aura Graveyard To Exile A",
+        "Return-As-Aura Graveyard To Exile B",
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_moved_to(Zone::Graveyard, Zone::Exile));
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().last_zone_changed_ids.push(host);
+    let ability = ResolvedAbility::new(
+        Effect::ReturnAsAura {
+            enchant_filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Land)),
+            grants: vec![ContinuousModification::RemoveAllAbilities],
+        },
+        vec![],
+        host,
+        P0,
+    );
+    let mut initial_events = Vec::new();
+    engine::game::effects::return_as_aura::resolve(
+        runner.state_mut(),
+        &ability,
+        &mut initial_events,
+    )
+    .expect("return-as-Aura reaches its replacement-safe no-host delivery");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(runner.state().objects[&host].zone, Zone::Battlefield);
+    assert!(
+        !initial_events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::ReturnAsAura,
+                source_id,
+                ..
+            } if *source_id == host
+        )),
+        "the ReturnAsAura tail must not precede the replacement choice"
+    );
+
+    let completed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the selected replacement settles the ReturnAsAura zone change");
+    assert!(matches!(
+        completed.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(runner.state().objects[&host].zone, Zone::Exile);
+    assert_eq!(
+        initial_events
+            .iter()
+            .chain(completed.events.iter())
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::ReturnAsAura,
+                    source_id,
+                    ..
+                } if *source_id == host
+            ))
+            .count(),
+        1,
+        "the settled replacement delivery runs the ReturnAsAura tail exactly once"
+    );
+}
+
+/// W-170-REG: the unredirected no-host path stays synchronous, strips the
+/// returned host's live trigger snapshot, and the one-host attachment path is
+/// unchanged.
+#[test]
+fn return_as_aura_no_target_stays_synchronous_and_attach_path_is_unchanged() {
+    let mut no_target_scenario = GameScenario::new();
+    no_target_scenario.at_phase(Phase::PreCombatMain);
+    let no_target_host = no_target_scenario
+        .add_creature(P0, "Return-As-Aura No-Target Host", 2, 2)
+        .id();
+    let mut no_target_runner = no_target_scenario.build();
+    no_target_runner
+        .state_mut()
+        .objects
+        .get_mut(&no_target_host)
+        .expect("returned host exists")
+        .trigger_definitions
+        .push(TriggerDefinition::new(TriggerMode::ChangesZone));
+    no_target_runner
+        .state_mut()
+        .last_zone_changed_ids
+        .push(no_target_host);
+    let no_target_ability = ResolvedAbility::new(
+        Effect::ReturnAsAura {
+            enchant_filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Land)),
+            grants: vec![ContinuousModification::RemoveAllAbilities],
+        },
+        vec![],
+        no_target_host,
+        P0,
+    );
+    let mut no_target_events = Vec::new();
+    engine::game::effects::return_as_aura::resolve(
+        no_target_runner.state_mut(),
+        &no_target_ability,
+        &mut no_target_events,
+    )
+    .expect("unredirected no-host ReturnAsAura resolves synchronously");
+
+    assert!(matches!(
+        no_target_runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(
+        no_target_runner.state().objects[&no_target_host].zone,
+        Zone::Graveyard
+    );
+    let GameEvent::ZoneChanged { record, .. } = no_target_events
+        .iter()
+        .find(|event| matches!(event, GameEvent::ZoneChanged { object_id, .. } if *object_id == no_target_host))
+        .expect("the no-host move emits its zone-change record")
+    else {
+        panic!("expected a no-host ZoneChanged event");
+    };
+    assert!(
+        record.trigger_definitions.is_empty(),
+        "the no-host move snapshots the aura-stripped live trigger definitions"
+    );
+    assert_eq!(
+        no_target_events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::ReturnAsAura,
+                    source_id,
+                    ..
+                } if *source_id == no_target_host
+            ))
+            .count(),
+        1,
+        "the synchronous no-host path resolves exactly once"
+    );
+
+    let mut attach_scenario = GameScenario::new();
+    attach_scenario.at_phase(Phase::PreCombatMain);
+    let attach_host = attach_scenario
+        .add_creature(P0, "Return-As-Aura Attach Host", 2, 2)
+        .id();
+    let target = attach_scenario
+        .add_creature(P0, "Return-As-Aura Attach Target", 1, 1)
+        .id();
+    let mut attach_runner = attach_scenario.build();
+    attach_runner
+        .state_mut()
+        .last_zone_changed_ids
+        .push(attach_host);
+    let attach_ability = ResolvedAbility::new(
+        Effect::ReturnAsAura {
+            enchant_filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+            grants: vec![],
+        },
+        vec![],
+        attach_host,
+        P0,
+    );
+    let mut attach_events = Vec::new();
+    engine::game::effects::return_as_aura::resolve(
+        attach_runner.state_mut(),
+        &attach_ability,
+        &mut attach_events,
+    )
+    .expect("one-host ReturnAsAura attaches synchronously");
+
+    assert_eq!(
+        attach_runner.state().objects[&attach_host].attached_to,
+        Some(AttachTarget::Object(target))
+    );
+    assert_eq!(
+        attach_runner.state().objects[&attach_host].zone,
+        Zone::Battlefield
+    );
+    assert_eq!(
+        attach_events
+            .iter()
+            .filter(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::ReturnAsAura,
+                    source_id,
+                    ..
+                } if *source_id == attach_host
+            ))
+            .count(),
+        1,
+        "the unchanged attach path resolves exactly once"
+    );
 }

--- a/scripts/zone-authority-baseline.txt
+++ b/scripts/zone-authority-baseline.txt
@@ -30,7 +30,6 @@ crates/engine/src/game/effects/copy_spell.rs	resolve	exempt	1
 crates/engine/src/game/effects/epic.rs	resolve	exempt	1
 crates/engine/src/game/effects/paradigm.rs	cast_paradigm_copy	exempt	1
 crates/engine/src/game/effects/prepare.rs	synthesize_prepared_copy_object	exempt	1
-crates/engine/src/game/effects/return_as_aura.rs	resolve	mover	1
 crates/engine/src/game/effects/token.rs	commit_liminal_token_entry_with_post_actions	exempt	1
 crates/engine/src/game/elimination.rs	do_eliminate	exempt	1
 crates/engine/src/game/engine.rs	normalize_recast_frame	exempt	3


### PR DESCRIPTION
- **fix(engine): route return_as_aura's no-target graveyard fallback through the replacement-safe zone pipeline**
- **chore(census): tighten zone-authority baseline to 38 hits / 24 rows after return_as_aura migration**
