### PR TITLE
feat(engine): implement CR 903.9b as a true replacement effect for commander hand/library returns

### DIFF
--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -122,17 +122,13 @@ pub fn commander_lethal_headroom(
 /// the last SBA check. Their owner may put them into the command zone. Returns
 /// the first eligible `(ObjectId, PlayerId, Zone)` tuple, or `None`.
 ///
-/// CR 903.9b (hand/library) is also covered here as an SBA approximation. This
-/// differs from the CR's replacement effect when the intermediate zone change
-/// is observable; a replacement-model migration remains necessary for full
-/// conformance.
+/// CR 903.9b hand/library returns are a replacement effect at the would-move
+/// boundary; see `replacement::commander_hand_or_library_return_applies`.
 ///
-/// CR 903.9c (merged/melded commander): when a commander is a component of a
-/// merged or melded permanent that leaves to hand or library, `split_merged_permanent_on_leave`
-/// places the absorbed commander component into the destination zone with
-/// `is_commander` intact. This function then finds that component here and
-/// returns it — the owner's choice and the subsequent `Zone::Command` move
-/// proceed identically to the standalone case.
+/// CR 903.9c (merged/melded commander): when a commander component is put into
+/// a graveyard or exile as its merged permanent leaves, it retains
+/// `is_commander` and is eligible for this CR 903.9a check like a standalone
+/// commander. Hand/library components are not eligible for this SBA helper.
 pub fn commander_eligible_for_zone_return(state: &GameState) -> Option<(ObjectId, PlayerId, Zone)> {
     state.objects.values().find_map(|obj| {
         // Oathbreaker RC: signature spells return to the command zone just like
@@ -140,11 +136,8 @@ pub fn commander_eligible_for_zone_return(state: &GameState) -> Option<(ObjectId
         if !obj.uses_command_zone_rules() {
             return None;
         }
-        // CR 903.9a: graveyard or exile; CR 903.9b: hand or library.
-        if !matches!(
-            obj.zone,
-            Zone::Graveyard | Zone::Exile | Zone::Hand | Zone::Library
-        ) {
+        // CR 903.9a: only graveyard and exile are state-based returns.
+        if !matches!(obj.zone, Zone::Graveyard | Zone::Exile) {
             return None;
         }
         // Skip if the owner already declined this SBA cycle.
@@ -532,7 +525,7 @@ mod tests {
         assert_eq!(commander_casts_from_command_zone(&state, PlayerId(0)), 1);
     }
 
-    // --- Zone Return Eligibility Tests (CR 903.9a/b) ---
+    // --- Zone Return Eligibility Tests (CR 903.9a) ---
 
     #[test]
     fn eligible_when_commander_in_graveyard() {
@@ -565,16 +558,14 @@ mod tests {
     }
 
     #[test]
-    fn eligible_when_commander_in_hand() {
+    fn not_sba_eligible_when_commander_in_hand() {
         let mut state = setup_commander_game();
         let cmd_id = create_commander_in_command_zone(&mut state, PlayerId(0), "Kaalia", vec![]);
         let mut events = Vec::new();
         crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Battlefield, &mut events);
         crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Hand, &mut events);
 
-        let result = commander_eligible_for_zone_return(&state);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().2, Zone::Hand);
+        assert!(commander_eligible_for_zone_return(&state).is_none());
     }
 
     #[test]
@@ -1749,14 +1740,10 @@ mod tests {
         id
     }
 
-    /// CR 903.9c: when a merged permanent with a commander component leaves to
-    /// hand, the SBA offers the owner CommanderZoneChoice for the commander
-    /// component (survivor case: the survivor itself is the commander).
-    ///
-    /// Discriminating: if `commander_eligible_for_zone_return` stops covering
-    /// Zone::Hand, or if `is_commander` is cleared on zone exit, this test fails.
+    /// A hand arrival is not eligible for the CR 903.9a SBA path. CR 903.9b
+    /// owns hand/library moves at the replacement boundary instead.
     #[test]
-    fn cr903_9c_merged_commander_to_hand_sba_offers_zone_choice() {
+    fn merged_commander_hand_arrival_is_not_sba_eligible() {
         use crate::game::sba::check_state_based_actions;
         use crate::types::game_state::WaitingFor;
 
@@ -1793,11 +1780,11 @@ mod tests {
             "is_commander must survive the zone transition"
         );
 
-        // SBA should detect the commander in hand and offer zone-return choice.
+        // CR 903.9a does not offer a post-arrival hand-zone choice.
         check_state_based_actions(&mut state, &mut events);
 
         assert!(
-            matches!(
+            !matches!(
                 state.waiting_for,
                 WaitingFor::CommanderZoneChoice {
                     commander_id,
@@ -1805,20 +1792,16 @@ mod tests {
                     ..
                 } if commander_id == cmd_id
             ),
-            "CR 903.9c: SBA offers CommanderZoneChoice for commander in hand; got {:?}",
+            "CR 903.9a must not approximate the CR 903.9b hand replacement; got {:?}",
             state.waiting_for
         );
     }
 
-    /// CR 903.9c: accepting CommanderZoneChoice for a merged commander in hand
-    /// moves the commander component to Zone::Command.
-    ///
-    /// Discriminating: reverts if the accept branch no longer calls
-    /// `move_to_zone(Zone::Command)` or if the SBA path is broken.
+    /// CR 903.9a regression: the retired hand-zone approximation must not
+    /// produce an SBA `CommanderZoneChoice` for a merged survivor.
     #[test]
-    fn cr903_9c_merged_commander_to_hand_accept_moves_to_command() {
+    fn merged_commander_hand_arrival_does_not_offer_sba_accept() {
         use crate::game::sba::check_state_based_actions;
-        use crate::types::actions::GameAction;
         use crate::types::game_state::WaitingFor;
 
         let mut state = setup_commander_game();
@@ -1843,33 +1826,21 @@ mod tests {
 
         check_state_based_actions(&mut state, &mut events);
         assert!(
-            matches!(state.waiting_for, WaitingFor::CommanderZoneChoice { .. }),
-            "SBA must pause with CommanderZoneChoice"
+            !matches!(state.waiting_for, WaitingFor::CommanderZoneChoice { .. }),
+            "CR 903.9a must not offer a hand-zone commander choice"
         );
-
-        let result = crate::game::engine::apply(
-            &mut state,
-            PlayerId(0),
-            GameAction::DecideOptionalEffect { accept: true },
-        );
-        assert!(result.is_ok(), "accepting zone choice must not error");
-
         assert_eq!(
             state.objects[&cmd_id].zone,
-            Zone::Command,
-            "CR 903.9c: commander component must be in Zone::Command after accepting"
+            Zone::Hand,
+            "the raw fixture move is not retroactively changed by an SBA"
         );
     }
 
-    /// CR 903.9c: declining CommanderZoneChoice for a merged commander in hand
-    /// leaves the commander component in hand (not moved to command zone).
-    ///
-    /// Discriminating: reverts if the decline branch stops setting
-    /// `commander_declined_zone_return` or incorrectly moves to command zone.
+    /// CR 903.9a regression: the retired hand-zone approximation must not
+    /// produce an SBA decline prompt for a merged survivor.
     #[test]
-    fn cr903_9c_merged_commander_to_hand_decline_stays_in_hand() {
+    fn merged_commander_hand_arrival_does_not_offer_sba_decline() {
         use crate::game::sba::check_state_based_actions;
-        use crate::types::actions::GameAction;
         use crate::types::game_state::WaitingFor;
 
         let mut state = setup_commander_game();
@@ -1892,33 +1863,22 @@ mod tests {
 
         crate::game::zones::move_to_zone(&mut state, cmd_id, Zone::Hand, &mut events);
         check_state_based_actions(&mut state, &mut events);
-        assert!(matches!(
-            state.waiting_for,
-            WaitingFor::CommanderZoneChoice { .. }
-        ));
-
-        let result = crate::game::engine::apply(
-            &mut state,
-            PlayerId(0),
-            GameAction::DecideOptionalEffect { accept: false },
-        );
-        assert!(result.is_ok());
+        assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
         assert_eq!(
             state.objects[&cmd_id].zone,
             Zone::Hand,
-            "CR 903.9c: declining zone choice must leave commander in hand"
+            "the raw fixture move remains in Hand without the retired SBA prompt"
         );
     }
 
-    /// CR 903.9c: absorbed (non-survivor) commander component is found by the SBA
-    /// after the merged pile leaves to hand.
+    /// CR 903.9a regression: an absorbed commander component in hand is not
+    /// picked up by the retired SBA approximation.
     ///
     /// Discriminating: the commander is the MERGING object, so it becomes an
     /// absorbed component routed exclusively through `merge::put_component_into_zone`
     /// (not `zones::move_to_zone`). If `put_component_into_zone` or
-    /// `apply_zone_exit_cleanup` dropped `is_commander`, the SBA would find nothing
-    /// and the assertion would fail. This is the novel path not covered by the
-    /// survivor-case tests above.
+    /// `apply_zone_exit_cleanup` dropped `is_commander`, the setup assertion
+    /// would fail.
     ///
     /// Setup:
     ///   host_id  = non-commander = TARGET  → survivor (keeps ObjectId, travels
@@ -1926,7 +1886,7 @@ mod tests {
     ///   cmd_id   = commander     = MERGING → absorbed component (travels through
     ///              `put_component_into_zone`, ends in hand with is_commander intact)
     #[test]
-    fn cr903_9c_absorbed_commander_component_in_hand_found_by_sba() {
+    fn absorbed_commander_component_hand_arrival_is_not_sba_eligible() {
         use crate::game::sba::check_state_based_actions;
         use crate::types::game_state::WaitingFor;
 
@@ -1965,11 +1925,11 @@ mod tests {
         );
         assert_eq!(state.objects[&cmd_id].zone, Zone::Hand);
 
-        // SBA must find the absorbed commander component in hand.
+        // CR 903.9a must not turn this hand arrival into an SBA choice.
         check_state_based_actions(&mut state, &mut events);
 
         assert!(
-            matches!(
+            !matches!(
                 state.waiting_for,
                 WaitingFor::CommanderZoneChoice {
                     commander_id,
@@ -1977,7 +1937,7 @@ mod tests {
                     ..
                 } if commander_id == cmd_id
             ),
-            "CR 903.9c: SBA must find the absorbed commander component in hand; got {:?}",
+            "CR 903.9a must not approximate a hand return; got {:?}",
             state.waiting_for
         );
     }

--- a/crates/engine/src/game/meld_tests.rs
+++ b/crates/engine/src/game/meld_tests.rs
@@ -838,100 +838,38 @@ fn meld_entry_consults_enters_with_replacement() {
     );
 }
 
-/// Drive a meld whose battlefield entry is redirected to hand while both
-/// physical components are commanders, then make the requested independent
-/// commander-zone decisions for the source and partner.
+/// Drive a melded permanent to Hand while both physical components are
+/// commanders, then make the requested independent CR 903.9b decisions for
+/// the source and partner components.
 fn run_redirected_meld_commander_choices(source_accepts: bool) {
     use std::collections::HashSet;
 
+    use crate::game::effects::resolve_ability_chain;
     use crate::game::scenario::GameRunner;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, Effect as AbilEffect, FilterProp, ReplacementDefinition,
-        TargetFilter, TypedFilter,
+        AbilityDefinition, AbilityKind, BounceSelection, Effect as AbilEffect, TargetFilter,
+        TargetRef, TriggerDefinition,
     };
     use crate::types::actions::GameAction;
-    use crate::types::replacements::ReplacementEvent;
+    use crate::types::triggers::TriggerMode;
 
     let mut sc = GameScenario::new();
     let source = sc.add_creature(P0, "Gisela, the Broken Blade", 4, 3).id();
     let partner = sc.add_creature(P0, "Bruna, the Fading Light", 5, 4).id();
-    let redirector = sc.add_creature(P1, "Entry Redirector", 2, 2).id();
+    let hand_arrival_observer = sc
+        .add_creature(P0, "Meld Hand Arrival Witness", 0, 0)
+        .as_enchantment()
+        .with_trigger_definition(
+            TriggerDefinition::new(TriggerMode::ChangesZoneAll)
+                .destination(Zone::Hand)
+                .trigger_zones(vec![Zone::Battlefield])
+                .execute(AbilityDefinition::new(AbilityKind::Spell, AbilEffect::NoOp)),
+        )
+        .id();
     seed_result_face(&mut sc.state);
     sc.state.format_config.command_zone = true;
     sc.state.objects.get_mut(&source).unwrap().is_commander = true;
     sc.state.objects.get_mut(&partner).unwrap().is_commander = true;
-
-    // CR 614.5: the same replacement effect gets only one opportunity to
-    // modify the result-entry event. The partner delivery inherits that
-    // applied-effect set, so this battlefield-to-hand redirect cannot loop or
-    // pause between the two physical components.
-    let redirect = ReplacementDefinition::new(ReplacementEvent::Moved)
-        .valid_card(TargetFilter::Any)
-        .destination_zone(Zone::Battlefield)
-        .execute(AbilityDefinition::new(
-            AbilityKind::Spell,
-            AbilEffect::ChangeZone {
-                destination: Zone::Hand,
-                origin: None,
-                target: TargetFilter::SelfRef,
-                owner_library: false,
-                enter_transformed: false,
-                enters_under: None,
-                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
-                enters_attacking: false,
-                up_to: false,
-                enter_with_counters: vec![],
-                conditional_enter_with_counters: vec![],
-                face_down_profile: None,
-                enters_modified_if: None,
-            },
-        ))
-        .description("If a permanent would enter, put it into its owner's hand instead.".into());
-    sc.state
-        .objects
-        .get_mut(&redirector)
-        .unwrap()
-        .replacement_definitions
-        .push(redirect);
-
-    // CR 400.6 + CR 614.5: the physical partner's derived Exile→Hand move is a
-    // separately replaceable event, seeded with the result redirect's applied
-    // set. The original Battlefield→Hand redirect cannot recur, while this
-    // partner-specific Hand→Graveyard replacement still gets one opportunity.
-    let split_partner = ReplacementDefinition::new(ReplacementEvent::Moved)
-        .valid_card(TargetFilter::Typed(TypedFilter::default().properties(
-            vec![FilterProp::Named {
-                name: "Bruna, the Fading Light".to_string(),
-            }],
-        )))
-        .destination_zone(Zone::Hand)
-        .execute(AbilityDefinition::new(
-            AbilityKind::Spell,
-            AbilEffect::ChangeZone {
-                destination: Zone::Graveyard,
-                origin: None,
-                target: TargetFilter::SelfRef,
-                owner_library: false,
-                enter_transformed: false,
-                enters_under: None,
-                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
-                enters_attacking: false,
-                up_to: false,
-                enter_with_counters: vec![],
-                conditional_enter_with_counters: vec![],
-                face_down_profile: None,
-                enters_modified_if: None,
-            },
-        ))
-        .description(
-            "If Bruna would move to hand, put it into its owner's graveyard instead.".into(),
-        );
-    sc.state
-        .objects
-        .get_mut(&redirector)
-        .unwrap()
-        .replacement_definitions
-        .push(split_partner);
 
     let mut meld_events = Vec::new();
     perform_meld(
@@ -941,8 +879,6 @@ fn run_redirected_meld_commander_choices(source_accepts: bool) {
     )
     .unwrap();
 
-    assert_eq!(sc.state.objects[&source].zone, Zone::Hand);
-    assert_eq!(sc.state.objects[&partner].zone, Zone::Graveyard);
     assert_eq!(
         meld_events
             .iter()
@@ -955,36 +891,53 @@ fn run_redirected_meld_commander_choices(source_accepts: bool) {
             ))
             .count(),
         1,
-        "the redirected meld finishes exactly once after both component deliveries"
+        "the meld finishes exactly once before its later component deliveries"
     );
 
-    // CR 903.9a / CR 903.9b: each commander component receives its own choice
-    // from its independently replaced destination. Choice order is engine-
-    // defined, so decide by component identity while proving neither is
-    // prompted twice and the second prompt follows the first decision.
-    crate::game::sba::check_state_based_actions(&mut sc.state, &mut meld_events);
     let mut runner = GameRunner::from_state(sc.state);
+    let bounce = ResolvedAbility::new(
+        AbilEffect::Bounce {
+            target: TargetFilter::Any,
+            destination: None,
+            selection: BounceSelection::Targeted,
+        },
+        vec![TargetRef::Object(source)],
+        hand_arrival_observer,
+        P0,
+    );
+    resolve_ability_chain(runner.state_mut(), &bounce, &mut meld_events, 0)
+        .expect("the merged commander components reach CR 903.9b choices");
+
+    // CR 903.9b + CR 903.9c: each commander component independently chooses
+    // Command or its normal Hand destination. Choice order is engine-defined,
+    // so decide by component identity while proving the raw split bypass cannot
+    // silently omit either prompt.
     let mut prompted = HashSet::new();
     let mut choice_events = Vec::new();
     for _ in 0..2 {
-        let WaitingFor::CommanderZoneChoice {
-            commander_id,
-            current_zone,
+        let WaitingFor::ReplacementChoice {
+            candidate_count,
+            candidates,
             ..
-        } = runner.state().waiting_for
+        } = &runner.state().waiting_for
         else {
             panic!(
-                "expected one commander prompt per meld component, got {:?}",
+                "expected one CR 903.9b prompt per meld component; a raw split bypassed the pipeline: {:?}",
                 runner.state().waiting_for
             );
         };
+        assert_eq!(*candidate_count, 2);
+        let commander_id = candidates
+            .first()
+            .map(|candidate| candidate.source_id)
+            .expect("the CR 903.9b accept candidate identifies its commander component");
         assert_eq!(
-            current_zone,
-            if commander_id == source {
-                Zone::Hand
-            } else {
-                Zone::Graveyard
-            }
+            candidates
+                .iter()
+                .map(|candidate| candidate.source_id)
+                .collect::<Vec<_>>(),
+            vec![commander_id, commander_id],
+            "CR 903.9b owns its ordinary accept/decline replacement prompt"
         );
         assert!(
             prompted.insert(commander_id),
@@ -997,8 +950,10 @@ fn run_redirected_meld_commander_choices(source_accepts: bool) {
             !source_accepts
         };
         let result = runner
-            .act(GameAction::DecideOptionalEffect { accept })
-            .expect("commander-zone decision resolves");
+            .act(GameAction::ChooseReplacement {
+                index: usize::from(!accept),
+            })
+            .expect("commander replacement decision resolves");
         choice_events.extend(result.events);
     }
 
@@ -1008,15 +963,24 @@ fn run_redirected_meld_commander_choices(source_accepts: bool) {
         WaitingFor::Priority { .. }
     ));
     assert!(
-        choice_events.iter().all(|event| !matches!(
+        !choice_events.iter().any(|event| matches!(
             event,
-            GameEvent::EffectResolved {
-                kind: crate::types::ability::EffectKind::Meld,
+            GameEvent::ZoneChanged {
+                object_id,
+                to: Zone::Hand,
                 ..
-            }
+            } if *object_id == if source_accepts { source } else { partner }
         )),
-        "commander choices must not resume the already-finished meld"
+        "an accepted CR 903.9b component must never produce a Hand-arrival event"
     );
+    assert!(choice_events.iter().any(|event| matches!(
+        event,
+        GameEvent::ZoneChanged {
+            object_id,
+            to: Zone::Hand,
+            ..
+        } if *object_id == if source_accepts { partner } else { source }
+    )));
 
     let expected_source_zone = if source_accepts {
         Zone::Command
@@ -1024,12 +988,22 @@ fn run_redirected_meld_commander_choices(source_accepts: bool) {
         Zone::Hand
     };
     let expected_partner_zone = if source_accepts {
-        Zone::Graveyard
+        Zone::Hand
     } else {
         Zone::Command
     };
     assert_eq!(runner.state().objects[&source].zone, expected_source_zone);
     assert_eq!(runner.state().objects[&partner].zone, expected_partner_zone);
+    assert_eq!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .filter(|entry| entry.source_id == hand_arrival_observer)
+            .count(),
+        1,
+        "the Hand-arrival observer sees only the component that declined CR 903.9b"
+    );
 }
 
 #[test]
@@ -1040,6 +1014,155 @@ fn redirected_meld_source_commander_accepts_partner_declines() {
 #[test]
 fn redirected_meld_source_commander_declines_partner_accepts() {
     run_redirected_meld_commander_choices(false);
+}
+
+/// CR 903.9b-c: a commander component redirected from a merged permanent's
+/// Library destination reaches Command before either the Library-arrival event
+/// or its shuffle/observer tails. The noncommander component's independent
+/// Library→graveyard replacement proves this is the component batch, not a
+/// commander-only shortcut.
+#[test]
+fn merged_commander_library_component_replacement_skips_arrival_shuffle_and_observer() {
+    use crate::game::effects::resolve_ability_chain;
+    use crate::game::scenario::GameRunner;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, BounceSelection, Effect as AbilEffect, FilterProp,
+        ReplacementDefinition, TargetFilter, TargetRef, TriggerDefinition, TypedFilter,
+    };
+    use crate::types::actions::GameAction;
+    use crate::types::events::PlayerActionKind;
+    use crate::types::replacements::ReplacementEvent;
+    use crate::types::triggers::TriggerMode;
+
+    let mut sc = GameScenario::new();
+    let source = sc.add_creature(P0, "Gisela, the Broken Blade", 4, 3).id();
+    let partner = sc.add_creature(P0, "Bruna, the Fading Light", 5, 4).id();
+    let observer = sc
+        .add_creature(P0, "Wan Shi Tong Component Witness", 0, 0)
+        .as_enchantment()
+        .with_trigger_definition(
+            TriggerDefinition::new(TriggerMode::ChangesZoneAll)
+                .destination(Zone::Library)
+                .trigger_zones(vec![Zone::Battlefield])
+                .execute(AbilityDefinition::new(AbilityKind::Spell, AbilEffect::NoOp)),
+        )
+        .id();
+    seed_result_face(&mut sc.state);
+    sc.state.format_config.command_zone = true;
+    sc.state.objects.get_mut(&source).unwrap().is_commander = true;
+
+    // A component-specific card replacement has no opportunity against the
+    // merged object's result-face characteristics, but must apply to Bruna's
+    // own routed component. This leaves no genuine Library arrival to mask the
+    // commander's CR 903.9b replacement observability.
+    sc.state
+        .objects
+        .get_mut(&observer)
+        .unwrap()
+        .replacement_definitions
+        .push(
+            ReplacementDefinition::new(ReplacementEvent::Moved)
+                .valid_card(TargetFilter::Typed(TypedFilter::default().properties(vec![
+                    FilterProp::Named {
+                        name: "Bruna, the Fading Light".to_string(),
+                    },
+                ])))
+                .destination_zone(Zone::Library)
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    AbilEffect::ChangeZone {
+                        destination: Zone::Graveyard,
+                        origin: None,
+                        target: TargetFilter::SelfRef,
+                        owner_library: false,
+                        enter_transformed: false,
+                        enters_under: None,
+                        enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                        enters_attacking: false,
+                        up_to: false,
+                        enter_with_counters: vec![],
+                        conditional_enter_with_counters: vec![],
+                        face_down_profile: None,
+                        enters_modified_if: None,
+                    },
+                ))
+                .description(
+                    "If Bruna would be put into a library, put it into its owner's graveyard instead."
+                        .to_string(),
+                ),
+        );
+
+    let mut events = Vec::new();
+    perform_meld(
+        &mut sc.state,
+        &meld_ability(source, P0, "Bruna, the Fading Light"),
+        &mut events,
+    )
+    .unwrap();
+
+    let mut runner = GameRunner::from_state(sc.state);
+    let bounce_to_library = ResolvedAbility::new(
+        AbilEffect::Bounce {
+            target: TargetFilter::Any,
+            destination: Some(Zone::Library),
+            selection: BounceSelection::Targeted,
+        },
+        vec![TargetRef::Object(source)],
+        observer,
+        P0,
+    );
+    resolve_ability_chain(runner.state_mut(), &bounce_to_library, &mut events, 0)
+        .expect("the commander component reaches its CR 903.9b choice");
+
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
+        panic!(
+            "expected the merged commander component's Library replacement choice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(
+        candidates.first().map(|candidate| candidate.source_id),
+        Some(source)
+    );
+    let accepted = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("accepting the component's command-zone replacement is valid");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert_eq!(runner.state().objects[&source].zone, Zone::Command);
+    assert_eq!(runner.state().objects[&partner].zone, Zone::Graveyard);
+    assert!(
+        !accepted.events.iter().any(|event| matches!(
+            event,
+            GameEvent::ZoneChanged {
+                object_id,
+                to: Zone::Library,
+                ..
+            } if *object_id == source || *object_id == partner
+        )),
+        "accepting CR 903.9b and the partner redirect leave no Library arrival"
+    );
+    assert!(
+        !accepted.events.iter().any(|event| matches!(
+            event,
+            GameEvent::PlayerPerformedAction {
+                action: PlayerActionKind::ShuffledLibrary,
+                ..
+            }
+        )),
+        "without a Library arrival, the delivery tail cannot shuffle"
+    );
+    assert!(
+        !runner
+            .state()
+            .stack
+            .iter()
+            .any(|entry| entry.source_id == observer),
+        "a Wan Shi Tong-shaped observer cannot trigger without a Library arrival"
+    );
 }
 
 /// CR 614.12 + CR 701.42: while an as-enters replacement choice is pending,

--- a/crates/engine/src/game/merge.rs
+++ b/crates/engine/src/game/merge.rs
@@ -47,13 +47,16 @@
 //! 702.140d downstream reflexive effects, and the CR 730.3a graveyard/library
 //! arrange-order UI (a deterministic order is used).
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::game::printed_cards::intrinsic_copiable_values;
+use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
 use crate::types::ability::{ContinuousModification, CopiableValues, Duration, TargetFilter};
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
+use crate::types::proposed_event::AppliedReplacementKey;
 use crate::types::zones::Zone;
 
 /// CR 702.140c + CR 730.2a: Which side of the target creature the mutating
@@ -353,16 +356,13 @@ pub(crate) fn install_merge_layer_effect(
 /// Called from the battlefield-exit seam in `zones::move_to_zone` BEFORE the
 /// surviving object is moved. Returns immediately for non-merged objects.
 ///
-/// CR 730.3d (replacement propagation): `dest` is the merged permanent's
-/// *resolved* destination — the merged-permanent leave is a single ZoneChange
-/// event consulted ONCE through `replace_event` (on the survivor) before
-/// `zones::move_to_zone` reaches this seam, so `dest` already reflects any
-/// applied `Moved` redirect (Rest in Peace / Leyline of the Void:
-/// graveyard → exile). Routing every component to that same resolved `dest`
-/// "applies one replacement effect to the object [and thereby] to all components
-/// of the object" — exactly CR 730.3d. Components are explicitly NOT re-consulted
-/// per component here (`put_component_into_zone` routes raw); re-consulting would
-/// double-apply ordering and is rules-wrong per 730.3d.
+/// CR 730.3d (replacement propagation): this raw primitive is retained only
+/// for callers that intentionally bypass the zone pipeline. Normal gameplay
+/// instead enters [`move_merged_permanent_on_leave`], which seeds each component
+/// with the merged event's applied set and lets the shared batch pipeline consult
+/// only still-applicable component replacements. That preserves the rule's
+/// direction that applying a replacement to the merged object applies it to all
+/// components, without suppressing the CR 903.9b-c commander exception.
 ///
 /// CR 730.3e (card-vs-token scope): a "card"-scoped redirect (one that applies to
 /// a card being put into a zone without also including tokens) follows the
@@ -386,17 +386,11 @@ pub(crate) fn install_merge_layer_effect(
 /// survivors and whenever no card-scoped redirect diverges from the survivor's
 /// destination.
 ///
-/// CR 903.9c (merged commander zone redirect): when a commander component is
-/// part of a merged permanent and the whole pile moves to hand or library (CR
-/// 903.9b destination), `put_component_into_zone` places the commander
-/// component in the destination zone with its `is_commander` flag intact. The
-/// next SBA pass calls `commander::commander_eligible_for_zone_return`, which
-/// covers `Zone::Hand | Zone::Library` (CR 903.9b), and presents
-/// `WaitingFor::CommanderZoneChoice` to the owner. On accept the commander
-/// component is moved to `Zone::Command` via `zones::move_to_zone` — the same
-/// path used for standalone commanders. Non-commander components remain in the
-/// destination zone. This function does not need special-case commander logic;
-/// the SBA path handles it identically to the standalone case.
+/// CR 903.9c (merged commander zone redirect): a Hand/Library component is
+/// never delivered through this raw fallback in ordinary play. The pipeline
+/// batch asks its owner the CR 903.9b replacement question before delivery;
+/// accepting places that commander component in Command while the other
+/// components receive their appropriate destinations.
 ///
 /// CR 730.3a deferred: the owner's arrange-order choice for graveyard/library
 /// destinations is not modeled — components are placed in their stored
@@ -466,6 +460,72 @@ pub fn split_merged_permanent_on_leave(
 
     // The surviving object's merge identity is cleared by its own
     // `reset_for_battlefield_exit` during the subsequent `move_to_zone`.
+}
+
+/// CR 730.3d: "If multiple replacement effects could be applied to the event
+/// of a merged permanent leaving the battlefield or being put into the new
+/// zone, applying one of those replacement effects to the object applies it to
+/// all components of the object. If the merged permanent is a commander, it
+/// may be exempt from this rule; see rules 903.9b-c."
+///
+/// This is the normal gameplay route for a merged permanent whose approved
+/// zone-change event is ready to deliver. Every component, including the
+/// survivor, is queued in `move_objects_simultaneously_then`: its inherited
+/// `applied` set prevents a replacement already applied to the merged event
+/// from applying again, while still letting a component-specific replacement
+/// (notably CR 903.9b) consult and pause. The batch owns every pause/restart,
+/// so replacement choices cannot clobber one another or expose partial event
+/// output. The survivor moves through the ordinary mover; absorbed components
+/// retain their `from: None` component-delivery event shape.
+///
+/// CR 903.9c: when an individual commander component accepts the CR 903.9b
+/// Hand/Library replacement, only that component's request changes to Command;
+/// noncommander components remain routed to their appropriate zones.
+pub(crate) fn move_merged_permanent_on_leave(
+    state: &mut GameState,
+    merged_id: ObjectId,
+    dest: Zone,
+    applied: &HashSet<AppliedReplacementKey>,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    let Some(survivor) = state.objects.get(&merged_id) else {
+        return BatchMoveResult::Done;
+    };
+    if survivor.merged_components.is_empty() {
+        return BatchMoveResult::Done;
+    }
+    let components = survivor.merged_components.clone();
+
+    // CR 730.3 + CR 400.7: restore each physical card's own characteristics
+    // before proposing its destination. Clearing this list also prevents the
+    // survivor's ordinary delivery at the tail of this batch from recursively
+    // entering the raw split seam in `zones::move_to_zone`.
+    remove_merge_layer_effect(state, merged_id);
+    crate::game::layers::flush_layers(state);
+    if let Some(survivor) = state.objects.get_mut(&merged_id) {
+        survivor.merged_components.clear();
+        survivor.merge_kind = None;
+    }
+
+    let requests = components
+        .into_iter()
+        .map(|component_id| {
+            if component_id != merged_id {
+                // This live marker distinguishes the absorbed component's
+                // pipeline delivery from an ordinary Battlefield departure.
+                // `put_component_into_zone` restores it after CR 400.7 cleanup.
+                state
+                    .objects
+                    .get_mut(&component_id)
+                    .expect("merged component exists")
+                    .split_from_merge_survivor = Some(merged_id);
+            }
+            ZoneMoveRequest::merged_component(component_id, dest)
+                .with_replacement_applied(applied.clone())
+        })
+        .collect();
+
+    zone_pipeline::move_objects_simultaneously_then(state, requests, None, events)
 }
 
 /// CR 730.2d + CR 400.7 + CR 111.7: restore the survivor's intrinsic token-ness
@@ -590,7 +650,7 @@ fn references_object_that_left(target_filter: &TargetFilter) -> bool {
 /// `zones::add_to_zone` rather than `zones::move_to_zone`, because the component
 /// is absorbed into the survivor (not present in any zone list) and its move must
 /// not be a battlefield exit.
-fn put_component_into_zone(
+pub(crate) fn put_component_into_zone(
     state: &mut GameState,
     component_id: ObjectId,
     dest: Zone,
@@ -608,8 +668,22 @@ fn put_component_into_zone(
     else {
         return;
     };
+    let split_from_merge_survivor = state
+        .objects
+        .get(&component_id)
+        .and_then(|obj| obj.split_from_merge_survivor);
 
     crate::game::zones::route_component(state, component_id, dest);
+
+    // CR 730.3c: `route_component` performs CR 400.7 cleanup and therefore
+    // clears the live marker used to select this special delivery. Restore the
+    // continuity link only after the component has actually reached its new
+    // zone, so a paused replacement cannot expose it as already split.
+    if let Some(survivor_id) = split_from_merge_survivor {
+        if let Some(obj) = state.objects.get_mut(&component_id) {
+            obj.split_from_merge_survivor = Some(survivor_id);
+        }
+    }
 
     let turn_zone_change_index =
         crate::game::restrictions::record_zone_change(state, record.clone());

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -63,6 +63,11 @@ const TURN_SCOPED_COMBAT_SKIP_INDEX: usize = usize::MAX - 4;
 /// past cleanup, like shield counters), so a reserved candidate id lets the
 /// CR 616 ordering pipeline own its choice/application.
 const FINALITY_COUNTER_INDEX: usize = usize::MAX - 5;
+/// CR 903.9b: A commander moving to its owner's hand or library may move to
+/// the command zone instead. This is a rules-source replacement rather than a
+/// card-granted `ReplacementDefinition`, so it uses the existing virtual-ID
+/// protocol shared by intrinsic shield, finality, and compleated effects.
+const COMMANDER_HAND_OR_LIBRARY_RETURN_INDEX: usize = usize::MAX - 6;
 
 /// CR 109.4 + CR 108.4a: Cards outside the battlefield/stack have no
 /// controller; if an effect asks for a card's controller, use its owner
@@ -161,6 +166,49 @@ fn finality_counter_replacement_id(object_id: ObjectId) -> ReplacementId {
 
 fn is_finality_counter_replacement(rid: ReplacementId) -> bool {
     rid.index == FINALITY_COUNTER_INDEX
+}
+
+fn commander_hand_or_library_return_replacement_id(object_id: ObjectId) -> ReplacementId {
+    ReplacementId {
+        source: object_id,
+        index: COMMANDER_HAND_OR_LIBRARY_RETURN_INDEX,
+    }
+}
+
+fn is_commander_hand_or_library_return_replacement(rid: ReplacementId) -> bool {
+    rid.index == COMMANDER_HAND_OR_LIBRARY_RETURN_INDEX
+}
+
+/// Prefer a prospective object's liminal projection when one exists, so a
+/// replacement redirected to Hand/Library still sees the entering card's
+/// command-zone identity.
+fn commander_hand_or_library_return_object(
+    state: &GameState,
+    object_id: ObjectId,
+) -> Option<&GameObject> {
+    state
+        .liminal_entries
+        .get(&object_id)
+        .map(|entry| &entry.object)
+        .or_else(|| state.objects.get(&object_id))
+}
+
+/// CR 903.9b: The rules-source replacement is available only in a command-zone
+/// format, for a commander/signature spell, and only while its proposed move
+/// would put it into its owner's hand or library.
+fn commander_hand_or_library_return_applies(state: &GameState, event: &ProposedEvent) -> bool {
+    let ProposedEvent::ZoneChange { object_id, to, .. } = event else {
+        return false;
+    };
+    matches!(to, Zone::Hand | Zone::Library)
+        && state.format_config.command_zone
+        && commander_hand_or_library_return_object(state, *object_id).is_some_and(|object| {
+            // CR 903.9c: a merged/melded commander does not redirect the
+            // undivided permanent to Command. Its leave delivery is expanded
+            // into component requests, where each commander independently
+            // receives the CR 903.9b choice before reaching Hand/Library.
+            object.uses_command_zone_rules() && object.merged_components.is_empty()
+        })
 }
 
 /// CR 122.1h: A permanent has the finality death→exile redirect while it carries
@@ -836,6 +884,29 @@ pub(crate) fn replacement_mode_is_optional(mode: &ReplacementMode) -> bool {
         mode,
         ReplacementMode::Optional { .. } | ReplacementMode::MayCost { .. }
     )
+}
+
+/// Whether a replacement needs the shared accept/decline prompt. Rules-source
+/// replacements use the same prompt seam as optional card definitions.
+fn replacement_is_optional(state: &GameState, rid: ReplacementId) -> bool {
+    is_commander_hand_or_library_return_replacement(rid)
+        || replacement_definition_for_id(state, rid)
+            .is_some_and(|repl| replacement_mode_is_optional(&repl.mode))
+}
+
+/// CR 903.9b: The commander owner makes this optional-replacement choice. All
+/// other replacement choices retain the ordinary CR 616.1 affected-player rule.
+fn replacement_choice_player(
+    state: &GameState,
+    proposed: &ProposedEvent,
+    rid: ReplacementId,
+) -> PlayerId {
+    if is_commander_hand_or_library_return_replacement(rid) {
+        return commander_hand_or_library_return_object(state, rid.source)
+            .map(|obj| obj.owner)
+            .unwrap_or_else(|| proposed.affected_player(state));
+    }
+    proposed.affected_player(state)
 }
 
 fn replacement_mode_decline(mode: &ReplacementMode) -> Option<&AbilityDefinition> {
@@ -2052,6 +2123,40 @@ fn apply_finality_counter_replacement(
                 source_id: rid.source,
                 event_type: ReplacementEvent::Moved.to_string(),
             });
+        }
+    }
+    Ok(event)
+}
+
+/// CR 903.9b: Replace the proposed move before delivery, so the commander never
+/// enters its owner's hand or library and no arrival event can trigger from it.
+/// The caller has already recorded this virtual replacement in the applied set.
+#[allow(clippy::result_large_err)]
+fn apply_commander_hand_or_library_return_replacement(
+    state: &GameState,
+    mut event: ProposedEvent,
+    rid: ReplacementId,
+    branch: ReplacementBranch,
+    events: &mut Vec<GameEvent>,
+) -> Result<ProposedEvent, ApplyResult> {
+    if branch == ReplacementBranch::Execute
+        && commander_hand_or_library_return_applies(state, &event)
+    {
+        if let ProposedEvent::ZoneChange {
+            object_id,
+            to,
+            applied,
+            ..
+        } = &mut event
+        {
+            if *object_id == rid.source {
+                *to = Zone::Command;
+                applied.insert(AppliedReplacementKey::object(rid.source, rid.index));
+                events.push(GameEvent::ReplacementApplied {
+                    source_id: rid.source,
+                    event_type: ReplacementEvent::Moved.to_string(),
+                });
+            }
         }
     }
     Ok(event)
@@ -5976,6 +6081,16 @@ pub fn find_applicable_replacements(
         _ => {}
     }
 
+    // CR 903.9b: This is an intrinsic rules-source replacement, not an
+    // ability granted by the commander. Expose it as a virtual candidate so
+    // the normal CR 616.1 ordering pipeline composes it with card effects.
+    if let ProposedEvent::ZoneChange { object_id, .. } = event {
+        let rid = commander_hand_or_library_return_replacement_id(*object_id);
+        if commander_hand_or_library_return_applies(state, event) && !event.already_applied(&rid) {
+            candidates.push(rid);
+        }
+    }
+
     // CR 702.150a: Compleated replaces the loyalty counters a permanent enters
     // with when life was paid for its Phyrexian mana symbols. In this engine,
     // ETB counters are delivered through the shared AddCounter replacement
@@ -6712,6 +6827,12 @@ fn apply_single_replacement(
         return apply_shield_counter_replacement(state, proposed, rid, kind, events);
     }
 
+    if is_commander_hand_or_library_return_replacement(rid) {
+        return apply_commander_hand_or_library_return_replacement(
+            state, proposed, rid, branch, events,
+        );
+    }
+
     if is_finality_counter_replacement(rid) {
         return apply_finality_counter_replacement(state, proposed, rid, events);
     }
@@ -7175,7 +7296,29 @@ fn apply_single_replacement_and_dirty(
     registry: &IndexMap<ReplacementEvent, ReplacementHandlerEntry>,
     events: &mut Vec<GameEvent>,
 ) -> Result<ProposedEvent, ApplyResult> {
-    let result = apply_single_replacement(state, proposed, rid, branch, registry, events);
+    let before = proposed.clone();
+    let mut result = apply_single_replacement(state, proposed, rid, branch, registry, events);
+    // CR 614.5 normally records a replacement once per event. CR 903.9b is the
+    // express exception: after ANOTHER replacement actually modifies the event
+    // back into a commander hand/library move, re-arm its virtual key for the
+    // next pipeline pass. A declined commander choice leaves `before` unchanged,
+    // so it retains its key and cannot immediately re-prompt in the same event.
+    if !is_commander_hand_or_library_return_replacement(rid) {
+        if let Ok(after) = &mut result {
+            if *after != before && commander_hand_or_library_return_applies(state, after) {
+                let object_id = match after {
+                    ProposedEvent::ZoneChange { object_id, .. } => *object_id,
+                    _ => unreachable!("commander replacement only applies to zone changes"),
+                };
+                after
+                    .applied_set_mut()
+                    .remove(&AppliedReplacementKey::object(
+                        object_id,
+                        COMMANDER_HAND_OR_LIBRARY_RETURN_INDEX,
+                    ));
+            }
+        }
+    }
     dirty_replacement_index(state);
     result
 }
@@ -7374,6 +7517,12 @@ fn candidate_materiality(
             field: EventField::Count,
             commute: CommuteClass::Subtractive,
         };
+    }
+
+    // CR 903.9b + CR 616.1: Moving to the command zone instead changes the
+    // destination, so it is order-material with every competing replacement.
+    if is_commander_hand_or_library_return_replacement(rid) {
+        return CandidateMateriality::Unconditional;
     }
 
     // CR 614.10: the turn-scoped combat skip fully prevents the BeginPhase event,
@@ -7653,12 +7802,10 @@ fn pipeline_loop(
             let rid = candidates[0];
 
             // Check if this single candidate is Optional — if so, present as a choice
-            let is_optional = replacement_definition_for_id(state, rid)
-                .map(|repl| replacement_mode_is_optional(&repl.mode))
-                .unwrap_or(false);
+            let is_optional = replacement_is_optional(state, rid);
 
             if is_optional {
-                let affected = proposed.affected_player(state);
+                let affected = replacement_choice_player(state, &proposed, rid);
                 let search_found_candidates =
                     snapshot_search_found_candidates(state, &proposed, &candidates);
                 state.pending_replacement = Some(PendingReplacement {
@@ -7955,7 +8102,7 @@ fn continue_replacement_impl(
             }
             return continue_search_found_after_decline(state, pending, rid, events);
         }
-        let payer = pending.proposed.affected_player(state);
+        let payer = replacement_choice_player(state, &pending.proposed, rid);
         // CR 614.12a: a `true` flag means this is the post-choice resume of an
         // accept whose `MayCost` payment paused for an interactive sub-choice
         // (e.g. a `DiscardChoice`). Re-park fields are captured up front so a
@@ -8225,6 +8372,19 @@ fn continue_replacement_impl(
         let proposed = apply_bound_search_found_candidate(state, pending.proposed, &bound, events);
         return pipeline_loop(state, proposed, pending.depth + 1, registry, events);
     }
+
+    // CR 616.1: Selecting an optional candidate from a material ordering prompt
+    // selects its turn to apply; it does not silently accept its "may" branch.
+    // Re-park it through the same optional seam used for a lone candidate, then
+    // re-scan the modified event so the other candidates remain available.
+    if replacement_is_optional(state, rid) {
+        let affected = replacement_choice_player(state, &pending.proposed, rid);
+        pending.candidates = vec![rid];
+        pending.is_optional = true;
+        state.pending_replacement = Some(pending);
+        return ReplacementResult::NeedsChoice(affected);
+    }
+
     let mut proposed = pending.proposed;
     proposed.mark_applied(rid);
     // CR 614.1a: per-player "first time each turn" window is consumed by

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -614,12 +614,13 @@ fn collect_poison_losers(state: &GameState) -> Vec<PlayerId> {
 
 /// CR 903.9a: If a commander is in a graveyard or exile (and was put there
 /// since the last SBA check), its owner may put it into the command zone.
-/// CR 903.9b: Hand and library are also covered (see `commander_eligible_for_zone_return`).
+/// CR 903.9b: Hand and library returns are handled before delivery by the
+/// replacement pipeline, not by this SBA check.
 /// CR 903.9c: Also handles merged/melded permanents — after
 /// `merge::split_merged_permanent_on_leave` places each absorbed component
-/// in its destination zone with `is_commander` intact, the next SBA pass
-/// finds the commander component here and presents the choice identically to
-/// the standalone case.
+/// in a graveyard or exile with `is_commander` intact, the next SBA pass finds
+/// the commander component here and presents the same choice as for a
+/// standalone commander.
 ///
 /// Pauses the SBA loop by setting `WaitingFor::CommanderZoneChoice` so the
 /// player can accept (move to command zone) or decline (leave in place).

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -82,7 +82,11 @@ pub enum ZoneChangeCause {
     PregameProcedure,
     /// CR 800.4a: owner left the game; all objects they own leave the game.
     PlayerLeftGame,
-    /// CR 730.3: merged-component routing already inside a delivering move.
+    /// CR 730.3d + CR 903.9b-c: a merged permanent's physical components are
+    /// delivered by the same pausable replacement-aware batch as other
+    /// simultaneous moves. The special delivery shape preserves the component
+    /// event's `from: None` observability without exempting it from replacement
+    /// consultation.
     MergedComponentRouting,
     /// Debug/admin tooling (engine_debug.rs). Loud by construction.
     DebugCommand,
@@ -99,8 +103,6 @@ impl ZoneChangeCause {
     ///   bottom-of-library returns happen before any effect exists to replace.
     /// - `PlayerLeftGame` (CR 800.4a): "This is not a state-based action"; all
     ///   objects the player owns leave the game as a single rules action.
-    /// - `MergedComponentRouting` (CR 730.3): the merged-permanent move already
-    ///   consulted replacements; the component split is internal routing.
     /// - `DebugCommand`: operator intent is "force the state".
     ///
     /// The unconditional primitive guards (CR 111.8 token, CR 614.1d ETB block,
@@ -124,8 +126,11 @@ impl ZoneChangeCause {
             ZoneChangeCause::CastingToStack { .. }
             | ZoneChangeCause::PregameProcedure
             | ZoneChangeCause::PlayerLeftGame
-            | ZoneChangeCause::MergedComponentRouting
             | ZoneChangeCause::DebugCommand => true,
+            // CR 730.3d + CR 903.9c: component moves inherit the original
+            // event's applied replacements, then consult any component-specific
+            // replacement (including CR 903.9b) through the normal pipeline.
+            ZoneChangeCause::MergedComponentRouting => false,
         }
     }
 }
@@ -389,6 +394,22 @@ impl ZoneMoveRequest {
             object_id,
             to,
             cause: ZoneChangeCause::PlayerLeftGame,
+            mods: EntryMods::default(),
+            placement: None,
+            exile_links: ExileLinkSpec::default(),
+            replacement_applied: HashSet::new(),
+        }
+    }
+
+    /// CR 730.3d + CR 903.9b-c: Route one absorbed component through the
+    /// replacement pipeline. The delivery recognizes its split marker and
+    /// preserves `ZoneChanged { from: None }`, so this is not an independent
+    /// battlefield exit even though its would-move event is replaceable.
+    pub(crate) fn merged_component(object_id: ObjectId, to: Zone) -> Self {
+        Self {
+            object_id,
+            to,
+            cause: ZoneChangeCause::MergedComponentRouting,
             mods: EntryMods::default(),
             placement: None,
             exile_links: ExileLinkSpec::default(),
@@ -1834,13 +1855,53 @@ pub(crate) fn deliver_replaced_zone_change(
     } = event
     {
         if let Some(entry) = state.liminal_entries.get_mut(&object_id) {
-            entry.replacement_applied = applied;
+            entry.replacement_applied = applied.clone();
         }
         let exile_tracking = if track_exiled_by_source {
             ZoneDeliveryExileTracking::TrackBySource
         } else {
             ZoneDeliveryExileTracking::None
         };
+
+        let merged_permanent_leave = from == Zone::Battlefield
+            && state
+                .objects
+                .get(&object_id)
+                .is_some_and(|object| !object.merged_components.is_empty());
+        if merged_permanent_leave {
+            // CR 730.3d + CR 903.9c: the merged permanent's already-approved
+            // event is expanded into a single pausable batch. Each component
+            // inherits `applied`, so a replacement that affected the merged
+            // event is not consulted again; the batch nevertheless consults
+            // component-specific replacements, including CR 903.9b.
+            state.merged_card_component_route = None;
+            return match crate::game::merge::move_merged_permanent_on_leave(
+                state, object_id, to, &applied, events,
+            ) {
+                BatchMoveResult::Done => apply_zone_delivery_tail(
+                    state,
+                    object_id,
+                    from,
+                    to,
+                    cause,
+                    source_id,
+                    duration,
+                    exile_tracking,
+                    drain,
+                    library_placement.as_ref(),
+                    events,
+                ),
+                BatchMoveResult::NeedsChoice => replacement_pause_delivery_result(state),
+            };
+        }
+
+        let split_component_survivor = state.objects.get(&object_id).and_then(|object| {
+            (from == Zone::Battlefield
+                && object.zone == Zone::Battlefield
+                && !state.battlefield.contains(&object_id))
+            .then_some(object.split_from_merge_survivor)
+            .flatten()
+        });
 
         // CR 614.1c: Static replacement effects that modify how an object enters
         // must already be functioning before that object enters. Snapshot the
@@ -1974,7 +2035,17 @@ pub(crate) fn deliver_replaced_zone_change(
                 };
                 zones::move_to_library_at_index(state, object_id, index, events);
             }
-            _ => zones::move_to_zone(state, object_id, to, events),
+            _ => {
+                if split_component_survivor.is_some() {
+                    // CR 903.9b + CR 903.9c: this component has completed its
+                    // replacement consult. Deliver the resulting destination
+                    // with the CR 730.3 `from: None` event shape rather than
+                    // pretending it independently left the battlefield.
+                    crate::game::merge::put_component_into_zone(state, object_id, to, events);
+                } else {
+                    zones::move_to_zone(state, object_id, to, events);
+                }
+            }
         }
         // CR 730.3e: the survivor split (inside `move_to_zone` above) has consumed
         // any clause-2 routing override; clear it so it never leaks into a later

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -5,7 +5,7 @@ use engine::game::mana_abilities::activate_mana_ability;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle_cost::parse_oracle_cost;
 use engine::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, CardPlayMode, CardSelectionMode,
+    AbilityCost, AbilityDefinition, AbilityKind, BounceSelection, CardPlayMode, CardSelectionMode,
     CastFromZoneDriver, CastingPermission, CategoryChooserScope, ChoiceType, Chooser,
     ContinuousModification, DigSource, DiscardSelfScope, Effect, EffectKind, FilterProp,
     ForEachCategoryAction, IterationCategory, ManaContribution, ManaProduction, ModalChoice,
@@ -17,7 +17,7 @@ use engine::types::actions::GameAction;
 use engine::types::card::CardFace;
 use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
-use engine::types::events::GameEvent;
+use engine::types::events::{GameEvent, PlayerActionKind};
 use engine::types::game_state::{
     BatchCompletion, CastPaymentMode, CollectEvidenceResume, GameState,
     ManaAbilityCostParentLifecycle, ManaAbilityCostResolutionMode, ManaAbilityResume, PayCostKind,
@@ -10500,5 +10500,497 @@ fn commander_zone_return_stays_synchronous_and_decline_is_unchanged() {
             .commander_declined_zone_return
             .contains(&declined_commander),
         "declining preserves the existing same-stay ledger behavior"
+    );
+}
+
+/// W-173 (red first): CR 903.9b replaces a commander bounce before the Hand
+/// arrival event. A Warped Devotion-shaped observer therefore cannot trigger
+/// when the owner chooses the command zone, but does trigger after a decline.
+#[test]
+fn commander_hand_return_replaces_bounce_before_warped_devotion_can_observe_it() {
+    let mut accept_scenario = GameScenario::new();
+    accept_scenario.at_phase(Phase::PreCombatMain);
+    let accepted_commander = accept_scenario
+        .add_creature(P0, "Commander Hand Replacement Accept", 2, 2)
+        .id();
+    accept_scenario.with_commander(accepted_commander);
+    let accepted_observer = accept_scenario
+        .add_creature(P0, "Warped Devotion Witness", 0, 0)
+        .as_enchantment()
+        .with_trigger_definition(
+            TriggerDefinition::new(TriggerMode::ChangesZone)
+                .valid_card(TargetFilter::Typed(TypedFilter::permanent()))
+                .origin(Zone::Battlefield)
+                .destination(Zone::Hand)
+                .trigger_zones(vec![Zone::Battlefield])
+                .execute(AbilityDefinition::new(AbilityKind::Spell, Effect::NoOp)),
+        )
+        .id();
+    let mut accept_runner = accept_scenario.build();
+    accept_runner.state_mut().format_config.command_zone = true;
+    let mut accept_setup_events = Vec::new();
+    engine::game::zones::move_to_zone(
+        accept_runner.state_mut(),
+        accepted_commander,
+        Zone::Battlefield,
+        &mut accept_setup_events,
+    );
+    let accept_bounce = ResolvedAbility::new(
+        Effect::Bounce {
+            target: TargetFilter::Any,
+            destination: None,
+            selection: BounceSelection::Targeted,
+        },
+        vec![TargetRef::Object(accepted_commander)],
+        accepted_observer,
+        P0,
+    );
+    let mut accept_events = Vec::new();
+    resolve_ability_chain(
+        accept_runner.state_mut(),
+        &accept_bounce,
+        &mut accept_events,
+        0,
+    )
+    .expect("the bounce reaches the command-zone replacement choice");
+    assert!(matches!(
+        accept_runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert_eq!(
+        accept_runner.state().objects[&accepted_commander].zone,
+        Zone::Battlefield,
+        "the original Hand move stays proposed until CR 903.9b is chosen"
+    );
+
+    let accepted = accept_runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("accepting the CR 903.9b replacement is valid");
+    assert_eq!(
+        accept_runner.state().objects[&accepted_commander].zone,
+        Zone::Command
+    );
+    assert!(
+        !accepted.events.iter().any(|event| matches!(
+            event,
+            GameEvent::ZoneChanged {
+                object_id,
+                from: Some(Zone::Battlefield),
+                to: Zone::Hand,
+                ..
+            } if *object_id == accepted_commander
+        )),
+        "accepting CR 903.9b emits no battlefield-to-Hand event"
+    );
+    assert!(
+        !accept_runner
+            .state()
+            .stack
+            .iter()
+            .any(|entry| entry.source_id == accepted_observer),
+        "Warped Devotion cannot trigger when the commander never reaches Hand"
+    );
+
+    let mut decline_scenario = GameScenario::new();
+    decline_scenario.at_phase(Phase::PreCombatMain);
+    let declined_commander = decline_scenario
+        .add_creature(P0, "Commander Hand Replacement Decline", 2, 2)
+        .id();
+    decline_scenario.with_commander(declined_commander);
+    let declined_observer = decline_scenario
+        .add_creature(P0, "Warped Devotion Decline Witness", 0, 0)
+        .as_enchantment()
+        .with_trigger_definition(
+            TriggerDefinition::new(TriggerMode::ChangesZone)
+                .valid_card(TargetFilter::Typed(TypedFilter::permanent()))
+                .origin(Zone::Battlefield)
+                .destination(Zone::Hand)
+                .trigger_zones(vec![Zone::Battlefield])
+                .execute(AbilityDefinition::new(AbilityKind::Spell, Effect::NoOp)),
+        )
+        .id();
+    let mut decline_runner = decline_scenario.build();
+    decline_runner.state_mut().format_config.command_zone = true;
+    let mut decline_setup_events = Vec::new();
+    engine::game::zones::move_to_zone(
+        decline_runner.state_mut(),
+        declined_commander,
+        Zone::Battlefield,
+        &mut decline_setup_events,
+    );
+    let decline_bounce = ResolvedAbility::new(
+        Effect::Bounce {
+            target: TargetFilter::Any,
+            destination: None,
+            selection: BounceSelection::Targeted,
+        },
+        vec![TargetRef::Object(declined_commander)],
+        declined_observer,
+        P0,
+    );
+    let mut decline_events = Vec::new();
+    resolve_ability_chain(
+        decline_runner.state_mut(),
+        &decline_bounce,
+        &mut decline_events,
+        0,
+    )
+    .expect("the bounce reaches the command-zone replacement choice");
+    let declined = decline_runner
+        .act(GameAction::ChooseReplacement { index: 1 })
+        .expect("declining the CR 903.9b replacement is valid");
+    assert_eq!(
+        decline_runner.state().objects[&declined_commander].zone,
+        Zone::Hand
+    );
+    assert!(declined.events.iter().any(|event| matches!(
+        event,
+        GameEvent::ZoneChanged {
+            object_id,
+            from: Some(Zone::Battlefield),
+            to: Zone::Hand,
+            ..
+        } if *object_id == declined_commander
+    )));
+    assert!(
+        decline_runner
+            .state()
+            .stack
+            .iter()
+            .any(|entry| entry.source_id == declined_observer),
+        "Warped Devotion triggers after a declined Hand replacement"
+    );
+}
+
+/// W-173: CR 903.9b also replaces a library return before both the library
+/// arrival observer (Wan Shi Tong-shaped) and the normal library shuffle tail.
+#[test]
+fn commander_library_return_skips_library_arrival_and_shuffle_when_replaced() {
+    let mut accept_scenario = GameScenario::new();
+    accept_scenario.at_phase(Phase::PreCombatMain);
+    let accepted_commander = accept_scenario
+        .add_creature(P0, "Commander Library Replacement Accept", 2, 2)
+        .id();
+    accept_scenario.with_commander(accepted_commander);
+    let accepted_observer = accept_scenario
+        .add_creature(P0, "Wan Shi Tong Library Witness", 0, 0)
+        .as_enchantment()
+        .with_trigger_definition(
+            TriggerDefinition::new(TriggerMode::ChangesZoneAll)
+                .destination(Zone::Library)
+                .trigger_zones(vec![Zone::Battlefield])
+                .execute(AbilityDefinition::new(AbilityKind::Spell, Effect::NoOp)),
+        )
+        .id();
+    let mut accept_runner = accept_scenario.build();
+    accept_runner.state_mut().format_config.command_zone = true;
+    let mut accept_setup_events = Vec::new();
+    engine::game::zones::move_to_zone(
+        accept_runner.state_mut(),
+        accepted_commander,
+        Zone::Battlefield,
+        &mut accept_setup_events,
+    );
+    let accept_library_return = ResolvedAbility::new(
+        Effect::Bounce {
+            target: TargetFilter::Any,
+            destination: Some(Zone::Library),
+            selection: BounceSelection::Targeted,
+        },
+        vec![TargetRef::Object(accepted_commander)],
+        accepted_observer,
+        P0,
+    );
+    let mut accept_events = Vec::new();
+    resolve_ability_chain(
+        accept_runner.state_mut(),
+        &accept_library_return,
+        &mut accept_events,
+        0,
+    )
+    .expect("the library return reaches the command-zone replacement choice");
+    let accepted = accept_runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("accepting the command-zone replacement is valid");
+    assert_eq!(
+        accept_runner.state().objects[&accepted_commander].zone,
+        Zone::Command
+    );
+    assert!(
+        !accepted.events.iter().any(|event| matches!(
+            event,
+            GameEvent::ZoneChanged {
+                object_id,
+                to: Zone::Library,
+                ..
+            } if *object_id == accepted_commander
+        )),
+        "accepting CR 903.9b emits no library-arrival event"
+    );
+    assert!(
+        !accepted.events.iter().any(|event| matches!(
+            event,
+            GameEvent::PlayerPerformedAction {
+                action: PlayerActionKind::ShuffledLibrary,
+                ..
+            }
+        )),
+        "a replaced library move must not run the delivery shuffle tail"
+    );
+    assert!(
+        !accept_runner
+            .state()
+            .stack
+            .iter()
+            .any(|entry| entry.source_id == accepted_observer),
+        "a Wan Shi Tong-shaped observer cannot trigger without a library arrival"
+    );
+
+    let mut decline_scenario = GameScenario::new();
+    decline_scenario.at_phase(Phase::PreCombatMain);
+    let declined_commander = decline_scenario
+        .add_creature(P0, "Commander Library Replacement Decline", 2, 2)
+        .id();
+    decline_scenario.with_commander(declined_commander);
+    let declined_observer = decline_scenario
+        .add_creature(P0, "Wan Shi Tong Decline Witness", 0, 0)
+        .as_enchantment()
+        .with_trigger_definition(
+            TriggerDefinition::new(TriggerMode::ChangesZoneAll)
+                .destination(Zone::Library)
+                .trigger_zones(vec![Zone::Battlefield])
+                .execute(AbilityDefinition::new(AbilityKind::Spell, Effect::NoOp)),
+        )
+        .id();
+    let mut decline_runner = decline_scenario.build();
+    decline_runner.state_mut().format_config.command_zone = true;
+    let mut decline_setup_events = Vec::new();
+    engine::game::zones::move_to_zone(
+        decline_runner.state_mut(),
+        declined_commander,
+        Zone::Battlefield,
+        &mut decline_setup_events,
+    );
+    let decline_library_return = ResolvedAbility::new(
+        Effect::Bounce {
+            target: TargetFilter::Any,
+            destination: Some(Zone::Library),
+            selection: BounceSelection::Targeted,
+        },
+        vec![TargetRef::Object(declined_commander)],
+        declined_observer,
+        P0,
+    );
+    let mut decline_events = Vec::new();
+    resolve_ability_chain(
+        decline_runner.state_mut(),
+        &decline_library_return,
+        &mut decline_events,
+        0,
+    )
+    .expect("the library return reaches the command-zone replacement choice");
+    let declined = decline_runner
+        .act(GameAction::ChooseReplacement { index: 1 })
+        .expect("declining the command-zone replacement is valid");
+    assert_eq!(
+        decline_runner.state().objects[&declined_commander].zone,
+        Zone::Library
+    );
+    assert!(declined.events.iter().any(|event| matches!(
+        event,
+        GameEvent::ZoneChanged {
+            object_id,
+            to: Zone::Library,
+            ..
+        } if *object_id == declined_commander
+    )));
+    assert!(declined.events.iter().any(|event| matches!(
+        event,
+        GameEvent::PlayerPerformedAction {
+            action: PlayerActionKind::ShuffledLibrary,
+            ..
+        }
+    )));
+    assert!(
+        decline_runner
+            .state()
+            .stack
+            .iter()
+            .any(|entry| entry.source_id == declined_observer),
+        "the observer triggers after a real library arrival"
+    );
+}
+
+/// W-173: CR 903.9b is the CR 614.5 exception. After it changes a Hand move
+/// to Command, a competing Command-to-Hand redirect modifies the same event
+/// and legally offers the commander replacement again.
+#[test]
+fn commander_hand_return_rearms_after_a_competing_redirect_recreates_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let commander = scenario
+        .add_creature(P0, "Commander Repeat-Replacement Witness", 2, 2)
+        .id();
+    scenario.with_commander(commander);
+    let redirect_source = scenario
+        .add_creature(P0, "Command To Hand Redirect Witness", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Command, Zone::Hand))
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().format_config.command_zone = true;
+    let mut setup_events = Vec::new();
+    engine::game::zones::move_to_zone(
+        runner.state_mut(),
+        commander,
+        Zone::Battlefield,
+        &mut setup_events,
+    );
+    let bounce = ResolvedAbility::new(
+        Effect::Bounce {
+            target: TargetFilter::Any,
+            destination: None,
+            selection: BounceSelection::Targeted,
+        },
+        vec![TargetRef::Object(commander)],
+        redirect_source,
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &bounce, &mut events, 0)
+        .expect("the initial commander replacement choice is available");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice {
+            candidate_count: 2,
+            ..
+        }
+    ));
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
+        unreachable!("the optional prompt was asserted above");
+    };
+    assert_eq!(
+        candidates
+            .iter()
+            .map(|candidate| candidate.source_id)
+            .collect::<Vec<_>>(),
+        vec![commander, commander],
+        "the lone initial candidate is the commander's accept/decline choice: {candidates:?}"
+    );
+
+    let reapplied = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("accepting the initial commander replacement is valid");
+    assert!(
+        matches!(
+            reapplied.waiting_for,
+            WaitingFor::ReplacementChoice {
+                candidate_count: 2,
+                ..
+            }
+        ),
+        "the modified event must re-offer the commander replacement"
+    );
+    assert_eq!(
+        runner.state().objects[&commander].zone,
+        Zone::Battlefield,
+        "the re-armed replacement parks before the modified event is delivered"
+    );
+
+    let settled = runner
+        .act(GameAction::ChooseReplacement { index: 1 })
+        .expect("declining the re-armed commander replacement is valid");
+    assert!(matches!(
+        settled.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(
+        runner.state().objects[&commander].zone,
+        Zone::Hand,
+        "the competing redirect's recreated Hand destination is delivered after the second decline"
+    );
+}
+
+/// W-173: In a material CR 616.1 ordering prompt, selecting the commander
+/// rule chooses its turn to apply; its CR 903.9b "may" choice remains separate.
+#[test]
+fn commander_hand_return_keeps_its_may_choice_inside_cr_616_ordering() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let commander = scenario
+        .add_creature(P0, "Commander Ordering Witness", 2, 2)
+        .id();
+    scenario.with_commander(commander);
+    let redirect_source = scenario
+        .add_creature(P0, "Hand To Command Redirect Witness", 0, 0)
+        .as_enchantment()
+        .with_replacement_definition(redirect_moved_to(Zone::Hand, Zone::Command))
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().format_config.command_zone = true;
+    let mut setup_events = Vec::new();
+    engine::game::zones::move_to_zone(
+        runner.state_mut(),
+        commander,
+        Zone::Battlefield,
+        &mut setup_events,
+    );
+    let bounce = ResolvedAbility::new(
+        Effect::Bounce {
+            target: TargetFilter::Any,
+            destination: None,
+            selection: BounceSelection::Targeted,
+        },
+        vec![TargetRef::Object(commander)],
+        redirect_source,
+        P0,
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &bounce, &mut events, 0)
+        .expect("the material replacement ordering choice is available");
+    let WaitingFor::ReplacementChoice {
+        candidate_count,
+        candidates,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!("CR 616.1 must present a replacement ordering prompt");
+    };
+    assert_eq!(*candidate_count, 2);
+    assert_eq!(
+        candidates
+            .iter()
+            .map(|candidate| candidate.source_id)
+            .collect::<Vec<_>>(),
+        vec![commander, redirect_source]
+    );
+
+    let selected = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("selecting the commander rule's place in the ordering is valid");
+    assert!(matches!(
+        selected.waiting_for,
+        WaitingFor::ReplacementChoice {
+            candidate_count: 2,
+            ..
+        }
+    ));
+    assert_eq!(
+        runner.state().objects[&commander].zone,
+        Zone::Battlefield,
+        "ordering selection must not silently accept the optional commander replacement"
+    );
+
+    let declined = runner
+        .act(GameAction::ChooseReplacement { index: 1 })
+        .expect("declining the commander rule after ordering it is valid");
+    assert!(matches!(
+        declined.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(
+        runner.state().objects[&commander].zone,
+        Zone::Command,
+        "the still-applicable Hand-to-Command redirect resolves after the decline"
     );
 }


### PR DESCRIPTION
The SBA approximation (arrive in hand/library, then offer the return) was
observably wrong: shipped triggers like Warped Devotion, Azorius
Aethermage, and Wan Shi Tong could see an arrival that CR 903.9b says
never happens. The old "functionally equivalent" claim was disproved in
the t171 conformance review.

The replacement is intrinsic rules-source infrastructure, not a card
ability: a reserved virtual ReplacementId (alongside the shield/finality/
compleated sources) discovered at the would-move boundary for commanders
headed to Hand or Library in a command-zone format. The owner chooses via
the existing optional-replacement prompt; the candidate composes with
card replacements under normal CR 616.1 ordering, and selecting it from a
material-ordering prompt re-parks its accept/decline rather than silently
accepting the "may".

CR 614.5 exception: the virtual key is re-armed only when another
replacement genuinely modifies the event back into an applicable
commander hand/library move; a decline leaves the event unchanged and
cannot re-prompt within the same event.

Merged permanents (CR 730.3d + CR 903.9c): component delivery now routes
through the batch zone pipeline with the merged event's applied set
inherited by every component — a replacement applied to the merged event
cannot re-apply per component, while component-specific replacements
(including 903.9b for each restored commander) still consult and pause.
The MergedComponentRouting cause is no longer replacement-exempt; the
component event keeps its from: None delivery shape.

commander_eligible_for_zone_return now covers only graveyard/exile
(CR 903.9a); hand/library are handled before delivery.

Witnesses: bounce + library observers prove no arrival event, no shuffle
history, and no observer trigger on accept (and all three on decline);
the CR 614.5 re-arm and CR 616.1 ordering composition are pinned; meld
tests rewritten to the CR-correct per-component outcomes after the
component consult landed (red-first for the bypass, not test drift).
