### PR TITLE
Fix transform DFC search front-face ordering

### DIFF
--- a/crates/engine/src/bin/oracle_gen.rs
+++ b/crates/engine/src/bin/oracle_gen.rs
@@ -31,6 +31,11 @@ struct CardExportEntry {
     /// `LayoutKind` when loading from the export (where `CardRules` is not available).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     layout: Option<String>,
+    /// Original zero-based position of this face within MTGJSON's multi-face
+    /// record. Used by runtime loaders to choose the card's front face
+    /// deterministically after flattening the JSON object.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    face_index: Option<usize>,
     /// Set codes the card has been printed in (from MTGJSON `printings`).
     /// Used by the coverage dashboard to group supported/gap cards by set.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -442,6 +447,7 @@ fn build_card_work<'a>(
                     face,
                     legalities,
                     layout: None,
+                    face_index: None,
                     printings: source.printings.clone(),
                     rulings: source.rulings.clone(),
                     rarities,
@@ -507,6 +513,7 @@ fn build_card_work<'a>(
                     face,
                     legalities,
                     layout: layout_str,
+                    face_index: Some(face_idx),
                     printings: faces[0].printings.clone(),
                     rulings,
                     rarities,
@@ -543,6 +550,7 @@ fn build_card_work<'a>(
                 face,
                 legalities,
                 layout: None,
+                face_index: None,
                 printings: faces[0].printings.clone(),
                 rulings: faces[0].rulings.clone(),
                 rarities,
@@ -1808,6 +1816,7 @@ mod tests {
     use engine::types::ability::TargetFilter;
     use engine::types::card::CardFace;
     use engine::types::keywords::Keyword;
+    use serde_json::json;
 
     use super::*;
 
@@ -1831,11 +1840,23 @@ mod tests {
                 .map(|(format, status)| (format.to_string(), status.to_string()))
                 .collect(),
             layout: layout.map(|s| s.to_string()),
+            face_index: None,
             printings: printings.iter().map(|s| s.to_string()).collect(),
             rulings: Vec::new(),
             rarities: BTreeSet::new(),
             bracket_signals: BracketSignals::default(),
         }
+    }
+
+    #[test]
+    fn card_export_entry_serializes_multiface_face_index() {
+        let mut entry = make_entry("ordered-oracle", &["TST"], Some("transform"));
+        entry.face.name = "Back Face".to_string();
+        entry.face_index = Some(1);
+
+        let value = serde_json::to_value(&entry).expect("entry should serialize");
+
+        assert_eq!(value["face_index"], json!(1));
     }
 
     fn atomic_single(name: &str, oracle_id: Option<&str>) -> AtomicCard {

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -18,6 +18,10 @@ pub struct CardDatabase {
     pub(crate) face_index: HashMap<String, CardFace>,
     pub(crate) name_alias_index: HashMap<String, String>,
     pub(crate) oracle_id_index: HashMap<String, Vec<String>>,
+    /// Maps face key (lowercased card name) to its original zero-based position
+    /// inside MTGJSON's multi-face record. Export loading flattens faces into a
+    /// JSON object, whose iteration order is not a rules authority.
+    pub(crate) face_order_index: HashMap<String, usize>,
     /// Maps oracle_id → runtime LayoutKind for multi-face cards.
     /// Populated only from the export path (the MTGJSON path uses `cards` directly).
     /// Enables `rehydrate_game_from_card_db` to determine the correct layout kind
@@ -77,6 +81,7 @@ impl CardDatabase {
     fn from_export_entries(entries: HashMap<String, CardExportEntry>) -> Self {
         let mut face_index = HashMap::with_capacity(entries.len());
         let mut oracle_id_index: HashMap<String, Vec<String>> = HashMap::new();
+        let mut face_order_index: HashMap<String, usize> = HashMap::new();
         let mut layout_index: HashMap<String, LayoutKind> = HashMap::new();
         let mut legalities = HashMap::new();
         let mut printings_index: HashMap<String, Vec<String>> = HashMap::new();
@@ -86,6 +91,9 @@ impl CardDatabase {
 
         for (export_key, entry) in entries {
             let storage_key = export_key.to_lowercase();
+            if let Some(face_order) = entry.face_index {
+                face_order_index.insert(storage_key.clone(), face_order);
+            }
             if let Some(oracle_id) = entry.face.scryfall_oracle_id.clone() {
                 oracle_id_index
                     .entry(oracle_id.clone())
@@ -111,6 +119,9 @@ impl CardDatabase {
                 legalities.insert(storage_key.clone(), normalized);
             }
         }
+        for keys in oracle_id_index.values_mut() {
+            keys.sort_by_key(|key| face_order_index.get(key).copied().unwrap_or(usize::MAX));
+        }
         let name_alias_index = build_name_alias_index(face_index.keys());
         let creature_type_vocabulary = collect_creature_type_vocabulary(face_index.values());
 
@@ -119,6 +130,7 @@ impl CardDatabase {
             face_index,
             name_alias_index,
             oracle_id_index,
+            face_order_index,
             layout_index,
             legalities,
             printings_index,
@@ -163,6 +175,7 @@ impl CardDatabase {
                 face: face.clone(),
                 legalities: HashMap::new(),
                 layout,
+                face_index: self.face_order_index.get(&key).copied(),
                 printings: self.printings_index.get(&key).cloned().unwrap_or_default(),
                 rulings: self.rulings_index.get(&key).cloned().unwrap_or_default(),
                 bracket_signals: self
@@ -488,6 +501,10 @@ struct CardExportEntry {
     /// MTGJSON layout string for multi-face cards (e.g. "modal_dfc", "transform").
     #[serde(default)]
     layout: Option<String>,
+    /// Original zero-based position of this face within MTGJSON's multi-face
+    /// record. Optional so older card-data exports remain loadable.
+    #[serde(default)]
+    face_index: Option<usize>,
     /// Set codes the card has been printed in (from MTGJSON `printings`).
     #[serde(default)]
     printings: Vec<String>,

--- a/crates/engine/src/database/card_db.rs
+++ b/crates/engine/src/database/card_db.rs
@@ -22,6 +22,10 @@ pub struct CardDatabase {
     /// inside MTGJSON's multi-face record. Export loading flattens faces into a
     /// JSON object, whose iteration order is not a rules authority.
     pub(crate) face_order_index: HashMap<String, usize>,
+    /// Deterministic card-search scan order. Built once by database loaders so
+    /// interactive search does not allocate and sort the full face index on
+    /// every query.
+    pub(crate) search_face_keys: Vec<String>,
     /// Maps oracle_id → runtime LayoutKind for multi-face cards.
     /// Populated only from the export path (the MTGJSON path uses `cards` directly).
     /// Enables `rehydrate_game_from_card_db` to determine the correct layout kind
@@ -122,6 +126,7 @@ impl CardDatabase {
         for keys in oracle_id_index.values_mut() {
             keys.sort_by_key(|key| face_order_index.get(key).copied().unwrap_or(usize::MAX));
         }
+        let search_face_keys = build_search_face_keys(&face_index, &face_order_index);
         let name_alias_index = build_name_alias_index(face_index.keys());
         let creature_type_vocabulary = collect_creature_type_vocabulary(face_index.values());
 
@@ -131,6 +136,7 @@ impl CardDatabase {
             name_alias_index,
             oracle_id_index,
             face_order_index,
+            search_face_keys,
             layout_index,
             legalities,
             printings_index,
@@ -381,6 +387,39 @@ impl CardDatabase {
         }
         lower
     }
+}
+
+pub(crate) fn build_search_face_keys(
+    face_index: &HashMap<String, CardFace>,
+    face_order_index: &HashMap<String, usize>,
+) -> Vec<String> {
+    let mut keys: Vec<String> = face_index.keys().cloned().collect();
+    keys.sort_by(|left_key, right_key| {
+        let left_oracle = face_index
+            .get(left_key)
+            .and_then(|face| face.scryfall_oracle_id.as_deref())
+            .unwrap_or("");
+        let right_oracle = face_index
+            .get(right_key)
+            .and_then(|face| face.scryfall_oracle_id.as_deref())
+            .unwrap_or("");
+        left_oracle
+            .cmp(right_oracle)
+            .then_with(|| {
+                face_order_index
+                    .get(left_key)
+                    .copied()
+                    .unwrap_or(usize::MAX)
+                    .cmp(
+                        &face_order_index
+                            .get(right_key)
+                            .copied()
+                            .unwrap_or(usize::MAX),
+                    )
+            })
+            .then_with(|| left_key.cmp(right_key))
+    });
+    keys
 }
 
 /// CR 205.2b + CR 205.3m + CR 308.1: subtype categories are disjoint — a

--- a/crates/engine/src/database/oracle_loader.rs
+++ b/crates/engine/src/database/oracle_loader.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::database::bracket_lists::BracketSignals;
 use crate::database::card_db::{
-    build_name_alias_index, collect_creature_type_vocabulary, CardDatabase,
+    build_name_alias_index, build_search_face_keys, collect_creature_type_vocabulary, CardDatabase,
 };
 use crate::database::legality::normalize_legalities;
 use crate::database::mtgjson::load_atomic_cards;
@@ -134,12 +134,14 @@ pub fn load_from_mtgjson(mtgjson_path: &Path) -> Result<CardDatabase, Box<dyn Er
     }
 
     let creature_type_vocabulary = collect_creature_type_vocabulary(face_index.values());
+    let search_face_keys = build_search_face_keys(&face_index, &face_order_index);
     Ok(CardDatabase {
         cards,
         name_alias_index: build_name_alias_index(face_index.keys()),
         face_index,
         oracle_id_index,
         face_order_index,
+        search_face_keys,
         layout_index,
         legalities,
         printings_index: HashMap::new(),
@@ -167,7 +169,9 @@ fn runtime_layout_kind(layout_kind: LayoutKind) -> Option<crate::types::card::La
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::database::search::CardSearchQuery;
     use std::path::Path;
+    use tempfile::NamedTempFile;
 
     #[test]
     fn load_from_mtgjson_test_fixture() {
@@ -183,5 +187,59 @@ mod tests {
         let bolt = db.get_face_by_name("Lightning Bolt").unwrap();
         assert_eq!(bolt.name, "Lightning Bolt");
         assert!(bolt.oracle_text.is_some());
+    }
+
+    #[test]
+    fn load_from_mtgjson_transform_dfc_search_uses_front_face_order() {
+        let fixture = NamedTempFile::new().expect("temporary AtomicCards fixture");
+        std::fs::write(
+            fixture.path(),
+            r#"{
+                "data": {
+                    "The Legend of Kyoshi // Avatar Kyoshi": [
+                        {
+                            "name": "The Legend of Kyoshi",
+                            "colors": ["G"],
+                            "colorIdentity": ["G"],
+                            "layout": "transform",
+                            "types": ["Enchantment"],
+                            "subtypes": ["Saga"],
+                            "supertypes": ["Legendary"],
+                            "manaCost": "{4}{G}{G}",
+                            "manaValue": 6.0,
+                            "text": "",
+                            "identifiers": { "scryfallOracleId": "o-kyoshi-raw" }
+                        },
+                        {
+                            "name": "Avatar Kyoshi",
+                            "colors": ["G"],
+                            "colorIdentity": ["G"],
+                            "layout": "transform",
+                            "types": ["Creature"],
+                            "subtypes": ["Avatar"],
+                            "manaValue": 0.0,
+                            "text": "",
+                            "identifiers": { "scryfallOracleId": "o-kyoshi-raw" }
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .expect("write AtomicCards fixture");
+
+        let db = load_from_mtgjson(fixture.path()).expect("raw MTGJSON fixture loads");
+
+        assert_eq!(
+            db.get_face_by_oracle_id("o-kyoshi-raw")
+                .map(|face| face.name.as_str()),
+            Some("The Legend of Kyoshi")
+        );
+
+        let results = db.search(&CardSearchQuery {
+            text: "avatar kyoshi".into(),
+            ..Default::default()
+        });
+        assert_eq!(results.total, 1);
+        assert_eq!(results.results[0].name, "The Legend of Kyoshi");
     }
 }

--- a/crates/engine/src/database/oracle_loader.rs
+++ b/crates/engine/src/database/oracle_loader.rs
@@ -19,6 +19,9 @@ pub fn load_from_mtgjson(mtgjson_path: &Path) -> Result<CardDatabase, Box<dyn Er
 
     let mut cards: HashMap<String, CardRules> = HashMap::new();
     let mut face_index: HashMap<String, CardFace> = HashMap::new();
+    let mut oracle_id_index: HashMap<String, Vec<String>> = HashMap::new();
+    let mut face_order_index: HashMap<String, usize> = HashMap::new();
+    let mut layout_index: HashMap<String, crate::types::card::LayoutKind> = HashMap::new();
     let mut bracket_signals_by_name: HashMap<String, BracketSignals> = HashMap::new();
     let mut legalities = HashMap::new();
     let errors: Vec<(PathBuf, String)> = Vec::new();
@@ -62,8 +65,22 @@ pub fn load_from_mtgjson(mtgjson_path: &Path) -> Result<CardDatabase, Box<dyn Er
                 }
                 LayoutKind::Single => CardLayout::Single(face_a),
             };
-            for (face, source) in layout_faces(&layout).into_iter().zip(faces.iter()) {
+            for (face_idx, (face, source)) in layout_faces(&layout)
+                .into_iter()
+                .zip(faces.iter())
+                .enumerate()
+            {
                 let key = face.name.to_lowercase();
+                if let Some(oracle_id) = face.scryfall_oracle_id.clone() {
+                    oracle_id_index
+                        .entry(oracle_id.clone())
+                        .or_default()
+                        .push(key.clone());
+                    face_order_index.insert(key.clone(), face_idx);
+                    if let Some(runtime_kind) = runtime_layout_kind(layout_kind) {
+                        layout_index.entry(oracle_id).or_insert(runtime_kind);
+                    }
+                }
                 face_index.insert(key.clone(), face.clone());
                 if source.is_game_changer {
                     bracket_signals_by_name.insert(
@@ -87,6 +104,13 @@ pub fn load_from_mtgjson(mtgjson_path: &Path) -> Result<CardDatabase, Box<dyn Er
         } else {
             let face = build_oracle_face(&faces[0], oracle_id);
             let key = face.name.to_lowercase();
+            if let Some(oracle_id) = face.scryfall_oracle_id.clone() {
+                oracle_id_index
+                    .entry(oracle_id)
+                    .or_default()
+                    .push(key.clone());
+                face_order_index.insert(key.clone(), 0);
+            }
             let card_legalities = normalize_legalities(&faces[0].legalities);
             let rules = CardRules {
                 layout: CardLayout::Single(face.clone()),
@@ -114,8 +138,9 @@ pub fn load_from_mtgjson(mtgjson_path: &Path) -> Result<CardDatabase, Box<dyn Er
         cards,
         name_alias_index: build_name_alias_index(face_index.keys()),
         face_index,
-        oracle_id_index: HashMap::new(),
-        layout_index: HashMap::new(),
+        oracle_id_index,
+        face_order_index,
+        layout_index,
         legalities,
         printings_index: HashMap::new(),
         rulings_index: HashMap::new(),
@@ -124,6 +149,19 @@ pub fn load_from_mtgjson(mtgjson_path: &Path) -> Result<CardDatabase, Box<dyn Er
         bracket_signals_by_name,
         creature_type_vocabulary,
     })
+}
+
+fn runtime_layout_kind(layout_kind: LayoutKind) -> Option<crate::types::card::LayoutKind> {
+    match layout_kind {
+        LayoutKind::Split => Some(crate::types::card::LayoutKind::Split),
+        LayoutKind::Flip => Some(crate::types::card::LayoutKind::Flip),
+        LayoutKind::Transform => Some(crate::types::card::LayoutKind::Transform),
+        LayoutKind::Meld => Some(crate::types::card::LayoutKind::Meld),
+        LayoutKind::Adventure => Some(crate::types::card::LayoutKind::Adventure),
+        LayoutKind::Modal => Some(crate::types::card::LayoutKind::Modal),
+        LayoutKind::Prepare => Some(crate::types::card::LayoutKind::Prepare),
+        LayoutKind::Single | LayoutKind::Specialize => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/engine/src/database/search.rs
+++ b/crates/engine/src/database/search.rs
@@ -102,7 +102,29 @@ impl CardDatabase {
         // (relevance rank, lowercased name for tiebreak, result)
         let mut matched: Vec<(u8, String, CardSearchResult)> = Vec::new();
 
-        for (key, face) in self.face_index.iter() {
+        let mut face_entries: Vec<_> = self.face_index.iter().collect();
+        face_entries.sort_by(|(left_key, left_face), (right_key, right_face)| {
+            let left_oracle = left_face.scryfall_oracle_id.as_deref().unwrap_or("");
+            let right_oracle = right_face.scryfall_oracle_id.as_deref().unwrap_or("");
+            left_oracle
+                .cmp(right_oracle)
+                .then_with(|| {
+                    self.face_order_index
+                        .get(left_key.as_str())
+                        .copied()
+                        .unwrap_or(usize::MAX)
+                        .cmp(
+                            &self
+                                .face_order_index
+                                .get(right_key.as_str())
+                                .copied()
+                                .unwrap_or(usize::MAX),
+                        )
+                })
+                .then_with(|| left_key.cmp(right_key))
+        });
+
+        for (key, face) in face_entries {
             let name_lower = face.name.to_lowercase();
 
             if !words.is_empty() && !self.text_matches(&name_lower, face, &words) {
@@ -146,9 +168,10 @@ impl CardDatabase {
                 }
             }
 
-            // Deduplicate multi-face cards: keep the first matching face per
-            // oracle id. The frontend re-derives the combined display name from
-            // the image map, so which face won here doesn't affect display.
+            // Deduplicate multi-face cards: keep the front face per oracle id
+            // when the export carries face order. The chosen face still matters
+            // for deck addition when the presentation sidecar is missing, and it
+            // must be the physical front face for transform DFCs (CR 712.8a).
             if let Some(oracle_id) = face.scryfall_oracle_id.as_deref() {
                 if !seen_oracle.insert(oracle_id) {
                     continue;
@@ -160,7 +183,7 @@ impl CardDatabase {
             } else {
                 1
             };
-            matched.push((rank, name_lower, self.build_result(key, face)));
+            matched.push((rank, name_lower, self.build_result(key.as_str(), face)));
         }
 
         let total = matched.len();
@@ -603,6 +626,55 @@ mod tests {
         });
         assert_eq!(res.results.len(), 1, "both faces share an oracle id");
         assert_eq!(res.total, 1);
+    }
+
+    #[test]
+    fn transform_dfc_search_dedupes_to_exported_front_face() {
+        let mut front = card(
+            "The Legend of Kyoshi",
+            "o-kyoshi",
+            &["Green", "Green"],
+            4,
+            "Enchantment",
+            &["Green"],
+            "Exile this Saga, then return it to the battlefield transformed under your control.",
+            json!({ "standard": "legal" }),
+            &["TLA"],
+        );
+        front["layout"] = json!("transform");
+        front["face_index"] = json!(0);
+        let mut back = card(
+            "Avatar Kyoshi",
+            "o-kyoshi",
+            &[],
+            0,
+            "Creature",
+            &["Green"],
+            "Lands you control have trample and hexproof.",
+            json!({ "standard": "legal" }),
+            &["TLA"],
+        );
+        back["mana_cost"] = json!({ "type": "NoCost" });
+        back["layout"] = json!("transform");
+        back["face_index"] = json!(1);
+
+        let db = db_from(&[("avatar kyoshi", back), ("the legend of kyoshi", front)]);
+
+        let res = db.search(&CardSearchQuery {
+            text: "avatar kyoshi".into(),
+            ..Default::default()
+        });
+        assert_eq!(res.results.len(), 1);
+        assert_eq!(
+            result_names(&res),
+            vec!["The Legend of Kyoshi"],
+            "CR 712.8a: transform DFCs are represented by their front face outside the battlefield"
+        );
+        assert_eq!(
+            db.get_face_by_oracle_id("o-kyoshi")
+                .map(|face| face.name.as_str()),
+            Some("The Legend of Kyoshi")
+        );
     }
 
     #[test]

--- a/crates/engine/src/database/search.rs
+++ b/crates/engine/src/database/search.rs
@@ -102,29 +102,10 @@ impl CardDatabase {
         // (relevance rank, lowercased name for tiebreak, result)
         let mut matched: Vec<(u8, String, CardSearchResult)> = Vec::new();
 
-        let mut face_entries: Vec<_> = self.face_index.iter().collect();
-        face_entries.sort_by(|(left_key, left_face), (right_key, right_face)| {
-            let left_oracle = left_face.scryfall_oracle_id.as_deref().unwrap_or("");
-            let right_oracle = right_face.scryfall_oracle_id.as_deref().unwrap_or("");
-            left_oracle
-                .cmp(right_oracle)
-                .then_with(|| {
-                    self.face_order_index
-                        .get(left_key.as_str())
-                        .copied()
-                        .unwrap_or(usize::MAX)
-                        .cmp(
-                            &self
-                                .face_order_index
-                                .get(right_key.as_str())
-                                .copied()
-                                .unwrap_or(usize::MAX),
-                        )
-                })
-                .then_with(|| left_key.cmp(right_key))
-        });
-
-        for (key, face) in face_entries {
+        for key in &self.search_face_keys {
+            let Some(face) = self.face_index.get(key) else {
+                continue;
+            };
             let name_lower = face.name.to_lowercase();
 
             if !words.is_empty() && !self.text_matches(&name_lower, face, &words) {
@@ -168,10 +149,10 @@ impl CardDatabase {
                 }
             }
 
-            // Deduplicate multi-face cards: keep the front face per oracle id
-            // when the export carries face order. The chosen face still matters
-            // for deck addition when the presentation sidecar is missing, and it
-            // must be the physical front face for transform DFCs (CR 712.8a).
+            // CR 712.8a: Outside the game or in a zone other than the
+            // battlefield or stack, a double-faced card has only its front-face
+            // characteristics. Deduplicate multi-face cards by oracle id while
+            // scanning the precomputed front-face order.
             if let Some(oracle_id) = face.scryfall_oracle_id.as_deref() {
                 if !seen_oracle.insert(oracle_id) {
                     continue;


### PR DESCRIPTION
## Summary
- Preserve MTGJSON face order in flattened card-data exports with optional `face_index`.
- Load and retain face order in both export and raw MTGJSON card databases.
- Use exported face order when deduping search results by oracle id so transform DFCs resolve to the physical front face, with a Kyoshi-shaped regression test.

Closes #6008

Model: codex-5
Thinking: high
Tier: Standard

## Anchored on
- `crates/engine/src/database/card_db.rs:97` - existing export loader metadata indexing for `oracle_id_index`/`layout_index`.
- `crates/engine/src/database/search.rs:233` - existing sibling-name fold using `scryfall_oracle_id` -> `oracle_id_index` -> `face_index`.
- `crates/engine/src/database/search.rs:262` - existing off-stack face authority through `oracle_id_index` and `layout_index`.

## Gate A
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=a525f09ed84e5da5421997e12599ea305ca5653f base=a85315219baf4021344f58f16b930a80ef059bf5

## Validation
- Final head: `cargo fmt --all`
- Final head: `cargo fmt --all -- --check`
- Final head: `git diff --check HEAD`
- Final head: Gate A/Gate G above
- PR CI before the follow-up: full workflow green.
- Pre-final-main-merge validation, with no conflicts in touched files during the final merge:
  - `cargo test -p engine database::search::tests`
  - `cargo test -p engine database::oracle_loader::tests`
  - `cargo test -p engine --features cli --bin oracle-gen card_export_entry_serializes_multiface_face_index`
  - `cargo test -p engine --features cli --bin oracle-gen --no-run`
  - `cargo clippy -p engine --all-targets -- -D warnings`

## Notes
- Verified The Legend of Kyoshi on Scryfall as a `transform` DFC with Saga front and Avatar Kyoshi creature back.
- Verified CR 712.8a locally before adding the CR reference.
