### PR TITLE
refactor(parser): route try_parse_balance_equalization through EffectChainIr (P05-U3)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -11,8 +11,8 @@
 
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::effect_chain::{
-    ClauseDisposition, ClauseId, EffectChainIr, OtherwiseKind, PriorModifier, ReplaceMeaningKind,
-    ReplicateKind,
+    ClauseDisposition, ClauseId, EffectChainIr, OtherwiseKind, PlayerScopeRewrite, PriorModifier,
+    ReplaceMeaningKind, ReplicateKind,
 };
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, CastFromZoneDriver,
@@ -2350,12 +2350,14 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
         })
     };
 
-    // CR 608.2 + CR 107.2: Wherever an ability in the chain carries
-    // `player_scope` (outermost OR a nested sub-ability), rewrite target-scoped
-    // refs ("their life", "their hand") to their per-iterating-player
-    // equivalents. Walks the whole tree so a scoped clause buried under earlier
-    // non-scoped clauses (Betor, Kin to All) is still rewritten.
-    apply_player_scope_rewrites(&mut result);
+    // CR 608.2 + CR 107.2: Ordinary parsed clauses rewrite target-scoped refs
+    // ("their life", "their hand") to their per-iterating-player equivalents.
+    // Whole-body recognizers can preserve explicitly constructed scoped fields;
+    // the walk still covers a scoped clause buried under earlier non-scoped
+    // clauses (Betor, Kin to All).
+    if matches!(ir.player_scope_rewrite, PlayerScopeRewrite::Apply) {
+        apply_player_scope_rewrites(&mut result);
+    }
 
     // CR 107.1a: Apply the chain-level rounding annotation (captured above)
     // to every DivideRounded in the built tree. No-op when the sentence was

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -154,7 +154,8 @@ use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
-    EffectChainIr, OtherwiseKind, PriorModifier, ReplaceMeaningKind, ReplicateKind,
+    EffectChainIr, OtherwiseKind, PlayerScopeRewrite, PriorModifier, ReplaceMeaningKind,
+    ReplicateKind,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -12593,7 +12594,7 @@ fn parse_balance_arm_c(input: &str) -> OracleResult<'_, Vec<(EqualizeVerb, Targe
     Ok((input, pairs))
 }
 
-/// CR 107.1 + CR 608.2e: Whole-line interceptor for the Balance equalization
+/// CR 107.1 + CR 608.2e: Whole-chain recognizer for the Balance equalization
 /// class (Balance, Restore Balance, Balancing Act).
 ///
 /// Arm B parses the first sentence and Arm C parses the "the same way"
@@ -12602,10 +12603,11 @@ fn parse_balance_arm_c(input: &str) -> OracleResult<'_, Vec<(EqualizeVerb, Targe
 /// count; the clauses are chained via `sub_ability` as three independent steps
 /// (CR 608.2e — each clause computes its own minimum at its own resolution
 /// time, guaranteed by the §8 per-link clause-minimum snapshot).
-pub(crate) fn try_parse_balance_equalization(
+fn parse_balance_equalization_ir(
     text: &str,
     kind: AbilityKind,
-) -> Option<AbilityDefinition> {
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
     let lower = text.to_lowercase();
 
     let parsed = nom_on_lower(text, &lower, |input| {
@@ -12623,26 +12625,66 @@ pub(crate) fn try_parse_balance_equalization(
     clauses.push(first);
     clauses.extend(rest);
 
-    // Lower each (verb, filter) into a `player_scope: All` link, chained via
-    // `sub_ability` (CR 608.2e — three independent steps).
-    let mut links: Vec<AbilityDefinition> = clauses
-        .into_iter()
-        .map(|(verb, filter)| {
-            let filter = balance_filter_you_control(filter);
-            let mut def = AbilityDefinition::new(kind, balance_clause_effect(verb, filter));
-            def.player_scope = Some(PlayerFilter::All);
-            def.sub_link = SubAbilityLink::SequentialSibling;
-            def
-        })
-        .collect();
-
-    // Fold the chain back-to-front so each link's `sub_ability` is the next.
-    let mut chain = links.pop()?;
-    while let Some(mut prev) = links.pop() {
-        prev.sub_ability = Some(Box::new(chain));
-        chain = prev;
+    // Provenance bookkeeping only: the grammar above has already validated
+    // both sentences. Split the continuation's explicit "and" list into the
+    // source fragments for the corresponding parsed arms.
+    let (first_source, continuation_source) =
+        super::oracle_nom::bridge::split_once_on_lower(text, &lower, ". ")?;
+    let continuation_lower = &lower[lower.len() - continuation_source.len()..];
+    let continuation = TextPair::new(continuation_source, continuation_lower);
+    // allow-noncombinator: structural punctuation cleanup on a clause already parsed by nom
+    let continuation = continuation.strip_suffix(".").unwrap_or(continuation);
+    let (continuation, _) = continuation.rsplit_around(" the same way")?;
+    let mut continuation_sources = Vec::with_capacity(clauses.len().saturating_sub(1));
+    let mut remaining = continuation;
+    while let Some((source, rest)) = remaining.split_around(" and ") {
+        continuation_sources.push(source.original);
+        remaining = rest;
     }
-    Some(chain)
+    continuation_sources.push(remaining.original);
+    if continuation_sources.len() != clauses.len().saturating_sub(1) {
+        return None;
+    }
+
+    let mut builder = ClauseIrBuilder::new(text);
+    let clause_count = clauses.len();
+    for (index, (verb, filter)) in clauses.into_iter().enumerate() {
+        let source_text = if index == 0 {
+            first_source
+        } else {
+            continuation_sources[index - 1]
+        };
+        // CR 608.2c: the boundary after each nonterminal clause makes the
+        // FOLLOWING lowered definition a SequentialSibling. The root has no
+        // previous boundary and is stamped by the AbilityShellIr below.
+        let boundary = (index + 1 < clause_count).then_some(ClauseBoundary::Sentence);
+        builder
+            .clause(
+                source_text,
+                parsed_clause(balance_clause_effect(
+                    verb,
+                    balance_filter_you_control(filter),
+                )),
+                boundary,
+                ClauseDisposition::Emit {
+                    followup: None,
+                    intrinsic: None,
+                },
+            )
+            .player_scope(Some(PlayerFilter::All))
+            .push();
+    }
+
+    Some(EffectChainIr {
+        clauses: builder.finish(),
+        kind,
+        continuation_kind: Some(kind),
+        player_scope_rewrite: PlayerScopeRewrite::Preserve,
+        chain_rounding: None,
+        actor: ctx.actor.clone(),
+        in_trigger: ctx.in_trigger,
+        repeat_until: None,
+    })
 }
 
 /// CR 101.4 + CR 701.21a + CR 701.23i: Whole-line parser for the generic
@@ -12801,7 +12843,7 @@ pub(crate) fn try_parse_threshold_land_balance(
 
 /// CR 121.1 + CR 402.1 + CR 608.2e: Whole-line interceptor for the "catch up to
 /// the player with the most cards in hand" equalize-upward draw (Tales of the
-/// Ancestors). Structured like [`try_parse_balance_equalization`]: the
+/// Ancestors). Structured like [`parse_balance_equalization_ir`]: the
 /// cross-player extremum operand is PRODUCED by the typed
 /// [`nom_quantity::parse_player_with_extremum_cards_in_hand`] combinator (not a
 /// literal tag), and a `Verify`-style structural guard (mirroring
@@ -25047,16 +25089,16 @@ fn rewrite_filter_prop_another_to_tracked_set(prop: &mut FilterProp) {
 ///
 /// | mode | bypasses | bypass #1's `ParseContext` |
 /// |---|---|---|
-/// | `Standalone` | 8 | a fresh `default()`, discarded |
-/// | `WithContext` | the same 8 as a strict prefix, plus `try_parse_exile_pile_shuffle_cloak` | the caller's real `ctx` |
+/// | `Standalone` | remaining shared recognizers | a fresh `default()`, discarded |
+/// | `WithContext` | the same recognizers as a strict prefix, plus `try_parse_exile_pile_shuffle_cloak` | the caller's real `ctx` |
 ///
 /// Callers split cleanly: die-result branch bodies (`oracle_special.rs`) take
 /// `Standalone`; spell/activated dispatch takes `WithContext`.
 ///
 /// **The asymmetry is suspected-accidental and is preserved byte-for-byte on
 /// purpose.** Nothing about a die-roll branch body should exclude the cloak
-/// recognizer, but unifying to 9 makes die branches newly take it and unifying
-/// to 8 makes spells lose it — either is silent lowered drift across the
+/// recognizer, but unifying the two sets makes die branches newly take it or
+/// makes spells lose it — either is silent lowered drift across the
 /// die-result cards. Fixing it is a separate, reviewed change with its own
 /// discriminating card; a parity migration never absorbs a bug fix.
 ///
@@ -25077,15 +25119,12 @@ fn try_parse_chain_bypass(
     mode: ChainLoweringMode,
     ctx: &mut ParseContext,
 ) -> Option<AbilityDefinition> {
-    // The eight shared bypasses, in their established order. Only the first
+    // The remaining shared bypasses, in their established order. Only the first
     // consults `ctx`.
     if let Some(def) = try_parse_conditional_protection_grant_ability(text, kind, ctx) {
         return Some(def);
     }
     if let Some(def) = try_parse_grant_graveyard_keyword_to_target(text, kind) {
-        return Some(def);
-    }
-    if let Some(def) = try_parse_balance_equalization(text, kind) {
         return Some(def);
     }
     if let Some(def) = try_parse_threshold_land_balance(text, kind) {
@@ -25121,6 +25160,25 @@ pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     def
 }
 
+fn parse_ability_ir(text: &str, kind: AbilityKind, ctx: &mut ParseContext) -> AbilityIr {
+    if let Some(body) = parse_balance_equalization_ir(text, kind, ctx) {
+        return AbilityIr {
+            source_text: text.to_string(),
+            body,
+            // CR 608.2c: Balance's root is an independent equalization step;
+            // no preceding ClauseBoundary can stamp its link.
+            shell: AbilityShellIr {
+                sub_link: Some(SubAbilityLink::SequentialSibling),
+            },
+        };
+    }
+    AbilityIr {
+        source_text: text.to_string(),
+        body: parse_effect_chain_ir(text, kind, ctx),
+        shell: AbilityShellIr::default(),
+    }
+}
+
 pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
     // A fresh context per call, exactly as before: the bypasses may mutate `ctx`
     // before declining, and those mutations must not reach `parse_effect_chain_ir`.
@@ -25132,11 +25190,7 @@ pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
     ) {
         return def;
     }
-    lower_ability_ir(&AbilityIr {
-        source_text: text.to_string(),
-        body: parse_effect_chain_ir(text, kind, &mut ParseContext::default()),
-        shell: AbilityShellIr::default(),
-    })
+    lower_ability_ir(&parse_ability_ir(text, kind, &mut ParseContext::default()))
 }
 
 /// Parse a compound effect chain with subject context for pronoun resolution.
@@ -25150,11 +25204,7 @@ pub(crate) fn parse_effect_chain_with_context(
     if let Some(def) = try_parse_chain_bypass(text, kind, ChainLoweringMode::WithContext, ctx) {
         return def;
     }
-    lower_ability_ir(&AbilityIr {
-        source_text: text.to_string(),
-        body: parse_effect_chain_ir(text, kind, ctx),
-        shell: AbilityShellIr::default(),
-    })
+    lower_ability_ir(&parse_ability_ir(text, kind, ctx))
 }
 
 /// CR 701.24a + CR 701.58a/e + CR 608.2c: Expose the Culprit mode 2 — "Exile any
@@ -25505,6 +25555,7 @@ fn parse_return_target_and_same_name_from_your_graveyard_ir(
         clauses: builder.finish(),
         kind,
         continuation_kind: Some(kind),
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
         chain_rounding: None,
         actor: ctx.actor.clone(),
         in_trigger: ctx.in_trigger,
@@ -25738,6 +25789,9 @@ pub(crate) fn parse_effect_chain_ir(
     if let Some(ir) = parse_exile_top_each_library_with_collection_counter_ir(text, kind, ctx) {
         return ir;
     }
+    if let Some(ir) = parse_balance_equalization_ir(text, kind, ctx) {
+        return ir;
+    }
     if let Some(ir) = parse_return_target_and_same_name_from_your_graveyard_ir(text, kind, ctx) {
         return ir;
     }
@@ -25832,6 +25886,7 @@ pub(crate) fn parse_effect_chain_ir(
                 clauses: meld_builder.finish(),
                 kind,
                 continuation_kind: None,
+                player_scope_rewrite: PlayerScopeRewrite::Apply,
                 chain_rounding,
                 actor: ctx.actor.clone(),
                 in_trigger: ctx.in_trigger,
@@ -29081,6 +29136,7 @@ pub(crate) fn parse_effect_chain_ir(
         clauses,
         kind,
         continuation_kind: None,
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
         chain_rounding,
         actor: ctx.actor.clone(),
         in_trigger: ctx.in_trigger,

--- a/crates/engine/src/parser/oracle_effect/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_effect/snapshot_tests.rs
@@ -1173,13 +1173,14 @@ fn skullwinder_etb_parses_choose_opponent() {
 }
 
 // -----------------------------------------------------------------------
-// Balance equalization parser arms (try_parse_balance_equalization)
+// Balance equalization parser arms (parse_balance_equalization_ir)
 // -----------------------------------------------------------------------
 
 /// Assert a `Difference { ObjectCount(Land, You), ControlledByEachPlayer }`
 /// sacrifice link with `player_scope: All`.
 fn assert_land_sacrifice_clause(def: &AbilityDefinition) {
     assert_eq!(def.player_scope, Some(PlayerFilter::All));
+    assert_eq!(def.sub_link, SubAbilityLink::SequentialSibling);
     let Effect::Sacrifice { target, count, .. } = &*def.effect else {
         panic!("expected Effect::Sacrifice, got {:?}", def.effect);
     };
@@ -1233,6 +1234,7 @@ fn assert_land_sacrifice_clause(def: &AbilityDefinition) {
 /// discard link with `player_scope: All`.
 fn assert_hand_discard_clause(def: &AbilityDefinition) {
     assert_eq!(def.player_scope, Some(PlayerFilter::All));
+    assert_eq!(def.sub_link, SubAbilityLink::SequentialSibling);
     let Effect::Discard { target, count, .. } = &*def.effect else {
         panic!("expected Effect::Discard, got {:?}", def.effect);
     };
@@ -1279,6 +1281,7 @@ fn balance_parses_to_three_link_equalization_chain() {
         .as_ref()
         .expect("expected creature sacrifice clause");
     assert_eq!(link3.player_scope, Some(PlayerFilter::All));
+    assert_eq!(link3.sub_link, SubAbilityLink::SequentialSibling);
     let Effect::Sacrifice { target, .. } = &*link3.effect else {
         panic!("link 3 must be Effect::Sacrifice, got {:?}", link3.effect);
     };
@@ -1330,7 +1333,12 @@ fn balancing_act_single_continuation_clause_parses() {
 fn non_balance_text_is_not_intercepted() {
     // The interceptor must not fire on unrelated "each player" text.
     assert!(
-        try_parse_balance_equalization("Each player draws a card.", AbilityKind::Spell).is_none(),
+        parse_balance_equalization_ir(
+            "Each player draws a card.",
+            AbilityKind::Spell,
+            &ParseContext::default(),
+        )
+        .is_none(),
         "interceptor must only match the Balance equalization shape"
     );
 }
@@ -1343,9 +1351,10 @@ fn balance_arm_b_rejects_non_equalization_quantity() {
     // ref) must NOT be intercepted. Confirms Arm B verifies the structure
     // rather than discarding the parsed ref.
     assert!(
-            try_parse_balance_equalization(
+            parse_balance_equalization_ir(
                 "Each player chooses a number of lands they control equal to the number of cards in their hand, then sacrifices the rest. Players discard cards and sacrifice creatures the same way.",
                 AbilityKind::Spell,
+                &ParseContext::default(),
             )
             .is_none(),
             "interceptor must reject inputs whose inner quantity is not the equalization shape"

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -46334,6 +46334,7 @@ fn drawn_this_turn_followup_overwrites_prior_life_payment() {
         clauses: builder.finish(),
         kind: AbilityKind::Spell,
         continuation_kind: None,
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
         chain_rounding: None,
         actor: None,
         in_trigger: false,

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -40,6 +40,8 @@ pub(crate) struct EffectChainIr {
     /// with the enclosing kind can opt into preserving that serialized shape
     /// while still routing through the shared chain assembly.
     pub(crate) continuation_kind: Option<AbilityKind>,
+    /// Whether assembly applies the ordinary player-scope reference rewrites.
+    pub(crate) player_scope_rewrite: PlayerScopeRewrite,
     /// CR 107.1a: Chain-level rounding annotation ("Round down/up each time").
     pub(crate) chain_rounding: Option<RoundingMode>,
     /// CR 701.21a: Actor context threaded from ParseContext (per D-07).
@@ -59,6 +61,16 @@ pub(crate) struct EffectChainIr {
     /// this process" directive is recognized. Lowering applies it to the root
     /// `AbilityDefinition` so the resolver re-follows the whole chain.
     pub(crate) repeat_until: Option<crate::types::ability::RepeatContinuation>,
+}
+
+/// Whether `lower_effect_chain_ir` rewrites player-scoped references after
+/// assembling a chain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) enum PlayerScopeRewrite {
+    /// Apply the shared player-scope rewrites used by ordinary parsed clauses.
+    Apply,
+    /// Preserve the recognizer's explicit scoped fields as parsed.
+    Preserve,
 }
 
 impl EffectChainIr {
@@ -94,6 +106,7 @@ impl EffectChainIr {
             clauses: builder.finish(),
             kind,
             continuation_kind: None,
+            player_scope_rewrite: PlayerScopeRewrite::Apply,
             chain_rounding: None,
             actor,
             in_trigger,
@@ -124,7 +137,7 @@ pub(crate) struct AbilityShellIr {
     /// it, which is required because the root clause has no *previous* boundary:
     /// `lower.rs` derives `sub_link` from `prev_boundary`, and `None` maps
     /// unconditionally to `ContinuationStep`. A recognizer whose root is three
-    /// independent steps (`try_parse_balance_equalization`) therefore cannot say so
+    /// independent steps (`parse_balance_equalization_ir`) therefore cannot say so
     /// through the chain, only through the shell.
     ///
     /// `Option<SubAbilityLink>` rather than a bare `SubAbilityLink`: the latter's
@@ -815,6 +828,7 @@ mod tests {
             clauses: vec![],
             kind: AbilityKind::Spell,
             continuation_kind: None,
+            player_scope_rewrite: PlayerScopeRewrite::Apply,
             chain_rounding: None,
             actor: None,
             in_trigger: false,
@@ -931,6 +945,7 @@ mod tests {
             clauses: b.finish(),
             kind: AbilityKind::Spell,
             continuation_kind: None,
+            player_scope_rewrite: PlayerScopeRewrite::Apply,
             chain_rounding: None,
             actor: None,
             in_trigger: false,

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -4,6 +4,7 @@ use crate::parser::oracle::parse_oracle_text;
 use crate::parser::oracle_ir::context::ParseContext;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::doc::PrintedTriggerIndex;
+use crate::parser::oracle_ir::effect_chain::PlayerScopeRewrite;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
     AttackSubject, BounceSelection, CardSelectionMode, CastingPermission, ChosenAttribute,
@@ -17558,6 +17559,7 @@ fn lower_effect_chain_ir_advances_boundary_past_special_clause() {
         clauses: builder.finish(),
         kind: AbilityKind::Spell,
         continuation_kind: None,
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
         chain_rounding: None,
         actor: None,
         in_trigger: true,
@@ -17638,6 +17640,7 @@ fn branch_otherwise_fallback_self_emits_unimplemented_marker_and_else() {
         clauses: builder.finish(),
         kind: AbilityKind::Spell,
         continuation_kind: None,
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
         chain_rounding: None,
         actor: None,
         in_trigger: true,
@@ -17732,6 +17735,7 @@ fn modify_prior_enters_tapped_attacking_patches_prior_token_with_condition_else(
         clauses: builder.finish(),
         kind: AbilityKind::Spell,
         continuation_kind: None,
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
         chain_rounding: None,
         actor: None,
         in_trigger: true,


### PR DESCRIPTION
CR 608.2c/e and CR 101.4: lower each source-ordered equalization instruction with PlayerFilter::All and preserve the legacy SequentialSibling links, including the root shell link.

full-pool card-data byte-identical (sha256 85ec32b31511fc30a0ddc822dcafe8f39cb8657b8aa7390048702ff12826ee85)
