### PR TITLE
test(engine): end-step regression for Braids opponent decline (#5988)

### DIFF
--- a/crates/engine/tests/integration/issue_5988_braids_arisen_nightmare.rs
+++ b/crates/engine/tests/integration/issue_5988_braids_arisen_nightmare.rs
@@ -63,7 +63,7 @@ fn braids_end_step_opponent_without_match_loses_two_and_controller_draws() {
             WaitingFor::OrderTriggers { .. } => {
                 runner
                     .act(GameAction::OrderTriggers { order: vec![0] })
-                    .ok();
+                    .expect("order end-step triggers");
             }
             WaitingFor::OptionalEffectChoice { player, .. } => {
                 let accept = player == P0;
@@ -79,7 +79,9 @@ fn braids_end_step_opponent_without_match_loses_two_and_controller_draws() {
                     .expect("controller sacrifice");
             }
             WaitingFor::Priority { .. } if !runner.state().stack.is_empty() => {
-                runner.act(GameAction::PassPriority).ok();
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority while stack resolving");
             }
             _ => runner.pass_both_players(),
         }
@@ -130,7 +132,7 @@ fn braids_end_step_opponent_declines_matching_sacrifice_loses_two_and_controller
             WaitingFor::OrderTriggers { .. } => {
                 runner
                     .act(GameAction::OrderTriggers { order: vec![0] })
-                    .ok();
+                    .expect("order end-step triggers");
             }
             WaitingFor::OptionalEffectChoice { player, .. } => {
                 let accept = player == P0;
@@ -146,7 +148,9 @@ fn braids_end_step_opponent_declines_matching_sacrifice_loses_two_and_controller
                     .expect("controller sacrifice");
             }
             WaitingFor::Priority { .. } if !runner.state().stack.is_empty() => {
-                runner.act(GameAction::PassPriority).ok();
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority while stack resolving");
             }
             _ => runner.pass_both_players(),
         }

--- a/crates/engine/tests/integration/issue_5988_braids_arisen_nightmare.rs
+++ b/crates/engine/tests/integration/issue_5988_braids_arisen_nightmare.rs
@@ -1,0 +1,166 @@
+//! Issue #5988 — Braids, Arisen Nightmare: when an opponent does not sacrifice a
+//! matching permanent, that opponent loses 2 life and Braids' controller draws.
+//!
+//! Drives the real end-step trigger through `apply()` (not a hand-built execute
+//! chain) to catch wiring defects in trigger dispatch / continuation resume.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const BRAIDS_ORACLE: &str = "At the beginning of your end step, you may sacrifice an artifact, \
+creature, enchantment, land, or planeswalker. If you do, each opponent may sacrifice a permanent \
+of their choice that shares a card type with it. For each opponent who doesn't, that player loses \
+2 life and you draw a card.";
+
+fn life(state: &engine::types::game_state::GameState, player: PlayerId) -> i32 {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player")
+        .life
+}
+
+fn hand_len(state: &engine::types::game_state::GameState, player: PlayerId) -> usize {
+    state
+        .players
+        .iter()
+        .find(|p| p.id == player)
+        .expect("player")
+        .hand
+        .len()
+}
+
+#[test]
+fn braids_end_step_opponent_without_match_loses_two_and_controller_draws() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+    scenario
+        .add_creature(P0, "Braids, Arisen Nightmare", 3, 3)
+        .from_oracle_text(BRAIDS_ORACLE);
+    let p0_creature = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    // P1 controls only a land — nothing shares the sacrificed creature type.
+    scenario.add_basic_land(P1, engine::types::mana::ManaColor::Green);
+    scenario.add_card_to_library_top(P0, "Library Card");
+
+    let mut runner = scenario.build();
+    let p0_life_before = life(runner.state(), P0);
+    let p1_life_before = life(runner.state(), P1);
+    let p0_hand_before = hand_len(runner.state(), P0);
+
+    runner.advance_to_end_step();
+
+    for _ in 0..80 {
+        if matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+            && runner.state().stack.is_empty()
+        {
+            break;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .ok();
+            }
+            WaitingFor::OptionalEffectChoice { player, .. } => {
+                let accept = player == P0;
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept })
+                    .expect("optional effect decision");
+            }
+            WaitingFor::EffectZoneChoice { player, .. } if player == P0 => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![p0_creature],
+                    })
+                    .expect("controller sacrifice");
+            }
+            WaitingFor::Priority { .. } if !runner.state().stack.is_empty() => {
+                runner.act(GameAction::PassPriority).ok();
+            }
+            _ => runner.pass_both_players(),
+        }
+    }
+
+    assert_eq!(
+        life(runner.state(), P1),
+        p1_life_before - 2,
+        "opponent who could not sacrifice a matching permanent loses 2 life"
+    );
+    assert_eq!(
+        life(runner.state(), P0),
+        p0_life_before,
+        "Braids' controller does not lose life"
+    );
+    assert_eq!(
+        hand_len(runner.state(), P0),
+        p0_hand_before + 1,
+        "Braids' controller draws one card for the declining opponent"
+    );
+}
+
+#[test]
+fn braids_end_step_opponent_declines_matching_sacrifice_loses_two_and_controller_draws() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+    scenario
+        .add_creature(P0, "Braids, Arisen Nightmare", 3, 3)
+        .from_oracle_text(BRAIDS_ORACLE);
+    let p0_creature = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    scenario.add_creature(P1, "Bear Cub", 2, 2);
+    scenario.add_card_to_library_top(P0, "Library Card");
+
+    let mut runner = scenario.build();
+    let p0_life_before = life(runner.state(), P0);
+    let p1_life_before = life(runner.state(), P1);
+    let p0_hand_before = hand_len(runner.state(), P0);
+
+    runner.advance_to_end_step();
+
+    for _ in 0..80 {
+        if matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+            && runner.state().stack.is_empty()
+        {
+            break;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .ok();
+            }
+            WaitingFor::OptionalEffectChoice { player, .. } => {
+                let accept = player == P0;
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept })
+                    .expect("optional effect decision");
+            }
+            WaitingFor::EffectZoneChoice { player, .. } if player == P0 => {
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![p0_creature],
+                    })
+                    .expect("controller sacrifice");
+            }
+            WaitingFor::Priority { .. } if !runner.state().stack.is_empty() => {
+                runner.act(GameAction::PassPriority).ok();
+            }
+            _ => runner.pass_both_players(),
+        }
+    }
+
+    assert_eq!(
+        life(runner.state(), P1),
+        p1_life_before - 2,
+        "opponent who declines to sacrifice loses 2 life"
+    );
+    assert_eq!(life(runner.state(), P0), p0_life_before);
+    assert_eq!(
+        hand_len(runner.state(), P0),
+        p0_hand_before + 1,
+        "controller draws for the declining opponent"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -527,6 +527,7 @@ mod issue_581_mystic_remora_cumulative_upkeep;
 mod issue_5820_susan_foreman;
 mod issue_5821_psychic_paper_attach_choice;
 mod issue_583_vivi_ornitier_mana_source;
+mod issue_5988_braids_arisen_nightmare;
 mod issue_5999_aura_exile_host;
 mod issue_6002_neera_wild_mage_bottom_of_library;
 mod issue_6006_aminatou_veil_piercer_own_turn_miracle;


### PR DESCRIPTION
Fixes #5988

## Summary

Discord report ([#5988](https://github.com/phase-rs/phase/issues/5988)): when an opponent fails to sacrifice a permanent sharing a card type with the controller's sacrificed permanent, there is no consequence — the opponent should lose 2 life and Braids' controller should draw a card.

Classifier verdict: **supported_aspect_defect** — the parser AST is correct; the suspected gap was runtime per-opponent `Not{IfYouDo}` decline routing or `ParentTarget` LKI for the `SharesQuality` filter.

Investigation on current `main` showed the engine already handles this correctly:

- **Chain-level tests** in `braids_arisen_nightmare_decline.rs` (issues #491 / #4246) cover decline-consequence routing, multi-opponent fan-out, controller decline, and accept-path `ParentTarget` LKI — all pass.
- **End-step trigger path** was untested: prior coverage built a hand-resolved `execute` chain rather than firing the real "beginning of your end step" trigger through `apply()`.

This PR adds end-to-end trigger-path regressions. Both scenarios pass on current head without engine changes.

## Oracle text (verified)

> At the beginning of your end step, you may sacrifice an artifact, creature, enchantment, land, or planeswalker. If you do, each opponent may sacrifice a permanent of their choice that shares a card type with it. For each opponent who doesn't, that player loses 2 life and you draw a card.

## Changes

- **`crates/engine/tests/integration/issue_5988_braids_arisen_nightmare.rs`** — two end-step integration tests:
  - **`braids_end_step_opponent_without_match_loses_two_and_controller_draws`** — P1 controls only a land; after P0 sacrifices a creature, P1 loses 2 life and P0 draws.
  - **`braids_end_step_opponent_declines_matching_sacrifice_loses_two_and_controller_draws`** — P1 has a matching creature but declines the optional sacrifice; same consequences.
- **`crates/engine/tests/integration/main.rs`** — register the new module.

No engine, parser, frontend, or AI code changes.

## Test plan

```bash
cargo fmt --all -- --check
cargo test -p engine issue_5988
```

Expected: both integration tests pass.

Related Braids regressions (should remain green):

```bash
cargo test -p engine braids_arisen_nightmare
cargo test -p engine braids_
```

## Notes

If live Discord repros persist after merge, the next investigation target is **UI/AI optional-choice dispatch** (`DecideOptionalEffect { accept: false }` for the opponent), not the decline-consequence engine path — these tests prove the engine applies life loss and draw correctly once the trigger resolves.
