### PR TITLE
feat(engine): life-gated layer escalation on player life mutations

### DIFF
--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -81,7 +81,11 @@ pub fn resolve_gain(
                 player.life += gain_amount as i32;
                 // CR 119.9: Track life gained this turn for triggered ability matching.
                 player.life_gained_this_turn += gain_amount;
-                crate::game::layers::mark_layers_full(state);
+                // CR 611.3a + CR 119: escalate layers only if a live continuous
+                // static reads the life family (life total / life-above-starting
+                // / per-turn life counters); otherwise this life change cannot
+                // flip any derived board.
+                crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
 
                 events.push(GameEvent::LifeChanged {
                     player_id,
@@ -211,7 +215,8 @@ pub fn apply_life_gain_after_replacement(
         player.life += gain_amount as i32;
         player.life_gained_this_turn += gain_amount;
     }
-    crate::game::layers::mark_layers_full(state);
+    // CR 611.3a + CR 119: gate escalation on a live life-reading static.
+    crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
     events.push(GameEvent::LifeChanged {
         player_id: pid,
         amount: gain_amount as i32,
@@ -287,7 +292,9 @@ pub fn apply_life_loss_after_replacement(
         player.life -= loss_amount as i32;
         player.life_lost_this_turn += loss_amount;
     }
-    crate::game::layers::mark_layers_full(state);
+    // CR 611.3a + CR 119 + CR 120.3a: gate escalation on a live life-reading
+    // static. Also the sink for non-infect player damage (deal_damage.rs).
+    crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
     events.push(GameEvent::LifeChanged {
         player_id: pid,
         amount: -(loss_amount as i32),
@@ -487,7 +494,8 @@ pub fn resolve_lose(
                     .ok_or(EffectError::PlayerNotFound)?;
                 player.life -= loss_amount as i32;
                 player.life_lost_this_turn += loss_amount;
-                crate::game::layers::mark_layers_full(state);
+                // CR 611.3a + CR 119: gate escalation on a live life-reading static.
+                crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
 
                 events.push(GameEvent::LifeChanged {
                     player_id,

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2786,9 +2786,9 @@ fn player_filter_reads_life(pf: &PlayerFilter) -> bool {
         PlayerFilter::OpponentLostLife | PlayerFilter::OpponentGainedLife => true,
         // CR 120.9: the damage-history player set can restrict by a source
         // `TargetFilter`; route it.
-        PlayerFilter::OpponentDealtDamage { source, .. } => {
-            source.as_ref().is_some_and(target_filter_reads_life_total)
-        }
+        PlayerFilter::OpponentDealtDamage { source, .. } => source
+            .as_deref()
+            .is_some_and(target_filter_reads_life_total),
         // CR 608.2c: self-composing exclusion anchor — recurse on the exclude.
         PlayerFilter::AllExcept { exclude } => player_filter_reads_life(exclude),
         // CR 109.4 + CR 109.5: controls-count routes its object `filter` and its
@@ -2846,7 +2846,7 @@ fn filter_prop_reads_life(prop: &FilterProp) -> bool {
         | FilterProp::Targets { filter: f } => target_filter_reads_life_total(f),
         // Multi-target group constraint carries an OPTIONAL reference filter.
         FilterProp::SharesQuality { reference, .. } => reference
-            .as_ref()
+            .as_deref()
             .is_some_and(target_filter_reads_life_total),
         // Quantity-bearing props route their `QuantityExpr` threshold.
         FilterProp::Counters { count: value, .. }
@@ -2959,9 +2959,9 @@ fn target_filter_reads_life_total(filter: &TargetFilter) -> bool {
             filters.iter().any(target_filter_reads_life_total)
         }
         TargetFilter::TrackedSetFiltered { filter, .. } => target_filter_reads_life_total(filter),
-        TargetFilter::ChosenDamageSource { filter } => {
-            filter.as_ref().is_some_and(target_filter_reads_life_total)
-        }
+        TargetFilter::ChosenDamageSource { filter } => filter
+            .as_deref()
+            .is_some_and(target_filter_reads_life_total),
         // Payload-free / player-reference / stack-reference / anaphoric filters —
         // none carry a nested walked payload and none read the life family.
         // Enumerated explicitly (no wildcard).

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2668,9 +2668,9 @@ fn quantity_ref_reads_life(qty: &QuantityRef) -> bool {
         QuantityRef::ZoneCardCount { filter, .. }
         | QuantityRef::SpellsCastThisTurn { filter, .. }
         | QuantityRef::SpellsCastThisGame { filter, .. }
-        | QuantityRef::AttackedThisTurn { filter, .. } => filter
-            .as_ref()
-            .is_some_and(|f| target_filter_reads_life_total(f)),
+        | QuantityRef::AttackedThisTurn { filter, .. } => {
+            filter.as_ref().is_some_and(target_filter_reads_life_total)
+        }
 
         // CR 120.1 + CR 120.9: damage-history read routes BOTH legs — the source
         // filter AND the recipient filter — never just one.
@@ -2786,9 +2786,9 @@ fn player_filter_reads_life(pf: &PlayerFilter) -> bool {
         PlayerFilter::OpponentLostLife | PlayerFilter::OpponentGainedLife => true,
         // CR 120.9: the damage-history player set can restrict by a source
         // `TargetFilter`; route it.
-        PlayerFilter::OpponentDealtDamage { source, .. } => source
-            .as_ref()
-            .is_some_and(|f| target_filter_reads_life_total(f)),
+        PlayerFilter::OpponentDealtDamage { source, .. } => {
+            source.as_ref().is_some_and(target_filter_reads_life_total)
+        }
         // CR 608.2c: self-composing exclusion anchor — recurse on the exclude.
         PlayerFilter::AllExcept { exclude } => player_filter_reads_life(exclude),
         // CR 109.4 + CR 109.5: controls-count routes its object `filter` and its
@@ -2847,7 +2847,7 @@ fn filter_prop_reads_life(prop: &FilterProp) -> bool {
         // Multi-target group constraint carries an OPTIONAL reference filter.
         FilterProp::SharesQuality { reference, .. } => reference
             .as_ref()
-            .is_some_and(|f| target_filter_reads_life_total(f)),
+            .is_some_and(target_filter_reads_life_total),
         // Quantity-bearing props route their `QuantityExpr` threshold.
         FilterProp::Counters { count: value, .. }
         | FilterProp::Cmc { value, .. }
@@ -2959,9 +2959,9 @@ fn target_filter_reads_life_total(filter: &TargetFilter) -> bool {
             filters.iter().any(target_filter_reads_life_total)
         }
         TargetFilter::TrackedSetFiltered { filter, .. } => target_filter_reads_life_total(filter),
-        TargetFilter::ChosenDamageSource { filter } => filter
-            .as_ref()
-            .is_some_and(|f| target_filter_reads_life_total(f)),
+        TargetFilter::ChosenDamageSource { filter } => {
+            filter.as_ref().is_some_and(target_filter_reads_life_total)
+        }
         // Payload-free / player-reference / stack-reference / anaphoric filters —
         // none carry a nested walked payload and none read the life family.
         // Enumerated explicitly (no wildcard).
@@ -3021,9 +3021,9 @@ fn target_filter_reads_life_total(filter: &TargetFilter) -> bool {
 fn static_condition_reads_life(condition: &StaticCondition) -> bool {
     match condition {
         // Presence gate: the filter is optional.
-        StaticCondition::IsPresent { filter } => filter
-            .as_ref()
-            .is_some_and(|f| target_filter_reads_life_total(f)),
+        StaticCondition::IsPresent { filter } => {
+            filter.as_ref().is_some_and(target_filter_reads_life_total)
+        }
         // Count/threshold gate — either operand may read life
         // (Serra Ascendant class: "if you have 30 or more life").
         StaticCondition::QuantityComparison { lhs, rhs, .. } => {
@@ -3107,14 +3107,14 @@ fn static_definition_reads_life_total(def: &StaticDefinition) -> bool {
         && (def
             .affected
             .as_ref()
-            .is_some_and(|filter| target_filter_reads_life_total(filter))
+            .is_some_and(target_filter_reads_life_total)
             || def
                 .condition
                 .as_ref()
-                .is_some_and(|condition| static_condition_reads_life(condition))
+                .is_some_and(static_condition_reads_life)
             || def.modifications.iter().any(|modification| {
                 continuous_modification_dynamic_quantity(modification)
-                    .is_some_and(|quantity| quantity_expr_reads_life(quantity))
+                    .is_some_and(quantity_expr_reads_life)
             }))
 }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -25,8 +25,8 @@ use crate::game::speed::{effective_speed, has_max_speed};
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction, BasicLandType,
     CastingPermission, ChosenSubtypeKind, CommanderOwnership, ContinuousModification,
-    CopiableValues, Duration, Effect, FilterProp, ManaContribution, ManaProduction, PlayerScope,
-    QuantityExpr, QuantityRef, StaticCondition, StaticDefinition, TargetFilter,
+    CopiableValues, Duration, Effect, FilterProp, ManaContribution, ManaProduction, PlayerFilter,
+    PlayerScope, QuantityExpr, QuantityRef, StaticCondition, StaticDefinition, TargetFilter,
     TriggerGrantProducerKey, TriggerProducerOrigin, TypedFilter,
 };
 use crate::types::attribution::EffectRef;
@@ -2547,6 +2547,605 @@ pub(crate) fn any_active_static_reads_top_of_library(state: &GameState) -> bool 
 /// move and shuffle helper so a stale layer cache can't survive the change.
 pub(crate) fn mark_layers_full_if_top_of_library_static_live(state: &mut GameState) {
     if any_active_static_reads_top_of_library(state) {
+        mark_layers_full(state);
+    }
+}
+
+// ===========================================================================
+// CR 119 + CR 611.3a: Life-reading continuous-static classifier family
+//
+// The four guarded life-mutation sites in `effects/life.rs` (life gain, life
+// loss, and their two post-replacement appliers) each change more than a
+// player's life value: they also bump the per-turn `life_gained_this_turn` /
+// `life_lost_this_turn` accumulators (CR 119.9 / CR 119.3). Previously each
+// escalated the layer system to a full O(battlefield) re-evaluation
+// unconditionally. This family gates that escalation on whether any LIVE
+// continuous static actually reads the life family, so simulated life changes
+// on the AI search path stay cheap when no static depends on life.
+//
+// Structural twin of the zone-template family
+// (`static_definition_reads_zone_membership` and its `quantity_ref_reads_zone`
+// / `quantity_expr_reads_zone` / `target_filter_reads_zone` leaves), and
+// mutually recursive exactly as the AST types themselves are (the
+// QuantityRef → TargetFilter → FilterProp → PlayerFilter → QuantityExpr
+// reference cycle). Two deliberate DIVERGENCES from that template:
+//
+//   1. NO wildcards. `target_filter_reads_zone` closes with `_ => false`; this
+//      family is EXHAUSTIVE over every walked enum (`QuantityExpr`,
+//      `QuantityRef`, `PlayerFilter`, `FilterProp`, `TargetFilter`,
+//      `StaticCondition`). Because this guard SUPPRESSES re-evaluation, a
+//      missed reader is a stale-board correctness bug — so a future variant
+//      must break the build, not fall silently into a `false` wildcard.
+//   2. Universal payload-routing. Any variant carrying a nested `TargetFilter`,
+//      `PlayerFilter`, `QuantityRef`, or `QuantityExpr` routes that payload
+//      through the corresponding walk (the six TargetFilter-bearing
+//      `FilterProp`s, `CardTypeSetSource::Objects`, `PlayerFilter` recursion,
+//      etc.) — all of which the zone template drops into its wildcard. Only
+//      payload-free leaves are classified `false` directly.
+//
+// Correctness doctrine (`StaticSourceIndex`): over-include, never
+// under-include; output byte-identical.
+//
+// SIBLING-CLUSTER TRIGGER (recorded follow-up): this is the SECOND
+// `mark_layers_full_if_*_static_live` guard after the library-top guard above.
+// At the THIRD such dimension, parameterize all three into a dimension enum and
+// migrate the library-top guard in the same change, rather than adding a fourth
+// bespoke classifier family.
+// ===========================================================================
+
+/// CR 119: Does a `QuantityExpr` read the life family? Expression-level walk,
+/// analog of `quantity_expr_reads_zone`; descends into `Ref(QuantityRef)` and
+/// every composite expression payload. Exhaustive, no wildcard.
+fn quantity_expr_reads_life(expr: &QuantityExpr) -> bool {
+    match expr {
+        QuantityExpr::Fixed { .. } => false,
+        QuantityExpr::Ref { qty } => quantity_ref_reads_life(qty),
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Multiply { inner, .. } => quantity_expr_reads_life(inner),
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            exprs.iter().any(quantity_expr_reads_life)
+        }
+        QuantityExpr::UpTo { max } => quantity_expr_reads_life(max),
+        QuantityExpr::Power { exponent, .. } => quantity_expr_reads_life(exponent),
+        QuantityExpr::Difference { left, right } => {
+            quantity_expr_reads_life(left) || quantity_expr_reads_life(right)
+        }
+    }
+}
+
+/// CR 119: Leaf classification for `quantity_expr_reads_life`. Modeled on
+/// `quantity_ref_reads_zone`, but the direct-leaf true-set is the life family
+/// and every filter-bearing variant ROUTES its nested payload (universal
+/// routing rule). EXHAUSTIVE and wildcard-free.
+fn quantity_ref_reads_life(qty: &QuantityRef) -> bool {
+    use crate::types::ability::{CardTypeSetSource, CastManaSpentMetric};
+    match qty {
+        // CR 119.3 + CR 119.9: the direct-leaf life-family readers — the exact
+        // quantities a guarded life-mutation site changes (119.3: gain/loss
+        // adjusts the life total; 119.9: life-gain events).
+        // `LifeTotal` reads the player's current life; `LifeAboveStarting` is
+        // life minus starting life (changes at all four sites); the two
+        // per-turn accumulators track life lost / gained this turn.
+        QuantityRef::LifeTotal { .. }
+        | QuantityRef::LifeAboveStarting
+        | QuantityRef::LifeLostThisTurn { .. }
+        | QuantityRef::LifeGainedThisTurn { .. } => true,
+        // `StartingLifeTotal` is a format constant (CR 119.1), NOT a live read —
+        // a life change never moves it. Classified with the payload-free leaves
+        // below.
+
+        // Filter-bearing counts route their (plain) `TargetFilter` — an
+        // `ObjectCount` over "creatures whose controller lost life this turn"
+        // flips its count at a life-loss site. `CounterAddedThisTurn`'s filter
+        // field is named `target`; routed the same regardless of field name.
+        QuantityRef::ObjectCount { filter }
+        | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::ObjectCountBySharedQuality { filter, .. }
+        | QuantityRef::CountersOnObjects { filter, .. }
+        | QuantityRef::Aggregate { filter, .. }
+        | QuantityRef::ControlledByEachPlayer { filter, .. }
+        | QuantityRef::DistinctColorsAmongPermanents { filter }
+        | QuantityRef::DistinctCounterKindsAmong { filter }
+        | QuantityRef::EnteredThisTurn { filter }
+        | QuantityRef::SacrificedThisTurn { filter, .. }
+        | QuantityRef::BattlefieldEntriesThisTurn { filter, .. }
+        | QuantityRef::ZoneChangeCountThisTurn { filter, .. }
+        | QuantityRef::ZoneChangeAggregateThisTurn { filter, .. }
+        | QuantityRef::CounterAddedThisTurn { target: filter, .. }
+        | QuantityRef::TokensCreatedThisTurn { filter, .. } => {
+            target_filter_reads_life_total(filter)
+        }
+
+        // Boxed single-`TargetFilter` variants (deref coercion → &TargetFilter).
+        QuantityRef::TargetObjectManaValue { filter }
+        | QuantityRef::FilteredTrackedSetSize { filter, .. } => {
+            target_filter_reads_life_total(filter)
+        }
+
+        // Optional-`TargetFilter` variants route through the `Option`.
+        QuantityRef::ZoneCardCount { filter, .. }
+        | QuantityRef::SpellsCastThisTurn { filter, .. }
+        | QuantityRef::SpellsCastThisGame { filter, .. }
+        | QuantityRef::AttackedThisTurn { filter, .. } => filter
+            .as_ref()
+            .is_some_and(|f| target_filter_reads_life_total(f)),
+
+        // CR 120.1 + CR 120.9: damage-history read routes BOTH legs — the source
+        // filter AND the recipient filter — never just one.
+        QuantityRef::DamageDealtThisTurn { source, target, .. } => {
+            target_filter_reads_life_total(source) || target_filter_reads_life_total(target)
+        }
+
+        // Player-count routes its `PlayerFilter`: `PlayerCount{OpponentLostLife}`
+        // reads `life_lost_this_turn` per candidate.
+        QuantityRef::PlayerCount { filter } => player_filter_reads_life(filter),
+
+        // Distinct card-type / subtype counts route an `Objects { filter }`
+        // set-source; the other set-sources carry no `TargetFilter`.
+        QuantityRef::DistinctCardTypes { source }
+        | QuantityRef::DistinctSubtypes { source, .. } => match source {
+            CardTypeSetSource::Objects { filter } => target_filter_reads_life_total(filter),
+            CardTypeSetSource::Zone { .. }
+            | CardTypeSetSource::ExiledBySource
+            | CardTypeSetSource::TrackedSet { .. } => false,
+        },
+
+        // CR 601.2h: `ManaSpentToCast` carries no direct `TargetFilter`, but its
+        // `metric` can nest a mana-source filter one level deeper
+        // (`CastManaSpentMetric::FromSource`). Routed for completeness per the
+        // over-include doctrine — a mana-source predicate reading the life
+        // family is not a known live card, but under-including it would risk a
+        // stale board if one ever printed.
+        QuantityRef::ManaSpentToCast { metric, .. } => match metric {
+            CastManaSpentMetric::FromSource { source_filter } => {
+                target_filter_reads_life_total(source_filter)
+            }
+            CastManaSpentMetric::Total | CastManaSpentMetric::DistinctColors => false,
+        },
+
+        // CR 603.2c: the trigger-event player set filters candidates through a
+        // `PlayerFilter` (e.g. "each opponent dealt damage"); route it.
+        QuantityRef::EventContextPlayerCount { filter } => player_filter_reads_life(filter),
+
+        // Payload-free leaves: player-scalar reads other than life, single-object
+        // characteristics, battlefield-only populations, per-turn accumulators
+        // unrelated to life, cost/vote/history records, and format constants.
+        // None carry a nested TargetFilter / PlayerFilter / QuantityRef /
+        // QuantityExpr, so none can hide a life read. Enumerated explicitly (no
+        // wildcard) so a future life-reading variant is forced through this
+        // classification.
+        QuantityRef::HandSize { .. }
+        | QuantityRef::GraveyardSize { .. }
+        | QuantityRef::StartingLifeTotal
+        | QuantityRef::TriggeringDiscoverValue
+        | QuantityRef::CountersOn { .. }
+        | QuantityRef::PlayerCounter { .. }
+        | QuantityRef::TargetControllerCounter { .. }
+        | QuantityRef::Variable { .. }
+        | QuantityRef::Power { .. }
+        | QuantityRef::Intensity { .. }
+        | QuantityRef::Toughness { .. }
+        | QuantityRef::ObjectManaValue { .. }
+        | QuantityRef::ObjectColorCount { .. }
+        | QuantityRef::ObjectNameWordCount { .. }
+        | QuantityRef::ObjectTypelineComponentCount { .. }
+        | QuantityRef::ManaSymbolsInManaCost { .. }
+        | QuantityRef::SelfManaValue
+        | QuantityRef::TargetZoneCardCount { .. }
+        | QuantityRef::Devotion { .. }
+        | QuantityRef::CardsExiledBySource
+        | QuantityRef::ExiledCardPower { .. }
+        | QuantityRef::BasicLandTypeCount { .. }
+        | QuantityRef::TrackedSetSize
+        | QuantityRef::TrackedSetAggregate { .. }
+        | QuantityRef::ExiledFromHandThisResolution
+        | QuantityRef::PreviousEffectAmount { .. }
+        | QuantityRef::PartySize { .. }
+        | QuantityRef::UnspentMana { .. }
+        | QuantityRef::Speed { .. }
+        | QuantityRef::EventContextAmount
+        | QuantityRef::AttachmentsOnLeavingObject { .. }
+        | QuantityRef::EventContextSourceCostX
+        | QuantityRef::EventContextSourceModesChosen
+        | QuantityRef::CrimesCommittedThisTurn
+        | QuantityRef::BendTypesThisTurn
+        | QuantityRef::CardsDrawnThisTurn { .. }
+        | QuantityRef::LandsPlayedThisTurn { .. }
+        | QuantityRef::TurnsTaken
+        | QuantityRef::ChosenNumber
+        | QuantityRef::DescendedThisTurn
+        | QuantityRef::LoyaltyAbilitiesActivatedThisTurn { .. }
+        | QuantityRef::SpellsCastLastTurn
+        | QuantityRef::CardsDiscardedThisTurn { .. }
+        | QuantityRef::PlayerActionsThisTurn { .. }
+        | QuantityRef::DungeonsCompleted
+        | QuantityRef::CostXPaid
+        | QuantityRef::KickerCount
+        | QuantityRef::AdditionalCostPaymentCount
+        | QuantityRef::AdditionalCostPaymentCountFor { .. }
+        | QuantityRef::ConvokedCreatureCount
+        | QuantityRef::TimesCostPaidThisResolution
+        | QuantityRef::ColorsInCommandersColorIdentity
+        | QuantityRef::CommanderCastFromCommandZoneCount
+        | QuantityRef::CommanderManaValue { .. }
+        | QuantityRef::VoteCount { .. } => false,
+    }
+}
+
+/// CR 119: Does a `PlayerFilter` read the life family per candidate player?
+/// EXHAUSTIVE over `PlayerFilter`. True/recursive cases are named explicitly;
+/// every payload-bearing variant routes its nested filter / quantity.
+fn player_filter_reads_life(pf: &PlayerFilter) -> bool {
+    match pf {
+        // CR 119.3 + CR 119.9: per-candidate life-history predicates ("each
+        // opponent who lost / gained life this turn") read
+        // `life_lost_this_turn` / `life_gained_this_turn` directly (119.3:
+        // loss/gain adjusts the total; 119.9: gain events).
+        PlayerFilter::OpponentLostLife | PlayerFilter::OpponentGainedLife => true,
+        // CR 120.9: the damage-history player set can restrict by a source
+        // `TargetFilter`; route it.
+        PlayerFilter::OpponentDealtDamage { source, .. } => source
+            .as_ref()
+            .is_some_and(|f| target_filter_reads_life_total(f)),
+        // CR 608.2c: self-composing exclusion anchor — recurse on the exclude.
+        PlayerFilter::AllExcept { exclude } => player_filter_reads_life(exclude),
+        // CR 109.4 + CR 109.5: controls-count routes its object `filter` and its
+        // comparison `count` expression.
+        PlayerFilter::ControlsCount { filter, count, .. } => {
+            target_filter_reads_life_total(filter) || quantity_expr_reads_life(count)
+        }
+        // CR 119.1: per-candidate scalar attribute (`attr = LifeTotal` reads
+        // life) compared against a controller-relative `value` expression
+        // (Wolfcaller's Howl class). Route both.
+        PlayerFilter::PlayerAttribute { attr, value, .. } => {
+            quantity_ref_reads_life(attr) || quantity_expr_reads_life(value)
+        }
+        // Payload-free player sets — none read the life family. Enumerated
+        // explicitly (no wildcard).
+        PlayerFilter::Controller
+        | PlayerFilter::Opponent
+        | PlayerFilter::DefendingPlayer
+        | PlayerFilter::HasLostTheGame
+        | PlayerFilter::OpponentAttacked { .. }
+        | PlayerFilter::OpponentAttackingEnchantedPlayer
+        | PlayerFilter::All
+        | PlayerFilter::HighestSpeed
+        | PlayerFilter::ZoneChangedThisWay
+        | PlayerFilter::PerformedActionThisWay { .. }
+        | PlayerFilter::OwnersOfCardsExiledBySource
+        | PlayerFilter::TriggeringPlayer
+        | PlayerFilter::OpponentOtherThanTriggering
+        | PlayerFilter::OpponentOfTriggeringPlayer
+        | PlayerFilter::OpponentOfTriggeringPlayerNotAttacked
+        | PlayerFilter::VotedFor { .. }
+        | PlayerFilter::ParentObjectTargetController
+        | PlayerFilter::ChosenPlayer { .. }
+        | PlayerFilter::ParentObjectTargetOwner => false,
+    }
+}
+
+/// CR 119: Does a single `FilterProp` read the life family? EXHAUSTIVE over
+/// `FilterProp`, with NO wildcard — the divergence from `target_filter_reads_zone`
+/// that closes the six TargetFilter-bearing props the zone template drops into
+/// its `_ => false`. Every prop carrying a nested filter / player / quantity
+/// routes it; the `AnyOf` / `Not` combinators recurse.
+fn filter_prop_reads_life(prop: &FilterProp) -> bool {
+    match prop {
+        // CR 109.4 + CR 611.2c: the object's CONTROLLER is tested by a
+        // `PlayerFilter` — route it (`ControllerMatches{OpponentLostLife}` anthem
+        // flips its affected set at a life-loss site).
+        FilterProp::ControllerMatches { player } => player_filter_reads_life(player),
+        // The six TargetFilter-bearing props all route their nested filter
+        // (deref coercion → &TargetFilter). Field names differ; unified here.
+        FilterProp::CanEnchant { target: f }
+        | FilterProp::DifferentNameFrom { filter: f }
+        | FilterProp::DistinctFrom { reference: f }
+        | FilterProp::TargetsOnly { filter: f }
+        | FilterProp::Targets { filter: f } => target_filter_reads_life_total(f),
+        // Multi-target group constraint carries an OPTIONAL reference filter.
+        FilterProp::SharesQuality { reference, .. } => reference
+            .as_ref()
+            .is_some_and(|f| target_filter_reads_life_total(f)),
+        // Quantity-bearing props route their `QuantityExpr` threshold.
+        FilterProp::Counters { count: value, .. }
+        | FilterProp::Cmc { value, .. }
+        | FilterProp::PtComparison { value, .. } => quantity_expr_reads_life(value),
+        // Recursive combinators.
+        FilterProp::AnyOf { props } => props.iter().any(filter_prop_reads_life),
+        FilterProp::Not { prop } => filter_prop_reads_life(prop),
+        // Payload-free props — none read the life family. Enumerated explicitly
+        // (no wildcard) so a future life-reading prop is forced through this
+        // classification.
+        FilterProp::Token
+        | FilterProp::NonToken
+        | FilterProp::RepresentedByCard
+        | FilterProp::ControllerChoseLabel { .. }
+        | FilterProp::WasPlayed
+        | FilterProp::Attacking { .. }
+        | FilterProp::Blocking
+        | FilterProp::BlockingSource
+        | FilterProp::CombatRelation { .. }
+        | FilterProp::Unblocked
+        | FilterProp::AttackingAlone
+        | FilterProp::BlockingAlone
+        | FilterProp::Tapped
+        | FilterProp::Untapped
+        | FilterProp::IsSaddled
+        | FilterProp::SaddledSource
+        | FilterProp::ConvokedSource
+        | FilterProp::ProtectorMatches { .. }
+        | FilterProp::HasHasteOrControlledSinceTurnBegan
+        | FilterProp::WithKeyword { .. }
+        | FilterProp::HasKeywordKind { .. }
+        | FilterProp::WithoutKeyword { .. }
+        | FilterProp::WithoutKeywordKind { .. }
+        | FilterProp::ManaValueParity { .. }
+        | FilterProp::ManaCostIn { .. }
+        | FilterProp::InZone { .. }
+        | FilterProp::Owned { .. }
+        | FilterProp::Foretold
+        | FilterProp::HasAdventure
+        | FilterProp::EnchantedBy
+        | FilterProp::EquippedBy
+        | FilterProp::AttachedToSource
+        | FilterProp::AttachedToRecipient
+        | FilterProp::HasAttachment { .. }
+        | FilterProp::HasAnyAttachmentOf { .. }
+        | FilterProp::Another
+        | FilterProp::Unpaired
+        | FilterProp::OtherThanTriggerObject
+        | FilterProp::InTrackedSet { .. }
+        | FilterProp::HasColor { .. }
+        | FilterProp::PowerGTSource
+        | FilterProp::ColorCount { .. }
+        | FilterProp::ManaSymbolCount { .. }
+        | FilterProp::HasSupertype { .. }
+        | FilterProp::IsChosenCreatureType
+        | FilterProp::MostPrevalentCreatureTypeIn { .. }
+        | FilterProp::IsChosenColor
+        | FilterProp::IsChosenCardType
+        | FilterProp::MatchesLastChosenCardPredicate
+        | FilterProp::HasSingleTarget
+        | FilterProp::Modal
+        | FilterProp::NotColor { .. }
+        | FilterProp::NotSupertype { .. }
+        | FilterProp::Suspected
+        | FilterProp::Renowned
+        | FilterProp::Goaded
+        | FilterProp::ToughnessGTPower
+        | FilterProp::PowerExceedsBase
+        | FilterProp::InAnyZone { .. }
+        | FilterProp::WasDealtDamageThisTurn
+        | FilterProp::DealtDamageThisTurn
+        | FilterProp::EnteredThisTurn
+        | FilterProp::ControlledContinuouslySinceTurnBegan
+        | FilterProp::ZoneChangedThisTurn { .. }
+        | FilterProp::AttackedThisTurn { .. }
+        | FilterProp::BlockedThisTurn
+        | FilterProp::AttackedOrBlockedThisTurn
+        | FilterProp::CountersPutOnThisTurn { .. }
+        | FilterProp::FaceDown
+        | FilterProp::Transformed
+        | FilterProp::CouldBeTargetedByTriggeringSpell
+        | FilterProp::HasXInManaCost
+        | FilterProp::HasXInActivationCost
+        | FilterProp::WasKicked
+        | FilterProp::HasManaAbility
+        | FilterProp::HasNoAbilities
+        | FilterProp::Named { .. }
+        | FilterProp::SameName
+        | FilterProp::SameNameAsParentTarget
+        | FilterProp::NameMatchesAnyPermanent { .. }
+        | FilterProp::IsCommander
+        | FilterProp::SharesCreatureTypeWithCommander
+        | FilterProp::Modified
+        | FilterProp::Historic
+        | FilterProp::NotHistoric
+        | FilterProp::Other { .. } => false,
+    }
+}
+
+/// CR 119 + CR 611.3a: Does a `TargetFilter` read the life family through any of
+/// its properties or nested sub-filters? Mirrors `target_filter_reads_zone`'s
+/// position but NOT its wildcards — EXHAUSTIVE, routing `Typed` properties
+/// through `filter_prop_reads_life` and every nested filter recursively.
+fn target_filter_reads_life_total(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed.properties.iter().any(filter_prop_reads_life),
+        TargetFilter::Not { filter } => target_filter_reads_life_total(filter),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(target_filter_reads_life_total)
+        }
+        TargetFilter::TrackedSetFiltered { filter, .. } => target_filter_reads_life_total(filter),
+        TargetFilter::ChosenDamageSource { filter } => filter
+            .as_ref()
+            .is_some_and(|f| target_filter_reads_life_total(f)),
+        // Payload-free / player-reference / stack-reference / anaphoric filters —
+        // none carry a nested walked payload and none read the life family.
+        // Enumerated explicitly (no wildcard).
+        TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::ControllerAndControlledPermanents { .. }
+        | TargetFilter::Opponent
+        | TargetFilter::SelfRef
+        | TargetFilter::GrantingObject
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::StackSpell
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::PlayerWhoChoseLabel { .. }
+        | TargetFilter::Neighbor { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastCreated
+        | TargetFilter::LastRevealed
+        | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::ExiledCardByIndex { .. }
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::EventTarget
+        | TargetFilter::TriggeringSourceController
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::OriginalController
+        | TargetFilter::OriginalSource
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageSource
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::PostReplacementDamageTargetOwner
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => false,
+    }
+}
+
+/// CR 119 + CR 611.3a: Does a static-ability enabling CONDITION depend on the
+/// life family? Recurses `Not`/`And`/`Or`, routes `QuantityComparison` operands
+/// through `quantity_expr_reads_life`, and routes every nested `TargetFilter`
+/// condition surface. EXHAUSTIVE, no wildcard.
+fn static_condition_reads_life(condition: &StaticCondition) -> bool {
+    match condition {
+        // Presence gate: the filter is optional.
+        StaticCondition::IsPresent { filter } => filter
+            .as_ref()
+            .is_some_and(|f| target_filter_reads_life_total(f)),
+        // Count/threshold gate — either operand may read life
+        // (Serra Ascendant class: "if you have 30 or more life").
+        StaticCondition::QuantityComparison { lhs, rhs, .. } => {
+            quantity_expr_reads_life(lhs) || quantity_expr_reads_life(rhs)
+        }
+        // Nested-filter condition surfaces (doc-comment conventions are not
+        // type-enforced, so all are routed).
+        StaticCondition::DefendingPlayerControls { filter }
+        | StaticCondition::SourceMatchesFilter { filter }
+        | StaticCondition::TopOfLibraryMatches { filter }
+        | StaticCondition::RecipientMatchesFilter { filter } => {
+            target_filter_reads_life_total(filter)
+        }
+        // Recursive combinators.
+        StaticCondition::Not { condition } => static_condition_reads_life(condition),
+        StaticCondition::And { conditions } | StaticCondition::Or { conditions } => {
+            conditions.iter().any(static_condition_reads_life)
+        }
+        // Payload-free conditions — none read the life family. Enumerated
+        // explicitly (no wildcard).
+        StaticCondition::DevotionGE { .. }
+        | StaticCondition::ChosenColorIs { .. }
+        | StaticCondition::ChosenLabelIs { .. }
+        | StaticCondition::HasMaxSpeed
+        | StaticCondition::SpeedGE { .. }
+        | StaticCondition::DayNightIs { .. }
+        | StaticCondition::HasCounters { .. }
+        | StaticCondition::CastVariantPaid { .. }
+        | StaticCondition::RecipientHasCounters { .. }
+        | StaticCondition::ClassLevelGE { .. }
+        | StaticCondition::SourceAttackingAlone
+        | StaticCondition::SourceIsAttacking
+        | StaticCondition::SourceIsBlocking
+        | StaticCondition::SourceIsBlocked
+        | StaticCondition::IsMonarch
+        | StaticCondition::IsInitiative
+        | StaticCondition::NoMonarch
+        | StaticCondition::HasCityBlessing
+        | StaticCondition::CompletedADungeon
+        | StaticCondition::WasStartingPlayer { .. }
+        | StaticCondition::SpellCastWithVariantThisTurn { .. }
+        | StaticCondition::OpponentPoisonAtLeast { .. }
+        | StaticCondition::UnlessPay { .. }
+        | StaticCondition::Unrecognized { .. }
+        | StaticCondition::DuringYourTurn
+        | StaticCondition::SharesColorWithMostCommonColorAmongPermanents
+        | StaticCondition::SourceEnteredThisTurn
+        | StaticCondition::SourceHasDealtDamage
+        | StaticCondition::WasCast { .. }
+        | StaticCondition::IsRingBearer
+        | StaticCondition::RingLevelAtLeast { .. }
+        | StaticCondition::ControlsCommander { .. }
+        | StaticCondition::SourceIsTapped
+        | StaticCondition::IsTapped { .. }
+        | StaticCondition::SourceIsFaceUp
+        | StaticCondition::SourceIsSaddled
+        | StaticCondition::SourceControllerEquals { .. }
+        | StaticCondition::SourceIsEquipped
+        | StaticCondition::SourceIsEnchanted
+        | StaticCondition::SourceIsMonstrous
+        | StaticCondition::SourceIsHarnessed
+        | StaticCondition::SourceAttachedToCreature
+        | StaticCondition::RecipientAttackingOwnerTarget { .. }
+        | StaticCondition::SourceIsPaired
+        | StaticCondition::SourceInZone { .. }
+        | StaticCondition::EnchantedIsFaceDown
+        | StaticCondition::AdditionalCostPaid
+        | StaticCondition::CastingAsVariant { .. }
+        | StaticCondition::None => false,
+    }
+}
+
+/// CR 611.3a + CR 613.1: Does a CONTINUOUS static definition depend on the life
+/// family through its recipient filter, enabling condition, or a dynamic
+/// modification quantity? All three surfaces participate (mirrors
+/// `static_definition_reads_zone_membership`). CR 604.3a / CR 613.4a (layer 7a
+/// CDA P/T) and CR 613.4c (layer 7c P/T modifiers) are the modification
+/// surfaces a life-keyed dynamic quantity feeds.
+fn static_definition_reads_life_total(def: &StaticDefinition) -> bool {
+    def.mode == StaticMode::Continuous
+        && (def
+            .affected
+            .as_ref()
+            .is_some_and(|filter| target_filter_reads_life_total(filter))
+            || def
+                .condition
+                .as_ref()
+                .is_some_and(|condition| static_condition_reads_life(condition))
+            || def.modifications.iter().any(|modification| {
+                continuous_modification_dynamic_quantity(modification)
+                    .is_some_and(|quantity| quantity_expr_reads_life(quantity))
+            }))
+}
+
+/// CR 611.3a: Is any functioning continuous static dependent on the life family?
+/// Scans live static sources (including currently-false gates — a life change
+/// may be exactly what flips one). Mirrors `any_active_static_reads_top_of_library`.
+/// NOT indexed into `StaticSourceIndex` bits by design: an off-zone generator arm
+/// is unindexed, so an indexed guard could under-include (unsound).
+fn any_active_static_reads_life_total(state: &GameState) -> bool {
+    let mut found = false;
+    for_each_static_effect_source(state, |_state, obj| {
+        if found {
+            return;
+        }
+        if obj
+            .static_definitions
+            .iter_all()
+            .any(static_definition_reads_life_total)
+        {
+            found = true;
+        }
+    });
+    found
+}
+
+/// CR 611.3a + CR 119: Force a full layer recompute after a life-changing event,
+/// but only when a life-reading continuous static is actually live. Single
+/// authority called by the four guarded life-mutation sites in `effects/life.rs`
+/// so a stale layer cache can't survive a life change that flips a derived board.
+pub(crate) fn mark_layers_full_if_life_reading_static_live(state: &mut GameState) {
+    if any_active_static_reads_life_total(state) {
         mark_layers_full(state);
     }
 }
@@ -6355,12 +6954,13 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::parser::oracle_nom::condition::parse_inner_condition;
     use crate::types::ability::{
-        AbilityCost, AbilityDefinition, AbilityKind, BasicLandType, CastVariantPaid,
-        ChosenSubtypeKind, CommanderOwnership, Comparator, ContinuousModification, ControllerRef,
-        CountScope, Duration, Effect, FilterProp, ManaProduction, ObjectScope, PlayerFilter,
-        PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, SacrificeCost,
-        StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TriggerDefinition,
-        TypeFilter, TypedFilter, ZoneRef,
+        AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, BasicLandType,
+        CastManaObjectScope, CastManaSpentMetric, CastVariantPaid, ChosenSubtypeKind,
+        CommanderOwnership, Comparator, ContinuousModification, ControllerRef, CountScope,
+        DamageChannel, DamageKindFilter, Duration, Effect, FilterProp, ManaProduction, ObjectScope,
+        PlayerFilter, PlayerRelation, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef,
+        SacrificeCost, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition,
+        TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::counter::{CounterMatch, CounterType};
@@ -18467,6 +19067,408 @@ mod tests {
                 StaticModeKind::Shroud
             ),
             "phased-out static (CR 702.26b) must not appear in presence"
+        );
+    }
+
+    // ── U3: life-gated layer escalation (CR 611.3a + CR 119) ──────────────
+    //
+    // Every fixture below is REVERT-FAILING: reverting the classifier arm it
+    // exercises to `=> false` makes `mark_layers_full_if_life_reading_static_live`
+    // a no-op, so the escalation assertion (and, where present, the differential
+    // derived-board / `layers_full_eval == 1` reach-guard) fails.
+
+    /// Attach a CONTINUOUS static `def` to a fresh 1/1 creature on the
+    /// battlefield. `base_static_definitions` is synced from `static_definitions`
+    /// at the top of the next layer pass (mirrors `make_anthem`), so the
+    /// generator survives the per-pass reset.
+    fn make_life_static_source(
+        state: &mut GameState,
+        name: &str,
+        player: PlayerId,
+        def: StaticDefinition,
+    ) -> ObjectId {
+        let id = make_creature(state, name, 1, 1, player);
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .static_definitions
+            .push(def);
+        id
+    }
+
+    /// A self-affecting CDA that adds the controller's life total to its own
+    /// power (Serra Avatar class) — the canonical dynamic-quantity life reader.
+    fn life_total_cda(player_scope: PlayerScope) -> StaticDefinition {
+        StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))
+            .modifications(vec![ContinuousModification::AddDynamicPower {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::LifeTotal {
+                        player: player_scope,
+                    },
+                },
+            }])
+    }
+
+    /// Direct-leaf true-set + the `StartingLifeTotal` inversion trap (rev-2 had
+    /// this backwards) locked at the classifier boundary.
+    #[test]
+    fn quantity_ref_life_family_leaves_classified_directly() {
+        // CR 119: the four life-family quantities every guarded site changes.
+        assert!(quantity_ref_reads_life(&QuantityRef::LifeTotal {
+            player: PlayerScope::Controller
+        }));
+        assert!(quantity_ref_reads_life(&QuantityRef::LifeAboveStarting));
+        assert!(quantity_ref_reads_life(&QuantityRef::LifeLostThisTurn {
+            player: PlayerScope::Controller
+        }));
+        assert!(quantity_ref_reads_life(&QuantityRef::LifeGainedThisTurn {
+            player: PlayerScope::Controller
+        }));
+        // CR 119.1: a format constant, not a live read.
+        assert!(!quantity_ref_reads_life(&QuantityRef::StartingLifeTotal));
+        // A non-life player scalar.
+        assert!(!quantity_ref_reads_life(&QuantityRef::HandSize {
+            player: PlayerScope::Controller
+        }));
+    }
+
+    /// Router-arm regression lock for the walks a wrong `=> false` would break
+    /// silently: the two-leg `DamageDealtThisTurn`, `ManaSpentToCast`'s metric
+    /// filter, the `PlayerFilter` routers (`OpponentDealtDamage.source`,
+    /// `AllExcept`, `ControlsCount`), a TargetFilter-bearing `FilterProp`
+    /// (`Targets`), and a nested-filter `StaticCondition`
+    /// (`SourceMatchesFilter`). Each must classify true when its nested
+    /// payload reads life.
+    #[test]
+    fn router_arms_route_life_reading_payloads() {
+        let life_filter = TargetFilter::Typed(TypedFilter::creature().properties(vec![
+            FilterProp::ControllerMatches {
+                player: Box::new(PlayerFilter::OpponentLostLife),
+            },
+        ]));
+        let plain = TargetFilter::Typed(TypedFilter::creature());
+
+        // CR 120.10: both damage-record legs route — target leg life-reading
+        // here while the source leg stays plain.
+        assert!(quantity_ref_reads_life(&QuantityRef::DamageDealtThisTurn {
+            source: Box::new(plain.clone()),
+            target: Box::new(life_filter.clone()),
+            aggregate: AggregateFunction::Sum,
+            group_by: None,
+            damage_kind: DamageKindFilter::Any,
+            channel: DamageChannel::Total,
+        }));
+        // CR 601.2h: the cast-mana metric's source filter routes.
+        assert!(quantity_ref_reads_life(&QuantityRef::ManaSpentToCast {
+            scope: CastManaObjectScope::SelfObject,
+            metric: CastManaSpentMetric::FromSource {
+                source_filter: life_filter.clone(),
+            },
+        }));
+        // CR 120.9: the damage-history source filter routes.
+        assert!(player_filter_reads_life(
+            &PlayerFilter::OpponentDealtDamage {
+                kind: DamageKindFilter::Any,
+                source: Some(Box::new(life_filter.clone())),
+                min_sources: 1,
+            }
+        ));
+        // CR 608.2c: exclusion anchor recurses.
+        assert!(player_filter_reads_life(&PlayerFilter::AllExcept {
+            exclude: Box::new(PlayerFilter::OpponentGainedLife),
+        }));
+        // CR 109.4 + CR 109.5: controls-count routes its object filter.
+        assert!(player_filter_reads_life(&PlayerFilter::ControlsCount {
+            relation: PlayerRelation::Opponent,
+            filter: life_filter.clone(),
+            comparator: Comparator::GE,
+            count: Box::new(QuantityExpr::Fixed { value: 1 }),
+        }));
+        // A TargetFilter-bearing FilterProp routes (one of the six the zone
+        // template's wildcard drops).
+        assert!(target_filter_reads_life_total(&TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::Targets {
+                filter: Box::new(life_filter.clone()),
+            }]),
+        )));
+        // A nested-filter StaticCondition routes.
+        assert!(static_condition_reads_life(
+            &StaticCondition::SourceMatchesFilter {
+                filter: life_filter,
+            }
+        ));
+    }
+
+    /// Filter-routed reads: the classifier descends nested payloads on every
+    /// surface (FilterProp → PlayerFilter, and PlayerCount → PlayerFilter), and
+    /// stays `false` for a life-free filter.
+    #[test]
+    fn nested_filter_and_player_surfaces_route_to_life() {
+        let lost_life_controller = TargetFilter::Typed(TypedFilter::creature().properties(vec![
+            FilterProp::ControllerMatches {
+                player: Box::new(PlayerFilter::OpponentLostLife),
+            },
+        ]));
+        // FilterProp::ControllerMatches routes into PlayerFilter::OpponentLostLife.
+        assert!(target_filter_reads_life_total(&lost_life_controller));
+        // PlayerCount routes its PlayerFilter (Gap-A quantity route).
+        assert!(quantity_ref_reads_life(&QuantityRef::PlayerCount {
+            filter: PlayerFilter::OpponentLostLife
+        }));
+        // ObjectCount routes its TargetFilter (the other Gap-A route).
+        assert!(quantity_ref_reads_life(&QuantityRef::ObjectCount {
+            filter: lost_life_controller
+        }));
+        // A plain creature filter reads no life.
+        assert!(!target_filter_reads_life_total(&TargetFilter::Typed(
+            TypedFilter::creature()
+        )));
+        assert!(!player_filter_reads_life(&PlayerFilter::Controller));
+    }
+
+    /// CDA quantity surface — a live `AddDynamicPower{ LifeTotal }` CDA. The
+    /// guard escalates on a life change AND the derived power tracks the new
+    /// life after the guarded flush (`layers_full_eval == 1`).
+    #[test]
+    fn life_cda_escalates_and_derived_power_tracks_life() {
+        let mut state = setup();
+        let controller = P0;
+        let id = make_life_static_source(
+            &mut state,
+            "Serra Avatar-ish",
+            controller,
+            life_total_cda(PlayerScope::Controller),
+        );
+
+        // Baseline: power = base 1 + controller life (20 in a two-player game).
+        evaluate_layers(&mut state);
+        let start_life = state
+            .players
+            .iter()
+            .find(|p| p.id == controller)
+            .unwrap()
+            .life;
+        assert_eq!(state.objects.get(&id).unwrap().power, Some(1 + start_life));
+
+        // Simulate a life change, then run ONLY the guard (as the guarded site
+        // does) and flush.
+        state
+            .players
+            .iter_mut()
+            .find(|p| p.id == controller)
+            .unwrap()
+            .life = start_life + 5;
+        state.layers_dirty = LayersDirty::Clean;
+        crate::game::perf_counters::reset();
+        mark_layers_full_if_life_reading_static_live(&mut state);
+        assert!(
+            matches!(state.layers_dirty, LayersDirty::Full),
+            "a live LifeTotal CDA must force full escalation on a life change"
+        );
+        flush_layers(&mut state);
+
+        let counters = crate::game::perf_counters::snapshot();
+        assert_eq!(
+            counters.layers_full_eval, 1,
+            "one full pass on the guarded flush"
+        );
+        assert_eq!(
+            state.objects.get(&id).unwrap().power,
+            Some(1 + start_life + 5),
+            "derived power must track the new life after the guarded flush"
+        );
+    }
+
+    /// Condition surface — Serra Ascendant class: a `QuantityComparison` gate
+    /// over `LifeTotal`. Reverting the `QuantityComparison`/`LifeTotal` arm
+    /// stops escalation.
+    #[test]
+    fn condition_over_life_total_escalates() {
+        let mut state = setup();
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))
+            .condition(StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::LifeTotal {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 30 },
+            })
+            .modifications(vec![ContinuousModification::AddPower { value: 2 }]);
+        make_life_static_source(&mut state, "Serra Ascendant-ish", P0, def);
+        assert_full_escalation_on_guard(&mut state);
+    }
+
+    /// `LifeAboveStarting` reader — a CDA keyed on life-above-starting. Reverting
+    /// `LifeAboveStarting => false` stops escalation.
+    #[test]
+    fn life_above_starting_reader_escalates() {
+        let mut state = setup();
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))
+            .modifications(vec![ContinuousModification::AddDynamicPower {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::LifeAboveStarting,
+                },
+            }]);
+        make_life_static_source(&mut state, "Above Starting", P0, def);
+        assert_full_escalation_on_guard(&mut state);
+    }
+
+    /// Per-turn-counter-gated static — `LifeGainedThisTurn` in a condition.
+    #[test]
+    fn per_turn_life_counter_gate_escalates() {
+        let mut state = setup();
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))
+            .condition(StaticCondition::QuantityComparison {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::LifeGainedThisTurn {
+                        player: PlayerScope::Controller,
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 1 },
+            })
+            .modifications(vec![ContinuousModification::AddPower { value: 1 }]);
+        make_life_static_source(&mut state, "Ajani's Pridemate-ish", P0, def);
+        assert_full_escalation_on_guard(&mut state);
+    }
+
+    /// `ControllerMatches{OpponentLostLife}` anthem — a life read on the
+    /// AFFECTED filter surface (the class the zone template's `_ => false`
+    /// wildcard drops). Reverting the FilterProp/PlayerFilter arm stops it.
+    #[test]
+    fn controller_lost_life_anthem_escalates() {
+        let mut state = setup();
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(TypedFilter::creature().properties(
+                vec![FilterProp::ControllerMatches {
+                    player: Box::new(PlayerFilter::OpponentLostLife),
+                }],
+            )))
+            .modifications(vec![ContinuousModification::AddPower { value: 1 }]);
+        make_life_static_source(&mut state, "Lost-Life Anthem", P0, def);
+        assert_full_escalation_on_guard(&mut state);
+    }
+
+    /// Gap A — filter-routed dynamic quantity: a P/T modifier whose magnitude is
+    /// `ObjectCount{ ControllerMatches{OpponentLostLife} }`. Reverting
+    /// `ObjectCount => false` (or the FilterProp/PlayerFilter arm) stops it.
+    #[test]
+    fn filter_routed_quantity_escalates() {
+        let mut state = setup();
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))
+            .modifications(vec![ContinuousModification::AddDynamicPower {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                            FilterProp::ControllerMatches {
+                                player: Box::new(PlayerFilter::OpponentLostLife),
+                            },
+                        ])),
+                    },
+                },
+            }]);
+        make_life_static_source(&mut state, "Gap-A Quantity", P0, def);
+        assert_full_escalation_on_guard(&mut state);
+    }
+
+    /// `PlayerAttribute{ attr = LifeTotal }` filter (Wolfcaller's Howl class),
+    /// reached through `PlayerCount`. Routes attr → `quantity_ref_reads_life`.
+    #[test]
+    fn player_attribute_life_filter_escalates() {
+        let mut state = setup();
+        let def = StaticDefinition::continuous()
+            .affected(TargetFilter::Typed(
+                TypedFilter::creature().controller(ControllerRef::You),
+            ))
+            .modifications(vec![ContinuousModification::AddDynamicPower {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::PlayerCount {
+                        filter: PlayerFilter::PlayerAttribute {
+                            relation: crate::types::ability::PlayerRelation::Opponent,
+                            attr: Box::new(QuantityRef::LifeTotal {
+                                player: PlayerScope::Controller,
+                            }),
+                            comparator: Comparator::GE,
+                            value: Box::new(QuantityExpr::Fixed { value: 1 }),
+                        },
+                    },
+                },
+            }]);
+        make_life_static_source(&mut state, "Wolfcaller-ish", P0, def);
+        assert_full_escalation_on_guard(&mut state);
+    }
+
+    /// Skip path — a plain board with a NON-life static must NOT escalate, and
+    /// the skipped derived board must be byte-identical to a forced-escalation
+    /// control (differential reach-guard: the flush genuinely ran).
+    #[test]
+    fn plain_board_skips_and_stays_byte_identical() {
+        let mut state = setup();
+        // A live continuous static that reads no life (plain anthem).
+        make_anthem(&mut state, "Vanilla Anthem", P0);
+        let bear = make_creature(&mut state, "Bear", 2, 2, P0);
+        evaluate_layers(&mut state);
+
+        // Control clone: force a full escalation and flush.
+        let mut control = state.clone();
+        mark_layers_full(&mut control);
+        flush_layers(&mut control);
+
+        // Guarded path: run the guard on a life change with no life-reading static.
+        let start_life = state.players.iter().find(|p| p.id == P0).unwrap().life;
+        state.players.iter_mut().find(|p| p.id == P0).unwrap().life = start_life - 3;
+        state.layers_dirty = LayersDirty::Clean;
+        crate::game::perf_counters::reset();
+        mark_layers_full_if_life_reading_static_live(&mut state);
+        assert!(
+            matches!(state.layers_dirty, LayersDirty::Clean),
+            "no life-reading static ⇒ no escalation"
+        );
+        flush_layers(&mut state);
+        let counters = crate::game::perf_counters::snapshot();
+        assert_eq!(
+            counters.layers_full_eval, 0,
+            "the skip path must not run a full layer pass"
+        );
+
+        // Differential: the anthem-derived board is identical either way.
+        let guarded = state.objects.get(&bear).unwrap();
+        let forced = control.objects.get(&bear).unwrap();
+        assert_eq!(
+            (guarded.power, guarded.toughness),
+            (forced.power, forced.toughness),
+            "skipping escalation must leave a board byte-identical to a forced full pass"
+        );
+    }
+
+    /// Shared reach-guard: run ONLY the guard from a Clean baseline and assert it
+    /// forces a full escalation (the `mark_layers_full` the guarded site would
+    /// otherwise call unconditionally).
+    fn assert_full_escalation_on_guard(state: &mut GameState) {
+        evaluate_layers(state);
+        state.layers_dirty = LayersDirty::Clean;
+        mark_layers_full_if_life_reading_static_live(state);
+        assert!(
+            matches!(state.layers_dirty, LayersDirty::Full),
+            "a live life-reading continuous static must force full escalation"
         );
     }
 }


### PR DESCRIPTION
The four player-life mutation sites in effects/life.rs swap their
unconditional mark_layers_full for
mark_layers_full_if_life_reading_static_live: full layer re-derivation
escalates only when a live Continuous static actually reads life state.
Display freshness is unchanged - it rides the existing LifeChanged ->
mark_public_state_from_events path (CR 119.3 / CR 119.9).

The classifier family in layers.rs mirrors the top-of-library zone
template but is exhaustive with no wildcards under a universal
payload-routing rule: every variant of every walked enum (QuantityRef,
QuantityExpr, TargetFilter/FilterProp, PlayerFilter, StaticCondition)
that carries a nested filter or quantity routes it through the
corresponding walk; only payload-free leaves classify false directly, so
a future life-reading variant breaks the build instead of going stale.
Perf witness: layers_full_eval -29.5% on the perf suite with the
full-down/incremental-up conversion fingerprint.
