### PR TITLE
Fix Ragavan, Nimble Pilferer exile-cast controller regression

### DIFF
--- a/crates/engine/tests/integration/issue_6010_ragavan_exile_cast_controller.rs
+++ b/crates/engine/tests/integration/issue_6010_ragavan_exile_cast_controller.rs
@@ -1,0 +1,138 @@
+//! Regression for issue #6010: an opponent-owned permanent spell cast through
+//! Ragavan, Nimble Pilferer's combat-damage permission must enter under the
+//! Ragavan player's control, not its owner's control.
+//!
+//! https://github.com/phase-rs/phase/issues/6010
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::types::ability::{CastingPermission, Duration};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::keywords::Keyword;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const RAGAVAN_ORACLE: &str = "Whenever Ragavan deals combat damage to a player, create a Treasure token and exile the top card of that player's library. Until end of turn, you may cast that card.\n\
+Dash {1}{R} (You may cast this spell for its dash cost. If you do, it gains haste, and it's returned from the battlefield to its owner's hand at the beginning of the next end step.)";
+
+fn add_zero_cost_flash_creature_to_library_top(
+    runner: &mut GameRunner,
+    player: PlayerId,
+    name: &str,
+) -> ObjectId {
+    let state = runner.state_mut();
+    let card_id = CardId(state.next_object_id);
+    let id = create_object(state, card_id, player, name.to_string(), Zone::Library);
+    let obj = state.objects.get_mut(&id).expect("library card exists");
+    obj.card_types.core_types.push(CoreType::Creature);
+    obj.base_card_types = obj.card_types.clone();
+    obj.keywords.push(Keyword::Flash);
+    obj.base_keywords.push(Keyword::Flash);
+    obj.power = Some(2);
+    obj.toughness = Some(2);
+    obj.base_power = Some(2);
+    obj.base_toughness = Some(2);
+    obj.mana_cost = ManaCost::zero();
+    obj.base_mana_cost = ManaCost::zero();
+
+    let player_state = state
+        .players
+        .iter_mut()
+        .find(|p| p.id == player)
+        .expect("player exists");
+    player_state.library.retain(|&object_id| object_id != id);
+    player_state.library.insert(0, id);
+    id
+}
+
+#[test]
+fn ragavan_casts_opponent_owned_exiled_creature_under_casters_control() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let ragavan = scenario
+        .add_creature_from_oracle(P0, "Ragavan, Nimble Pilferer", 2, 1, RAGAVAN_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    let stolen = add_zero_cost_flash_creature_to_library_top(&mut runner, P1, "Nimble Pilferer");
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(ragavan, AttackTarget::Player(P1))])
+        .expect("declare Ragavan attacking P1");
+    runner.pass_both_players();
+    if matches!(
+        runner.state().waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    ) {
+        runner
+            .act(GameAction::DeclareBlockers {
+                assignments: vec![],
+            })
+            .expect("declare no blockers");
+    }
+    runner.combat_damage();
+
+    let stolen_obj = runner
+        .state()
+        .objects
+        .get(&stolen)
+        .expect("the exiled opponent card must still exist");
+    assert_eq!(
+        stolen_obj.zone,
+        Zone::Exile,
+        "Ragavan must exile the top card of the damaged player's library"
+    );
+    assert!(
+        stolen_obj
+            .casting_permissions
+            .iter()
+            .any(|permission| matches!(
+                permission,
+                CastingPermission::PlayFromExile {
+                    duration: Duration::UntilEndOfTurn,
+                    granted_to,
+                    ..
+                } if *granted_to == P0
+            )),
+        "Ragavan must grant its controller permission to cast the exiled card; got {:?}",
+        stolen_obj.casting_permissions
+    );
+
+    let card_id = stolen_obj.card_id;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+    runner.state_mut().priority_player = P0;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: stolen,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast the opponent-owned card using Ragavan's permission");
+    runner.advance_until_stack_empty();
+
+    let stolen_obj = runner
+        .state()
+        .objects
+        .get(&stolen)
+        .expect("the cast creature must still exist");
+    assert_eq!(
+        stolen_obj.zone,
+        Zone::Battlefield,
+        "the opponent-owned creature must resolve onto the battlefield"
+    );
+    assert_eq!(
+        stolen_obj.owner, P1,
+        "the physical card remains owned by P1"
+    );
+    assert_eq!(
+        stolen_obj.controller, P0,
+        "CR 608.3a: the permanent enters under the spell controller's control"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -529,6 +529,7 @@ mod issue_583_vivi_ornitier_mana_source;
 mod issue_5999_aura_exile_host;
 mod issue_6002_neera_wild_mage_bottom_of_library;
 mod issue_6006_aminatou_veil_piercer_own_turn_miracle;
+mod issue_6010_ragavan_exile_cast_controller;
 mod issue_629_fractured_sanity_cycling;
 mod issue_654_stridehangar_automaton;
 mod issue_680_shalai_and_hallar_forgotten_ancient;


### PR DESCRIPTION
## Summary
Adds a regression test for **Ragavan, Nimble Pilferer**.

Closes #6010.

This is intentionally test-only: current `origin/main` already resolves opponent-owned permanent spells cast through Ragavan's exile permission under the caster's control. The new test documents that finding and pins the full reported path: Ragavan combat damage exiles the opponent's top card, grants P0 permission to cast it, P0 casts the P1-owned creature, and the creature enters under P0's control while remaining owned by P1.

## Files changed
- crates/engine/tests/integration/main.rs
- crates/engine/tests/integration/issue_6010_ragavan_exile_cast_controller.rs

## CR references
- CR 608.3a — referenced by the regression assertion for resolving permanent spells entering under the spell controller's control.

## Implementation method (required)
Method: not-applicable — test-only regression added after pipeline triage found the behavior already fixed on main.

## Track
Developer

## LLM
Model: codex-5
Thinking: high
Tier: Standard

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — passed
- `cargo test -p engine --test integration issue_6010_ragavan_exile_cast_controller -- --nocapture` — passed; 1 passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo test -p engine` — passed
- `grep -n "^608.3a" docs/MagicCompRules.txt` — verified CR 608.3a

Tilt note: `tilt get uiresource clippy` was unreachable from the isolated worktree, so direct cargo fallback was used.

## Gate A
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=40b03e978554e2df9e6d121c58ec2e9843d94966 base=d04420b159e7b1ca6626bec5512f9bc5a45eaf20

## Anchored on
- crates/engine/src/game/stack.rs:845 — existing stack resolution path already stamps resolving permanent spells with the spell controller.
- crates/engine/src/game/casting_tests.rs:1441 — existing lower-level regression for opponent-owned permanents cast via `CastingPermission::PlayFromExile`.
- crates/engine/tests/integration/issue_566_ragavan_dash_cast.rs:61 — existing Ragavan issue regression style using the scenario runner.

## Final review-impl
Final review-impl PASS head=40b03e978554e2df9e6d121c58ec2e9843d94966

## Claimed parse impact
None.

## Validation Failures
None.

## CI Failures
None.
