### PR TITLE
refactor(parser): lower pile separation through the trigger EffectChain arm (P05-U4)

### DIFF
--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -49,7 +49,11 @@ pub(crate) enum TriggerBody {
     /// CR 701.38: A vote block with its typed ballot effect and optional
     /// pre-ballot random choice.
     Vote(Box<VoteIr>),
-    /// Pre-lowered ability (vote blocks produce `AbilityDefinition` directly).
+    /// CR 700.3: A pile-separation block retains its semantic root effect.
+    Pile(Box<PileIr>),
+    #[allow(dead_code)]
+    /// P05-U4 completion: no construction sites remain. U6 owns removal of
+    /// this transitional variant and its lowering arm.
     PreLowered(Box<AbilityDefinition>),
 }
 
@@ -146,6 +150,61 @@ impl VoteIr {
             .sub_ability(vote),
             None => vote,
         }
+    }
+}
+
+/// CR 700.3: Typed pile-separation trigger body.
+///
+/// The root `Effect::SeparateIntoPiles` is an ordinary one-clause chain at
+/// trigger lowering, preserving every root-level transform applied to a normal
+/// trigger effect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct PileIr {
+    source_text: String,
+    effect: Effect,
+    actor: Option<ControllerRef>,
+    in_trigger: bool,
+}
+
+impl PileIr {
+    pub(crate) fn new(effect: Effect) -> Self {
+        debug_assert!(matches!(effect, Effect::SeparateIntoPiles { .. }));
+        Self {
+            source_text: String::new(),
+            effect,
+            actor: None,
+            in_trigger: false,
+        }
+    }
+
+    pub(crate) fn with_source(mut self, source_text: &str) -> Self {
+        self.source_text = source_text.to_string();
+        self
+    }
+
+    pub(crate) fn with_context(mut self, ctx: &ParseContext) -> Self {
+        self.actor = ctx.actor.clone();
+        self.in_trigger = ctx.in_trigger;
+        self
+    }
+
+    /// Construct the trigger-context chain without lowering the root outside
+    /// ordinary trigger lowering.
+    pub(crate) fn effect_chain(&self, kind: AbilityKind) -> EffectChainIr {
+        EffectChainIr::single_clause(
+            &self.source_text,
+            kind,
+            parsed_clause(self.effect.clone()),
+            None,
+            self.actor.clone(),
+            self.in_trigger,
+        )
+    }
+
+    /// Compatibility lowering for non-trigger callers that still consume a
+    /// lowered definition. Trigger parsing uses [`Self::effect_chain`] instead.
+    pub(crate) fn into_ability(self, kind: AbilityKind) -> AbilityDefinition {
+        AbilityDefinition::new(kind, self.effect)
     }
 }
 

--- a/crates/engine/src/parser/oracle_separate_piles.rs
+++ b/crates/engine/src/parser/oracle_separate_piles.rs
@@ -37,10 +37,10 @@ use crate::types::zones::{EtbTapState, Zone};
 
 use super::oracle_effect::parse_effect_chain_with_context;
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::trigger::PileIr;
 
-/// CR 700.3: Detect and parse the full pile-separation block. Returns a
-/// synthesized `AbilityDefinition` wrapping the new `Effect::SeparateIntoPiles`,
-/// or `None` if the input doesn't match.
+/// CR 700.3: Detect and parse the full pile-separation block into typed trigger
+/// IR, or return `None` if the input doesn't match.
 ///
 /// The input is the joined effect-body text (multi-sentence). The dispatcher
 /// in `parser/oracle.rs` calls this BEFORE generic chain parsing so the
@@ -55,45 +55,42 @@ use super::oracle_ir::context::ParseContext;
 ///    library. An opponent separates those cards into two piles. Put one pile
 ///    into your hand and the other into your graveyard." The disposition seam
 ///    also accepts the sibling wording "the rest".
-pub(crate) fn parse_separate_into_piles(
+pub(crate) fn parse_separate_into_piles_ir(
     text: &str,
     kind: AbilityKind,
-) -> Option<AbilityDefinition> {
+    ctx: &ParseContext,
+) -> Option<PileIr> {
     // Try the reveal-from-library shape first (Fact or Fiction family).
-    if let Some(def) = try_parse_reveal_separate(text, kind) {
-        return Some(def);
-    }
-    // Fall through to the battlefield partition shape (Make an Example family).
-    let (rest, partition_subject) = parse_separates_line(text)?;
-    let (rest, chooser) = parse_choose_line(rest)?;
-    let trailing = rest.trim_start();
-    if trailing.is_empty() {
-        return None;
-    }
-    // Parse the trailing sentence (the per-pile sub-effect) through the
-    // standard imperative chain parser. For Make an Example this yields a
-    // `Sacrifice { target: ParentTarget }` chain — the runtime resolver
-    // re-binds `controller` to each subject before applying it.
-    //
-    // CR 700.3b: the pile is not an object — the sub-effect's target is
-    // wired by the resolver per-object, not via the parsed `target_filter`.
-    let parsed = parse_effect_chain_with_context(trailing, kind, &mut ParseContext::default());
-    // Reject if the trailing sentence didn't yield a real effect (the parser
-    // returns an Unimplemented stub on failure).
-    if matches!(*parsed.effect, Effect::Unimplemented { .. }) {
-        return None;
-    }
-    // CR 700.3 + CR 608.2c: Build a sub-effect with a generic ParentTarget
-    // filter so the runtime's per-object loop in `apply_pile_effect` sets
-    // the target via `TargetRef::Object`. Force-rewrite the sub-effect's
-    // target filter to `ParentTarget` so the per-object pipeline routes
-    // through the standard sacrifice handler unambiguously.
-    let mut sub_def = parsed;
-    rewrite_sub_effect_target_to_parent(&mut sub_def.effect);
+    let effect = try_parse_reveal_separate(text, kind).or_else(|| {
+        // Fall through to the battlefield partition shape (Make an Example family).
+        let (rest, partition_subject) = parse_separates_line(text)?;
+        let (rest, chooser) = parse_choose_line(rest)?;
+        let trailing = rest.trim_start();
+        if trailing.is_empty() {
+            return None;
+        }
+        // Parse the trailing sentence (the per-pile sub-effect) through the
+        // standard imperative chain parser. For Make an Example this yields a
+        // `Sacrifice { target: ParentTarget }` chain — the runtime resolver
+        // re-binds `controller` to each subject before applying it.
+        //
+        // CR 700.3b: the pile is not an object — the sub-effect's target is
+        // wired by the resolver per-object, not via the parsed `target_filter`.
+        let parsed = parse_effect_chain_with_context(trailing, kind, &mut ParseContext::default());
+        // Reject if the trailing sentence didn't yield a real effect (the parser
+        // returns an Unimplemented stub on failure).
+        if matches!(*parsed.effect, Effect::Unimplemented { .. }) {
+            return None;
+        }
+        // CR 700.3 + CR 608.2c: Build a sub-effect with a generic ParentTarget
+        // filter so the runtime's per-object loop in `apply_pile_effect` sets
+        // the target via `TargetRef::Object`. Force-rewrite the sub-effect's
+        // target filter to `ParentTarget` so the per-object pipeline routes
+        // through the standard sacrifice handler unambiguously.
+        let mut sub_def = parsed;
+        rewrite_sub_effect_target_to_parent(&mut sub_def.effect);
 
-    Some(AbilityDefinition::new(
-        kind,
-        Effect::SeparateIntoPiles {
+        Some(Effect::SeparateIntoPiles {
             partition_subject,
             // CR 700.3: Make an Example partitions creatures specifically;
             // the Liliana −6 follow-up will pass a wider filter. Defaulting
@@ -104,8 +101,21 @@ pub(crate) fn parse_separate_into_piles(
             chosen_pile_effect: Box::new(sub_def),
             pile_source: crate::types::ability::PileSource::Battlefield,
             unchosen_pile_effect: None,
-        },
-    ))
+        })
+    })?;
+
+    Some(PileIr::new(effect).with_source(text).with_context(ctx))
+}
+
+/// Compatibility entry point for non-trigger callers that still consume a
+/// lowered definition. Trigger parsing uses [`parse_separate_into_piles_ir`]
+/// so the root flows through ordinary trigger lowering.
+pub(crate) fn parse_separate_into_piles(
+    text: &str,
+    kind: AbilityKind,
+) -> Option<AbilityDefinition> {
+    parse_separate_into_piles_ir(text, kind, &ParseContext::default())
+        .map(|pile| pile.into_ability(kind))
 }
 
 /// CR 700.3 + CR 700.3a: Consume the "Each opponent separates the creatures
@@ -191,7 +201,7 @@ fn rewrite_sub_effect_target_to_parent(effect: &mut Effect) {
 /// `PileSource::RevealedFromLibraryTop { count: u32 }` holds a fixed count, so
 /// variable-count members like Epiphany at the Drownyard ("top X cards") are
 /// not representable here yet.
-fn try_parse_reveal_separate(text: &str, kind: AbilityKind) -> Option<AbilityDefinition> {
+fn try_parse_reveal_separate(text: &str, kind: AbilityKind) -> Option<Effect> {
     // Sentence 1: "Reveal the top N cards of your library."
     let (rest, count) = parse_reveal_top_sentence(text)?;
     // Sentence 2: "An opponent separates those cards into two piles."
@@ -211,19 +221,16 @@ fn try_parse_reveal_separate(text: &str, kind: AbilityKind) -> Option<AbilityDef
         make_change_zone_effect(unchosen_zone),
     )));
 
-    Some(AbilityDefinition::new(
-        kind,
-        Effect::SeparateIntoPiles {
-            partition_subject,
-            // CR 700.3: revealed cards are the objects being separated —
-            // no battlefield filter applies.
-            object_filter: TargetFilter::Any,
-            chooser: PlayerScope::Controller,
-            chosen_pile_effect,
-            pile_source: PileSource::RevealedFromLibraryTop { count },
-            unchosen_pile_effect,
-        },
-    ))
+    Some(Effect::SeparateIntoPiles {
+        partition_subject,
+        // CR 700.3: revealed cards are the objects being separated —
+        // no battlefield filter applies.
+        object_filter: TargetFilter::Any,
+        chooser: PlayerScope::Controller,
+        chosen_pile_effect,
+        pile_source: PileSource::RevealedFromLibraryTop { count },
+        unchosen_pile_effect,
+    })
 }
 
 /// Parse "Reveal the top N cards of your library." — returns remainder and count.

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1420,17 +1420,14 @@ pub(crate) fn parse_trigger_line_with_index_ir(
         // CR 700.3 + CR 701.20a: Pile-separation (Fact or Fiction / Sphinx of
         // Uthuun family). The multi-sentence block must be consumed as a single
         // unit — chain parsing would fragment it into Unimplemented chunks.
-        } else if let Some(pile_def) =
-            crate::parser::oracle_separate_piles::parse_separate_into_piles(
+        } else if let Some(pile) =
+            crate::parser::oracle_separate_piles::parse_separate_into_piles_ir(
                 &effect_for_parse,
                 AbilityKind::Spell,
+                &effect_ctx,
             )
         {
-            let mut ability = pile_def;
-            if optional {
-                ability.optional = true;
-            }
-            Some(TriggerBody::PreLowered(Box::new(ability)))
+            Some(TriggerBody::Pile(Box::new(pile)))
         } else {
             // CR 608.2c + CR 613.1f + CR 701.3a + CR 701.21a: whole-body
             // reanimator-Aura ETB effect (Animate Dead / Dance of the Dead) —
@@ -1617,10 +1614,15 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
             &vote.effect_chain(AbilityKind::Spell),
             modifiers,
         ))),
+        Some(TriggerBody::Pile(pile)) => Some(Box::new(lower_trigger_effect_chain(
+            &pile.effect_chain(AbilityKind::Spell),
+            modifiers,
+        ))),
         Some(TriggerBody::PreLowered(ability)) => {
-            // CR 603.5: Remaining pre-lowered bodies may not have stamped
-            // `optional` during extraction even when the trigger effect began
-            // with "you may".
+            // P05-U4 completion: no producers remain. U6 removes this legacy
+            // arm after the enum variant is deleted.
+            // CR 603.5: Pre-lowered bodies may not have stamped `optional`
+            // during extraction even when the trigger effect began with "you may".
             let mut ability = ability.clone();
             if modifiers.optional {
                 ability.optional = true;


### PR DESCRIPTION
CR 700.3a-b makes each pile member an individual object; the typed
SeparateIntoPiles root preserves its per-object effects. CR 701.20a covers
the reveal-first pile family. CR 608.2c preserves the printed instruction
order, and CR 603.5 keeps an optional trigger optional at resolution.

Transform disposition: ordinary assembly is inert/equivalent: the root has
no rewritable player reference, result anchor, or target-timing special case,
so its generated default fields equal the former AbilityDefinition defaults.
finalize_effect_chain is inert because SeparateIntoPiles matches none of its
reveal, labeled-choice, dig, choose-tracked-set, speed, or extra-combat gates.
Mana-scope and optional-targeting are inert because the root is not Mana and
has no non-context target filter. Optional handling is equivalent, preserving
the prior trigger may flag.

BYTE-DIFF PENDING LEAD ADJUDICATION (inherited only): this producer is
byte-identical to its immediate U4 predecessor (sha256
f5158df2fc7577f3a32143072d48e168dc54858953f7a554c7645279dedb9be3;
35,396 faces). Against BASE_SHA, the only remaining difference is the
already-pending Animate Dead and Dance of the Dead target_choice_timing change
from the reanimator-Aura commit; this commit introduces no additional affected
cards.
