### PR TITLE
refactor(parser): hoist Class-H replacement producers to the oracle document IR seam

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -57,7 +57,7 @@ use super::oracle_dispatch::dispatch_line_nom;
 use super::oracle_effect::sequence::try_parse_same_is_true_continuation;
 use super::oracle_effect::{
     lower_effect_chain_ir, parse_additional_cost_instead_condition_fragment, parse_effect_chain,
-    parse_effect_chain_with_context, rewrite_condition_keyword,
+    parse_effect_chain_ir, parse_effect_chain_with_context, rewrite_condition_keyword,
     try_parse_temporal_delayed_trigger_ability,
 };
 use super::oracle_ir::context::ParseContext;
@@ -68,6 +68,7 @@ use super::oracle_ir::doc::{
 };
 use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
+use super::oracle_ir::replacement::ReplacementIr;
 pub use super::oracle_keyword::keyword_display_name;
 use super::oracle_keyword::{
     is_keyword_cost_line, is_kicker_family_line, parse_kicker_additional_cost_line,
@@ -82,6 +83,7 @@ use super::oracle_modal::{
 use super::oracle_replacement::{
     find_copy_verb_present, lower_as_enters_becomes_choice_modal,
     lower_as_enters_or_face_up_counters, lower_replacement_ir, parse_replacement_line,
+    parse_replacement_line_ir,
 };
 use super::oracle_saga::{is_saga_chapter, parse_saga_chapters};
 use super::oracle_spacecraft::parse_spacecraft_threshold_lines;
@@ -207,10 +209,10 @@ pub(crate) fn is_commander_permission_sentence(line: &str) -> bool {
     parsed
 }
 
-fn parse_replacement_sentence_sequence(
+fn parse_replacement_sentence_sequence_ir(
     line: &str,
     card_name: &str,
-) -> Option<Vec<ReplacementDefinition>> {
+) -> Option<Vec<ReplacementIr>> {
     // CR 614.1c: Effects that read "[This permanent] enters with ...",
     // "As [this permanent] enters ...", or "[This permanent] enters as ..."
     // are replacement effects.
@@ -225,7 +227,7 @@ fn parse_replacement_sentence_sequence(
         if !is_replacement_pattern(&sentence.to_lowercase()) {
             return None;
         }
-        replacements.push(parse_replacement_line(sentence, card_name)?);
+        replacements.push(parse_replacement_line_ir(sentence, card_name)?);
     }
     Some(replacements)
 }
@@ -624,13 +626,21 @@ fn parse_begin_game_counter_clause(
     ))
 }
 
+fn lower_spell_node(node: &OracleNodeIr) -> Option<AbilityDefinition> {
+    match node {
+        OracleNodeIr::Spell(effect_ir) => Some(lower_effect_chain_ir(effect_ir)),
+        OracleNodeIr::PreLoweredSpell(definition) => Some(definition.clone()),
+        _ => None,
+    }
+}
+
 fn parsed_result_recently_granted_flashback(emitter: &DocEmitter<'_>) -> bool {
     // u4-c2: reads the emitter's last-emitted-per-category peeks instead of
     // `result.{abilities,triggers,statics}.last()` (the vectors moved into the
     // source-ordered builder). Same semantics: was flashback just granted?
     emitter
-        .last_ability()
-        .is_some_and(definition_grants_flashback)
+        .last_ability_definition()
+        .is_some_and(|definition| definition_grants_flashback(&definition))
         || emitter.last_trigger().is_some_and(|trigger| {
             trigger
                 .execute
@@ -950,7 +960,7 @@ fn parse_static_replacement_compound(
     line: &str,
     lower: &str,
     card_name: &str,
-) -> Option<(Vec<StaticDefinition>, Vec<ReplacementDefinition>)> {
+) -> Option<(Vec<StaticDefinition>, Vec<ReplacementIr>)> {
     // Re-attach the shared subject to each conjunct so each clause parses
     // independently (Oracle text drops the subject on the second conjunct).
     let (subject, p1, p2) = split_dual_cant_clause(line, lower)?;
@@ -959,8 +969,8 @@ fn parse_static_replacement_compound(
 
     let left_statics = parse_static_line_with_graveyard_keyword_continuation(&left, None, None);
     let right_statics = parse_static_line_with_graveyard_keyword_continuation(&right, None, None);
-    let left_repl = parse_replacement_line(&left, card_name);
-    let right_repl = parse_replacement_line(&right, card_name);
+    let left_repl = parse_replacement_line_ir(&left, card_name);
+    let right_repl = parse_replacement_line_ir(&right, card_name);
 
     // Each conjunct must be claimed by at least one layer; otherwise this is not
     // a clean cross-layer compound and the line belongs to the single-layer
@@ -1116,12 +1126,15 @@ fn try_split_and_cant_become_untapped(
 // vectors for a matching shape (a dual authority the parse/lower split removes).
 // ===========================================================================
 
-/// The lowered replacement definition an item carries, if it is a replacement.
-/// Only `PreLowered*` nodes are inspected: the dedicated IR variants
-/// (`Spell`/`Trigger`/`Static`/`Replacement`) are never constructed today, and
-/// gain relation participation when the dispatch-cutover unit builds them.
+/// The replacement definition an item carries, if it is a replacement.
+///
+/// `ReplacementIr` already owns the parsed definition relation discovery needs;
+/// lowering it is currently an identity conversion. Treat both representations
+/// uniformly so document relations are recovered before the lower seam folds
+/// the items into category vectors.
 fn item_replacement(item: &OracleItemIr) -> Option<&ReplacementDefinition> {
     match &item.node {
+        OracleNodeIr::Replacement(replacement_ir) => Some(&replacement_ir.definition),
         OracleNodeIr::PreLoweredReplacement(def) => Some(def),
         _ => None,
     }
@@ -3328,9 +3341,9 @@ struct DocEmitter<'a> {
     /// `result.{triggers,statics}.last()` (`parsed_result_recently_granted_flashback`).
     /// INSERTION recency: overwritten on each emit of that category. Safe as a
     /// clone-on-emit slot because NO `triggers.pop()`/`statics.pop()` exists in the
-    /// parser (doc.rs verifies this) — nothing can revert them. The ABILITY peek is
-    /// deliberately NOT here: it must be pop-aware, so `last_ability()` reads the
-    /// builder's `spells_emitted` stack via `peek_last_spell` instead.
+    /// parser (doc.rs verifies this) — nothing can revert them. The ability peek is
+    /// deliberately NOT here: it must be pop-aware, so `last_ability_node()` reads
+    /// the builder's `spells_emitted` stack via `peek_last_spell_node` instead.
     ///
     /// If a trigger/static pop is ever introduced, make these
     /// `*_emitted: Vec<OracleItemId>` stacks (like `spells_emitted`) first.
@@ -3399,8 +3412,8 @@ impl<'a> DocEmitter<'a> {
     }
 
     fn ability_at(&mut self, line: usize, def: AbilityDefinition) {
-        // No `last_ability` clone: the ability peek is pop-aware, read from the
-        // builder's `spells_emitted` stack (see `last_ability`).
+        // No ability clone: the ability peek is pop-aware, read from the builder's
+        // `spells_emitted` stack (see `last_ability_node`).
         self.emit_at(line, OracleNodeIr::PreLoweredSpell(def));
     }
     fn trigger_at(&mut self, line: usize, def: TriggerDefinition) {
@@ -3412,13 +3425,16 @@ impl<'a> DocEmitter<'a> {
         self.emit_at(line, OracleNodeIr::PreLoweredStatic(def));
     }
 
-    /// Last-emitted definition per category — the read-only peeks for
+    /// Last-emitted node per category — the read-only peeks for
     /// `parsed_result_recently_granted_flashback` (the one mid-loop reader of
-    /// `result.{abilities,triggers,statics}.last()`). All three are INSERTION
-    /// recency; `last_ability` is pop-aware (via `spells_emitted`), the other two
-    /// are clone-on-emit slots (no pop exists to revert them).
-    fn last_ability(&self) -> Option<&AbilityDefinition> {
-        self.builder.peek_last_spell()
+    /// `result.{abilities,triggers,statics}.last()`). All three are insertion
+    /// recency; `last_ability_node` is pop-aware (via `spells_emitted`), the other
+    /// two are clone-on-emit slots (no pop exists to revert them).
+    fn last_ability_node(&self) -> Option<&OracleNodeIr> {
+        self.builder.peek_last_spell_node()
+    }
+    fn last_ability_definition(&self) -> Option<AbilityDefinition> {
+        self.last_ability_node().and_then(lower_spell_node)
     }
     fn last_trigger(&self) -> Option<&TriggerDefinition> {
         self.last_trigger.as_ref()
@@ -4444,8 +4460,8 @@ pub(crate) fn parse_oracle_ir(
             && scan_contains(&lower, "enters with")
             && !scan_contains(&lower, "enters this way,")
         {
-            if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                emitter.replacement_at(item_line, rep_def);
+            if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
+                emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                 i += 1;
                 continue;
             }
@@ -4733,8 +4749,8 @@ pub(crate) fn parse_oracle_ir(
         // Corpus: Traxos, Scourge of Kroog; Grimgrin, Corpse-Born; Leviathan.
         if is_enters_tapped_cant_untap_compound(&lower) {
             let mut consumed = false;
-            if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                emitter.replacement_at(item_line, rep_def);
+            if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
+                emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                 consumed = true;
             }
             let defs = parse_static_line_with_graveyard_keyword_continuation(
@@ -4776,8 +4792,8 @@ pub(crate) fn parse_oracle_ir(
             for __item in statics {
                 emitter.static_at(item_line, __item);
             }
-            for __item in replacements {
-                emitter.replacement_at(item_line, __item);
+            for replacement_ir in replacements {
+                emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
             }
             i += 1;
             continue;
@@ -4913,21 +4929,23 @@ pub(crate) fn parse_oracle_ir(
             // replacement parsers; the legacy `as long as` precondition still
             // routes the duration-gated replacement fallback.
             if find_copy_verb_present(&lower) {
-                if let Some(rep_defs) = parse_replacement_sentence_sequence(&line, card_name) {
-                    for __item in rep_defs {
-                        emitter.replacement_at(item_line, __item);
+                if let Some(replacement_irs) =
+                    parse_replacement_sentence_sequence_ir(&line, card_name)
+                {
+                    for replacement_ir in replacement_irs {
+                        emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                     }
                     i += 1;
                     continue;
                 }
-                if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                    emitter.replacement_at(item_line, rep_def);
+                if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
+                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                     i += 1;
                     continue;
                 }
             } else if lower_starts_with(&lower, "as long as ") && is_replacement_pattern(&lower) {
-                if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                    emitter.replacement_at(item_line, rep_def);
+                if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
+                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                     i += 1;
                     continue;
                 }
@@ -4940,8 +4958,8 @@ pub(crate) fn parse_oracle_ir(
                 // replacement parser first; a line that is not actually an
                 // enters-with-counter replacement returns `None` and falls
                 // through to the static parser below.
-                if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                    emitter.replacement_at(item_line, rep_def);
+                if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
+                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                     i += 1;
                     continue;
                 }
@@ -5108,9 +5126,9 @@ pub(crate) fn parse_oracle_ir(
         {
             ctx.subject = None;
             ctx.actor = None;
-            let def = parse_effect_chain_with_context(&line, AbilityKind::Spell, &mut ctx);
-            if !has_unimplemented(&def) {
-                emitter.ability_at(item_line, def);
+            let effect_ir = parse_effect_chain_ir(&line, AbilityKind::Spell, &mut ctx);
+            if !has_unimplemented(&lower_effect_chain_ir(&effect_ir)) {
+                emitter.emit_at(item_line, OracleNodeIr::Spell(effect_ir));
                 i += 1;
                 continue;
             }
@@ -5158,15 +5176,16 @@ pub(crate) fn parse_oracle_ir(
             // A single Oracle paragraph can contain multiple independent ETB
             // replacement sentences. Parse each replacement sentence instead of
             // letting the first successful parser drop sibling modifiers.
-            if let Some(rep_defs) = parse_replacement_sentence_sequence(&line, card_name) {
-                for __item in rep_defs {
-                    emitter.replacement_at(item_line, __item);
+            if let Some(replacement_irs) = parse_replacement_sentence_sequence_ir(&line, card_name)
+            {
+                for replacement_ir in replacement_irs {
+                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                 }
                 i += 1;
                 continue;
             }
-            if let Some(rep_def) = parse_replacement_line(&line, card_name) {
-                emitter.replacement_at(item_line, rep_def);
+            if let Some(replacement_ir) = parse_replacement_line_ir(&line, card_name) {
+                emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                 i += 1;
                 continue;
             }
@@ -5179,16 +5198,17 @@ pub(crate) fn parse_oracle_ir(
             // exactly as the unprefixed Blind Obedience / Authority of the
             // Consuls lines do.
             if let Some(effect_text) = strip_ability_word(&line) {
-                if let Some(rep_defs) = parse_replacement_sentence_sequence(&effect_text, card_name)
+                if let Some(replacement_irs) =
+                    parse_replacement_sentence_sequence_ir(&effect_text, card_name)
                 {
-                    for __item in rep_defs {
-                        emitter.replacement_at(item_line, __item);
+                    for replacement_ir in replacement_irs {
+                        emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                     }
                     i += 1;
                     continue;
                 }
-                if let Some(rep_def) = parse_replacement_line(&effect_text, card_name) {
-                    emitter.replacement_at(item_line, rep_def);
+                if let Some(replacement_ir) = parse_replacement_line_ir(&effect_text, card_name) {
+                    emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
                     i += 1;
                     continue;
                 }
@@ -5532,7 +5552,8 @@ pub(crate) fn parse_oracle_ir(
             // the ability-word merge and the cross-line binder below exactly like any
             // other override — the binder wraps it in `ConditionInstead` and parks the
             // printed Dig as the `else_ability` fallback.
-            let dig_alt = emitter.builder.peek_last_spell().and_then(|previous| {
+            let previous_spell = emitter.last_ability_definition();
+            let dig_alt = previous_spell.as_ref().and_then(|previous| {
                 crate::parser::oracle_effect::conditions::try_parse_dig_instead_alternative(
                     &effect_line,
                     Some(previous),
@@ -5633,7 +5654,7 @@ pub(crate) fn parse_oracle_ir(
                     }
                     // No previous ability to compose with — restore condition and push standalone.
                     def.condition = Some(condition);
-                } else if emitter.builder.peek_last_spell().is_some() {
+                } else if emitter.last_ability_node().is_some() {
                     // CR 614.6: "If an event is replaced, it never happens."
                     //
                     // The line IS a self-replacement override of the preceding
@@ -5657,8 +5678,7 @@ pub(crate) fn parse_oracle_ir(
                     def.sub_ability = None;
                     def.else_ability = None;
                 }
-            } else if is_unbindable_self_replacement && emitter.builder.peek_last_spell().is_some()
-            {
+            } else if is_unbindable_self_replacement && emitter.last_ability_node().is_some() {
                 // CR 614.6 + CR 614.15: the residual self-replacement printings — a
                 // PARTIAL override whose antecedent is not a Dig ("search your library
                 // for up to three basic Forest cards instead of two"), or one that

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -143,7 +143,6 @@ pub struct OracleSourceSpan {
 impl OracleSourceSpan {
     /// An exactly-located span. The constructor unit 3b uses once emission moves
     /// into the dispatch loop and the real line/byte range is in hand.
-    #[allow(dead_code)] // production caller lands in unit 3b.
     pub(crate) fn exact(
         first_line: usize,
         last_line: usize,
@@ -226,7 +225,6 @@ impl OracleSourceSpan {
     }
 
     /// True when `self` lies entirely within `other`'s byte range.
-    #[allow(dead_code)] // production caller lands in unit 3b.
     pub(crate) fn is_contained_by(&self, other: &Self) -> bool {
         self.start_byte >= other.start_byte && self.end_byte <= other.end_byte
     }
@@ -313,16 +311,16 @@ pub(crate) enum OracleNodeIr {
     /// Unit 3b replaces this payload with `AbilityIr { source, body, shell }` so
     /// the activation metadata the router currently applies around the chain
     /// becomes typed IR rather than a pre-lowered `AbilityDefinition`.
-    #[allow(dead_code)] // constructed by ordinary dispatch in unit 3b.
     Spell(EffectChainIr),
     /// Triggered ability.
-    #[allow(dead_code)] // constructed by ordinary dispatch in unit 3b.
+    // PLAN-05 DEBT (2026-07-17, post-U2): constructed only by the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
     Trigger(TriggerIr),
     /// Static ability.
-    #[allow(dead_code)] // constructed by ordinary dispatch in unit 3b.
+    // PLAN-05 DEBT (2026-07-17, post-U2): constructed only by the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
     Static(StaticIr),
     /// Replacement effect.
-    #[allow(dead_code)] // constructed by ordinary dispatch in unit 3b.
     Replacement(ReplacementIr),
     /// Keyword ability from a keyword line.
     Keyword(Keyword),
@@ -393,13 +391,6 @@ macro_rules! printed_index_impl {
                 self.0
             }
 
-            /// The slot `n` positions after this one. Compound splitting emits
-            /// several definitions from one line and needs each one's own slot.
-            #[allow(dead_code)] // ability side gains a caller in unit 3b.
-            pub(crate) fn offset(self, n: usize) -> Self {
-                Self(self.0 + n)
-            }
-
             /// A parse-time placeholder printed slot (always `0`).
             ///
             /// CR 707.9a: an "…except it has this ability" clause must resolve to
@@ -424,6 +415,24 @@ macro_rules! printed_index_impl {
 
 printed_index_impl!(PrintedAbilityIndex);
 printed_index_impl!(PrintedTriggerIndex);
+
+impl PrintedAbilityIndex {
+    /// The slot `n` positions after this one. Compound splitting emits several
+    /// definitions from one line and needs each one's own slot.
+    // PLAN-05 DEBT (2026-07-17, post-U2): used only by the printed-index consumers in the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
+    pub(crate) fn offset(self, n: usize) -> Self {
+        Self(self.0 + n)
+    }
+}
+
+impl PrintedTriggerIndex {
+    /// The slot `n` positions after this one. Compound splitting emits several
+    /// definitions from one line and needs each one's own slot.
+    pub(crate) fn offset(self, n: usize) -> Self {
+        Self(self.0 + n)
+    }
+}
 
 /// Test-only constructors. Kept behind `cfg(test)` so production code cannot
 /// mint a printed index out of a bare integer: the only production producers are
@@ -464,7 +473,8 @@ pub(crate) struct OracleDocIr {
 impl OracleDocIr {
     /// Look up an item by its stable id. Cross-item lowering binds through this,
     /// never by scanning category vectors for a matching shape.
-    #[allow(dead_code)] // production caller lands in unit 3b.
+    // PLAN-05 DEBT (2026-07-17, post-U2): used only by the source-context consumers in the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
     pub(crate) fn item(&self, id: OracleItemId) -> Option<&OracleItemIr> {
         self.items.iter().find(|item| item.id == id)
     }
@@ -477,7 +487,6 @@ impl OracleDocIr {
 /// Reason an item or unit was rejected by the builder. These are contract
 /// violations in the parser, not Oracle-text problems.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)] // production caller lands in unit 3b.
 pub(crate) enum DocBuilderError {
     DuplicateItemPosition {
         span: OracleSourceSpan,
@@ -502,7 +511,6 @@ pub(crate) enum DocBuilderError {
 /// Handed to nested clause/mode/body parsers through `ParseContext`. A nested
 /// parser may allocate child units but can never invent an `OracleItemId`.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // production caller lands in unit 3b.
 pub(crate) struct UnitAllocator {
     item: OracleItemId,
     /// The owning item's span. Held here, not on `ItemSlot`, because the
@@ -513,7 +521,6 @@ pub(crate) struct UnitAllocator {
     issued: Vec<u32>,
 }
 
-#[allow(dead_code)] // production caller lands in unit 3b.
 impl UnitAllocator {
     fn new(item: OracleItemId, parent_span: OracleSourceSpan) -> Self {
         // Ordinal 0 is reserved for the item's own header unit.
@@ -552,6 +559,8 @@ impl UnitAllocator {
         Ok(source)
     }
 
+    // PLAN-05 DEBT (2026-07-17, post-U2): used only by the source-context consumers in the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
     pub(crate) fn item(&self) -> OracleItemId {
         self.item
     }
@@ -669,12 +678,15 @@ pub(crate) struct ItemSlot {
     allocator: UnitAllocator,
 }
 
-#[allow(dead_code)] // production caller lands in unit 3b.
 impl ItemSlot {
+    // PLAN-05 DEBT (2026-07-17, post-U2): used only by the source-context consumers in the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
     pub(crate) fn id(&self) -> OracleItemId {
         self.id
     }
 
+    // PLAN-05 DEBT (2026-07-17, post-U2): used only by the source-context consumers in the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
     pub(crate) fn source(&self) -> &OracleUnitSource {
         &self.source
     }
@@ -721,13 +733,15 @@ impl OracleDocBuilder {
     /// source-ordered item map after all emission is done. These accessors remain
     /// only as the read-before-emission form; anything that needs a *true* printed
     /// slot must go through `finish()`.
-    #[allow(dead_code)] // becomes the sole index authority in unit 3b.
+    // PLAN-05 DEBT (2026-07-17, post-U2): used only by the printed-index consumers in the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
     pub(crate) fn ability_index(&self) -> PrintedAbilityIndex {
         PrintedAbilityIndex(self.spells_emitted.len())
     }
 
     /// The next trigger's printed index (CR 707.9a). Read before emission.
-    #[allow(dead_code)] // becomes the sole index authority in unit 3b.
+    // PLAN-05 DEBT (2026-07-17, post-U2): used only by the printed-index consumers in the Class-B bring-up (unit 3); retire this allow there.
+    #[allow(dead_code)]
     pub(crate) fn trigger_index(&self) -> PrintedTriggerIndex {
         PrintedTriggerIndex(self.trigger_index)
     }
@@ -868,23 +882,17 @@ impl OracleDocBuilder {
         self.items.remove(&key)
     }
 
-    /// Peek the most-recently-EMITTED spell's definition without removing it —
-    /// INSERTION recency, via the `spells_emitted` stack. This is the pop-aware
-    /// source of truth for the old `result.abilities.last()` read: `take_last_spell`
-    /// pops this stack and the "instead"/min_x re-emit re-pushes, so a peek derived
-    /// from it is correct across any pop/re-emit interleave — unlike a clone-on-emit
-    /// mirror, which a pop would not revert. Deliberately NOT a `self.items` span
-    /// maximum: a preprocessor may emit a higher-line spell before the dispatch loop
-    /// emits a lower-line one, and the reader wants the JUST-emitted (loop) spell.
-    pub(crate) fn peek_last_spell(&self) -> Option<&AbilityDefinition> {
+    /// Peek the most-recently-EMITTED spell node without removing it — insertion
+    /// recency, via the `spells_emitted` stack. This is the pop-aware source of
+    /// truth for the old `result.abilities.last()` read: `take_last_spell` pops this
+    /// stack and the "instead"/min_x re-emit re-pushes, so a peek derived from it is
+    /// correct across any pop/re-emit interleave — unlike a clone-on-emit mirror,
+    /// which a pop would not revert. Deliberately NOT a `self.items` span maximum:
+    /// a preprocessor may emit a higher-line spell before the dispatch loop emits a
+    /// lower-line one, and the reader wants the just-emitted loop spell.
+    pub(crate) fn peek_last_spell_node(&self) -> Option<&OracleNodeIr> {
         let id = *self.spells_emitted.last()?;
-        self.items
-            .values()
-            .find(|i| i.id == id)
-            .and_then(|i| match &i.node {
-                OracleNodeIr::PreLoweredSpell(def) => Some(def),
-                _ => None,
-            })
+        self.items.values().find(|i| i.id == id).map(|i| &i.node)
     }
 
     /// Finish, producing items already in Oracle source order.

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 993
 expression: "&ir"
 ---
 {
@@ -22,42 +23,46 @@ expression: "&ir"
         "fragment": "~ enters with X charge counters on it."
       },
       "node": {
-        "PreLoweredReplacement": {
-          "event": "Moved",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "charge",
-              "count": {
-                "type": "Ref",
-                "qty": {
-                  "type": "CostXPaid"
+        "Replacement": {
+          "definition": {
+            "event": "Moved",
+            "execute": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "charge",
+                "count": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "CostXPaid"
+                  }
+                },
+                "target": {
+                  "type": "SelfRef"
                 }
               },
-              "target": {
-                "type": "SelfRef"
-              }
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
+            "mode": {
+              "type": "Mandatory"
+            },
+            "valid_card": {
+              "type": "SelfRef"
+            },
+            "description": "~ enters with X charge counters on it.",
             "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            "destination_zone": "Battlefield"
           },
-          "mode": {
-            "type": "Mandatory"
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "description": "~ enters with X charge counters on it.",
-          "condition": null,
-          "destination_zone": "Battlefield"
+          "source_text": "~ enters with X charge counters on it.",
+          "execute_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 453
 expression: "&ir"
 ---
 {
@@ -22,30 +23,34 @@ expression: "&ir"
         "fragment": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead."
       },
       "node": {
-        "PreLoweredReplacement": {
-          "event": "AddCounter",
-          "execute": null,
-          "mode": {
-            "type": "Mandatory"
+        "Replacement": {
+          "definition": {
+            "event": "AddCounter",
+            "execute": null,
+            "mode": {
+              "type": "Mandatory"
+            },
+            "valid_card": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": []
+            },
+            "description": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.",
+            "condition": null,
+            "quantity_modification": {
+              "type": "Plus",
+              "value": 1
+            },
+            "counter_match": {
+              "type": "OfType",
+              "data": "P1P1"
+            }
           },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": "You",
-            "properties": []
-          },
-          "description": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.",
-          "condition": null,
-          "quantity_modification": {
-            "type": "Plus",
-            "value": 1
-          },
-          "counter_match": {
-            "type": "OfType",
-            "data": "P1P1"
-          }
+          "source_text": "If one or more +1/+1 counters would be put on a creature you control, that many plus one +1/+1 counters are put on that creature instead.",
+          "execute_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__savage_summoning_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__savage_summoning_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 152
 expression: "&ir"
 ---
 {
@@ -55,40 +56,44 @@ expression: "&ir"
         "fragment": "The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters with an additional +1/+1 counter on it."
       },
       "node": {
-        "PreLoweredReplacement": {
-          "event": "Moved",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "P1P1",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Replacement": {
+          "definition": {
+            "event": "Moved",
+            "execute": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "P1P1",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "target": {
+                  "type": "SelfRef"
+                }
               },
-              "target": {
-                "type": "SelfRef"
-              }
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
+            "mode": {
+              "type": "Mandatory"
+            },
+            "valid_card": {
+              "type": "SelfRef"
+            },
+            "description": "The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters with an additional +1/+1 counter on it.",
             "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            "destination_zone": "Battlefield"
           },
-          "mode": {
-            "type": "Mandatory"
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "description": "The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters with an additional +1/+1 counter on it.",
-          "condition": null,
-          "destination_zone": "Battlefield"
+          "source_text": "The next creature spell you cast this turn can be cast as though it had flash. That spell can't be countered. That creature enters with an additional +1/+1 counter on it.",
+          "execute_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 981
 expression: "&ir"
 ---
 {
@@ -22,42 +23,46 @@ expression: "&ir"
         "fragment": "~ enters with X +1/+1 counters on it."
       },
       "node": {
-        "PreLoweredReplacement": {
-          "event": "Moved",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "P1P1",
-              "count": {
-                "type": "Ref",
-                "qty": {
-                  "type": "CostXPaid"
+        "Replacement": {
+          "definition": {
+            "event": "Moved",
+            "execute": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "P1P1",
+                "count": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "CostXPaid"
+                  }
+                },
+                "target": {
+                  "type": "SelfRef"
                 }
               },
-              "target": {
-                "type": "SelfRef"
-              }
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
+            "mode": {
+              "type": "Mandatory"
+            },
+            "valid_card": {
+              "type": "SelfRef"
+            },
+            "description": "~ enters with X +1/+1 counters on it.",
             "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            "destination_zone": "Battlefield"
           },
-          "mode": {
-            "type": "Mandatory"
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "description": "~ enters with X +1/+1 counters on it.",
-          "condition": null,
-          "destination_zone": "Battlefield"
+          "source_text": "~ enters with X +1/+1 counters on it.",
+          "execute_ir": null
         }
       }
     },


### PR DESCRIPTION
Replacement producers now emit typed OracleNodeIr::Replacement document
nodes instead of PreLoweredReplacement, giving the document seam a single
authority for replacement lowering. Relation discovery (item_replacement)
accepts both representations so ID-keyed LinkedChoice relations survive
the hoist: choose + chosen-dependent ETB counters still compose into one
replacement and chosen-type cost reducers keep their linkage.

Six not-yet-constructed IR/index APIs are re-homed to the Class-B bring-up
under dated PLAN-05 DEBT item-level allows. The four oracle_ir snapshots
move representation-only (PreLoweredReplacement -> Replacement).

Full-corpus card-data export verified byte-identical to the pre-hoist
baseline (sha256 18fe47ae07...aac7e8b5, 35424 faces).
