### PR TITLE
fix(parser): bind "those creatures" after "draw for each creature" to the count filter (#6065)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -60,13 +60,14 @@ use super::{
     bind_anaphoric_damage_subject_keep_recipient, collapse_ephemeral_color_choice_mana,
     contains_explicit_tracked_set_pronoun, contains_implicit_tracked_set_pronoun,
     def_is_damage_dealer, def_is_dig_look, def_is_dig_or_mill, def_is_generic_effect_head,
-    def_is_keyword_counter_placement, demote_unbindable_batch_aggregate,
+    def_is_keyword_counter_placement, demote_unbindable_batch_aggregate, draw_object_count_filter,
     fold_cast_copy_of_card_defs, has_explicit_player_target, inject_chosen_color_choice_grant,
     mark_uses_tracked_set, parse_spell_graveyard_replacement_rider,
     publishes_aggregate_set_from_resolution, publishes_tracked_set_from_resolution,
     rebind_tracked_aggregate_to_chain_set, retarget_counter_additional_cost_to_target,
-    rewrite_parent_targets_to_tracked_set, rewrite_rounding_mode, rewrite_that_type_mana_instead,
-    stamp_delayed_returns, try_fold_token_repeat_into_count, wire_optional_cast_decline_fallback,
+    rewrite_grant_parent_to_filter, rewrite_parent_targets_to_tracked_set, rewrite_rounding_mode,
+    rewrite_that_type_mana_instead, stamp_delayed_returns, try_fold_token_repeat_into_count,
+    wire_optional_cast_decline_fallback,
 };
 
 // ===========================================================================
@@ -2086,6 +2087,23 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
                     for current in &mut current_defs {
                         mark_uses_tracked_set(current);
                         rewrite_parent_targets_to_tracked_set(&mut current.effect);
+                    }
+                }
+            } else if contains_explicit_tracked_set_pronoun(&source_text_lower) {
+                // CR 603.7 + issue #6065: "those creatures gain <keyword>" after a
+                // "draw a card for each <creature filter>" clause (Inspiring Call).
+                // Draw publishes no tracked set (its target is the drawing player),
+                // so the branch above skips it and the grant's ParentTarget would
+                // resolve to the controller. Bind it directly to the nearest prior
+                // Draw's count filter — the counted creatures the pronoun names.
+                if let Some(filter) = defs
+                    .iter()
+                    .rev()
+                    .find_map(|d| draw_object_count_filter(&d.effect))
+                    .cloned()
+                {
+                    for current in &mut current_defs {
+                        rewrite_grant_parent_to_filter(&mut current.effect, &filter);
                     }
                 }
             }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22597,6 +22597,64 @@ fn rewrite_filter_parent_to_tracked_set(filter: &mut TargetFilter) {
     }
 }
 
+/// issue #6065: If `effect` is "draw a card for each `<filter>`" — a `Draw` whose
+/// count is `ObjectCount { filter }` — return that count filter. This is the
+/// antecedent a following "those creatures" grant refers to. Unlike a tracked-set
+/// publisher, `Draw` does not publish the counted objects at resolution (its
+/// `target` is the drawing player), so a `ParentTarget` grant chained after it
+/// must bind directly to this filter rather than to the tracked-set sentinel.
+pub(super) fn draw_object_count_filter(effect: &Effect) -> Option<&TargetFilter> {
+    match effect {
+        Effect::Draw {
+            count:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                },
+            ..
+        } => Some(filter),
+        _ => None,
+    }
+}
+
+/// Re-anchor a `ParentTarget` anaphor in `filter` to `replacement`. Mirrors
+/// `rewrite_filter_parent_to_tracked_set` but binds to a concrete antecedent
+/// filter (issue #6065: "those creatures" → the counted-creature filter).
+fn rewrite_filter_parent_to(filter: &mut TargetFilter, replacement: &TargetFilter) {
+    match filter {
+        TargetFilter::ParentTarget => *filter = replacement.clone(),
+        TargetFilter::Not { filter } => rewrite_filter_parent_to(filter, replacement),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            for f in filters {
+                rewrite_filter_parent_to(f, replacement);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// CR 603.7 + issue #6065: Re-anchor a "those creatures gain `<keyword>`" grant's
+/// `ParentTarget` to `replacement` — the filter of a preceding "draw a card for
+/// each `<creature filter>`" count (Inspiring Call). Only the grant surface
+/// (`GenericEffect`) is rewritten; the tracked-set path (`PutCounterAll` etc.)
+/// is untouched and keeps producing `TrackedSet(0)`.
+pub(super) fn rewrite_grant_parent_to_filter(effect: &mut Effect, replacement: &TargetFilter) {
+    if let Effect::GenericEffect {
+        target,
+        static_abilities,
+        ..
+    } = effect
+    {
+        if let Some(target) = target {
+            rewrite_filter_parent_to(target, replacement);
+        }
+        for static_def in static_abilities {
+            if let Some(affected) = &mut static_def.affected {
+                rewrite_filter_parent_to(affected, replacement);
+            }
+        }
+    }
+}
+
 fn fold_cast_copy_of_card_defs(defs: &mut Vec<AbilityDefinition>) {
     let mut index = 0;
     while index + 1 < defs.len() {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -2480,6 +2480,68 @@ fn compound_mass_counter_first_conjunct_stays_put_counter_all() {
     assert!(!matches!(*sub.effect, Effect::Unimplemented { .. }));
 }
 
+/// CR 603.7 + issue #6065: Inspiring Call — "Draw a card for each creature you
+/// control with a +1/+1 counter on it. Those creatures gain indestructible until
+/// end of turn." Unlike Nalia (whose `PutCounterAll` publishes a tracked set),
+/// the `Draw` clause publishes NO tracked set — its target is the drawing player
+/// — so "those creatures" must bind to the Draw's COUNT filter (the counted
+/// creatures), not the `ParentTarget` anaphor (which resolved to the controller
+/// and left the grant inert), and not `TrackedSet(0)` (no publisher).
+#[test]
+fn inspiring_call_those_creatures_bind_to_draw_count_filter() {
+    let def = parse_effect_chain(
+        "draw a card for each creature you control with a +1/+1 counter on it. those creatures gain indestructible until end of turn",
+        AbilityKind::Spell,
+    );
+    assert!(
+        matches!(&*def.effect, Effect::Draw { .. }),
+        "primary clause must be Draw, got {:?}",
+        def.effect
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("'those creatures gain indestructible ...' must attach as sub_ability");
+    match &*sub.effect {
+        Effect::GenericEffect {
+            target,
+            static_abilities,
+            ..
+        } => {
+            // The "those creatures" anaphor may live in the GenericEffect `target`
+            // or the static's `affected` — the binding must land in one of them.
+            let affected = static_abilities.first().and_then(|s| s.affected.as_ref());
+            let bound = target.as_ref().or(affected);
+            assert!(
+                !matches!(target, Some(TargetFilter::ParentTarget))
+                    && !matches!(affected, Some(TargetFilter::ParentTarget)),
+                "no ParentTarget may remain (would resolve to the controller); \
+                 target={target:?} affected={affected:?}"
+            );
+            assert!(
+                matches!(
+                    bound,
+                    Some(TargetFilter::Typed(tf)) if tf.type_filters.contains(&TypeFilter::Creature)
+                ),
+                "grant must bind to the counted Typed creature filter; \
+                 target={target:?} affected={affected:?}"
+            );
+            assert!(
+                static_abilities
+                    .iter()
+                    .any(|s| s.modifications.iter().any(|m| matches!(
+                        m,
+                        ContinuousModification::AddKeyword {
+                            keyword: Keyword::Indestructible
+                        }
+                    ))),
+                "grant must add Indestructible, got {static_abilities:?}"
+            );
+        }
+        other => panic!("expected GenericEffect grant sub-ability, got {other:?}"),
+    }
+}
+
 /// CR 608.2c + CR 611.2a + CR 613.1f: Nalia de'Arnise's full-party trigger
 /// body. The "and those creatures gain deathtouch until end of turn"
 /// conjunct must split at the chain level so the anaphoric back-reference

--- a/crates/engine/tests/integration/inspiring_call_indestructible_grant.rs
+++ b/crates/engine/tests/integration/inspiring_call_indestructible_grant.rs
@@ -1,0 +1,55 @@
+//! Runtime regression for issue #6065 — Inspiring Call.
+//!
+//! Oracle: "Draw a card for each creature you control with a +1/+1 counter on
+//! it. Those creatures gain indestructible until end of turn."
+//!
+//! The draw half worked, but "those creatures" lowered to `ParentTarget`, which
+//! at runtime resolves to the parent Draw effect's target — the CONTROLLER (a
+//! player) — so no creatures gained indestructible. The parser now rebinds it to
+//! the Draw's count filter (creatures you control with a +1/+1 counter). This
+//! drives the real cast pipeline (live-parsed, no card-data dependency) and
+//! asserts the grant lands on exactly the countered creatures.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::keywords::Keyword;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const INSPIRING_CALL: &str = "Draw a card for each creature you control with a +1/+1 counter on \
+it. Those creatures gain indestructible until end of turn.";
+
+#[test]
+fn inspiring_call_grants_indestructible_only_to_countered_creatures() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // A: has a +1/+1 counter → must gain indestructible.
+    let countered = scenario
+        .add_creature(P0, "Countered Bear", 2, 2)
+        .with_plus_counters(1)
+        .id();
+    // B: no counter → must NOT gain indestructible.
+    let plain = scenario.add_creature(P0, "Plain Bear", 2, 2).id();
+    let call = scenario
+        .add_spell_to_hand(P0, "Inspiring Call", true)
+        .from_oracle_text(INSPIRING_CALL)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    // Library card so the "draw a card for each ..." half has something to draw.
+    scenario.with_library_top(P0, &["P0 Lib A", "P0 Lib B"]);
+
+    let mut runner = scenario.build();
+    runner.state_mut().debug_mode = true;
+
+    runner.cast(call).resolve();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        runner.state().objects[&countered].has_keyword(&Keyword::Indestructible),
+        "the creature with a +1/+1 counter must gain indestructible"
+    );
+    assert!(
+        !runner.state().objects[&plain].has_keyword(&Keyword::Indestructible),
+        "the creature WITHOUT a +1/+1 counter must NOT gain indestructible \
+         (the grant must not resolve to all creatures or to the controller)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -169,6 +169,7 @@ mod hollow_one_cost_reduction;
 mod hunters_insight_combat_draw;
 mod inevitable_betrayal_no_mana_cost;
 mod infantry_shield_mobilize_grant;
+mod inspiring_call_indestructible_grant;
 mod integration_adventure;
 mod integration_bending;
 mod integration_landfall;


### PR DESCRIPTION
Fixes #6065

## Problem

Inspiring Call — *"Draw a card for each creature you control with a +1/+1 counter on it. **Those creatures** gain indestructible until end of turn."* — drew the right number of cards but never granted indestructible.

"Those creatures" lowers to `TargetFilter::ParentTarget`. The chain assembler only rebinds that anaphor when a prior clause is a **tracked-set publisher** (`publishes_tracked_set_from_resolution` — exile/token/`PutCounterAll`/…). `Effect::Draw` is not a publisher (it publishes nothing at resolution; its `target` is the drawing player), so the rebind was skipped and `ParentTarget` survived — resolving at runtime to the Draw's target, the **controller**. The grant landed on a player, so no creatures gained indestructible.

## Fix

`Draw a card for each <filter>` carries the counted creatures in its `count: ObjectCount { filter }`, not in a tracked set. So in the cross-clause pronoun block (`assembly.rs`), when there is **no** tracked-set publisher but the nearest prior clause is such a `Draw`, bind the following "those creatures" grant's `ParentTarget` directly to that count `filter`.

Scoping: the new branch is an `else` to the existing `any_prior_publishes` path, so the `PutCounterAll → TrackedSet(0)` behavior (Nalia de'Arnise) is untouched. It only fires for a `Draw{count: ObjectCount{filter}}` antecedent + an explicit "those creatures" pronoun. Only the grant surface (`GenericEffect`) is rewritten. This is a 1-card class today (Inspiring Call is the only "draw for each creature … those creatures gain" card).

The resulting continuous keyword grant to a Typed creature filter is the standard anthem-style path (Archangel Avacyn etc.) — no runtime change needed.

## Tests

- **Parser** (`inspiring_call_those_creatures_bind_to_draw_count_filter`): the grant binds to the counted Typed creature filter, not `ParentTarget`/`TrackedSet`. The existing Nalia test (`PutCounterAll → TrackedSet(0)`) is the regression guard and stays green.
- **Runtime** (`inspiring_call_indestructible_grant.rs`): casts Inspiring Call (live-parsed) with one creature carrying a +1/+1 counter and one without — the countered creature gains indestructible, the other does not (the grant resolves to the counted set, not to all creatures or the controller).

CR: 603.7.
