### PR TITLE
refactor(parser): lower monarch fallback through the trigger EffectChain arm (P05-U4)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11,8 +11,10 @@ use super::oracle_effect::{
     condition_text_is_rehomeable, lower_effect_chain_ir, parse_effect_chain_ir,
     try_parse_reanimator_aura_etb_effect, try_parse_reanimator_aura_grant_etb_effect,
 };
+use super::oracle_ir::ast::parsed_clause;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::doc::PrintedTriggerIndex;
+use super::oracle_ir::effect_chain::EffectChainIr;
 use super::oracle_ir::trigger::{FirstTimeLimit, TriggerBody, TriggerIr, TriggerModifiers};
 use super::oracle_modal::try_parse_inline_modal;
 use super::oracle_nom::condition::parse_inner_condition;
@@ -1397,13 +1399,17 @@ pub(crate) fn parse_trigger_line_with_index_ir(
         || scan_contains(&effect_for_parse_lower, "any number of target");
     let body = if !effect_for_parse.is_empty() {
         if parse_monarch_turn_began_condition(effect_for_parse_lower.as_str()).is_some() {
-            Some(TriggerBody::PreLowered(Box::new(AbilityDefinition::new(
+            Some(TriggerBody::EffectChain(EffectChainIr::single_clause(
+                &effect_for_parse,
                 AbilityKind::Spell,
-                Effect::Unimplemented {
-                    name: "Unsupported monarch turn-began condition".to_string(),
-                    description: Some(effect_for_parse.clone()),
-                },
-            ))))
+                parsed_clause(Effect::unimplemented(
+                    "Unsupported monarch turn-began condition",
+                    &effect_for_parse,
+                )),
+                None,
+                effect_ctx.actor.clone(),
+                effect_ctx.in_trigger,
+            )))
         // CR 701.38 + CR 207.2c: Vote blocks produce AbilityDefinition directly.
         } else if let Some(vote_def) =
             crate::parser::oracle_vote::parse_vote_block(&effect_for_parse, AbilityKind::Spell)


### PR DESCRIPTION
CR summary: CR 603.2/603.3 preserves the triggered ability body as an explicit unsupported instruction; CR 603.5 optionality remains applied by trigger lowering.

Transform asymmetry:
- finalize_effect_chain: inert; each finalizer gates on supported chain shapes (RevealUntil, labeled choice, Dig, ChangeSpeed, tracked selection, or combat-restriction chains), never Effect::Unimplemented.
- mana-scope rebind: inert; its gate additionally requires Effect::Mana, while this body remains Effect::Unimplemented.
- optional_targeting: inert; it requires a concrete non-context target filter, which Effect::Unimplemented has none.
- optional: already applied by both the legacy PreLowered arm and the EffectChain arm.

full-pool card-data byte-identical (sha256 85ec32b31511fc30a0ddc822dcafe8f39cb8657b8aa7390048702ff12826ee85)
