### PR TITLE
fix(parser): distribute source-linked exiled-object keyword grants per item (Eater of Virtue, Urborg Scavengers)

### DIFF
--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1424,22 +1424,183 @@ fn parse_keyword_grant_from_exiled_object_static(text: &str) -> Option<Vec<Stati
         );
     }
 
-    let defs = keywords
+    // CR 611.3a: one INDEPENDENT SelfRef grant per listed keyword (per-item core).
+    // Each keyword's presence check is the exiled-`<type>`-card filter (in the
+    // exile zone) narrowed to cards that HAVE that keyword.
+    Some(per_keyword_conditional_grants(
+        &TargetFilter::SelfRef,
+        keywords,
+        text,
+        |ki| {
+            let mut tf = base.clone();
+            tf.properties.push(FilterProp::WithKeyword { value: ki });
+            TargetFilter::Typed(tf)
+        },
+    ))
+}
+
+/// CR 611.3a: Build one INDEPENDENT conditional keyword grant per listed keyword.
+/// `subject` is what receives the keyword ([`TargetFilter::SelfRef`] for
+/// "~"/"this creature", an `EquippedBy`/`EnchantedBy` filter for an attached
+/// subject); `presence_filter_for` yields, per keyword `Ki`, the presence filter
+/// for the card that must HAVE `Ki` (gating that grant on THAT keyword alone).
+/// Modeling the list as one static under the first keyword's condition (the
+/// observed collapse) made every keyword apply whenever ANY one matched — this is
+/// the per-item seam both the exiled-`<type>`-card and source-linked callers share.
+fn per_keyword_conditional_grants(
+    subject: &TargetFilter,
+    keywords: Vec<Keyword>,
+    description: &str,
+    presence_filter_for: impl Fn(Keyword) -> TargetFilter,
+) -> Vec<StaticDefinition> {
+    keywords
         .into_iter()
         .map(|ki| {
-            let mut tf = base.clone();
-            tf.properties
-                .push(FilterProp::WithKeyword { value: ki.clone() });
+            let filter = presence_filter_for(ki.clone());
             StaticDefinition::continuous()
-                .affected(TargetFilter::SelfRef)
+                .affected(subject.clone())
                 .modifications(vec![ContinuousModification::AddKeyword { keyword: ki }])
                 .condition(StaticCondition::IsPresent {
-                    filter: Some(TargetFilter::Typed(tf)),
+                    filter: Some(filter),
                 })
-                .description(text.to_string())
+                .description(description.to_string())
         })
-        .collect();
-    Some(defs)
+        .collect()
+}
+
+/// nom: the source-linked exile-pool object phrase — "a card exiled with ~|it"
+/// (the pool of cards exiled *with* this permanent, not the whole exile zone).
+fn parse_source_exiled_object_nom(input: &str) -> OracleResult<'_, ()> {
+    value(
+        (),
+        alt((
+            tag::<_, _, OracleError<'_>>("a card exiled with ~"),
+            tag("a card exiled with it"),
+        )),
+    )
+    .parse(input)
+}
+
+/// CR 702.5 + CR 702.6: nom combinator for the granted SUBJECT of a same-is-true
+/// keyword grant (lowercased). "~"/"it" is the source itself
+/// ([`TargetFilter::SelfRef`]); "equipped/enchanted creature|permanent" is the
+/// attached permanent ([`FilterProp::EquippedBy`]/[`FilterProp::EnchantedBy`],
+/// mirroring [`attached_subject_filter`]). One `value(_, tag())` arm per subject;
+/// the attached-subject arms precede the bare self-refs so "equipped creature" is
+/// not misread. The trailing space is consumed so the remainder begins at "has".
+fn parse_source_exiled_subject_nom(input: &str) -> OracleResult<'_, TargetFilter> {
+    alt((
+        value(
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::EquippedBy])),
+            tag::<_, _, OracleError<'_>>("equipped creature "),
+        ),
+        value(
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::EnchantedBy])),
+            tag("enchanted creature "),
+        ),
+        value(
+            TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::EquippedBy])),
+            tag("equipped permanent "),
+        ),
+        value(
+            TargetFilter::Typed(TypedFilter::permanent().properties(vec![FilterProp::EnchantedBy])),
+            tag("enchanted permanent "),
+        ),
+        value(TargetFilter::SelfRef, tag("~ ")),
+        value(TargetFilter::SelfRef, tag("it ")),
+    ))
+    .parse(input)
+}
+
+/// nom: "<object> has <K0>, <subject> has <K0>" — the PREFIX clause order (Eater
+/// of Virtue, Death-Mask Duplicant). Returns `(subject, K0)`; the condition
+/// keyword and the granted keyword must match (they are the same keyword).
+fn parse_source_exiled_grant_prefix(input: &str) -> OracleResult<'_, (TargetFilter, &str)> {
+    let (input, _) = tag::<_, _, OracleError<'_>>("as long as ").parse(input)?;
+    let (input, _) = parse_source_exiled_object_nom(input)?;
+    let (input, _) = tag(" has ").parse(input)?;
+    let (input, k0a) = nom_primitives::parse_keyword_name(input)?;
+    let (input, _) = tag(", ").parse(input)?;
+    let (input, subject) = parse_source_exiled_subject_nom(input)?;
+    let (input, _) = tag("has ").parse(input)?;
+    let (input, k0b) = nom_primitives::parse_keyword_name(input)?;
+    if k0a != k0b {
+        return Err(super::oracle_nom::error::oracle_err(input));
+    }
+    Ok((input, (subject, k0a)))
+}
+
+/// nom: "<subject> has <K0> as long as <object> has <K0>" — the POSTFIX clause
+/// order (Urborg Scavengers). Returns `(subject, K0)`.
+fn parse_source_exiled_grant_postfix(input: &str) -> OracleResult<'_, (TargetFilter, &str)> {
+    let (input, subject) = parse_source_exiled_subject_nom(input)?;
+    let (input, _) = tag::<_, _, OracleError<'_>>("has ").parse(input)?;
+    let (input, k0a) = nom_primitives::parse_keyword_name(input)?;
+    let (input, _) = tag(" as long as ").parse(input)?;
+    let (input, _) = parse_source_exiled_object_nom(input)?;
+    let (input, _) = tag(" has ").parse(input)?;
+    let (input, k0b) = nom_primitives::parse_keyword_name(input)?;
+    if k0a != k0b {
+        return Err(super::oracle_nom::error::oracle_err(input));
+    }
+    Ok((input, (subject, k0a)))
+}
+
+/// CR 611.3a + CR 400.7 (Eater of Virtue, Death-Mask Duplicant, Urborg
+/// Scavengers): the source-linked sibling of
+/// [`parse_keyword_grant_from_exiled_object_static`]. The condition object is "a
+/// card exiled WITH this permanent" ([`TargetFilter::ExiledBySource`] — the linked
+/// exile pool, not every card in the exile zone), the grant lands on "~" or the
+/// equipped/enchanted creature, and it appears in either clause order:
+///   PREFIX  — "As long as a card exiled with ~ has `<K0>`, `<subject>` has `<K0>`.
+///             The same is true for `<K1>`, …"  (Eater of Virtue, Death-Mask)
+///   POSTFIX — "`<subject>` has `<K0>` as long as a card exiled with it has `<K0>`.
+///             The same is true for `<K1>`, …"  (Urborg Scavengers)
+/// Each listed keyword becomes one INDEPENDENT grant via the shared per-item core;
+/// the prior parse collapsed the whole list under the first keyword's condition
+/// (an exiled flyer granted every keyword) or dropped the tail into an
+/// `Unrecognized` condition (every continuation keyword lost).
+fn parse_keyword_grant_from_source_exiled_object_static(
+    text: &str,
+) -> Option<Vec<StaticDefinition>> {
+    let lower = text.to_lowercase();
+    let (tail, (subject, k0_name)) = alt((
+        parse_source_exiled_grant_prefix,
+        parse_source_exiled_grant_postfix,
+    ))
+    .parse(lower.as_str())
+    .ok()?;
+
+    let k0: Keyword = k0_name.parse().ok()?;
+    // tail: ". the same is true for <list>." (or "." / "" for a single keyword).
+    let tail = tail.trim_start_matches('.').trim_start();
+    let mut keywords = vec![k0];
+    if !tail.is_empty() {
+        keywords.extend(
+            super::super::oracle_effect::sequence::try_parse_same_is_true_continuation(tail)?,
+        );
+    }
+
+    // CR 400.7 / CR 610.3: the presence check is a card in the source-linked exile
+    // pool ([`TargetFilter::ExiledBySource`] — cards exiled *with* this permanent,
+    // not every card in the exile zone) that HAS the keyword. `ExiledBySource` is
+    // a whole-object ref, so it is AND-composed with the exile-zone keyword filter
+    // (the same `InZone{Exile} + WithKeyword` shape the exiled-`<type>`-card path
+    // relies on) rather than folded in as a property.
+    Some(per_keyword_conditional_grants(
+        &subject,
+        keywords,
+        text,
+        |ki| TargetFilter::And {
+            filters: vec![
+                TargetFilter::ExiledBySource,
+                TargetFilter::Typed(TypedFilter::card().properties(vec![
+                    FilterProp::InZone { zone: Zone::Exile },
+                    FilterProp::WithKeyword { value: ki },
+                ])),
+            ],
+        },
+    ))
 }
 
 /// CR 508.1c + CR 509.1b: predicate combinator for the defensive-flyer compound
@@ -1720,6 +1881,17 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
     // the shared condition on the first keyword only (the observed bug: the grant
     // applies unconditionally to every keyword).
     if let Some(defs) = parse_keyword_grant_from_exiled_object_static(&stripped) {
+        return defs;
+    }
+
+    // CR 611.3a + CR 400.7 (Eater of Virtue, Death-Mask Duplicant, Urborg
+    // Scavengers): the source-linked exile-pool sibling of the handler above —
+    // "a card exiled WITH ~" in either clause order, granting to "~" or the
+    // equipped/enchanted creature. Same precedence rationale: it must run before
+    // generic multi-sentence splitting, which collapses the "the same is true
+    // for" list under the first keyword's condition (an exiled flyer would then
+    // grant every keyword) or strands the tail in an `Unrecognized` condition.
+    if let Some(defs) = parse_keyword_grant_from_source_exiled_object_static(&stripped) {
         return defs;
     }
 

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1468,6 +1468,7 @@ fn per_keyword_conditional_grants(
         .collect()
 }
 
+/// CR 607.2a: linked abilities identify cards exiled with this permanent.
 /// nom: the source-linked exile-pool object phrase — "a card exiled with ~|it"
 /// (the pool of cards exiled *with* this permanent, not the whole exile zone).
 fn parse_source_exiled_object_nom(input: &str) -> OracleResult<'_, ()> {
@@ -1546,7 +1547,7 @@ fn parse_source_exiled_grant_postfix(input: &str) -> OracleResult<'_, (TargetFil
     Ok((input, (subject, k0a)))
 }
 
-/// CR 611.3a + CR 400.7 (Eater of Virtue, Death-Mask Duplicant, Urborg
+/// CR 611.3a + CR 607.2a (Eater of Virtue, Death-Mask Duplicant, Urborg
 /// Scavengers): the source-linked sibling of
 /// [`parse_keyword_grant_from_exiled_object_static`]. The condition object is "a
 /// card exiled WITH this permanent" ([`TargetFilter::ExiledBySource`] — the linked
@@ -1581,7 +1582,7 @@ fn parse_keyword_grant_from_source_exiled_object_static(
         );
     }
 
-    // CR 400.7 / CR 610.3: the presence check is a card in the source-linked exile
+    // CR 607.2a + CR 611.3a: the presence check is a card in the source-linked exile
     // pool ([`TargetFilter::ExiledBySource`] — cards exiled *with* this permanent,
     // not every card in the exile zone) that HAS the keyword. `ExiledBySource` is
     // a whole-object ref, so it is AND-composed with the exile-zone keyword filter
@@ -1884,7 +1885,7 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
         return defs;
     }
 
-    // CR 611.3a + CR 400.7 (Eater of Virtue, Death-Mask Duplicant, Urborg
+    // CR 611.3a + CR 607.2a (Eater of Virtue, Death-Mask Duplicant, Urborg
     // Scavengers): the source-linked exile-pool sibling of the handler above —
     // "a card exiled WITH ~" in either clause order, granting to "~" or the
     // equipped/enchanted creature. Same precedence rationale: it must run before

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -30140,6 +30140,105 @@ fn rayami_flying_grant_is_conditional_on_matching_exiled_card() {
     );
 }
 
+/// Shared assertions for a source-linked exiled-object per-keyword grant: one
+/// Continuous static per listed keyword, each granting exactly `AddKeyword(K)` to
+/// `expected_subject`, gated on `IsPresent { Typed { ExiledBySource + WithKeyword(K) } }`.
+/// Discriminator vs `main`: the whole list collapses to ONE static under the
+/// first keyword's condition (or an `Unrecognized` gate), so the count and the
+/// per-keyword `WithKeyword` binding both fail there.
+#[cfg(test)]
+fn assert_source_exiled_per_keyword_grants(
+    line: &str,
+    expected_len: usize,
+    expected_subject: &TargetFilter,
+) -> Vec<Keyword> {
+    let statics = super::shared::parse_static_line_multi(line);
+    assert_eq!(
+        statics.len(),
+        expected_len,
+        "expected one conditional grant per listed keyword, got {statics:?}"
+    );
+    for s in &statics {
+        let Some(ContinuousModification::AddKeyword { keyword }) = s.modifications.first() else {
+            panic!(
+                "each static grants exactly one keyword, got {:?}",
+                s.modifications
+            );
+        };
+        assert_eq!(
+            s.affected.as_ref(),
+            Some(expected_subject),
+            "the grant lands on the stated subject"
+        );
+        let Some(StaticCondition::IsPresent {
+            filter: Some(TargetFilter::And { filters }),
+        }) = &s.condition
+        else {
+            panic!(
+                "expected an independently-evaluated IsPresent(And) condition, got {:?}",
+                s.condition
+            );
+        };
+        assert!(
+            filters.contains(&TargetFilter::ExiledBySource),
+            "presence check is scoped to the source-linked exile pool, got {filters:?}"
+        );
+        assert!(
+            filters.iter().any(|f| matches!(
+                f,
+                TargetFilter::Typed(tf)
+                    if tf.properties.contains(&FilterProp::WithKeyword { value: keyword.clone() })
+                        && tf.properties.contains(&FilterProp::InZone { zone: crate::types::zones::Zone::Exile })
+            )),
+            "each keyword K is granted only while a card exiled with the source that HAS K is present, got {filters:?}"
+        );
+    }
+    statics
+        .iter()
+        .filter_map(|s| match s.modifications.first() {
+            Some(ContinuousModification::AddKeyword { keyword }) => Some(keyword.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Eater of Virtue — PREFIX order, `equipped creature` subject. "As long as a
+/// card exiled with ~ has flying, equipped creature has flying. The same is true
+/// for first strike, …, and vigilance." (13 keywords, identical set to Rayami).
+/// The grant lands on the EQUIPPED creature (`EquippedBy`), not the Equipment.
+#[test]
+fn eater_of_virtue_source_exiled_grant_splits_per_keyword_to_equipped_creature() {
+    let line = "As long as a card exiled with ~ has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance.";
+    let subject =
+        TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::EquippedBy]));
+    let granted = assert_source_exiled_per_keyword_grants(line, 13, &subject);
+    assert!(
+        granted.contains(&Keyword::Flying),
+        "grants flying: {granted:?}"
+    );
+    assert!(
+        granted.contains(&Keyword::Vigilance),
+        "grants vigilance: {granted:?}"
+    );
+}
+
+/// Urborg Scavengers — POSTFIX order, `~` subject. "~ has flying as long as a
+/// card exiled with it has flying. The same is true for first strike, …, and
+/// vigilance." (12 keywords). Exercises the trailing-`as long as` clause order.
+#[test]
+fn urborg_scavengers_postfix_source_exiled_grant_splits_per_keyword() {
+    let line = "~ has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.";
+    let granted = assert_source_exiled_per_keyword_grants(line, 12, &TargetFilter::SelfRef);
+    assert!(
+        granted.contains(&Keyword::Flying),
+        "grants flying: {granted:?}"
+    );
+    assert!(
+        granted.contains(&Keyword::Deathtouch),
+        "grants deathtouch: {granted:?}"
+    );
+}
+
 /// DISPATCH-SITE INVARIANT (pipeline-level): a standalone printed reducer line
 /// (Training Grounds) is claimed by `parse_static_line` as a `ReduceAbilityCost`
 /// static BEFORE `parse_imperative_effect` ever runs. Training Grounds' text and

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -774,6 +774,7 @@ mod typhoon_per_opponent_island_count;
 mod tyvar_activate_as_though_haste;
 mod unravel_counter_mana_value;
 mod unstoppable_slasher_half_life;
+mod urborg_scavengers_source_exiled_keyword_grant;
 mod ureni_attack_trigger;
 mod urge_to_feed_regression;
 mod urza_lord_high_artificer_shuffle_exile_free_cast;

--- a/crates/engine/tests/integration/urborg_scavengers_source_exiled_keyword_grant.rs
+++ b/crates/engine/tests/integration/urborg_scavengers_source_exiled_keyword_grant.rs
@@ -1,4 +1,4 @@
-//! CR 611.3a + CR 400.7: Urborg Scavengers — "~ has flying as long as a card
+//! CR 611.3a + CR 607.2a: Urborg Scavengers — "This creature has flying as long as a card
 //! exiled with it has flying. The same is true for first strike, double strike,
 //! deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample,
 //! and vigilance."
@@ -23,7 +23,7 @@ use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
-const URBORG_SCAVENGERS: &str = "~ has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.";
+const URBORG_SCAVENGERS: &str = "This creature has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.";
 
 #[test]
 fn urborg_scavengers_source_exiled_grant_is_conditional_and_per_item() {

--- a/crates/engine/tests/integration/urborg_scavengers_source_exiled_keyword_grant.rs
+++ b/crates/engine/tests/integration/urborg_scavengers_source_exiled_keyword_grant.rs
@@ -1,0 +1,85 @@
+//! CR 611.3a + CR 400.7: Urborg Scavengers — "~ has flying as long as a card
+//! exiled with it has flying. The same is true for first strike, double strike,
+//! deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample,
+//! and vigilance."
+//!
+//! Runtime regression proving the source-linked exiled-object keyword grant is
+//! (a) CONDITIONAL — Urborg has none of the granted keywords with no matching
+//! card exiled with it — and (b) PER-ITEM INDEPENDENT — a card exiled with it that
+//! has vigilance grants ONLY vigilance, never flying. On `main` the "the same is
+//! true for" tail collapses (the continuation is swallowed into an `Unrecognized`
+//! condition), so the continuation keywords are never grantable and assertion (b)
+//! flips. This drives the real parse → `evaluate_layers` path, not a hand-built
+//! AST.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{ExileLink, ExileLinkKind};
+use engine::types::identifiers::CardId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const URBORG_SCAVENGERS: &str = "~ has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance.";
+
+#[test]
+fn urborg_scavengers_source_exiled_grant_is_conditional_and_per_item() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let urborg = scenario
+        .add_creature_from_oracle(P0, "Urborg Scavengers", 2, 2, URBORG_SCAVENGERS)
+        .id();
+    let mut runner = scenario.build();
+    // Force continuous-effect recomputation (SBAs, layers).
+    runner.act(GameAction::PassPriority).ok();
+
+    // (a) Conditional: nothing is exiled with Urborg, so it has NONE of the
+    // granted keywords. (On `main`, if the collapsed static's `Unrecognized`
+    // condition resolves true, Urborg would already have flying here.)
+    assert!(
+        !runner.state().objects[&urborg].has_keyword(&Keyword::Flying),
+        "no card exiled with Urborg ⇒ no flying"
+    );
+    assert!(
+        !runner.state().objects[&urborg].has_keyword(&Keyword::Vigilance),
+        "no card exiled with Urborg ⇒ no vigilance"
+    );
+
+    // Seed a card exiled WITH Urborg that has vigilance but NOT flying. (A raw
+    // state edit bypasses normal change tracking, so re-run the layer engine.)
+    {
+        let state = runner.state_mut();
+        let exiled = create_object(
+            state,
+            CardId(900),
+            P0,
+            "Exiled Sentinel".to_string(),
+            Zone::Exile,
+        );
+        let obj = state.objects.get_mut(&exiled).expect("exiled card exists");
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.keywords.push(Keyword::Vigilance);
+        state.exile_links.push(ExileLink {
+            exiled_id: exiled,
+            source_id: urborg,
+            kind: ExileLinkKind::TrackedBySource,
+        });
+    }
+    evaluate_layers(runner.state_mut());
+
+    // (b) Per-item independence: the card exiled with Urborg has vigilance, so
+    // Urborg gains VIGILANCE — a *continuation* keyword that `main` drops entirely
+    // — and does NOT gain flying, because no card exiled with it has flying.
+    assert!(
+        runner.state().objects[&urborg].has_keyword(&Keyword::Vigilance),
+        "a card exiled with Urborg that has vigilance ⇒ Urborg gains vigilance (continuation keyword, independently gated)"
+    );
+    assert!(
+        !runner.state().objects[&urborg].has_keyword(&Keyword::Flying),
+        "the exiled card has no flying ⇒ Urborg must NOT gain flying (per-item independence, not a shared condition)"
+    );
+}


### PR DESCRIPTION
## Summary

"The same is true for …" keyword-replication grants sourced from a card **exiled with this permanent** were misparsed for two clause orders. This generalizes the exiled-object keyword-grant seam so each listed keyword becomes an **independent** conditional grant, and adds the source-linked exile-pool object plus the equipped/enchanted subject and the postfix clause order.

Cards fixed (Oracle text verified against Scryfall):

- **Eater of Virtue** — "As long as a card exiled with Eater of Virtue has flying, equipped creature has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, protection, reach, trample, and vigilance."
- **Urborg Scavengers** — "This creature has flying as long as a card exiled with it has flying. The same is true for first strike, double strike, deathtouch, haste, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance."

## Root cause

`parse_keyword_grant_from_exiled_object_static` (the Rayami / #5257 class) recognized only the `"as long as an exiled <type> card"` object phrase with a `~`/`it` subject in prefix order. It did not recognize:

1. the **source-linked** object phrase `"a card exiled with ~|it"` (the pool of cards exiled *with* this permanent — `TargetFilter::ExiledBySource` — not every card in the exile zone),
2. the **equipped/enchanted creature** subject (Eater of Virtue grants to the equipped creature, not the Equipment), or
3. the **postfix** clause order `"<subject> has <K0> as long as <object> has <K0>."` (Urborg).

So these lines fell through to generic multi-sentence handling, which collapsed the whole keyword list under the first keyword's condition (an exiled flyer would grant *every* keyword) or dropped the continuation into an `Unrecognized` condition.

## Fix (parameterize the seam, don't add a special case)

Extract the per-item core `per_keyword_conditional_grants(subject, keywords, description, presence_filter_for)` — one **independent** `IsPresent`-gated grant per listed keyword, each gated on its **own** keyword. Both callers feed it:

- the existing exiled-`<type>`-card path (unchanged behavior, now routed through the core), and
- the new source-linked path `parse_keyword_grant_from_source_exiled_object_static`, whose presence filter is `And[ExiledBySource, Typed{InZone Exile, WithKeyword(K)}]`.

New nom combinators: `parse_source_exiled_object_nom`, `parse_source_exiled_subject_nom` (`value(_, tag())` arms → `SelfRef` / `EquippedBy` / `EnchantedBy`), and `parse_source_exiled_grant_prefix` / `parse_source_exiled_grant_postfix` for the two clause orders. All new parser code is nom-combinator-pure (Gate A below).

## CR

- **CR 611.3a** — each listed keyword is an independent continuous effect gated on its own condition.
- **CR 400.7 / CR 610.3** — "a card exiled with [this permanent]" is the source-linked exile pool.

## Parse + runtime evidence

Before (postfix, `main`): the list collapses to a single always-active grant (every keyword granted whenever any one matches / condition `Unrecognized`).

After:

- Eater of Virtue → **13** continuous `EquippedBy`-creature statics, one keyword each, gated on `IsPresent(And[ExiledBySource, Typed{InZone Exile, WithKeyword(K)}])`.
- Urborg Scavengers → **12** continuous `SelfRef` statics, same per-item gating.

A **registered integration test** drives the real `parse → evaluate_layers` path: with no card exiled with Urborg it has **none** of the keywords; once a card exiled with it that has **vigilance** (but not flying) is present, Urborg gains **only vigilance** — proving the grant is conditional and per-item independent. Fails on revert.

## Tests

- `oracle_static::tests::eater_of_virtue_source_exiled_grant_splits_per_keyword_to_equipped_creature`
- `oracle_static::tests::urborg_scavengers_postfix_source_exiled_grant_splits_per_keyword`
- `tests/integration/urborg_scavengers_source_exiled_keyword_grant.rs` (runtime `evaluate_layers` regression)
- Full `oracle_static` parser suite (1133 tests) + the Rayami exiled-`<type>`-card regression remain green (the refactor is behavior-preserving for that class).

## Gate A

```
Gate A PASS head=0a9eb2f13fabd0606f64e6a0724fc790b9db26f7 base=e52d4caf728186c74354dcc43d63795be453bde2
```

## Anchored on

- crates/engine/src/parser/oracle_static/shared.rs:1380 — `parse_keyword_grant_from_exiled_object_static`: the exiled-`<type>`-card sibling this generalizes; same one-static-per-listed-keyword `IsPresent{… WithKeyword(K)}` shape.
- crates/engine/src/parser/oracle_static/shared.rs:1697 — `parse_color_conditional_keyword_grants` (Scion of Draco): sibling per-item keyword-grant splitter in the same multi-static dispatch, one independent static per listed item.
- crates/engine/src/parser/oracle_static/shared.rs:134 — `parse_when_clause`: the `alt((value(_, tag()), …))` combinator shape the new object/subject combinators mirror.
- crates/engine/src/parser/oracle_static/shared.rs:718 — `attached_subject_filter`: the `EquippedBy`/`EnchantedBy` `TargetFilter` construction reused by `parse_source_exiled_subject_nom`.

Tier: Frontier

🤖 Generated with [Claude Code](https://claude.com/claude-code)
