### PR TITLE
fix(client): emit chunk_reload loop-abort synchronously and latch once per chunk

### DIFF
--- a/client/src/pwa/__tests__/chunkReloadHandler.test.ts
+++ b/client/src/pwa/__tests__/chunkReloadHandler.test.ts
@@ -37,16 +37,30 @@ function firePreloadError(message: string): void {
   window.dispatchEvent(event);
 }
 
+function firePayloadlessError(): void {
+  window.dispatchEvent(new Event("vite:preloadError", { cancelable: true }));
+}
+
 function guardEntry(message: string): { count: number; firstAt: number } | null {
   const raw = window.sessionStorage.getItem(`chunk-reload:${message}`);
   return raw ? (JSON.parse(raw) as { count: number; firstAt: number }) : null;
 }
 
-async function expectLoopAbortEvent(fields: Record<string, unknown>): Promise<void> {
+// NOTE: the handler latches loop-abort reporting per guard key at module
+// level (survives across tests in this file), so every test that reaches the
+// breach path must use its own unique chunk message.
+function expectAbortEvent(chunk: string | undefined): void {
+  expect(mocks.trackEvent).toHaveBeenCalledWith(
+    "chunk_reload",
+    expect.objectContaining({ reason: "loop-abort", deferred: false, chunk }),
+  );
+}
+
+async function expectProbeEvent(fields: Record<string, unknown>): Promise<void> {
   await vi.waitFor(() => {
     expect(mocks.trackEvent).toHaveBeenCalledWith(
       "chunk_reload",
-      expect.objectContaining({ reason: "loop-abort", deferred: false, ...fields }),
+      expect.objectContaining({ reason: "loop-abort-probe", deferred: false, ...fields }),
     );
   });
 }
@@ -101,8 +115,9 @@ describe("chunkReloadHandler loop breaker", () => {
     });
   });
 
-  it("aborts the loop on the third error: no reload, error surfaced, probe reported", async () => {
-    const message = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+  it("aborts the loop on the third error: no reload, error surfaced, marker then probe", async () => {
+    const url = "https://phase-rs.dev/assets/GamePage-abort.js";
+    const message = `Failed to fetch dynamically imported module: ${url}`;
 
     firePreloadError(message);
     firePreloadError(message);
@@ -110,19 +125,58 @@ describe("chunkReloadHandler loop breaker", () => {
 
     expect(reloadSpy).toHaveBeenCalledTimes(2);
     expect(mocks.setUpdateError).toHaveBeenCalledTimes(1);
-    await expectLoopAbortEvent({
+    // The abort marker is emitted synchronously — it must not depend on the
+    // async probe resolving (the user may refresh/close during the probe).
+    expectAbortEvent(message);
+    expect(mocks.flushNow).toHaveBeenCalled();
+    await expectProbeEvent({
       probe_status: 200,
       probe_cache: "HIT",
       probe_ray: "ray-1",
       probe_sw: 0,
     });
-    expect(fetchMock).toHaveBeenCalledWith(
-      CHUNK_URL,
-      expect.objectContaining({ cache: "no-store" }),
-    );
+    expect(fetchMock).toHaveBeenCalledWith(url, expect.objectContaining({ cache: "no-store" }));
     // The abort path replaces (not accompanies) the preload-error event.
     const reasons = mocks.trackEvent.mock.calls.map(([, fields]) => fields.reason);
     expect(reasons.filter((r) => r === "preload-error")).toHaveLength(2);
+  });
+
+  it("reports probe_status 0 when the probe fetch itself fails", async () => {
+    const message =
+      "Failed to fetch dynamically imported module: https://phase-rs.dev/assets/GamePage-dead.js";
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+    window.sessionStorage.setItem(
+      `chunk-reload:${message}`,
+      JSON.stringify({ count: 2, firstAt: Date.now() }),
+    );
+
+    firePreloadError(message);
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expectAbortEvent(message);
+    await expectProbeEvent({ probe_status: 0, probe_sw: 0 });
+  });
+
+  it("reports the abort exactly once per chunk despite repeated failures", async () => {
+    const message =
+      "Failed to fetch dynamically imported module: https://phase-rs.dev/assets/GamePage-latch.js";
+    window.sessionStorage.setItem(
+      `chunk-reload:${message}`,
+      JSON.stringify({ count: 2, firstAt: Date.now() }),
+    );
+
+    firePreloadError(message);
+    firePreloadError(message);
+    firePreloadError(message);
+
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(mocks.setUpdateError).toHaveBeenCalledTimes(1);
+    await expectProbeEvent({ probe_status: 200 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const abortCount = mocks.trackEvent.mock.calls.filter(
+      ([, fields]) => fields.reason === "loop-abort",
+    ).length;
+    expect(abortCount).toBe(1);
   });
 
   it("skips the probe fetch when the message carries no URL", async () => {
@@ -135,8 +189,21 @@ describe("chunkReloadHandler loop breaker", () => {
     firePreloadError(message);
 
     expect(reloadSpy).not.toHaveBeenCalled();
-    await expectLoopAbortEvent({ probe_sw: 0 });
+    expectAbortEvent(message);
+    await expectProbeEvent({ probe_sw: 0 });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("guards payload-less events under the shared unknown key, failing conservative", () => {
+    firePayloadlessError();
+    firePayloadlessError();
+    expect(reloadSpy).toHaveBeenCalledTimes(2);
+
+    firePayloadlessError();
+
+    expect(reloadSpy).toHaveBeenCalledTimes(2);
+    expect(mocks.setUpdateError).toHaveBeenCalledTimes(1);
+    expectAbortEvent(undefined);
   });
 
   it("tracks each failing chunk independently", () => {
@@ -187,9 +254,10 @@ describe("chunkReloadHandler loop breaker", () => {
     expect(guardEntry(message)?.count).toBe(1);
   });
 
-  it("leaves an already-queued deferred reload intact when a later error breaches", async () => {
+  it("leaves an already-queued deferred reload intact when a later error breaches", () => {
     mocks.isMultiplayerGameLive.mockReturnValue(true);
-    const message = `Failed to fetch dynamically imported module: ${CHUNK_URL}`;
+    const message =
+      "Failed to fetch dynamically imported module: https://phase-rs.dev/assets/GamePage-mp.js";
 
     firePreloadError(message);
     expect(mocks.whenMultiplayerGameEnds).toHaveBeenCalledTimes(1);
@@ -204,7 +272,7 @@ describe("chunkReloadHandler loop breaker", () => {
 
     expect(mocks.whenMultiplayerGameEnds).toHaveBeenCalledTimes(1);
     expect(mocks.setUpdateError).toHaveBeenCalledTimes(1);
-    await expectLoopAbortEvent({});
+    expectAbortEvent(message);
 
     for (const cb of gameEndCallbacks) cb();
     expect(reloadSpy).toHaveBeenCalledTimes(1);

--- a/client/src/pwa/chunkReloadHandler.ts
+++ b/client/src/pwa/chunkReloadHandler.ts
@@ -78,10 +78,22 @@ function recordReload(key: string): void {
   }
 }
 
+/** Chunks whose loop-abort has already been reported this pageload. Without
+ *  this latch, a component retrying a failing dynamic import would re-probe
+ *  and re-emit on every attempt (loop-abort events have no per-event session
+ *  cap). Module-level on purpose: after a breach there are no reloads, so
+ *  per-pageload scope is exactly once-per-stuck-page; a manual refresh
+ *  starting a fresh page reports once more, which is the desired signal. */
+const abortReported = new Set<string>();
+
 /** Best-effort diagnosis of a persistently failing chunk: refetch it and
  *  report status + Cloudflare cache/colo headers (same-origin, all readable)
  *  plus whether a service worker controls this page. Runs only on the
- *  loop-abort path, where no reload is pending — never delays recovery. */
+ *  loop-abort path, where no reload is pending — never delays recovery.
+ *  Interpretation rule: when `probe_sw` is 1 the page is SW-controlled and
+ *  the probe routes through the SW fetch handler (`cache: "no-store"` only
+ *  bypasses the HTTP cache), so status/cache/ray may describe the SW's
+ *  cached copy rather than the Cloudflare edge. */
 async function probeFailedChunk(message: string): Promise<Record<string, unknown>> {
   const probeSw =
     typeof navigator !== "undefined" &&
@@ -117,6 +129,9 @@ export function installChunkReloadHandler(): void {
 
     // The failed chunk identifier lives in the event's `.payload` Error
     // (its message carries the failing URL). Best-effort; truncated at enqueue.
+    // Payload-less events share the "unknown" key deliberately: distinct
+    // identity-less failures cross-count toward one breach, which fails
+    // conservative (stops reloading) rather than risking a loop.
     const chunk = (event as { payload?: Error }).payload?.message;
     const guardKey = `chunk-reload:${chunk ?? "unknown"}`;
 
@@ -125,9 +140,22 @@ export function installChunkReloadHandler(): void {
       // a third won't either. Stop reloading and don't queue a new deferred
       // reload — an already-queued one from an earlier failure is left intact
       // (it's a single reload and may succeed after the game ends).
+      if (abortReported.has(guardKey)) return;
+      abortReported.add(guardKey);
       setUpdateError("App update failed to load. Please refresh the page.");
+      // Emit the abort marker synchronously — the user was just told to
+      // refresh, and a refresh (or tab close) during the async probe below
+      // must not lose the one event this breaker exists to capture. The
+      // probe result follows as its own event when (if) it resolves.
+      trackEvent("chunk_reload", { reason: "loop-abort", deferred: false, chunk });
+      flushNow();
       void probeFailedChunk(chunk ?? "").then((probe) => {
-        trackEvent("chunk_reload", { reason: "loop-abort", deferred: false, chunk, ...probe });
+        trackEvent("chunk_reload", {
+          reason: "loop-abort-probe",
+          deferred: false,
+          chunk,
+          ...probe,
+        });
         flushNow();
       });
       return;


### PR DESCRIPTION
Review follow-up to the loop breaker: the abort marker previously rode on
the async probe's .then — a refresh or tab close during the 3s probe window
dropped the one diagnostic event the breaker exists to capture. The marker
now flushes synchronously and the probe result follows as a separate
loop-abort-probe event (reason is a plain blob value; no worker schema
change). A module-level per-chunk latch stops repeated import retries from
re-probing and re-emitting on every attempt. New fixtures cover the probe's
failure arm (the primary production shape: probe_status 0), the latch, and
payload-less events under the shared unknown guard key.
