### PR TITLE
fix(parser): recognize "you exile ... this way" reflexive triggers

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -963,6 +963,21 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
                     text[offset..].to_string(),
                 );
             }
+            // CR 603.12 + CR 701.16a: "when you exile a[n] X this way, [body]" —
+            // the reflexive gate created by a preceding "exile [target] X"
+            // instruction (Ardyn, the Usurper, issue #5989). The exile's move
+            // into the (public, CR 400.2) exile zone publishes the card into
+            // `state.last_zone_changed_ids`, which `ZoneChangedThisWay` checks.
+            if let Ok((after_clause, (filter, _negated))) =
+                crate::parser::oracle_nom::condition::parse_you_exile_this_way_clause(rest)
+            {
+                let body_lower = strip_reflexive_conditional_body_separator(after_clause);
+                let offset = text.len() - body_lower.len();
+                return (
+                    Some(AbilityCondition::ZoneChangedThisWay { filter }),
+                    text[offset..].to_string(),
+                );
+            }
         }
     }
     (None, text.to_string())

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -922,6 +922,24 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
                 text[offset..].to_string(),
             );
         }
+        // CR 603.12 + CR 701.16a: active-voice "you exile[d] a[n] X this way,
+        // [body]" — the reflexive gate created by a preceding "exile [target]
+        // X" instruction. Runs under BOTH prefixes because the printed idiom
+        // appears in both tenses: past "If you exiled a card this way, …"
+        // (Ardyn, the Usurper's actual Oracle text, issue #5989) and present
+        // "When you exile a card this way, …". The exile's move into the
+        // (public, CR 400.2) exile zone publishes the card into
+        // `state.last_zone_changed_ids`, which `ZoneChangedThisWay` checks.
+        if let Ok((after_clause, (filter, _negated))) =
+            nom_cond::parse_you_exile_this_way_clause(rest)
+        {
+            let body_lower = strip_reflexive_conditional_body_separator(after_clause);
+            let offset = text.len() - body_lower.len();
+            return (
+                Some(AbilityCondition::ZoneChangedThisWay { filter }),
+                text[offset..].to_string(),
+            );
+        }
         if let Ok((after_clause, (filter, _negated))) =
             nom_cond::parse_zone_changed_this_way_clause(rest)
         {
@@ -955,21 +973,6 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
             // `state.last_zone_changed_ids`, which `ZoneChangedThisWay` checks.
             if let Ok((after_clause, (filter, _negated))) =
                 crate::parser::oracle_nom::condition::parse_you_sacrifice_this_way_clause(rest)
-            {
-                let body_lower = strip_reflexive_conditional_body_separator(after_clause);
-                let offset = text.len() - body_lower.len();
-                return (
-                    Some(AbilityCondition::ZoneChangedThisWay { filter }),
-                    text[offset..].to_string(),
-                );
-            }
-            // CR 603.12 + CR 701.16a: "when you exile a[n] X this way, [body]" —
-            // the reflexive gate created by a preceding "exile [target] X"
-            // instruction (Ardyn, the Usurper, issue #5989). The exile's move
-            // into the (public, CR 400.2) exile zone publishes the card into
-            // `state.last_zone_changed_ids`, which `ZoneChangedThisWay` checks.
-            if let Ok((after_clause, (filter, _negated))) =
-                crate::parser::oracle_nom::condition::parse_you_exile_this_way_clause(rest)
             {
                 let body_lower = strip_reflexive_conditional_body_separator(after_clause);
                 let offset = text.len() - body_lower.len();

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -349,6 +349,55 @@ fn rewrite_cant_rider_for_non_zone_change_parent(
     condition
 }
 
+/// CR 603.12 + CR 701.16a + CR 608.2c: rebind an active-past "you exiled …
+/// this way" reflexive gate to the zone-change ledger when its antecedent is
+/// an EXILE EFFECT in the same chain (Ardyn, the Usurper: "exile up to one
+/// target creature card from a graveyard. If you exiled a card this way,
+/// create a token that's a copy of that card…", issue #5989).
+///
+/// The context-free condition grammar reads "you exiled a[n] X this way" as
+/// `CostPaidObjectMatchesFilter` — correct for its original cost-paid class
+/// (the Shilgengar shape, where the exile happened as a COST and the
+/// `cost_paid_object` snapshot answers the check), but wrong when the exile
+/// is the immediately-preceding EFFECT instruction: no cost snapshot exists,
+/// and the runtime fallback constrains the moved object's controller to the
+/// ability controller — a card exiled from an OPPONENT's graveyard fails that
+/// check, which is exactly the reported "only works on my own graveyard"
+/// symptom. Only the clause context can disambiguate the two classes, so this
+/// rewrite (mirroring `rewrite_cant_rider_for_non_zone_change_parent` above)
+/// fires ONLY when the previous non-continuation clause is a
+/// `ChangeZone { destination: Exile }` effect; the cost-paid class (no such
+/// preceding clause) and the subject-scoped sacrifice class (Deadly Brew's
+/// "If you sacrificed a permanent this way" after a per-player sacrifice,
+/// whose `Sacrifice` parent is not a `ChangeZone`) are untouched.
+fn rewrite_cost_paid_exiled_reflexive_for_effect_exile_parent(
+    condition: Option<AbilityCondition>,
+    clauses: &[ClauseIr],
+) -> Option<AbilityCondition> {
+    let Some(AbilityCondition::CostPaidObjectMatchesFilter { filter }) = &condition else {
+        return condition;
+    };
+    let prev_is_effect_exile = clauses
+        .iter()
+        .rev()
+        .find(|clause| !matches!(clause.disposition, ClauseDisposition::Continue { .. }))
+        .is_some_and(|clause| {
+            matches!(
+                clause.parsed.effect,
+                Effect::ChangeZone {
+                    destination: Zone::Exile,
+                    ..
+                }
+            )
+        });
+    if prev_is_effect_exile {
+        return Some(AbilityCondition::ZoneChangedThisWay {
+            filter: filter.clone(),
+        });
+    }
+    condition
+}
+
 fn merge_clause_conditions(
     outer: AbilityCondition,
     inner: Option<AbilityCondition>,
@@ -27739,6 +27788,13 @@ pub(crate) fn parse_effect_chain_ir(
         // zone-change ledger (a successful turn-up changes no zone). See the
         // helper for the full rationale (Etrata, Deadly Fugitive).
         let condition = rewrite_cant_rider_for_non_zone_change_parent(condition, builder.clauses());
+        // CR 603.12 + CR 701.16a: "If you exiled … this way" after an exile
+        // EFFECT is the reflexive zone-change gate, not the cost-paid class —
+        // see the helper for the full disambiguation rationale (issue #5989).
+        let condition = rewrite_cost_paid_exiled_reflexive_for_effect_exile_parent(
+            condition,
+            builder.clauses(),
+        );
         // CR 608.2c: "[effect] a number of times equal to the difference" — when
         // a leading comparison condition was just stripped, a trailing
         // difference-repeat suffix repeats the effect by the unsigned magnitude

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -21814,6 +21814,54 @@ fn exile_then_copy_that_card_as_enchantment_uses_tracked_set_and_set_card_types(
     );
 }
 
+/// Issue #5989 — Ardyn, the Usurper (exact current Oracle wording of the
+/// trigger body): "Exile up to one target creature card from a graveyard.
+/// If you exiled a card this way, create a token that's a copy of that card,
+/// except it's a 5/5 black Demon." Unlike the sentence-connected "then
+/// create" sibling above, the copy here sits behind the active-PAST
+/// reflexive gate "If you exiled a card this way," (CR 603.12 + CR 701.16a)
+/// — an "if "-prefixed, subject-first form neither the passive article-first
+/// combinator nor the "when "-only active arms could consume, so the whole
+/// clause previously fell through to `Effect::Unimplemented`.
+#[test]
+fn issue_5989_if_you_exiled_this_way_gates_copy_of_that_card() {
+    let def = parse_effect_chain(
+        "Exile up to one target creature card from a graveyard. If you exiled a card \
+         this way, create a token that's a copy of that card, except it's a 5/5 black \
+         Demon.",
+        AbilityKind::Spell,
+    );
+
+    let Effect::ChangeZone { destination, .. } = def.effect.as_ref() else {
+        panic!("expected ChangeZone, got {:?}", def.effect);
+    };
+    assert_eq!(*destination, Zone::Exile);
+
+    let copy = def.sub_ability.as_deref().expect("copy sub-ability");
+    assert!(
+        matches!(
+            &copy.condition,
+            Some(AbilityCondition::ZoneChangedThisWay { .. })
+        ),
+        "the reflexive \"If you exiled a card this way\" clause must lower to a \
+         ZoneChangedThisWay gate, got {:?}",
+        copy.condition
+    );
+    let Effect::CopyTokenOf { target, .. } = copy.effect.as_ref() else {
+        panic!(
+            "expected CopyTokenOf behind the reflexive gate, got {:?}",
+            copy.effect
+        );
+    };
+    assert_eq!(
+        *target,
+        TargetFilter::TrackedSet {
+            id: TrackedSetId(0)
+        },
+        "\"that card\" must rebind to the exiled tracked set"
+    );
+}
+
 /// Issue #377 — Anikthea, Hand of Erebos: "exile up to one target non-Aura
 /// enchantment card from your graveyard and create a token that's a copy of
 /// it, except it's a 3/3 black Zombie creature in addition to its other

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -8994,22 +8994,24 @@ pub fn parse_you_sacrifice_this_way_clause(input: &str) -> OracleResult<'_, (Tar
     Ok((rest, (filter, false)))
 }
 
-/// CR 608.2c + CR 701.16a: Parse "you exile [quantifier] [type] this way" — the
-/// active-voice reflexive gate created by a preceding "exile [quantifier]
-/// [type]" instruction in the same ability (Ardyn, the Usurper: "you may
-/// exile up to one target creature card from a graveyard. When you exile a
-/// card this way, create a token that's a copy of it, except it's a 5/5
-/// black Demon").
+/// CR 608.2c + CR 701.16a: Parse "you exile[d] [quantifier] [type] this way"
+/// — the active-voice reflexive gate created by a preceding "exile
+/// [quantifier] [type]" instruction in the same ability. Covers BOTH tenses
+/// of the printed idiom: the past-tense "If you exiled a card this way, …"
+/// (Ardyn, the Usurper's actual current Oracle text, issue #5989) and the
+/// present-tense "When you exile a card this way, …" sibling shape.
 ///
 /// CR 400.2: exile is a public zone, so the exiled card is published into
 /// `state.last_zone_changed_ids` by the parent `ChangeZone` effect just like
 /// the discard/sacrifice siblings below. Semantically identical to the active
 /// `parse_you_discard_this_way_clause` / `parse_you_sacrifice_this_way_clause`
-/// existential check, differing only in the active verb ("exile") and its
-/// exile-zone destination — unlike those two, exile's destination is not
-/// fixed to the graveyard, so no destination is implied here.
+/// existential check, differing only in the active verb ("exile"/"exiled")
+/// and its exile-zone destination — unlike those two, exile's destination is
+/// not fixed to the graveyard, so no destination is implied here.
 pub fn parse_you_exile_this_way_clause(input: &str) -> OracleResult<'_, (TargetFilter, bool)> {
-    let (rest, _) = tag("you exile ").parse(input)?;
+    let (rest, _) = tag("you exile").parse(input)?;
+    let (rest, _) = opt(tag("d")).parse(rest)?;
+    let (rest, _) = tag(" ").parse(rest)?;
     let (rest, _) = alt((
         value((), tag::<_, _, OracleError<'_>>("at least one ")),
         value((), tag("one or more ")),

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -8994,6 +8994,40 @@ pub fn parse_you_sacrifice_this_way_clause(input: &str) -> OracleResult<'_, (Tar
     Ok((rest, (filter, false)))
 }
 
+/// CR 608.2c + CR 701.16a: Parse "you exile [quantifier] [type] this way" — the
+/// active-voice reflexive gate created by a preceding "exile [quantifier]
+/// [type]" instruction in the same ability (Ardyn, the Usurper: "you may
+/// exile up to one target creature card from a graveyard. When you exile a
+/// card this way, create a token that's a copy of it, except it's a 5/5
+/// black Demon").
+///
+/// CR 400.2: exile is a public zone, so the exiled card is published into
+/// `state.last_zone_changed_ids` by the parent `ChangeZone` effect just like
+/// the discard/sacrifice siblings below. Semantically identical to the active
+/// `parse_you_discard_this_way_clause` / `parse_you_sacrifice_this_way_clause`
+/// existential check, differing only in the active verb ("exile") and its
+/// exile-zone destination — unlike those two, exile's destination is not
+/// fixed to the graveyard, so no destination is implied here.
+pub fn parse_you_exile_this_way_clause(input: &str) -> OracleResult<'_, (TargetFilter, bool)> {
+    let (rest, _) = tag("you exile ").parse(input)?;
+    let (rest, _) = alt((
+        value((), tag::<_, _, OracleError<'_>>("at least one ")),
+        value((), tag("one or more ")),
+        parse_article,
+    ))
+    .parse(rest)?;
+    let (filter, after_filter) = parse_type_phrase(rest);
+    if matches!(filter, TargetFilter::Any) {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    let after_filter = after_filter.trim_start();
+    let (rest, _) = tag("this way").parse(after_filter)?;
+    Ok((rest, (filter, false)))
+}
+
 /// CR 608.2c + CR 205: Fold trailing " or <article/another> <type>" segments that
 /// share the leading clause's single verb into an `Or` filter. `remainder` is the
 /// slice immediately after the first parsed type phrase (untrimmed). Returns the

--- a/crates/engine/tests/integration/issue_5989_ardyn_exile_copy.rs
+++ b/crates/engine/tests/integration/issue_5989_ardyn_exile_copy.rs
@@ -1,0 +1,191 @@
+//! Regression for GitHub issue #5989 — Ardyn, the Usurper's combat-trigger
+//! ability that exiles a graveyard creature and creates a copy of it as a 5/5
+//! black Demon.
+//!
+//! Oracle (Final Fantasy crossover, verified via Scryfall):
+//!   "At the beginning of combat on your turn, you may exile up to one
+//!   target creature card from a graveyard. When you exile a card this way,
+//!   create a token that's a copy of it, except it's a 5/5 black Demon."
+//!
+//! Root cause: `strip_if_you_do_conditional` (the reflexive "when you <verb>
+//! this way" gate recognizer) only had active-voice combinators for
+//! "you discard"/"you sacrifice" this way — no "you exile this way" arm. The
+//! entire "when you exile a card this way, create a token…" clause fell
+//! through to `Effect::Unimplemented`, so the ability exiled a card and then
+//! silently did nothing — matching the reported "I have to make the copy
+//! myself" symptom. Fixed by adding `parse_you_exile_this_way_clause`
+//! (`parser/oracle_nom/condition.rs`), mirroring the existing discard/
+//! sacrifice siblings, and wiring it into `strip_if_you_do_conditional`.
+//!
+//! This test drives the real activation -> target-selection -> exile ->
+//! reflexive-copy pipeline through the actual game-action interface (not a
+//! bare `resolve_ability_chain` call with pre-empty targets — this ability
+//! is genuinely TARGETED, so target selection must happen at announce time,
+//! same lesson as `issue_4948_samwise_gamgee_sacrifice_target_order.rs`).
+//! The combat-trigger condition itself ("at the beginning of combat") is not
+//! the bug and is replaced with a trivial activation cost so the body can be
+//! driven directly via `GameAction::ActivateAbility`.
+//!
+//! Discriminating scenario: TWO legal graveyard targets so target selection
+//! genuinely pauses instead of auto-resolving a lone candidate (the #4948
+//! single-legal-target auto-resolve lesson), one in EACH player's graveyard
+//! — per the issue's own "only works for my own graveyard" claim, which
+//! this test disproves: the parsed target filter carries no controller
+//! restriction.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::zones::Zone;
+
+const ARDYN_ORACLE: &str = "{0}: You may exile up to one target creature card from a \
+     graveyard. When you exile a card this way, create a token that's a copy of it, \
+     except it's a 5/5 black Demon.";
+
+fn ardyn_ability_index(runner: &GameRunner, ardyn: ObjectId) -> usize {
+    runner
+        .state()
+        .objects
+        .get(&ardyn)
+        .expect("ardyn on battlefield")
+        .abilities
+        .iter()
+        .position(|a| a.cost.is_some())
+        .expect("Ardyn has a costed activated ability")
+}
+
+#[test]
+fn ardyn_exiles_opponents_graveyard_creature_and_creates_5_5_black_demon_copy() {
+    let mut scenario = GameScenario::new();
+
+    let ardyn = scenario
+        .add_creature_from_oracle(P0, "Ardyn, the Usurper", 4, 4, ARDYN_ORACLE)
+        .id();
+
+    // Two legal targets — one in EACH player's graveyard — so target
+    // selection genuinely pauses (a lone candidate auto-resolves inline on
+    // this engine, defeating the point of choosing one) and the fix's "any
+    // graveyard, not just yours" claim is actually exercised.
+    let own_grave_creature = scenario
+        .add_creature_to_graveyard(P0, "Own Graveyard Golem", 3, 3)
+        .id();
+    let opp_grave_creature = scenario
+        .add_creature_to_graveyard(P1, "Opponent's Graveyard Bear", 2, 2)
+        .id();
+
+    let mut runner = scenario.build();
+    let ability_index = ardyn_ability_index(&runner, ardyn);
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: ardyn,
+            ability_index,
+        })
+        .expect("activating Ardyn's ability must succeed");
+
+    // "You may exile up to one target ..." manifests as an OPTIONAL target
+    // slot (min 0, max 1), not a separate accept/decline prompt — this is a
+    // genuine CR 601.2c target, resolved at announce time.
+    let WaitingFor::TargetSelection { target_slots, .. } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "expected a TargetSelection prompt for the optional exile target, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    let legal = &target_slots[0].legal_targets;
+    assert!(
+        legal.contains(&TargetRef::Object(own_grave_creature)),
+        "the controller's own graveyard creature must be a legal target; legal={legal:?}"
+    );
+    assert!(
+        legal.contains(&TargetRef::Object(opp_grave_creature)),
+        "issue #5989: the OPPONENT's graveyard creature must also be a legal target — \
+         the filter carries no controller restriction; legal={legal:?}"
+    );
+
+    // Choose the opponent's creature — the half of the reported symptom
+    // ("only works if I do it to my graveyard") this test is pinning.
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(opp_grave_creature)],
+        })
+        .expect("choosing the opponent's graveyard creature must succeed");
+
+    // Let the activated ability resolve off the stack. The TARGET is locked
+    // in at announce time (CR 601.2c, already done above), but whether the
+    // "you may" instruction is actually PERFORMED is decided separately at
+    // resolution time.
+    runner.pass_both_players();
+    runner.advance_until_stack_empty();
+
+    match runner.state().waiting_for.clone() {
+        WaitingFor::OptionalEffectChoice { player, .. } => {
+            assert_eq!(player, P0, "the controller must be asked, not the opponent");
+            runner
+                .act(GameAction::DecideOptionalEffect { accept: true })
+                .expect("accepting the optional exile must succeed");
+        }
+        other => panic!("expected an OptionalEffectChoice prompt for \"you may\", got {other:?}"),
+    }
+
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&opp_grave_creature)
+            .map(|o| o.zone),
+        Some(Zone::Exile),
+        "the chosen creature must actually be exiled"
+    );
+
+    // The reflexive "when you exile a card this way, create a token copy of
+    // it" must have fired automatically — no further player action needed.
+    let demon = runner
+        .state()
+        .battlefield
+        .iter()
+        .copied()
+        .find(|id| {
+            runner
+                .state()
+                .objects
+                .get(id)
+                .is_some_and(|o| o.is_token && o.controller == P0)
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "issue #5989: no Demon token was created — the reflexive copy effect \
+                 never fired; battlefield={:?}",
+                runner.state().battlefield
+            )
+        });
+
+    let demon_obj = &runner.state().objects[&demon];
+    assert_eq!(
+        demon_obj.power,
+        Some(5),
+        "the copy must be a 5/5, got power={:?}",
+        demon_obj.power
+    );
+    assert_eq!(
+        demon_obj.toughness,
+        Some(5),
+        "the copy must be a 5/5, got toughness={:?}",
+        demon_obj.toughness
+    );
+    assert!(
+        demon_obj
+            .card_types
+            .subtypes
+            .iter()
+            .any(|s| s.eq_ignore_ascii_case("Demon")),
+        "the copy must be a Demon, got subtypes={:?}",
+        demon_obj.card_types.subtypes
+    );
+    assert_ne!(
+        demon, opp_grave_creature,
+        "the token must be a NEW, distinct object — not the original exiled creature itself"
+    );
+}

--- a/crates/engine/tests/integration/issue_5989_ardyn_exile_copy.rs
+++ b/crates/engine/tests/integration/issue_5989_ardyn_exile_copy.rs
@@ -1,36 +1,38 @@
 //! Regression for GitHub issue #5989 — Ardyn, the Usurper's combat-trigger
-//! ability that exiles a graveyard creature and creates a copy of it as a 5/5
-//! black Demon.
+//! ability that exiles a graveyard creature card and creates a copy of it as
+//! a 5/5 black Demon.
 //!
-//! Oracle (Final Fantasy crossover, verified via Scryfall):
-//!   "At the beginning of combat on your turn, you may exile up to one
-//!   target creature card from a graveyard. When you exile a card this way,
-//!   create a token that's a copy of it, except it's a 5/5 black Demon."
+//! Oracle (Final Fantasy, verified via Scryfall — exact current wording):
+//!   "Demons you control have menace, lifelink, and haste.
+//!    Starscourge — At the beginning of combat on your turn, exile up to one
+//!    target creature card from a graveyard. If you exiled a card this way,
+//!    create a token that's a copy of that card, except it's a 5/5 black
+//!    Demon."
 //!
-//! Root cause: `strip_if_you_do_conditional` (the reflexive "when you <verb>
-//! this way" gate recognizer) only had active-voice combinators for
-//! "you discard"/"you sacrifice" this way — no "you exile this way" arm. The
-//! entire "when you exile a card this way, create a token…" clause fell
-//! through to `Effect::Unimplemented`, so the ability exiled a card and then
-//! silently did nothing — matching the reported "I have to make the copy
-//! myself" symptom. Fixed by adding `parse_you_exile_this_way_clause`
-//! (`parser/oracle_nom/condition.rs`), mirroring the existing discard/
-//! sacrifice siblings, and wiring it into `strip_if_you_do_conditional`.
+//! Root cause: `strip_if_you_do_conditional` (the reflexive "you <verb> this
+//! way" gate recognizer) had no active-voice exile arm at all, and the card's
+//! actual reflexive clause is the active-PAST "If you exiled a card this
+//! way," — an "if "-prefixed form the passive article-first combinator can't
+//! consume either. The whole "If you exiled a card this way, create a
+//! token…" clause fell through to `Effect::Unimplemented`, so the ability
+//! exiled the target and then silently did nothing — the reported "I have to
+//! make the copy myself" symptom. Fixed by `parse_you_exile_this_way_clause`
+//! (`parser/oracle_nom/condition.rs`), which accepts both tenses
+//! ("exile"/"exiled"), wired into `strip_if_you_do_conditional` under BOTH
+//! the "if " and "when " prefixes (like the other hoisted active arms).
 //!
-//! This test drives the real activation -> target-selection -> exile ->
-//! reflexive-copy pipeline through the actual game-action interface (not a
-//! bare `resolve_ability_chain` call with pre-empty targets — this ability
-//! is genuinely TARGETED, so target selection must happen at announce time,
-//! same lesson as `issue_4948_samwise_gamgee_sacrifice_target_order.rs`).
-//! The combat-trigger condition itself ("at the beginning of combat") is not
-//! the bug and is replaced with a trivial activation cost so the body can be
-//! driven directly via `GameAction::ActivateAbility`.
+//! This test drives the PRINTED path end to end: the real begin-combat
+//! trigger (not a hand-written activated approximation) parsed from Ardyn's
+//! full, exact Oracle text — turn advances into BeginCombat, the trigger
+//! fires, its "up to one target" slot pauses for selection between two legal
+//! candidates, the exile resolves mandatorily (no "you may" in the printed
+//! text), and the reflexive copy must follow automatically.
 //!
 //! Discriminating scenario: TWO legal graveyard targets so target selection
 //! genuinely pauses instead of auto-resolving a lone candidate (the #4948
 //! single-legal-target auto-resolve lesson), one in EACH player's graveyard
-//! — per the issue's own "only works for my own graveyard" claim, which
-//! this test disproves: the parsed target filter carries no controller
+//! — per the issue's own "only works for my own graveyard" claim, which this
+//! test disproves: the parsed target filter carries no controller
 //! restriction.
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
@@ -38,35 +40,39 @@ use engine::types::ability::TargetRef;
 use engine::types::actions::GameAction;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
-const ARDYN_ORACLE: &str = "{0}: You may exile up to one target creature card from a \
-     graveyard. When you exile a card this way, create a token that's a copy of it, \
-     except it's a 5/5 black Demon.";
+/// Ardyn's full, exact current Oracle text (Scryfall), including the Demon
+/// keyword-grant static and the `Starscourge —` ability word — the test must
+/// prove the printed card, not a paraphrase.
+const ARDYN_ORACLE: &str = "Demons you control have menace, lifelink, and haste.\n\
+    Starscourge — At the beginning of combat on your turn, exile up to one target \
+    creature card from a graveyard. If you exiled a card this way, create a token \
+    that's a copy of that card, except it's a 5/5 black Demon.";
 
-fn ardyn_ability_index(runner: &GameRunner, ardyn: ObjectId) -> usize {
-    runner
-        .state()
-        .objects
-        .get(&ardyn)
-        .expect("ardyn on battlefield")
-        .abilities
-        .iter()
-        .position(|a| a.cost.is_some())
-        .expect("Ardyn has a costed activated ability")
+fn find_new_token(runner: &GameRunner, known: &[ObjectId]) -> Option<ObjectId> {
+    runner.state().battlefield.iter().copied().find(|id| {
+        !known.contains(id)
+            && runner
+                .state()
+                .objects
+                .get(id)
+                .is_some_and(|o| o.is_token && o.controller == P0)
+    })
 }
 
 #[test]
-fn ardyn_exiles_opponents_graveyard_creature_and_creates_5_5_black_demon_copy() {
+fn ardyn_combat_trigger_exiles_opponents_graveyard_creature_and_copies_it_as_demon() {
     let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
 
-    let ardyn = scenario
-        .add_creature_from_oracle(P0, "Ardyn, the Usurper", 4, 4, ARDYN_ORACLE)
-        .id();
+    scenario.add_creature_from_oracle(P0, "Ardyn, the Usurper", 4, 4, ARDYN_ORACLE);
 
     // Two legal targets — one in EACH player's graveyard — so target
     // selection genuinely pauses (a lone candidate auto-resolves inline on
-    // this engine, defeating the point of choosing one) and the fix's "any
+    // this engine, defeating the point of choosing one) and the "any
     // graveyard, not just yours" claim is actually exercised.
     let own_grave_creature = scenario
         .add_creature_to_graveyard(P0, "Own Graveyard Golem", 3, 3)
@@ -76,21 +82,24 @@ fn ardyn_exiles_opponents_graveyard_creature_and_creates_5_5_black_demon_copy() 
         .id();
 
     let mut runner = scenario.build();
-    let ability_index = ardyn_ability_index(&runner, ardyn);
-    runner
-        .act(GameAction::ActivateAbility {
-            source_id: ardyn,
-            ability_index,
-        })
-        .expect("activating Ardyn's ability must succeed");
 
-    // "You may exile up to one target ..." manifests as an OPTIONAL target
-    // slot (min 0, max 1), not a separate accept/decline prompt — this is a
-    // genuine CR 601.2c target, resolved at announce time.
-    let WaitingFor::TargetSelection { target_slots, .. } = runner.state().waiting_for.clone()
+    // Advance out of the pre-combat main phase; the begin-combat trigger
+    // fires as the game enters BeginCombat on P0's own turn.
+    runner.pass_both_players();
+    assert_eq!(
+        runner.state().phase,
+        Phase::BeginCombat,
+        "the game must be at the beginning of combat for Starscourge to fire"
+    );
+
+    // "up to one target creature card from a graveyard": a genuine optional
+    // target slot on the TRIGGER, chosen when the trigger goes on the stack.
+    let WaitingFor::TriggerTargetSelection { target_slots, .. } =
+        runner.state().waiting_for.clone()
     else {
         panic!(
-            "expected a TargetSelection prompt for the optional exile target, got {:?}",
+            "expected a TriggerTargetSelection prompt for Starscourge's optional \
+             exile target, got {:?}",
             runner.state().waiting_for
         );
     };
@@ -113,22 +122,20 @@ fn ardyn_exiles_opponents_graveyard_creature_and_creates_5_5_black_demon_copy() 
         })
         .expect("choosing the opponent's graveyard creature must succeed");
 
-    // Let the activated ability resolve off the stack. The TARGET is locked
-    // in at announce time (CR 601.2c, already done above), but whether the
-    // "you may" instruction is actually PERFORMED is decided separately at
-    // resolution time.
-    runner.pass_both_players();
-    runner.advance_until_stack_empty();
+    let known: Vec<ObjectId> = runner.state().battlefield.iter().copied().collect();
 
-    match runner.state().waiting_for.clone() {
-        WaitingFor::OptionalEffectChoice { player, .. } => {
-            assert_eq!(player, P0, "the controller must be asked, not the opponent");
-            runner
-                .act(GameAction::DecideOptionalEffect { accept: true })
-                .expect("accepting the optional exile must succeed");
-        }
-        other => panic!("expected an OptionalEffectChoice prompt for \"you may\", got {other:?}"),
-    }
+    // Resolve the trigger off the stack. The printed instruction has no
+    // "you may": once a target was chosen, the exile is mandatory, so no
+    // optional-effect prompt may interpose.
+    runner.advance_until_stack_empty();
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "the printed exile is mandatory (no \"you may\") — got an unexpected \
+         optional-effect prompt"
+    );
 
     assert_eq!(
         runner
@@ -137,42 +144,31 @@ fn ardyn_exiles_opponents_graveyard_creature_and_creates_5_5_black_demon_copy() 
             .get(&opp_grave_creature)
             .map(|o| o.zone),
         Some(Zone::Exile),
-        "the chosen creature must actually be exiled"
+        "the chosen creature card must actually be exiled"
     );
 
-    // The reflexive "when you exile a card this way, create a token copy of
-    // it" must have fired automatically — no further player action needed.
-    let demon = runner
-        .state()
-        .battlefield
-        .iter()
-        .copied()
-        .find(|id| {
-            runner
-                .state()
-                .objects
-                .get(id)
-                .is_some_and(|o| o.is_token && o.controller == P0)
-        })
-        .unwrap_or_else(|| {
-            panic!(
-                "issue #5989: no Demon token was created — the reflexive copy effect \
-                 never fired; battlefield={:?}",
-                runner.state().battlefield
-            )
-        });
+    // The reflexive "If you exiled a card this way, create a token that's a
+    // copy of that card, except it's a 5/5 black Demon" must have fired
+    // automatically — no further player action needed.
+    let demon = find_new_token(&runner, &known).unwrap_or_else(|| {
+        panic!(
+            "issue #5989: no token was created — the reflexive copy clause \
+             never fired; battlefield={:?}",
+            runner.state().battlefield
+        )
+    });
 
     let demon_obj = &runner.state().objects[&demon];
     assert_eq!(
-        demon_obj.power,
-        Some(5),
-        "the copy must be a 5/5, got power={:?}",
-        demon_obj.power
+        demon_obj.name, "Opponent's Graveyard Bear",
+        "the token must be a COPY OF THAT CARD (the exiled Bear), got name={:?}",
+        demon_obj.name
     );
     assert_eq!(
-        demon_obj.toughness,
-        Some(5),
-        "the copy must be a 5/5, got toughness={:?}",
+        (demon_obj.power, demon_obj.toughness),
+        (Some(5), Some(5)),
+        "the copy must be a 5/5 (the \"except\" clause), got {:?}/{:?}",
+        demon_obj.power,
         demon_obj.toughness
     );
     assert!(
@@ -186,6 +182,14 @@ fn ardyn_exiles_opponents_graveyard_creature_and_creates_5_5_black_demon_copy() 
     );
     assert_ne!(
         demon, opp_grave_creature,
-        "the token must be a NEW, distinct object — not the original exiled creature itself"
+        "the token must be a NEW, distinct object — not the original exiled card itself"
+    );
+
+    // Full-card cross-check: the first printed line ("Demons you control have
+    // menace, lifelink, and haste.") must reach the new Demon token too.
+    assert!(
+        demon_obj.keywords.contains(&Keyword::Haste),
+        "Ardyn's own Demon anthem must grant the new Demon token haste, got {:?}",
+        demon_obj.keywords
     );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -554,6 +554,7 @@ mod issue_5978_roar_chapter_ii_creature_mana;
 mod issue_5983_sothera_dies_edict;
 mod issue_5984_aloy_discover_on_attack;
 mod issue_5988_braids_arisen_nightmare;
+mod issue_5989_ardyn_exile_copy;
 mod issue_5996_planetarium_look_cast;
 mod issue_5997_malcolm_treasure_trigger;
 mod issue_5999_aura_exile_host;


### PR DESCRIPTION
Fixes #5989.

Ardyn, the Usurper: "At the beginning of combat on your turn, you may exile up to one target creature card from a graveyard. When you exile a card this way, create a token that's a copy of it, except it's a 5/5 black Demon."

## Root cause & fix

`strip_if_you_do_conditional` (the reflexive "when you <verb> this way" gate recognizer) already had active-voice combinators for "you discard"/"you sacrifice" this way, but no "you exile" arm. The entire "When you exile a card this way, create a token..." clause fell through to `Effect::Unimplemented` — the ability exiled the target and then silently did nothing, matching the reported "I have to make the copy myself" symptom.

Fixed by adding `parse_you_exile_this_way_clause` (`parser/oracle_nom/condition.rs`), mirroring the existing `parse_you_discard_this_way_clause` / `parse_you_sacrifice_this_way_clause` siblings (same active-voice grammar, differing only in the verb and that exile's destination isn't fixed to a single zone the way discard/sacrifice are), and wiring it into `strip_if_you_do_conditional` (`parser/oracle_effect/conditions.rs`) alongside the existing two.

Also investigated the issue's own paraphrase — "only works if I do it to my graveyard" — and disproved it: the parsed exile target filter carries no controller restriction (any player's graveyard is a legal source), so this reads as an imprecise description of the same underlying "nothing happens" bug, not a second, narrower defect.

## Testing

New end-to-end test drives the real activate → target-selection → resolve → optional-effect-decision → reflexive-copy pipeline (not a hand-built `ResolvedAbility`), with two legal graveyard targets — one in EACH player's graveyard — so target selection genuinely pauses and the opponent's-graveyard case is explicitly exercised. Confirms the resulting token is a distinct 5/5 black Demon.

Verified locally: fmt clean, clippy clean (`-D warnings`), full integration suite 3546 tests (3543 pre-existing + 2 pre-existing ignored + 1 new), 0 regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of Oracle text using the “you exile… this way” idiom.
  * Correctly links exile-conditions to reflexive “this way” clauses so follow-up effects fire as intended.
  * Ensures the resulting token copy behavior matches the exiled card’s expected characteristics and related abilities.
* **Tests**
  * Added regression coverage for Ardyn, the Usurper’s exile-and-copy interaction (including correct gating behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->