### PR TITLE
fix(engine): materialize trigger occurrence refs on token-copy and emblem paths (no Unmaterialized in serializable state)

### DIFF
--- a/crates/engine/src/game/effects/create_emblem.rs
+++ b/crates/engine/src/game/effects/create_emblem.rs
@@ -52,8 +52,8 @@ pub fn grant_emblem(
     obj.base_static_definitions = Arc::new(statics);
     // CR 113.1c + CR 114.4: install triggered abilities so
     // `active_trigger_definitions` yields them during command-zone scans.
-    obj.trigger_definitions = triggers.clone().into();
-    obj.base_trigger_definitions = Arc::new(triggers);
+    obj.install_trigger_base_definitions(Arc::new(triggers))
+        .expect("trigger base-set generation must not overflow");
     // CR 113.1b + CR 114.4: install activated abilities so they can be activated
     // from the command zone (e.g. the Momir Basic emblem ability).
     obj.abilities = Arc::new(abilities.clone());

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -1072,31 +1072,7 @@ pub(crate) fn apply_copiable_values_to_liminal_object(
     object.printed_ref = printed_ref.clone();
     object.base_printed_ref = printed_ref;
     object.token_image_ref = token_image_ref;
-    object.name = values.name.clone();
-    object.base_name = values.name.clone();
-    object.mana_cost = values.mana_cost.clone();
-    object.base_mana_cost = values.mana_cost.clone();
-    object.base_color = values.color.clone();
-    object.color = values.color.clone();
-    object.base_card_types = values.card_types.clone();
-    object.card_types = values.card_types.clone();
-    object.base_power = values.power;
-    object.power = values.power;
-    object.base_toughness = values.toughness;
-    object.toughness = values.toughness;
-    object.base_loyalty = values.loyalty;
-    object.loyalty = values.loyalty;
-    object.base_keywords = values.keywords.clone();
-    object.keywords = values.keywords.clone();
-    object.base_abilities = Arc::clone(&values.abilities);
-    object.abilities = Arc::clone(&values.abilities);
-    object.base_trigger_definitions = Arc::clone(&values.trigger_definitions);
-    object.trigger_definitions = Arc::clone(&values.trigger_definitions).into();
-    object.base_replacement_definitions = Arc::clone(&values.replacement_definitions);
-    object.replacement_definitions = Arc::clone(&values.replacement_definitions).into();
-    object.base_static_definitions = Arc::clone(&values.static_definitions);
-    object.static_definitions = Arc::clone(&values.static_definitions).into();
-    object.base_characteristics_initialized = true;
+    crate::game::printed_cards::install_copiable_values_as_base(object, values);
 }
 
 pub(crate) fn commit_liminal_token_entry_and_continue_copy_batch(
@@ -3191,14 +3167,18 @@ mod tests {
         build_resolved_from_def, build_resolved_from_def_with_targets,
     };
     use crate::game::engine::apply_as_current;
+    use crate::game::printed_cards::intrinsic_copiable_values;
     use crate::game::zones::create_object;
+    use crate::types::ability::TriggerDefinition;
     use crate::types::actions::GameAction;
     use crate::types::card_type::CardType;
     use crate::types::game_state::WaitingFor;
-    use crate::types::identifiers::ObjectId;
+    use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::ManaType;
     use crate::types::player::PlayerId;
+    use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
+    use std::sync::Arc;
 
     // ── Parser unit tests ───────────────────────────────────────────────
 
@@ -3211,6 +3191,39 @@ mod tests {
         assert!(a.core_types.contains(&CoreType::Creature));
         assert_eq!(a.colors, vec![ManaColor::White]);
         assert_eq!(a.subtypes, vec!["Soldier"]);
+    }
+
+    #[test]
+    fn liminal_copy_token_trigger_state_serializes() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Trigger Source".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.base_trigger_definitions =
+                Arc::new(vec![TriggerDefinition::new(TriggerMode::ChangesZone)]);
+            source.materialize_base_trigger_definitions();
+        }
+        let values = intrinsic_copiable_values(state.objects.get(&source_id).unwrap());
+        let (token_id, mut token) =
+            reserve_liminal_token_object(&mut state, PlayerId(0), values.name.clone());
+        token.is_token = true;
+        apply_copiable_values_to_liminal_object(
+            &mut token,
+            &values,
+            DisplaySource::Token,
+            None,
+            None,
+        );
+        state.objects.insert(token_id, token);
+
+        serde_json::to_string(&state)
+            .expect("a liminal copy token with triggered abilities must serialize");
     }
 
     #[test]

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1,7 +1,7 @@
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::game_object::{DisplaySource, GameObject};
 use crate::game::layers::{compute_current_copiable_values, has_active_copy_layer_effects};
-use crate::game::printed_cards::intrinsic_copiable_values;
+use crate::game::printed_cards::{install_copiable_values_as_base, intrinsic_copiable_values};
 use crate::game::quantity::resolve_quantity;
 use crate::game::{targeting, zones};
 use crate::types::ability::{
@@ -640,32 +640,9 @@ pub(crate) fn apply_copy_token_after_replacement_with_created_ids(
         // CR 111.1 + CR 707.2: when copying a true token, carry its exact token
         // art pointer so the copy resolves the same art (not a name fallback).
         token.token_image_ref = token_image_ref.clone();
-        token.name = values.name.clone();
-        token.base_name = values.name.clone();
-        token.mana_cost = values.mana_cost.clone();
-        token.base_mana_cost = values.mana_cost.clone();
-        token.base_color = values.color.clone();
-        token.color = values.color.clone();
-        token.base_card_types = values.card_types.clone();
-        token.card_types = values.card_types.clone();
-        token.base_power = values.power;
-        token.power = values.power;
-        token.base_toughness = values.toughness;
-        token.toughness = values.toughness;
+        install_copiable_values_as_base(token, &values);
         token.base_loyalty = copied_loyalty;
         token.loyalty = copied_loyalty;
-        token.base_keywords = values.keywords.clone();
-        token.keywords = values.keywords.clone();
-        // All four ability sets are Arc-shared — refcount bumps, no deep copy.
-        token.base_abilities = Arc::clone(&values.abilities);
-        token.abilities = Arc::clone(&values.abilities);
-        token.base_trigger_definitions = Arc::clone(&values.trigger_definitions);
-        token.trigger_definitions = Arc::clone(&values.trigger_definitions).into();
-        token.base_replacement_definitions = Arc::clone(&values.replacement_definitions);
-        token.replacement_definitions = Arc::clone(&values.replacement_definitions).into();
-        token.base_static_definitions = Arc::clone(&values.static_definitions);
-        token.static_definitions = Arc::clone(&values.static_definitions).into();
-        token.base_characteristics_initialized = true;
         // CR 400.7 + CR 302.6: Single authority for ETB state. Haste granted
         // below via `extra_keywords` (Twinflame, etc.) is folded in at query
         // time by `has_summoning_sickness`.

--- a/crates/engine/src/types/definitions.rs
+++ b/crates/engine/src/types/definitions.rs
@@ -160,10 +160,10 @@ impl<T> From<Arc<Vec<T>>> for Definitions<T> {
     }
 }
 
-// Card-face data deliberately remains payload-only, while the live trigger
-// collection owns `TriggerEntry` provenance. These conversions are only a
-// construction bridge: the live layer/base-install authorities materialize a
-// concrete occurrence before runtime enumeration.
+// Production construction must materialize payload trigger definitions through
+// a base-install or grant authority. Test fixtures retain this bridge for
+// focused tests that deliberately exercise unmaterialized entries.
+#[cfg(any(test, feature = "test-support"))]
 impl From<Vec<crate::types::ability::TriggerDefinition>>
     for Definitions<crate::types::ability::TriggerEntry>
 {
@@ -172,6 +172,7 @@ impl From<Vec<crate::types::ability::TriggerDefinition>>
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl From<Arc<Vec<crate::types::ability::TriggerDefinition>>>
     for Definitions<crate::types::ability::TriggerEntry>
 {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -782,6 +782,7 @@ mod twice_instead_repeat_for;
 mod twilight_prophet_upkeep_drain_1375;
 mod typhoon_per_opponent_island_count;
 mod tyvar_activate_as_though_haste;
+mod unmaterialized_lki_serialization;
 mod unravel_counter_mana_value;
 mod unstoppable_slasher_half_life;
 mod urborg_scavengers_source_exiled_keyword_grant;

--- a/crates/engine/tests/integration/unmaterialized_lki_serialization.rs
+++ b/crates/engine/tests/integration/unmaterialized_lki_serialization.rs
@@ -1,0 +1,96 @@
+//! A dies-trigger LKI restoration must leave only serializable trigger entries.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::triggers::process_triggers;
+use engine::types::ability::{TriggerDefinitionOccurrenceRef, TriggerEntry};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+
+const DIES_TRIGGER: &str = "When this creature dies, create a 1/1 green Squirrel creature token.";
+
+fn drain_to_priority(runner: &mut GameRunner) {
+    for _ in 0..256 {
+        if matches!(runner.state().waiting_for, WaitingFor::Priority { .. })
+            && runner.state().stack.is_empty()
+        {
+            return;
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            return;
+        }
+    }
+    panic!(
+        "dies trigger did not drain; waiting_for={:?}, stack={}",
+        runner.state().waiting_for,
+        runner.state().stack.len()
+    );
+}
+
+fn assert_materialized(label: &str, entries: impl IntoIterator<Item = TriggerEntry>) {
+    for entry in entries {
+        assert!(
+            !matches!(
+                entry.occurrence,
+                TriggerDefinitionOccurrenceRef::Unmaterialized
+            ),
+            "{label} retained an Unmaterialized trigger entry"
+        );
+    }
+}
+
+#[test]
+fn dies_lki_trigger_restoration_keeps_game_state_serializable() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+    let dying = scenario
+        .add_creature_from_oracle(P0, "LKI Trigger Bear", 1, 1, DIES_TRIGGER)
+        .id();
+    let mut runner = scenario.build();
+
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&dying)
+        .expect("dying source exists")
+        .damage_marked = 99;
+    let mut events = Vec::new();
+    engine::game::sba::check_state_based_actions(runner.state_mut(), &mut events);
+    process_triggers(runner.state_mut(), &events);
+    drain_to_priority(&mut runner);
+
+    let state = runner.state();
+    let dies_record = state
+        .zone_changes_this_turn
+        .iter()
+        .find(|record| record.object_id == dying)
+        .expect("dies event retains its zone-change LKI record");
+    assert!(
+        !dies_record.trigger_definitions.is_empty(),
+        "the source's dies trigger must survive in the LKI record used for off-zone restoration"
+    );
+
+    for (object_id, object) in &state.objects {
+        assert_materialized(
+            &format!("object {object_id:?}"),
+            object.trigger_definitions.iter_unchecked().cloned(),
+        );
+    }
+    for (ledger, records) in [
+        ("created_tokens_this_turn", &state.created_tokens_this_turn),
+        (
+            "sacrificed_permanents_this_turn",
+            &state.sacrificed_permanents_this_turn,
+        ),
+        ("zone_changes_this_turn", &state.zone_changes_this_turn),
+    ] {
+        for (index, record) in records.iter().enumerate() {
+            assert_materialized(
+                &format!("{ledger}[{index}]"),
+                record.trigger_definitions.clone(),
+            );
+        }
+    }
+
+    serde_json::to_string(state)
+        .expect("a game state after dies-trigger LKI restoration must serialize");
+}


### PR DESCRIPTION
Compiler census after removing the payload-to-live trigger conversions found three runtime callers: create_emblem, liminal token copy, and direct token copy. Each now uses the base-set materialization authority; the conversions are test-support only.
