### PR TITLE
fix(engine+ai): remove per-process HashMap iteration-order leaks from AI decision paths (#4878)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -4226,7 +4226,7 @@ fn remove_counter_cost_distribution_candidate(
         let Some(obj) = state.objects.get(&object_id) else {
             continue;
         };
-        let available: Vec<_> = match counter_type {
+        let mut available: Vec<_> = match counter_type {
             CounterMatch::OfType(counter_type) => obj
                 .counters
                 .get(counter_type)
@@ -4240,6 +4240,10 @@ fn remove_counter_cost_distribution_candidate(
                 .map(|(counter_type, count)| (counter_type.clone(), *count))
                 .collect(),
         };
+        // Issue #4878: `obj.counters` is a default-RandomState HashMap; sort by
+        // CounterType so the emitted distribution's content is a function of
+        // game state, not per-process hash iteration order.
+        available.sort_by(|a, b| a.0.cmp(&b.0));
         for (counter_type, available) in available {
             if remaining == 0 {
                 break;

--- a/crates/engine/src/ai_support/context.rs
+++ b/crates/engine/src/ai_support/context.rs
@@ -9,8 +9,16 @@ pub struct AiDecisionContext {
 }
 
 pub fn build_decision_context(state: &GameState) -> AiDecisionContext {
+    // Issue #4878: sort via the same `GameAction::cmp_stable` total order
+    // `validated_candidate_actions_with_probe` uses (ai_support/mod.rs), so
+    // this context's candidates don't carry raw enumeration-order variance
+    // into phase-ai's decision loop. Intentionally does NOT switch to
+    // `validated_candidate_actions` — that also runs the FilterPipeline,
+    // which would change candidate semantics, not just their order.
+    let mut candidates = candidate_actions(state);
+    candidates.sort_by(|a, b| a.action.cmp_stable(&b.action));
     AiDecisionContext {
         waiting_for: state.waiting_for.clone(),
-        candidates: candidate_actions(state),
+        candidates,
     }
 }

--- a/crates/engine/src/ai_support/context.rs
+++ b/crates/engine/src/ai_support/context.rs
@@ -22,3 +22,65 @@ pub fn build_decision_context(state: &GameState) -> AiDecisionContext {
         candidates,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::{
+        actions::GameAction, card_type::CoreType, identifiers::CardId, player::PlayerId,
+        zones::Zone, Phase,
+    };
+
+    /// Issue #4878: the decision context is consumed directly by phase-ai, so
+    /// it must canonicalize candidate enumeration order before trajectories
+    /// score tied actions. The hand deliberately enumerates the two land
+    /// actions in descending object-id order; removing the context sort makes
+    /// this assertion fail while tests for other candidate consumers still pass.
+    #[test]
+    fn build_decision_context_canonicalizes_candidate_action_order() {
+        let player = PlayerId(0);
+        let mut state = GameState::new_two_player(42);
+        state.phase = Phase::PreCombatMain;
+        state.active_player = player;
+        state.priority_player = player;
+        state.waiting_for = WaitingFor::Priority { player };
+
+        let first_land = create_object(
+            &mut state,
+            CardId(1),
+            player,
+            "First Land".to_string(),
+            Zone::Hand,
+        );
+        let second_land = create_object(
+            &mut state,
+            CardId(2),
+            player,
+            "Second Land".to_string(),
+            Zone::Hand,
+        );
+        for object_id in [first_land, second_land] {
+            state
+                .objects
+                .get_mut(&object_id)
+                .expect("created land must exist")
+                .card_types
+                .core_types
+                .push(CoreType::Land);
+        }
+        state.players[0].hand = [second_land, first_land].into_iter().collect();
+
+        let context = build_decision_context(&state);
+        let land_actions: Vec<_> = context
+            .candidates
+            .iter()
+            .filter_map(|candidate| match &candidate.action {
+                GameAction::PlayLand { object_id, .. } => Some(*object_id),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(land_actions, vec![first_land, second_land]);
+    }
+}

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1398,7 +1398,7 @@ fn pay_ability_cost_inner(
             if *count == REMOVE_COUNTER_COST_ALL
                 && matches!(counter_type, crate::types::counter::CounterMatch::Any)
             {
-                let counters: Vec<_> = state
+                let mut counters: Vec<_> = state
                     .objects
                     .get(&source_id)
                     .map(|obj| {
@@ -1408,6 +1408,10 @@ fn pay_ability_cost_inner(
                             .collect()
                     })
                     .unwrap_or_default();
+                // Issue #4878: `obj.counters` is a default-RandomState HashMap;
+                // sort by CounterType so the removal (and any per-type triggers
+                // it emits) happen in a deterministic, process-independent order.
+                counters.sort_by(|a, b| a.0.cmp(&b.0));
                 for (counter_type, count) in counters {
                     super::effects::counters::remove_counter_with_replacement(
                         state,

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -887,7 +887,11 @@ pub fn resolve_counter_match_for_removal(
             .counters
             .iter()
             .filter(|(_, &n)| n > 0)
-            .max_by_key(|(_, &n)| n)
+            // Issue #4878: `obj.counters` is a default-RandomState HashMap, so
+            // `max_by_key` alone would break ties by per-process hash-iteration
+            // order. Tie-break by CounterType's derived Ord for a deterministic
+            // choice when two or more types share the max count.
+            .max_by(|(ta, &na), (tb, &nb)| na.cmp(&nb).then_with(|| ta.cmp(tb)))
             .map(|(ty, _)| ty.clone()),
     }
 }
@@ -2510,6 +2514,38 @@ mod tests {
         assert_eq!(
             resolve_defined_or_targets(&state, &put_counter(1)),
             vec![obj1]
+        );
+    }
+
+    /// Issue #4878: `resolve_counter_match_for_removal`'s `CounterMatch::Any`
+    /// arm used to break count ties with a bare `max_by_key`, which falls back
+    /// to `obj.counters`' per-process HashMap (RandomState) iteration order —
+    /// a different `CounterType` could be selected for removal across
+    /// processes on an identical seed. The fix tie-breaks by `CounterType`'s
+    /// derived `Ord`, so a tied object always resolves to the same,
+    /// Ord-greatest type. Reverting to bare `max_by_key` makes this assertion
+    /// flip to "unspecified" (test would become flaky, not merely wrong).
+    #[test]
+    fn resolve_counter_match_for_removal_breaks_ties_by_counter_type_ord() {
+        use crate::types::counter::{CounterMatch, CounterType};
+
+        let mut state = GameState::new_two_player(42);
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Tied Counters Test".to_string(),
+            Zone::Battlefield,
+        );
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.counters.insert(CounterType::Plus1Plus1, 2);
+        obj.counters.insert(CounterType::Minus1Minus1, 2);
+
+        // CounterType::Minus1Minus1 is declared after Plus1Plus1, so it is the
+        // Ord-greater of the two tied types and must win deterministically.
+        assert_eq!(
+            resolve_counter_match_for_removal(&state, id, &CounterMatch::Any),
+            Some(CounterType::Minus1Minus1)
         );
     }
 

--- a/crates/engine/src/game/mana_sources.rs
+++ b/crates/engine/src/game/mana_sources.rs
@@ -1422,8 +1422,11 @@ fn shard_payment_options(shard: ManaCostShard) -> Option<Vec<ManaType>> {
 fn group_profiles_by_object(
     profiles: Vec<ActivatableManaProfile>,
 ) -> Vec<(ObjectId, Vec<ActivatableManaProfileKind>)> {
-    use std::collections::HashMap;
-    let mut grouped: HashMap<ObjectId, Vec<ActivatableManaProfileKind>> = HashMap::new();
+    // Issue #4878: BTreeMap (not HashMap) so the grouped Vec below is
+    // ObjectId-sorted and deterministic across processes, rather than
+    // following per-process HashMap iteration order.
+    use std::collections::BTreeMap;
+    let mut grouped: BTreeMap<ObjectId, Vec<ActivatableManaProfileKind>> = BTreeMap::new();
     for profile in profiles {
         grouped
             .entry(profile.object_id)

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1147,9 +1147,10 @@ fn check_legend_rule(
             })
             .collect();
 
-        // Group by name
-        let mut by_name: std::collections::HashMap<String, Vec<_>> =
-            std::collections::HashMap::new();
+        // Group by name. BTreeMap (not HashMap) so iteration below is
+        // name-sorted and deterministic across processes — issue #4878.
+        let mut by_name: std::collections::BTreeMap<String, Vec<_>> =
+            std::collections::BTreeMap::new();
         for id in legendaries {
             if let Some(obj) = state.objects.get(&id) {
                 by_name.entry(obj.name.clone()).or_default().push(id);
@@ -2584,6 +2585,41 @@ mod tests {
                 assert_eq!(legend_name, "Thalia");
                 assert!(candidates.contains(&id1));
                 assert!(candidates.contains(&id2));
+            }
+            other => panic!("Expected ChooseLegend, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sba_legend_rule_presents_groups_in_deterministic_name_order() {
+        // Issue #4878: `check_legend_rule` used to group same-name legendaries
+        // into a `std::collections::HashMap<String, Vec<ObjectId>>` (default
+        // RandomState) and present the FIRST group encountered during hash
+        // iteration — process-random order, not a function of game state.
+        // With two independently-duplicated legend names controlled by the
+        // same player, the BTreeMap fix must always present the
+        // alphabetically-first name first, deterministically, regardless of
+        // insertion order.
+        let mut state = setup();
+        // Insert the alphabetically-LATER name's duplicates first, so a
+        // naive insertion-order-preserving container (or a lucky HashMap
+        // iteration) would be tempted to present "Zeppelin Twins" first —
+        // only a genuine sort-by-name fixes this.
+        add_legendary(&mut state, CardId(1), PlayerId(0), "Zeppelin Twins", 1);
+        add_legendary(&mut state, CardId(2), PlayerId(0), "Zeppelin Twins", 2);
+        add_legendary(&mut state, CardId(3), PlayerId(0), "Aardvark Sentinel", 1);
+        add_legendary(&mut state, CardId(4), PlayerId(0), "Aardvark Sentinel", 2);
+
+        let mut events = Vec::new();
+        check_state_based_actions(&mut state, &mut events);
+
+        match &state.waiting_for {
+            WaitingFor::ChooseLegend { legend_name, .. } => {
+                assert_eq!(
+                    legend_name, "Aardvark Sentinel",
+                    "the alphabetically-first duplicated legend name must be presented \
+                     first, deterministically — got {legend_name:?}"
+                );
             }
             other => panic!("Expected ChooseLegend, got {:?}", other),
         }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3336,7 +3336,13 @@ fn collect_ring_emblem_triggers(
     pending: &mut Vec<PendingTriggerContext>,
 ) {
     for event in events {
-        let players: Vec<_> = state.ring_level.keys().copied().collect();
+        // Issue #4878: `state.ring_level` is a default-RandomState HashMap;
+        // sort by the stable PlayerId inner value so multi-teammate Ring
+        // emblem triggers land in `pending` in a deterministic, process-
+        // independent order (matters when a stable sort downstream ties on
+        // both APNAP rank and timestamp — see `ring_pending_trigger`).
+        let mut players: Vec<_> = state.ring_level.keys().copied().collect();
+        players.sort_by_key(|p| p.0);
         for player in players {
             let level = state.ring_level.get(&player).copied().unwrap_or(0);
             let Some(bearer_id) = super::effects::ring::ring_bearer_for(state, player) else {

--- a/crates/phase-ai/src/planner/mod.rs
+++ b/crates/phase-ai/src/planner/mod.rs
@@ -694,6 +694,11 @@ impl<'a> PlannerServices<'a> {
             b.prior
                 .partial_cmp(&a.prior)
                 .unwrap_or(std::cmp::Ordering::Equal)
+                // Issue #4878: without this tie-break, a prior tie falls back
+                // to `priors`' pre-sort order, ultimately traceable to the
+                // engine's unsorted `candidate_actions(state)` — mirrors
+                // search.rs:1956/2205 and the sibling fix in `rank_candidates`.
+                .then_with(|| a.candidate.action.cmp_stable(&b.candidate.action))
         });
         priors
             .into_iter()
@@ -1323,6 +1328,10 @@ where
         b.score
             .partial_cmp(&a.score)
             .unwrap_or(std::cmp::Ordering::Equal)
+            // Issue #4878: without this tie-break, equal-score candidates fall
+            // back to `ranked`'s pre-sort (enumeration) order, which is not
+            // guaranteed stable across processes — mirrors search.rs:1956/2205.
+            .then_with(|| a.candidate.action.cmp_stable(&b.candidate.action))
     });
     ranked.truncate(limit);
     ranked
@@ -1664,6 +1673,46 @@ mod tests {
             ranked[0].candidate.action,
             GameAction::MulliganDecision { .. }
         ));
+    }
+
+    /// Issue #4878: on an exact score tie, `rank_candidates`' tie-break must
+    /// be `GameAction::cmp_stable` (a total order), not `ranked`'s pre-sort
+    /// (encounter) order. Reverting the `.then_with(cmp_stable)` tie-break
+    /// makes this test flip: `sort_by` is stable, so two calls differing only
+    /// in input order would then rank the same tied pair differently.
+    #[test]
+    fn rank_candidates_ties_break_by_cmp_stable_not_encounter_order() {
+        let pass = CandidateAction {
+            action: GameAction::PassPriority,
+            metadata: ActionMetadata {
+                actor: Some(PlayerId(0)),
+                tactical_class: TacticalClass::Pass,
+            },
+        };
+        let mulligan = CandidateAction {
+            action: GameAction::MulliganDecision {
+                choice: MulliganChoice::Keep,
+            },
+            metadata: ActionMetadata {
+                actor: Some(PlayerId(0)),
+                tactical_class: TacticalClass::Selection,
+            },
+        };
+        let tied_scorer = |_candidate: &CandidateAction| 1.0;
+
+        let forward = rank_candidates(vec![pass.clone(), mulligan.clone()], tied_scorer, 2);
+        let reversed = rank_candidates(vec![mulligan, pass], tied_scorer, 2);
+
+        let forward_actions: Vec<_> = forward.iter().map(|r| r.candidate.action.clone()).collect();
+        let reversed_actions: Vec<_> = reversed
+            .iter()
+            .map(|r| r.candidate.action.clone())
+            .collect();
+
+        assert_eq!(
+            forward_actions, reversed_actions,
+            "tied candidates must rank identically regardless of input encounter order"
+        );
     }
 
     #[test]


### PR DESCRIPTION
References #4878. Addresses the AI-decision-path portion of #4878.

## Motivation

A pod-lab harness measurement found 18% of 4-player Commander games diverge across 5 same-binary same-seed repeats — cross-process `HashMap` iteration order leaking into AI decisions.

## Discovery

A 3-angle loop-until-dry discovery sweep found 11 candidate sites; 2 were false positives (`im::HashMap` with `FxBuildHasher` — already deterministic per-keyset). The 9 real sites are fixed here using the repo's established idiom (canonical order by stable key — the same pattern as the existing #4878 fixes at `ai_support/mod.rs:65`, `search.rs:1956`, and `sba.rs` check_role_uniqueness):

- `BTreeMap` for local disposable maps (legend-rule grouping, mana-profile grouping)
- Boundary sorts/tie-breaks by stable inner key for persistent-field reads (counter maps, `ring_level`)
- `cmp_stable` tie-breaks for score-tied candidate sorts (beam ranker, continuation sampler)
- A `cmp_stable` sort at the one unsorted candidate-emission boundary (`build_decision_context`)

Four commits, one per pattern.

## Semantics

Legality/affordability outcomes unchanged — fixpoints and backtracker correctness are order-independent. Only previously-arbitrary choices are now stable.

## Verification

- `cargo fmt`, `cargo clippy -D warnings`
- Full engine suite (3542 passed)
- Full `phase-ai` suite
- Three discriminating tests added: legend-rule presentation order, counter tie-break by `CounterType` `Ord`, `rank_candidates` tie stability

Empirical cross-process re-verification (re-running the 100-seed x 5-repeat divergence sweep against a rebuilt binary, expecting the 18% to collapse) is planned harness-side and results will be reported on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)