### PR TITLE
Fix Tithe Taker: parse the dropped opponent-activator activated-ability cost tax

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -3033,11 +3033,14 @@ pub(crate) fn parse_static_line_inner(
     }
 
     // --- "Activated abilities cost {N} less/more to activate [unless they're mana abilities]" (global)
-    // --- "Abilities you activate [that aren't mana abilities] cost {N} less/more to activate" (activator) ---
-    // CR 601.2f + CR 118.7 + CR 605.1a: Unscoped (Suppression Field: "Activated
-    // abilities cost {2} more to activate unless they're mana abilities") or
-    // activator-scoped (Zirda, the Dawnwaker: "Abilities you activate that aren't
-    // mana abilities cost {2} less to activate") activated-ability cost modifier.
+    // --- "Abilities [you|your opponents] activate [that aren't mana abilities] cost {N} less/more to activate" (activator) ---
+    // CR 601.2f + CR 118.7 + CR 605.1a + CR 602.2: Unscoped (Suppression Field:
+    // "Activated abilities cost {2} more to activate unless they're mana
+    // abilities"), controller-activator (Zirda, the Dawnwaker: "Abilities you
+    // activate that aren't mana abilities cost {2} less to activate"), or
+    // opponent-activator (Tithe Taker: "abilities your opponents activate cost
+    // {1} more to activate unless they're mana abilities") activated-ability cost
+    // modifier.
     // The scoped "Activated abilities OF <subject>" form is owned by the branch
     // above; this handles the two subjects that carry no "of <subject>" filter.
     // `keyword == "activated"` matches every activated ability at runtime; the
@@ -3052,6 +3055,27 @@ pub(crate) fn parse_static_line_inner(
     if let Some(((activator, exemption, amount, mode), _)) =
         nom_on_lower(tp.original, tp.lower, |i| {
             let (i, (activator, prefix_exempt)) = alt((
+                // CR 602.2: opponent-activator scope — "abilities your opponents
+                // activate" (Tithe Taker) keys the adjustment off an OPPONENT of
+                // the static's controller activating the ability, not the
+                // controller. The runtime resolves `PlayerFilter::Opponent`
+                // against the static's controller (`is_opponent`) in
+                // `apply_one_reduce_ability_cost`. Ordered before the "you
+                // activate" arm so the longer, more specific subject is tried
+                // first. The target-restricted sibling (Kopala, Warden of Waves:
+                // "…activate that target a Merfolk you control cost {2}…") is NOT
+                // covered here — its intervening target clause breaks " cost {"
+                // and the branch declines (fail-closed); modeling that filter on
+                // `ReduceAbilityCost` is a separate runtime change.
+                map(
+                    (
+                        tag("abilities your opponents activate"),
+                        opt(tag(" that aren't mana abilities")),
+                    ),
+                    |(_, exempt): (&str, Option<&str>)| {
+                        (Some(PlayerFilter::Opponent), exempt.is_some())
+                    },
+                ),
                 map(
                     (
                         tag("abilities you activate"),

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1669,6 +1669,74 @@ pub(crate) fn parse_cant_win_lose_compound_statics(
     )
 }
 
+/// CR 601.2f + CR 602.2 + CR 604.1 + CR 611.3: Compound cost-tax static that
+/// conjoins a spell-cast cost modifier and an activated-ability cost modifier in
+/// one (optionally condition-scoped) sentence — "[<timing>,] spells <scope> cast
+/// cost {N} <more|less> to cast and abilities <scope> activate cost {M}
+/// <more|less> to activate [unless they're mana abilities]". The marquee member
+/// is Tithe Taker ("During your turn, spells your opponents cast cost {1} more to
+/// cast and abilities your opponents activate cost {1} more to activate unless
+/// they're mana abilities").
+///
+/// The single-return pipeline (`parse_static_line`) can emit at most one
+/// definition, so it keeps the cast half and SILENTLY drops the "and abilities …"
+/// activate half. This splits the conjunction at the cast/activate boundary and
+/// emits BOTH halves as independent statics (CR 611.3). CR 604.1: a leading
+/// timing condition ("During your turn,") scopes the whole conjunction — the cast
+/// half already carries it (the condition precedes the conjunction in the text),
+/// so it is propagated onto the otherwise-conditionless activate half. CR 602.2:
+/// the activate half's activator scope ("you"/"your opponents") is resolved by
+/// the reused single-line handler, not here.
+///
+/// The split is adopted ONLY when the cast half resolves to a `ModifyCost` static
+/// AND the activate half to a `ReduceAbilityCost` static, so any other "… and …"
+/// line (a dual anthem, a keyword grant, …) falls through to the generic handlers
+/// untouched.
+fn parse_compound_spell_and_ability_cost_tax(text: &str) -> Option<Vec<StaticDefinition>> {
+    let lower = text.to_lowercase();
+    // Gate: a spell-cast cost clause conjoined with an activated-ability cost
+    // clause. `scan_contains` matches at word boundaries (leading whitespace is
+    // trimmed), so the probe phrases must start on a word, not a space.
+    if !(nom_primitives::scan_contains(&lower, "to cast and ")
+        && nom_primitives::scan_contains(&lower, "to activate"))
+    {
+        return None;
+    }
+
+    // Split the conjunction into the cast clause (which retains any leading timing
+    // condition) and the activate clause. `take_until` matches the ASCII-lowercase
+    // marker verbatim in the original-case text, keeping the split combinator-driven.
+    const MARKER: &str = " to cast and ";
+    let (after_marker, before) = take_until::<_, _, OracleError<'_>>(MARKER)
+        .parse(text)
+        .ok()?;
+    let (activate_clause, _) = tag::<_, _, OracleError<'_>>(MARKER)
+        .parse(after_marker)
+        .ok()?;
+    // The cast clause is `before` plus the marker's leading " to cast" fragment.
+    let cast_clause = &text[..before.len() + " to cast".len()];
+
+    // Parse each half through the single-line pipeline; adopt only when both
+    // resolve to the expected cost-static shapes (CR 601.2f).
+    let mut cast_def = parse_static_line(cast_clause)?;
+    let mut activate_def = parse_static_line(activate_clause)?;
+    if !matches!(cast_def.mode, StaticMode::ModifyCost { .. })
+        || !matches!(activate_def.mode, StaticMode::ReduceAbilityCost { .. })
+    {
+        return None;
+    }
+
+    // CR 604.1: propagate the shared leading condition to the conditionless
+    // activate half so the tax is gated identically on both halves.
+    if activate_def.condition.is_none() {
+        activate_def.condition = cast_def.condition.clone();
+    }
+    // Preserve the full Oracle text on both emitted statics' `description`.
+    cast_def.description = Some(text.to_string());
+    activate_def.description = Some(text.to_string());
+    Some(vec![cast_def, activate_def])
+}
+
 fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
     let stripped = strip_reminder_text(text);
     let lower = stripped.to_lowercase();
@@ -1743,6 +1811,16 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
     // trigger per granted instance). Mirrors the exiled-object / color-conditional
     // grant handlers above (one static per listed keyword).
     if let Some(defs) = parse_spells_have_quoted_keyword_list(&stripped) {
+        return defs;
+    }
+
+    // CR 601.2f + CR 602.2 + CR 611.3: "[<timing>,] spells <scope> cast cost {N}
+    // <more|less> to cast and abilities <scope> activate cost {M} <more|less> to
+    // activate [unless they're mana abilities]" (Tithe Taker) — one cast-cost
+    // static + one activated-ability-cost static, both under the shared leading
+    // timing condition. Must precede the single-return fallback, which keeps the
+    // cast half and silently drops the "and abilities …" activate half.
+    if let Some(defs) = parse_compound_spell_and_ability_cost_tax(&stripped) {
         return defs;
     }
 

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1669,6 +1669,19 @@ pub(crate) fn parse_cant_win_lose_compound_statics(
     )
 }
 
+/// CR 601.2f: Split "<cast-cost clause> to cast and <activate-cost clause>" into
+/// its two clauses with composed combinators. `recognize` captures the cast
+/// clause THROUGH its "to cast" tail (so the reused single-line cost parser sees a
+/// complete "… cost {N} more to cast" clause); `tag(" and ")` consumes the
+/// conjunction; the remainder is the activate clause. Mirrors the `take_until` +
+/// `tag` split idiom used by the gated-combat tail parsers — no manual slicing.
+fn parse_compound_cost_tax_clauses(input: &str) -> OracleResult<'_, (&str, &str)> {
+    let (rest, cast_clause) =
+        recognize((take_until(" to cast and "), tag(" to cast"))).parse(input)?;
+    let (activate_clause, _) = tag(" and ").parse(rest)?;
+    Ok(("", (cast_clause, activate_clause)))
+}
+
 /// CR 601.2f + CR 602.2 + CR 604.1 + CR 611.3: Compound cost-tax static that
 /// conjoins a spell-cast cost modifier and an activated-ability cost modifier in
 /// one (optionally condition-scoped) sentence — "[<timing>,] spells <scope> cast
@@ -1703,18 +1716,11 @@ fn parse_compound_spell_and_ability_cost_tax(text: &str) -> Option<Vec<StaticDef
         return None;
     }
 
-    // Split the conjunction into the cast clause (which retains any leading timing
-    // condition) and the activate clause. `take_until` matches the ASCII-lowercase
-    // marker verbatim in the original-case text, keeping the split combinator-driven.
-    const MARKER: &str = " to cast and ";
-    let (after_marker, before) = take_until::<_, _, OracleError<'_>>(MARKER)
-        .parse(text)
-        .ok()?;
-    let (activate_clause, _) = tag::<_, _, OracleError<'_>>(MARKER)
-        .parse(after_marker)
-        .ok()?;
-    // The cast clause is `before` plus the marker's leading " to cast" fragment.
-    let cast_clause = &text[..before.len() + " to cast".len()];
+    // Split the conjunction with composed combinators (no manual slicing): the
+    // cast clause (which retains any leading timing condition) is `recognize`d
+    // THROUGH its "to cast" tail so the reused single-line parser sees a complete
+    // clause; the " and " conjunction and the trailing activate clause follow.
+    let (_, (cast_clause, activate_clause)) = parse_compound_cost_tax_clauses(text).ok()?;
 
     // Parse each half through the single-line pipeline; adopt only when both
     // resolve to the expected cost-static shapes (CR 601.2f).

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -22080,6 +22080,64 @@ fn static_activated_ability_cost_generic_reduce_vs_raise_discriminates() {
 }
 
 #[test]
+fn static_activated_ability_cost_opponent_activator_scope() {
+    // CR 602.2: "abilities your opponents activate" is activator-scoped on the
+    // OPPONENT axis — the tax keys off an opponent of the static's controller
+    // activating the ability (Tithe Taker), distinct from the "you activate"
+    // (controller) and bare "activated abilities" (unscoped) forms. (Kopala's
+    // target-restricted variant is a separate, not-yet-covered sibling.)
+    let raise = parse_static_line("Abilities your opponents activate cost {2} more to activate.")
+        .expect("opponent-activator raise must parse");
+    assert_eq!(
+        raise.mode,
+        StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Raise,
+            keyword: "activated".to_string(),
+            amount: 2,
+            minimum_mana: None,
+            dynamic_count: None,
+            exemption: ActivationExemption::None,
+            activator: Some(PlayerFilter::Opponent),
+        },
+    );
+
+    // CR 605.1a: the "unless they're mana abilities" suffix folds into the same
+    // opponent-scoped static as an `ActivationExemption::ManaAbilities` (Tithe
+    // Taker's exact ability clause).
+    let exempt = parse_static_line(
+        "Abilities your opponents activate cost {1} more to activate unless they're mana abilities.",
+    )
+    .expect("opponent-activator raise with exemption must parse");
+    assert_eq!(
+        exempt.mode,
+        StaticMode::ReduceAbilityCost {
+            mode: CostModifyMode::Raise,
+            keyword: "activated".to_string(),
+            amount: 1,
+            minimum_mana: None,
+            dynamic_count: None,
+            exemption: ActivationExemption::ManaAbilities,
+            activator: Some(PlayerFilter::Opponent),
+        },
+    );
+
+    // Regression: the pre-existing controller-activator form (Zirda) is
+    // unchanged by the added opponent branch — same grammar, `you` → Controller.
+    let you = parse_static_line(
+        "Abilities you activate that aren't mana abilities cost {2} less to activate.",
+    )
+    .expect("controller-activator reduce must still parse");
+    let StaticMode::ReduceAbilityCost {
+        mode, activator, ..
+    } = &you.mode
+    else {
+        panic!("expected ReduceAbilityCost, got {:?}", you.mode);
+    };
+    assert_eq!(*mode, CostModifyMode::Reduce);
+    assert_eq!(*activator, Some(PlayerFilter::Controller));
+}
+
+#[test]
 fn static_possessive_equip_ability_cost_reduction_self_ref() {
     // Firion, Wild Rose Warrior's granted equip-cost reduction leaf:
     // "This Equipment's equip abilities cost {2} less to activate." Keyed on the

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -22137,6 +22137,37 @@ fn static_activated_ability_cost_opponent_activator_scope() {
     assert_eq!(*activator, Some(PlayerFilter::Controller));
 }
 
+/// CR 601.2f + CR 611.3: the composed cast/activate split (Tithe Taker) emits
+/// BOTH the spell-cast `ModifyCost` and the activated-ability `ReduceAbilityCost`
+/// statics from one line, each carrying the shared leading `DuringYourTurn`
+/// condition. Regression for the combinator-driven `parse_compound_cost_tax_clauses`
+/// split (no manual slicing): the single-return path keeps only the cast half.
+#[test]
+fn compound_cost_tax_line_splits_into_cast_and_ability_statics() {
+    let defs = parse_static_line_multi(
+        "During your turn, spells your opponents cast cost {1} more to cast and abilities your opponents activate cost {1} more to activate unless they're mana abilities.",
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "compound line must split into cast + ability statics, got {defs:?}",
+    );
+    let cast = defs
+        .iter()
+        .find(|d| matches!(d.mode, StaticMode::ModifyCost { .. }))
+        .expect("spell-cast half");
+    let ability = defs
+        .iter()
+        .find(|d| matches!(d.mode, StaticMode::ReduceAbilityCost { .. }))
+        .expect("activated-ability half");
+    assert_eq!(cast.condition, Some(StaticCondition::DuringYourTurn));
+    assert_eq!(
+        ability.condition,
+        Some(StaticCondition::DuringYourTurn),
+        "the leading condition must propagate to the activate half",
+    );
+}
+
 #[test]
 fn static_possessive_equip_ability_cost_reduction_self_ref() {
     // Firion, Wild Rose Warrior's granted equip-cost reduction leaf:

--- a/crates/engine/tests/integration/issue_3872_tithe_taker_turn_scoped_tax.rs
+++ b/crates/engine/tests/integration/issue_3872_tithe_taker_turn_scoped_tax.rs
@@ -16,12 +16,15 @@
 //! cost-modification resolver, which passes the caster as the scope player.
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
-use engine::parser::oracle_static::parse_static_line;
-use engine::types::ability::StaticCondition;
+use engine::parser::oracle_static::{parse_static_line, parse_static_line_multi};
+use engine::types::ability::{PlayerFilter, StaticCondition};
 use engine::types::actions::GameAction;
 use engine::types::game_state::{CastPaymentMode, WaitingFor};
 use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::statics::{ActivationExemption, CostModifyMode, StaticMode};
 
 const TITHE_TAKER: &str = "During your turn, spells your opponents cast cost {1} more to cast and abilities your opponents activate cost {1} more to activate unless they're mana abilities.";
 
@@ -110,5 +113,155 @@ fn tithe_taker_taxes_opponent_during_controllers_turn() {
         resolved_cost_mana_value(&mut runner, spell_id),
         1,
         "During the Tithe Taker controller's turn, the opponent's spell must be taxed by {{1}}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Ability-cost half — "abilities your opponents activate cost {1} more to
+// activate unless they're mana abilities" (previously dropped silently).
+// ---------------------------------------------------------------------------
+
+const POOL_UNITS: usize = 5;
+
+/// P0 controls Tithe Taker (wired from the production multi-parse, so it carries
+/// BOTH cost statics). P1 (an opponent) controls a permanent with a `{1}`
+/// non-mana activated ability and a funded mana pool. Announce the activation as
+/// P1 during `active`'s turn, finalize the mana payment from the pool, and
+/// return how much generic mana the activation consumed (the taxed cost).
+fn mana_consumed_activating_opponent_ability(active: PlayerId) -> usize {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // BOTH statics from the compound line (the ability half is the fix under test).
+    {
+        let mut b = scenario.add_creature(P0, "Tithe Taker", 1, 2);
+        for def in parse_static_line_multi(TITHE_TAKER) {
+            b.with_static_definition(def);
+        }
+    }
+
+    // P1's permanent with a plain `{1}` activated ability (NOT a mana ability).
+    let pinger = scenario
+        .add_creature_from_oracle(P1, "Test Pinger", 1, 1, "{1}: You gain 1 life.")
+        .id();
+
+    // Source auto-tap is not modeled; fund the pool so payment finalizes from it.
+    let pool: Vec<ManaUnit> = (0..POOL_UNITS)
+        .map(|_| ManaUnit::new(ManaType::White, ObjectId(0), false, vec![]))
+        .collect();
+    scenario.with_mana_pool(P1, pool);
+
+    let mut runner = scenario.build();
+    // Hand P1 priority to activate; `active` decides whose turn it is.
+    {
+        let state = runner.state_mut();
+        state.active_player = active;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: pinger,
+            ability_index: 0,
+        })
+        .expect("P1 announces its {1} activated ability");
+    // Finalize the mana payment from the funded pool (mirrors AbilityActivation:
+    // PassPriority pays from the pool since source auto-tap is not modeled).
+    for _ in 0..8 {
+        if matches!(runner.state().waiting_for, WaitingFor::ManaPayment { .. }) {
+            runner
+                .act(GameAction::PassPriority)
+                .expect("finalize the ability's mana payment from the pool");
+        } else {
+            break;
+        }
+    }
+
+    let remaining = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .expect("P1 exists")
+        .mana_pool
+        .total();
+    POOL_UNITS - remaining
+}
+
+#[test]
+fn tithe_taker_compound_line_yields_cast_and_ability_cost_statics() {
+    // The production multi-parse of the full compound line must emit BOTH the
+    // spell-cast tax and the activated-ability tax — the ability half was
+    // previously dropped silently (the single-return pipeline kept only the cast
+    // half). CR 602.2: opponent-activator-scoped; CR 605.1a: mana abilities are
+    // exempt; CR 604.1: it inherits the leading "During your turn" gate.
+    let defs = parse_static_line_multi(TITHE_TAKER);
+    assert_eq!(
+        defs.len(),
+        2,
+        "the compound line must yield the cast + ability statics, got {defs:?}",
+    );
+    assert!(
+        defs.iter()
+            .any(|d| matches!(d.mode, StaticMode::ModifyCost { .. })),
+        "the spell-cast tax half must be present",
+    );
+    let ability = defs
+        .iter()
+        .find(|d| matches!(d.mode, StaticMode::ReduceAbilityCost { .. }))
+        .expect("the activated-ability tax half must be present (was silently dropped)");
+    assert_eq!(
+        ability.condition,
+        Some(StaticCondition::DuringYourTurn),
+        "the ability half inherits the shared \"During your turn\" gate",
+    );
+    let StaticMode::ReduceAbilityCost {
+        mode,
+        amount,
+        activator,
+        exemption,
+        ..
+    } = &ability.mode
+    else {
+        unreachable!("filtered to ReduceAbilityCost above")
+    };
+    assert_eq!(*mode, CostModifyMode::Raise);
+    assert_eq!(*amount, 1);
+    assert_eq!(
+        *activator,
+        Some(PlayerFilter::Opponent),
+        "the tax keys off an OPPONENT activating the ability (CR 602.2)",
+    );
+    assert_eq!(
+        *exemption,
+        ActivationExemption::ManaAbilities,
+        "\"unless they're mana abilities\" exempts mana abilities (CR 605.1a)",
+    );
+}
+
+#[test]
+fn tithe_taker_taxes_opponent_activated_ability_during_controllers_turn() {
+    // On the Tithe Taker controller's (P0's) turn, an opponent's {1} activated
+    // ability is taxed to {2} — the opponent-activator ability-cost static
+    // applies end-to-end (parse -> runtime). Reverting the parser fix drops the
+    // ability static, so the activation would consume only {1} and this fails.
+    assert_eq!(
+        mana_consumed_activating_opponent_ability(P0),
+        2,
+        "on the controller's turn, an opponent's {{1}} ability must cost {{2}}",
+    );
+}
+
+#[test]
+fn tithe_taker_does_not_tax_opponent_activated_ability_on_their_own_turn() {
+    // On the opponent's (P1's) OWN turn, the "During your turn" gate (P0's turn)
+    // is not satisfied, so the same {1} ability costs {1} — no tax. This is the
+    // differential that proves the DuringYourTurn gate is honored on the ability
+    // half (CR 604.1), not merely that some tax exists.
+    assert_eq!(
+        mana_consumed_activating_opponent_ability(P1),
+        1,
+        "on the opponent's own turn the DuringYourTurn gate is off; the ability costs {{1}}",
     );
 }


### PR DESCRIPTION
## Summary
Fixes the silently-dropped **opponent-activator activated-ability cost tax** for **Tithe Taker**.

Tithe Taker's static — *"During your turn, spells your opponents cast cost {1} more to cast and abilities your opponents activate cost {1} more to activate unless they're mana abilities"* — parsed only the spell-cast half. The single-return static pipeline kept the cast tax and **silently dropped** the `and abilities your opponents activate …` activate half, so an opponent's activated abilities were never taxed.

Two composable parser building blocks fix the whole class:

1. **Opponent-activator scope** (`oracle_static/dispatch.rs`): the activator-scoped activated-ability cost handler now accepts the **opponent** activator subject (`"abilities your opponents activate …"`) alongside the existing controller (`"abilities you activate"`, Zirda) and unscoped (`"activated abilities"`, Suppression Field) forms — a leaf parameterization of the activator axis (`you → {you, opponents}`). The runtime already resolves `PlayerFilter::Opponent` against the static's controller (`is_opponent`) and already supports `Raise` + the mana-ability exemption, so this is **parse-only**.
2. **Compound cast+activate split** (`oracle_static/shared.rs`): a multi-static handler splits the `<cast-cost clause> and <activate-cost clause>` conjunction and emits **both** halves as independent statics, propagating the shared leading `During your turn` condition (CR 604.1) onto the activate half. Adopted only when the cast half is a `ModifyCost` static **and** the activate half a `ReduceAbilityCost` static, so unrelated `… and …` lines are untouched.

### Parse impact (before → after) — Tithe Taker's full line
- **Before:** `1` static — `ModifyCost { Raise, {1} }` (opponent, `DuringYourTurn`); the ability half dropped with no diagnostic.
- **After:** `2` statics — the cast `ModifyCost` **plus** `ReduceAbilityCost { Raise, amount 1, activator: Opponent, exemption: ManaAbilities, condition: DuringYourTurn }`.

## Files changed
- `crates/engine/src/parser/oracle_static/dispatch.rs`
- `crates/engine/src/parser/oracle_static/shared.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`
- `crates/engine/tests/integration/issue_3872_tithe_taker_turn_scoped_tax.rs`

## CR references
- `CR 601.2f` — cost determination (increases/reductions)
- `CR 602.2` — activating an ability / activator scope
- `CR 604.1` — static abilities function continuously; the `condition` gate
- `CR 605.1a` — mana-ability exemption ("unless they're mana abilities")
- `CR 611.3` — a continuous effect generated by a static ability (multi-static emission)

## Implementation method (required)
Method: not-applicable — targeted two-function parser fix extending existing dense handlers in `oracle_static/{dispatch,shared}.rs`. Implemented directly, then an independent fresh-context review-impl pass (§5.3) was run on the committed diff (result in **Final review-impl** below).

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean (exit 0)
- `cargo test -p engine --lib parser::oracle_static` — **1188 passed; 0 failed** (full parser module incl. snapshot tests)
- `cargo test -p engine --lib static_activated_ability_cost` — 3 passed (new opponent-activator parser unit test + existing activator tests)
- `cargo test -p engine --test integration issue_3872` — **6 passed; 0 failed** (2 pre-existing spell-cost tests + AST assertion + 2 runtime ability-cost differentials + parse-condition test)
- `cargo clippy -p engine --all-targets --features proptest` — clean, exit 0, no warnings
- Gate A coverage/semantic-audit (`cargo coverage`, `cargo semantic-audit`): not run locally — both read `client/public/card-data.json`, which is stale in this checkout, and the audit binaries currently drift against the card-data schema. CI owns these checks.

## Gate A
Gate A PASS head=6581342846fb37f15f1c6296eeb307927f51c4a4 base=4e26c7ed709bb43f508891058ae518cebe9079ae
<!-- coverage/semantic-audit deferred to CI per Verification note above -->

## Anchored on
- `crates/engine/src/parser/oracle_static/dispatch.rs:3088` — the existing activator-scoped ability-cost `alt` (controller + unscoped arms) that the opponent arm parameterizes.
- `crates/engine/src/parser/oracle_static/restriction.rs:19` (`parse_cast_and_activate_only_during`, City of Solitude) — the established compound-line → `Vec<StaticDefinition>` split-and-emit pattern the new handler mirrors.
- `crates/engine/src/game/casting.rs:15757` — runtime `player_may_begin_activating` already resolves `PlayerFilter::Opponent` via `is_opponent`; `casting.rs:17802` already applies `CostModifyMode::Raise` (`increase_generic_in_cost`), so no runtime change was needed.

## Final review-impl
Final review-impl PASS head=6581342846fb37f15f1c6296eeb307927f51c4a4

An independent fresh-context review-impl was run on the committed diff (handed only the unified diff + `CLAUDE.md`). Result: **no blocking defects** — correct seam, nom-mandate compliant, all five CR citations verified real and authorizing, offset math panic-safe, the `scan_contains` leading-space subtlety handled correctly, and the compound-split gate has no false-positive risk (requires `ModifyCost` cast half + `ReduceAbilityCost` activate half). The runtime differentials were confirmed genuinely discriminating and revert-failing (the DuringYourTurn gate is honored via `active_static_definitions` condition filtering, not merely asserted). One accuracy finding — two comments named Kopala as covered, but its `that target a Merfolk you control` target-restriction makes the branch decline (fail-closed) — was addressed in this head (the comments now annotate Kopala as the deferred target-restricted sibling).

## Claimed parse impact
- Tithe Taker
<!-- Also enables the standalone opponent-activator form ("Abilities your opponents activate cost {N} more to activate [unless they're mana abilities]"). Kopala, Warden of Waves' ability half remains deferred: its "that target a Merfolk you control" target-filter is not yet modeled on ReduceAbilityCost (runtime/types scope, out of scope here). -->

## Validation Failures
None.

## CI Failures
None.
