### PR TITLE
feat(lobby-worker): accept chunk_reload probe columns

### DIFF
--- a/lobby-worker/src/telemetry.ts
+++ b/lobby-worker/src/telemetry.ts
@@ -46,7 +46,13 @@ export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] 
   engine_panic: { blobs: ["reason", "panic", "game_mode"], doubles: ["fatal", "turn"] },
   stuck_decision: { blobs: ["waiting_for_kind", "game_mode", "phase"], doubles: [] },
   js_error: { blobs: ["name", "message", "top_frame", "source", "route"], doubles: [] },
-  chunk_reload: { blobs: ["reason", "chunk"], doubles: ["deferred"] },
+  // `probe_*` columns are appended (never inserted — AE columns are
+  // positional) and populated only on `reason: "loop-abort"` events: the
+  // client refetches the failing chunk and reports what it actually got.
+  chunk_reload: {
+    blobs: ["reason", "chunk", "probe_cache", "probe_ray"],
+    doubles: ["deferred", "probe_status", "probe_sw"],
+  },
   game_end: {
     blobs: [
       "result",

--- a/lobby-worker/test/telemetry.test.mjs
+++ b/lobby-worker/test/telemetry.test.mjs
@@ -81,13 +81,48 @@ test("toDataPoint prepends the envelope blobs and sets the single index", () => 
   );
   const point = toDataPoint(e);
   assert.deepEqual(point.indexes, ["chunk_reload"]);
-  // blobs: [event, app_version, build_hash, platform, ...schema.blobs]
-  assert.deepEqual(point.blobs, ["chunk_reload", "0.42.1", "02b26c3", "web", "preload-error", "c.js"]);
+  // blobs: [event, app_version, build_hash, platform, ...schema.blobs].
+  // Absent probe_* fields project as ""/0 in their appended positions.
+  assert.deepEqual(point.blobs, [
+    "chunk_reload",
+    "0.42.1",
+    "02b26c3",
+    "web",
+    "preload-error",
+    "c.js",
+    "",
+    "",
+  ]);
   // deferred=true coerces to 1.
-  assert.deepEqual(point.doubles, [1]);
+  assert.deepEqual(point.doubles, [1, 0, 0]);
   assert.equal(point.indexes.length, 1);
   assert.ok(point.blobs.length <= 20);
   assert.ok(point.doubles.length <= 20);
+});
+
+test("chunk_reload probe fields land in the appended columns", () => {
+  const [e] = sanitizeTelemetryBatch(
+    batch([
+      {
+        event: "chunk_reload",
+        reason: "loop-abort",
+        deferred: false,
+        chunk: "Failed to fetch dynamically imported module: https://x/a.js",
+        probe_cache: "HIT",
+        probe_ray: "8f3a2-SJC",
+        probe_status: 200,
+        probe_sw: 1,
+      },
+    ]),
+  );
+  const point = toDataPoint(e);
+  assert.deepEqual(point.blobs.slice(4), [
+    "loop-abort",
+    "Failed to fetch dynamically imported module: https://x/a.js",
+    "HIT",
+    "8f3a2-SJC",
+  ]);
+  assert.deepEqual(point.doubles, [0, 200, 1]);
 });
 
 test("unknown events are dropped, not errors", () => {


### PR DESCRIPTION
Append probe_cache/probe_ray blobs and probe_status/probe_sw doubles to
the chunk_reload schema — appended at the end only, since AE columns are
positional and existing Grafana queries key on blob5/blob6. Populated by
the client's loop-abort path; absent fields project as ""/0.
