### PR TITLE
fix(parser): parse the ordinal gate on "the Nth spell you cast each turn costs less"

### DIFF
--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -1957,27 +1957,73 @@ pub(crate) fn inject_keyword_kind_filter_prop(
 }
 
 /// CR 601.2f: Classification of a cost-modifier subject against the
-/// "the first <qualifier> spell <timing> costs …" template.
+/// "the <ordinal> <qualifier> spell <timing> costs …" template.
 ///
 /// Three outcomes, kept as a typed enum rather than an `Option` so the caller
-/// can tell "not a first-spell line" apart from "a first-spell line whose
+/// can tell "not an Nth-spell line" apart from "an Nth-spell line whose
 /// qualifier we can't yet represent." The latter MUST decline the whole cost
 /// static — emitting a filterless, gateless reducer would silently drop both
-/// the printed "first … each turn" once-per-turn restriction and the qualifier
-/// (e.g. "kicked"), reducing every spell the controller casts.
-pub(crate) enum FirstQualifiedSpell {
-    /// The subject is not a "the first … spell <timing> costs …" line; the
+/// the printed "<ordinal> … each turn" once-per-turn restriction and the
+/// qualifier (e.g. "kicked"), reducing every spell the controller casts.
+pub(crate) enum NthQualifiedSpell {
+    /// The subject is not a "the <ordinal> … spell <timing> costs …" line; the
     /// caller proceeds with its ordinary cost-modifier parsing.
     NotApplicable,
-    /// A representable first-spell subject: the qualifying spell filter and the
-    /// timing window over which "first" is measured.
-    Supported(TargetFilter, NthEventTimingKind),
-    /// The "the first … spell <timing>" shape is present, but the qualifier or
+    /// A representable Nth-spell subject: the qualifying spell filter, the timing
+    /// window over which the ordinal is measured, and the 1-based ordinal `N`
+    /// ("first" → 1, "second" → 2, …). The gate is
+    /// `SpellsCastThisTurn(filter) == N - 1` (see [`nth_qualified_spell_condition`]).
+    Supported {
+        filter: TargetFilter,
+        timing: NthEventTimingKind,
+        ordinal: u32,
+    },
+    /// The "the <ordinal> … spell <timing>" shape is present, but the qualifier or
     /// timing window can't be lowered to a spell filter + once-per-turn gate
     /// (e.g. "the first kicked spell you cast each turn" — kicker-paid state is
     /// not a representable spell-cost filter, or an opponent-/their-turn window
     /// with no static condition). The caller must decline the cost static.
     UnsupportedQualifier,
+}
+
+/// CR 601.2f: Parse the leading "the <ordinal> " of an
+/// "the <ordinal> <qualifier> spell <timing> costs/has …" subject, returning the
+/// 1-based ordinal (`"first"` → 1, `"second"` → 2, …) and the remaining subject.
+///
+/// Parameterizes what was a hardcoded `"the first "` prefix so every printed
+/// ordinal — not just the first — is covered (Highspire Bell-Ringer, Uthros
+/// Psionicist, Monk Class, Raging Battle Mouse, and Alisaie Leveilleur all print
+/// "the second spell you cast each turn costs …"). The ordinal threads into
+/// [`nth_qualified_spell_condition`] as the `SpellsCastThisTurn == N - 1` gate.
+fn parse_spell_ordinal_prefix(subject: &str) -> Option<(u32, &str)> {
+    preceded(
+        tag::<_, _, OracleError<'_>>("the "),
+        terminated(parse_ordinal_word, tag(" ")),
+    )
+    .parse(subject)
+    .ok()
+    .map(|(rest, ordinal)| (ordinal, rest))
+}
+
+/// Map an English ordinal word to its 1-based value. Only "first"/"second" occur
+/// on printed once-per-turn spell-cost modifiers today; the higher ordinals are
+/// included so the whole ordinal class stays covered without a follow-up edit.
+/// The trailing `" "` guard in [`parse_spell_ordinal_prefix`] enforces a word
+/// boundary, so "firstborn" / "seconds" never partial-match.
+fn parse_ordinal_word(i: &str) -> OracleResult<'_, u32> {
+    alt((
+        value(1u32, tag("first")),
+        value(2, tag("second")),
+        value(3, tag("third")),
+        value(4, tag("fourth")),
+        value(5, tag("fifth")),
+        value(6, tag("sixth")),
+        value(7, tag("seventh")),
+        value(8, tag("eighth")),
+        value(9, tag("ninth")),
+        value(10, tag("tenth")),
+    ))
+    .parse(i)
 }
 
 /// CR 601.2f + CR 107.3: Parse a "first qualified spell <timing> costs less"
@@ -2004,13 +2050,13 @@ pub(crate) enum FirstQualifiedSpell {
 ///   - "The first non-Lemur creature spell with flying you cast during each of
 ///     your turns costs {1} less to cast."
 ///
-/// Returns [`FirstQualifiedSpell::UnsupportedQualifier`] when the
-/// "the first … spell <timing>" shape is present but the qualifier/timing can't
-/// be represented (e.g. "the first kicked spell you cast each turn"), so the
-/// caller declines the static instead of emitting a broad reducer.
-pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedSpell {
-    let Some(after_prefix) = nom_tag_lower(lower, lower, "the first ") else {
-        return FirstQualifiedSpell::NotApplicable;
+/// Returns [`NthQualifiedSpell::UnsupportedQualifier`] when the
+/// "the <ordinal> … spell <timing>" shape is present but the qualifier/timing
+/// can't be represented (e.g. "the first kicked spell you cast each turn"), so
+/// the caller declines the static instead of emitting a broad reducer.
+pub(crate) fn parse_nth_qualified_spell_filter(lower: &str) -> NthQualifiedSpell {
+    let Some((ordinal, after_prefix)) = parse_spell_ordinal_prefix(lower) else {
+        return NthQualifiedSpell::NotApplicable;
     };
 
     // Split the subject at the cast infix that separates the pre-spell
@@ -2018,7 +2064,7 @@ pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedS
     // ("with {X} in its mana cost each turn cost[s] ..."). CR templating always
     // places the caster phrase between the spell noun and any post-spell modifier.
     let Some((pre, post)) = split_first_spell_cast_region(after_prefix) else {
-        return FirstQualifiedSpell::NotApplicable;
+        return NthQualifiedSpell::NotApplicable;
     };
 
     // Scan the post-caster region for the timing phrase. Everything before
@@ -2029,7 +2075,7 @@ pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedS
     // phrase means this is some other "the first … you cast" construction, not
     // the per-turn first-spell cost template.
     let Some((timing, post_modifier_text)) = split_first_spell_timing(post.trim()) else {
-        return FirstQualifiedSpell::NotApplicable;
+        return NthQualifiedSpell::NotApplicable;
     };
 
     // From here the "the first … spell <timing> costs …" shape is confirmed, so
@@ -2045,7 +2091,7 @@ pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedS
         timing,
         NthEventTimingKind::Unrestricted | NthEventTimingKind::Restricted(PlayerFilter::Controller)
     ) {
-        return FirstQualifiedSpell::UnsupportedQualifier;
+        return NthQualifiedSpell::UnsupportedQualifier;
     }
 
     // Pre-spell type/keyword qualifier (strip a bare trailing "spell" noun so a
@@ -2098,7 +2144,7 @@ pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedS
         } else {
             // Unrecognized pre-spell qualifier — decline rather than emit a cost
             // reduction that ignores the printed restriction.
-            return FirstQualifiedSpell::UnsupportedQualifier;
+            return NthQualifiedSpell::UnsupportedQualifier;
         }
     };
 
@@ -2110,7 +2156,7 @@ pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedS
     } else {
         match super::oracle_trigger::parse_post_spell_modifier(post_modifier_text) {
             Some(filter) => Some(filter),
-            None => return FirstQualifiedSpell::UnsupportedQualifier,
+            None => return NthQualifiedSpell::UnsupportedQualifier,
         }
     };
 
@@ -2121,14 +2167,18 @@ pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedS
             filters: vec![a, b],
         },
     };
-    FirstQualifiedSpell::Supported(filter, timing)
+    NthQualifiedSpell::Supported {
+        filter,
+        timing,
+        ordinal,
+    }
 }
 
-/// CR 601.2f: Audit that a "the first … spell <timing> has [keyword]" subject is
-/// FULLY represented by `parse_first_qualified_spell_filter` — i.e. the text
+/// CR 601.2f: Audit that a "the <ordinal> … spell <timing> has [keyword]" subject
+/// is FULLY represented by `parse_nth_qualified_spell_filter` — i.e. the text
 /// AFTER the timing phrase is empty.
 ///
-/// `parse_first_qualified_spell_filter` discards everything after the timing
+/// `parse_nth_qualified_spell_filter` discards everything after the timing
 /// phrase (the cost-modification verb on the cost-reducer path, "costs {1} less
 /// …"). On the keyword-grant path the grant verb was already split off by the
 /// caller, so a clean subject must terminate at the timing phrase. Any trailing
@@ -2140,9 +2190,9 @@ pub(crate) fn parse_first_qualified_spell_filter(lower: &str) -> FirstQualifiedS
 /// Lives next to the parser whose discard it audits. Called ONLY from the
 /// keyword-grant arm — the cost-modifier consumer legitimately expects trailing
 /// cost-verb text, so this guard must NOT move into the shared
-/// `parse_first_qualified_spell_filter`.
-pub(crate) fn first_qualified_spell_subject_fully_consumed(subject: &str) -> bool {
-    let Some(after_prefix) = nom_tag_lower(subject, subject, "the first ") else {
+/// `parse_nth_qualified_spell_filter`.
+pub(crate) fn nth_qualified_spell_subject_fully_consumed(subject: &str) -> bool {
+    let Some((_ordinal, after_prefix)) = parse_spell_ordinal_prefix(subject) else {
         return false;
     };
     let Some((_, post)) = split_first_spell_cast_region(after_prefix) else {
@@ -2209,16 +2259,20 @@ fn split_first_spell_timing(text: &str) -> Option<(NthEventTimingKind, &str)> {
     Some((timing, before.trim_end()))
 }
 
-/// CR 601.2f + CR 107.3: Build the "first qualified spell <timing>" gate.
-/// The reduction applies only while no matching spell has yet been cast this
-/// turn (`SpellsCastThisTurn(filter) == 0`). The timing axis adds a turn-owner
-/// restriction only for the "during each of your turns" form; "each turn" allows
-/// the first qualifying spell on any player's turn.
-pub(crate) fn first_qualified_spell_condition(
+/// CR 601.2f + CR 107.3: Build the "the <ordinal> qualified spell <timing>" gate.
+/// The 1-based `ordinal` (`"first"` → 1, `"second"` → 2, …) lowers to
+/// `SpellsCastThisTurn(filter) == ordinal - 1`: the reduction applies precisely
+/// while exactly `ordinal - 1` matching spells have already been cast this turn,
+/// so the spell now being cast is the Nth (the currently-casting spell is not yet
+/// counted, matching the merged `first == 0` behavior). The timing axis adds a
+/// turn-owner restriction only for the "during each of your turns" form; "each
+/// turn" allows the Nth qualifying spell on any player's turn.
+pub(crate) fn nth_qualified_spell_condition(
     filter: &TargetFilter,
     timing: &NthEventTimingKind,
+    ordinal: u32,
 ) -> StaticCondition {
-    let first_this_turn = StaticCondition::QuantityComparison {
+    let nth_this_turn = StaticCondition::QuantityComparison {
         lhs: QuantityExpr::Ref {
             qty: QuantityRef::SpellsCastThisTurn {
                 scope: CountScope::Controller,
@@ -2226,17 +2280,19 @@ pub(crate) fn first_qualified_spell_condition(
             },
         },
         comparator: Comparator::EQ,
-        rhs: QuantityExpr::Fixed { value: 0 },
+        rhs: QuantityExpr::Fixed {
+            value: ordinal as i32 - 1,
+        },
     };
 
     match timing {
-        // "each turn" — no turn-ownership restriction (CR 601.2: the first
+        // "each turn" — no turn-ownership restriction (CR 601.2: the Nth
         // qualifying spell of the turn regardless of whose turn it is).
-        NthEventTimingKind::Unrestricted => first_this_turn,
+        NthEventTimingKind::Unrestricted => nth_this_turn,
         // "during each of your turns" — additionally gate on the controller's
         // turn (CR 102.1 active-player reading for a cost static).
         NthEventTimingKind::Restricted(PlayerFilter::Controller) => StaticCondition::And {
-            conditions: vec![StaticCondition::DuringYourTurn, first_this_turn],
+            conditions: vec![StaticCondition::DuringYourTurn, nth_this_turn],
         },
         // Other player-scoped turn windows have no representable `StaticCondition`
         // for a cost static; the caller declines these via the filter parser.

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -339,26 +339,30 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
     // [keyword]" — a once-per-turn keyword grant gated on the first qualifying
     // spell of the turn (Peri Brown, The Twelfth Doctor, Maelstrom Nexus,
     // Wild-Magic Sorcerer, Current Curriculum). Reuses the same
-    // `parse_first_qualified_spell_filter` grammar + `first_qualified_spell_condition`
+    // `parse_nth_qualified_spell_filter` grammar + `nth_qualified_spell_condition`
     // gate as the paired cost-modifier consumer, so the qualifying spell filter,
     // cast-origin restriction, and `SpellsCastThisTurn == 0` gate are all preserved
     // instead of collapsing to "every spell you cast".
-    match parse_first_qualified_spell_filter(subject) {
-        // Not a first-qualified-spell line — fall through to the ordinary
+    match parse_nth_qualified_spell_filter(subject) {
+        // Not an Nth-qualified-spell line — fall through to the ordinary
         // "[type] spells you cast [from zone] have [keyword]" patterns below.
-        FirstQualifiedSpell::NotApplicable => {}
+        NthQualifiedSpell::NotApplicable => {}
         // The shape is present but the qualifier/timing isn't representable. Fall
         // through (NOT a `return None`) so the existing gateless static is
         // preserved for not-yet-representable qualifiers — no regression.
-        FirstQualifiedSpell::UnsupportedQualifier => {}
-        FirstQualifiedSpell::Supported(filter, timing) => {
-            // CR 601.2f: trailing-residue guard. `parse_first_qualified_spell_filter`
+        NthQualifiedSpell::UnsupportedQualifier => {}
+        NthQualifiedSpell::Supported {
+            filter,
+            timing,
+            ordinal,
+        } => {
+            // CR 601.2f: trailing-residue guard. `parse_nth_qualified_spell_filter`
             // discards any text after the timing phrase; if that region is
             // non-empty an unrepresentable qualifier was dropped (Rain of Riches'
             // "that mana from a Treasure was spent to cast"; TARDIS Bay's
             // post-timing "with mana value 2 or greater"). Decline rather than emit
             // a residue-blind gate — fall through to the existing gateless static.
-            if first_qualified_spell_subject_fully_consumed(subject) {
+            if nth_qualified_spell_subject_fully_consumed(subject) {
                 // CR 601.2a: scope `ControllerRef::You` to every leaf (And/Not
                 // recursion) so an opponent's qualifying spell never qualifies.
                 let affected =
@@ -369,12 +373,12 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
                 // TARDIS Bay itself declines above because its MV qualifier follows
                 // the timing). When a leading "during your turn," scope was already
                 // stripped, combine both rather than dropping either.
-                let first_qualified = first_qualified_spell_condition(&filter, &timing);
+                let nth_qualified = nth_qualified_spell_condition(&filter, &timing, ordinal);
                 let combined_condition = match condition.clone() {
                     Some(leading) => StaticCondition::And {
-                        conditions: vec![leading, first_qualified],
+                        conditions: vec![leading, nth_qualified],
                     },
-                    None => first_qualified,
+                    None => nth_qualified,
                 };
                 return Some(
                     StaticDefinition::new(StaticMode::CastWithKeyword { keyword })

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -543,7 +543,7 @@ pub(crate) fn try_parse_cost_modification(
         None
     };
 
-    let first_qualified_spell = match parse_first_qualified_spell_filter(lower) {
+    let nth_qualified_spell = match parse_nth_qualified_spell_filter(lower) {
         // CR 601.2f: A recognized "the first … spell <timing> costs …" subject
         // whose qualifier/timing can't be lowered to a filter + once-per-turn
         // gate (e.g. "the first kicked spell you cast each turn costs {1} less").
@@ -551,11 +551,15 @@ pub(crate) fn try_parse_cost_modification(
         // cost-modifier path would emit a filterless, conditionless reducer that
         // drops both the printed "first … each turn" restriction and the
         // qualifier, reducing every spell the controller casts.
-        FirstQualifiedSpell::UnsupportedQualifier => return None,
-        FirstQualifiedSpell::NotApplicable => None,
-        FirstQualifiedSpell::Supported(filter, timing) => Some((filter, timing)),
+        NthQualifiedSpell::UnsupportedQualifier => return None,
+        NthQualifiedSpell::NotApplicable => None,
+        NthQualifiedSpell::Supported {
+            filter,
+            timing,
+            ordinal,
+        } => Some((filter, timing, ordinal)),
     };
-    let first_qualified_spell_filter = first_qualified_spell.as_ref().map(|(filter, _)| filter);
+    let nth_qualified_spell_filter = nth_qualified_spell.as_ref().map(|(filter, _, _)| filter);
     let target_cost_filter = parse_cost_modifier_target_filter(lower);
 
     // Extract "from [zone(s)]" clause between player scope and "cost".
@@ -600,7 +604,7 @@ pub(crate) fn try_parse_cost_modification(
     let mut during_your_turn_scope = None;
     let spell_filter = if is_self_spell {
         parse_self_spell_target_cost_filter(lower)
-    } else if let Some(filter) = first_qualified_spell_filter.cloned() {
+    } else if let Some(filter) = nth_qualified_spell_filter.cloned() {
         Some(filter)
     // allow-noncombinator: moved legacy static parser code; refactor-only split preserves behavior.
     } else if let Some(cost_idx) = lower.find(" cost") {
@@ -875,8 +879,8 @@ pub(crate) fn try_parse_cost_modification(
     if is_self_spell {
         definition.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
     }
-    if let Some((filter, timing)) = first_qualified_spell.as_ref() {
-        definition.condition = Some(first_qualified_spell_condition(filter, timing));
+    if let Some((filter, timing, ordinal)) = nth_qualified_spell.as_ref() {
+        definition.condition = Some(nth_qualified_spell_condition(filter, timing, *ordinal));
     } else if let Some(during_your_turn_scope) = during_your_turn_scope {
         definition.condition = Some(during_your_turn_scope);
     }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -22852,14 +22852,20 @@ fn static_rain_of_riches_treasure_qualifier_declined_to_existing() {
 }
 
 #[test]
-fn first_qualified_spell_filter_bare_historic_supported() {
+fn nth_qualified_spell_filter_bare_historic_supported() {
     // CR 700.6: bare "historic spell" must lower to a Historic-property filter.
-    let result = super::grammar::parse_first_qualified_spell_filter(
+    let result = super::grammar::parse_nth_qualified_spell_filter(
         "the first historic spell you cast each turn",
     );
-    let super::grammar::FirstQualifiedSpell::Supported(filter, timing) = result else {
-        panic!("expected Supported, got a non-Supported FirstQualifiedSpell");
+    let super::grammar::NthQualifiedSpell::Supported {
+        filter,
+        timing,
+        ordinal,
+    } = result
+    else {
+        panic!("expected Supported, got a non-Supported NthQualifiedSpell");
     };
+    assert_eq!(ordinal, 1, "\"the first …\" is ordinal 1");
     assert_eq!(
         timing,
         super::oracle_trigger::NthEventTimingKind::Unrestricted
@@ -22871,29 +22877,75 @@ fn first_qualified_spell_filter_bare_historic_supported() {
 }
 
 #[test]
-fn first_qualified_spell_subject_residue_rejected() {
+fn nth_qualified_spell_filter_second_spell_gates_on_one_prior_cast() {
+    // CR 601.2f: "the second spell you cast each turn costs {N} less" must NOT
+    // collapse to a filterless, conditionless reducer (which would cheapen every
+    // spell). The ordinal threads to `SpellsCastThisTurn == ordinal - 1`, so the
+    // reduction applies only while exactly one qualifying spell has already been
+    // cast this turn (the spell now being cast is the second).
+    let result =
+        super::grammar::parse_nth_qualified_spell_filter("the second spell you cast each turn");
+    let super::grammar::NthQualifiedSpell::Supported {
+        filter,
+        timing,
+        ordinal,
+    } = result
+    else {
+        panic!("expected Supported, got a non-Supported NthQualifiedSpell");
+    };
+    assert_eq!(ordinal, 2, "\"the second …\" is ordinal 2");
+    assert_eq!(
+        timing,
+        super::oracle_trigger::NthEventTimingKind::Unrestricted
+    );
+
+    let condition = super::grammar::nth_qualified_spell_condition(&filter, &timing, ordinal);
+    let StaticCondition::QuantityComparison {
+        lhs,
+        comparator,
+        rhs,
+    } = condition
+    else {
+        panic!("expected a bare QuantityComparison for the unrestricted-timing form");
+    };
+    assert_eq!(comparator, Comparator::EQ);
+    assert!(matches!(
+        lhs,
+        QuantityExpr::Ref {
+            qty: QuantityRef::SpellsCastThisTurn {
+                scope: CountScope::Controller,
+                ..
+            },
+        }
+    ));
+    // The second spell ⇒ one qualifying spell already cast this turn.
+    assert_eq!(rhs, QuantityExpr::Fixed { value: 1 });
+}
+
+#[test]
+fn nth_qualified_spell_subject_residue_rejected() {
     // CR 601.2f: a subject with non-empty post-timing residue is NOT fully
     // consumed; a clean "...each turn" subject is.
     assert!(
-        !super::grammar::first_qualified_spell_subject_fully_consumed(
+        !super::grammar::nth_qualified_spell_subject_fully_consumed(
             "the first spell you cast each turn that mana from a treasure was spent to cast"
         ),
         "Treasure residue must report not-fully-consumed"
     );
     assert!(
-        !super::grammar::first_qualified_spell_subject_fully_consumed(
+        !super::grammar::nth_qualified_spell_subject_fully_consumed(
             "the first spell you cast during each of your turns with mana value 2 or greater"
         ),
         "post-timing MV residue must report not-fully-consumed"
     );
     assert!(
-        super::grammar::first_qualified_spell_subject_fully_consumed(
+        super::grammar::nth_qualified_spell_subject_fully_consumed(
             "the first spell you cast each turn"
         ),
         "clean subject must report fully-consumed"
     );
     assert!(
-        super::grammar::first_qualified_spell_subject_fully_consumed(
+        super::grammar::nth_qualified_spell_subject_fully_consumed(
             "the first spell you cast from exile each turn"
         ),
         "clean from-exile subject must report fully-consumed"

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -667,6 +667,7 @@ mod ninjutsu_cluster;
 mod nissa_ascended_animist_loyalty_token_6012;
 mod nix_counter_no_mana_spent;
 mod no_witnesses_most_creatures_investigate;
+mod nth_spell_ordinal_cost_reduction;
 mod ob_nixilis_captive_kingpin_life_loss;
 mod obeka_splitter_additional_phases;
 mod obliterate_regression;

--- a/crates/engine/tests/integration/nth_spell_ordinal_cost_reduction.rs
+++ b/crates/engine/tests/integration/nth_spell_ordinal_cost_reduction.rs
@@ -1,0 +1,91 @@
+//! CR 601.2f regression (runtime cast pipeline): an ordinal "the second spell you
+//! cast each turn costs {N} less" cost reducer (Highspire Bell-Ringer, Uthros
+//! Psionicist, Monk Class, Raging Battle Mouse, Alisaie Leveilleur) must discount
+//! ONLY the second qualifying spell of the turn — not the first, not the third.
+//!
+//! Before the parser fix, `parse_nth_qualified_spell_filter` matched only the
+//! literal "the first " prefix, so "the second spell you cast each turn costs {1}
+//! less" fell through to the generic cost-modifier path and emitted a filterless,
+//! conditionless reducer — discounting EVERY spell the controller cast. The fix
+//! parameterizes the ordinal seam so "second" lowers to
+//! `SpellsCastThisTurn(you) == 1`, applied here through the real cost pipeline
+//! (`collect_battlefield_cost_modifiers` → `evaluate_cost_mod_static_condition`).
+//!
+//! This test drives `GameScenario` → `cast().resolve()` and measures the mana
+//! actually spent per cast. On the pre-fix behavior the first cast is discounted
+//! and this test fails (spent1 == 1, not 2).
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+#[test]
+fn second_spell_ordinal_reduction_discounts_only_the_second_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The static source: a battlefield permanent that reduces the SECOND spell
+    // its controller casts each turn by {1}. Verbatim Oracle text so the whole
+    // parse → layers → cost pipeline is exercised (no card-DB dependency).
+    scenario.add_creature_from_oracle(
+        P0,
+        "Ordinal Bell-Ringer",
+        2,
+        1,
+        "The second spell you cast each turn costs {1} less to cast.",
+    );
+
+    // Three {2}-generic vanilla creature spells to cast in sequence.
+    let s1 = scenario
+        .add_creature_to_hand(P0, "Spell One", 1, 1)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let s2 = scenario
+        .add_creature_to_hand(P0, "Spell Two", 1, 1)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let s3 = scenario
+        .add_creature_to_hand(P0, "Spell Three", 1, 1)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let mut runner = scenario.build();
+
+    // Exactly enough colorless mana for full {2} + reduced {1} + full {2} = 5.
+    for _ in 0..5 {
+        runner.state_mut().players[0].mana_pool.add(ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    }
+
+    // Cast 1 (first spell this turn): gate is `SpellsCastThisTurn == 1`, but zero
+    // spells have been cast, so NO discount — pays full {2}.
+    let before1 = runner.state().players[0].mana_pool.total();
+    runner.cast(s1).resolve();
+    let spent1 = before1 - runner.state().players[0].mana_pool.total();
+    assert_eq!(
+        spent1, 2,
+        "the FIRST spell pays full {{2}} (the second-spell gate is not yet satisfied)"
+    );
+
+    // Cast 2 (second spell): one spell already cast this turn ⇒ gate satisfied ⇒
+    // discounted by {1} ⇒ pays {1}.
+    let before2 = runner.state().players[0].mana_pool.total();
+    runner.cast(s2).resolve();
+    let spent2 = before2 - runner.state().players[0].mana_pool.total();
+    assert_eq!(spent2, 1, "the SECOND spell is discounted by {{1}} (2 - 1)");
+
+    // Cast 3 (third spell): two spells already cast ⇒ gate (`== 1`) no longer
+    // satisfied ⇒ full {2} again. This is what distinguishes the ordinal gate
+    // from a plain "spells you cast cost {1} less" reducer.
+    let before3 = runner.state().players[0].mana_pool.total();
+    runner.cast(s3).resolve();
+    let spent3 = before3 - runner.state().players[0].mana_pool.total();
+    assert_eq!(
+        spent3, 2,
+        "the THIRD spell pays full {{2}} again (only the second spell is discounted)"
+    );
+}

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4758
-- **Total card appearances across root causes:** 4792 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4755
+- **Total card appearances across root causes:** 4789 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -13,7 +13,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
 | 1 | Relative-clause / filter restriction on target dropped | 746 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
-| 2 | Dropped intervening-if / gating condition (condition: null) | 606 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
+| 2 | Dropped intervening-if / gating condition (condition: null) | 604 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
 | 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 330 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
@@ -39,7 +39,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 25 | Wrong / dropped effect duration | 29 | oracle_nom/duration.rs — add until-event / two-turn / permanent duration variants |
 | 26 | Delayed / future-phase trigger flattened to immediate effect | 20 | add-trigger: wrap future-phase effects in CreateDelayedTrigger |
 | 27 | Cross-target group / shared-quality constraint dropped | 20 | oracle_target.rs multi_target — add SameController/SameZone/DistinctNames/Parity constraints |
-| 28 | Trigger/activation timing or ordinal restriction dropped | 17 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
+| 28 | Trigger/activation timing or ordinal restriction dropped | 16 | oracle_casting.rs scan_timing_restrictions + trigger constraint parsing |
 | 30 | Token/named-card name corrupted by normalization or overrun | 10 | oracle_util.rs SELF_REF normalization + Named-filter parsing — guard literal 'named X' spans |
 | 31 | Other / uncategorized misparse | 5 | manual triage |
 
@@ -805,7 +805,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 2. Dropped intervening-if / gating condition (condition: null)  (605 cards)
+### 2. Dropped intervening-if / gating condition (condition: null)  (603 cards)
 
 **Signature.** Trigger/static/replacement/spell condition left null though Oracle has an 'if/while/as long as/unless' game-state gate; the effect resolves unconditionally (CR 603.4 / 608.2c).
 
@@ -1224,7 +1224,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Quicksilver Servitor
 - Quilled Charger
 - Rage Extractor
-- Raging Battle Mouse
 - Rakdos, Lord of Riots
 - Rakish Scoundrel
 - Ramses, Assassin Lord
@@ -1364,7 +1363,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Unyaro
 - Urborg Stalker
 - Urza's Miter
-- Uthros Psionicist
 - Vadrik, Astral Archmage
 - Valakut Exploration
 - Valiant Emberkin
@@ -5073,7 +5071,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 28. Trigger/activation timing or ordinal restriction dropped  (15 cards)
+### 28. Trigger/activation timing or ordinal restriction dropped  (14 cards)
 
 **Signature.** A timing/scope restriction (OnlyDuringYourTurn / OncePerTurn / 'during an opponent's turn' / Nth-spell ordinal / cast-timing) is null; the constraint tail is not parsed.
 
@@ -5086,7 +5084,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Goremand
 - Grizzled Wolverine
 - Hermit of the Natterknolls
-- Highspire Bell-Ringer
 - Hurkyl's Final Meditation
 - Ichneumon Druid
 - MACH-1, Swooping Scoundrel


### PR DESCRIPTION
## Summary

The cost-mod ordinal gate was dropped for every ordinal past "first". The parser's
`FirstQualifiedSpell` machinery hard-coded the literal prefix `"the first "` and a
`SpellsCastThisTurn == 0` gate, so **"The second spell you cast each turn costs {N}
less to cast"** returned `NotApplicable` and fell through to the generic
cost-modifier path — emitting a **filterless, conditionless reducer** that
cheapened *every* spell the controller cast, not just the second.

This parameterizes the existing seam by ordinal (`FirstQualifiedSpell` →
`NthQualifiedSpell { filter, timing, ordinal }`; `"first"` → 1, `"second"` → 2, …)
so the gate becomes `SpellsCastThisTurn(you) == ordinal - 1` — exactly `N - 1`
qualifying spells already cast this turn ⇒ the spell now being cast is the Nth.
`"first"` is the unchanged `N = 1` (`== 0`) case, so the merged first-spell
behavior is byte-for-byte preserved. This is a **parameterize-don't-proliferate**
refactor of one combinator seam, not a new sibling; new `parse_spell_ordinal_prefix`
+ `parse_ordinal_word` combinators cover first..tenth.

**Class (5 cards):** Highspire Bell-Ringer, Uthros Psionicist, Raging Battle Mouse,
Monk Class, Alisaie Leveilleur — all print "the second spell you cast each turn
costs {N} less" and all previously cheapened every spell.

## Files changed

- `crates/engine/src/parser/oracle_static/grammar.rs` — new `parse_spell_ordinal_prefix` + `parse_ordinal_word` nom combinators; `FirstQualifiedSpell` → `NthQualifiedSpell { filter, timing, ordinal }`; `parse_nth_qualified_spell_filter` / `nth_qualified_spell_condition` / `nth_qualified_spell_subject_fully_consumed` parameterized by ordinal (gate `== ordinal - 1`).
- `crates/engine/src/parser/oracle_static/static_helpers.rs` — cost-mod consumer threads the ordinal into the condition builder.
- `crates/engine/src/parser/oracle_static/keyword_grant.rs` — keyword-grant consumer threads the ordinal (renamed call sites).
- `crates/engine/src/parser/oracle_static/tests.rs` — renamed seam unit tests; new `nth_qualified_spell_filter_second_spell_gates_on_one_prior_cast` asserting ordinal → `SpellsCastThisTurn == 1`.
- `crates/engine/tests/integration/nth_spell_ordinal_cost_reduction.rs` (new, registered) — cast-pipeline regression.
- `docs/parser-misparse-backlog.md` — backlog hygiene (see Claimed parse impact).

## CR references

- **CR 601.2f** — determining a spell's total cost (cost modifiers apply at this step); the ordinal gate is evaluated here.
- **CR 107.3** — numeric/ordinal values in rules text.

Both were carried over from the existing seam (already verified against `docs/MagicCompRules.txt`); no new CR number introduced.

## Implementation method (required)

Found via a fresh live-parse semantic-misparse audit of cost-modifier statics (the
07-09 card-data snapshot re-parsed against Oracle text; three independent auditor
passes converged on this pattern). Live-verified against HEAD before writing code
(parse was `ModifyCost { spell_filter: None, condition: None }`). Designed as a
leaf-level parameterization of the existing `FirstQualifiedSpell` combinator seam
per "parameterize, don't proliferate".

## Track

Developer / misparse fix.

## LLM

Claude Opus 4.8 (1M context).

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — **0 warnings**.
- `cargo test -p engine --lib parser::oracle_static` — **1204 passed, 0 failed** (incl. the 3 seam tests).
- `cargo test -p engine --test integration nth_spell_ordinal_cost_reduction` — **pass**; first spell pays full {2}, second discounted to {1}, third full {2} again (revert-failing — pre-fix discounts the first cast).
- AST live-verify: first → `SpellsCastThisTurn == 0`, second → `== 1`, third → `== 2`, filter → `Typed[Card]`.

## Gate A

Tilt was down; ran the checks directly. clippy (all-targets, proptest, -D warnings)
0 warnings; parser lib suite 1204/0; integration regression green; fmt clean.

## Anchored on

upstream/main @ `44c59a6f4` (release: v0.30.0).

## Final review-impl

Independent fresh-context review (diff + CLAUDE.md + review-impl skill only, no
prior conversation). Verdict: **clean** on all checked lenses — correct seam
(single cost-mod ordinal authority; two production consumers both threaded),
nom-mandate (pure combinators; word-boundary safe against "firstborn"/"seconds"),
new-field threading (all 4 sites thread `ordinal`), off-by-one (confirmed against
`game_object.rs` — cost mods evaluated in `finalize_cast` *before*
`record_spell_cast_from_zone` increments the counter, so the Nth cast sees exactly
`N-1` recorded), discriminating runtime test (flips on revert), CR citations
resolve and describe the code.

One **LOW / pre-existing / out-of-scope** note: `nth_qualified_spell_condition`
hardcodes `CountScope::Controller`, so a *hypothetical* "the second spell **your
opponents** cast each turn costs {N} more" would count the controller's spells.
This is pre-existing (the opponent-cast phrases + Controller scope both predate
this PR and were already reachable for "first"), and **zero real cards** use an
opponent-scoped ordinal cost/keyword form (verified against card data), so nothing
ships incorrect. Left out of scope to keep this a focused parameterization; a
future fix would thread the caster scope or decline the opponent branch once a real
card exists.

## Claimed parse impact

5 cards move from a filterless/conditionless (every-spell) reducer to a correct
ordinal-gated reducer: Highspire Bell-Ringer, Uthros Psionicist, Raging Battle
Mouse, Monk Class, Alisaie Leveilleur. No card regresses (the `N = 1` path is
unchanged). Backlog hygiene: removed Uthros Psionicist + Raging Battle Mouse from
root cause #2 and Highspire Bell-Ringer from #28 (all now parse fully clean, live-
verified); decremented the associated counts. Monk Class (§2) and Alisaie
Leveilleur (§5) retain unrelated misparses and stay listed.

## Validation Failures

None.

## CI Failures

None expected.
