### PR TITLE
Fix March of the Machines

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -100,6 +100,26 @@ struct PreparedIncrementalFlush {
     active_effects: Vec<ActiveContinuousEffect>,
 }
 
+/// Identity of one continuous effect whose modifications may apply in several
+/// layers. The identity deliberately excludes `mod_index`: every modification
+/// produced by the same effect shares the CR 613.6 affected-object set.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ContinuousEffectGroupKey {
+    Static {
+        source: ObjectIncarnationRef,
+        definition_index: usize,
+    },
+    Transient {
+        continuous_effect_id: u64,
+    },
+    GrantedStatic {
+        grant_origin: TriggerProducerOrigin,
+        recipient: ObjectIncarnationRef,
+    },
+}
+
+type StartedContinuousEffectSets = HashMap<ContinuousEffectGroupKey, Vec<ObjectId>>;
+
 // CR 205.3c: Each subtype is correlated to its appropriate card type.
 /// CR 205.1a: Whether a subtype correlates to at least one of the given core
 /// types — i.e. whether it survives a card-type replacement. Shared with the
@@ -1898,10 +1918,17 @@ pub fn evaluate_layers(state: &mut GameState) {
 
     // Step 2: Apply copy effects first so copied static abilities exist before later layers.
     let mut zone_cache = LayerZoneObjectCache::default();
+    let mut started_effect_sets = StartedContinuousEffectSets::new();
     let copy_effects = gather_active_effects_for_layer(state, Layer::Copy);
     let ordered_copy = order_active_continuous_effects(Layer::Copy, &copy_effects, state);
     for effect in &ordered_copy {
-        apply_continuous_effect(state, effect, &mut abilities_suppressed, &mut zone_cache);
+        apply_continuous_effect(
+            state,
+            effect,
+            &mut abilities_suppressed,
+            &mut zone_cache,
+            &mut started_effect_sets,
+        );
     }
     if crate::game::stickers::apply_battlefield_name_and_ability_stickers(state, &bf_ids) {
         // Sticker ability text is appended after the top-of-pass reset/copy
@@ -1945,7 +1972,13 @@ pub fn evaluate_layers(state: &mut GameState) {
             };
 
             for effect in &ordered {
-                apply_continuous_effect(state, effect, &mut abilities_suppressed, &mut zone_cache);
+                apply_continuous_effect(
+                    state,
+                    effect,
+                    &mut abilities_suppressed,
+                    &mut zone_cache,
+                    &mut started_effect_sets,
+                );
             }
         }
 
@@ -2995,6 +3028,7 @@ fn apply_layers_incremental(state: &mut GameState, prepared: PreparedIncremental
     } = prepared;
     let mut abilities_suppressed = HashSet::new();
     let mut zone_cache = LayerZoneObjectCache::default();
+    let mut started_effect_sets = StartedContinuousEffectSets::new();
     // Step 1 (per-recipient subset) ran in `prepare_incremental_flush` before the
     // static-source index rebuild and shared active-effect collection.
 
@@ -3012,6 +3046,7 @@ fn apply_layers_incremental(state: &mut GameState, prepared: PreparedIncremental
             &recipient_ids,
             &mut abilities_suppressed,
             &mut zone_cache,
+            &mut started_effect_sets,
         );
     }
 
@@ -3051,6 +3086,7 @@ fn apply_layers_incremental(state: &mut GameState, prepared: PreparedIncremental
                     &recipient_ids,
                     &mut abilities_suppressed,
                     &mut zone_cache,
+                    &mut started_effect_sets,
                 );
             }
         }
@@ -3508,6 +3544,15 @@ fn active_continuous_effects_from_static_definitions(
             if is_combat_assignment_rule_modification(modification) {
                 continue;
             }
+            let trigger_producer_origin =
+                state
+                    .objects
+                    .get(&source_id)
+                    .map(|source| TriggerProducerOrigin::Static {
+                        source: ObjectIncarnationRef::from_object(source),
+                        definition_index: def_idx,
+                        modification_index: mod_index,
+                    });
             // CR 113.3d + CR 604.1 + CR 611.2c: A `GrantStaticAbility` modification
             // installs the inner static onto every recipient matching the host's
             // `affected_filter`. The recipient is the granted-static's *source*
@@ -3527,6 +3572,7 @@ fn active_continuous_effects_from_static_definitions(
                     timestamp,
                     &affected_filter,
                     inner.as_ref(),
+                    trigger_producer_origin.clone(),
                 ));
                 // Continue: also push the meta-effect below so layer-6 apply
                 // pushes the inner static onto the recipient's
@@ -3579,15 +3625,6 @@ fn active_continuous_effects_from_static_definitions(
                 ));
                 continue;
             }
-            let trigger_producer_origin =
-                state
-                    .objects
-                    .get(&source_id)
-                    .map(|source| TriggerProducerOrigin::Static {
-                        source: ObjectIncarnationRef::from_object(source),
-                        definition_index: def_idx,
-                        modification_index: mod_index,
-                    });
             effects.push(ActiveContinuousEffect {
                 source_id,
                 controller,
@@ -3641,6 +3678,7 @@ fn expand_granted_static_effects(
     host_timestamp: u64,
     host_affected_filter: &TargetFilter,
     inner: &StaticDefinition,
+    host_origin: Option<TriggerProducerOrigin>,
 ) -> Vec<ActiveContinuousEffect> {
     if inner.mode != StaticMode::Continuous {
         return Vec::new();
@@ -3685,7 +3723,10 @@ fn expand_granted_static_effects(
                 // confuse them with the host's `static_definitions[def_idx]`.
                 def_index: None,
                 transient_id: None,
-                trigger_producer_origin: None,
+                // Retain the exact host grant origin so every modification
+                // synthesized from this granted static shares one CR 613.6
+                // affected-object set for this recipient.
+                trigger_producer_origin: host_origin.clone(),
                 expanded_trigger_provider: None,
                 mod_index,
                 layer: modification.layer(),
@@ -4775,8 +4816,16 @@ fn apply_continuous_effect(
     effect: &ActiveContinuousEffect,
     abilities_suppressed: &mut HashSet<ObjectId>,
     zone_cache: &mut LayerZoneObjectCache,
+    started_effect_sets: &mut StartedContinuousEffectSets,
 ) {
-    apply_continuous_effect_filtered(state, effect, None, abilities_suppressed, zone_cache);
+    apply_continuous_effect_filtered(
+        state,
+        effect,
+        None,
+        abilities_suppressed,
+        zone_cache,
+        started_effect_sets,
+    );
 }
 
 /// Installs one Layer-6-produced trigger by producer identity, never by payload
@@ -4826,6 +4875,7 @@ fn apply_continuous_effect_to(
     restrict_to: &BTreeSet<ObjectId>,
     abilities_suppressed: &mut HashSet<ObjectId>,
     zone_cache: &mut LayerZoneObjectCache,
+    started_effect_sets: &mut StartedContinuousEffectSets,
 ) {
     apply_continuous_effect_filtered(
         state,
@@ -4833,7 +4883,57 @@ fn apply_continuous_effect_to(
         Some(restrict_to),
         abilities_suppressed,
         zone_cache,
+        started_effect_sets,
     );
+}
+
+fn continuous_effect_group_key(
+    state: &GameState,
+    effect: &ActiveContinuousEffect,
+) -> Option<ContinuousEffectGroupKey> {
+    if let Some(definition_index) = effect.def_index {
+        let source = state.objects.get(&effect.source_id)?;
+        return Some(ContinuousEffectGroupKey::Static {
+            source: ObjectIncarnationRef::from_object(source),
+            definition_index,
+        });
+    }
+    if let Some(continuous_effect_id) = effect.transient_id {
+        return Some(ContinuousEffectGroupKey::Transient {
+            continuous_effect_id,
+        });
+    }
+    let grant_origin = effect.trigger_producer_origin.clone()?;
+    let recipient = state.objects.get(&effect.source_id)?;
+    Some(ContinuousEffectGroupKey::GrantedStatic {
+        grant_origin,
+        recipient: ObjectIncarnationRef::from_object(recipient),
+    })
+}
+
+/// CR 613.1f + CR 613.6: Ability removal prevents an effect that has not begun
+/// applying from starting in a later layer. Synthesized granted statics depend
+/// on both the granting source and the recipient that carries the granted
+/// ability. Other synthetic effects (such as CR 123.8 P/T stickers) do not carry
+/// this explicit grant provenance and remain independent of ability removal.
+fn unstarted_effect_generator_is_suppressed(
+    effect: &ActiveContinuousEffect,
+    abilities_suppressed: &HashSet<ObjectId>,
+) -> bool {
+    if effect.def_index.is_some() {
+        return abilities_suppressed.contains(&effect.source_id);
+    }
+    if effect.transient_id.is_some() {
+        return false;
+    }
+
+    let Some(TriggerProducerOrigin::Static { source, .. }) =
+        effect.trigger_producer_origin.as_ref()
+    else {
+        return false;
+    };
+    abilities_suppressed.contains(&effect.source_id)
+        || abilities_suppressed.contains(&source.object_id)
 }
 
 /// CR 611.3a + CR 611.3b: computes the set of zones `apply_continuous_effect_filtered`
@@ -4992,39 +5092,63 @@ fn apply_continuous_effect_filtered(
     restrict_to: Option<&BTreeSet<ObjectId>>,
     abilities_suppressed: &mut HashSet<ObjectId>,
     zone_cache: &mut LayerZoneObjectCache,
+    started_effect_sets: &mut StartedContinuousEffectSets,
 ) {
+    let group_key = continuous_effect_group_key(state, effect);
+    let retained_affected_ids = group_key
+        .as_ref()
+        .and_then(|key| started_effect_sets.get(key));
+
     // CR 613.1f: A printed static on an object that lost all abilities this
     // pass must not re-apply in later layers (Death's Shadow CDA after
     // Abigale — issue #1321).
-    if effect.def_index.is_some() && abilities_suppressed.contains(&effect.source_id) {
+    // CR 613.6: Once a multi-layer effect started applying, its remaining
+    // parts continue over the same object set even if its source loses the
+    // ability that generated it during an intervening layer.
+    if retained_affected_ids.is_none()
+        && unstarted_effect_generator_is_suppressed(effect, abilities_suppressed)
+    {
         return;
     }
 
-    let scan_ids = effect_candidate_ids(state, &effect.affected_filter, zone_cache);
-    let ctx = FilterContext::from_source(state, effect.source_id);
-    let affected_ids: Vec<ObjectId> = scan_ids
-        .iter()
-        // Incremental fast path: re-apply only to the freshly-entered objects.
-        // The rest of the battlefield was not reset and keeps its prior derived
-        // values, so re-applying to it would double-apply.
-        .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
-        .filter(|&&id| matches_target_filter(state, id, &effect.affected_filter, &ctx))
-        .filter(|&&id| {
-            effect.condition.as_ref().is_none_or(|condition| {
-                evaluate_condition_with_recipient(
-                    state,
-                    condition,
-                    effect.controller,
-                    effect.source_id,
-                    id,
-                )
+    let newly_affected_ids;
+    let affected_ids: &[ObjectId] = if let Some(retained) = retained_affected_ids {
+        retained
+    } else {
+        let scan_ids = effect_candidate_ids(state, &effect.affected_filter, zone_cache);
+        let ctx = FilterContext::from_source(state, effect.source_id);
+        newly_affected_ids = scan_ids
+            .iter()
+            // Incremental fast path: re-apply only to the freshly-entered objects.
+            // The rest of the battlefield was not reset and keeps its prior derived
+            // values, so re-applying to it would double-apply.
+            .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
+            .filter(|&&id| matches_target_filter(state, id, &effect.affected_filter, &ctx))
+            .filter(|&&id| {
+                effect.condition.as_ref().is_none_or(|condition| {
+                    evaluate_condition_with_recipient(
+                        state,
+                        condition,
+                        effect.controller,
+                        effect.source_id,
+                        id,
+                    )
+                })
             })
-        })
-        .copied()
-        .collect();
+            .copied()
+            .collect();
+        if let Some(key) = group_key {
+            started_effect_sets
+                .entry(key)
+                .or_insert(newly_affected_ids)
+                .as_slice()
+        } else {
+            newly_affected_ids.as_slice()
+        }
+    };
 
-    record_remote_type_layer_recipients(state, effect, &affected_ids);
-    record_attribution(state, effect, &affected_ids);
+    record_remote_type_layer_recipients(state, effect, affected_ids);
+    record_attribution(state, effect, affected_ids);
 
     // Pre-read chosen subtype from source (avoids borrow conflict in the loop).
     // Populated for `AddChosenSubtype { kind }` (additive — creature type or
@@ -5258,7 +5382,7 @@ fn apply_continuous_effect_filtered(
     };
     let all_creature_types = state.all_creature_types.clone();
 
-    for id in affected_ids {
+    for &id in affected_ids {
         // CR 613.4c: When the dynamic modification's QuantityExpr depends on
         // the recipient, resolve here under a recipient-bound FilterContext.
         // The immutable read finishes before the mutable borrow of `obj` below.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -646,6 +646,7 @@ mod mr_foxglove_defending_hand_minus_yours_draw;
 mod ms_marvel_power_exceeds_base;
 mod msh_wave5a_group1_classifier;
 mod msh_wave5a_group2_conditions;
+mod multi_layer_continuous_effect;
 mod multi_upkeep_triggers_suspend;
 mod mycoloth_upkeep_trigger;
 mod myrkul_crew_phase1_incarnation;

--- a/crates/engine/tests/integration/multi_layer_continuous_effect.rs
+++ b/crates/engine/tests/integration/multi_layer_continuous_effect.rs
@@ -1,0 +1,438 @@
+//! Runtime coverage for CR 613.6 affected-set retention across layers.
+
+use engine::game::layers::{evaluate_layers, flush_layers, mark_layers_entered};
+use engine::game::perf_counters;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    ContinuousModification, Duration, ObjectScope, QuantityExpr, QuantityRef, StaticDefinition,
+    TargetFilter, TypeFilter, TypedFilter,
+};
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::ManaCost;
+use engine::types::player::PlayerId;
+use engine::types::stickers::{AppliedSticker, StickerLocator};
+use engine::types::zones::Zone;
+
+fn make_creature(
+    state: &mut GameState,
+    name: &str,
+    power: i32,
+    toughness: i32,
+    player: PlayerId,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(0),
+        player,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let timestamp = state.next_timestamp();
+    let object = state.objects.get_mut(&id).expect("created creature exists");
+    object.card_types.core_types.push(CoreType::Creature);
+    object.base_card_types = object.card_types.clone();
+    object.power = Some(power);
+    object.toughness = Some(toughness);
+    object.base_power = Some(power);
+    object.base_toughness = Some(toughness);
+    object.timestamp = timestamp;
+    id
+}
+
+fn make_noncreature_permanent(
+    state: &mut GameState,
+    name: &str,
+    core_type: CoreType,
+    mana_value: u32,
+    player: PlayerId,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(0),
+        player,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let timestamp = state.next_timestamp();
+    let object = state
+        .objects
+        .get_mut(&id)
+        .expect("created permanent exists");
+    object.card_types.core_types.push(core_type);
+    object.base_card_types = object.card_types.clone();
+    object.mana_cost = ManaCost::generic(mana_value);
+    object.base_mana_cost = object.mana_cost.clone();
+    object.timestamp = timestamp;
+    id
+}
+
+fn noncreature_type_filter(core_type: TypeFilter) -> TargetFilter {
+    TargetFilter::Typed(TypedFilter {
+        type_filters: vec![core_type, TypeFilter::Non(Box::new(TypeFilter::Creature))],
+        controller: None,
+        properties: Vec::new(),
+    })
+}
+
+fn add_mana_value_animation_static(
+    state: &mut GameState,
+    source: ObjectId,
+    affected_type: TypeFilter,
+) {
+    let mana_value = QuantityExpr::Ref {
+        qty: QuantityRef::ObjectManaValue {
+            scope: ObjectScope::Recipient,
+        },
+    };
+    let definition = StaticDefinition::continuous()
+        .affected(noncreature_type_filter(affected_type))
+        .modifications(vec![
+            ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            },
+            ContinuousModification::SetPowerDynamic {
+                value: mana_value.clone(),
+            },
+            ContinuousModification::SetToughnessDynamic { value: mana_value },
+        ]);
+    state
+        .objects
+        .get_mut(&source)
+        .expect("static source exists")
+        .static_definitions
+        .push(definition);
+}
+
+fn add_granted_set_pt_static(
+    state: &mut GameState,
+    grant_host: ObjectId,
+    recipient: ObjectId,
+    value: i32,
+) {
+    let granted = StaticDefinition::continuous()
+        .affected(TargetFilter::SelfRef)
+        .modifications(vec![
+            ContinuousModification::SetPower { value },
+            ContinuousModification::SetToughness { value },
+        ]);
+    let grant = StaticDefinition::continuous()
+        .affected(TargetFilter::SpecificObject { id: recipient })
+        .modifications(vec![ContinuousModification::GrantStaticAbility {
+            definition: Box::new(granted),
+        }]);
+    state
+        .objects
+        .get_mut(&grant_host)
+        .expect("grant host exists")
+        .static_definitions
+        .push(grant);
+}
+
+fn add_ability_suppressor(state: &mut GameState, target: ObjectId) {
+    let suppressor = make_creature(state, "Suppressor", 1, 1, PlayerId(1));
+    let suppression = StaticDefinition::continuous()
+        .affected(TargetFilter::SpecificObject { id: target })
+        .modifications(vec![ContinuousModification::RemoveAllAbilities]);
+    state
+        .objects
+        .get_mut(&suppressor)
+        .expect("suppression source exists")
+        .static_definitions
+        .push(suppression);
+}
+
+/// CR 613.6: A multi-layer effect retains the object set it began applying to.
+/// Type-changing an object into a creature cannot make that effect's later
+/// base-P/T parts lose the object.
+#[test]
+fn multi_layer_effect_retains_affected_set_across_type_and_set_pt_layers() {
+    let mut state = GameState::new_two_player(42);
+    let artifact_animator = make_creature(&mut state, "Artifact Animator", 1, 1, PlayerId(0));
+    add_mana_value_animation_static(&mut state, artifact_animator, TypeFilter::Artifact);
+
+    // A second source also uses definition index 0. Its independent recipient
+    // set is a hostile fixture for effect-group provenance.
+    let enchantment_animator = make_creature(&mut state, "Enchantment Animator", 1, 1, PlayerId(0));
+    add_mana_value_animation_static(&mut state, enchantment_animator, TypeFilter::Enchantment);
+
+    let artifact = make_noncreature_permanent(
+        &mut state,
+        "Three-Mana Artifact",
+        CoreType::Artifact,
+        3,
+        PlayerId(0),
+    );
+    let enchantment = make_noncreature_permanent(
+        &mut state,
+        "Five-Mana Enchantment",
+        CoreType::Enchantment,
+        5,
+        PlayerId(0),
+    );
+    let artifact_creature = make_creature(&mut state, "Already a Creature", 4, 4, PlayerId(0));
+    {
+        let object = state
+            .objects
+            .get_mut(&artifact_creature)
+            .expect("artifact creature exists");
+        object.card_types.core_types.push(CoreType::Artifact);
+        object.base_card_types = object.card_types.clone();
+        object.mana_cost = ManaCost::generic(9);
+        object.base_mana_cost = object.mana_cost.clone();
+    }
+
+    evaluate_layers(&mut state);
+
+    let artifact = &state.objects[&artifact];
+    assert!(artifact.card_types.core_types.contains(&CoreType::Creature));
+    assert_eq!(artifact.power, Some(3));
+    assert_eq!(artifact.toughness, Some(3));
+
+    let enchantment = &state.objects[&enchantment];
+    assert!(enchantment
+        .card_types
+        .core_types
+        .contains(&CoreType::Creature));
+    assert_eq!(enchantment.power, Some(5));
+    assert_eq!(enchantment.toughness, Some(5));
+
+    assert_eq!(state.objects[&artifact_creature].power, Some(4));
+    assert_eq!(state.objects[&artifact_creature].toughness, Some(4));
+}
+
+/// CR 613.6: A resolving spell or ability can create a continuous effect with
+/// parts in several layers. Its stable transient-effect identity retains one
+/// affected set just like a static-ability effect.
+#[test]
+fn transient_multi_layer_effect_retains_affected_set() {
+    let mut state = GameState::new_two_player(42);
+    let source = make_creature(&mut state, "Animation Source", 1, 1, PlayerId(0));
+    let artifact = make_noncreature_permanent(
+        &mut state,
+        "Transiently Animated Artifact",
+        CoreType::Artifact,
+        3,
+        PlayerId(0),
+    );
+    state.add_transient_continuous_effect(
+        source,
+        PlayerId(0),
+        Duration::UntilEndOfTurn,
+        noncreature_type_filter(TypeFilter::Artifact),
+        vec![
+            ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            },
+            ContinuousModification::SetPower { value: 8 },
+            ContinuousModification::SetToughness { value: 8 },
+        ],
+        None,
+    );
+
+    evaluate_layers(&mut state);
+
+    let artifact = &state.objects[&artifact];
+    assert!(artifact.card_types.core_types.contains(&CoreType::Creature));
+    assert_eq!(artifact.power, Some(8));
+    assert_eq!(artifact.toughness, Some(8));
+}
+
+/// CR 613.6: A static ability granted to an object generates its own
+/// multi-layer effect. The host grant origin and recipient incarnation form an
+/// independent identity whose later parts retain the initial object set.
+#[test]
+fn granted_static_multi_layer_effect_retains_affected_set() {
+    let mut state = GameState::new_two_player(42);
+    let grant_host = make_creature(&mut state, "Grant Host", 1, 1, PlayerId(0));
+    let recipient = make_noncreature_permanent(
+        &mut state,
+        "Granted Animator",
+        CoreType::Artifact,
+        2,
+        PlayerId(0),
+    );
+    let granted = StaticDefinition::continuous()
+        .affected(noncreature_type_filter(TypeFilter::Artifact))
+        .modifications(vec![
+            ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            },
+            ContinuousModification::SetPower { value: 7 },
+            ContinuousModification::SetToughness { value: 7 },
+        ]);
+    let grant = StaticDefinition::continuous()
+        .affected(TargetFilter::SpecificObject { id: recipient })
+        .modifications(vec![ContinuousModification::GrantStaticAbility {
+            definition: Box::new(granted),
+        }]);
+    state
+        .objects
+        .get_mut(&grant_host)
+        .expect("grant host exists")
+        .static_definitions
+        .push(grant);
+
+    evaluate_layers(&mut state);
+
+    let recipient = &state.objects[&recipient];
+    assert!(recipient
+        .card_types
+        .core_types
+        .contains(&CoreType::Creature));
+    assert_eq!(recipient.power, Some(7));
+    assert_eq!(recipient.toughness, Some(7));
+}
+
+/// CR 613.1f + CR 613.6: A granted static whose first applicable part is in
+/// layer 7 never starts if the recipient loses the granted ability in layer 6.
+#[test]
+fn unstarted_granted_static_is_suppressed_with_recipient_abilities() {
+    let mut state = GameState::new_two_player(42);
+    let grant_host = make_creature(&mut state, "Grant Host", 1, 1, PlayerId(0));
+    let recipient = make_creature(&mut state, "Grant Recipient", 2, 2, PlayerId(0));
+    add_granted_set_pt_static(&mut state, grant_host, recipient, 9);
+    add_ability_suppressor(&mut state, recipient);
+
+    evaluate_layers(&mut state);
+
+    assert_eq!(state.objects[&recipient].power, Some(2));
+    assert_eq!(state.objects[&recipient].toughness, Some(2));
+
+    evaluate_layers(&mut state);
+    assert_eq!(state.objects[&recipient].power, Some(2));
+    assert_eq!(state.objects[&recipient].toughness, Some(2));
+}
+
+/// CR 613.1f + CR 613.6: A granted static whose first applicable part is in
+/// layer 7 never starts if the ability generating the grant is removed in
+/// layer 6.
+#[test]
+fn unstarted_granted_static_is_suppressed_with_grant_host_abilities() {
+    let mut state = GameState::new_two_player(42);
+    let grant_host = make_creature(&mut state, "Grant Host", 1, 1, PlayerId(0));
+    let recipient = make_creature(&mut state, "Grant Recipient", 2, 2, PlayerId(0));
+    add_granted_set_pt_static(&mut state, grant_host, recipient, 9);
+    add_ability_suppressor(&mut state, grant_host);
+
+    evaluate_layers(&mut state);
+
+    assert_eq!(state.objects[&recipient].power, Some(2));
+    assert_eq!(state.objects[&recipient].toughness, Some(2));
+
+    evaluate_layers(&mut state);
+    assert_eq!(state.objects[&recipient].power, Some(2));
+    assert_eq!(state.objects[&recipient].toughness, Some(2));
+}
+
+/// CR 123.8: A P/T sticker sets a creature's power and toughness independently
+/// of its abilities, so layer-6 ability removal cannot suppress the sticker's
+/// layer-7b effect.
+#[test]
+fn pt_sticker_survives_remove_all_abilities() {
+    let mut state = GameState::new_two_player(42);
+    let creature = make_creature(&mut state, "Stickered Creature", 2, 2, PlayerId(0));
+    let timestamp = state.next_timestamp();
+    state
+        .objects
+        .get_mut(&creature)
+        .expect("stickered creature exists")
+        .stickers
+        .push(AppliedSticker::PowerToughness {
+            locator: StickerLocator {
+                sheet: "Regression Sheet".to_string(),
+                index: 0,
+            },
+            ticket_cost: 0,
+            power: 8,
+            toughness: 9,
+            timestamp,
+        });
+    add_ability_suppressor(&mut state, creature);
+
+    evaluate_layers(&mut state);
+
+    assert_eq!(state.objects[&creature].power, Some(8));
+    assert_eq!(state.objects[&creature].toughness, Some(9));
+}
+
+/// CR 613.6: The incremental entry path uses the same retained-set semantics
+/// as a full layer pass for a newly entered affected object.
+#[test]
+fn incremental_entry_retains_multi_layer_effect_affected_set() {
+    let mut state = GameState::new_two_player(42);
+    let animator = make_creature(&mut state, "Artifact Animator", 1, 1, PlayerId(0));
+    add_mana_value_animation_static(&mut state, animator, TypeFilter::Artifact);
+    evaluate_layers(&mut state);
+
+    let artifact = make_noncreature_permanent(
+        &mut state,
+        "Four-Mana Artifact",
+        CoreType::Artifact,
+        4,
+        PlayerId(0),
+    );
+    perf_counters::reset();
+    mark_layers_entered(&mut state, artifact);
+    flush_layers(&mut state);
+
+    let counters = perf_counters::snapshot();
+    assert_eq!(counters.layers_incremental, 1);
+    assert_eq!(counters.layers_escalated, 0);
+    assert_eq!(counters.layers_full_eval, 0);
+    assert!(state.objects[&artifact]
+        .card_types
+        .core_types
+        .contains(&CoreType::Creature));
+    assert_eq!(state.objects[&artifact].power, Some(4));
+    assert_eq!(state.objects[&artifact].toughness, Some(4));
+}
+
+/// CR 613.6: If a multi-layer effect starts applying before its source loses
+/// the generating ability, its later parts still apply.
+#[test]
+fn started_multi_layer_effect_survives_source_ability_removal() {
+    let mut state = GameState::new_two_player(42);
+    let source = make_noncreature_permanent(
+        &mut state,
+        "Self Animator",
+        CoreType::Artifact,
+        2,
+        PlayerId(0),
+    );
+    let definition = StaticDefinition::continuous()
+        .affected(TargetFilter::SelfRef)
+        .modifications(vec![
+            ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            },
+            ContinuousModification::SetPower { value: 6 },
+            ContinuousModification::SetToughness { value: 6 },
+        ]);
+    state
+        .objects
+        .get_mut(&source)
+        .expect("self-animation source exists")
+        .static_definitions
+        .push(definition);
+
+    let suppressor = make_creature(&mut state, "Suppressor", 1, 1, PlayerId(1));
+    let suppression = StaticDefinition::continuous()
+        .affected(TargetFilter::SpecificObject { id: source })
+        .modifications(vec![ContinuousModification::RemoveAllAbilities]);
+    state
+        .objects
+        .get_mut(&suppressor)
+        .expect("suppression source exists")
+        .static_definitions
+        .push(suppression);
+
+    evaluate_layers(&mut state);
+
+    let source = &state.objects[&source];
+    assert!(source.card_types.core_types.contains(&CoreType::Creature));
+    assert!(source.static_definitions.is_empty());
+    assert_eq!(source.power, Some(6));
+    assert_eq!(source.toughness, Some(6));
+}


### PR DESCRIPTION
## Summary

Fixes **March of the Machines** by retaining the object set a continuous effect began applying to when its later parts apply in subsequent layers. The fix covers printed statics, transient effects, granted statics, and incremental layer evaluation while preserving ability-removal and P/T sticker semantics.

Closes #5995

## Files changed

- `crates/engine/src/game/layers.rs`
- `crates/engine/tests/integration/main.rs`
- `crates/engine/tests/integration/multi_layer_continuous_effect.rs`

## CR references

- CR 613.1f
- CR 613.6
- CR 123.8

## Implementation method (required)

Method: /pipeline

## Track

Developer

## LLM

Model: gpt-5
Thinking: high
Tier: Standard

## Verification

- [x] Required relevant checks ran clean; parser/card-data audits are not applicable because this changes no parser or export surface.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- `cargo test -p engine --test integration multi_layer_continuous_effect::` — PASS (8 passed, 0 failed)
- `cargo clippy --all-targets -- -D warnings` — PASS
- `cargo test -p engine` — PASS (17,120 unit tests; 3,504 integration tests; doctests clean)
- Card-data generation, coverage, and semantic audit — not applicable; no parser, card-data, or coverage classification changed

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=43c4ddd97d45b7674e4654f3050b47e070791674 base=4351f1246157a4855434dc52eca216766c943b1f

## Anchored on

- `crates/engine/src/game/layers.rs:3551` — existing static-effect provenance uses the source incarnation plus definition/modification indices.
- `crates/engine/src/game/layers.rs:4050` — existing transient effects use their stable continuous-effect ID across modifications.

## Final review-impl

Final review-impl PASS head=43c4ddd97d45b7674e4654f3050b47e070791674

## Claimed parse impact

None.

## Validation Failures

None.

## CI Failures

None.
