### PR TITLE
feat(parser+engine): Gideon of the Trials — compound conditional emblem locks

### DIFF
--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -189,6 +189,17 @@ pub(crate) fn is_damage_prevention_pattern(lower: &str) -> bool {
 }
 
 pub(crate) fn should_defer_spell_to_effect(lower: &str) -> bool {
+    // CR 114.1: An emblem-granting instant/sorcery ("You get an emblem with
+    // \"…\"") whose quoted body contains static text (Gideon of the Trials'
+    // can't-lose/win locks) matches `is_static_pattern` on the unmasked view, so
+    // the spell IR loop would otherwise consume the whole line through the static
+    // classifier — splitting the quoted body mid-sentence. Defer it to the
+    // effect-chain parser, whose `try_parse_emblem_creation` seam produces a
+    // single `Effect::CreateEmblem`. Reuses the emblem-head prefix combinator.
+    if super::oracle_effect::sequence::is_emblem_creation_head(lower) {
+        return true;
+    }
+
     if is_self_spell_cost_modification(lower) {
         return false;
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19806,13 +19806,22 @@ fn try_parse_emblem_creation(lower: &str, original: &str) -> Option<Effect> {
         });
     }
 
-    // Try to parse the emblem text as a static ability line.
-    if let Some(mut static_def) = super::oracle_static::parse_static_line(inner) {
+    // Try to parse the emblem text as one or more static ability lines.
+    // CR 604.1 + CR 114.4: a compound emblem body ("… you can't lose the game
+    // and your opponents can't win the game" — Gideon of the Trials) defines
+    // several statics at once; `parse_static_line_multi` emits them all and
+    // internally falls back to the single-def parser for simple bodies. An
+    // empty result still routes to the honest `EmblemStatic` fallback below,
+    // so an unparseable body stays a visible coverage gap.
+    let mut static_defs = super::oracle_static::parse_static_line_multi(inner);
+    if !static_defs.is_empty() {
         // CR 114: retain the emblem's granted rules text for the display
-        // tooltip, mirroring the trigger and fallback branches.
-        static_def.description = Some(inner.to_string());
+        // tooltip on the first def only, mirroring the trigger branch.
+        if let Some(first) = static_defs.first_mut() {
+            first.description = Some(inner.to_string());
+        }
         Some(Effect::CreateEmblem {
-            statics: vec![static_def],
+            statics: static_defs,
             triggers: Vec::new(),
         })
     } else {

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -1355,8 +1355,10 @@ pub(super) fn split_clause_sequence(text: &str) -> Vec<ClauseChunk> {
 /// (`you get an emblem with "…"` or the subject-stripped `get an emblem with
 /// "…"`). Combinator-only dispatch mirroring `try_parse_emblem_creation`'s prefix
 /// so the clause splitter treats an emblem's granted-ability quote as a
-/// self-contained sentence.
-fn clause_is_emblem_creation_head(current: &str) -> bool {
+/// self-contained sentence. Also the emblem-head deferral predicate for
+/// `should_defer_spell_to_effect`: a spell line matching this head routes to
+/// the effect parser even when its quoted body looks like a static pattern.
+pub(crate) fn is_emblem_creation_head(current: &str) -> bool {
     let is_emblem_head = alt((
         tag_no_case::<_, _, OracleError<'_>>("you get an emblem with \""),
         tag_no_case("get an emblem with \""),
@@ -1385,7 +1387,7 @@ fn quote_closes_sentence_before_sequence(current: &str, remainder: &str) -> bool
     // sibling effects split into their own clauses — Nissa, Who Shakes the World's
     // "… Search your library …" would otherwise be swallowed into the emblem's
     // static text (issue #5282).
-    if clause_is_emblem_creation_head(current) {
+    if is_emblem_creation_head(current) {
         return true;
     }
 

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1596,6 +1596,79 @@ fn parse_color_conditional_keyword_grant(input: &str) -> OracleResult<'_, (Keywo
     Ok((i, (keyword, color)))
 }
 
+/// CR 104.2b + CR 104.3e + CR 810.8a: Compound player-scope game-outcome lock —
+/// "<player-scope> can't lose|win the game and <player-scope> can't win|lose
+/// the game" — lowered to one `CantLoseTheGame`/`CantWinTheGame` static per
+/// conjunct, each carrying its own subject's affected filter (Platinum Angel:
+/// "You can't lose the game and your opponents can't win the game."; Abyssal
+/// Persecutor reverses the modes; Gideon of the Trials' emblem wraps the same
+/// sentence in an "as long as" gate handled by the inverted-split arm in
+/// `parse_static_line_multi_dispatch`). Requires ≥ 2 conjuncts and consumes
+/// the whole line, so single-mode lines keep their existing
+/// `parse_static_line_inner` arms and rider-bearing one-shot effect sentences
+/// (Angel's Grace: "You can't lose the game this turn and …") fall through
+/// untouched.
+pub(crate) fn parse_cant_win_lose_compound_statics(
+    text: &str,
+    lower: &str,
+) -> Option<Vec<StaticDefinition>> {
+    // Subject axis: the player scope each conjunct names. Filter shapes match
+    // the single-mode arms' `parse_player_scope_filter` output so both runtime
+    // readers (`static_affects_player`, `static_filter_matches`) see the same
+    // vocabulary. "your opponents " precedes "you " in source order for
+    // clarity only — `tag("you ")` requires a trailing space, so it cannot
+    // claim the "your…" prefix.
+    fn parse_subject(i: &str) -> OracleResult<'_, TargetFilter> {
+        alt((
+            value(
+                TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+                tag("your opponents "),
+            ),
+            value(
+                TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::You)),
+                tag("you "),
+            ),
+            value(
+                TargetFilter::Typed(TypedFilter::default()),
+                alt((tag("each player "), tag("players "))),
+            ),
+        ))
+        .parse(i)
+    }
+    // Predicate axis: which game outcome is locked (CR 104.2b win effects /
+    // CR 104.3e loss effects; CR 810.8a is the "can't win"/"can't lose"
+    // effect language).
+    fn parse_predicate(i: &str) -> OracleResult<'_, StaticMode> {
+        preceded(
+            alt((tag("can't "), tag("cannot "))),
+            alt((
+                value(StaticMode::CantLoseTheGame, tag("lose the game")),
+                value(StaticMode::CantWinTheGame, tag("win the game")),
+            )),
+        )
+        .parse(i)
+    }
+
+    let (rest, first) = (parse_subject, parse_predicate).parse(lower).ok()?;
+    let (rest, tail) = many1(preceded(tag(" and "), (parse_subject, parse_predicate)))
+        .parse(rest)
+        .ok()?;
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(rest).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    Some(
+        std::iter::once(first)
+            .chain(tail)
+            .map(|(affected, mode)| {
+                StaticDefinition::new(mode)
+                    .affected(affected)
+                    .description(text.to_string())
+            })
+            .collect(),
+    )
+}
+
 fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
     let stripped = strip_reminder_text(text);
     let lower = stripped.to_lowercase();
@@ -1724,6 +1797,29 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
             }
             return defs;
         }
+        // CR 104.2b + CR 104.3e + CR 611.3a: conditional game-outcome lock —
+        // "As long as <condition>, you can't lose the game and your opponents
+        // can't win the game" (Gideon of the Trials' emblem). Each conjunct
+        // becomes its own condition-gated static. CR 611.3a: fail CLOSED — an
+        // unrecognized condition falls through to the existing fallback (the
+        // line keeps its honest `Condition_AsLongAs` swallow flag) rather
+        // than emitting an unconditional outcome lock:
+        // `StaticCondition::Unrecognized` evaluates as always-true in the
+        // layer system, which for "you can't lose the game" would be
+        // game-breaking. Mirrors the CantPlayLand trailing-gate precedent in
+        // `dispatch.rs`.
+        let effect_lower = split.effect_text.to_lowercase();
+        if let Some(mut defs) =
+            parse_cant_win_lose_compound_statics(&split.effect_text, &effect_lower)
+        {
+            if let Some(condition) = parse_static_condition(&split.condition_text) {
+                for def in &mut defs {
+                    def.condition = Some(condition.clone());
+                    def.description = Some(stripped.to_string());
+                }
+                return defs;
+            }
+        }
     }
 
     // CR 601.2 + CR 602.5: City of Solitude class — "can cast spells and
@@ -1841,6 +1937,16 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
                 .affected(affected)
                 .description(stripped.to_string()),
         ];
+    }
+
+    // CR 104.2b + CR 104.3e + CR 810.8a: "<player-scope> can't lose/win the
+    // game and <player-scope> can't win/lose the game" — one game-outcome-lock
+    // static per conjunct, each with its own player scope (Platinum Angel
+    // wording class, both mode orders; emblem bodies such as Gideon of the
+    // Trials' reach this via `try_parse_emblem_creation` →
+    // `parse_static_line_multi`). Sibling of the life-lock compound above.
+    if let Some(defs) = parse_cant_win_lose_compound_statics(&stripped, &lower) {
+        return defs;
     }
 
     let tp = TextPair::new(&stripped, &lower);

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -30536,3 +30536,132 @@ fn flying_cant_attack_you_alone_is_unchanged() {
         "single-clause can't-attack-you must stay a defender-scoped subject static: {defs:?}"
     );
 }
+
+/// CR 104.2b + CR 104.3e + CR 810.8a: the compound game-outcome lock emits one
+/// static per conjunct, each scoped to its own subject (Platinum Angel,
+/// verbatim Oracle text). Reverting `parse_cant_win_lose_compound_statics`
+/// collapses this to the single-def scan arm's lone `CantWinTheGame`.
+#[test]
+fn cant_win_lose_compound_emits_both_scoped_statics() {
+    let defs =
+        parse_static_line_multi("You can't lose the game and your opponents can't win the game.");
+    assert_eq!(defs.len(), 2, "one static per conjunct: {defs:?}");
+    assert_eq!(defs[0].mode, StaticMode::CantLoseTheGame);
+    assert_eq!(
+        defs[0].affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You)
+        ))
+    );
+    assert_eq!(defs[1].mode, StaticMode::CantWinTheGame);
+    assert_eq!(
+        defs[1].affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::Opponent)
+        ))
+    );
+}
+
+/// CR 104.2b + CR 104.3e: the mode axis composes with the subject axis — the
+/// reversed order (Abyssal Persecutor, verbatim) yields the mirrored pair.
+#[test]
+fn cant_win_lose_compound_reversed_modes() {
+    let defs =
+        parse_static_line_multi("You can't win the game and your opponents can't lose the game.");
+    assert_eq!(defs.len(), 2, "one static per conjunct: {defs:?}");
+    assert_eq!(defs[0].mode, StaticMode::CantWinTheGame);
+    assert_eq!(
+        defs[0].affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You)
+        ))
+    );
+    assert_eq!(defs[1].mode, StaticMode::CantLoseTheGame);
+    assert_eq!(
+        defs[1].affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::Opponent)
+        ))
+    );
+}
+
+/// CR 104.2b + CR 104.3e: the one-shot spell sentence (Angel's Grace, verbatim
+/// first clause) carries "this turn" riders that break the all-consuming
+/// conjunction grammar — the compound STATIC arm must decline so the effect
+/// parser keeps owning it. Reach guard: the rider-free Platinum Angel sentence
+/// IS claimed by the same arm, so the negative is not vacuous.
+#[test]
+fn cant_win_lose_compound_declines_turn_rider_spell_sentence() {
+    let grace =
+        "You can't lose the game this turn and your opponents can't win the game this turn.";
+    assert!(
+        parse_cant_win_lose_compound_statics(grace, &grace.to_lowercase()).is_none(),
+        "turn-rider sentence must fall through to the effect parser"
+    );
+    let platinum = "You can't lose the game and your opponents can't win the game.";
+    assert!(
+        parse_cant_win_lose_compound_statics(platinum, &platinum.to_lowercase()).is_some(),
+        "reach guard: the rider-free static sentence is claimed"
+    );
+}
+
+/// CR 104.2b + CR 104.3e + CR 611.3a: the inverted "As long as <cond>,
+/// <compound>" form (Gideon of the Trials' emblem body, verbatim inner text)
+/// yields both statics, each gated on the parsed condition — an
+/// `IsPresent` check for a Gideon planeswalker you control (CR 205.3j).
+#[test]
+fn conditional_cant_win_lose_compound_attaches_condition_to_each_static() {
+    let defs = parse_static_line_multi(
+        "As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game",
+    );
+    assert_eq!(defs.len(), 2, "one static per conjunct: {defs:?}");
+    assert_eq!(defs[0].mode, StaticMode::CantLoseTheGame);
+    assert_eq!(defs[1].mode, StaticMode::CantWinTheGame);
+    for def in &defs {
+        let Some(StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(typed)),
+        }) = &def.condition
+        else {
+            panic!("each conjunct must carry the IsPresent gate: {def:?}");
+        };
+        assert_eq!(typed.controller, Some(ControllerRef::You));
+        assert!(
+            typed.type_filters.contains(&TypeFilter::Planeswalker),
+            "condition filter must require a planeswalker: {typed:?}"
+        );
+        assert!(
+            typed
+                .type_filters
+                .contains(&TypeFilter::Subtype("Gideon".to_string())),
+            "condition filter must require the Gideon planeswalker type: {typed:?}"
+        );
+    }
+}
+
+/// CR 611.3a: fail CLOSED — an unrecognized "as long as" condition must not
+/// produce an unconditional outcome lock (`StaticCondition::Unrecognized`
+/// evaluates as always-true at runtime, which for "you can't lose the game"
+/// would be game-breaking). The line falls through to today's fallback, which
+/// never emits `CantLoseTheGame` for this shape. Reach guard: the recognized
+/// condition in `conditional_cant_win_lose_compound_attaches_condition_to_each_static`
+/// proves the same sentence shape parses when the gate is parseable.
+#[test]
+fn conditional_cant_win_lose_compound_fails_closed_on_unrecognized_condition() {
+    let defs = parse_static_line_multi(
+        "As long as the froopiness is maximal, you can't lose the game and your opponents can't win the game",
+    );
+    assert!(
+        defs.iter().all(|d| d.mode != StaticMode::CantLoseTheGame),
+        "an unrecognized gate must never yield an (unconditional) CantLoseTheGame: {defs:?}"
+    );
+    assert!(
+        defs.iter().all(
+            |d| !matches!(d.condition, Some(StaticCondition::Unrecognized { .. }))
+                || !matches!(
+                    d.mode,
+                    StaticMode::CantLoseTheGame | StaticMode::CantWinTheGame
+                )
+        ),
+        "no outcome lock may ride on an Unrecognized (always-true) condition: {defs:?}"
+    );
+}

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -22315,3 +22315,125 @@ fn azors_gateway_transform_condition_parses_with_zero_swallowed_clauses() {
     assert_eq!(transform.condition, expected_ability_condition);
     assert!(transform.sub_ability.is_none());
 }
+
+/// CR 104.2b + CR 104.3e + CR 114.1 + CR 611.3a + CR 205.3j: Gideon of the
+/// Trials (verbatim MTGJSON Oracle text) — the third loyalty ability creates
+/// an emblem carrying BOTH game-outcome locks, each gated on an `IsPresent`
+/// check for a Gideon planeswalker you control. Exercises all three seams of
+/// the fix in one production-shaped parse: the name normalizer keeps the
+/// type-adjective "Gideon" literal, the compound cant-win/lose multi arm
+/// splits the conjunction, and the emblem parser carries multiple statics.
+/// Reverting any of the three fails this test.
+#[test]
+fn gideon_of_the_trials_emblem_full_parse() {
+    let r = parse(
+        "[+1]: Until your next turn, prevent all damage target permanent would deal.\n[0]: Until end of turn, Gideon becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n[0]: You get an emblem with \"As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game.\"",
+        "Gideon of the Trials",
+        &[],
+        &["Planeswalker"],
+        &["Gideon"],
+    );
+    assert_eq!(
+        r.abilities.len(),
+        3,
+        "three loyalty abilities, got {:#?}",
+        r.abilities
+    );
+    // Positive reach guard for the swallow assertion below: every ability
+    // parses with zero residual `Effect::Unimplemented`.
+    for def in &r.abilities {
+        assert!(
+            !has_unimplemented(def),
+            "no residual Unimplemented node, got {:#?}",
+            def
+        );
+    }
+
+    let Effect::CreateEmblem { statics, triggers } = &*r.abilities[2].effect else {
+        panic!(
+            "third loyalty ability must create an emblem, got {:?}",
+            r.abilities[2].effect
+        );
+    };
+    assert!(triggers.is_empty(), "emblem grants statics, not triggers");
+    assert_eq!(
+        statics.len(),
+        2,
+        "one static per conjunct of the emblem body, got {statics:#?}"
+    );
+    assert_eq!(statics[0].mode, StaticMode::CantLoseTheGame);
+    assert_eq!(
+        statics[0].affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::You)
+        ))
+    );
+    assert_eq!(statics[1].mode, StaticMode::CantWinTheGame);
+    assert_eq!(
+        statics[1].affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::Opponent)
+        ))
+    );
+    // CR 611.3a + CR 205.3j: each lock is gated on controlling a Gideon
+    // planeswalker — live, typed, never `Unrecognized`.
+    for static_def in statics {
+        let Some(StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(typed)),
+        }) = &static_def.condition
+        else {
+            panic!("each emblem static carries the IsPresent gate: {static_def:#?}");
+        };
+        assert_eq!(typed.controller, Some(ControllerRef::You));
+        assert!(
+            typed.type_filters.contains(&TypeFilter::Planeswalker),
+            "gate requires a planeswalker: {typed:?}"
+        );
+        assert!(
+            typed
+                .type_filters
+                .contains(&TypeFilter::Subtype("Gideon".to_string())),
+            "gate requires the Gideon planeswalker type: {typed:?}"
+        );
+    }
+
+    // The `Condition_AsLongAs` swallow flag must clear — non-vacuously: the
+    // fully-typed positive shape asserted above IS the reach guard.
+    assert!(
+        r.parse_warnings.iter().all(|warning| {
+            let s = warning.to_string();
+            s.split_whitespace().next() != Some("Swallow:Condition_AsLongAs")
+        }),
+        "as-long-as gate is typed, so the swallow flag must clear: {:?}",
+        r.parse_warnings
+    );
+}
+
+/// CR 114.1: a standalone emblem-granting instant/sorcery ("You get an emblem
+/// with ...") must parse its spell effect to a `CreateEmblem` carrying the full
+/// static payload — the same emblem body outside any loyalty-ability context.
+/// Pins the spell-path class so any emblem-granting instant/sorcery is covered,
+/// not just Gideon.
+#[test]
+fn standalone_spell_emblem_grant_parses_to_create_emblem() {
+    let r = parse(
+        "You get an emblem with \"As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game.\"",
+        "Test Emblem Grant",
+        &[],
+        &["Sorcery"],
+        &[],
+    );
+    let create = r
+        .abilities
+        .iter()
+        .find_map(|def| match &*def.effect {
+            Effect::CreateEmblem { statics, .. } => Some(statics),
+            _ => None,
+        })
+        .expect("standalone spell emblem grant must parse to a CreateEmblem effect");
+    assert_eq!(
+        create.len(),
+        2,
+        "emblem carries both outcome-lock statics, got {create:#?}"
+    );
+}

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1478,6 +1478,40 @@ fn precedes_type_addition_clause(haystack: &str, end: usize) -> bool {
     parse_in_addition_type_probe(&lower).is_ok()
 }
 
+/// CR 205.3j + CR 205.2: A subtype-word occurrence immediately followed by a
+/// core-type word is a TYPE reference ("a Gideon planeswalker", "Sliver
+/// creatures"), never a self-reference — the type-adjective position is
+/// grammatically incompatible with a name subject, which is always followed
+/// by a verb ("Gideon becomes …"). Keep such occurrences literal so
+/// type-phrase parsers (e.g. the "you control a Gideon planeswalker"
+/// condition on Gideon of the Trials' emblem) can read the subtype.
+/// Per-occurrence sibling of `precedes_type_addition_clause`.
+///
+/// Scoped to true CR 205.2a core-type words: the informational "card"/"spell"
+/// suffixes are deliberately excluded, because "a <Subtype> card" phrases
+/// (Curse of Misfortunes' "a Curse card that doesn't have the same name as
+/// …") ride search-filter suffix grammar that today parses only through the
+/// `~`-normalized short name; keeping them normalizing preserves that
+/// behavior. Extend to "card"/"spell" only together with search-filter
+/// support for literal subtype words.
+/// `end` is the byte index just past the matched word.
+fn precedes_core_type_word(haystack: &str, end: usize) -> bool {
+    let next_word = haystack[end..]
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+        .to_ascii_lowercase();
+    // Accept the regular plural too ("Sliver creatures").
+    [
+        next_word.as_str(),
+        // allow-noncombinator: plural fold on a word already extracted by split_whitespace (structural, not parsing dispatch)
+        next_word.strip_suffix('s').unwrap_or(""),
+    ]
+    .iter()
+    .any(|word| is_core_type_name(word) && !matches!(*word, "card" | "spell"))
+}
+
 fn replace_all_words_case_sensitive_preserving_subtype_status_refs(
     haystack: &str,
     needle: &str,
@@ -1497,6 +1531,7 @@ fn replace_all_words_case_sensitive_preserving_subtype_status_refs(
             && pos >= last_end
             && !follows_subtype_status_qualifier(haystack, pos)
             && !precedes_type_addition_clause(haystack, end)
+            && !precedes_core_type_word(haystack, end)
         {
             result.push_str(&haystack[last_end..pos]);
             result.push_str(replacement);
@@ -2213,7 +2248,21 @@ pub fn normalize_card_name_refs(text: &str, card_name: &str) -> String {
                 && !subtype_in_type_change_context
                 && !of_short_name_collides_with_possessive_zone_phrase(&result, short_name)
             {
-                result = replace_all_words(&result, short_name, "~");
+                // CR 205.3j + CR 201.3a: when the short name is also a subtype
+                // word ("Gideon of the Trials" → "Gideon", a planeswalker
+                // type), an occurrence used as a type adjective ("a Gideon
+                // planeswalker") must stay literal while subject occurrences
+                // ("Gideon becomes …") still normalize to `~`. Route through
+                // the per-occurrence preserving replacer — the same replacer
+                // (and case-sensitivity precedent) the single-word subtype
+                // name branch above already uses.
+                result = if is_subtype_word(&lower_short) {
+                    replace_all_words_case_sensitive_preserving_subtype_status_refs(
+                        &result, short_name, "~",
+                    )
+                } else {
+                    replace_all_words(&result, short_name, "~")
+                };
             }
         }
     }
@@ -2523,6 +2572,46 @@ mod tests {
                 "Manifest Dread"
             ),
             "Manifest dread. A manifested permanent you control gets +1/+1."
+        );
+    }
+
+    #[test]
+    fn normalize_of_short_name_keeps_subtype_type_reference_literal() {
+        // CR 205.3j + CR 201.3a: "Gideon of the Trials" — the of-derived short
+        // name "Gideon" is also a planeswalker type. A subject occurrence
+        // ("Gideon becomes …") normalizes to `~`, while a type-adjective
+        // occurrence ("a Gideon planeswalker") must stay literal so the
+        // emblem's "you control a Gideon planeswalker" condition can parse.
+        // Full three-line Oracle text, production-shaped (normalization runs
+        // once over the whole text).
+        let text = "[+1]: Until your next turn, prevent all damage target permanent would deal.\n[0]: Until end of turn, Gideon becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n[0]: You get an emblem with \"As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game.\"";
+        let normalized = normalize_card_name_refs(text, "Gideon of the Trials");
+        // Subject occurrence ("Gideon becomes") folds to `~`; the type-adjective
+        // occurrence ("a Gideon planeswalker") stays literal — asserted against
+        // the full normalized text so no other span silently changes.
+        assert_eq!(
+            normalized,
+            "[+1]: Until your next turn, prevent all damage target permanent would deal.\n[0]: Until end of turn, ~ becomes a 4/4 Human Soldier creature with indestructible that's still a planeswalker. Prevent all damage that would be dealt to him this turn.\n[0]: You get an emblem with \"As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game.\""
+        );
+    }
+
+    #[test]
+    fn normalize_of_short_name_curse_of_misfortunes_keeps_card_suffix_normalizing() {
+        // CR 205.3j + CR 201.3a: Curse of Misfortunes — the sensitive sibling
+        // the of-branch guard comment names. The `precedes_core_type_word`
+        // probe is scoped to true CR 205.2a core-type words, so the
+        // informational "card" suffix does NOT suppress replacement: both
+        // occurrences keep today's `~` normalization (the search-filter
+        // suffix grammar parses through the normalized short name; keeping
+        // this pinned prevents a coverage flip on this card).
+        let text = "At the beginning of your upkeep, you may search your library for a Curse card that doesn't have the same name as a Curse attached to enchanted player, put it onto the battlefield attached to that player, then shuffle.";
+        let normalized = normalize_card_name_refs(text, "Curse of Misfortunes");
+        // Both occurrences keep today's `~` normalization ("card" is an
+        // informational suffix, not a CR 205.2a core type) — asserted against the
+        // full normalized text so a coverage flip on this card cannot slip past.
+        assert_eq!(
+            normalized,
+            "At the beginning of your upkeep, you may search your library for a ~ card that doesn't have the same name as a ~ attached to enchanted player, put it onto the battlefield attached to that player, then shuffle."
         );
     }
 

--- a/crates/engine/tests/integration/gideon_trials_emblem.rs
+++ b/crates/engine/tests/integration/gideon_trials_emblem.rs
@@ -1,0 +1,209 @@
+//! Gideon of the Trials' emblem — conditional game-outcome locks (issue-free
+//! coverage gap: `Swallow:Condition_AsLongAs`).
+//!
+//! Emblem text (verbatim MTGJSON, the third loyalty ability's payload):
+//!   "As long as you control a Gideon planeswalker, you can't lose the game
+//!    and your opponents can't win the game."
+//!
+//! These tests drive the REAL pipeline: the emblem-granting clause is parsed
+//! at test time by the production parser (so reverting the compound
+//! cant-win/lose multi arm or the emblem multi-static upgrade fails every
+//! test here), the emblem is created by resolving a cast spell through
+//! `GameRunner::cast(..).resolve()`, and the locks are enforced by the SBA /
+//! win-lose seams that landed with Angel's Grace (PR #6093).
+//!
+//! CR references (verified against `docs/MagicCompRules.txt`):
+//!   - CR 114.1 + CR 114.4: emblems live in the command zone and their
+//!     abilities function there.
+//!   - CR 109.4c: an emblem is controlled by the player who put it into the
+//!     command zone — the condition's "you" binds to that player.
+//!   - CR 104.3b-e: loss by SBA / effect is precluded by "can't lose the
+//!     game"; CR 104.2b: an effect-stated win is precluded by "can't win the
+//!     game" (CR 810.8a is the printed effect language).
+//!   - CR 611.3a: the "as long as" gate is live — re-evaluated whenever the
+//!     statics are read, so the protection evaporates the moment no Gideon
+//!     planeswalker is controlled (never latched).
+//!   - CR 205.3j: "Gideon" is a planeswalker type.
+
+use engine::game::sba::check_state_based_actions;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+use engine::types::zones::Zone;
+
+/// Verbatim emblem-granting clause of the third loyalty ability. The synthetic
+/// spell name shares no words with "Gideon", so the card-name normalizer is
+/// deliberately inert here — the normalizer's own revert-failing coverage
+/// lives in the `oracle_util` unit tests and the full-card parse test.
+const GIDEON_EMBLEM_ORACLE: &str = "You get an emblem with \"As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game.\"";
+
+/// Build a game where P0 has cast a sorcery granting the emblem. When
+/// `with_gideon` is set, P0 also controls a permanent with the Planeswalker
+/// core type and the Gideon planeswalker type (CR 205.3j), satisfying the
+/// emblem's condition.
+fn setup_with_emblem(with_gideon: bool) -> (GameRunner, Option<ObjectId>) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Test Emblem Grant", false, GIDEON_EMBLEM_ORACLE)
+        .id();
+    let gideon = with_gideon.then(|| scenario.add_creature(P0, "Test Walker", 4, 4).id());
+    let mut runner = scenario.build();
+    if let Some(id) = gideon {
+        // CR 205.3j: stamp the planeswalker type + Gideon planeswalker type.
+        let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Planeswalker);
+        obj.card_types.subtypes.push("Gideon".to_string());
+        obj.base_card_types = obj.card_types.clone();
+    }
+    runner.cast(spell).resolve();
+    (runner, gideon)
+}
+
+/// Shape guard shared by every test: the resolved spell must have produced a
+/// command-zone emblem carrying BOTH conditioned locks. This is what makes
+/// the negative assertions below non-vacuous — the emblem demonstrably
+/// exists and parsed to the full two-static shape.
+fn assert_emblem_shape(runner: &GameRunner) {
+    let state = runner.state();
+    let emblem = state
+        .command_zone
+        .iter()
+        .filter_map(|id| state.objects.get(id))
+        .find(|obj| obj.is_emblem)
+        .expect("resolving the spell must create a command-zone emblem (CR 114.1)");
+    let modes: Vec<&StaticMode> = emblem
+        .static_definitions
+        .iter_unchecked()
+        .map(|d| &d.mode)
+        .collect();
+    assert!(
+        modes.contains(&&StaticMode::CantLoseTheGame)
+            && modes.contains(&&StaticMode::CantWinTheGame),
+        "emblem must carry both outcome locks, got {modes:?}"
+    );
+    assert!(
+        emblem
+            .static_definitions
+            .iter_unchecked()
+            .all(|d| d.condition.is_some()),
+        "both locks must be condition-gated (CR 611.3a)"
+    );
+}
+
+/// CR 104.3b + CR 114.4: while its controller controls a Gideon planeswalker,
+/// the emblem precludes the 0-or-less-life loss SBA — and ONLY for its
+/// controller: the unprotected opponent at 0 life IS eliminated, proving the
+/// loss SBA executed (reach guard) and the You-scoped filter is per-player.
+#[test]
+fn emblem_blocks_loss_sba_while_controlling_gideon_planeswalker() {
+    let (mut runner, _gideon) = setup_with_emblem(true);
+    assert_emblem_shape(&runner);
+
+    runner.state_mut().players[0].life = 0;
+    runner.state_mut().players[1].life = 0;
+    let mut events = Vec::new();
+    check_state_based_actions(runner.state_mut(), &mut events);
+
+    assert!(
+        !runner.state().players[0].is_eliminated,
+        "emblem's controller at 0 life must not lose while controlling a Gideon planeswalker"
+    );
+    assert!(
+        runner.state().players[1].is_eliminated,
+        "unprotected opponent at 0 life must still be eliminated (reach guard)"
+    );
+}
+
+/// CR 611.3a: the gate is LIVE — once the Gideon planeswalker leaves the
+/// battlefield, the same loss SBA eliminates the emblem's controller. This
+/// discriminates against both an unconditional parse and a latched condition.
+#[test]
+fn emblem_stops_protecting_after_gideon_leaves() {
+    let (mut runner, gideon) = setup_with_emblem(true);
+    assert_emblem_shape(&runner);
+    let gideon = gideon.expect("setup placed a Gideon planeswalker");
+
+    // The Gideon planeswalker dies; the emblem stays (CR 114.4), but its
+    // condition is no longer met.
+    engine::game::zones::move_to_zone(runner.state_mut(), gideon, Zone::Graveyard, &mut Vec::new());
+
+    runner.state_mut().players[0].life = 0;
+    let mut events = Vec::new();
+    check_state_based_actions(runner.state_mut(), &mut events);
+
+    assert!(
+        runner.state().players[0].is_eliminated,
+        "with no Gideon planeswalker controlled, the emblem's condition fails and the loss SBA applies (CR 611.3a)"
+    );
+}
+
+/// CR 104.2b: while the condition holds, an opponent's "You win the game."
+/// effect resolved through the real cast pipeline does not end the game.
+#[test]
+fn emblem_blocks_opponent_win_effect_while_condition_holds() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let grant = scenario
+        .add_spell_to_hand_from_oracle(P0, "Test Emblem Grant", false, GIDEON_EMBLEM_ORACLE)
+        .id();
+    let win = scenario
+        .add_spell_to_hand_from_oracle(P1, "Test Win Spell", true, "You win the game.")
+        .id();
+    let gideon = scenario.add_creature(P0, "Test Walker", 4, 4).id();
+    let mut runner = scenario.build();
+    {
+        let obj = runner.state_mut().objects.get_mut(&gideon).unwrap();
+        obj.card_types.core_types.push(CoreType::Planeswalker);
+        obj.card_types.subtypes.push("Gideon".to_string());
+        obj.base_card_types = obj.card_types.clone();
+    }
+    runner.cast(grant).resolve();
+    assert_emblem_shape(&runner);
+
+    // CR 117.3d: the active player (P0) passes priority so P1 can cast.
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes priority so P1 can cast");
+    runner.cast(win).resolve();
+
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
+        "opponent's win effect must be precluded while the emblem's condition holds (CR 104.2b), got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+/// Reach-guard sibling for the win-block test: with the emblem present but NO
+/// Gideon planeswalker controlled, the identical win spell ends the game —
+/// the win path is live and the block above genuinely came from the
+/// condition-gated emblem static.
+#[test]
+fn opponent_win_effect_resolves_when_condition_fails() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let grant = scenario
+        .add_spell_to_hand_from_oracle(P0, "Test Emblem Grant", false, GIDEON_EMBLEM_ORACLE)
+        .id();
+    let win = scenario
+        .add_spell_to_hand_from_oracle(P1, "Test Win Spell", true, "You win the game.")
+        .id();
+    let mut runner = scenario.build();
+    runner.cast(grant).resolve();
+    assert_emblem_shape(&runner);
+
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes priority so P1 can cast");
+    runner.cast(win).resolve();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::GameOver { .. }),
+        "with no Gideon planeswalker controlled, the win effect resolves (reach guard), got {:?}",
+        runner.state().waiting_for
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -159,6 +159,7 @@ mod gemstone_caverns_begin_game;
 mod gev_scaled_scorch_enter_counters;
 mod giada_angel_counters;
 mod giant_ox_crew_toughness;
+mod gideon_trials_emblem;
 mod gift_delivery_draw_sequence_migration;
 mod giggling_skitterspike_issue_890;
 mod gimbal_gremlin_prodigy;


### PR DESCRIPTION
## Summary

Implements **Gideon of the Trials** (AKH #14), with the emblem's compound conditional lock as the class-level target: *"As long as you control a Gideon planeswalker, you can't lose the game and your opponents can't win the game."*

- Emblem bodies parse to **multiple condition-gated statics** (`parse_static_line_multi`): the can't-lose/can't-win conjunct splits into `CantLoseTheGame` + `CantWinTheGame`, each gated on `IsPresent(Gideon planeswalker, you)`.
- Both statics live in the **command zone** and are evaluated there (CR 114.4 seam built for Angel's Grace, #6093).
- Card-name normalizer keeps subtype-word short names literal in type-adjective position ("a **Gideon** planeswalker", CR 205.3j) while subject uses still normalize to `~`.

## Root cause (why the emblem never appeared)

Standalone emblem-granting spell lines (`You get an emblem with "…"`) were misclassified by the spell IR loop: the quoted static body ("can't lose the game") pattern-matched as a static ability, so the line never reached the effect parser and no emblem was created. Fixed at the classification seam — `should_defer_spell_to_effect` now defers any line whose head matches the shared combinator predicate `is_emblem_creation_head` (single authority, reused from the effect parser; both call sites spell-scoped).

## Class coverage

- Any emblem whose body contains static-looking text (Gideon of the Trials, Teferi Hero of Dominaria–style bodies, etc.) now classifies correctly — the fix is at the head predicate, not per-card.
- Multi-static emblem bodies generalize: any conjunct of continuous effects inside one emblem line yields N gated statics.
- Condition gate (`as long as you control …`) goes through the shared condition combinator, not bespoke matching.

## CR citations (all verified against MagicCompRules.txt)

- CR 104.2b / 104.3e — can't-win / can't-lose replacement of win/loss events
- CR 611.3a — conditional continuous effects from static abilities
- CR 114.1 / 114.4 — emblems are command-zone objects with static abilities
- CR 205.3j — "Gideon" is a planeswalker subtype word

## Tests

- 4 new integration tests (`gideon_trials_emblem.rs`): emblem materializes on −0; loss SBA blocked per-controller while a Gideon is controlled; opponents' win events blocked; protection evaporates when the last Gideon leaves.
- Permanent parser probe: standalone spell emblem grant parses to `CreateEmblem` (guards the classifier seam).
- 147 targeted parser lib tests pass; full pre-push gate (fmt, clippy, card-data release validate, combinator Gates A+G, parser tests, frontend type-check) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
