### PR TITLE
fix(client): break chunk-reload loops after two failed reloads, with self-diagnosing probe

### DIFF
--- a/client/src/pwa/__tests__/chunkReloadHandler.test.ts
+++ b/client/src/pwa/__tests__/chunkReloadHandler.test.ts
@@ -1,0 +1,236 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { installChunkReloadHandler } from "../chunkReloadHandler";
+
+const mocks = vi.hoisted(() => ({
+  isMultiplayerGameLive: vi.fn<() => boolean>(() => false),
+  whenMultiplayerGameEnds: vi.fn<(cb: () => void) => () => void>(),
+  trackEvent: vi.fn(),
+  flushNow: vi.fn(),
+  pushUpdateDebug: vi.fn(),
+  setUpdateError: vi.fn(),
+  setUpdateStatus: vi.fn(),
+}));
+
+vi.mock("../multiplayerGuard", () => ({
+  isMultiplayerGameLive: mocks.isMultiplayerGameLive,
+  whenMultiplayerGameEnds: mocks.whenMultiplayerGameEnds,
+}));
+vi.mock("../updateStatus", () => ({
+  pushUpdateDebug: mocks.pushUpdateDebug,
+  setUpdateError: mocks.setUpdateError,
+  setUpdateStatus: mocks.setUpdateStatus,
+}));
+vi.mock("../../services/telemetry", () => ({
+  trackEvent: mocks.trackEvent,
+  flushNow: mocks.flushNow,
+}));
+
+const CHUNK_URL = "https://phase-rs.dev/assets/GamePage-abc.js";
+const RELOAD_GUARD_WINDOW_MS = 10 * 60 * 1000;
+
+function firePreloadError(message: string): void {
+  const event = new Event("vite:preloadError", { cancelable: true }) as Event & {
+    payload?: Error;
+  };
+  event.payload = new Error(message);
+  window.dispatchEvent(event);
+}
+
+function guardEntry(message: string): { count: number; firstAt: number } | null {
+  const raw = window.sessionStorage.getItem(`chunk-reload:${message}`);
+  return raw ? (JSON.parse(raw) as { count: number; firstAt: number }) : null;
+}
+
+async function expectLoopAbortEvent(fields: Record<string, unknown>): Promise<void> {
+  await vi.waitFor(() => {
+    expect(mocks.trackEvent).toHaveBeenCalledWith(
+      "chunk_reload",
+      expect.objectContaining({ reason: "loop-abort", deferred: false, ...fields }),
+    );
+  });
+}
+
+describe("chunkReloadHandler loop breaker", () => {
+  let reloadSpy: ReturnType<typeof vi.fn>;
+  let gameEndCallbacks: Array<() => void>;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeAll(() => {
+    installChunkReloadHandler();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    gameEndCallbacks = [];
+    mocks.isMultiplayerGameLive.mockReturnValue(false);
+    mocks.whenMultiplayerGameEnds.mockImplementation((cb: () => void) => {
+      gameEndCallbacks.push(cb);
+      return () => {};
+    });
+    reloadSpy = vi.fn();
+    Object.defineProperty(window.location, "reload", {
+      value: reloadSpy,
+      configurable: true,
+    });
+    fetchMock = vi.fn(async () => ({
+      status: 200,
+      headers: {
+        get: (name: string) =>
+          ({ "cf-cache-status": "HIT", "cf-ray": "ray-1" })[name.toLowerCase()] ?? null,
+      },
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("reloads on the first two preload errors and counts each executed reload", () => {
+    const message = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+
+    firePreloadError(message);
+    firePreloadError(message);
+
+    expect(reloadSpy).toHaveBeenCalledTimes(2);
+    expect(guardEntry(message)?.count).toBe(2);
+    expect(mocks.setUpdateError).not.toHaveBeenCalled();
+    expect(mocks.trackEvent).toHaveBeenCalledTimes(2);
+    expect(mocks.trackEvent).toHaveBeenCalledWith("chunk_reload", {
+      reason: "preload-error",
+      deferred: false,
+      chunk: message,
+    });
+  });
+
+  it("aborts the loop on the third error: no reload, error surfaced, probe reported", async () => {
+    const message = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+
+    firePreloadError(message);
+    firePreloadError(message);
+    firePreloadError(message);
+
+    expect(reloadSpy).toHaveBeenCalledTimes(2);
+    expect(mocks.setUpdateError).toHaveBeenCalledTimes(1);
+    await expectLoopAbortEvent({
+      probe_status: 200,
+      probe_cache: "HIT",
+      probe_ray: "ray-1",
+      probe_sw: 0,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      CHUNK_URL,
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    // The abort path replaces (not accompanies) the preload-error event.
+    const reasons = mocks.trackEvent.mock.calls.map(([, fields]) => fields.reason);
+    expect(reasons.filter((r) => r === "preload-error")).toHaveLength(2);
+  });
+
+  it("skips the probe fetch when the message carries no URL", async () => {
+    const message = "Unable to preload CSS";
+    window.sessionStorage.setItem(
+      `chunk-reload:${message}`,
+      JSON.stringify({ count: 2, firstAt: Date.now() }),
+    );
+
+    firePreloadError(message);
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    await expectLoopAbortEvent({ probe_sw: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("tracks each failing chunk independently", () => {
+    const messageA = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+    const messageB = "Failed to fetch dynamically imported module: https://phase-rs.dev/assets/DeckPage-def.js";
+    window.sessionStorage.setItem(
+      `chunk-reload:${messageA}`,
+      JSON.stringify({ count: 2, firstAt: Date.now() }),
+    );
+
+    firePreloadError(messageB);
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(guardEntry(messageB)?.count).toBe(1);
+  });
+
+  it("resets the counter once the guard window has expired", () => {
+    const message = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+    window.sessionStorage.setItem(
+      `chunk-reload:${message}`,
+      JSON.stringify({ count: 2, firstAt: Date.now() - RELOAD_GUARD_WINDOW_MS - 1000 }),
+    );
+
+    firePreloadError(message);
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(guardEntry(message)?.count).toBe(1);
+  });
+
+  it("never trips during a multiplayer game: queuing is not counting", () => {
+    mocks.isMultiplayerGameLive.mockReturnValue(true);
+    const message = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+
+    firePreloadError(message);
+    firePreloadError(message);
+    firePreloadError(message);
+
+    // First-failure-wins: one queued reload, no executed reloads, no breach.
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(mocks.whenMultiplayerGameEnds).toHaveBeenCalledTimes(1);
+    expect(mocks.setUpdateStatus).toHaveBeenCalledWith("deferred");
+    expect(mocks.setUpdateError).not.toHaveBeenCalled();
+    expect(guardEntry(message)).toBeNull();
+
+    // The deferred reload counts when it fires, not when queued.
+    for (const cb of gameEndCallbacks) cb();
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    expect(guardEntry(message)?.count).toBe(1);
+  });
+
+  it("leaves an already-queued deferred reload intact when a later error breaches", async () => {
+    mocks.isMultiplayerGameLive.mockReturnValue(true);
+    const message = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+
+    firePreloadError(message);
+    expect(mocks.whenMultiplayerGameEnds).toHaveBeenCalledTimes(1);
+
+    // A breach mid-game (counter pre-filled from before the game started)
+    // must not queue more work, but must not cancel the queued reload either.
+    window.sessionStorage.setItem(
+      `chunk-reload:${message}`,
+      JSON.stringify({ count: 2, firstAt: Date.now() }),
+    );
+    firePreloadError(message);
+
+    expect(mocks.whenMultiplayerGameEnds).toHaveBeenCalledTimes(1);
+    expect(mocks.setUpdateError).toHaveBeenCalledTimes(1);
+    await expectLoopAbortEvent({});
+
+    for (const cb of gameEndCallbacks) cb();
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("degrades to always-reload when sessionStorage is unavailable", () => {
+    const getItem = vi
+      .spyOn(window.sessionStorage, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    const setItem = vi
+      .spyOn(window.sessionStorage, "setItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    const message = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+
+    firePreloadError(message);
+    firePreloadError(message);
+    firePreloadError(message);
+
+    expect(reloadSpy).toHaveBeenCalledTimes(3);
+    expect(mocks.setUpdateError).not.toHaveBeenCalled();
+
+    getItem.mockRestore();
+    setItem.mockRestore();
+  });
+});

--- a/client/src/pwa/chunkReloadHandler.ts
+++ b/client/src/pwa/chunkReloadHandler.ts
@@ -1,5 +1,5 @@
 import { isMultiplayerGameLive, whenMultiplayerGameEnds } from "./multiplayerGuard";
-import { pushUpdateDebug, setUpdateStatus } from "./updateStatus";
+import { pushUpdateDebug, setUpdateError, setUpdateStatus } from "./updateStatus";
 import { flushNow, trackEvent } from "../services/telemetry";
 
 /**
@@ -20,10 +20,91 @@ import { flushNow, trackEvent } from "../services/telemetry";
  * everyone else in it. The user lives with a degraded UI for the rest of
  * the game (one missing lazy route), but the game itself stays alive and
  * the reconnect-on-end story remains intact.
+ *
+ * Loop breaker: when the failure *persists* (bad cached edge variant,
+ * broken client cache), reloading forever turns one broken client into a
+ * telemetry storm — observed 2026-07-18 as ~6,500 events/hour from a
+ * handful of clients. Reloads are counted per failing chunk in
+ * `sessionStorage` (survives reload in the same tab; keys self-reset when
+ * chunk hashes change on the next deploy). Only *executed* reloads count —
+ * queuing a deferred multiplayer reload does not — so repeated failures
+ * during one game can never trip the breaker. After
+ * {@link RELOAD_GUARD_MAX} reloads inside {@link RELOAD_GUARD_WINDOW_MS},
+ * the handler stops reloading, surfaces the failure via `setUpdateError`,
+ * and reports what the failing URL actually returns (status +
+ * `cf-cache-status` + `cf-ray` + SW-controlled bit) so a stuck client
+ * diagnoses itself in telemetry.
  */
 let isInstalled = false;
 let deferredReload: (() => void) | null = null;
 let deferredReloadUnsub: (() => void) | null = null;
+
+/** Reloads allowed per failing chunk within {@link RELOAD_GUARD_WINDOW_MS}. */
+const RELOAD_GUARD_MAX = 2;
+const RELOAD_GUARD_WINDOW_MS = 10 * 60 * 1000;
+
+interface ReloadGuardState {
+  count: number;
+  firstAt: number;
+}
+
+/** Read the guard state for a chunk key; `null` when absent, expired, or
+ *  storage is unavailable (lockdown/embedded contexts — the breaker then
+ *  degrades to the pre-guard always-reload behavior). */
+function readReloadGuard(key: string): ReloadGuardState | null {
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as ReloadGuardState;
+    if (typeof parsed.count !== "number" || typeof parsed.firstAt !== "number") return null;
+    if (Date.now() - parsed.firstAt > RELOAD_GUARD_WINDOW_MS) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/** Count an *executed* reload (called immediately before `location.reload()`,
+ *  so deferred reloads count when they fire, not when queued). */
+function recordReload(key: string): void {
+  try {
+    const prior = readReloadGuard(key);
+    const next: ReloadGuardState = prior
+      ? { count: prior.count + 1, firstAt: prior.firstAt }
+      : { count: 1, firstAt: Date.now() };
+    window.sessionStorage.setItem(key, JSON.stringify(next));
+  } catch {
+    // Storage unavailable — degrade to always-reload.
+  }
+}
+
+/** Best-effort diagnosis of a persistently failing chunk: refetch it and
+ *  report status + Cloudflare cache/colo headers (same-origin, all readable)
+ *  plus whether a service worker controls this page. Runs only on the
+ *  loop-abort path, where no reload is pending — never delays recovery. */
+async function probeFailedChunk(message: string): Promise<Record<string, unknown>> {
+  const probeSw =
+    typeof navigator !== "undefined" &&
+    "serviceWorker" in navigator &&
+    navigator.serviceWorker.controller !== null
+      ? 1
+      : 0;
+  const url = /https?:\/\/[^\s'"()]+/.exec(message)?.[0];
+  if (!url) return { probe_sw: probeSw };
+  try {
+    const res = await fetch(url, { cache: "no-store", signal: AbortSignal.timeout(3000) });
+    return {
+      probe_status: res.status,
+      probe_cache: res.headers.get("cf-cache-status") ?? "",
+      probe_ray: res.headers.get("cf-ray") ?? "",
+      probe_sw: probeSw,
+    };
+  } catch {
+    // Fetch threw or timed out — status 0 mirrors the browser's own
+    // network-error convention.
+    return { probe_status: 0, probe_sw: probeSw };
+  }
+}
 
 export function installChunkReloadHandler(): void {
   if (isInstalled) return;
@@ -34,16 +115,32 @@ export function installChunkReloadHandler(): void {
     // the console — we're handling it by reloading (or deferring).
     event.preventDefault();
 
-    const deferred = isMultiplayerGameLive();
     // The failed chunk identifier lives in the event's `.payload` Error
     // (its message carries the failing URL). Best-effort; truncated at enqueue.
     const chunk = (event as { payload?: Error }).payload?.message;
+    const guardKey = `chunk-reload:${chunk ?? "unknown"}`;
+
+    if ((readReloadGuard(guardKey)?.count ?? 0) >= RELOAD_GUARD_MAX) {
+      // Loop breaker: two reloads inside the window didn't fix this chunk, so
+      // a third won't either. Stop reloading and don't queue a new deferred
+      // reload — an already-queued one from an earlier failure is left intact
+      // (it's a single reload and may succeed after the game ends).
+      setUpdateError("App update failed to load. Please refresh the page.");
+      void probeFailedChunk(chunk ?? "").then((probe) => {
+        trackEvent("chunk_reload", { reason: "loop-abort", deferred: false, chunk, ...probe });
+        flushNow();
+      });
+      return;
+    }
+
+    const deferred = isMultiplayerGameLive();
     trackEvent("chunk_reload", { reason: "preload-error", deferred, chunk });
 
     const doReload = () => {
       pushUpdateDebug("Chunk preload failed; reloading to pick up new bundle.", "warn");
       // Drain the telemetry queue before navigating away.
       flushNow();
+      recordReload(guardKey);
       window.location.reload();
     };
 


### PR DESCRIPTION
A persistently failing lazy chunk (observed 2026-07-18: ~5-20 production
clients looping on GamePage, ~6,500 telemetry events/hour) previously
reloaded forever: every vite:preloadError triggered an unconditional
location.reload(). Reloads are now counted per failing chunk in
sessionStorage (2 max per 10 min; only *executed* reloads count, so
deferred multiplayer reloads never trip the breaker mid-game and an
already-queued deferred reload survives a breach). On breach the handler
stops reloading, surfaces the failure via setUpdateError, refetches the
failing URL once, and reports status + cf-cache-status + cf-ray +
SW-controlled bit as a chunk_reload loop-abort event so stuck clients
diagnose themselves in Analytics Engine. Storage-unavailable contexts
degrade to the previous always-reload behavior.
