### PR TITLE
fix(engine): produce snow mana from snow sources so {S} costs are payable

### DIFF
--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -600,12 +600,18 @@ pub(super) fn handle_replacement_choice(
                     // already no-ops on a missing player, so emitting unconditionally
                     // would report mana that was never added).
                     if state.players.iter().any(|p| p.id == player_id) {
+                        // CR 107.4h + CR 106.3: mana produced by a snow source is snow mana
+                        // (payable for {S}), even when the ProduceMana replacement surfaces as
+                        // an interactive choice.
+                        let source_is_snow =
+                            crate::game::mana_sources::source_is_snow(state, source_id);
                         for _ in 0..count {
                             let unit = crate::types::mana::ManaUnit {
                                 color: mana_type,
                                 source_id,
                                 pip_id: crate::types::mana::ManaPipId(0),
-                                supertype: None,
+                                supertype: source_is_snow
+                                    .then_some(crate::types::mana::ManaSupertype::Snow),
                                 source_could_produce_two_or_more_colors: false,
                                 restrictions: Vec::new(),
                                 grants: Vec::new(),

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -348,12 +348,15 @@ pub(crate) fn produce_mana_with_attributes_from_source_quality(
         _ => (mana_type, 1),
     };
 
+    // CR 107.4h + CR 106.3: mana produced by a snow source is snow mana (payable for {S}).
+    let source_is_snow = super::mana_sources::source_is_snow(state, source_id);
+
     for _ in 0..final_count {
         let unit = ManaUnit {
             color: final_mana_type,
             source_id,
             pip_id: crate::types::mana::ManaPipId(0),
-            supertype: None,
+            supertype: source_is_snow.then_some(crate::types::mana::ManaSupertype::Snow),
             source_could_produce_two_or_more_colors,
             restrictions: restrictions.to_vec(),
             grants: grants.to_vec(),

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -19,6 +19,7 @@ use crate::types::ability::{
     PlayerFilter, QuantityExpr, TargetFilter, TriggerDefinition, TypedFilter,
 };
 use crate::types::card_type::CoreType;
+use crate::types::card_type::Supertype;
 use crate::types::game_state::{GameState, ProductionOverride};
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{
@@ -2050,6 +2051,18 @@ fn mana_options_from_production(
         // option set and contributes nothing to mana-source analysis.
         ManaProduction::TriggerEventManaType => Vec::new(),
     }
+}
+
+/// CR 205.4g / CR 106.3 / CR 107.4h: a permanent with the "snow" supertype is a snow
+/// source; mana produced by its abilities is snow mana (spendable for {S}). Reads the
+/// LAYERED (post-CR-613) supertype set on the object, so continuously-granted Snow counts
+/// and continuously-removed Snow does not (CR 205.4b). A missing object / ObjectId(0)
+/// sentinel is not a snow source.
+pub(crate) fn source_is_snow(state: &GameState, source_id: ObjectId) -> bool {
+    state
+        .objects
+        .get(&source_id)
+        .is_some_and(|obj| obj.card_types.supertypes.contains(&Supertype::Snow))
 }
 
 pub(crate) fn source_could_produce_two_or_more_colors(
@@ -4621,5 +4634,51 @@ mod tests {
 
         let sources = beneficial_non_mana_tap_trigger_sources(&state, PlayerId(0));
         assert_eq!(sources, vec![dork], "only P0's controlled source is listed");
+    }
+
+    /// CR 205.4b + CR 205.4g: `source_is_snow` reads the LAYERED (post-CR-613)
+    /// supertype set, not the printed base set. A permanent whose Snow supertype
+    /// was continuously granted (base lacks it, layered set contains it) is a
+    /// snow source. This is the discriminating fixture for "reads layered, not
+    /// base": a `base_card_types`-reading implementation would return `false`.
+    #[test]
+    fn source_is_snow_reads_layered_not_base_supertypes() {
+        let mut state = GameState::new_two_player(42);
+        let id = create_object(
+            &mut state,
+            CardId(910),
+            PlayerId(0),
+            "Continuously-Snowed Land".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Land);
+        // Printed (base) supertypes deliberately LACK Snow ...
+        obj.base_card_types = obj.card_types.clone();
+        // ... while the layered result (post-CR-613 continuous grant) HAS Snow.
+        obj.card_types.supertypes.push(Supertype::Snow);
+
+        // Non-vacuity guard: the base set must genuinely lack Snow, so a
+        // base-reading implementation would fail this test.
+        assert!(
+            !obj.base_card_types.supertypes.contains(&Supertype::Snow),
+            "fixture invalid: base supertypes must NOT contain Snow for this to \
+             discriminate layered vs. base reads",
+        );
+        assert!(
+            source_is_snow(&state, id),
+            "a permanent continuously granted the Snow supertype is a snow source \
+             (CR 205.4g); source_is_snow must read the layered supertype set",
+        );
+    }
+
+    /// A missing object / `ObjectId(0)` sentinel is not a snow source.
+    #[test]
+    fn source_is_snow_false_for_missing_object() {
+        let state = GameState::new_two_player(42);
+        assert!(
+            !source_is_snow(&state, ObjectId(0)),
+            "the ObjectId(0) sentinel (and any absent object) is not a snow source",
+        );
     }
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -703,6 +703,7 @@ mod skullwinder_chosen_opponent;
 mod slaughter_the_strong_total_power_4380;
 mod slitherwisp_flash_spell_cast_trigger;
 mod sliver_static_grants;
+mod snow_mana_production;
 mod sothera_supervoid_edict_reanimate;
 mod special_action_x_runtime;
 mod specialize_runtime;

--- a/crates/engine/tests/integration/snow_mana_production.rs
+++ b/crates/engine/tests/integration/snow_mana_production.rs
@@ -1,0 +1,153 @@
+//! Regression: a snow permanent's mana ability must PRODUCE snow mana so that
+//! {S} costs (CR 107.4h) become payable.
+//!
+//! The {S} CONSUME path (`spend_snow_unit`, `ManaUnit::is_snow`) was already
+//! complete, but the PRODUCE path never stamped `ManaUnit.supertype =
+//! Some(ManaSupertype::Snow)`: mana produced by a Snow-Covered basic was
+//! indistinguishable from ordinary mana, so {S} could never be paid. The fix
+//! computes snow-ness from the source (CR 205.4g / CR 106.3) and stamps it at
+//! the mana-production `ManaUnit` construction site.
+//!
+//! Each test drives the real production pipeline via `ActivateAbility` through
+//! `apply()`; the assertions flip if the produce-site stamp is reverted to
+//! `supertype: None`.
+
+use engine::game::can_pay;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::card_type::Supertype;
+use engine::types::game_state::CastPaymentMode;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+
+/// A bare `{S}` cost (one mana from a snow source, CR 107.4h).
+fn snow_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![ManaCostShard::Snow],
+        generic: 0,
+    }
+}
+
+/// Mark an existing battlefield permanent as a snow source (CR 205.4g): a
+/// printed Snow supertype lives on both the base and the layered type set so a
+/// layer recompute preserves it.
+fn make_snow_source(runner: &mut engine::game::scenario::GameRunner, id: ObjectId) {
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    if !obj.base_card_types.supertypes.contains(&Supertype::Snow) {
+        obj.base_card_types.supertypes.push(Supertype::Snow);
+    }
+    if !obj.card_types.supertypes.contains(&Supertype::Snow) {
+        obj.card_types.supertypes.push(Supertype::Snow);
+    }
+}
+
+/// Test 1: activating a Snow-Covered basic's `{T}: Add {G}` mana ability
+/// produces snow mana. Reverting site 1 to `supertype: None` makes the
+/// `is_snow()` assertion fail; the `total() > 0` reach-guard proves mana was
+/// actually produced (defeats a vacuous pass).
+#[test]
+fn snow_source_produces_snow_mana() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let land = scenario.add_basic_land(P0, ManaColor::Green);
+    let mut runner = scenario.build();
+    make_snow_source(&mut runner, land);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: land,
+            ability_index: 0,
+        })
+        .expect("activating the snow land's mana ability must succeed");
+
+    let pool = &runner.state().players[0].mana_pool;
+    assert!(
+        pool.total() > 0,
+        "reach-guard: the mana ability must have produced mana (found none)",
+    );
+    assert!(
+        pool.mana.iter().any(|u| u.is_snow()),
+        "mana produced by a snow source must be snow mana (CR 107.4h); the \
+         produce site must stamp ManaSupertype::Snow",
+    );
+}
+
+/// Test 2 (positive cast pipeline): with snow mana produced by a snow source,
+/// a spell whose cost contains `{S}` becomes castable. Reverting site 1 makes
+/// the produced mana non-snow, so `{S}` is unpayable and the cast fails —
+/// flipping this test.
+#[test]
+fn snow_mana_pays_snow_cost_in_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let land = scenario.add_basic_land(P0, ManaColor::Green);
+    // A sorcery costing {S}. Verbatim effect text is irrelevant to the {S}
+    // payability under test; it is a no-op spell that only needs to reach the
+    // stack once its cost is paid.
+    let spell = scenario
+        .add_spell_to_hand(P0, "Snow Snap", false)
+        .with_mana_cost(snow_cost())
+        .id();
+    let mut runner = scenario.build();
+    make_snow_source(&mut runner, land);
+
+    // Produce one snow mana into the pool.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: land,
+            ability_index: 0,
+        })
+        .expect("activating the snow land's mana ability must succeed");
+
+    let spell_card = runner.state().objects[&spell].card_id;
+    let stack_before = runner.state().stack.len();
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id: spell_card,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting a {S} spell must succeed once snow mana is floating");
+    assert_eq!(
+        runner.state().stack.len(),
+        stack_before + 1,
+        "the {{S}} spell must reach the stack — its snow cost was paid from the \
+         snow mana produced by the snow source",
+    );
+}
+
+/// Test 3 (negative sibling): a NON-snow source of the same color produces
+/// ordinary mana. The `is_snow() == false` assertion is paired with a
+/// `total() > 0` reach-guard (mana WAS produced) so the negative is not vacuous,
+/// and a `{S}` cost is not payable from it.
+#[test]
+fn nonsnow_source_produces_nonsnow_mana_and_cannot_pay_snow() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // A plain Forest — no Snow supertype.
+    let land = scenario.add_basic_land(P0, ManaColor::Green);
+    let mut runner = scenario.build();
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: land,
+            ability_index: 0,
+        })
+        .expect("activating the plain land's mana ability must succeed");
+
+    let pool = &runner.state().players[0].mana_pool;
+    assert!(
+        pool.total() > 0,
+        "reach-guard: the mana ability must have produced mana (found none)",
+    );
+    assert!(
+        pool.mana.iter().all(|u| !u.is_snow()),
+        "mana produced by a nonsnow source must NOT be snow mana (CR 205.4g)",
+    );
+    assert!(
+        !can_pay(pool, &snow_cost()),
+        "a {{S}} cost must not be payable from nonsnow mana (CR 107.4h)",
+    );
+}


### PR DESCRIPTION
Snow permanents' mana abilities produced mana with supertype: None, so no
snow mana ever entered the pool and {S} costs were structurally unpayable.
The {S} consume path (spend_snow_unit / ManaUnit::is_snow) was already
complete; only the produce path failed to stamp snow-ness.

Add source_is_snow(state, source_id) reading the object's layered supertype
set (CR 205.4g), and stamp supertype: Some(Snow) at both mana-production
ManaUnit construction sites: produce_mana_with_attributes_from_source_quality
and the handle_replacement_choice ProduceMana arm.

CR 107.4h: {S} is paid with one mana of any type produced by a snow source.
CR 106.3: the source of ability-produced mana is the source of the ability.
