### PR TITLE
refactor(parser): route try_parse_grant_graveyard_keyword_to_target through EffectChainIr (P05-U3)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11995,10 +11995,11 @@ pub(crate) fn parse_exile_top_each_library_with_collection_counter_ir(
 /// Fail-closed at every step: non-matching text returns `None`, the input falls
 /// through to the normal pipeline, and an unrecognized cost surfaces as an honest
 /// `Unimplemented` rather than a cost-free (and thus illegal) escape grant.
-pub(crate) fn try_parse_grant_graveyard_keyword_to_target(
+pub(crate) fn parse_grant_graveyard_keyword_to_target_ir(
     text: &str,
     kind: AbilityKind,
-) -> Option<AbilityDefinition> {
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
     let stripped = super::oracle_util::strip_reminder_text(text);
     let lower = stripped.to_lowercase();
 
@@ -12074,7 +12075,14 @@ pub(crate) fn try_parse_grant_graveyard_keyword_to_target(
         duration: Some(Duration::UntilEndOfTurn),
         target: Some(target_filter),
     };
-    Some(AbilityDefinition::new(kind, effect))
+    Some(EffectChainIr::single_clause(
+        text,
+        kind,
+        parsed_clause(effect),
+        None,
+        ctx.actor.clone(),
+        ctx.in_trigger,
+    ))
 }
 
 /// CR 608.2c + CR 613.1f + CR 701.3a + CR 701.21a: Whole-body, fail-closed recognizer
@@ -25172,9 +25180,6 @@ fn try_parse_chain_bypass(
     if let Some(def) = try_parse_conditional_protection_grant_ability(text, kind, ctx) {
         return Some(def);
     }
-    if let Some(def) = try_parse_grant_graveyard_keyword_to_target(text, kind) {
-        return Some(def);
-    }
     if let Some(def) = try_parse_for_each_attacker_copy_blocker(text, kind) {
         return Some(def);
     }
@@ -25825,6 +25830,9 @@ pub(crate) fn parse_effect_chain_ir(
     kind: AbilityKind,
     ctx: &mut ParseContext,
 ) -> EffectChainIr {
+    if let Some(ir) = parse_grant_graveyard_keyword_to_target_ir(text, kind, ctx) {
+        return ir;
+    }
     if let Some(ir) = parse_catch_up_draw_ir(text, kind, ctx) {
         return ir;
     }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -14124,19 +14124,21 @@ fn effect_target_graveyard_card_gains_escape_compound_cost() {
 /// (flashback/embalm/harmonize) so they keep flowing through their existing
 /// absorber — the two mechanisms partition the class by cost shape.
 #[test]
-fn grant_graveyard_keyword_front_door_declines_self_mana_cost_siblings() {
+fn grant_graveyard_keyword_ir_declines_self_mana_cost_siblings() {
     assert!(
-            try_parse_grant_graveyard_keyword_to_target(
+            parse_grant_graveyard_keyword_to_target_ir(
                 "target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
                 AbilityKind::Spell,
+                &ParseContext::default(),
             )
             .is_none(),
             "flashback (self-mana-cost) must not be claimed by the compound-cost front door"
         );
     assert!(
-            try_parse_grant_graveyard_keyword_to_target(
+            parse_grant_graveyard_keyword_to_target_ir(
                 "target creature card in your graveyard gains embalm until end of turn. The embalm cost is equal to its mana cost.",
                 AbilityKind::Spell,
+                &ParseContext::default(),
             )
             .is_none(),
             "embalm (self-mana-cost) must not be claimed by the compound-cost front door"

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9,8 +9,7 @@ use nom::Parser;
 
 use super::oracle_effect::{
     condition_text_is_rehomeable, lower_effect_chain_ir, parse_effect_chain_ir,
-    try_parse_grant_graveyard_keyword_to_target, try_parse_reanimator_aura_etb_effect,
-    try_parse_reanimator_aura_grant_etb_effect,
+    try_parse_reanimator_aura_etb_effect, try_parse_reanimator_aura_grant_etb_effect,
 };
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::doc::PrintedTriggerIndex;
@@ -1440,24 +1439,15 @@ pub(crate) fn parse_trigger_line_with_index_ir(
             }
             Some(TriggerBody::PreLowered(Box::new(ability)))
         } else {
-            // CR 702.138a: triggered one-shot grant of escape to a target
-            // graveyard card whose compound cost rides a continuation sentence
-            // (Desdemona, Freedom's Edge). Fail-closed: declines unless the
-            // whole two-sentence shape parses, so a card with an unparsed
-            // target filter stays an honest Unimplemented rather than misparsing.
-            try_parse_grant_graveyard_keyword_to_target(&effect_for_parse, AbilityKind::Spell)
+            // CR 608.2c + CR 613.1f + CR 701.3a + CR 701.21a: whole-body
+            // reanimator-Aura ETB effect (Animate Dead / Dance of the Dead) —
+            // "it loses ... and gains ...", return/put the enchanted creature
+            // card to the battlefield under your control, attach the Aura to
+            // it, and register the leaves-battlefield sacrifice. Fail-closed:
+            // declines unless the entire body matches, so a deviating card
+            // stays an honest Unimplemented rather than misparsing.
+            try_parse_reanimator_aura_etb_effect(&effect_for_parse, AbilityKind::Spell)
                 .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
-                .or_else(|| {
-                    // CR 608.2c + CR 613.1f + CR 701.3a + CR 701.21a: whole-body
-                    // reanimator-Aura ETB effect (Animate Dead / Dance of the Dead) —
-                    // "it loses ... and gains ...", return/put the enchanted creature
-                    // card to the battlefield under your control, attach the Aura to
-                    // it, and register the leaves-battlefield sacrifice. Fail-closed:
-                    // declines unless the entire body matches, so a deviating card
-                    // stays an honest Unimplemented rather than misparsing.
-                    try_parse_reanimator_aura_etb_effect(&effect_for_parse, AbilityKind::Spell)
-                        .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
-                })
                 .or_else(|| {
                     // CR 603.3d + CR 608.2c + CR 613.1d + CR 613.1f + CR 701.3a + CR 701.21a:
                     // whole-body reanimator-Aura GRANT-shape ETB effect (Necromancy) — a plain


### PR DESCRIPTION
CR 702.138a + CR 611.2c: targeted graveyard escape grants retain their compound-cost continuous effect and EOT duration in a single ordinary EffectChainIr clause. Trigger bodies now use that same producer; lower_trigger_ir newly applies finalize_effect_chain (inert), the owner-library anchor (inert), and ordinary optional/targeting transforms (not applicable, therefore inert).

full-pool card-data byte-identical (sha256 85ec32b31511fc30a0ddc822dcafe8f39cb8657b8aa7390048702ff12826ee85)
