### PR TITLE
refactor(parser): route catch_up_draw through EffectChainIr (P05-U3)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12812,7 +12812,11 @@ pub(crate) fn try_parse_threshold_land_balance(
 /// `.abs()` and `Draw` clamps `.max(0)` (CR 107.1b), so the leader(s) draw 0 and
 /// the "with fewer cards in hand" subject restriction needs no separate
 /// `PlayerFilter`.
-pub(crate) fn try_parse_catch_up_draw(text: &str, kind: AbilityKind) -> Option<AbilityDefinition> {
+pub(crate) fn parse_catch_up_draw_ir(
+    text: &str,
+    kind: AbilityKind,
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
     let lower = text.to_lowercase();
 
     let (extremum, _) = nom_on_lower(text, &lower, |input| {
@@ -12856,16 +12860,18 @@ pub(crate) fn try_parse_catch_up_draw(text: &str, kind: AbilityKind) -> Option<A
             },
         }),
     };
-    let mut def = AbilityDefinition::new(
+    Some(EffectChainIr::single_clause(
+        text,
         kind,
-        Effect::Draw {
+        parsed_clause(Effect::Draw {
             count,
             target: TargetFilter::Controller,
-        },
-    );
-    // CR 101.4: APNAP fan-out over every player.
-    def.player_scope = Some(PlayerFilter::All);
-    Some(def)
+        }),
+        // CR 101.4: APNAP fan-out over every player.
+        Some(PlayerFilter::All),
+        ctx.actor.clone(),
+        ctx.in_trigger,
+    ))
 }
 
 /// Parse "for each" quantity patterns on draw/life/damage/mill effects.
@@ -25075,9 +25081,6 @@ fn try_parse_chain_bypass(
     if let Some(def) = try_parse_each_player_copy_chosen(text, kind) {
         return Some(def);
     }
-    if let Some(def) = try_parse_catch_up_draw(text, kind) {
-        return Some(def);
-    }
     if let Some(def) = try_parse_return_target_and_same_name_from_your_graveyard(text, kind) {
         return Some(def);
     }
@@ -25691,6 +25694,9 @@ pub(crate) fn parse_effect_chain_ir(
     kind: AbilityKind,
     ctx: &mut ParseContext,
 ) -> EffectChainIr {
+    if let Some(ir) = parse_catch_up_draw_ir(text, kind, ctx) {
+        return ir;
+    }
     let text = strip_trailing_activation_restriction_sentence(text);
     // CR 107.1a: Strip a trailing "Round down each time" / "Round up each time"
     // sentence before chain splitting — it is a chain-level rounding annotation

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -53,6 +53,46 @@ pub(crate) struct EffectChainIr {
     pub(crate) repeat_until: Option<crate::types::ability::RepeatContinuation>,
 }
 
+impl EffectChainIr {
+    /// Build a one-clause chain while retaining every field represented by
+    /// `ParsedEffectClause` plus the clause-level player iteration scope.
+    ///
+    /// Whole-body recognizers use this instead of reconstructing an
+    /// `AbilityDefinition`: `ParsedEffectClause` carries nested sub-abilities and
+    /// durations, while `ClauseIr` carries `player_scope`. The actor and trigger
+    /// context match the ordinary chain parser's output.
+    pub(crate) fn single_clause(
+        source_text: &str,
+        kind: AbilityKind,
+        parsed: ParsedEffectClause,
+        player_scope: Option<PlayerFilter>,
+        actor: Option<ControllerRef>,
+        in_trigger: bool,
+    ) -> Self {
+        let mut builder = ClauseIrBuilder::new(source_text);
+        builder
+            .clause(
+                source_text,
+                parsed,
+                None,
+                ClauseDisposition::Emit {
+                    followup: None,
+                    intrinsic: None,
+                },
+            )
+            .player_scope(player_scope)
+            .push();
+        Self {
+            clauses: builder.finish(),
+            kind,
+            chain_rounding: None,
+            actor,
+            in_trigger,
+            repeat_until: None,
+        }
+    }
+}
+
 /// Root-level `AbilityDefinition` metadata that no `ClauseIr` can express.
 ///
 /// The shell is the typed replacement for the `AbilityDefinition` escape hatch:
@@ -758,7 +798,7 @@ impl ClauseDraft<'_> {
 mod tests {
     use super::*;
     use crate::parser::oracle_ir::ast::parsed_clause;
-    use crate::types::ability::Effect;
+    use crate::types::ability::{Duration, Effect};
 
     #[test]
     fn effect_chain_ir_empty_construction() {
@@ -887,5 +927,32 @@ mod tests {
         };
         assert_eq!(ir.clauses.len(), 1);
         assert_eq!(ir.kind, AbilityKind::Spell);
+    }
+
+    #[test]
+    fn single_clause_preserves_parsed_fields_and_player_scope() {
+        let mut parsed = parsed_clause(Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        });
+        parsed.duration = Some(Duration::Permanent);
+        parsed.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::NoOp,
+        )));
+
+        let ir = EffectChainIr::single_clause(
+            "draw a card",
+            AbilityKind::Spell,
+            parsed,
+            Some(PlayerFilter::All),
+            None,
+            false,
+        );
+
+        let clause = &ir.clauses[0];
+        assert_eq!(clause.player_scope, Some(PlayerFilter::All));
+        assert_eq!(clause.parsed.duration, Some(Duration::Permanent));
+        assert!(clause.parsed.sub_ability.is_some());
     }
 }


### PR DESCRIPTION
CR 121.1 + CR 101.4: Tales of the Ancestors draws the frozen hand-size difference for every player in APNAP order. The IR clause preserves that Difference draw and PlayerFilter::All through ordinary chain lowering.

full-pool card-data byte-identical (sha256 85ec32b31511fc30a0ddc822dcafe8f39cb8657b8aa7390048702ff12826ee85)
