### PR TITLE
refactor(parser): lower vote block through the trigger EffectChain arm (P05-U4)

### DIFF
--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -6,10 +6,12 @@
 
 use serde::Serialize;
 
+use super::ast::parsed_clause;
+use super::context::ParseContext;
 use super::effect_chain::EffectChainIr;
 use crate::types::ability::{
-    AbilityDefinition, ControllerRef, ModalChoice, TargetFilter, TriggerCondition,
-    TriggerConstraint, TriggerDefinition, UnlessPayModifier,
+    AbilityDefinition, AbilityKind, ChoiceType, ControllerRef, Effect, ModalChoice, TargetFilter,
+    TargetSelectionMode, TriggerCondition, TriggerConstraint, TriggerDefinition, UnlessPayModifier,
 };
 use crate::types::triggers::TriggerMode;
 
@@ -44,6 +46,9 @@ pub(crate) enum TriggerBody {
     /// bodies. The marker still flows through ordinary trigger-chain lowering;
     /// this payload carries the modal metadata no clause can represent.
     Modal(Box<ModalIr>),
+    /// CR 701.38: A vote block with its typed ballot effect and optional
+    /// pre-ballot random choice.
+    Vote(Box<VoteIr>),
     /// Pre-lowered ability (vote blocks produce `AbilityDefinition` directly).
     PreLowered(Box<AbilityDefinition>),
 }
@@ -59,6 +64,89 @@ pub(crate) struct ModalIr {
     pub(crate) marker: EffectChainIr,
     pub(crate) choice: ModalChoice,
     pub(crate) mode_abilities: Vec<AbilityDefinition>,
+}
+
+/// CR 701.38: Typed vote trigger body.
+///
+/// `vote` is always an `Effect::Vote`; `pre_vote_choose` captures the one
+/// structural wrapper in this class (Truth or Consequences' random opponent
+/// choice). Lowering reconstructs that wrapper around the typed vote effect and
+/// then sends the root through ordinary trigger-chain lowering.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct VoteIr {
+    source_text: String,
+    vote: Effect,
+    pre_vote_choose: Option<ChoiceType>,
+    actor: Option<ControllerRef>,
+    in_trigger: bool,
+}
+
+impl VoteIr {
+    pub(crate) fn new(vote: Effect, pre_vote_choose: Option<ChoiceType>) -> Self {
+        debug_assert!(matches!(vote, Effect::Vote { .. }));
+        Self {
+            source_text: String::new(),
+            vote,
+            pre_vote_choose,
+            actor: None,
+            in_trigger: false,
+        }
+    }
+
+    pub(crate) fn with_source(mut self, source_text: &str) -> Self {
+        self.source_text = source_text.to_string();
+        self
+    }
+
+    pub(crate) fn with_context(mut self, ctx: &ParseContext) -> Self {
+        self.actor = ctx.actor.clone();
+        self.in_trigger = ctx.in_trigger;
+        self
+    }
+
+    /// Construct the trigger-context chain without allocating a pre-lowered
+    /// root definition. The nested vote definition is a continuation payload
+    /// of the typed random-choice wrapper, not the trigger body itself.
+    pub(crate) fn effect_chain(&self, kind: AbilityKind) -> EffectChainIr {
+        let parsed = match &self.pre_vote_choose {
+            Some(choice_type) => {
+                let mut root = parsed_clause(Effect::Choose {
+                    choice_type: choice_type.clone(),
+                    persist: true,
+                    selection: TargetSelectionMode::Random,
+                });
+                root.sub_ability = Some(Box::new(AbilityDefinition::new(kind, self.vote.clone())));
+                root
+            }
+            None => parsed_clause(self.vote.clone()),
+        };
+        EffectChainIr::single_clause(
+            &self.source_text,
+            kind,
+            parsed,
+            None,
+            self.actor.clone(),
+            self.in_trigger,
+        )
+    }
+
+    /// Compatibility lowering for non-trigger callers that have not yet moved
+    /// to trigger-body IR. Trigger parsing uses [`Self::effect_chain`] instead.
+    pub(crate) fn into_ability(self, kind: AbilityKind) -> AbilityDefinition {
+        let vote = AbilityDefinition::new(kind, self.vote);
+        match self.pre_vote_choose {
+            Some(choice_type) => AbilityDefinition::new(
+                kind,
+                Effect::Choose {
+                    choice_type,
+                    persist: true,
+                    selection: TargetSelectionMode::Random,
+                },
+            )
+            .sub_ability(vote),
+            None => vote,
+        }
+    }
 }
 
 /// Modifier fields extracted during IR production.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1391,10 +1391,9 @@ pub(crate) fn parse_trigger_line_with_index_ir(
 
     // Parse the effect body
     let effect_for_parse_lower = effect_for_parse.to_lowercase();
-    // CR 115.1d: Pre-lowered vote blocks do not flow through clause-level
-    // multi-target extraction, so keep their legacy optional-targeting marker
-    // local to that PreLowered path. Normal effect chains carry this metadata on
-    // the specific parsed clause.
+    // CR 115.1d: Record root-level optional-target phrasing for the shared
+    // trigger-chain lowerer. Clause-level multi-target extraction carries the
+    // richer per-clause form when a chain has one.
     let has_up_to = scan_contains(&effect_for_parse_lower, "up to one")
         || scan_contains(&effect_for_parse_lower, "any number of target");
     let body = if !effect_for_parse.is_empty() {
@@ -1410,26 +1409,14 @@ pub(crate) fn parse_trigger_line_with_index_ir(
                 effect_ctx.actor.clone(),
                 effect_ctx.in_trigger,
             )))
-        // CR 701.38 + CR 207.2c: Vote blocks produce AbilityDefinition directly.
-        } else if let Some(vote_def) =
-            crate::parser::oracle_vote::parse_vote_block(&effect_for_parse, AbilityKind::Spell)
-        {
-            let mut ability = vote_def;
-            if has_up_to {
-                ability.optional_targeting = true;
-            }
-            if effect_adds_mana_to_triggering_player(&effect_lower)
-                && matches!(
-                    ability.effect.as_ref(),
-                    crate::types::ability::Effect::Mana { .. }
-                )
-            {
-                ability.player_scope = Some(PlayerFilter::TriggeringPlayer);
-            }
-            if optional {
-                ability.optional = true;
-            }
-            Some(TriggerBody::PreLowered(Box::new(ability)))
+        // CR 701.38 + CR 207.2c: Whole vote blocks retain the ballot as typed
+        // IR and use the ordinary trigger-chain lowerer for root transforms.
+        } else if let Some(vote) = crate::parser::oracle_vote::parse_vote_block_ir(
+            &effect_for_parse,
+            AbilityKind::Spell,
+            &effect_ctx,
+        ) {
+            Some(TriggerBody::Vote(Box::new(vote)))
         // CR 700.3 + CR 701.20a: Pile-separation (Fact or Fiction / Sphinx of
         // Uthuun family). The multi-sentence block must be consumed as a single
         // unit — chain parsing would fragment it into Unimplemented chunks.
@@ -1626,6 +1613,10 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
             lower_trigger_effect_chain(&modal.marker, modifiers)
                 .with_modal(modal.choice.clone(), modal.mode_abilities.clone()),
         )),
+        Some(TriggerBody::Vote(vote)) => Some(Box::new(lower_trigger_effect_chain(
+            &vote.effect_chain(AbilityKind::Spell),
+            modifiers,
+        ))),
         Some(TriggerBody::PreLowered(ability)) => {
             // CR 603.5: Remaining pre-lowered bodies may not have stamped
             // `optional` during extraction even when the trigger effect began

--- a/crates/engine/src/parser/oracle_vote.rs
+++ b/crates/engine/src/parser/oracle_vote.rs
@@ -28,27 +28,33 @@ use nom::Parser;
 
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, ChoiceType, ContinuousModification, ControllerRef, Duration,
-    Effect, PlayerFilter, QuantityExpr, QuantityRef, StaticDefinition, TargetFilter,
-    TargetSelectionMode, TieResolution, VoteSubject, VoteTally, VoteVisibility, VoterScope,
+    Effect, PlayerFilter, QuantityExpr, QuantityRef, StaticDefinition, TargetFilter, TieResolution,
+    VoteSubject, VoteTally, VoteVisibility, VoterScope,
 };
 use crate::types::keywords::Keyword;
 use crate::types::zones::{EtbTapState, Zone};
 
 use super::oracle_effect::{parse_effect_chain_with_context, strip_trailing_duration};
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::trigger::VoteIr;
 use super::oracle_keyword::parse_granted_keyword_fragment;
 use super::oracle_target::parse_target;
 use super::oracle_util::SELF_REF_TYPE_PHRASES;
 
-/// Detect and parse the entire Council's-dilemma vote block. Returns a single
-/// `AbilityDefinition` whose `effect` is `Effect::Vote` populated with the
-/// per-choice sub-effects, or `None` if the input doesn't match the pattern.
+/// Detect and parse the entire Council's-dilemma vote block into typed trigger
+/// IR. The vote's per-choice sub-effects remain independently lowered payloads;
+/// the root ballot and optional pre-ballot random choice stay typed until
+/// trigger lowering.
 ///
 /// The input is the trigger/effect *body* text — i.e., what comes after
 /// "Whenever ~ enters or deals combat damage to a player, ". The "starting
 /// with you, " prefix is consumed here (kept inside this module so chain-level
 /// stripping in `parse_effect_chain_ir` doesn't interfere).
-pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityDefinition> {
+pub(crate) fn parse_vote_block_ir(
+    text: &str,
+    kind: AbilityKind,
+    ctx: &ParseContext,
+) -> Option<VoteIr> {
     // Case-insensitive nom tags (`tag_no_case`) match directly against the
     // original-case input, so the entire vote-detection pipeline operates on
     // `text` without an upfront `to_lowercase()` allocation. On the failure
@@ -100,6 +106,7 @@ pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityD
                 voter_scope,
                 visibility,
             )
+            .map(|vote| vote.with_source(text).with_context(ctx))
         }
     };
     // CR 701.38a: Will-of-the-council threshold votes. Shape:
@@ -120,7 +127,7 @@ pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityD
         voter_scope,
         visibility,
     ) {
-        return Some(def);
+        return Some(def.with_source(text).with_context(ctx));
     }
     // CR 701.38a: "...or tied for most votes" all-tied outcome over named
     // choices (Council Guardian: "This creature gains protection from each
@@ -134,7 +141,7 @@ pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityD
         voter_scope,
         visibility,
     ) {
-        return Some(def);
+        return Some(def.with_source(text).with_context(ctx));
     }
     // Phase 3: per-choice clauses. Three shapes covered, dispatched by scope:
     //   * "For each <choice> vote, <effect>."                     (Tivit / classic)
@@ -257,18 +264,18 @@ pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityD
     let per_choice_effect: Vec<Box<AbilityDefinition>> =
         slots.into_iter().collect::<Option<Vec<_>>>()?;
 
-    let vote_def = AbilityDefinition::new(
-        kind,
-        Effect::Vote {
-            choices,
-            per_choice_effect,
-            starting_with,
-            voter_scope,
-            tally_mode: VoteTally::PerVote,
-            subject: VoteSubject::Named,
-            visibility,
-        },
-    );
+    let vote = Effect::Vote {
+        choices,
+        per_choice_effect,
+        starting_with,
+        voter_scope,
+        tally_mode: VoteTally::PerVote,
+        subject: VoteSubject::Named,
+        visibility,
+    };
+    // CR 701.38 + CR 608.2d: retain the ballot and its optional random setup
+    // as typed trigger IR. The setup becomes the root only during lowering;
+    // the trigger body itself never needs a pre-lowered AbilityDefinition.
     match pre_vote_choose {
         // CR 608.2d + CR 102.2: the card chooses the opponent unconditionally
         // ("Then choose an opponent at random"), even with a zero tally, so the
@@ -279,18 +286,19 @@ pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityD
         // (CR 608.2c). The random pick is independent of the tally, so choosing
         // before vs. after the ballot is outcome-equivalent.
         Some(choice_type) => Some(
-            AbilityDefinition::new(
-                kind,
-                Effect::Choose {
-                    choice_type,
-                    persist: true,
-                    selection: TargetSelectionMode::Random,
-                },
-            )
-            .sub_ability(vote_def),
+            VoteIr::new(vote, Some(choice_type))
+                .with_source(text)
+                .with_context(ctx),
         ),
-        None => Some(vote_def),
+        None => Some(VoteIr::new(vote, None).with_source(text).with_context(ctx)),
     }
+}
+
+/// Compatibility entry point for non-trigger callers that still consume a
+/// lowered definition. Trigger parsing uses [`parse_vote_block_ir`] so its root
+/// goes through the ordinary trigger effect-chain arm.
+pub(crate) fn parse_vote_block(text: &str, kind: AbilityKind) -> Option<AbilityDefinition> {
+    parse_vote_block_ir(text, kind, &ParseContext::default()).map(|vote| vote.into_ability(kind))
 }
 
 /// CR 701.38a: Parse the Will-of-the-council threshold-clause body that
@@ -325,7 +333,7 @@ fn parse_threshold_vote_clauses(
     starting_with: ControllerRef,
     voter_scope: VoterScope,
     visibility: VoteVisibility,
-) -> Option<AbilityDefinition> {
+) -> Option<VoteIr> {
     // Per-choice effect slots, parallel to `choices`, plus the discovered
     // tie-breaker index. Each named clause binds to its choice's slot; unlisted
     // choices stay `None` and are filled with `Effect::NoOp` below.
@@ -380,8 +388,7 @@ fn parse_threshold_vote_clauses(
         .map(|slot| slot.unwrap_or_else(|| Box::new(AbilityDefinition::new(kind, Effect::NoOp))))
         .collect();
 
-    Some(AbilityDefinition::new(
-        kind,
+    Some(VoteIr::new(
         Effect::Vote {
             choices: choices.to_vec(),
             per_choice_effect,
@@ -393,6 +400,7 @@ fn parse_threshold_vote_clauses(
             subject: VoteSubject::Named,
             visibility,
         },
+        None,
     ))
 }
 
@@ -424,7 +432,7 @@ fn parse_all_tied_vote_clause(
     starting_with: ControllerRef,
     voter_scope: VoterScope,
     visibility: VoteVisibility,
-) -> Option<AbilityDefinition> {
+) -> Option<VoteIr> {
     let (sentence, _rest) = read_sentence(input);
     // Locate the "with the most votes [or tied for most votes]" suffix; `head`
     // is the grant template preceding it.
@@ -459,8 +467,7 @@ fn parse_all_tied_vote_clause(
         )));
     }
 
-    Some(AbilityDefinition::new(
-        kind,
+    Some(VoteIr::new(
         Effect::Vote {
             choices: choices.to_vec(),
             per_choice_effect,
@@ -472,6 +479,7 @@ fn parse_all_tied_vote_clause(
             subject: VoteSubject::Named,
             visibility,
         },
+        None,
     ))
 }
 
@@ -493,7 +501,7 @@ fn parse_object_vote_block(
     starting_with: ControllerRef,
     voter_scope: VoterScope,
     visibility: VoteVisibility,
-) -> Option<AbilityDefinition> {
+) -> Option<VoteIr> {
     // Strip a leading article so `parse_target` sees the bare descriptor.
     let candidate_phrase = strip_leading_article(choice_text.trim());
     let (candidate_filter, rest) = parse_target(candidate_phrase);
@@ -538,8 +546,7 @@ fn parse_object_vote_block(
     };
     let outcome_template = Box::new(AbilityDefinition::new(kind, exile));
 
-    Some(AbilityDefinition::new(
-        kind,
+    Some(VoteIr::new(
         Effect::Vote {
             choices: Vec::new(),
             per_choice_effect: Vec::new(),
@@ -554,6 +561,7 @@ fn parse_object_vote_block(
             },
             visibility,
         },
+        None,
     ))
 }
 


### PR DESCRIPTION
CR 701.38a-b defines the ballot choices and resolution order. CR 608.2d
places the non-target random-opponent choice at resolution; CR 115.1d
confirms that these vote roots do not create a stack-time target.

Transform disposition: finalize_effect_chain is inert because Vote and its
optional Choose wrapper match none of its reveal, labeled-choice, dig,
choose-tracked-set, speed, or extra-combat gates. Mana-scope rebinding is
inert because neither root is Mana. Optional-targeting is inert and correct:
the roots have no non-context target filter (CR 115.1d); ordinary optional
handling is equivalent, stamping the same flag when the trigger says may.

The full-pool export is byte-identical to the immediately preceding U4
reanimator corpus (sha256 f5158df2fc7577f3a32143072d48e168dc54858953f7a554c7645279dedb9be3).
That corpus retains the earlier reanimator BYTE-DIFF PENDING LEAD ADJUDICATION;
this commit introduces no incremental byte diff.
