### PR TITLE
fix(client): degrade to single-worker AI when pool subset rebuild fails

### DIFF
--- a/client/src/adapter/__tests__/ai-card-subset.test.ts
+++ b/client/src/adapter/__tests__/ai-card-subset.test.ts
@@ -142,6 +142,42 @@ describe("WasmAdapter AI-pool subset lifecycle", () => {
     expect(loadedB).not.toContain("Game A Card");
   });
 
+  it("degrades to the single-worker path when the rebuild subset fails, then retries next decision", async () => {
+    const { WasmAdapter } = await import("../wasm-adapter");
+
+    mockWorkerClient.buildAiCardSubset
+      .mockResolvedValueOnce(
+        JSON.stringify({ kind: "subset", json: '{"Game A Card":{}}', count: 1 }),
+      )
+      .mockRejectedValueOnce(new Error("subset build failed"))
+      .mockResolvedValueOnce(
+        JSON.stringify({ kind: "subset", json: '{"Retry Card":{}}', count: 1 }),
+      );
+    mockWorkerClient.getAiAction.mockResolvedValue({ type: "PassPriority" });
+
+    const adapter = new WasmAdapter();
+    await adapter.initialize();
+    await adapter.warmCardDatabase();
+
+    // Game A: pool created and loaded normally.
+    await adapter.getAiAction("VeryHard", 0, "Priority");
+
+    // Game B: the rebuild's subset resolution rejects. The decision must NOT
+    // reject (ensureAiPool is called outside getAiAction's try block) — it
+    // degrades to the single-worker path for this decision.
+    await adapter.resetGameState();
+    const degraded = await adapter.getAiAction("VeryHard", 0, "Priority");
+    expect(degraded).toEqual({ type: "PassPriority" });
+    expect(mockWorkerClient.getAiAction).toHaveBeenCalled();
+
+    // The failure is transient, not latched: the next decision retries the
+    // subset build and restores the pool with the fresh subset.
+    await adapter.getAiAction("VeryHard", 0, "Priority");
+    expect(mockWorkerClient.buildAiCardSubset).toHaveBeenCalledTimes(3);
+    const calls = mockWorkerClient.loadCardDb.mock.calls;
+    expect(calls[calls.length - 1][0] as string).toContain("Retry Card");
+  });
+
   it("drops the pool for an unbounded game (Momir) and restores it next game", async () => {
     const { WasmAdapter } = await import("../wasm-adapter");
 

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -455,7 +455,17 @@ export class WasmAdapter implements EngineAdapter {
       // The pool's subset is game-scoped: after `resetGameState` invalidated it,
       // rebuild this game's subset (the pool instance is preserved across games).
       if (this.cardDbLoaded && this.engine && !this.aiPool.isCardDbLoaded) {
-        return await this.loadAiPoolGameDb(this.engine, this.aiPool);
+        try {
+          return await this.loadAiPoolGameDb(this.engine, this.aiPool);
+        } catch (err) {
+          // Degrade to the single-worker path for this decision instead of
+          // crashing the AI flow (`getAiAction` calls ensureAiPool outside its
+          // try block). `isCardDbLoaded` stays false, so a transient failure
+          // retries on the next decision. A dead engine worker surfaces
+          // properly downstream via the single-worker path's classifier.
+          console.warn("Failed to load game DB into AI pool:", err);
+          return null;
+        }
       }
       return this.aiPool;
     }


### PR DESCRIPTION
The existing-pool rebuild path in ensureAiPool called loadAiPoolGameDb
unguarded, and getAiAction invokes ensureAiPool outside its try block —
a rejected buildAiCardSubset (transient worker hiccup, malformed JSON)
crashed the AI decision instead of falling back to the single-worker
path. Pre-existing gap flagged by review on #6170.

The failure is not latched: isCardDbLoaded stays false, so the next
decision retries the subset build. A genuinely dead engine worker still
surfaces via the single-worker path's error classifier.
