### PR TITLE
Fix Overlord of the Balemurk impending cost choice

### DIFF
--- a/crates/engine/tests/integration/overlord_impending_offer_2859.rs
+++ b/crates/engine/tests/integration/overlord_impending_offer_2859.rs
@@ -30,10 +30,14 @@
 //! Overlord-cycle creature that also carries an enter/attack trigger.
 
 use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::AlternativeCastDecision;
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
 use engine::types::game_state::{AlternativeCastKeyword, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::zones::Zone;
 
 /// Overlord of the Balemurk's full Oracle text, including the Impending keyword
 /// line and the "enters or attacks" trigger that defines the Overlord cycle.
@@ -105,4 +109,44 @@ fn overlord_cycle_creature_surfaces_impending_alternative_cast() {
              creature with both costs affordable, got {other:?}"
         ),
     }
+}
+
+#[test]
+fn overlord_cycle_creature_can_commit_with_impending_cost_choice() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let overlord = scenario
+        .add_creature_to_hand_from_oracle(P0, "Overlord of the Balemurk", 6, 5, OVERLORD_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black, ManaCostShard::Black],
+            generic: 3,
+        })
+        .from_oracle_text_with_keywords(&["Impending"], OVERLORD_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    add_black_mana(runner.state_mut(), 5);
+
+    // CR 702.176a: with both the printed and impending costs affordable, the
+    // player may choose the impending cost. This drives the same
+    // `ChooseAlternativeCast { Alternative }` branch used by the client modal.
+    let outcome = runner
+        .cast(overlord)
+        .alternative_cast(AlternativeCastDecision::Alternative)
+        .resolve();
+    let state = outcome.state();
+    let object = &state.objects[&overlord];
+
+    outcome.assert_zone(&[overlord], Zone::Battlefield);
+    outcome.assert_counters(overlord, CounterType::Time, 5);
+    assert!(
+        !object.card_types.core_types.contains(&CoreType::Creature),
+        "an impending-cast Overlord with time counters must not be a creature"
+    );
+    assert_eq!(
+        state.players[0].mana_pool.total(),
+        3,
+        "choosing Impending 5-{{1}}{{B}} should spend two mana, not the printed five"
+    );
 }


### PR DESCRIPTION
## Summary
Adds a regression test for **Overlord of the Balemurk** choosing and resolving its Impending alternative cost.

Closes #6019.

Current `origin/main` already presents and honors the Impending branch, so this PR locks the reported path rather than changing engine behavior.

## Files changed
- `crates/engine/tests/integration/overlord_impending_offer_2859.rs`

## CR references
- `CR 702.176a`

## Implementation method (required)
Method: /pipeline

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- `cargo test -p engine --test integration overlord_cycle_creature` — PASS: 2 passed, 0 failed
- `./scripts/check-parser-combinators.sh` — PASS
- `grep -n "^702.176a" docs/MagicCompRules.txt` — PASS: verified Impending rule text

## Gate A
Gate A PASS head=d58b2521e83e19fbd31db6e1c7f5ac0a6a1e34f5 base=d04420b159e7b1ca6626bec5512f9bc5a45eaf20

## Anchored on
- `crates/engine/tests/integration/overlord_impending_offer_2859.rs:53` — existing Overlord Impending prompt regression using the same production `CastSpell` path.
- `crates/engine/src/game/scenario.rs:2204` — scenario cast driver handling announcement-time cost choices through `WaitingFor`/`GameAction` rather than helper-only shortcuts.

## Final review-impl
Final review-impl PASS head=d58b2521e83e19fbd31db6e1c7f5ac0a6a1e34f5

## Claimed parse impact
None.

## Validation Failures
None.

## CI Failures
None.