### PR TITLE
test(engine): Plan 04 Phase 0 baselines against shipped Plan-03 shapes

### DIFF
--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -1555,6 +1555,98 @@ mod tests {
         );
     }
 
+    /// Phase-0 G1 red baseline. CR 400.7 says the returning permanent is a new
+    /// object; CR 701.50b/f nevertheless requires the original conniver's LKI
+    /// to finish the connive. Today `PendingConniveReentry` stores only an
+    /// `ObjectId`, so this deliberately pins the current wrong behavior: a
+    /// battlefield -> graveyard -> battlefield round trip under the same id lets
+    /// the deferred tail put a counter on the return. Phase 1 must carry exact
+    /// identity for the connive subject: the original completes by LKI and this
+    /// return remains untouched.
+    #[test]
+    fn phase0_g1_pending_connive_reentry_rebinds_same_id_return() {
+        use crate::game::engine::apply_as_current;
+        use crate::types::ability::{QuantityModification, ReplacementDefinition};
+        use crate::types::actions::GameAction;
+        use crate::types::game_state::PendingConniveReentry;
+        use crate::types::replacements::ReplacementEvent;
+
+        let mut state = GameState::new_two_player(42);
+        let _leader = install_leader_replacement(&mut state, PlayerId(0));
+        let conniver = make_battlefield_creature(&mut state, PlayerId(0));
+
+        // Two one-shot draw replacements make Leader's replacement draw pause
+        // on a real CR 616.1 choice, leaving its connive tail in the dedicated
+        // carrier before it can resolve.
+        for modification in [
+            QuantityModification::Times { factor: 2 },
+            QuantityModification::Plus { value: 1 },
+        ] {
+            let host = make_battlefield_creature(&mut state, PlayerId(0));
+            let mut replacement = ReplacementDefinition::new(ReplacementEvent::Draw)
+                .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw);
+            replacement.quantity_modification = Some(modification);
+            replacement.consume_on_apply = true;
+            state
+                .objects
+                .get_mut(&host)
+                .expect("replacement host exists")
+                .replacement_definitions
+                .push(replacement);
+        }
+        for index in 0..6 {
+            add_card_to_library(&mut state, PlayerId(0), &format!("Card {index}"), false);
+        }
+
+        let ability = make_connive_ability(conniver, conniver);
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).expect("Leader connive resolves to the pause");
+        assert!(
+            matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. })
+                && matches!(state.pending_connive_reentry, Some(PendingConniveReentry { .. })),
+            "reach guard: Leader's deferred connive tail must be pending at the draw replacement choice"
+        );
+
+        let before = state.objects[&conniver].incarnation;
+        crate::game::zones::move_to_zone(&mut state, conniver, Zone::Graveyard, &mut events);
+        crate::game::zones::move_to_zone(&mut state, conniver, Zone::Battlefield, &mut events);
+        assert!(
+            state.objects[&conniver].incarnation > before,
+            "reach guard: the same storage id must now identify a new CR 400.7 incarnation"
+        );
+
+        let result = apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+            .expect("resume the parked Leader draw");
+        events.extend(result.events);
+        let waiting = state.waiting_for.clone();
+        let WaitingFor::ConniveDiscard { cards, .. } = waiting else {
+            panic!(
+                "the raw-id reentry must reach ConniveDiscard, got {:?}",
+                state.waiting_for
+            );
+        };
+        let waiting_for_discard = state.waiting_for.clone();
+        crate::game::engine_resolution_choices::handle_resolution_choice(
+            &mut state,
+            waiting_for_discard,
+            GameAction::SelectCards {
+                cards: vec![cards[0]],
+            },
+            &mut events,
+        )
+        .expect("discard for the re-bound connive");
+
+        assert_eq!(
+            state.objects[&conniver]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            1,
+            "CURRENT (wrong): raw PendingConniveReentry::conniver rebinds the connive tail to the same-id return; Phase 1 must leave the return at zero counters"
+        );
+    }
+
     /// CR 701.50a + CR 614.5 + CR 616.1f: the Leader connive replacement's
     /// leading draw is itself replaced by a draw-PREVENT replacement (Living
     /// Conundrum "skip that draw" shape). CR 701.50a's "instead you draw a card,

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -4991,6 +4991,115 @@ mod tests {
         assert_eq!(state.players[1].life, initial_life - 3);
     }
 
+    /// Phase-0 G4 baseline. A general post-replacement drain begins a true draw
+    /// that pauses on a replacement consult, the paused state is saved/reloaded,
+    /// and a continuation then reads `PostReplacementSourceController`. Today
+    /// `finish_dispatch` pops the resident drain before that continuation resumes,
+    /// so the event-source context is lost. Phase 1 must retain typed ownership
+    /// across this pause: P1 must draw the second card instead of P0.
+    #[test]
+    fn phase0_g4_general_drain_loses_event_context_across_pausing_draw_resume() {
+        use crate::types::ability::{
+            AbilityDefinition, Effect, PostReplacementContinuation, QuantityModification,
+            TargetFilter,
+        };
+
+        let mut state = GameState::new_two_player(42);
+        let shield = make_creature(&mut state, PlayerId(0), "Swans-class shield");
+        let damage_source = make_creature(&mut state, PlayerId(1), "Damage source");
+
+        for player in [PlayerId(0), PlayerId(1)] {
+            for index in 0..6 {
+                let card_id = CardId(state.next_object_id);
+                create_object(
+                    &mut state,
+                    card_id,
+                    player,
+                    format!("P{} library {index}", player.0),
+                    Zone::Library,
+                );
+            }
+        }
+        // Two one-shot mandatory modifiers produce one real replacement-ordering
+        // pause; after the selected modifier applies the lone survivor finishes
+        // automatically, matching the paused-draw seam G4 needs.
+        for modification in [
+            QuantityModification::Times { factor: 2 },
+            QuantityModification::Plus { value: 1 },
+        ] {
+            let host = make_creature(&mut state, PlayerId(0), "Draw replacement host");
+            let mut replacement = ReplacementDefinition::new(ReplacementEvent::Draw)
+                .draw_scope(crate::types::ability::DrawReplacementScope::IndividualDraw);
+            replacement.quantity_modification = Some(modification);
+            replacement.consume_on_apply = true;
+            state
+                .objects
+                .get_mut(&host)
+                .expect("draw replacement host exists")
+                .replacement_definitions
+                .push(replacement);
+        }
+
+        let mut draw_then_context_draw = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        draw_then_context_draw.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::PostReplacementSourceController,
+            },
+        )));
+        state.install_ready_continuation(PostReplacementContinuation::Template(Box::new(
+            draw_then_context_draw,
+        )));
+        let drain = state
+            .post_replacement_drains
+            .resident_mut()
+            .expect("general drain is resident");
+        drain.source = Some(shield);
+        drain.event_source = Some(damage_source);
+
+        let mut events = Vec::new();
+        let waiting = apply_pending_post_replacement_effect(
+            &mut state,
+            Some(shield),
+            None,
+            Some(ReplacementEvent::DamageDone),
+            &mut events,
+        );
+        assert!(
+            matches!(waiting, Some(WaitingFor::ReplacementChoice { .. }))
+                && matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }),
+            "reach guard: general drain's first draw must pause on a replacement consult"
+        );
+        assert!(
+            state.post_replacement_drains.is_empty(),
+            "CURRENT behavior: finish_dispatch already popped the dispatching drain at the pause"
+        );
+
+        let serialized = serde_json::to_string(&state).expect("save paused state");
+        let mut restored: GameState =
+            serde_json::from_str(&serialized).expect("reload paused state");
+        restored.rehydrate_rng();
+        apply_as_current(&mut restored, GameAction::ChooseReplacement { index: 0 })
+            .expect("resume the paused draw after reload");
+
+        assert!(
+            !restored.players[0].hand.is_empty(),
+            "reach guard: the first draw completed after the replacement consult"
+        );
+        assert_eq!(
+            restored.players[1].hand.len(),
+            0,
+            "CURRENT (wrong): the post-resume PostReplacementSourceController read has no resident drain context, so P1 draws zero; Phase 1 must make P1 draw one"
+        );
+    }
+
     /// 2026-05-09 audit M4 backward-compat: legacy serialized GameState with
     /// the pre-fold `post_replacement_effect` field (Template binding state)
     /// migrates into the new unified slot when `finalize_public_state` runs

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -26618,6 +26618,409 @@ pub mod tests {
         observer
     }
 
+    /// A dies observer deliberately permitted to function both before and after
+    /// it leaves the battlefield. The Phase-0 hostile baselines use this shape
+    /// to exercise the graveyard cache rather than relying on a battlefield-only
+    /// candidate scan.
+    fn add_battlefield_or_graveyard_dies_observer(
+        state: &mut GameState,
+        owner: PlayerId,
+        batched: bool,
+    ) -> ObjectId {
+        let observer = make_creature(state, owner, "Phase-0 observer", 0, 1);
+        let mut trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+            .origin(Zone::Battlefield)
+            .destination(Zone::Graveyard)
+            .trigger_zones(vec![Zone::Battlefield, Zone::Graveyard])
+            .valid_card(TargetFilter::Typed(
+                TypedFilter::default().with_type(TypeFilter::Creature),
+            ))
+            .execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            ));
+        trigger.batched = batched;
+        let obj = state.objects.get_mut(&observer).unwrap();
+        obj.trigger_definitions.push(trigger.clone());
+        std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trigger);
+        observer
+    }
+
+    /// Phase-0 red baseline for the rejected per-segment-exclusion + final
+    /// co-departed-only prototype. B observes A in the first segment, then B
+    /// leaves in a later segment. A final replay of both segments reaches B from
+    /// the graveyard cache and registers A again because `registered_this_event`
+    /// is per collector invocation. Phase 1 must instead carry membership and
+    /// settle the exact observer once, so B/A is observed exactly once.
+    #[test]
+    fn phase0_segment_exclusion_prototype_would_double_register_early_observer() {
+        let mut state = setup();
+        let observer = add_battlefield_or_graveyard_dies_observer(&mut state, PlayerId(0), false);
+        let first_subject = make_creature(&mut state, PlayerId(0), "First subject", 2, 2);
+
+        let mut first_segment = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            first_subject,
+            Zone::Graveyard,
+            &mut first_segment,
+        );
+        let first_count = observer_fire_count(&mut state, &first_segment, observer);
+        assert_eq!(first_count, 1, "B observes A in its live first segment");
+
+        let mut later_segment = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, observer, Zone::Graveyard, &mut later_segment);
+        let mut rejected_final_replay = first_segment;
+        rejected_final_replay.extend(later_segment);
+        let replay_count = observer_fire_count(&mut state, &rejected_final_replay, observer);
+
+        assert_eq!(
+            replay_count, 2,
+            "CURRENT rejected-prototype proof: the final replay revisits B/A from the \
+             off-zone cache as well as B's own departure; Phase 1 must not replay B/A"
+        );
+    }
+
+    /// Phase-0 hostile cache baseline: an early departed observer remains an
+    /// eligible graveyard source while a later segment's subject is collected.
+    /// Phase 1 changes *when* its authority is latched, not this two-event
+    /// result (B observes itself and C exactly once each).
+    #[test]
+    fn phase0_off_zone_cache_observer_sees_later_segment() {
+        let mut state = setup();
+        let observer = add_battlefield_or_graveyard_dies_observer(&mut state, PlayerId(0), false);
+        let later_subject = make_creature(&mut state, PlayerId(0), "Later subject", 2, 2);
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, observer, Zone::Graveyard, &mut events);
+        crate::game::zones::move_to_zone(&mut state, later_subject, Zone::Graveyard, &mut events);
+
+        assert_eq!(
+            observer_fire_count(&mut state, &events, observer),
+            2,
+            "CURRENT behavior: the graveyard cache visits B before settlement for B and C; \
+             Phase 1 must preserve both exact event-time observations"
+        );
+    }
+
+    /// Phase-0 hostile batched baseline: the collector's per-call batch set is
+    /// intentionally reset today. A surviving source sees the same logical move
+    /// split into two calls twice; a departing self-inclusive source is still
+    /// collected once in the latter call. Phase 1 replaces this with one
+    /// logical-group batched observation per exact definition.
+    #[test]
+    fn phase0_batched_sources_are_per_call_not_logical_group() {
+        let mut state = setup();
+        let survivor = add_battlefield_or_graveyard_dies_observer(&mut state, PlayerId(0), true);
+        let departing = add_battlefield_or_graveyard_dies_observer(&mut state, PlayerId(0), true);
+        let first_subject = make_creature(&mut state, PlayerId(0), "First batched subject", 2, 2);
+        let later_subject = make_creature(&mut state, PlayerId(0), "Later batched subject", 2, 2);
+
+        let mut first_segment = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            first_subject,
+            Zone::Graveyard,
+            &mut first_segment,
+        );
+        let first = collect_pending_triggers(&mut state, &first_segment);
+
+        let mut later_segment = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            departing,
+            Zone::Graveyard,
+            &mut later_segment,
+        );
+        crate::game::zones::move_to_zone(
+            &mut state,
+            later_subject,
+            Zone::Graveyard,
+            &mut later_segment,
+        );
+        let later = collect_pending_triggers(&mut state, &later_segment);
+
+        let survivor_contexts = first
+            .iter()
+            .chain(later.iter())
+            .filter(|context| context.pending.source_id == survivor)
+            .count();
+        let departing_contexts = later
+            .iter()
+            .filter(|context| context.pending.source_id == departing)
+            .count();
+        assert_eq!(
+            survivor_contexts, 2,
+            "CURRENT per-call duplication for the survivor"
+        );
+        assert_eq!(
+            departing_contexts, 1,
+            "CURRENT self-inclusive source is collected in its departure segment"
+        );
+    }
+
+    /// Phase-0 hostile all-origin baseline. These are both legitimate batched
+    /// occurrences even though the source stays in a nonbattlefield zone and
+    /// the moved subjects originate from mixed zones. Phase 1 must retain all
+    /// origins on both paused carriers instead of deriving a departures-only set.
+    #[test]
+    fn phase0_batched_off_zone_source_preserves_nonbattlefield_and_mixed_origins() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(0xA110),
+            PlayerId(0),
+            "Off-zone batched observer".to_string(),
+            Zone::Graveyard,
+        );
+        let mut trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+            .destination(Zone::Graveyard)
+            .trigger_zones(vec![Zone::Graveyard])
+            .valid_card(TargetFilter::Typed(
+                TypedFilter::default().with_type(TypeFilter::Creature),
+            ))
+            .execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            ));
+        trigger.batched = true;
+        trigger.origin_zones = vec![Zone::Battlefield, Zone::Hand];
+        let source_obj = state.objects.get_mut(&source).unwrap();
+        source_obj.trigger_definitions.push(trigger.clone());
+        std::sync::Arc::make_mut(&mut source_obj.base_trigger_definitions).push(trigger);
+
+        let battlefield_subject =
+            make_creature(&mut state, PlayerId(0), "Battlefield origin", 2, 2);
+        let hand_subject = create_object(
+            &mut state,
+            CardId(0xA111),
+            PlayerId(0),
+            "Hand origin".to_string(),
+            Zone::Hand,
+        );
+        let hand_obj = state.objects.get_mut(&hand_subject).unwrap();
+        hand_obj.card_types.core_types.push(CoreType::Creature);
+        hand_obj.base_card_types = hand_obj.card_types.clone();
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            battlefield_subject,
+            Zone::Graveyard,
+            &mut events,
+        );
+        crate::game::zones::move_to_zone(&mut state, hand_subject, Zone::Graveyard, &mut events);
+
+        let pending = collect_pending_triggers(&mut state, &events);
+        let source_contexts: Vec<_> = pending
+            .iter()
+            .filter(|context| context.pending.source_id == source)
+            .collect();
+        assert_eq!(
+            source_contexts.len(),
+            1,
+            "one batched off-zone occurrence is retained"
+        );
+        assert_eq!(
+            source_contexts[0].trigger_events.len(),
+            2,
+            "CURRENT behavior retains battlefield and hand origins; Phase 1 must carry both on either paused carrier"
+        );
+    }
+
+    /// Phase-0 hostile runtime-grant baseline. The recipient's batched trigger
+    /// was granted by a lord that leaves in the same event. The current collector
+    /// preserves this pre-event producer; Phase 1 must retain that one event-time
+    /// occurrence through its explicit grant latch.
+    #[test]
+    fn phase0_departing_runtime_grant_is_not_rediscovered_from_final_live_state() {
+        let mut state = setup();
+        let grantor = make_creature(&mut state, PlayerId(0), "Phase-0 trigger lord", 2, 2);
+        let recipient = make_creature(&mut state, PlayerId(0), "Granted recipient", 2, 2);
+        let victim = make_creature(&mut state, PlayerId(0), "Granted trigger subject", 2, 2);
+        let mut granted_trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+            .origin(Zone::Battlefield)
+            .destination(Zone::Graveyard)
+            .valid_card(TargetFilter::Typed(
+                TypedFilter::default().with_type(TypeFilter::Creature),
+            ))
+            .execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            ));
+        granted_trigger.batched = true;
+        let static_def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(TypedFilter::creature()))
+            .modifications(vec![ContinuousModification::GrantTrigger {
+                trigger: Box::new(granted_trigger),
+            }]);
+        let grantor_obj = state.objects.get_mut(&grantor).unwrap();
+        grantor_obj.static_definitions.push(static_def.clone());
+        std::sync::Arc::make_mut(&mut grantor_obj.base_static_definitions).push(static_def);
+        state.layers_dirty.mark_full();
+        crate::game::layers::flush_layers(&mut state);
+        assert!(
+            state.objects[&recipient]
+                .trigger_definitions
+                .iter_all()
+                .any(|trigger| trigger.batched),
+            "setup must materialize the grant before the simultaneous departure"
+        );
+
+        let mut events = Vec::new();
+        for object_id in [grantor, recipient, victim] {
+            crate::game::zones::move_to_zone(&mut state, object_id, Zone::Graveyard, &mut events);
+        }
+        crate::game::zones::mark_simultaneous_departures(
+            &mut events,
+            &[grantor, recipient, victim],
+        );
+        let contexts = collect_pending_triggers(&mut state, &events);
+        let recipient_contexts = contexts
+            .iter()
+            .filter(|context| context.pending.source_id == recipient)
+            .count();
+
+        assert_eq!(
+            recipient_contexts, 1,
+            "CURRENT behavior: the departing grant contributes one recipient context; \
+             Phase 1 must retain that event-time occurrence through settlement"
+        );
+    }
+
+    /// A co-departing Hushbringer-class suppressor is absent from the current
+    /// final live-static cache. This pins the current over-trigger so Phase 1
+    /// can replace it with an event-time suppressor latch.
+    #[test]
+    fn phase0_co_departing_suppressor_currently_over_triggers() {
+        let mut state = setup();
+        let suppressor = add_suppress_triggers_permanent(
+            &mut state,
+            PlayerId(0),
+            TargetFilter::Typed(TypedFilter::creature()),
+            vec![SuppressedTriggerEvent::Dies],
+        );
+        let victim = add_battlefield_or_graveyard_dies_observer(&mut state, PlayerId(0), false);
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, victim, Zone::Graveyard, &mut events);
+        crate::game::zones::move_to_zone(&mut state, suppressor, Zone::Graveyard, &mut events);
+        crate::game::zones::mark_simultaneous_departures(&mut events, &[victim, suppressor]);
+
+        assert_eq!(
+            observer_fire_count(&mut state, &events, victim),
+            1,
+            "CURRENT (wrong) outcome: a co-departing suppressor is gone from the final cache; \
+             Phase 1 must latch it and suppress the victim's dies trigger"
+        );
+    }
+
+    /// Real-card Phase-0 baseline — Species Specialist:
+    /// "As this creature enters, choose a creature type. Whenever a creature of
+    /// the chosen type dies, you may draw a card."  The selected type is source
+    /// data, so a co-departure must be matched from the leaving incarnation's
+    /// event-time authority, never by rereading a returned object in Phase 1.
+    #[test]
+    fn phase0_species_specialist_co_departure_uses_current_source_identity() {
+        let mut state = setup();
+        let specialist = make_creature(&mut state, PlayerId(0), "Species Specialist", 2, 3);
+        state
+            .objects
+            .get_mut(&specialist)
+            .unwrap()
+            .chosen_attributes
+            .push(ChosenAttribute::CreatureType("Elf".to_string()));
+        let trigger = TriggerDefinition::new(TriggerMode::ChangesZone)
+            .origin(Zone::Battlefield)
+            .destination(Zone::Graveyard)
+            .trigger_zones(vec![Zone::Battlefield])
+            .valid_card(TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                controller: None,
+                properties: vec![FilterProp::IsChosenCreatureType],
+            }))
+            .optional()
+            .execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            ));
+        let specialist_obj = state.objects.get_mut(&specialist).unwrap();
+        specialist_obj.trigger_definitions.push(trigger.clone());
+        std::sync::Arc::make_mut(&mut specialist_obj.base_trigger_definitions).push(trigger);
+
+        let elf = make_creature(&mut state, PlayerId(0), "Co-departing Elf", 2, 2);
+        let elf_obj = state.objects.get_mut(&elf).unwrap();
+        elf_obj.card_types.subtypes.push("Elf".to_string());
+        elf_obj.base_card_types = elf_obj.card_types.clone();
+
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, specialist, Zone::Graveyard, &mut events);
+        crate::game::zones::move_to_zone(&mut state, elf, Zone::Graveyard, &mut events);
+        crate::game::zones::mark_simultaneous_departures(&mut events, &[specialist, elf]);
+        let specialist_contexts = collect_pending_triggers(&mut state, &events)
+            .into_iter()
+            .filter(|context| context.pending.source_id == specialist)
+            .count();
+
+        assert_eq!(
+            specialist_contexts, 1,
+            "CURRENT (wrong) baseline: this raw-ID/LKI collector sees only one Species \
+             Specialist context; Phase 1 must preserve the exact selected-type source context \
+             and produce one context covering both matching co-departures"
+        );
+    }
+
+    /// Real-card Phase-0 baseline — Elvish Soultiller:
+    /// "When this creature dies, choose a creature type. Shuffle all creature
+    /// cards of that type from your graveyard into your library."  The current
+    /// raw `NamedChoice.source_id` rebinds to a same-ID return and writes the
+    /// answer onto that new object. Phase 1 must carry the departed source
+    /// context instead: the returned Soultiller stays untouched.
+    #[test]
+    fn phase0_elvish_soultiller_choice_same_id_return_mutates_return() {
+        use crate::types::ability::ChoiceType;
+
+        let mut state = setup();
+        let soultiller = make_creature(&mut state, PlayerId(0), "Elvish Soultiller", 5, 4);
+        state.waiting_for = WaitingFor::NamedChoice {
+            player: PlayerId(0),
+            choice_type: ChoiceType::creature_type(),
+            options: vec!["Elf".to_string()],
+            source_id: Some(soultiller),
+            persist_player: None,
+        };
+
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, soultiller, Zone::Graveyard, &mut events);
+        crate::game::zones::move_to_zone(&mut state, soultiller, Zone::Battlefield, &mut events);
+        crate::game::engine::apply_as_current(
+            &mut state,
+            GameAction::ChooseOption {
+                choice: "Elf".to_string(),
+            },
+        )
+        .expect("current raw-ID named choice accepts the answer");
+
+        assert_eq!(
+            state
+                .objects
+                .get(&soultiller)
+                .and_then(|object| object.chosen_creature_type()),
+            Some("Elf"),
+            "CURRENT (wrong) raw-ID outcome: the choice mutates the same-ID return; \
+             Phase 1 must bind it to the departed Soultiller context instead"
+        );
+    }
+
     /// Count how many times `observer`'s trigger fired against `events`.
     fn observer_fire_count(
         state: &mut GameState,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -14557,6 +14557,89 @@ mod tests {
         assert_eq!(state.max_lands_per_turn, 1);
     }
 
+    /// Phase-0 migration oracle for Amendment B's shipped, split authority.
+    /// This is intentionally test-only: Phase 2/3 will replace these labels
+    /// with resolution frames, but must preserve the current nesting order for
+    /// each valid mixed shape. `PostReplacementDrainStack` is positional today
+    /// (there are no drain ids), while draw work is addressed by frame id and
+    /// the connive tail has its dedicated slot.
+    #[test]
+    fn phase0_migration_oracle_shipped_mixed_slots_preserve_drain_order() {
+        #[derive(Debug, PartialEq, Eq)]
+        enum ShippedLegacySlot {
+            GeneralPostReplacement,
+            DrawSequence,
+            ConniveTail,
+        }
+
+        fn outer_to_inner(state: &GameState) -> Vec<ShippedLegacySlot> {
+            let mut order = Vec::new();
+            if state.pending_connive_reentry.is_some() {
+                order.push(ShippedLegacySlot::ConniveTail);
+            }
+            if state.post_replacement_drains.has_ready() {
+                order.push(ShippedLegacySlot::GeneralPostReplacement);
+            }
+            if state.draw_sequences.active().is_some() {
+                order.push(ShippedLegacySlot::DrawSequence);
+            }
+            order
+        }
+
+        let draw = |state: &mut GameState| {
+            state.draw_sequences.push(PlayerId(0), 1);
+        };
+        let general = |state: &mut GameState| {
+            state.install_ready_continuation(
+                crate::types::ability::PostReplacementContinuation::Template(Box::new(
+                    crate::types::ability::AbilityDefinition::new(
+                        crate::types::ability::AbilityKind::Spell,
+                        crate::types::ability::Effect::Draw {
+                            count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                            target: crate::types::ability::TargetFilter::Controller,
+                        },
+                    ),
+                )),
+            );
+        };
+
+        // A general drain that has entered a true draw keeps the general work
+        // outside the draw sequence; the child draw is the active (inner) work.
+        let mut general_then_draw = GameState::new_two_player(42);
+        general(&mut general_then_draw);
+        draw(&mut general_then_draw);
+        assert!(general_then_draw.post_replacement_drains.has_ready());
+        assert!(general_then_draw.draw_sequences.active().is_some());
+        assert_eq!(
+            outer_to_inner(&general_then_draw),
+            vec![
+                ShippedLegacySlot::GeneralPostReplacement,
+                ShippedLegacySlot::DrawSequence,
+            ],
+            "outer-to-inner migration order for a general drain that started a draw"
+        );
+
+        // Leader-style "draw, then connive" carries its tail separately. The
+        // connive tail is outer work and the draw remains the active inner work.
+        let mut draw_then_connive = GameState::new_two_player(42);
+        draw(&mut draw_then_connive);
+        draw_then_connive.pending_connive_reentry = Some(PendingConniveReentry {
+            conniver: ObjectId(99),
+            count: 1,
+            applied: HashSet::new(),
+        });
+        assert!(draw_then_connive.draw_sequences.active().is_some());
+        assert!(draw_then_connive.pending_connive_reentry.is_some());
+        assert_eq!(
+            outer_to_inner(&draw_then_connive),
+            vec![
+                ShippedLegacySlot::ConniveTail,
+                ShippedLegacySlot::DrawSequence,
+            ],
+            "outer-to-inner migration order for the dedicated connive tail and its draw"
+        );
+    }
+
     #[test]
     fn new_two_player_creates_game_with_seed() {
         let state = GameState::new_two_player(12345);


### PR DESCRIPTION
Test-only additions pinning current behavior before the resolution-frame
migration: seven trigger-index baselines (segment exclusion, off-zone cache,
per-call batching, mixed origins, grantor departure, co-departing suppressor,
Species Specialist / Elvish Soultiller identity), the G1 connive same-ID-return
rebinding hazard (CR 400.7 + CR 701.50b/f), the G4 general-drain x pausing-draw
composition baseline proving the drain's event context is lost across a
save/reload at the pause (finish_dispatch pops unconditionally), and a
test-only migration oracle mapping shipped mixed draw/drain/connive slots to
their outer-to-inner order. Each baseline documents the Phase-1 expected flip
in its assertion message.
