### PR TITLE
Fix bare color-category & historic spell-cost modifiers dropping their filter (Herald of Kozilek, Ugin, Urza's Filter)

### DIFF
--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -76,13 +76,16 @@ fn parse_bare_spell_subject_filter(base: &str) -> Option<TargetFilter> {
         ));
     }
     // CR 700.6: "historic" = legendary supertype, artifact card type, or Saga subtype.
-    if lower == "historic" {
+    if all_consuming(tag::<_, _, OracleError<'_>>("historic"))
+        .parse(lower.as_str())
+        .is_ok()
+    {
         return Some(TargetFilter::Typed(
             TypedFilter::card().properties(vec![FilterProp::Historic]),
         ));
     }
     // CR 205.4a: a lone supertype word ("legendary", "snow", ...).
-    parse_bare_supertype_spell_filter(base)
+    parse_bare_supertype_spell_filter(&lower)
 }
 
 /// CR 202.3: Nom parse of a trailing "with/of mana value N or greater/less"

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -53,6 +53,38 @@ fn parse_bare_supertype_spell_filter(base: &str) -> Option<TargetFilter> {
     ])))
 }
 
+/// CR 105.2 + CR 700.6 + CR 205.4a + CR 601.2f: Resolve a BARE-word spell-subject
+/// filter for a cost modifier — a color or color-CATEGORY ("white", "colorless",
+/// "monocolored", "multicolored"), "historic", or a supertype ("legendary").
+/// `parse_type_phrase` declines all of these because they carry no trailing type
+/// noun (it needs "white creature", not a lone "white"), so without this the
+/// whole restriction dropped and the cost modifier (mis)applied to EVERY spell.
+///
+/// The color word routes through the single [`nom_filter::parse_color_property`]
+/// authority, so the color-CATEGORY axis resolves identically to the noun-bearing
+/// path: colorless → `ColorCount { EQ, 0 }`, monocolored → `{ EQ, 1 }`,
+/// multicolored → `{ GE, 2 }`, a named color → `HasColor`. The prior fallback
+/// hand-rolled only the five named colors via `parse_named_color`, so it dropped
+/// the category axis (Herald of Kozilek, Ugin, Urza's Filter, It That Heralds the
+/// End) and "historic" (Jhoira's Familiar) — all of which then cheapened every spell.
+fn parse_bare_spell_subject_filter(base: &str) -> Option<TargetFilter> {
+    let lower = base.trim().to_ascii_lowercase();
+    // CR 105.2: color / color-category, via the single color-property authority.
+    if let Ok((_, prop)) = all_consuming(nom_filter::parse_color_property).parse(lower.as_str()) {
+        return Some(TargetFilter::Typed(
+            TypedFilter::card().properties(vec![prop]),
+        ));
+    }
+    // CR 700.6: "historic" = legendary supertype, artifact card type, or Saga subtype.
+    if lower == "historic" {
+        return Some(TargetFilter::Typed(
+            TypedFilter::card().properties(vec![FilterProp::Historic]),
+        ));
+    }
+    // CR 205.4a: a lone supertype word ("legendary", "snow", ...).
+    parse_bare_supertype_spell_filter(base)
+}
+
 /// CR 202.3: Nom parse of a trailing "with/of mana value N or greater/less"
 /// (also "or more"/"or fewer") qualifier — returns the prefix BEFORE the
 /// qualifier plus the `FilterProp::Cmc` it selects. Fails (nom `Err`) when no
@@ -197,17 +229,14 @@ fn parse_cost_mod_spell_type_prefix(type_desc: &str) -> Option<TargetFilter> {
             TargetFilter::Or { filters } if !filters.is_empty() && remainder.is_empty() => {
                 Some(filter)
             }
-            // Bare color words ("white", "red") and bare supertype words
-            // ("legendary") are not consumed by parse_type_phrase, which requires
-            // a trailing type noun ("white creature", "legendary permanent").
+            // Bare color/color-category words ("white", "colorless",
+            // "multicolored"), "historic", and bare supertype words ("legendary")
+            // are not consumed by parse_type_phrase, which requires a trailing type
+            // noun ("white creature", "legendary permanent"). Route them through
+            // the single bare-subject authority so the color-category axis is not
+            // dropped (CR 105.2 + CR 700.6 + CR 205.4a).
             _ if remainder.is_empty() || remainder.eq_ignore_ascii_case(base_part) => {
-                parse_named_color(base_part)
-                    .map(|color| {
-                        TargetFilter::Typed(
-                            TypedFilter::card().properties(vec![FilterProp::HasColor { color }]),
-                        )
-                    })
-                    .or_else(|| parse_bare_supertype_spell_filter(base_part))
+                parse_bare_spell_subject_filter(base_part)
             }
             _ => None,
         }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1716,6 +1716,84 @@ fn cost_mod_no_mana_value_gate_unchanged() {
     );
 }
 
+/// CR 105.2 + CR 700.6 + CR 205.4a + CR 601.2f: a BARE-word spell-subject filter
+/// for a cost modifier resolves the full color-CATEGORY axis (colorless /
+/// monocolored / multicolored → `ColorCount`), "historic" (→ `Historic`), a named
+/// color (→ `HasColor`), and a supertype (→ `HasSupertype`) — routed through the
+/// single `parse_color_property` authority. Before the fix, the bare-word fallback
+/// hand-rolled only the five named colors, so "Colorless"/"Multicolored"/
+/// "Historic" spell subjects dropped the whole restriction (`spell_filter: None`)
+/// and the modifier (mis)applied to EVERY spell (Herald of Kozilek, Ugin, Urza's
+/// Filter, It That Heralds the End, Jhoira's Familiar).
+#[test]
+fn cost_mod_bare_color_category_and_historic_subject() {
+    fn props(line: &str) -> Vec<FilterProp> {
+        let def = parse_static_line(line).unwrap_or_else(|| panic!("{line} should parse"));
+        let StaticMode::ModifyCost { spell_filter, .. } = def.mode else {
+            panic!("expected ModifyCost for {line}");
+        };
+        match spell_filter.unwrap_or_else(|| panic!("{line} dropped its spell filter")) {
+            TargetFilter::Typed(tf) => tf.properties,
+            other => panic!("expected Typed for {line}, got {other:?}"),
+        }
+    }
+
+    // Color-category axis (the fix): each maps to the same ColorCount the
+    // noun-bearing path already produced.
+    assert_eq!(
+        props("Colorless spells you cast cost {1} less to cast."),
+        vec![FilterProp::ColorCount {
+            comparator: Comparator::EQ,
+            count: 0,
+        }],
+    );
+    assert_eq!(
+        props("Multicolored spells cost {2} less to cast."),
+        vec![FilterProp::ColorCount {
+            comparator: Comparator::GE,
+            count: 2,
+        }],
+    );
+    assert_eq!(
+        props("Monocolored spells cost {1} more to cast."),
+        vec![FilterProp::ColorCount {
+            comparator: Comparator::EQ,
+            count: 1,
+        }],
+    );
+    assert_eq!(
+        props("Historic spells you cast cost {1} less to cast."),
+        vec![FilterProp::Historic],
+    );
+    // Composes with a trailing mana-value qualifier (It That Heralds the End).
+    assert_eq!(
+        props("Colorless spells you cast with mana value 7 or greater cost {1} less to cast."),
+        vec![
+            FilterProp::ColorCount {
+                comparator: Comparator::EQ,
+                count: 0,
+            },
+            FilterProp::Cmc {
+                comparator: Comparator::GE,
+                value: QuantityExpr::Fixed { value: 7 },
+            },
+        ],
+    );
+    // Regression: named-color and supertype paths are unchanged.
+    assert_eq!(
+        props("White spells your opponents cast cost {1} more to cast."),
+        vec![FilterProp::HasColor {
+            color: crate::types::mana::ManaColor::White,
+        }],
+    );
+    assert_eq!(
+        props("Legendary spells you cast cost {1} less to cast."),
+        vec![FilterProp::HasSupertype {
+            value: crate::types::card_type::Supertype::Legendary,
+        }],
+    );
+}
+
 /// CR 508.1c + CR 509.1b: Grant + dual-gated restrictions emit the pump grant
 /// plus both gated combat statics on the enchanted/equipped host.
 #[test]

--- a/crates/engine/tests/integration/colorless_spell_cost_reduction.rs
+++ b/crates/engine/tests/integration/colorless_spell_cost_reduction.rs
@@ -1,0 +1,113 @@
+//! Bare color-category spell-cost modifiers ("Colorless/Multicolored spells …
+//! cost {N} less to cast") must scope the reduction to the color category, not
+//! every spell. Herald of Kozilek / Ugin, the Ineffable / Urza's Filter / It That
+//! Heralds the End previously parsed with `spell_filter: None`, so the modifier
+//! cheapened EVERY spell.
+//!
+//! CR 105.2: an object's colors; a colorless object has zero colors
+//! (`ColorCount { EQ, 0 }`). CR 601.2f: cost reductions apply during cost
+//! determination. The bare-word fallback now routes color words through the
+//! single `parse_color_property` authority, so a bare "Colorless" resolves to the
+//! same `ColorCount { EQ, 0 }` filter the noun-bearing path ("Colorless creature
+//! spells") already produced.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::parser::oracle_static::parse_static_line;
+use engine::types::ability::{Effect, QuantityExpr, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+
+const HERALD: &str = "Colorless spells you cast cost {1} less to cast.";
+
+/// Add a targeting instant (so casting surfaces `TargetSelection`, where the
+/// battlefield-modified cost is readable) with an explicit mana cost + derived
+/// color.
+fn add_targeted_spell(scenario: &mut GameScenario, name: &str, cost: ManaCost) -> ObjectId {
+    let mut b = scenario.add_spell_to_hand(P0, name, true);
+    b.with_mana_cost(cost);
+    b.with_ability(Effect::DealDamage {
+        amount: QuantityExpr::Fixed { value: 2 },
+        target: TargetFilter::Any,
+        damage_source: None,
+        excess: None,
+    });
+    b.id()
+}
+
+/// Cast the spell and return the mana value of the battlefield-modified cost the
+/// engine resolved (read at `TargetSelection`, before payment).
+fn resolved_cost_mv(runner: &mut GameRunner, spell_id: ObjectId) -> u32 {
+    let card_id = runner.state().objects[&spell_id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the test spell should begin");
+    match &runner.state().waiting_for {
+        WaitingFor::TargetSelection { pending_cast, .. } => pending_cast.cost.mana_value(),
+        other => panic!("expected TargetSelection after casting, got {other:?}"),
+    }
+}
+
+/// Build a P0 board with the bare-colorless cost reducer plus one test spell of
+/// `cost`, cast it, and return the resolved cost's mana value.
+fn resolved_cost_under_reducer(name: &str, cost: ManaCost) -> u32 {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain); // active player = P0
+    scenario
+        .add_creature(P0, "Colorless Cost Reducer", 2, 4)
+        .with_static_definition(parse_static_line(HERALD).expect("HERALD static parses"));
+    let spell = add_targeted_spell(&mut scenario, name, cost);
+    let mut runner = scenario.build();
+    resolved_cost_mv(&mut runner, spell)
+}
+
+#[test]
+fn bare_colorless_static_parses_to_color_count_filter() {
+    // The bare-word subject must resolve to a color-category filter, not None.
+    let def = parse_static_line(HERALD).expect("HERALD static parses");
+    let StaticMode::ModifyCost { spell_filter, .. } = def.mode else {
+        panic!("expected ModifyCost, got {:?}", def.mode);
+    };
+    let filter = spell_filter.expect("colorless restriction must not be dropped (was `None`)");
+    let dbg = format!("{filter:?}");
+    assert!(
+        dbg.contains("ColorCount") && dbg.contains("EQ") && dbg.contains("0"),
+        "bare \"Colorless spells\" must carry ColorCount{{EQ,0}}, got {dbg}",
+    );
+}
+
+#[test]
+fn bare_colorless_reducer_discounts_a_colorless_spell() {
+    // A {3}-generic (colorless) spell is reduced by {1} → mana value 2.
+    assert_eq!(
+        resolved_cost_under_reducer("Test Colorless Spell", ManaCost::generic(3)),
+        2,
+        "a colorless spell must get the {{1}} discount (ColorCount{{EQ,0}} matches)",
+    );
+}
+
+#[test]
+fn bare_colorless_reducer_does_not_discount_a_colored_spell() {
+    // A {2}{R} (red) spell must NOT be reduced → mana value stays 3. This is the
+    // revert-failing assertion: before the fix the static parsed with
+    // `spell_filter: None` and reduced EVERY spell, dropping this to 2.
+    assert_eq!(
+        resolved_cost_under_reducer(
+            "Test Red Spell",
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 2,
+            },
+        ),
+        3,
+        "a colored spell must NOT get the colorless-only discount",
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -64,6 +64,7 @@ mod claim_jumper_repeat;
 mod cleave_text_changing_cost;
 mod cloud_key_chosen_type_cost;
 mod coalition_relic_integration;
+mod colorless_spell_cost_reduction;
 mod combat_celebrant_exert;
 mod combat_damage_order_triggers_no_hang;
 mod companion_special_action;

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4760
-- **Total card appearances across root causes:** 4794 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4758
+- **Total card appearances across root causes:** 4792 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -12,7 +12,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
-| 1 | Relative-clause / filter restriction on target dropped | 748 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
+| 1 | Relative-clause / filter restriction on target dropped | 746 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
 | 2 | Dropped intervening-if / gating condition (condition: null) | 606 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
@@ -47,7 +47,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 ## Full card lists per root cause
 
-### 1. Relative-clause / filter restriction on target dropped  (748 cards)
+### 1. Relative-clause / filter restriction on target dropped  (746 cards)
 
 **Signature.** TargetFilter/affected emitted with empty or missing properties; a trailing restrictive clause (type, subtype, color, mana value, zone, combat/temporal/control predicate, exclusion) is silently dropped, over-broadening the filter.
 
@@ -383,7 +383,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Iridian Maelstrom
 - Isamaru and Yoshimaru
 - Isareth the Awakener
-- It That Heralds the End
 - Iterative Analysis
 - Ivorytusk Fortress
 - Jabari's Influence
@@ -733,7 +732,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Urborg Panther
 - Urborg Phantom
 - Ursine Fylgja
-- Urza's Filter
 - Urza's Hot Tub
 - Valley Questcaller
 - Vampire Socialite


### PR DESCRIPTION
## Summary
Fixes the dropped-filter misparse for **bare color-category & "historic" spell-cost modifiers**.

`"Colorless spells you cast cost {N} less to cast"` (**Herald of Kozilek**, **Ugin, the Ineffable**, **It That Heralds the End**), `"Multicolored spells cost {N} less to cast"` (**Urza's Filter**), and `"Historic spells you cast cost {N} less"` (**Jhoira's Familiar**) all parsed with **`spell_filter: None`** — the color-category / historic restriction was silently dropped, so the modifier wrongly cheapened **every** spell instead of only the named category.

**Root cause:** the bare-word fallback in `parse_cost_mod_spell_type_prefix` (`static_helpers.rs`) hand-rolled only the five **named** colors via `parse_named_color`. A bare `colorless`/`monocolored`/`multicolored` matched neither that nor `parse_bare_supertype_spell_filter`, so the whole filter returned `None`. (The noun-bearing path — "Colorless **creature** spells" — already produced the correct `ColorCount` via `parse_type_phrase`.)

**Fix (single-authority parameterization):** route the bare-word subject through one `parse_bare_spell_subject_filter` authority that resolves the color word via the existing **`nom_filter::parse_color_property`** combinator, so the color-CATEGORY axis resolves identically to the noun-bearing path — colorless → `ColorCount{EQ,0}`, monocolored → `{EQ,1}`, multicolored → `{GE,2}`, named color → `HasColor` — plus `historic` → `FilterProp::Historic` and the pre-existing bare-supertype path. This replaces the partial `parse_named_color` special-case with the complete color-property authority and composes with the trailing mana-value qualifier (It That Heralds the End → `ColorCount + Cmc`). **Parse-only**: `FilterProp::ColorCount` and `Historic` already exist and are evaluated by the spell-cost filter path.

### Parse impact (before → after)
| Card | Oracle | Before | After |
|---|---|---|---|
| Herald of Kozilek / Ugin | "Colorless spells you cast cost {N} less" | `None` (all spells) | `ColorCount{EQ,0}` |
| Urza's Filter | "Multicolored spells cost {2} less" | `None` | `ColorCount{GE,2}` |
| It That Heralds the End | "Colorless spells … with mana value 7 or greater cost {1} less" | `Cmc{GE,7}` only (colorless dropped) | `ColorCount{EQ,0} + Cmc{GE,7}` |
| Jhoira's Familiar | "Historic spells you cast cost {1} less" | `None` | `Historic` |

## Files changed
- `crates/engine/src/parser/oracle_static/static_helpers.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`
- `crates/engine/tests/integration/colorless_spell_cost_reduction.rs`
- `crates/engine/tests/integration/main.rs`
- `docs/parser-misparse-backlog.md`

## CR references
- `CR 105.2` — an object's colors; a colorless object has zero colors (`ColorCount{EQ,0}`)
- `CR 205.4a` — supertypes (the bare-supertype fallback)
- `CR 700.6` — "historic" = legendary supertype, artifact card type, or Saga subtype
- `CR 601.2f` — cost determination (cost reductions apply here)

## Implementation method (required)
Method: not-applicable — targeted single-function parser fix in an existing dense handler (`static_helpers.rs`). Implemented directly, then an independent fresh-context review-impl pass (§5.3) was run on the committed diff (result in **Final review-impl** below).

## Track
Developer

## LLM
Model: claude-opus-4-8
Thinking: high

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean (exit 0)
- `cargo test -p engine --lib parser::oracle_static` — **1195 passed; 0 failed** (full parser module incl. snapshot tests)
- `cargo test -p engine --lib cost_mod_bare_color_category_and_historic_subject` — passed (new parser unit test over the full bare-subject axis + named-color/supertype regression + MV composition)
- `cargo test -p engine --test integration colorless_spell_cost_reduction` — **3 passed; 0 failed** (AST + runtime cast-cost differential: colorless discounted, colored NOT)
- `cargo clippy -p engine --all-targets --features proptest` — clean, exit 0, no warnings
- Gate A coverage/semantic-audit (`cargo coverage`, `cargo semantic-audit`): not run locally — both read `client/public/card-data.json`, which is stale in this checkout, and the audit binaries currently drift against the card-data schema. CI owns these checks.

## Gate A
Gate A PASS head=81509d05d8cabda8e8a957db03da50c7f07e5aff base=0d7783c4e93dc364761735663348bbc03b1a6300
<!-- coverage/semantic-audit deferred to CI per Verification note above -->

## Anchored on
- `crates/engine/src/parser/oracle_static/static_helpers.rs:46` (`parse_bare_supertype_spell_filter`) — the sibling bare-word fallback this new authority mirrors and composes.
- `crates/engine/src/parser/oracle_nom/filter.rs:432` (`parse_color_property`) — the pre-existing single color-property authority the fix routes through (colorless/monocolored/multicolored → `ColorCount`, named colors → `HasColor`).
- `crates/engine/src/game/filter.rs:3261` — the spell-cost filter path already evaluates `FilterProp::ColorCount` and `FilterProp::Historic`, so no runtime/type change was needed (the working noun-path "Colorless creature spells" resolves through the same authority).

## Final review-impl
Final review-impl PASS head=81509d05d8cabda8e8a957db03da50c7f07e5aff

An independent fresh-context review-impl was run on the committed diff (handed only the unified diff + `CLAUDE.md`). Result: **no defects**. Confirmed: correct seam (the bare-subject fallback of `parse_cost_mod_spell_type_prefix`); genuine reuse of the single `parse_color_property` authority, behavior-preserving for the five named colors (`parse_named_color` still used elsewhere, not left dead); nom-mandate compliant (`lower == "historic"` is a single CR 700.6 game-term equality, not a verbatim Oracle-text match); all four CR citations real and authorizing; correct composition with the trailing mana-value qualifier (`ColorCount{EQ,0} + Cmc{GE,7}` for It That Heralds the End); no false positives (non-category words still fall through to `None`); mixed-case safe (the helper lowercases its own input); and the runtime cast-cost differential is genuinely revert-failing and non-vacuous (on revert the `None` filter matches every spell, dropping the `{2}{R}` spell from mv 3 to 2). Backlog hygiene verified internally consistent.

## Claimed parse impact
- Herald of Kozilek
- Ugin, the Ineffable
- Urza's Filter
- It That Heralds the End
- Jhoira's Familiar (parse of the cost line is fixed; the card retains a separate, unrelated unimplemented ability, so it stays in the backlog under root cause #23)
<!-- Backlog hygiene: removed It That Heralds the End and Urza's Filter from root cause #1 (both now parse fully clean); decremented #1 count 748→746 and the aggregate distinct/appearance counts by 2. -->

## Validation Failures
None.

## CI Failures
None.
