### PR TITLE
refactor(parser): route exile_top_each_library_with_collection_counter through EffectChainIr (P05-U3)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11899,10 +11899,11 @@ fn clause_is_pay_to_end_effect_termination(source_text: &str) -> bool {
     )
 }
 
-pub(crate) fn try_parse_exile_top_each_library_with_collection_counter(
+pub(crate) fn parse_exile_top_each_library_with_collection_counter_ir(
     text: &str,
     kind: AbilityKind,
-) -> Option<AbilityDefinition> {
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
     let lower = text.to_lowercase();
     let ((), _) = nom_on_lower(text, &lower, |input| {
         let (input, _) = tag("exile the top card of each player's library").parse(input)?;
@@ -11947,17 +11948,20 @@ pub(crate) fn try_parse_exile_top_each_library_with_collection_counter(
     )
     .sub_ability(grant);
 
-    let mut def = AbilityDefinition::new(
+    let mut clause = parsed_clause(Effect::ExileTop {
+        player: TargetFilter::Controller,
+        count: QuantityExpr::Fixed { value: 1 },
+        face_down: false,
+    });
+    clause.sub_ability = Some(Box::new(put_counter));
+    Some(EffectChainIr::single_clause(
+        text,
         kind,
-        Effect::ExileTop {
-            player: TargetFilter::Controller,
-            count: QuantityExpr::Fixed { value: 1 },
-            face_down: false,
-        },
-    );
-    def.player_scope = Some(PlayerFilter::All);
-    def.sub_ability = Some(Box::new(put_counter));
-    Some(def)
+        clause,
+        Some(PlayerFilter::All),
+        ctx.actor.clone(),
+        ctx.in_trigger,
+    ))
 }
 
 /// CR 702.138a + CR 601.2f / CR 601.2g / CR 601.2h: a targeted/triggered one-shot
@@ -25069,9 +25073,6 @@ fn try_parse_chain_bypass(
     if let Some(def) = try_parse_conditional_protection_grant_ability(text, kind, ctx) {
         return Some(def);
     }
-    if let Some(def) = try_parse_exile_top_each_library_with_collection_counter(text, kind) {
-        return Some(def);
-    }
     if let Some(def) = try_parse_grant_graveyard_keyword_to_target(text, kind) {
         return Some(def);
     }
@@ -25698,6 +25699,9 @@ pub(crate) fn parse_effect_chain_ir(
         return ir;
     }
     if let Some(ir) = parse_each_player_copy_chosen_ir(text, kind, ctx) {
+        return ir;
+    }
+    if let Some(ir) = parse_exile_top_each_library_with_collection_counter_ir(text, kind, ctx) {
         return ir;
     }
     let text = strip_trailing_activation_restriction_sentence(text);

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9,7 +9,6 @@ use nom::Parser;
 
 use super::oracle_effect::{
     condition_text_is_rehomeable, lower_effect_chain_ir, parse_effect_chain_ir,
-    try_parse_exile_top_each_library_with_collection_counter,
     try_parse_grant_graveyard_keyword_to_target, try_parse_reanimator_aura_etb_effect,
     try_parse_reanimator_aura_grant_etb_effect,
 };
@@ -1441,64 +1440,63 @@ pub(crate) fn parse_trigger_line_with_index_ir(
             }
             Some(TriggerBody::PreLowered(Box::new(ability)))
         } else {
-            try_parse_exile_top_each_library_with_collection_counter(
-                &effect_for_parse,
-                AbilityKind::Spell,
-            )
-            .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
-            .or_else(|| {
-                // CR 702.138a: triggered one-shot grant of escape to a target
-                // graveyard card whose compound cost rides a continuation sentence
-                // (Desdemona, Freedom's Edge). Fail-closed: declines unless the
-                // whole two-sentence shape parses, so a card with an unparsed
-                // target filter stays an honest Unimplemented rather than misparsing.
-                try_parse_grant_graveyard_keyword_to_target(&effect_for_parse, AbilityKind::Spell)
+            // CR 702.138a: triggered one-shot grant of escape to a target
+            // graveyard card whose compound cost rides a continuation sentence
+            // (Desdemona, Freedom's Edge). Fail-closed: declines unless the
+            // whole two-sentence shape parses, so a card with an unparsed
+            // target filter stays an honest Unimplemented rather than misparsing.
+            try_parse_grant_graveyard_keyword_to_target(&effect_for_parse, AbilityKind::Spell)
+                .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
+                .or_else(|| {
+                    // CR 608.2c + CR 613.1f + CR 701.3a + CR 701.21a: whole-body
+                    // reanimator-Aura ETB effect (Animate Dead / Dance of the Dead) —
+                    // "it loses ... and gains ...", return/put the enchanted creature
+                    // card to the battlefield under your control, attach the Aura to
+                    // it, and register the leaves-battlefield sacrifice. Fail-closed:
+                    // declines unless the entire body matches, so a deviating card
+                    // stays an honest Unimplemented rather than misparsing.
+                    try_parse_reanimator_aura_etb_effect(&effect_for_parse, AbilityKind::Spell)
+                        .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
+                })
+                .or_else(|| {
+                    // CR 603.3d + CR 608.2c + CR 613.1d + CR 613.1f + CR 701.3a + CR 701.21a:
+                    // whole-body reanimator-Aura GRANT-shape ETB effect (Necromancy) — a plain
+                    // (non-Aura) enchantment whose ETB ability becomes an Aura AND targets the
+                    // graveyard creature to reanimate itself (unlike the swap shape above,
+                    // which targets at CAST time via its printed Enchant restriction and
+                    // refers back to `TargetFilter::AttachedTo` here). Fail-closed: declines
+                    // unless the entire body matches, so a deviating card stays an honest
+                    // Unimplemented rather than misparsing.
+                    try_parse_reanimator_aura_grant_etb_effect(
+                        &effect_for_parse,
+                        AbilityKind::Spell,
+                    )
                     .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
-            })
-            .or_else(|| {
-                // CR 608.2c + CR 613.1f + CR 701.3a + CR 701.21a: whole-body
-                // reanimator-Aura ETB effect (Animate Dead / Dance of the Dead) —
-                // "it loses ... and gains ...", return/put the enchanted creature
-                // card to the battlefield under your control, attach the Aura to
-                // it, and register the leaves-battlefield sacrifice. Fail-closed:
-                // declines unless the entire body matches, so a deviating card
-                // stays an honest Unimplemented rather than misparsing.
-                try_parse_reanimator_aura_etb_effect(&effect_for_parse, AbilityKind::Spell)
-                    .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
-            })
-            .or_else(|| {
-                // CR 603.3d + CR 608.2c + CR 613.1d + CR 613.1f + CR 701.3a + CR 701.21a:
-                // whole-body reanimator-Aura GRANT-shape ETB effect (Necromancy) — a plain
-                // (non-Aura) enchantment whose ETB ability becomes an Aura AND targets the
-                // graveyard creature to reanimate itself (unlike the swap shape above,
-                // which targets at CAST time via its printed Enchant restriction and
-                // refers back to `TargetFilter::AttachedTo` here). Fail-closed: declines
-                // unless the entire body matches, so a deviating card stays an honest
-                // Unimplemented rather than misparsing.
-                try_parse_reanimator_aura_grant_etb_effect(&effect_for_parse, AbilityKind::Spell)
-                    .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
-            })
-            .or_else(|| {
-                // CR 700.2 + CR 608.2d: Inline modal trigger body — "choose one —
-                // mode1; or mode2" on a single line (no bullet-line modes). No
-                // printed card currently reaches this branch: it needs an em-dash
-                // *and* "; or " inside one trigger effect body. (Grenzo, Havoc
-                // Raiser — long named here as the canonical case — uses bullet-line
-                // modes, so `raw_modes.len() == 1` and it never arrives.) Route
-                // through the modal parser so each mode body is independently
-                // parsed with the trigger's established relative_player_scope (e.g.
-                // TriggeringPlayer for DamageDone triggers) so "that player" in mode
-                // bodies resolves to the damaged player (CR 603.7c).
-                if let Some(modal_ability) = try_parse_inline_modal(
-                    &effect_for_parse,
-                    effect_ctx.relative_player_scope.clone(),
-                ) {
-                    return Some(TriggerBody::PreLowered(Box::new(modal_ability)));
-                }
-                let ir =
-                    parse_effect_chain_ir(&effect_for_parse, AbilityKind::Spell, &mut effect_ctx);
-                Some(TriggerBody::EffectChain(ir))
-            })
+                })
+                .or_else(|| {
+                    // CR 700.2 + CR 608.2d: Inline modal trigger body — "choose one —
+                    // mode1; or mode2" on a single line (no bullet-line modes). No
+                    // printed card currently reaches this branch: it needs an em-dash
+                    // *and* "; or " inside one trigger effect body. (Grenzo, Havoc
+                    // Raiser — long named here as the canonical case — uses bullet-line
+                    // modes, so `raw_modes.len() == 1` and it never arrives.) Route
+                    // through the modal parser so each mode body is independently
+                    // parsed with the trigger's established relative_player_scope (e.g.
+                    // TriggeringPlayer for DamageDone triggers) so "that player" in mode
+                    // bodies resolves to the damaged player (CR 603.7c).
+                    if let Some(modal_ability) = try_parse_inline_modal(
+                        &effect_for_parse,
+                        effect_ctx.relative_player_scope.clone(),
+                    ) {
+                        return Some(TriggerBody::PreLowered(Box::new(modal_ability)));
+                    }
+                    let ir = parse_effect_chain_ir(
+                        &effect_for_parse,
+                        AbilityKind::Spell,
+                        &mut effect_ctx,
+                    );
+                    Some(TriggerBody::EffectChain(ir))
+                })
         }
     } else {
         None


### PR DESCRIPTION
CR 406.3 + CR 122.1 + CR 601.2: Evelyn exiles the top card of every library, marks each tracked result with a collection counter, and creates the once-per-turn play permission for that tracked set. The IR clause retains that nested ExileTop -> PutCounterAll -> GrantCastingPermission chain and PlayerFilter::All.

full-pool card-data byte-identical (sha256 85ec32b31511fc30a0ddc822dcafe8f39cb8657b8aa7390048702ff12826ee85)
