### PR TITLE
refactor(parser): route try_parse_conditional_protection_grant_ability through EffectChainIr (P05-U3)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24769,17 +24769,20 @@ fn try_parse_repeat_process_directive(
 /// stripper peels the final clause's "if ..." and re-applies it across the whole
 /// grant. Each color keeps its own land condition, so no spurious outer condition
 /// is created.
-fn try_parse_conditional_protection_grant_ability(
+fn parse_conditional_protection_grant_ir(
     text: &str,
     kind: AbilityKind,
     ctx: &mut ParseContext,
-) -> Option<AbilityDefinition> {
+) -> Option<EffectChainIr> {
     let clause = subject::try_parse_conditional_protection_grant_clause(text, ctx)?;
-    let mut def = AbilityDefinition::new(kind, clause.effect);
-    if let Some(duration) = clause.duration {
-        def = def.duration(duration);
-    }
-    Some(def)
+    Some(EffectChainIr::single_clause(
+        text,
+        kind,
+        clause,
+        None,
+        ctx.actor.clone(),
+        ctx.in_trigger,
+    ))
 }
 
 /// CR 101.4 + CR 707.2 + CR 122.1: Whole-body detector for the WHO phenomena
@@ -25166,20 +25169,17 @@ pub(crate) enum ChainLoweringMode {
     WithContext,
 }
 
-/// Run the whole-body recognizers that build a definition directly, in order.
+/// U3 completion seam: dispatch any remaining whole-body recognizers in order.
 ///
-/// Returns `None` when the text falls through to the ordinary clause pipeline.
+/// The shared list is intentionally retained until U6 removes this escape hatch.
+/// Returns `None` when the text falls through to the ordinary IR pipeline.
 fn try_parse_chain_bypass(
     text: &str,
     kind: AbilityKind,
     mode: ChainLoweringMode,
-    ctx: &mut ParseContext,
+    _ctx: &mut ParseContext,
 ) -> Option<AbilityDefinition> {
-    // The remaining shared bypasses, in their established order. Only the first
-    // consults `ctx`.
-    if let Some(def) = try_parse_conditional_protection_grant_ability(text, kind, ctx) {
-        return Some(def);
-    }
+    // The remaining shared bypasses do not consult `ctx`.
     if let Some(def) = try_parse_for_each_attacker_copy_blocker(text, kind) {
         return Some(def);
     }
@@ -25210,7 +25210,31 @@ pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     def
 }
 
-fn parse_ability_ir(text: &str, kind: AbilityKind, ctx: &mut ParseContext) -> AbilityIr {
+fn parse_ability_ir(
+    text: &str,
+    kind: AbilityKind,
+    mode: ChainLoweringMode,
+    ctx: &mut ParseContext,
+) -> AbilityIr {
+    // The conditional protection recognizer may mutate `ParseContext` before
+    // declining. Preserve the two legacy entry-point semantics exactly: the
+    // standalone bypass context was fresh and discarded on decline, while the
+    // with-context entry point passed its caller context through to the ordinary
+    // chain path after a decline.
+    let conditional_protection = match mode {
+        ChainLoweringMode::Standalone => {
+            let mut bypass_ctx = ParseContext::default();
+            parse_conditional_protection_grant_ir(text, kind, &mut bypass_ctx)
+        }
+        ChainLoweringMode::WithContext => parse_conditional_protection_grant_ir(text, kind, ctx),
+    };
+    if let Some(body) = conditional_protection {
+        return AbilityIr {
+            source_text: text.to_string(),
+            body,
+            shell: AbilityShellIr::default(),
+        };
+    }
     if let Some(body) = parse_balance_equalization_ir(text, kind, ctx) {
         return AbilityIr {
             source_text: text.to_string(),
@@ -25240,7 +25264,12 @@ pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
     ) {
         return def;
     }
-    lower_ability_ir(&parse_ability_ir(text, kind, &mut ParseContext::default()))
+    lower_ability_ir(&parse_ability_ir(
+        text,
+        kind,
+        ChainLoweringMode::Standalone,
+        &mut ParseContext::default(),
+    ))
 }
 
 /// Parse a compound effect chain with subject context for pronoun resolution.
@@ -25254,7 +25283,12 @@ pub(crate) fn parse_effect_chain_with_context(
     if let Some(def) = try_parse_chain_bypass(text, kind, ChainLoweringMode::WithContext, ctx) {
         return def;
     }
-    lower_ability_ir(&parse_ability_ir(text, kind, ctx))
+    lower_ability_ir(&parse_ability_ir(
+        text,
+        kind,
+        ChainLoweringMode::WithContext,
+        ctx,
+    ))
 }
 
 /// CR 701.24a + CR 701.58a/e + CR 608.2c: Expose the Culprit mode 2 — "Exile any

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -14152,6 +14152,29 @@ fn grant_graveyard_keyword_ir_declines_self_mana_cost_siblings() {
     assert!(def.sub_ability.is_none());
 }
 
+#[test]
+fn conditional_protection_grant_routes_through_ability_ir() {
+    let def = parse_effect_chain(
+        "Until end of turn, creatures you control gain protection from white if you control a Plains, from blue if you control an Island, from black if you control a Swamp, from red if you control a Mountain, and from green if you control a Forest.",
+        AbilityKind::Spell,
+    );
+    let Effect::GenericEffect {
+        static_abilities,
+        duration,
+        ..
+    } = def.effect.as_ref()
+    else {
+        panic!(
+            "expected conditional protection grant, got {:?}",
+            def.effect
+        );
+    };
+    assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+    assert_eq!(def.duration, Some(Duration::UntilEndOfTurn));
+    assert_eq!(static_abilities.len(), 5);
+    assert!(def.sub_ability.is_none());
+}
+
 /// The extracted keyword-word → kind combinator (deduplicated with the static
 /// `each … has <kw>` clause) recognizes every graveyard-cast keyword.
 #[test]


### PR DESCRIPTION
CR 611.3a + CR 702.16: each protection color retains its separately conditioned continuous grant and EOT duration in one ordinary EffectChainIr clause. Standalone declines use a fresh discarded ParseContext; WithContext declines retain the caller context exactly as the bypass did. lower_ability_ir newly applies finalize_effect_chain (inert), owner-library anchoring (inert), and shell sub_link (none/inert).

full-pool card-data byte-identical (sha256 85ec32b31511fc30a0ddc822dcafe8f39cb8657b8aa7390048702ff12826ee85)
