### PR TITLE
refactor(parser): lower inline modal through the trigger EffectChain arm (P05-U4)

### DIFF
--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -8,8 +8,8 @@ use serde::Serialize;
 
 use super::effect_chain::EffectChainIr;
 use crate::types::ability::{
-    AbilityDefinition, ControllerRef, TargetFilter, TriggerCondition, TriggerConstraint,
-    TriggerDefinition, UnlessPayModifier,
+    AbilityDefinition, ControllerRef, ModalChoice, TargetFilter, TriggerCondition,
+    TriggerConstraint, TriggerDefinition, UnlessPayModifier,
 };
 use crate::types::triggers::TriggerMode;
 
@@ -26,7 +26,7 @@ pub(crate) struct TriggerIr {
     /// Carries typed fields (`valid_card`, `origin`, `destination`, `phase`,
     /// `damage_kind`, etc.) that lowering merges into the final output.
     pub(crate) partial_def: TriggerDefinition,
-    /// The parsed effect body as an IR (or pre-lowered for vote blocks).
+    /// The parsed effect body as typed IR.
     pub(crate) body: Option<TriggerBody>,
     /// Extracted modifier fields.
     pub(crate) modifiers: TriggerModifiers,
@@ -34,14 +34,31 @@ pub(crate) struct TriggerIr {
     pub(crate) source_text: String,
 }
 
-/// The body of a trigger: either an effect chain IR (normal path) or a
-/// pre-lowered `AbilityDefinition` (vote block fallback).
+/// The body of a trigger. Whole-body recognizers retain their typed payloads
+/// here so trigger lowering owns all root-level transforms.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) enum TriggerBody {
     /// Normal effect chain — lowering calls `lower_effect_chain_ir`.
     EffectChain(EffectChainIr),
+    /// CR 700.2: An inline modal's marker clause and its already-lowered mode
+    /// bodies. The marker still flows through ordinary trigger-chain lowering;
+    /// this payload carries the modal metadata no clause can represent.
+    Modal(Box<ModalIr>),
     /// Pre-lowered ability (vote blocks produce `AbilityDefinition` directly).
     PreLowered(Box<AbilityDefinition>),
+}
+
+/// CR 700.2: Typed inline-modal trigger body.
+///
+/// The root marker is an ordinary effect chain so trigger lowering applies the
+/// same finalization, mana-scope, optional-targeting, and optional transforms
+/// as every other trigger. `ModalChoice` and the independently parsed mode
+/// bodies are root metadata rather than a pre-lowered root definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ModalIr {
+    pub(crate) marker: EffectChainIr,
+    pub(crate) choice: ModalChoice,
+    pub(crate) mode_abilities: Vec<AbilityDefinition>,
 }
 
 /// Modifier fields extracted during IR production.

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -19,6 +19,8 @@ use super::oracle::{find_activated_colon, strip_activated_constraints};
 use super::oracle_cost::parse_oracle_cost;
 use super::oracle_effect::{parse_effect_chain_with_context, try_parse_named_choice};
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::effect_chain::EffectChainIr;
+use super::oracle_ir::trigger::ModalIr;
 use super::oracle_nom::bridge::nom_on_lower;
 use super::oracle_nom::condition as nom_condition;
 use super::oracle_nom::primitives::{self as nom_primitives, scan_preceded};
@@ -26,7 +28,9 @@ use super::oracle_quantity::parse_cda_quantity;
 use super::oracle_static::{parse_pt_mod, parse_static_line};
 use super::oracle_trigger::parse_trigger_lines;
 use super::oracle_util::{parse_mana_symbols, strip_reminder_text, TextPair};
-use crate::parser::oracle_ir::ast::{ModalHeaderAst, ModalOptionality, ModeAst, OracleBlockAst};
+use crate::parser::oracle_ir::ast::{
+    parsed_clause, ModalHeaderAst, ModalOptionality, ModeAst, OracleBlockAst,
+};
 
 pub(crate) fn parse_oracle_block(lines: &[&str], start: usize) -> Option<(OracleBlockAst, usize)> {
     let line = strip_reminder_text(lines.get(start)?.trim());
@@ -1043,7 +1047,7 @@ pub(crate) fn lower_oracle_block(
             // the single-authority scope resolver expects. Without this, bullet-
             // line modes hit the `unwrap_or(ControllerRef::You)` fallback in
             // `oracle_target.rs` while the inline `"; or"` form (which threads the
-            // same scope via `try_parse_inline_modal`) resolved correctly — the
+            // same scope via `try_parse_inline_modal_ir`) resolved correctly — the
             // two modal surface forms of Grenzo, Havoc Raiser disagreed (#2346).
             let relative_player_scope = super::oracle_trigger::relative_player_scope_for_condition(
                 &trigger_line.to_lowercase(),
@@ -1298,7 +1302,7 @@ pub(crate) fn build_modal_ability(
 /// controls"` / `"that player's library"` anaphor resolves to the player the
 /// condition introduced (the damaged player) rather than falling back to the
 /// caster (`ControllerRef::You`). This mirrors the inline `"; or"` modal path
-/// (`try_parse_inline_modal`); both must thread the same scope so bullet-line
+/// (`try_parse_inline_modal_ir`); both must thread the same scope so bullet-line
 /// and inline modal forms of the same trigger agree (issue #2346).
 fn build_modal_ability_with_subject(
     kind: AbilityKind,
@@ -1511,10 +1515,7 @@ pub(crate) fn lower_mode_abilities_with_scope(
 /// The `relative_player_scope` from the trigger condition (e.g.
 /// `TriggeringPlayer` for DamageDone triggers) is propagated into every mode
 /// body so "that player" anaphora resolve to the correct player.
-pub(crate) fn try_parse_inline_modal(
-    effect_body: &str,
-    relative_player_scope: Option<crate::types::ability::ControllerRef>,
-) -> Option<AbilityDefinition> {
+pub(crate) fn try_parse_inline_modal_ir(effect_body: &str, ctx: &ParseContext) -> Option<ModalIr> {
     let em_dash_pos = effect_body.find('\u{2014}')?;
     let header_text = effect_body[..em_dash_pos].trim();
     let modes_text = effect_body[em_dash_pos + '\u{2014}'.len_utf8()..].trim();
@@ -1548,13 +1549,21 @@ pub(crate) fn try_parse_inline_modal(
         &modes,
         AbilityKind::Spell,
         None,
-        relative_player_scope,
+        ctx.relative_player_scope.clone(),
         None,
     );
-    Some(
-        AbilityDefinition::new(AbilityKind::Spell, modal_marker_effect(&header))
-            .with_modal(build_modal_choice(&header, &modes), mode_abilities),
-    )
+    Some(ModalIr {
+        marker: EffectChainIr::single_clause(
+            effect_body,
+            AbilityKind::Spell,
+            parsed_clause(modal_marker_effect(&header)),
+            None,
+            ctx.actor.clone(),
+            ctx.in_trigger,
+        ),
+        choice: build_modal_choice(&header, &modes),
+        mode_abilities,
+    })
 }
 
 /// Replace a parsed mode ability with `Effect::Unimplemented` when the mode body
@@ -2004,6 +2013,27 @@ fn scan_modal_count_override(text: &str) -> Option<ModalCountSpec> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn inline_modal_ir_keeps_marker_and_modes_typed() {
+        let modal = try_parse_inline_modal_ir(
+            "Choose one — Draw a card; or Create a Treasure token.",
+            &ParseContext::default(),
+        )
+        .expect("inline modal should parse into typed trigger IR");
+
+        assert_eq!(modal.marker.clauses.len(), 1);
+        assert!(matches!(
+            modal.marker.clauses[0].parsed.effect,
+            Effect::GenericEffect { .. }
+        ));
+        assert_eq!(modal.choice.mode_count, 2);
+        assert_eq!(modal.mode_abilities.len(), 2);
+        assert!(modal
+            .mode_abilities
+            .iter()
+            .all(|mode| { !matches!(mode.effect.as_ref(), Effect::Unimplemented { .. }) }));
+    }
 
     #[test]
     fn extract_ability_word_reminder_body_increment() {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -16,7 +16,7 @@ use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::doc::PrintedTriggerIndex;
 use super::oracle_ir::effect_chain::EffectChainIr;
 use super::oracle_ir::trigger::{FirstTimeLimit, TriggerBody, TriggerIr, TriggerModifiers};
-use super::oracle_modal::try_parse_inline_modal;
+use super::oracle_modal::try_parse_inline_modal_ir;
 use super::oracle_nom::condition::parse_inner_condition;
 use super::oracle_nom::condition::{parse_source_counters_exist, parse_source_has_counters};
 use super::oracle_nom::error::{oracle_err, OracleResult};
@@ -1485,11 +1485,8 @@ pub(crate) fn parse_trigger_line_with_index_ir(
                 // parsed with the trigger's established relative_player_scope (e.g.
                 // TriggeringPlayer for DamageDone triggers) so "that player" in mode
                 // bodies resolves to the damaged player (CR 603.7c).
-                if let Some(modal_ability) = try_parse_inline_modal(
-                    &effect_for_parse,
-                    effect_ctx.relative_player_scope.clone(),
-                ) {
-                    return Some(TriggerBody::PreLowered(Box::new(modal_ability)));
+                if let Some(modal) = try_parse_inline_modal_ir(&effect_for_parse, &effect_ctx) {
+                    return Some(TriggerBody::Modal(Box::new(modal)));
                 }
                 let ir =
                     parse_effect_chain_ir(&effect_for_parse, AbilityKind::Spell, &mut effect_ctx);
@@ -1574,6 +1571,48 @@ fn mode_exposes_subject_batch(mode: &TriggerMode) -> bool {
     )
 }
 
+/// Lower a trigger body through the ordinary effect-chain transforms.
+///
+/// CR 603.5 + CR 115.1d: Typed trigger bodies with root metadata (such as an
+/// inline modal) use this same path before attaching that metadata, so the
+/// trigger's optionality and target semantics cannot diverge from a plain
+/// `EffectChain` body.
+fn lower_trigger_effect_chain(
+    chain_ir: &EffectChainIr,
+    modifiers: &TriggerModifiers,
+) -> AbilityDefinition {
+    let mut ability = lower_effect_chain_ir(chain_ir);
+    crate::parser::oracle_effect::finalize_effect_chain(&mut ability);
+    if effect_adds_mana_to_triggering_player(&modifiers.effect_lower)
+        && matches!(
+            ability.effect.as_ref(),
+            crate::types::ability::Effect::Mana { .. }
+        )
+    {
+        ability.player_scope = Some(PlayerFilter::TriggeringPlayer);
+    }
+    // CR 115.1d: Singleton "up to one target ..." effects that lower
+    // without a `multi_target` spec still permit choosing zero targets.
+    // Do not stamp this onto non-target head clauses in chains like
+    // "draw a card. Attach any number of target Equipment ..."
+    if modifiers.has_up_to
+        && ability.multi_target.is_none()
+        && ability
+            .effect
+            .target_filter()
+            .is_some_and(|filter| !filter.is_context_ref())
+    {
+        ability.optional_targeting = true;
+    }
+    // CR 603.5: A triggered ability whose effect is optional ("may") goes
+    // on the stack regardless; the choice is made when it resolves. Carry
+    // that optionality onto the execute ability, which is what resolves.
+    if modifiers.optional {
+        ability.optional = true;
+    }
+    ability
+}
+
 pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
     let mut def = ir.partial_def.clone();
     let modifiers = &ir.modifiers;
@@ -1581,41 +1620,16 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
     // Lower the body
     let execute = match &ir.body {
         Some(TriggerBody::EffectChain(chain_ir)) => {
-            let mut ability = lower_effect_chain_ir(chain_ir);
-            crate::parser::oracle_effect::finalize_effect_chain(&mut ability);
-            if effect_adds_mana_to_triggering_player(&modifiers.effect_lower)
-                && matches!(
-                    ability.effect.as_ref(),
-                    crate::types::ability::Effect::Mana { .. }
-                )
-            {
-                ability.player_scope = Some(PlayerFilter::TriggeringPlayer);
-            }
-            // CR 115.1d: Singleton "up to one target ..." effects that lower
-            // without a `multi_target` spec still permit choosing zero targets.
-            // Do not stamp this onto non-target head clauses in chains like
-            // "draw a card. Attach any number of target Equipment ..."
-            if modifiers.has_up_to
-                && ability.multi_target.is_none()
-                && ability
-                    .effect
-                    .target_filter()
-                    .is_some_and(|filter| !filter.is_context_ref())
-            {
-                ability.optional_targeting = true;
-            }
-            // CR 603.5: A triggered ability whose effect is optional ("may") goes
-            // on the stack regardless; the choice is made when it resolves. Carry
-            // that optionality onto the execute ability, which is what resolves.
-            if modifiers.optional {
-                ability.optional = true;
-            }
-            Some(Box::new(ability))
+            Some(Box::new(lower_trigger_effect_chain(chain_ir, modifiers)))
         }
+        Some(TriggerBody::Modal(modal)) => Some(Box::new(
+            lower_trigger_effect_chain(&modal.marker, modifiers)
+                .with_modal(modal.choice.clone(), modal.mode_abilities.clone()),
+        )),
         Some(TriggerBody::PreLowered(ability)) => {
-            // CR 603.5: Pre-lowered bodies (inline modals, vote blocks, etc.)
-            // may not have stamped `optional` during extraction even when the
-            // trigger effect began with "you may".
+            // CR 603.5: Remaining pre-lowered bodies may not have stamped
+            // `optional` during extraction even when the trigger effect began
+            // with "you may".
             let mut ability = ability.clone();
             if modifiers.optional {
                 ability.optional = true;


### PR DESCRIPTION
CR 700.2b: represent an inline modal as ModalIr: an ordinary typed GenericEffect marker clause plus ModalChoice and independently lowered mode bodies. The marker flows through the shared trigger-chain lowering before modal metadata is attached.

Transform disposition: finalize_effect_chain inert (the marker is GenericEffect, not any finalizer input shape); mana-scope rebind inert (marker is not Mana); optional_targeting inert (marker has no target filter); optional equivalent (the prior PreLowered arm and the shared chain helper both stamp trigger optionality under CR 603.5). Modal mode selection and targeting remain on ModalChoice/mode bodies under CR 700.2b and CR 115.1d.

BYTE-DIFF PENDING LEAD ADJUDICATION (inherited only): this producer is byte-identical to its immediate U4 predecessor (sha256 f5158df2fc7577f3a32143072d48e168dc54858953f7a554c7645279dedb9be3; 35,396 faces). Against BASE_SHA, the only remaining difference is the already-pending Animate Dead and Dance of the Dead target_choice_timing change from the reanimator-Aura commit; this commit introduces no additional affected cards.
