### PR TITLE
fix(client): never fan the full card DB across AI pool workers for unbounded games

### DIFF
--- a/client/src/adapter/__tests__/ai-card-subset.test.ts
+++ b/client/src/adapter/__tests__/ai-card-subset.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { loadAiPoolCardDb } from "../card-db-subset";
-import type { EngineWorkerClient } from "../engine-worker-client";
+import { applyAiPoolCardDbPlan, resolveAiPoolCardDbPlan } from "../card-db-subset";
+import { EngineWorkerClient } from "../engine-worker-client";
 import type { AiWorkerPool } from "../ai-worker-pool";
 
 // The mocked EngineWorkerClient is shared by both the main engine and every AI
@@ -30,8 +30,8 @@ vi.mock("../engine-worker-client", () => ({
   }),
 }));
 
-// ── VM-4: loadAiPoolCardDb dispatch ───────────────────────────────────────
-describe("loadAiPoolCardDb", () => {
+// ── VM-4: plan resolution + application ───────────────────────────────────
+describe("resolveAiPoolCardDbPlan / applyAiPoolCardDbPlan", () => {
   function makeMocks() {
     const mainEngine = {
       buildAiCardSubset: vi.fn<() => Promise<string>>(),
@@ -48,36 +48,44 @@ describe("loadAiPoolCardDb", () => {
     return { mainEngine, aiPool };
   }
 
-  it("escalates a Momir game (kind:full) to the full DB, never the subset", async () => {
-    const { mainEngine, aiPool } = makeMocks();
+  it("resolves an unbounded universe (kind:full, e.g. Momir) without touching any pool", async () => {
+    const { mainEngine } = makeMocks();
     mainEngine.buildAiCardSubset.mockResolvedValue(JSON.stringify({ kind: "full" }));
 
-    await loadAiPoolCardDb("subset", mainEngine, aiPool);
+    const plan = await resolveAiPoolCardDbPlan("subset", mainEngine);
 
-    expect(aiPool.loadCardDb).toHaveBeenCalledOnce();
-    expect(aiPool.loadCardDbText).not.toHaveBeenCalled();
+    // The caller must skip creating (or dispose) the pool instead of fanning
+    // the full corpus (~380MB WASM linear memory per worker) across workers.
+    expect(plan).toEqual({ kind: "unbounded" });
   });
 
-  it("loads the subset JSON for a bounded (non-Momir) game", async () => {
+  it("resolves and applies the subset for a bounded (non-Momir) game", async () => {
     const { mainEngine, aiPool } = makeMocks();
     const innerJson = '{"Bounded Card":{}}';
     mainEngine.buildAiCardSubset.mockResolvedValue(
       JSON.stringify({ kind: "subset", json: innerJson, count: 1 }),
     );
 
-    await loadAiPoolCardDb("subset", mainEngine, aiPool);
+    const plan = await resolveAiPoolCardDbPlan("subset", mainEngine);
+    expect(plan).toEqual({ kind: "subset", json: innerJson });
+    if (plan.kind === "unbounded") throw new Error("unreachable");
 
+    await applyAiPoolCardDbPlan(plan, aiPool);
     expect(aiPool.loadCardDbText).toHaveBeenCalledWith(innerJson);
     expect(aiPool.loadCardDb).not.toHaveBeenCalled();
   });
 
-  it("mode=full loads the full DB without consulting the engine", async () => {
+  it("mode=full resolves without consulting the engine and applies the full DB", async () => {
     const { mainEngine, aiPool } = makeMocks();
 
-    await loadAiPoolCardDb("full", mainEngine, aiPool);
-
-    expect(aiPool.loadCardDb).toHaveBeenCalledOnce();
+    const plan = await resolveAiPoolCardDbPlan("full", mainEngine);
+    // Explicit user opt-in to the memory cost — the pool is kept.
+    expect(plan).toEqual({ kind: "full" });
     expect(mainEngine.buildAiCardSubset).not.toHaveBeenCalled();
+    if (plan.kind === "unbounded") throw new Error("unreachable");
+
+    await applyAiPoolCardDbPlan(plan, aiPool);
+    expect(aiPool.loadCardDb).toHaveBeenCalledOnce();
     expect(aiPool.loadCardDbText).not.toHaveBeenCalled();
   });
 });
@@ -132,5 +140,44 @@ describe("WasmAdapter AI-pool subset lifecycle", () => {
     // leaves the pool loaded with subset A, so both assertions flip.
     expect(loadedB).toContain("Game B Card");
     expect(loadedB).not.toContain("Game A Card");
+  });
+
+  it("drops the pool for an unbounded game (Momir) and restores it next game", async () => {
+    const { WasmAdapter } = await import("../wasm-adapter");
+
+    mockWorkerClient.buildAiCardSubset
+      .mockResolvedValueOnce(JSON.stringify({ kind: "full" }))
+      .mockResolvedValueOnce(
+        JSON.stringify({ kind: "subset", json: '{"Bounded Card":{}}', count: 1 }),
+      );
+    mockWorkerClient.getAiAction.mockResolvedValue({ type: "PassPriority" });
+
+    const adapter = new WasmAdapter();
+    await adapter.initialize();
+    await adapter.warmCardDatabase();
+    const workersBefore = vi.mocked(EngineWorkerClient).mock.calls.length;
+
+    // Momir game: the plan resolves to `unbounded` BEFORE any pool worker is
+    // spawned — no new EngineWorkerClient instances are created, and the AI
+    // answers via the single-worker path.
+    const action = await adapter.getAiAction("VeryHard", 0, "Priority");
+    expect(action).toEqual({ type: "PassPriority" });
+    expect(vi.mocked(EngineWorkerClient).mock.calls.length).toBe(workersBefore);
+    // Revert guard: without the unbounded branch the pool is created and the
+    // scored-candidates path answers instead of engine.getAiAction.
+    expect(mockWorkerClient.getAiAction).toHaveBeenCalled();
+
+    // Second decision in the same game: the pool is NOT recreated just to
+    // escalate again — the subset build ran exactly once.
+    await adapter.getAiAction("VeryHard", 0, "Priority");
+    expect(mockWorkerClient.buildAiCardSubset).toHaveBeenCalledTimes(1);
+
+    // Next game is bounded: the pool comes back with that game's subset.
+    await adapter.resetGameState();
+    await adapter.getAiAction("VeryHard", 0, "Priority");
+    expect(mockWorkerClient.buildAiCardSubset).toHaveBeenCalledTimes(2);
+    const calls = mockWorkerClient.loadCardDb.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls[calls.length - 1][0] as string).toContain("Bounded Card");
   });
 });

--- a/client/src/adapter/card-db-subset.ts
+++ b/client/src/adapter/card-db-subset.ts
@@ -5,8 +5,11 @@
  * and parsed the full ~93MB card-data corpus they would OOM WebKit. The MAIN
  * engine worker keeps the full database; the AI pool instead loads a
  * game-scoped subset built by the engine (`build_ai_card_subset`). Games whose
- * card universe is not statically bounded (today: Momir) escalate to the full
- * database on AI workers.
+ * card universe is not statically bounded (today: Momir) do NOT escalate the
+ * full database onto every pool worker — each full copy costs ~380MB of WASM
+ * linear memory, measured at ~3GB total on a desktop with a 4-worker pool.
+ * Instead the caller drops the pool for that game and the single main worker
+ * (which already holds the full corpus) serves the AI.
  */
 import type { EngineWorkerClient } from "./engine-worker-client";
 import type { AiWorkerPool } from "./ai-worker-pool";
@@ -16,32 +19,51 @@ export type AiCardDataMode = "auto" | "subset" | "full";
 export const DEFAULT_AI_CARD_DATA_MODE: AiCardDataMode = "auto";
 
 /**
- * Load the AI worker pool's card database according to `mode`.
+ * This game's AI-pool card-data resolution, decided WITHOUT touching a pool:
+ * - `full`: the user explicitly forced full-corpus workers (opt-in memory cost).
+ * - `subset`: the engine bounded this game's universe; `json` is the corpus.
+ * - `unbounded`: the universe cannot be statically bounded (e.g. Momir). A
+ *   pool must not carry this game — the caller skips creating one (or
+ *   disposes an existing one) and the main worker's full DB serves the AI.
+ */
+export type AiPoolCardDbPlan =
+  | { kind: "full" }
+  | { kind: "subset"; json: string }
+  | { kind: "unbounded" };
+
+/**
+ * Resolve this game's AI-pool card-data plan according to `mode`.
  *
  * INVARIANT: `mainEngine` is the MAIN `EngineWorkerClient` (full CARD_DB + live
  * GAME_STATE). `buildAiCardSubset()` is called ONLY here, on `mainEngine` —
  * never on a pool worker (pool workers carry only the subset and may have no
  * game state).
  *
- * - `full`: every pool worker fetches+parses the full corpus.
- * - `auto`/`subset`: the engine builds this game's subset on the main worker;
- *   a `full` result (unbounded universe, e.g. Momir) falls back to the full DB.
+ * Split into resolve (decision, main engine only) and apply (execution, pool
+ * only) so callers can decide whether a pool should EXIST before paying to
+ * spawn its workers — an unbounded game never creates one.
  */
-export async function loadAiPoolCardDb(
+export async function resolveAiPoolCardDbPlan(
   mode: AiCardDataMode,
   mainEngine: EngineWorkerClient,
-  aiPool: AiWorkerPool,
-): Promise<void> {
-  if (mode === "full") {
-    await aiPool.loadCardDb();
-    return;
-  }
+): Promise<AiPoolCardDbPlan> {
+  if (mode === "full") return { kind: "full" };
   const result: AiCardSubsetResult = JSON.parse(
     await mainEngine.buildAiCardSubset(),
   );
-  if (result.kind === "full") {
+  if (result.kind === "full") return { kind: "unbounded" };
+  return { kind: "subset", json: result.json };
+}
+
+/** Load a resolved plan into a live pool. `unbounded` is unrepresentable
+ *  here by construction — a pool must never carry an unbounded game. */
+export async function applyAiPoolCardDbPlan(
+  plan: Exclude<AiPoolCardDbPlan, { kind: "unbounded" }>,
+  aiPool: AiWorkerPool,
+): Promise<void> {
+  if (plan.kind === "full") {
     await aiPool.loadCardDb();
-  } else {
-    await aiPool.loadCardDbText(result.json);
+    return;
   }
+  await aiPool.loadCardDbText(plan.json);
 }

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -20,7 +20,12 @@ import { isBracketEstimate } from "../types/bracketEstimate";
 import { EngineWorkerClient } from "./engine-worker-client";
 import { AiWorkerPool } from "./ai-worker-pool";
 import type { AiCardDataMode } from "./card-db-subset";
-import { DEFAULT_AI_CARD_DATA_MODE, loadAiPoolCardDb } from "./card-db-subset";
+import {
+  applyAiPoolCardDbPlan,
+  DEFAULT_AI_CARD_DATA_MODE,
+  resolveAiPoolCardDbPlan,
+} from "./card-db-subset";
+import type { AiPoolCardDbPlan } from "./card-db-subset";
 
 /**
  * True on handheld browsers whose per-tab memory ceiling cannot hold the main
@@ -139,6 +144,10 @@ export class WasmAdapter implements EngineAdapter {
   // Multi-worker AI pool for VeryHard root parallelism (lazy-initialized)
   private aiPool: AiWorkerPool | null = null;
   private aiPoolFailed = false;
+  /** This game's card universe is unbounded (e.g. Momir): the pool was
+   *  disposed instead of loading the full corpus into every worker, and must
+   *  not be recreated until the next game (cleared in `resetGameState`). */
+  private aiPoolUnboundedGame = false;
 
   // How the AI worker pool loads its card database. `auto`/`subset` load an
   // engine-built game-scoped subset (escalating to full for unbounded games
@@ -208,9 +217,9 @@ export class WasmAdapter implements EngineAdapter {
         this.cardDbLoaded = true;
         // Also load into AI pool if it's already initialized. AI-pool workers
         // get the game-scoped subset (built on the main engine), not the full
-        // corpus, unless the mode is `full` or the universe is unbounded.
+        // corpus; an unbounded universe (e.g. Momir) disposes the pool instead.
         if (this.engine && this.aiPool && !this.aiPool.isCardDbLoaded) {
-          await loadAiPoolCardDb(this.aiCardDataMode, this.engine, this.aiPool);
+          await this.loadAiPoolGameDb(this.engine, this.aiPool);
         }
       } catch (err) {
         console.warn("Failed to load card database:", err);
@@ -410,13 +419,43 @@ export class WasmAdapter implements EngineAdapter {
     }
   }
 
-/** Lazy AI pool init — only created on first VeryHard request. */
+/** Load an EXISTING pool's per-game card data, or dispose it when the game's
+   * universe is unbounded (e.g. Momir). Fanning the full ~93MB corpus onto
+   * every pool worker costs ~380MB of WASM linear memory per worker — measured
+   * at ~3GB total on a desktop 4-worker pool (user report, 2026-07-18). The
+   * single-worker fallback (main engine already holds the full DB) runs the
+   * same fixed-budget beam search; the pool only adds cross-seed
+   * rollout-variance averaging — the same tradeoff already accepted for
+   * memory-constrained handhelds. Pool *creation* resolves the plan before
+   * spawning workers (see `ensureAiPool`); this handles the cross-game case
+   * where a pool from a bounded game meets an unbounded one. Returns the
+   * surviving pool or null. */
+  private async loadAiPoolGameDb(
+    engine: EngineWorkerClient,
+    aiPool: AiWorkerPool,
+  ): Promise<AiWorkerPool | null> {
+    const plan = await resolveAiPoolCardDbPlan(this.aiCardDataMode, engine);
+    if (plan.kind === "unbounded") {
+      aiPool.dispose();
+      this.aiPool = null;
+      this.aiPoolUnboundedGame = true;
+      return null;
+    }
+    await applyAiPoolCardDbPlan(plan, aiPool);
+    return aiPool;
+  }
+
+  /** Lazy AI pool init — only created on first VeryHard request. */
   private async ensureAiPool(): Promise<AiWorkerPool | null> {
+    // Unbounded-universe game (e.g. Momir): the pool was already dropped for
+    // this game — don't recreate it just to escalate and drop it again on
+    // every AI decision.
+    if (this.aiPoolUnboundedGame) return null;
     if (this.aiPool) {
       // The pool's subset is game-scoped: after `resetGameState` invalidated it,
       // rebuild this game's subset (the pool instance is preserved across games).
       if (this.cardDbLoaded && this.engine && !this.aiPool.isCardDbLoaded) {
-        await loadAiPoolCardDb(this.aiCardDataMode, this.engine, this.aiPool);
+        return await this.loadAiPoolGameDb(this.engine, this.aiPool);
       }
       return this.aiPool;
     }
@@ -429,12 +468,22 @@ export class WasmAdapter implements EngineAdapter {
     // the pool only adds cross-seed rollout-variance averaging, not search depth.
     if (isMemoryConstrainedDevice()) return null;
     try {
+      // Resolve this game's card-data plan BEFORE paying to spawn workers:
+      // an unbounded-universe game (e.g. Momir) never creates a pool at all.
+      let plan: AiPoolCardDbPlan | null = null;
+      if (this.cardDbLoaded && this.engine) {
+        plan = await resolveAiPoolCardDbPlan(this.aiCardDataMode, this.engine);
+        if (plan.kind === "unbounded") {
+          this.aiPoolUnboundedGame = true;
+          return null;
+        }
+      }
       const cores = navigator.hardwareConcurrency ?? 0;
       const count = Math.max(2, Math.min(cores - 1, 4));
       this.aiPool = new AiWorkerPool(count);
       await this.aiPool.initialize();
-      if (this.cardDbLoaded && this.engine) {
-        await loadAiPoolCardDb(this.aiCardDataMode, this.engine, this.aiPool);
+      if (plan) {
+        await applyAiPoolCardDbPlan(plan, this.aiPool);
       }
       return this.aiPool;
     } catch {
@@ -566,6 +615,9 @@ export class WasmAdapter implements EngineAdapter {
     if (this.aiCardDataMode !== "full") {
       this.aiPool?.invalidateCardDb();
     }
+    // A pool dropped for an unbounded-universe game may be recreated for the
+    // next (bounded) game.
+    this.aiPoolUnboundedGame = false;
   }
 
   async estimateBracket(deck: BracketDeckRequest): Promise<BracketEstimate | null> {
@@ -615,6 +667,7 @@ export class WasmAdapter implements EngineAdapter {
     this.aiPool?.dispose();
     this.aiPool = null;
     this.aiPoolFailed = false;
+    this.aiPoolUnboundedGame = false;
     this.fallback = null;
     this.initialized = false;
     this.initPromise = null;


### PR DESCRIPTION
A desktop Momir VeryHard game escalated the full ~93MB corpus onto every
AI pool worker (2-4 workers x ~380MB WASM linear memory + main), reaching
a user-reported ~3GB tab. The subset loader is now split into
resolveAiPoolCardDbPlan (decision, main engine only) and
applyAiPoolCardDbPlan (execution, pool only; the unbounded plan is
unrepresentable in its signature). ensureAiPool resolves the plan BEFORE
spawning workers, so an unbounded-universe game never creates a pool —
the main worker's resident full DB serves the AI via the single-worker
path, the same tradeoff already shipped for memory-constrained handhelds.
An existing pool meeting an unbounded game cross-game is disposed, latched
per game, and restored for the next bounded game in resetGameState.
Explicit mode=full remains a user opt-in that keeps the pool.
