### PR TITLE
refactor(parser): route try_parse_exile_pile_shuffle_cloak through EffectChainIr (P05-U3)

### DIFF
--- a/crates/engine/src/game/effects/cloak.rs
+++ b/crates/engine/src/game/effects/cloak.rs
@@ -315,8 +315,8 @@ mod tests {
     use crate::types::game_state::{ActionResult, WaitingFor};
     use crate::types::phase::Phase;
 
-    // Verbatim Oracle text so the runtime tests exercise the real parser branch
-    // (`try_parse_exile_pile_shuffle_cloak`) plus the whole
+    // Verbatim Oracle text so the runtime tests exercise the real WithContext
+    // parser branch (`parse_exile_pile_shuffle_cloak_ir`) plus the whole
     // ChooseObjectsIntoTrackedSet → Shuffle{TrackedSet} → Cloak{TrackedSet} chain.
     const EXPOSE_ORACLE: &str = "Choose one or both —\n\
         • Turn target face-down creature face up.\n\

--- a/crates/engine/src/game/off_zone_characteristics.rs
+++ b/crates/engine/src/game/off_zone_characteristics.rs
@@ -501,7 +501,7 @@ mod tests {
     /// graveyard" residual) makes a graveyard card castable via escape —
     /// `effective_escape_data` resolves the mana sub-cost (CR 601.2g) and surfaces
     /// the exile residual for `pay_additional_cost` (CR 601.2h). Runtime proof for
-    /// the parser front door `try_parse_grant_graveyard_keyword_to_target`
+    /// the parser front door `parse_grant_graveyard_keyword_to_target_ir`
     /// (Confession Dial / Desdemona). Tests the building block — a transient
     /// off-zone Escape grant — not a single card.
     #[test]

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -1958,27 +1958,32 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
             }
         }
         // CR 115.1d: Apply multi-target spec — prefer explicit choose-count text,
-        // then strip result, then clause-level propagation.
-        if let Some(spec) =
-            extract_exact_target_multi_target(clause_ir.source.fragment().unwrap_or_default())
-        {
-            def = def.multi_target(spec);
-        } else if let Some(spec) =
-            extract_bounded_target_multi_target(clause_ir.source.fragment().unwrap_or_default())
-        {
-            def = def.multi_target(spec);
-        } else if let Some(spec) =
-            extract_optional_target_multi_target(clause_ir.source.fragment().unwrap_or_default())
-        {
-            def = def.multi_target(spec);
-        } else if let Some(spec) =
-            extract_verb_up_to_multi_target(clause_ir.source.fragment().unwrap_or_default())
-        {
-            def = def.multi_target(spec);
-        } else if let Some(ref spec) = clause_ir.multi_target {
-            def = def.multi_target(spec.clone());
-        } else if let Some(ref spec) = clause_ir.parsed.multi_target {
-            def = def.multi_target(spec.clone());
+        // then strip result, then clause-level propagation. An explicit
+        // `ChooseObjectsIntoTrackedSet` instead owns its selection cardinality in
+        // the effect's `min`/`max`; adding `multi_target` would duplicate that
+        // resolver-owned selection state.
+        if !matches!(&*def.effect, Effect::ChooseObjectsIntoTrackedSet { .. }) {
+            if let Some(spec) =
+                extract_exact_target_multi_target(clause_ir.source.fragment().unwrap_or_default())
+            {
+                def = def.multi_target(spec);
+            } else if let Some(spec) =
+                extract_bounded_target_multi_target(clause_ir.source.fragment().unwrap_or_default())
+            {
+                def = def.multi_target(spec);
+            } else if let Some(spec) = extract_optional_target_multi_target(
+                clause_ir.source.fragment().unwrap_or_default(),
+            ) {
+                def = def.multi_target(spec);
+            } else if let Some(spec) =
+                extract_verb_up_to_multi_target(clause_ir.source.fragment().unwrap_or_default())
+            {
+                def = def.multi_target(spec);
+            } else if let Some(ref spec) = clause_ir.multi_target {
+                def = def.multi_target(spec.clone());
+            } else if let Some(ref spec) = clause_ir.parsed.multi_target {
+                def = def.multi_target(spec.clone());
+            }
         }
         if parse_controlled_by_different_players_target_constraint(
             clause_ir.source.fragment().unwrap_or_default(),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -25140,16 +25140,17 @@ fn rewrite_filter_prop_another_to_tracked_set(prop: &mut FilterProp) {
     }
 }
 
-/// Which whole-body bypass set a chain-lowering entry point runs.
+/// Which whole-body entry-point mode a chain-lowering call runs.
 ///
-/// The two entry points do **not** run the same set, and the difference is
-/// carried here as typed data rather than duplicated as two hand-maintained
+/// `try_parse_chain_bypass` is intentionally empty after U3c, but the two entry
+/// points still do **not** run the same whole-body recognizer set. The difference
+/// is carried here as typed data rather than duplicated as two hand-maintained
 /// `if let` stacks:
 ///
-/// | mode | bypasses | bypass #1's `ParseContext` |
+/// | mode | whole-body recognizers | context |
 /// |---|---|---|
-/// | `Standalone` | remaining shared recognizers | a fresh `default()`, discarded |
-/// | `WithContext` | the same recognizers as a strict prefix, plus `try_parse_exile_pile_shuffle_cloak` | the caller's real `ctx` |
+/// | `Standalone` | U3-complete shared list (empty); cloak is unavailable | a fresh `default()`, discarded |
+/// | `WithContext` | the same shared list, plus `parse_exile_pile_shuffle_cloak_ir` in `parse_ability_ir` | the caller's real `ctx` |
 ///
 /// Callers split cleanly: die-result branch bodies (`oracle_special.rs`) take
 /// `Standalone`; spell/activated dispatch takes `WithContext`.
@@ -25169,21 +25170,24 @@ pub(crate) enum ChainLoweringMode {
     WithContext,
 }
 
-/// U3 migration seam: dispatch any remaining whole-body recognizers in order.
+/// U3 completion seam: retain the now-empty bypass dispatcher until U6 deletes
+/// this escape hatch.
 ///
-/// The shared list is intentionally retained until U6 removes this escape hatch.
-/// Returns `None` when the text falls through to the ordinary IR pipeline.
+/// `ChainLoweringMode` remains the typed mode gate for the WithContext-only cloak
+/// IR producer in `parse_ability_ir`; removing either here would silently absorb
+/// the documented mode-asymmetry bug fix into this parity migration.
+/// Returns `None` so every recognizer lowers through ordinary ability IR.
 fn try_parse_chain_bypass(
-    text: &str,
-    kind: AbilityKind,
+    _text: &str,
+    _kind: AbilityKind,
     mode: ChainLoweringMode,
     _ctx: &mut ParseContext,
 ) -> Option<AbilityDefinition> {
-    // The shared bypass list is empty after U3c's third conversion. The
-    // mode-exclusive cloak recognizer remains until its ordered conversion.
+    // U3c completed the shared list and the formerly mode-exclusive cloak
+    // recognizer. Keep explicit arms: a future entry point must choose its mode.
     match mode {
         ChainLoweringMode::Standalone => None,
-        ChainLoweringMode::WithContext => try_parse_exile_pile_shuffle_cloak(text, kind),
+        ChainLoweringMode::WithContext => None,
     }
 }
 
@@ -25239,6 +25243,15 @@ fn parse_ability_ir(
             body,
             shell: AbilityShellIr::default(),
         };
+    }
+    if let ChainLoweringMode::WithContext = mode {
+        if let Some(body) = parse_exile_pile_shuffle_cloak_ir(text, kind, ctx) {
+            return AbilityIr {
+                source_text: text.to_string(),
+                body,
+                shell: AbilityShellIr::default(),
+            };
+        }
     }
     if let Some(body) = parse_balance_equalization_ir(text, kind, ctx) {
         return AbilityIr {
@@ -25316,7 +25329,11 @@ pub(crate) fn parse_effect_chain_with_context(
 ///
 /// The recognizer is deliberately narrow (the full pile/shuffle/cloak sentence
 /// is unique to this card) so it cannot swallow clauses on any other card.
-fn try_parse_exile_pile_shuffle_cloak(text: &str, kind: AbilityKind) -> Option<AbilityDefinition> {
+fn parse_exile_pile_shuffle_cloak_ir(
+    text: &str,
+    kind: AbilityKind,
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
     let lower = text.to_ascii_lowercase();
 
     // Head: "exile any number of face-up " — nom dispatch (the "any number of"
@@ -25349,37 +25366,82 @@ fn try_parse_exile_pile_shuffle_cloak(text: &str, kind: AbilityKind) -> Option<A
         id: crate::types::identifiers::TrackedSetId(0),
     };
 
-    // CR 701.58a/e: cloak them — exile-and-return each pile member face down.
-    let cloak = AbilityDefinition::new(
-        kind,
-        Effect::Cloak {
-            target: TargetFilter::Controller,
-            count: QuantityExpr::Fixed { value: 1 },
-            object_source: Some(tracked_sentinel.clone()),
-        },
-    );
-    // CR 701.24a: shuffle that pile — reorder the tracked set; the resolver emits
-    // no `ShuffledLibrary` action, so library-shuffle triggers do not fire.
-    let mut shuffle = AbilityDefinition::new(
-        kind,
-        Effect::Shuffle {
-            target: tracked_sentinel,
-        },
-    );
-    shuffle.sub_ability = Some(Box::new(cloak));
+    // CR 608.2c: retain the three nested legacy definitions as ordered ordinary
+    // clauses. The textual commas/then all stamp `ContinuationStep`, and the
+    // explicit continuation kind preserves the enclosing kind on every link.
+    let choose_source_len = text
+        .len()
+        .checked_sub(rest.len())?
+        .checked_add(filter_tp.original.len())?
+        .checked_add(" in a face-down pile".len())?;
+    let choose_source = text.get(..choose_source_len)?;
+    let shuffle_start = choose_source_len.checked_add(", ".len())?;
+    let shuffle_end = shuffle_start.checked_add("shuffle that pile".len())?;
+    let shuffle_source = text.get(shuffle_start..shuffle_end)?;
+    let cloak_start = shuffle_end.checked_add(", then ".len())?;
+    let cloak_end = cloak_start.checked_add("cloak them".len())?;
+    let cloak_source = text.get(cloak_start..cloak_end)?;
+
+    let mut builder = ClauseIrBuilder::new(text);
     // CR 608.2c: head — interactive selection of the eligible creatures into the
     // chain's tracked set (the "face-down pile").
-    let mut head = AbilityDefinition::new(
+    builder
+        .clause(
+            choose_source,
+            parsed_clause(Effect::ChooseObjectsIntoTrackedSet {
+                chooser: TargetFilter::Controller,
+                filter,
+                min: 0,
+                max: None,
+            }),
+            Some(ClauseBoundary::Comma),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+    // CR 701.24a: shuffle that pile — reorder the tracked set; the resolver emits
+    // no `ShuffledLibrary` action, so library-shuffle triggers do not fire.
+    builder
+        .clause(
+            shuffle_source,
+            parsed_clause(Effect::Shuffle {
+                target: tracked_sentinel.clone(),
+            }),
+            Some(ClauseBoundary::Then),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+    // CR 701.58a/e: cloak them — exile-and-return each pile member face down.
+    builder
+        .clause(
+            cloak_source,
+            parsed_clause(Effect::Cloak {
+                target: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 1 },
+                object_source: Some(tracked_sentinel),
+            }),
+            None,
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+    Some(EffectChainIr {
+        clauses: builder.finish(),
         kind,
-        Effect::ChooseObjectsIntoTrackedSet {
-            chooser: TargetFilter::Controller,
-            filter,
-            min: 0,
-            max: None,
-        },
-    );
-    head.sub_ability = Some(Box::new(shuffle));
-    Some(head)
+        continuation_kind: Some(kind),
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
+        chain_rounding: None,
+        actor: ctx.actor.clone(),
+        in_trigger: ctx.in_trigger,
+        repeat_until: None,
+    })
 }
 
 pub(crate) fn finalize_effect_chain(def: &mut AbilityDefinition) {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45615,6 +45615,10 @@ fn expose_the_culprit_mode2_lowers_to_choose_shuffle_cloak_chain() {
     assert_eq!(*chooser, TargetFilter::Controller);
     assert_eq!((*min, *max), (0, None));
     assert!(
+        head.multi_target.is_none(),
+        "tracked-set selection owns its cardinality in the effect, not multi_target"
+    );
+    assert!(
         matches!(filter, TargetFilter::Typed(t)
         if t.properties.iter().any(|p| matches!(
             p,
@@ -45651,6 +45655,34 @@ fn expose_the_culprit_mode2_lowers_to_choose_shuffle_cloak_chain() {
         ),
         "sub-sub must be Cloak{{object_source: Some(TrackedSet)}}, got {:?}",
         cloak.effect
+    );
+}
+
+/// The legacy bypass exposed the pile/shuffle/cloak recognizer only to the
+/// WithContext entry point. U3c routes it through `AbilityIr`, but retains that
+/// entry-point gate rather than making die-result (`Standalone`) callers newly
+/// recognize the card.
+#[test]
+fn exile_pile_shuffle_cloak_remains_with_context_only() {
+    let text = "Exile any number of face-up creatures you control with disguise in a face-down pile, shuffle that pile, then cloak them.";
+
+    let standalone = parse_effect_chain(text, AbilityKind::Spell);
+    assert!(
+        !matches!(
+            &*standalone.effect,
+            Effect::ChooseObjectsIntoTrackedSet { .. }
+        ),
+        "Standalone must not reach the WithContext-only pile recognizer: {standalone:?}"
+    );
+
+    let with_context =
+        parse_effect_chain_with_context(text, AbilityKind::Spell, &mut ParseContext::default());
+    assert!(
+        matches!(
+            &*with_context.effect,
+            Effect::ChooseObjectsIntoTrackedSet { .. }
+        ),
+        "WithContext must reach the pile recognizer: {with_context:?}"
     );
 }
 


### PR DESCRIPTION
CR 701.24a + CR 701.58a/e + CR 608.2c: the WithContext-only pile-selection, shuffle, and cloak chain retains its tracked-set links and enclosing kind while Standalone remains gated. Explicit tracked-set selection owns its min/max, so lowering does not add duplicate multi_target metadata. lower_ability_ir newly applies finalize_effect_chain (inert), owner-library anchoring (inert), and shell sub_link (none/inert).

full-pool card-data byte-identical (sha256 85ec32b31511fc30a0ddc822dcafe8f39cb8657b8aa7390048702ff12826ee85)
