### PR TITLE
Fix Malcolm, Keen-Eyed Navigator

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2062,6 +2062,7 @@ fn legacy_quantity_ref(x: &QuantityRef) -> bool {
         | QuantityRef::DistinctCounterKindsAmong { .. }
         | QuantityRef::Aggregate { .. }
         | QuantityRef::PlayerCount { .. }
+        | QuantityRef::EventContextPlayerCount { .. }
         | QuantityRef::TargetObjectManaValue { .. }
         | QuantityRef::PlayerCounter { .. }
         | QuantityRef::TargetControllerCounter { .. }
@@ -5659,6 +5660,7 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
             property: _,
         } => board_value_aggregate_read(filter, StateKind::ObjectPt),
         QuantityRef::PlayerCount { filter: _ } => RwProfile::empty(),
+        QuantityRef::EventContextPlayerCount { filter: _ } => reads_event_live(),
         QuantityRef::CountersOn { scope, .. } | QuantityRef::Intensity { scope, .. } => {
             read_object_scope(scope, StateKind::ObjectCounters)
         }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1651,6 +1651,15 @@ fn scan_quantity_ref(x: &QuantityRef) -> Axes {
             acc = acc.or(scan_player_filter(filter));
             acc
         }
+        QuantityRef::EventContextPlayerCount { filter } => {
+            let mut acc = Axes {
+                event: true,
+                sibling: false,
+                projected: false,
+            };
+            acc = acc.or(scan_player_filter(filter));
+            acc
+        }
         QuantityRef::CountersOn { scope, .. } => {
             let mut acc = Axes {
                 event: false,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1332,6 +1332,9 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             )
         }
         QuantityRef::PlayerCount { filter } => format!("# of {}", fmt_player_filter(filter)),
+        QuantityRef::EventContextPlayerCount { filter } => {
+            format!("# of trigger-event {}", fmt_player_filter(filter))
+        }
         QuantityRef::CountersOn {
             scope,
             counter_type,
@@ -7373,6 +7376,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::ObjectCountDistinct { .. } => ("ObjectCountDistinct", Handled),
         QuantityRef::ObjectCountBySharedQuality { .. } => ("ObjectCountBySharedQuality", Handled),
         QuantityRef::PlayerCount { .. } => ("PlayerCount", Handled),
+        QuantityRef::EventContextPlayerCount { .. } => ("EventContextPlayerCount", Handled),
         QuantityRef::CountersOn { .. } => ("CountersOn", Handled),
         QuantityRef::Intensity { .. } => ("Intensity", Handled),
         QuantityRef::CountersOnObjects { .. } => ("CountersOnObjects", Handled),

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2364,6 +2364,7 @@ fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
         | QuantityRef::EnteredThisTurn { .. }
         | QuantityRef::CommanderManaValue { .. }
         | QuantityRef::PlayerCount { .. }
+        | QuantityRef::EventContextPlayerCount { .. }
         | QuantityRef::CountersOn { .. }
         | QuantityRef::PlayerCounter { .. }
         | QuantityRef::TargetControllerCounter { .. }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -463,6 +463,7 @@ fn quantity_ref_uses_unspent_mana(qty: &QuantityRef) -> bool {
         | QuantityRef::ObjectCountDistinct { .. }
         | QuantityRef::ObjectCountBySharedQuality { .. }
         | QuantityRef::PlayerCount { .. }
+        | QuantityRef::EventContextPlayerCount { .. }
         | QuantityRef::CountersOn { .. }
         | QuantityRef::CountersOnObjects { .. }
         | QuantityRef::PlayerCounter { .. }
@@ -742,6 +743,7 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::StartingLifeTotal
         | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::PlayerCount { .. }
+        | QuantityRef::EventContextPlayerCount { .. }
         | QuantityRef::CountersOn { .. }
         | QuantityRef::PlayerCounter { .. }
         | QuantityRef::TargetControllerCounter { .. }
@@ -938,6 +940,7 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::StartingLifeTotal
         | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::PlayerCount { .. }
+        | QuantityRef::EventContextPlayerCount { .. }
         | QuantityRef::CountersOn { .. }
         | QuantityRef::PlayerCounter { .. }
         | QuantityRef::TargetControllerCounter { .. }
@@ -1978,6 +1981,14 @@ fn resolve_ref(
         }
         QuantityRef::PlayerCount { filter } => {
             resolve_player_count(state, filter, controller, source_id)
+        }
+        // CR 120.1 + CR 603.2c + CR 608.2c: "for each opponent dealt damage"
+        // on a batched damage trigger counts DISTINCT damaged players carried by
+        // the resolving trigger event batch. This intentionally does not read
+        // `total_damage`; the scalar damage amount remains the job of
+        // `EventContextAmount`.
+        QuantityRef::EventContextPlayerCount { filter } => {
+            resolve_event_context_player_count(state, filter, controller, source_id)
         }
         // CR 122.1: Counters on an object, scoped via ObjectScope (Π-5).
         // Replaces CountersOnSelf / CountersOnTarget / AnyCountersOnSelf /
@@ -5372,6 +5383,32 @@ pub(crate) fn resolve_player_count(
     )
 }
 
+fn resolve_event_context_player_count(
+    state: &GameState,
+    filter: &PlayerFilter,
+    controller: PlayerId,
+    source_id: ObjectId,
+) -> i32 {
+    let events: Vec<&crate::types::events::GameEvent> = if state.current_trigger_events.is_empty() {
+        state.current_trigger_event.iter().collect()
+    } else {
+        state.current_trigger_events.iter().collect()
+    };
+
+    let mut players = HashSet::new();
+    for event in events {
+        if let Some(player) = crate::game::targeting::extract_player_from_event(event, state) {
+            if crate::game::effects::matches_player_scope(
+                state, player, filter, controller, source_id,
+            ) {
+                players.insert(player);
+            }
+        }
+    }
+
+    usize_to_i32_saturating(players.len())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -5385,7 +5422,7 @@ mod tests {
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::counter::{CounterMatch, CounterType};
-    use crate::types::events::PlayerActionKind;
+    use crate::types::events::{GameEvent, PlayerActionKind};
     use crate::types::game_state::{
         DamageRecord, ExileLink, ExileLinkKind, ManaSpentSourceSnapshot, ZoneChangeRecord,
     };
@@ -8953,6 +8990,46 @@ mod tests {
             },
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 0);
+    }
+
+    /// CR 120.1 + CR 603.2c + CR 608.2c: Malcolm-style "for each opponent
+    /// dealt damage" counts distinct damaged opponents in the resolving trigger
+    /// event batch, not combat-damage amount and not duplicate events for the
+    /// same player.
+    #[test]
+    fn event_context_player_count_counts_distinct_damaged_opponents_from_batch() {
+        use crate::types::format::FormatConfig;
+
+        let mut state = GameState::new(FormatConfig::commander(), 3, 42);
+        state.current_trigger_events = vec![
+            GameEvent::CombatDamageDealtToPlayer {
+                player_id: PlayerId(1),
+                source_amounts: vec![(ObjectId(11), 4)],
+                total_damage: 4,
+            },
+            GameEvent::CombatDamageDealtToPlayer {
+                player_id: PlayerId(2),
+                source_amounts: vec![(ObjectId(12), 9)],
+                total_damage: 9,
+            },
+            GameEvent::CombatDamageDealtToPlayer {
+                player_id: PlayerId(1),
+                source_amounts: vec![(ObjectId(13), 2)],
+                total_damage: 2,
+            },
+            GameEvent::CombatDamageDealtToPlayer {
+                player_id: PlayerId(0),
+                source_amounts: vec![(ObjectId(14), 7)],
+                total_damage: 7,
+            },
+        ];
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::EventContextPlayerCount {
+                filter: PlayerFilter::Opponent,
+            },
+        };
+        assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), ObjectId(1)), 2);
     }
 
     /// CR 120.1 + CR 510.1: Resolving `PlayerCount { OpponentDealtDamage }`

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -5383,26 +5383,33 @@ pub(crate) fn resolve_player_count(
     )
 }
 
+/// CR 603.2c + CR 608.2c: a resolving triggered ability that says "for each
+/// [player] dealt damage" counts distinct players from the triggering event
+/// context, not the whole turn ledger.
 fn resolve_event_context_player_count(
     state: &GameState,
     filter: &PlayerFilter,
     controller: PlayerId,
     source_id: ObjectId,
 ) -> i32 {
-    let events: Vec<&crate::types::events::GameEvent> = if state.current_trigger_events.is_empty() {
-        state.current_trigger_event.iter().collect()
-    } else {
-        state.current_trigger_events.iter().collect()
-    };
-
     let mut players = HashSet::new();
-    for event in events {
+    let mut record_player = |event: &crate::types::events::GameEvent| {
         if let Some(player) = crate::game::targeting::extract_player_from_event(event, state) {
             if crate::game::effects::matches_player_scope(
                 state, player, filter, controller, source_id,
             ) {
                 players.insert(player);
             }
+        }
+    };
+
+    if state.current_trigger_events.is_empty() {
+        if let Some(event) = &state.current_trigger_event {
+            record_player(event);
+        }
+    } else {
+        for event in &state.current_trigger_events {
+            record_player(event);
         }
     }
 

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1249,6 +1249,8 @@ fn damage_kind_matches(filter: DamageKindFilter, is_combat: bool) -> bool {
     }
 }
 
+/// CR 120.1 + CR 603.2c: an amount-qualified damage trigger evaluates the
+/// amount carried by the individual triggering damage event.
 fn damage_amount_matches(trigger: &TriggerDefinition, amount: u32) -> bool {
     trigger
         .damage_amount
@@ -1448,6 +1450,8 @@ pub(super) fn match_damage_done_once_by_controller(
     }
 }
 
+/// CR 120.1 + CR 603.2c: a player-recipient damage trigger must match its
+/// target filter against the player dealt the triggering damage.
 fn valid_damage_done_once_player_target(
     trigger: &TriggerDefinition,
     state: &GameState,
@@ -1462,6 +1466,8 @@ fn valid_damage_done_once_player_target(
     valid_player_matches(trigger, state, player_id, source_id)
 }
 
+/// CR 120.1 + CR 603.2c: a controller-batched damage trigger admits only a
+/// source that satisfies its source filter for the triggering event.
 fn damage_done_once_source_matches(
     trigger: &TriggerDefinition,
     state: &GameState,
@@ -1475,6 +1481,8 @@ fn damage_done_once_source_matches(
     }
 }
 
+/// CR 120.1 + CR 603.2c: filters the aggregate combat event to the sources
+/// that actually caused this controller-batched trigger to trigger.
 fn matching_combat_damage_once_by_controller_sources<'a>(
     trigger: &'a TriggerDefinition,
     source_id: ObjectId,

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -655,7 +655,11 @@ fn player_matches_filter(
     let trigger_controller = state.objects.get(&source_id).map(|o| o.controller);
     match filter {
         TargetFilter::Player => true,
+        TargetFilter::AllPlayers => true,
         TargetFilter::Controller => trigger_controller == Some(player_id),
+        TargetFilter::Opponent => {
+            trigger_controller.is_some_and(|controller| controller != player_id)
+        }
         TargetFilter::Typed(TypedFilter {
             controller: Some(ControllerRef::You),
             ..
@@ -706,7 +710,10 @@ fn player_matches_filter(
 /// filter (e.g. "to a creature an opponent controls") and is excluded here.
 fn is_player_scope_damage_filter(filter: &TargetFilter) -> bool {
     match filter {
-        TargetFilter::Player | TargetFilter::Controller => true,
+        TargetFilter::Player
+        | TargetFilter::AllPlayers
+        | TargetFilter::Controller
+        | TargetFilter::Opponent => true,
         TargetFilter::Typed(TypedFilter {
             type_filters,
             controller: Some(_),
@@ -1231,6 +1238,20 @@ fn matching_combat_damage_to_player_sources(
         .collect()
 }
 
+fn damage_kind_matches(filter: DamageKindFilter, is_combat: bool) -> bool {
+    match filter {
+        DamageKindFilter::Any => true,
+        DamageKindFilter::CombatOnly => is_combat,
+        DamageKindFilter::NoncombatOnly => !is_combat,
+    }
+}
+
+fn damage_amount_matches(trigger: &TriggerDefinition, amount: u32) -> bool {
+    trigger
+        .damage_amount
+        .is_none_or(|(cmp, threshold)| cmp.evaluate(amount as i32, threshold as i32))
+}
+
 pub(super) fn match_damage_done(
     event: &GameEvent,
     trigger: &TriggerDefinition,
@@ -1255,22 +1276,18 @@ pub(super) fn match_damage_done(
         if !valid_source_matches(trigger, state, *dmg_source, source_id) {
             return false;
         }
-        // CR 120.3: Check damage kind filter (combat/noncombat/any)
-        match trigger.damage_kind {
-            DamageKindFilter::Any => {}
-            DamageKindFilter::CombatOnly if !is_combat => return false,
-            DamageKindFilter::NoncombatOnly if *is_combat => return false,
-            _ => {}
+        // CR 120.2a + CR 120.2b: Check damage kind filter
+        // (combat/noncombat/any).
+        if !damage_kind_matches(trigger.damage_kind, *is_combat) {
+            return false;
         }
         // CR 603.2 + CR 120.1: Optional per-event damage-amount threshold
         // ("…deals 5 or more damage to a player"). When set, only damage events
         // whose amount satisfies the comparator vs the threshold fire the
         // trigger. CR 120.1 events carry a single nonnegative amount, so the
         // u32→i32 widening here cannot truncate.
-        if let Some((cmp, threshold)) = trigger.damage_amount {
-            if !cmp.evaluate(*amount as i32, threshold as i32) {
-                return false;
-            }
+        if !damage_amount_matches(trigger, *amount) {
+            return false;
         }
         // Check valid_target for damage target filtering (e.g. "to an opponent")
         if let Some(ref vt) = trigger.valid_target {
@@ -1385,45 +1402,92 @@ pub(super) fn match_damage_done_once_by_controller(
     source_id: ObjectId,
     state: &GameState,
 ) -> bool {
-    let GameEvent::CombatDamageDealtToPlayer {
-        player_id,
-        source_amounts,
-        ..
-    } = event
-    else {
-        return false;
-    };
+    match event {
+        GameEvent::CombatDamageDealtToPlayer {
+            player_id,
+            source_amounts,
+            ..
+        } => {
+            if !damage_kind_matches(trigger.damage_kind, true) {
+                return false;
+            }
+            matching_combat_damage_once_by_controller_sources(
+                trigger,
+                source_id,
+                state,
+                *player_id,
+                source_amounts,
+            )
+            .next()
+            .is_some()
+        }
+        // CR 120.1 + CR 603.2c: Unqualified "deal damage" controller-batch
+        // triggers (Malcolm, Keen-Eyed Navigator) can fire from noncombat
+        // `DamageDealt` events as well as combat aggregates.
+        GameEvent::DamageDealt {
+            source_id: damage_source,
+            target: TargetRef::Player(player_id),
+            amount,
+            is_combat,
+            ..
+        } => {
+            if *is_combat
+                || !damage_kind_matches(trigger.damage_kind, *is_combat)
+                || !damage_amount_matches(trigger, *amount)
+                || !valid_damage_done_once_player_target(trigger, state, *player_id, source_id)
+                || !damage_done_once_source_matches(trigger, state, *damage_source, source_id)
+            {
+                return false;
+            }
+            true
+        }
+        _ => false,
+    }
+}
 
+fn valid_damage_done_once_player_target(
+    trigger: &TriggerDefinition,
+    state: &GameState,
+    player_id: PlayerId,
+    source_id: ObjectId,
+) -> bool {
     if let Some(ref vt) = trigger.valid_target {
-        let trigger_controller = state.objects.get(&source_id).map(|o| o.controller);
-        match vt {
-            TargetFilter::Controller if trigger_controller != Some(*player_id) => {
-                return false;
-            }
-            TargetFilter::Typed(TypedFilter {
-                controller: Some(ControllerRef::You),
-                ..
-            }) if trigger_controller != Some(*player_id) => {
-                return false;
-            }
-            TargetFilter::Typed(TypedFilter {
-                controller: Some(ControllerRef::Opponent),
-                ..
-            }) if trigger_controller == Some(*player_id) => {
-                return false;
-            }
-            TargetFilter::Player => {}
-            _ => {}
+        if !damage_recipient_filter_can_match_player(vt) {
+            return false;
         }
     }
+    valid_player_matches(trigger, state, player_id, source_id)
+}
 
+fn damage_done_once_source_matches(
+    trigger: &TriggerDefinition,
+    state: &GameState,
+    damage_source: ObjectId,
+    source_id: ObjectId,
+) -> bool {
     if let Some(filter) = &trigger.valid_source {
-        return source_amounts
-            .iter()
-            .any(|(source, _)| target_filter_matches_object(state, *source, filter, source_id));
+        target_filter_matches_object(state, damage_source, filter, source_id)
+    } else {
+        damage_source == source_id
     }
+}
 
-    source_amounts.iter().any(|(id, _)| *id == source_id)
+fn matching_combat_damage_once_by_controller_sources<'a>(
+    trigger: &'a TriggerDefinition,
+    source_id: ObjectId,
+    state: &'a GameState,
+    player_id: PlayerId,
+    source_amounts: &'a [(ObjectId, u32)],
+) -> impl Iterator<Item = (ObjectId, u32)> + 'a {
+    let player_matches = valid_damage_done_once_player_target(trigger, state, player_id, source_id);
+    source_amounts
+        .iter()
+        .copied()
+        .filter(move |(source, amount)| {
+            player_matches
+                && damage_amount_matches(trigger, *amount)
+                && damage_done_once_source_matches(trigger, state, *source, source_id)
+        })
 }
 
 pub(super) fn matching_damage_done_once_by_controller_event(
@@ -1432,53 +1496,69 @@ pub(super) fn matching_damage_done_once_by_controller_event(
     source_id: ObjectId,
     state: &GameState,
 ) -> Option<GameEvent> {
-    // CR 603.2c + CR 608.2c: Preserve the single aggregate combat-damage
-    // trigger event while narrowing its source set to the objects that
-    // satisfied this trigger's source filter. Downstream "those creatures"
-    // effects read this filtered event context.
-    let GameEvent::CombatDamageDealtToPlayer {
-        player_id,
-        source_amounts,
-        ..
-    } = event
-    else {
-        return None;
-    };
+    match event {
+        // CR 603.2c + CR 608.2c: Preserve the single aggregate combat-damage
+        // trigger event while narrowing its source set to the objects that
+        // satisfied this trigger's source filter. Downstream "those creatures"
+        // effects read this filtered event context.
+        GameEvent::CombatDamageDealtToPlayer {
+            player_id,
+            source_amounts,
+            ..
+        } => {
+            if !damage_kind_matches(trigger.damage_kind, true) {
+                return None;
+            }
+            // CR 120.1 + CR 510.2 + CR 608.2c: Filter to matching sources using
+            // the step-local per-source amounts carried by the event (the
+            // resolving ability reads its triggering-event context per the
+            // function header above). This avoids summing
+            // `damage_dealt_this_turn` which accumulates across combat damage
+            // steps and would inflate the total on double-strike / extra-combat.
+            let matching_sources: Vec<(ObjectId, u32)> =
+                matching_combat_damage_once_by_controller_sources(
+                    trigger,
+                    source_id,
+                    state,
+                    *player_id,
+                    source_amounts,
+                )
+                .collect();
 
-    if !valid_player_matches(trigger, state, *player_id, source_id) {
-        return None;
-    }
-
-    // CR 120.1 + CR 510.2 + CR 608.2c: Filter to matching sources using the
-    // step-local per-source amounts carried by the event (the resolving ability
-    // reads its triggering-event context per the function header above). This
-    // avoids summing `damage_dealt_this_turn` which accumulates across combat
-    // damage steps and would inflate the total on double-strike / extra-combat.
-    let matching_sources: Vec<(ObjectId, u32)> = if let Some(filter) = &trigger.valid_source {
-        source_amounts
-            .iter()
-            .filter(|(src, _)| target_filter_matches_object(state, *src, filter, source_id))
-            .copied()
-            .collect()
-    } else if source_amounts.iter().any(|(id, _)| *id == source_id) {
-        source_amounts
-            .iter()
-            .filter(|(id, _)| *id == source_id)
-            .copied()
-            .collect()
-    } else {
-        Vec::new()
-    };
-
-    if matching_sources.is_empty() {
-        None
-    } else {
-        let filtered_total: u32 = matching_sources.iter().map(|(_, amt)| amt).sum();
-        Some(GameEvent::CombatDamageDealtToPlayer {
-            player_id: *player_id,
-            source_amounts: matching_sources,
-            total_damage: filtered_total,
-        })
+            if matching_sources.is_empty() {
+                None
+            } else {
+                let filtered_total: u32 = matching_sources.iter().map(|(_, amt)| amt).sum();
+                Some(GameEvent::CombatDamageDealtToPlayer {
+                    player_id: *player_id,
+                    source_amounts: matching_sources,
+                    total_damage: filtered_total,
+                })
+            }
+        }
+        // CR 120.1 + CR 603.2c + CR 608.2c: Noncombat damage reaches this
+        // one-or-more trigger family as per-damage `DamageDealt` events; combat
+        // player damage is handled exclusively by the aggregate event above to
+        // avoid firing once per source and once for the batch.
+        GameEvent::DamageDealt {
+            source_id: damage_source,
+            target: TargetRef::Player(player_id),
+            amount,
+            is_combat,
+            ..
+        } => {
+            if !is_combat
+                && damage_kind_matches(trigger.damage_kind, *is_combat)
+                && damage_amount_matches(trigger, *amount)
+                && valid_damage_done_once_player_target(trigger, state, *player_id, source_id)
+                && damage_done_once_source_matches(trigger, state, *damage_source, source_id)
+            {
+                Some(event.clone())
+            } else {
+                None
+            }
+        }
+        _ => None,
     }
 }
 
@@ -7914,6 +7994,184 @@ mod tests {
             trigger_source,
             &state
         ));
+    }
+
+    #[test]
+    fn damage_done_once_by_controller_matches_noncombat_player_damage() {
+        let mut state = setup();
+        let trigger_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Malcolm, Keen-Eyed Navigator".to_string(),
+            Zone::Battlefield,
+        );
+        let pirate = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Pirate Pinger".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&pirate).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes.push("Pirate".to_string());
+        }
+
+        let mut trigger = make_trigger(TriggerMode::DamageDoneOnceByController);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::creature()
+                .controller(ControllerRef::You)
+                .subtype("Pirate".to_string()),
+        ));
+        trigger.valid_target = Some(TargetFilter::Typed(TypedFilter {
+            type_filters: vec![],
+            controller: Some(ControllerRef::Opponent),
+            properties: vec![],
+        }));
+        trigger.damage_kind = DamageKindFilter::Any;
+
+        let event = GameEvent::DamageDealt {
+            source_id: pirate,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 1,
+            is_combat: false,
+            excess: 0,
+        };
+
+        assert!(match_damage_done_once_by_controller(
+            &event,
+            &trigger,
+            trigger_source,
+            &state,
+        ));
+        assert!(matches!(
+            matching_damage_done_once_by_controller_event(
+                &event,
+                &trigger,
+                trigger_source,
+                &state,
+            ),
+            Some(GameEvent::DamageDealt {
+                source_id,
+                target: TargetRef::Player(PlayerId(1)),
+                amount: 1,
+                is_combat: false,
+                ..
+            }) if source_id == pirate
+        ));
+    }
+
+    #[test]
+    fn damage_done_once_by_controller_combat_only_rejects_noncombat_damage() {
+        let mut state = setup();
+        let trigger_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Combat Damage Watcher".to_string(),
+            Zone::Battlefield,
+        );
+        let source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Pinger".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut trigger = make_trigger(TriggerMode::DamageDoneOnceByController);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        trigger.valid_target = Some(TargetFilter::Player);
+        trigger.damage_kind = DamageKindFilter::CombatOnly;
+
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let event = GameEvent::DamageDealt {
+            source_id: source,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 1,
+            is_combat: false,
+            excess: 0,
+        };
+
+        assert!(!match_damage_done_once_by_controller(
+            &event,
+            &trigger,
+            trigger_source,
+            &state,
+        ));
+        assert!(matching_damage_done_once_by_controller_event(
+            &event,
+            &trigger,
+            trigger_source,
+            &state,
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn damage_done_once_by_controller_ignores_per_source_combat_player_damage() {
+        let mut state = setup();
+        let trigger_source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Combat Damage Watcher".to_string(),
+            Zone::Battlefield,
+        );
+        let source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let mut trigger = make_trigger(TriggerMode::DamageDoneOnceByController);
+        trigger.valid_source = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        trigger.valid_target = Some(TargetFilter::Player);
+        trigger.damage_kind = DamageKindFilter::Any;
+
+        let event = GameEvent::DamageDealt {
+            source_id: source,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 1,
+            is_combat: true,
+            excess: 0,
+        };
+
+        assert!(!match_damage_done_once_by_controller(
+            &event,
+            &trigger,
+            trigger_source,
+            &state,
+        ));
+        assert!(matching_damage_done_once_by_controller_event(
+            &event,
+            &trigger,
+            trigger_source,
+            &state,
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -1238,6 +1238,9 @@ fn matching_combat_damage_to_player_sources(
         .collect()
 }
 
+/// CR 120.2a + CR 120.2b: damage events are classified as combat damage or
+/// damage dealt by a spell/ability effect; trigger filters may require either
+/// class or accept both.
 fn damage_kind_matches(filter: DamageKindFilter, is_combat: bool) -> bool {
     match filter {
         DamageKindFilter::Any => true,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -8357,6 +8357,7 @@ fn quantity_ref_refs_cost_paid_object(qty: &QuantityRef) -> bool {
         | QuantityRef::StartingLifeTotal
         | QuantityRef::TriggeringDiscoverValue
         | QuantityRef::PlayerCount { .. }
+        | QuantityRef::EventContextPlayerCount { .. }
         | QuantityRef::PlayerCounter { .. }
         | QuantityRef::TargetControllerCounter { .. }
         | QuantityRef::Variable { .. }

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -742,6 +742,27 @@ fn parse_token_description_with_context(
         }
     }
 
+    // CR 120.1 + CR 603.2c + CR 608.2c: Malcolm-style trigger-context player
+    // counts do not always carry the literal "this way" ("for each opponent
+    // dealt damage"). Recognize that phrase before the tracked-set block below,
+    // whose object-set fallback would be the wrong anaphor class.
+    {
+        let suffix_lower = suffix.to_lowercase();
+        if let Ok((clause, _)) = take_until::<_, _, OracleError<'_>>("for each ")
+            .parse(suffix_lower.as_str())
+            .and_then(|(rest, _)| tag("for each ").parse(rest))
+        {
+            let clause = clause.trim_end_matches('.').trim();
+            if let Ok(("", qty)) =
+                crate::parser::oracle_nom::quantity::parse_event_context_opponent_dealt_damage(
+                    clause,
+                )
+            {
+                count = QuantityExpr::Ref { qty };
+            }
+        };
+    }
+
     // CR 608.2c: "for each [thing] this way" -- the "this way" anaphor counts from
     // the preceding zone moves in the same effect.
     // Matches "for each card put into a graveyard this way", "for each creature
@@ -768,6 +789,16 @@ fn parse_token_description_with_context(
                     .ok()
                     .filter(|(rest, _)| rest.is_empty())
                     .map(|(_, qty)| QuantityExpr::Ref { qty })
+                    // CR 120.1 + CR 603.2c + CR 608.2c: Malcolm-style token
+                    // counts named players in the current trigger event batch,
+                    // not the previous chain tracked object set.
+                    .or_else(|| {
+                        crate::parser::oracle_quantity::parse_for_each_clause(clause)
+                            .filter(|qty| {
+                                matches!(qty, QuantityRef::EventContextPlayerCount { .. })
+                            })
+                            .map(|qty| QuantityExpr::Ref { qty })
+                    })
                     // CR 608.2c + CR 205.2a: a TYPE-restricted "for each <type> card
                     // <verb> this way" (Dread Summons: "for each creature card put
                     // into a graveyard this way") counts only the matching cards
@@ -1575,7 +1606,9 @@ pub(super) fn push_unique_string(values: &mut Vec<String>, value: impl Into<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{ObjectScope, QuantityExpr, QuantityRef, RoundingMode, TypeFilter};
+    use crate::types::ability::{
+        ObjectScope, PlayerFilter, QuantityExpr, QuantityRef, RoundingMode, TypeFilter,
+    };
     use crate::types::card_type::CoreType;
 
     #[test]
@@ -1887,6 +1920,26 @@ mod tests {
                 qty: QuantityRef::TrackedSetSize,
             },
             "bare 'card discarded this way' must keep TrackedSetSize"
+        );
+    }
+
+    #[test]
+    fn treasure_for_each_opponent_dealt_damage_counts_trigger_players() {
+        let txt = "Create a Treasure token for each opponent dealt damage.";
+        let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
+            .expect("expected Malcolm token effect");
+        let Effect::Token { name, count, .. } = effect else {
+            panic!("expected Effect::Token, got {effect:?}");
+        };
+        assert_eq!(name, "Treasure");
+        assert_eq!(
+            count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::EventContextPlayerCount {
+                    filter: PlayerFilter::Opponent,
+                },
+            },
+            "Malcolm must count damaged opponents, not damage amount or tracked objects"
         );
     }
 

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3642,6 +3642,25 @@ fn parse_for_each_card_drawn_this_way(input: &str) -> OracleResult<'_, QuantityR
     Ok((rest, QuantityRef::EventContextAmount))
 }
 
+/// CR 120.1 + CR 603.2c + CR 608.2c: "opponent(s) dealt damage [this way]"
+/// inside a trigger effect counts the distinct damaged opponents carried by the
+/// current trigger event batch. This is not `EventContextAmount`: the scalar
+/// damage amount is a separate quantity axis.
+pub(crate) fn parse_event_context_opponent_dealt_damage(
+    input: &str,
+) -> OracleResult<'_, QuantityRef> {
+    let (input, _) = opt(alt((tag("the number of "), tag("number of ")))).parse(input)?;
+    let (rest, _) = alt((tag("opponents"), tag("opponent"))).parse(input)?;
+    let (rest, _) = tag(" dealt damage").parse(rest)?;
+    let (rest, _) = opt(tag(" this way")).parse(rest)?;
+    Ok((
+        rest,
+        QuantityRef::EventContextPlayerCount {
+            filter: PlayerFilter::Opponent,
+        },
+    ))
+}
+
 /// CR 106.4: "unspent [color] mana you have" counts floating mana in the
 /// controller's mana pool.
 fn parse_for_each_unspent_mana(input: &str) -> OracleResult<'_, QuantityRef> {
@@ -3656,6 +3675,7 @@ fn parse_for_each_clause_ref_with_they_controller(
     they_controller: ControllerRef,
 ) -> OracleResult<'_, QuantityRef> {
     alt((
+        parse_event_context_opponent_dealt_damage,
         parse_for_each_card_drawn_this_way,
         alt((
             parse_for_each_one_life_changed,
@@ -5156,8 +5176,8 @@ fn parse_player_counter_possessor(input: &str) -> OracleResult<'_, CountScope> {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        AggregateFunction, ControllerRef, FilterProp, ObjectProperty, QuantityRef, SharedQuality,
-        SharedQualityRelation, TargetFilter, TypeFilter, TypedFilter,
+        AggregateFunction, ControllerRef, FilterProp, ObjectProperty, PlayerFilter, QuantityRef,
+        SharedQuality, SharedQualityRelation, TargetFilter, TypeFilter, TypedFilter,
     };
     use crate::types::mana::ManaColor;
 
@@ -5169,6 +5189,30 @@ mod tests {
                 right: Box::new(pt_stat_quantity(right, scope)),
             }
         );
+    }
+
+    #[test]
+    fn for_each_opponent_dealt_damage_is_event_context_player_count() {
+        for phrase in [
+            "opponent dealt damage",
+            "opponents dealt damage",
+            "opponent dealt damage this way",
+            "opponents dealt damage this way",
+            "the number of opponent dealt damage this way",
+            "the number of opponents dealt damage this way",
+            "number of opponents dealt damage this way",
+        ] {
+            let (rest, qty) = parse_for_each_clause_ref_complete(phrase)
+                .unwrap_or_else(|error| panic!("phrase {phrase:?}: {error:?}"));
+            assert_eq!(rest, "");
+            assert_eq!(
+                qty,
+                QuantityRef::EventContextPlayerCount {
+                    filter: PlayerFilter::Opponent,
+                },
+                "phrase {phrase:?} must count trigger-event players"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -1709,14 +1709,20 @@ pub(crate) fn parse_event_context_quantity(text: &str) -> Option<QuantityExpr> {
     {
         return Some(expr);
     }
+    // CR 120.1 + CR 603.2c + CR 608.2c: "opponents dealt damage this way" in
+    // trigger-context effects counts the damaged opponents, not the numeric
+    // damage amount. Must precede the passive-voice "dealt damage" numeric
+    // parser below.
+    if let Ok(("", qty)) = nom_quantity::parse_event_context_opponent_dealt_damage(lower) {
+        return Some(QuantityExpr::Ref { qty });
+    }
     // CR 608.2c + CR 608.2h: "the X <verb>ed/<verb> this way" — numeric result from the
     // preceding effect (or trigger event) in the same resolution. Must check
     // before "that much" to avoid false match on "this way" vs. "this turn".
     // Verb-phrase combinators cover:
     //   - life-payment/loss: "life lost", "life paid"
     //   - combat-damage triggers: "damage dealt" (active voice),
-    //     "dealt damage" (passive voice — e.g. Hordewing Skaab's
-    //     "opponents dealt damage this way")
+    //     "dealt damage" (passive voice)
     //   - counter-removal chains: "counters removed", "counter removed"
     //     (Sensational Spider-Man's "stun counters removed this way";
     //     `state.last_effect_amount` is stamped by the preceding RemoveCounter).
@@ -2961,6 +2967,14 @@ fn parse_for_each_clause_with_they_controller(
         }
     }
 
+    // CR 120.1 + CR 603.2c + CR 608.2c: "opponent(s) dealt damage this way"
+    // in a trigger effect counts damaged players from the current trigger
+    // event batch. It must not fall through to `TrackedSetSize` (object-set
+    // anaphor) or `PreviousEffectAmount` (numeric producer amount).
+    if let Ok(("", qty)) = nom_quantity::parse_event_context_opponent_dealt_damage(clause) {
+        return Some(qty);
+    }
+
     // "card put into a graveyard this way" / "creature card exiled this way" / etc.
     // "this way" references objects from the preceding effect's tracked set.
     if clause.contains("this way") {
@@ -3069,6 +3083,13 @@ fn parse_for_each_clause_with_they_controller(
                 min_sources: 1,
             },
         });
+    }
+
+    // CR 120.1 + CR 603.2c + CR 608.2c: Malcolm-style trigger-context count
+    // ("for each opponent dealt damage") has no "this turn" duration and must
+    // read the resolving trigger event batch, not the turn damage ledger.
+    if let Ok(("", qty)) = nom_quantity::parse_event_context_opponent_dealt_damage(clause) {
+        return Some(qty);
     }
 
     // CR 508.6: "opponent you attacked this turn".
@@ -5424,7 +5445,6 @@ mod tests {
             "the life lost this way",
             "the amount of life paid this way",
             "the damage dealt this way",
-            "opponents dealt damage this way",
             "the number of stun counters removed this way",
         ] {
             assert_eq!(
@@ -5435,6 +5455,25 @@ mod tests {
                     },
                 }),
                 "phrase {phrase:?} must map to PreviousEffectAmount on the TOTAL channel"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_event_context_quantity_opponents_dealt_damage_counts_event_players() {
+        for phrase in [
+            "opponents dealt damage this way",
+            "the number of opponents dealt damage this way",
+            "number of opponents dealt damage this way",
+        ] {
+            assert_eq!(
+                parse_event_context_quantity(phrase),
+                Some(QuantityExpr::Ref {
+                    qty: QuantityRef::EventContextPlayerCount {
+                        filter: PlayerFilter::Opponent,
+                    },
+                }),
+                "phrase {phrase:?} must count damaged players"
             );
         }
     }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -8854,6 +8854,8 @@ fn parse_damage_to_qualifier_with_rest(after_verb: &str) -> OracleResult<'_, Tar
             opponent_player_filter(),
             alt((
                 preceded(tag("an "), tag("opponent")),
+                preceded(tag("your "), tag("opponents")),
+                tag("opponents"),
                 preceded(tag("one of your "), tag("opponents")),
                 preceded(tag("one or more of your "), tag("opponents")),
                 preceded(tag("another "), tag("player")),
@@ -12483,34 +12485,49 @@ fn try_parse_one_or_more_combat_damage_to_player(
         let Ok((rest, ())) = value((), tag::<_, _, OracleError<'_>>(prefix)).parse(lower) else {
             continue;
         };
+        let Ok((after_subject, subject_text)) =
+            take_until::<_, _, OracleError<'_>>(" deal").parse(rest)
+        else {
+            continue;
+        };
+        let Ok((after_verb, _)) =
+            (tag::<_, _, OracleError<'_>>(" deal"), opt(tag("s"))).parse(after_subject)
+        else {
+            continue;
+        };
+        let Ok((after_damage, (damage_kind, _))) = preceded(
+            tag::<_, _, OracleError<'_>>(" "),
+            parse_damage_predicate_tail,
+        )
+        .parse(after_verb) else {
+            continue;
+        };
+        if matches!(damage_kind, DamageKindFilter::NoncombatOnly) {
+            continue;
+        }
+
         // CR 120.1a: Try battle-inclusive suffixes first (longer match wins).
         // Covers "deal(s) combat damage to a player or (a )battle".
-        let (subject_text, recipient_filter) = if let Ok(("", t)) = terminated(
-            take_until::<_, _, OracleError<'_>>(" deal"),
-            (
-                tag(" deal"),
-                opt(tag("s")),
-                tag(" combat damage to a player or "),
-                opt(tag("a ")),
-                tag("battle"),
-            ),
+        let recipient_filter = if let Ok(("", _)) = (
+            tag::<_, _, OracleError<'_>>(" to a player or "),
+            opt(tag("a ")),
+            tag("battle"),
         )
-        .parse(rest)
+            .parse(after_damage)
         {
-            (
-                t,
-                TargetFilter::Or {
-                    filters: vec![
-                        TargetFilter::Player,
-                        TargetFilter::Typed(TypedFilter::new(TypeFilter::Battle)),
-                    ],
-                },
-            )
-        } else if let Some(t) = rest
-            .strip_suffix(" deal combat damage to a player")
-            .or_else(|| rest.strip_suffix(" deals combat damage to a player"))
+            TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Player,
+                    TargetFilter::Typed(TypedFilter::new(TypeFilter::Battle)),
+                ],
+            }
+        } else if let Ok(("", filter)) = preceded(
+            tag::<_, _, OracleError<'_>>(" "),
+            parse_damage_to_qualifier_with_rest,
+        )
+        .parse(after_damage)
         {
-            (t, TargetFilter::Player)
+            filter
         } else {
             continue;
         };
@@ -12538,14 +12555,25 @@ fn try_parse_one_or_more_combat_damage_to_player(
                     }
                     other => other,
                 }
+            } else if let Some(subtype_filter) = parse_controlled_subtype_subject(subject_text) {
+                subtype_filter
             } else {
-                continue;
+                let mut ctx = ParseContext::default();
+                let (subject_filter, subject_remainder) =
+                    parse_trigger_subject(subject_text, &mut ctx);
+                if subject_remainder.trim().is_empty()
+                    && !matches!(subject_filter, TargetFilter::Any)
+                {
+                    subject_filter
+                } else {
+                    continue;
+                }
             }
         };
 
         let mut def = make_base();
         def.mode = TriggerMode::DamageDoneOnceByController;
-        def.damage_kind = DamageKindFilter::CombatOnly;
+        def.damage_kind = damage_kind;
         def.valid_source = Some(filter);
         def.valid_target = Some(recipient_filter);
         def.batched = true;
@@ -12553,6 +12581,30 @@ fn try_parse_one_or_more_combat_damage_to_player(
     }
 
     None
+}
+
+fn parse_controlled_subtype_subject(subject_text: &str) -> Option<TargetFilter> {
+    let (rest, subtype_text) = terminated(
+        take_until::<_, _, OracleError<'_>>(" you control"),
+        tag(" you control"),
+    )
+    .parse(subject_text)
+    .ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    let subtype_text = subtype_text.trim();
+    let (subtype, consumed) = parse_subtype(subtype_text)?;
+    if consumed != subtype_text.len() {
+        return None;
+    }
+
+    Some(TargetFilter::Typed(
+        TypedFilter::creature()
+            .controller(ControllerRef::You)
+            .subtype(subtype),
+    ))
 }
 
 /// CR 205.3m: Try to split "subtype or subtype [card_type] [you control]" into an Or filter.

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -2445,6 +2445,46 @@ fn grim_hireling_combat_damage_trigger_is_batched() {
 }
 
 #[test]
+fn malcolm_keen_eyed_navigator_damage_trigger_counts_damaged_opponents() {
+    let def = parse_trigger_line(
+        "Whenever one or more Pirates you control deal damage to your opponents, you create a Treasure token for each opponent dealt damage.",
+        "Malcolm, Keen-Eyed Navigator",
+    );
+    assert_eq!(def.mode, TriggerMode::DamageDoneOnceByController);
+    assert_eq!(def.damage_kind, DamageKindFilter::Any);
+    assert_eq!(
+        def.valid_source,
+        Some(TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Subtype("Pirate".to_string())],
+            controller: Some(ControllerRef::You),
+            properties: vec![],
+        }))
+    );
+    assert!(matches!(
+        def.valid_target,
+        Some(TargetFilter::Typed(TypedFilter {
+            controller: Some(ControllerRef::Opponent),
+            ..
+        }))
+    ));
+    assert!(def.batched);
+
+    let execute = def.execute.as_ref().expect("trigger should execute");
+    let Effect::Token { name, count, .. } = execute.effect.as_ref() else {
+        panic!("expected Token effect, got {:?}", execute.effect);
+    };
+    assert_eq!(name, "Treasure");
+    assert_eq!(
+        count,
+        &QuantityExpr::Ref {
+            qty: QuantityRef::EventContextPlayerCount {
+                filter: PlayerFilter::Opponent,
+            },
+        }
+    );
+}
+
+#[test]
 fn primo_the_unbounded_combat_damage_trigger() {
     // Primo, the Unbounded (#1361): the triggering creatures' base power is 0,
     // and the Fractal token enters with +1/+1 counters equal to the combat

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5633,6 +5633,12 @@ pub enum QuantityRef {
     /// CR 603.7c: Numeric value from the triggering event.
     /// Extracts amount/count from DamageDealt, LifeChanged, CardsDrawn, CounterAdded, etc.
     EventContextAmount,
+    /// CR 120.1 + CR 603.2c + CR 608.2c: Count distinct players named by the
+    /// current triggering event batch, after applying a player filter relative
+    /// to the resolving ability's controller. Used by "for each opponent dealt
+    /// damage" on one-or-more damage triggers: the count is the number of
+    /// opponents in the trigger event batch, not the amount of damage dealt.
+    EventContextPlayerCount { filter: PlayerFilter },
     /// CR 603.10a + CR 603.6e: Count of attachments of a given kind that were attached
     /// to the leaving-battlefield object at the moment it left, optionally filtered by
     /// attachment controller. Resolved via the triggering `ZoneChangeRecord`'s

--- a/crates/engine/tests/integration/issue_5997_malcolm_treasure_trigger.rs
+++ b/crates/engine/tests/integration/issue_5997_malcolm_treasure_trigger.rs
@@ -1,0 +1,131 @@
+//! Issue #5997 - Malcolm, Keen-Eyed Navigator must create one Treasure for each
+//! distinct opponent dealt damage by one or more Pirates you control.
+//!
+//! Oracle text verified from generated MTGJSON/card-data:
+//! "Whenever one or more Pirates you control deal damage to your opponents, you
+//! create a Treasure token for each opponent dealt damage."
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P2: PlayerId = PlayerId(2);
+
+const MALCOLM_ORACLE: &str = "Flying\nWhenever one or more Pirates you control deal damage to \
+your opponents, you create a Treasure token for each opponent dealt damage. (It's an artifact \
+with \"{T}, Sacrifice this token: Add one mana of any color.\")\nPartner";
+
+fn count_treasures(runner: &GameRunner, player: PlayerId) -> usize {
+    runner
+        .state()
+        .battlefield
+        .iter()
+        .filter_map(|id| runner.state().objects.get(id))
+        .filter(|obj| {
+            obj.controller == player
+                && obj.zone == Zone::Battlefield
+                && obj.is_token
+                && obj.name.eq_ignore_ascii_case("Treasure")
+        })
+        .count()
+}
+
+fn drive_to_declare_attackers(runner: &mut GameRunner) {
+    for _ in 0..32 {
+        match runner.state().waiting_for {
+            WaitingFor::DeclareAttackers { .. } => return,
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("passing priority should reach declare attackers");
+            }
+            ref other => panic!("expected priority or declare attackers, got {other:?}"),
+        }
+    }
+    panic!("did not reach declare attackers");
+}
+
+fn drive_until_trigger_stacked(runner: &mut GameRunner) {
+    for _ in 0..64 {
+        if !runner.state().stack.is_empty() {
+            return;
+        }
+
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("passing priority should advance combat");
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("defender should be able to declare no blockers");
+            }
+            WaitingFor::OrderTriggers { triggers, .. } => {
+                let order = (0..triggers.len()).collect();
+                runner
+                    .act(GameAction::OrderTriggers { order })
+                    .expect("default trigger order should be accepted");
+            }
+            ref other => panic!("unexpected wait state while advancing combat: {other:?}"),
+        }
+    }
+    panic!("Malcolm trigger never reached the stack");
+}
+
+#[test]
+fn malcolm_creates_treasure_per_distinct_damaged_opponent() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "Malcolm, Keen-Eyed Navigator", 2, 2, MALCOLM_ORACLE)
+        .with_subtypes(vec!["Siren", "Pirate"]);
+    let pirate_to_p1 = scenario
+        .add_creature(P0, "Boarding Party A", 1, 1)
+        .with_subtypes(vec!["Pirate"])
+        .id();
+    let first_pirate_to_p2 = scenario
+        .add_creature(P0, "Boarding Party B", 1, 1)
+        .with_subtypes(vec!["Pirate"])
+        .id();
+    let second_pirate_to_p2 = scenario
+        .add_creature(P0, "Boarding Party C", 1, 1)
+        .with_subtypes(vec!["Pirate"])
+        .id();
+    let non_pirate_to_p2 = scenario.add_creature(P0, "Deckhand", 1, 1).id();
+    let mut runner = scenario.build();
+
+    let treasures_before = count_treasures(&runner, P0);
+
+    drive_to_declare_attackers(&mut runner);
+    runner
+        .declare_attackers(&[
+            (pirate_to_p1, AttackTarget::Player(P1)),
+            (first_pirate_to_p2, AttackTarget::Player(P2)),
+            (second_pirate_to_p2, AttackTarget::Player(P2)),
+            (non_pirate_to_p2, AttackTarget::Player(P2)),
+        ])
+        .expect("all attackers should be legal");
+    drive_until_trigger_stacked(&mut runner);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(runner.life(P1), 19, "P1 took one Pirate combat damage");
+    assert_eq!(
+        runner.life(P2),
+        17,
+        "P2 took two Pirate combat damage plus one non-Pirate combat damage"
+    );
+    assert_eq!(
+        count_treasures(&runner, P0),
+        treasures_before + 2,
+        "Malcolm must create one Treasure per distinct damaged opponent: P1 and P2. \
+         The second Pirate hit on P2 and the non-Pirate hit on P2 must not inflate the count."
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -530,6 +530,7 @@ mod issue_5821_psychic_paper_attach_choice;
 mod issue_583_vivi_ornitier_mana_source;
 mod issue_5984_aloy_discover_on_attack;
 mod issue_5988_braids_arisen_nightmare;
+mod issue_5997_malcolm_treasure_trigger;
 mod issue_5999_aura_exile_host;
 mod issue_6002_neera_wild_mage_bottom_of_library;
 mod issue_6006_aminatou_veil_piercer_own_turn_miracle;


### PR DESCRIPTION
## Summary
Fixes **Malcolm, Keen-Eyed Navigator** so its "one or more Pirates" damage trigger creates Treasure for each distinct opponent dealt damage. Closes #5997.

## Files changed
- `crates/engine/src/types/ability.rs`
- `crates/engine/src/game/quantity.rs`
- `crates/engine/src/game/trigger_matchers.rs`
- `crates/engine/src/game/triggers.rs`
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/parser/oracle_nom/quantity.rs`
- `crates/engine/src/parser/oracle_quantity.rs`
- `crates/engine/src/parser/oracle_effect/token.rs`
- Supporting scanner/coverage/layer plumbing and parser/runtime tests

## CR references
- CR 120.1
- CR 120.2a
- CR 120.2b
- CR 510.2
- CR 603.2c
- CR 608.2c

## Implementation method
Method: /pipeline

## Track
Track: Developer

## LLM
Model: GPT-5 Codex
Thinking: high
Tier: Standard

## Verification
- [x] `cargo fmt --all -- --check` - pass
- [x] `./scripts/check-parser-combinators.sh` - pass via Gate A below
- [x] `cargo check -p engine --lib` - pass
- [x] `cargo test -p engine malcolm_keen_eyed_navigator_damage_trigger_counts_damaged_opponents` - pass
- [x] `cargo test -p engine damage_done_once_by_controller_matches_noncombat_player_damage` - pass
- [x] `cargo test -p engine damage_done_once_by_controller_ignores_per_source_combat_player_damage` - pass
- [x] `cargo test -p engine parse_event_context_quantity_opponents_dealt_damage_counts_event_players` - pass
- [x] `cargo test -p engine one_or_more_combat_damage_trigger` - pass
- [x] `cargo test -p engine ordering_parity_sweep` - pass
- [x] `./scripts/gen-card-data.sh` - pass, schema validation OK
- [x] `cargo test -p engine` - pass before final rebase with the same implementation diff
- [x] `cargo clippy --all-targets -- -D warnings` - pass before final rebase with the same implementation diff

## Gate A
```text
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=3e3735bb07503051754d3713952ad4406cf0474f base=4351f1246157a4855434dc52eca216766c943b1f
```

## Anchored on
- `crates/engine/src/game/trigger_matchers.rs:1368` - existing aggregate combat-damage event expansion for per-source trigger context.
- `crates/engine/src/parser/oracle_nom/quantity.rs:3638` - existing nom parser for trigger-context "this way" quantities.

## Final review-impl
```text
Final review-impl PASS head=3e3735bb07503051754d3713952ad4406cf0474f
```

## Claimed parse impact
- Malcolm, Keen-Eyed Navigator now parses and resolves its Pirate damage trigger.
- Trigger-effect quantities such as "for each opponent dealt damage" and "the number of opponents dealt damage this way" now count distinct damaged opponents from the current trigger event context.

## Validation Failures
- `FORGE_TEST_FULL_DB=1 cargo test -p engine ordering_parity_sweep` fails on 19 unrelated Hidden/Opal/Veiled same-event prompt diffs in the regenerated full database; the fixture-backed `ordering_parity_sweep` passes.

## CI Failures
None.
