### PR TITLE
refactor(parser): lower reanimator Aura through the trigger EffectChain arm (P05-U4)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -12110,16 +12110,18 @@ pub(crate) fn parse_grant_graveyard_keyword_to_target_ir(
 /// checked ("both present, both open with `enchant`") — never semantically parsed —
 /// and a fixed `RemoveKeyword`/`AddKeyword` pair is always emitted.
 ///
-/// Returns the fully-constructed 4-node effect chain directly, bypassing the
-/// per-clause chunker. Declines (returns `None`) unless the ENTIRE body matches,
-/// so any card whose text deviates stays an honest `Effect::Unimplemented`.
+/// Returns one typed root clause whose nested continuation chain preserves the
+/// class's source-rebind structure. Declines (returns `None`) unless the ENTIRE
+/// body matches, so any card whose text deviates stays an honest
+/// `Effect::Unimplemented`.
 ///
-/// See `build_aura_attach_chain` for why each node uses the anaphor it
+/// See `build_aura_attach_clause` for why each node uses the anaphor it
 /// does (source-rebind interplay with `ChangeZone { forward_result: true }`).
-pub(crate) fn try_parse_reanimator_aura_etb_effect(
+pub(crate) fn try_parse_reanimator_aura_etb_effect_ir(
     text: &str,
     kind: AbilityKind,
-) -> Option<AbilityDefinition> {
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
     let stripped = super::oracle_util::strip_reminder_text(text);
     let lower = stripped.to_lowercase();
     let tap_state =
@@ -12127,11 +12129,18 @@ pub(crate) fn try_parse_reanimator_aura_etb_effect(
     // CR 613.1f: Animate Dead / Dance of the Dead are printed as Auras, so the
     // ETB swaps the printed Enchant restriction (Swap) and refers back to the
     // already-established attachment via `TargetFilter::AttachedTo`.
-    Some(build_aura_attach_chain(
+    Some(EffectChainIr::single_clause(
+        text,
         kind,
-        tap_state,
-        EnchantGrantShape::Swap,
-        TargetFilter::AttachedTo,
+        build_aura_attach_clause(
+            tap_state,
+            EnchantGrantShape::Swap,
+            TargetFilter::AttachedTo,
+            kind,
+        ),
+        None,
+        ctx.actor.clone(),
+        ctx.in_trigger,
     ))
 }
 
@@ -12204,23 +12213,26 @@ fn parse_reanimator_aura_etb_body(i: &str) -> OracleResult<'_, crate::types::zon
 /// only via the shared `parse_quoted_enchant_clause` (never semantically
 /// parsed), matching the swap shape.
 ///
-/// Returns the fully-constructed 4-node chain via `build_aura_attach_chain`
-/// with `EnchantGrantShape::GrantOnly` and the genuinely-parsed target.
+/// Returns one typed root clause with `EnchantGrantShape::GrantOnly` and the
+/// genuinely-parsed target.
 /// Declines (returns `None`) unless the ENTIRE body matches, so any card whose
 /// text deviates stays an honest `Effect::Unimplemented`.
-pub(crate) fn try_parse_reanimator_aura_grant_etb_effect(
+pub(crate) fn try_parse_reanimator_aura_grant_etb_effect_ir(
     text: &str,
     kind: AbilityKind,
-) -> Option<AbilityDefinition> {
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
     let stripped = super::oracle_util::strip_reminder_text(text);
     let lower = stripped.to_lowercase();
     let (target, tap_state) =
         super::oracle_nom::bridge::nom_parse_lower(&lower, parse_reanimator_aura_grant_etb_shape)?;
-    Some(build_aura_attach_chain(
+    Some(EffectChainIr::single_clause(
+        text,
         kind,
-        tap_state,
-        EnchantGrantShape::GrantOnly,
-        target,
+        build_aura_attach_clause(tap_state, EnchantGrantShape::GrantOnly, target, kind),
+        None,
+        ctx.actor.clone(),
+        ctx.in_trigger,
     ))
 }
 
@@ -12285,9 +12297,10 @@ enum EnchantGrantShape {
     GrantOnly,
 }
 
-/// Build the reanimator-Aura attach chain shared by the two ETB shapes:
-/// `try_parse_reanimator_aura_etb_effect` (swap; Animate Dead / Dance of the
-/// Dead) and `try_parse_reanimator_aura_grant_etb_effect` (grant; Necromancy).
+/// Build the reanimator-Aura root clause shared by the two ETB shapes:
+/// `try_parse_reanimator_aura_etb_effect_ir` (swap; Animate Dead / Dance of
+/// the Dead) and `try_parse_reanimator_aura_grant_etb_effect_ir` (grant;
+/// Necromancy).
 /// Two documented parameters vary across call sites: the producer target of the
 /// root `ChangeZone` (`root_target` — `AttachedTo` for the swap shape, whose
 /// creature was chosen at cast time via the printed Enchant restriction; a
@@ -12316,12 +12329,12 @@ enum EnchantGrantShape {
 ///   leaves-battlefield condition watches the Aura, and its `Sacrifice { ParentTarget }`
 ///   snapshots the creature at delayed-trigger creation time (CR 701.21a /
 ///   CR 603.7c: "that creature's controller sacrifices it").
-fn build_aura_attach_chain(
-    kind: AbilityKind,
+fn build_aura_attach_clause(
     tap_state: crate::types::zones::EtbTapState,
     shape: EnchantGrantShape,
     root_target: TargetFilter,
-) -> AbilityDefinition {
+    kind: AbilityKind,
+) -> ParsedEffectClause {
     // CR 701.21a + CR 603.7c: "When ~ leaves the battlefield, that creature's
     // controller sacrifices it." — delayed leaves-battlefield sacrifice of the
     // reanimated creature (ParentTarget, snapshotted at creation).
@@ -12390,28 +12403,25 @@ fn build_aura_attach_chain(
     // CR 608.2c + CR 400.7: ROOT — return/put the enchanted creature card to the
     // battlefield under the caster's control (follow the instruction, CR 608.2c).
     // The card becomes a NEW object on arrival (CR 400.7), which is why
-    // `forward_result` rebinds the sub-chain source to the reanimated creature;
-    // set explicitly (not by auto-detection).
-    let mut root = AbilityDefinition::new(
-        kind,
-        Effect::ChangeZone {
-            origin: Some(Zone::Graveyard),
-            destination: Zone::Battlefield,
-            target: root_target,
-            owner_library: false,
-            enter_transformed: false,
-            enters_under: Some(ControllerRef::You),
-            enter_tapped: tap_state,
-            enters_attacking: false,
-            up_to: false,
-            enter_with_counters: vec![],
-            conditional_enter_with_counters: vec![],
-            face_down_profile: None,
-            enters_modified_if: None,
-        },
-    )
-    .sub_ability(generic);
-    root.forward_result = true;
+    // `forward_result` rebinds the sub-chain source to the reanimated creature.
+    // The effect-chain assembler recognizes the typed nested anaphora and sets
+    // that flag during ordinary lowering.
+    let mut root = parsed_clause(Effect::ChangeZone {
+        origin: Some(Zone::Graveyard),
+        destination: Zone::Battlefield,
+        target: root_target,
+        owner_library: false,
+        enter_transformed: false,
+        enters_under: Some(ControllerRef::You),
+        enter_tapped: tap_state,
+        enters_attacking: false,
+        up_to: false,
+        enter_with_counters: vec![],
+        conditional_enter_with_counters: vec![],
+        face_down_profile: None,
+        enters_modified_if: None,
+    });
+    root.sub_ability = Some(Box::new(generic));
     root
 }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9,7 +9,7 @@ use nom::Parser;
 
 use super::oracle_effect::{
     condition_text_is_rehomeable, lower_effect_chain_ir, parse_effect_chain_ir,
-    try_parse_reanimator_aura_etb_effect, try_parse_reanimator_aura_grant_etb_effect,
+    try_parse_reanimator_aura_etb_effect_ir, try_parse_reanimator_aura_grant_etb_effect_ir,
 };
 use super::oracle_ir::ast::parsed_clause;
 use super::oracle_ir::context::ParseContext;
@@ -1452,47 +1452,49 @@ pub(crate) fn parse_trigger_line_with_index_ir(
             // it, and register the leaves-battlefield sacrifice. Fail-closed:
             // declines unless the entire body matches, so a deviating card
             // stays an honest Unimplemented rather than misparsing.
-            try_parse_reanimator_aura_etb_effect(&effect_for_parse, AbilityKind::Spell)
-                .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
-                .or_else(|| {
-                    // CR 603.3d + CR 608.2c + CR 613.1d + CR 613.1f + CR 701.3a + CR 701.21a:
-                    // whole-body reanimator-Aura GRANT-shape ETB effect (Necromancy) — a plain
-                    // (non-Aura) enchantment whose ETB ability becomes an Aura AND targets the
-                    // graveyard creature to reanimate itself (unlike the swap shape above,
-                    // which targets at CAST time via its printed Enchant restriction and
-                    // refers back to `TargetFilter::AttachedTo` here). Fail-closed: declines
-                    // unless the entire body matches, so a deviating card stays an honest
-                    // Unimplemented rather than misparsing.
-                    try_parse_reanimator_aura_grant_etb_effect(
-                        &effect_for_parse,
-                        AbilityKind::Spell,
-                    )
-                    .map(|ability| TriggerBody::PreLowered(Box::new(ability)))
-                })
-                .or_else(|| {
-                    // CR 700.2 + CR 608.2d: Inline modal trigger body — "choose one —
-                    // mode1; or mode2" on a single line (no bullet-line modes). No
-                    // printed card currently reaches this branch: it needs an em-dash
-                    // *and* "; or " inside one trigger effect body. (Grenzo, Havoc
-                    // Raiser — long named here as the canonical case — uses bullet-line
-                    // modes, so `raw_modes.len() == 1` and it never arrives.) Route
-                    // through the modal parser so each mode body is independently
-                    // parsed with the trigger's established relative_player_scope (e.g.
-                    // TriggeringPlayer for DamageDone triggers) so "that player" in mode
-                    // bodies resolves to the damaged player (CR 603.7c).
-                    if let Some(modal_ability) = try_parse_inline_modal(
-                        &effect_for_parse,
-                        effect_ctx.relative_player_scope.clone(),
-                    ) {
-                        return Some(TriggerBody::PreLowered(Box::new(modal_ability)));
-                    }
-                    let ir = parse_effect_chain_ir(
-                        &effect_for_parse,
-                        AbilityKind::Spell,
-                        &mut effect_ctx,
-                    );
-                    Some(TriggerBody::EffectChain(ir))
-                })
+            try_parse_reanimator_aura_etb_effect_ir(
+                &effect_for_parse,
+                AbilityKind::Spell,
+                &effect_ctx,
+            )
+            .map(TriggerBody::EffectChain)
+            .or_else(|| {
+                // CR 603.3d + CR 608.2c + CR 613.1d + CR 613.1f + CR 701.3a + CR 701.21a:
+                // whole-body reanimator-Aura GRANT-shape ETB effect (Necromancy) — a plain
+                // (non-Aura) enchantment whose ETB ability becomes an Aura AND targets the
+                // graveyard creature to reanimate itself (unlike the swap shape above,
+                // which targets at CAST time via its printed Enchant restriction and
+                // refers back to `TargetFilter::AttachedTo` here). Fail-closed: declines
+                // unless the entire body matches, so a deviating card stays an honest
+                // Unimplemented rather than misparsing.
+                try_parse_reanimator_aura_grant_etb_effect_ir(
+                    &effect_for_parse,
+                    AbilityKind::Spell,
+                    &effect_ctx,
+                )
+                .map(TriggerBody::EffectChain)
+            })
+            .or_else(|| {
+                // CR 700.2 + CR 608.2d: Inline modal trigger body — "choose one —
+                // mode1; or mode2" on a single line (no bullet-line modes). No
+                // printed card currently reaches this branch: it needs an em-dash
+                // *and* "; or " inside one trigger effect body. (Grenzo, Havoc
+                // Raiser — long named here as the canonical case — uses bullet-line
+                // modes, so `raw_modes.len() == 1` and it never arrives.) Route
+                // through the modal parser so each mode body is independently
+                // parsed with the trigger's established relative_player_scope (e.g.
+                // TriggeringPlayer for DamageDone triggers) so "that player" in mode
+                // bodies resolves to the damaged player (CR 603.7c).
+                if let Some(modal_ability) = try_parse_inline_modal(
+                    &effect_for_parse,
+                    effect_ctx.relative_player_scope.clone(),
+                ) {
+                    return Some(TriggerBody::PreLowered(Box::new(modal_ability)));
+                }
+                let ir =
+                    parse_effect_chain_ir(&effect_for_parse, AbilityKind::Spell, &mut effect_ctx);
+                Some(TriggerBody::EffectChain(ir))
+            })
         }
     } else {
         None


### PR DESCRIPTION
CR 608.2c / 400.7 / 701.3a / 701.21a: represent the reanimator-Aura ETB class as a typed ChangeZone root clause with its existing generic, attach, and delayed-sacrifice continuation chain. Shared chain assembly re-establishes forward_result from the typed ParentTarget anaphora.

Transform disposition: finalize_effect_chain inert (no RevealUntil+ForEachCategoryExile, labeled choice, reorder-only Dig, speed-floor, tracked-choice exclusion, or additional-combat shape); mana-scope rebind inert (root is ChangeZone, not Mana); target-choice timing newly applies and is rules-correct for the two swap-shape cards (CR 115.1d + CR 608.2d: the non-targeted graveyard move selects its AttachedTo referent while resolving, so explicit Resolution replaces the wrong implicit Stack default); optional_targeting inert (no has_up_to root-target case in either shape); optional equivalent (neither shape is optional, and both old/new paths apply trigger optionality).

BYTE-DIFF PENDING LEAD ADJUDICATION: full-pool export differs only for Animate Dead and Dance of the Dead. In each, target_choice_timing changes Stack -> Resolution; all 35,394 other faces are byte-identical. CR 603.3d / 608.2d supports the new byte: the triggered ability is placed on the stack before its non-targeted attached-card ChangeZone instruction selects the already attached card during resolution. BASE SHA 85ec32b31511fc30a0ddc822dcafe8f39cb8657b8aa7390048702ff12826ee85; new SHA f5158df2fc7577f3a32143072d48e168dc54858953f7a554c7645279dedb9be3.

BYTE-DIFF ADJUDICATED (lead-approved): corpus diff vs BASE_SHA is exactly Animate Dead and Dance of the Dead, single field triggers[0].execute.target_choice_timing default-Stack -> Resolution. CR 115.1d: the ETB instruction names no target, so the trigger is non-targeted and a stack-time target demand was wrong; CR 608.2d places the choice during resolution.
