### PR TITLE
fix(parser): parse the leading negated-turn scope on static cost modifiers (Geyser Drake, Naiad of Hidden Coves)

### DIFF
--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -352,9 +352,9 @@ fn strip_cost_mod_cast_scope_suffix(input: &str) -> &str {
 /// yours, " turn-scope clause into its `StaticCondition`. Shares the negated-turn
 /// vocabulary the CDA / dispatch / type-change static parsers already recognize
 /// (`nom_tag_tp("during turns other than yours, ")`), and the affirmative form
-/// mirrors the trailing suffix arm below — so a cost modifier fronted by the
-/// clause (Geyser Drake, Naiad of Hidden Coves: "During turns other than yours,
-/// spells you cast cost {1} less") no longer drops the timing restriction.
+/// mirrors the trailing suffix arm below. `peel_leading_cost_modifier_condition`
+/// consumes this before self-spell and first-qualified dispatch, so every
+/// cost-modifier branch retains the scope.
 fn parse_leading_turn_scope(text: &str) -> OracleResult<'_, StaticCondition> {
     alt((
         value(
@@ -371,8 +371,8 @@ fn parse_leading_turn_scope(text: &str) -> OracleResult<'_, StaticCondition> {
 /// CR 604.1 + CR 601.2f: Strip an inline "during your turn" timing clause from
 /// a cost-modification subject before type parsing. Paladin Class: "Spells your
 /// opponents cast during your turn cost {1} more to cast." The LEADING clause
-/// (affirmative + negated) is handled once for every branch by the shared
-/// `parse_leading_turn_scope` fallback near the end of `try_parse_cost_modification`.
+/// (affirmative + negated) is handled once for every branch before dispatch by
+/// `peel_leading_cost_modifier_condition`.
 fn strip_cost_mod_during_your_turn_scope(text: &str) -> (&str, Option<StaticCondition>) {
     if let Ok((_, prefix)) = terminated(
         take_until(" during your turn"),
@@ -897,14 +897,19 @@ pub(crate) fn try_parse_cost_modification(
     if is_self_spell {
         definition.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
     }
-    if let Some((filter, timing)) = first_qualified_spell.as_ref() {
-        definition.condition = Some(first_qualified_spell_condition(filter, timing));
-    } else if let Some(during_your_turn_scope) = during_your_turn_scope {
-        definition.condition = Some(during_your_turn_scope);
-    }
-    if definition.condition.is_none() {
-        definition.condition = leading_condition;
-    }
+    let branch_condition = if let Some((filter, timing)) = first_qualified_spell.as_ref() {
+        Some(first_qualified_spell_condition(filter, timing))
+    } else {
+        during_your_turn_scope
+    };
+    definition.condition = match (leading_condition, branch_condition) {
+        (Some(leading), Some(branch)) => Some(StaticCondition::And {
+            conditions: vec![leading, branch],
+        }),
+        (Some(leading), None) => Some(leading),
+        (None, Some(branch)) => Some(branch),
+        (None, None) => None,
+    };
 
     // Extract trailing "if [condition]" / "as long as [condition]" clause from
     // cost modification lines.
@@ -968,23 +973,6 @@ pub(crate) fn try_parse_cost_modification(
         }
     }
 
-    // CR 102.1 + CR 604.1 + CR 601.2f: Leading "During your turn," / "During turns
-    // other than yours," timing restriction — the cost modification functions only
-    // on (affirmative) or off (negated) the static controller's turn: Tithe Taker
-    // ("During your turn, spells your opponents cast cost {1} more"); Geyser Drake /
-    // Naiad of Hidden Coves ("During turns other than yours, spells you cast cost
-    // {1} less"). The trailing/`if` scans above miss this because it is a
-    // comma-separated timing prefix, not an "if"/"as long as" clause. A single
-    // authority for every cost-mod branch (self-spell, first-qualified, generic):
-    // the cost resolver gates on the resulting StaticCondition
-    // (`DuringYourTurn` / `Not(DuringYourTurn)`), evaluated against the source
-    // permanent's controller (CR 102.1: active player).
-    if definition.condition.is_none() {
-        if let Ok((_, cond)) = parse_leading_turn_scope(lower.trim_start()) {
-            definition.condition = Some(cond);
-        }
-    }
-
     // CR 601.2f + CR 702.34a: Caller-proven casting variant (e.g. Flashback from
     // the compound-line parser) gates self-spell cost modifiers — never inferred
     // from generic "cast this way" wording alone.
@@ -1004,6 +992,18 @@ fn peel_leading_cost_modifier_condition<'a>(
     pair: TextPair<'a>,
 ) -> (TextPair<'a>, Option<StaticCondition>) {
     let trimmed = pair.trim_start();
+    if let Ok((remainder, condition)) = parse_leading_turn_scope(trimmed.lower) {
+        let consumed = trimmed.lower.len() - remainder.len();
+        let cost_clause = trimmed.slice(consumed, trimmed.lower.len()).trim_start();
+        if nom_primitives::scan_contains(cost_clause.lower, "less to cast")
+            || nom_primitives::scan_contains(cost_clause.lower, "more to cast")
+            || nom_primitives::scan_contains(cost_clause.lower, "less to activate")
+            || nom_primitives::scan_contains(cost_clause.lower, "more to activate")
+        {
+            return (cost_clause, Some(condition));
+        }
+    }
+
     let Ok((after_if, _)) = tag::<_, _, OracleError<'_>>("if ").parse(trimmed.lower) else {
         return (pair, None);
     };

--- a/crates/engine/src/parser/oracle_static/static_helpers.rs
+++ b/crates/engine/src/parser/oracle_static/static_helpers.rs
@@ -348,9 +348,31 @@ fn strip_cost_mod_cast_scope_suffix(input: &str) -> &str {
     stripped.trim()
 }
 
+/// CR 604.1: Parse a LEADING "during your turn, " / "during turns other than
+/// yours, " turn-scope clause into its `StaticCondition`. Shares the negated-turn
+/// vocabulary the CDA / dispatch / type-change static parsers already recognize
+/// (`nom_tag_tp("during turns other than yours, ")`), and the affirmative form
+/// mirrors the trailing suffix arm below — so a cost modifier fronted by the
+/// clause (Geyser Drake, Naiad of Hidden Coves: "During turns other than yours,
+/// spells you cast cost {1} less") no longer drops the timing restriction.
+fn parse_leading_turn_scope(text: &str) -> OracleResult<'_, StaticCondition> {
+    alt((
+        value(
+            StaticCondition::Not {
+                condition: Box::new(StaticCondition::DuringYourTurn),
+            },
+            tag("during turns other than yours, "),
+        ),
+        value(StaticCondition::DuringYourTurn, tag("during your turn, ")),
+    ))
+    .parse(text)
+}
+
 /// CR 604.1 + CR 601.2f: Strip an inline "during your turn" timing clause from
 /// a cost-modification subject before type parsing. Paladin Class: "Spells your
-/// opponents cast during your turn cost {1} more to cast."
+/// opponents cast during your turn cost {1} more to cast." The LEADING clause
+/// (affirmative + negated) is handled once for every branch by the shared
+/// `parse_leading_turn_scope` fallback near the end of `try_parse_cost_modification`.
 fn strip_cost_mod_during_your_turn_scope(text: &str) -> (&str, Option<StaticCondition>) {
     if let Ok((_, prefix)) = terminated(
         take_until(" during your turn"),
@@ -946,19 +968,21 @@ pub(crate) fn try_parse_cost_modification(
         }
     }
 
-    // CR 102.1 + CR 601.2f: Leading "During your turn," timing restriction —
-    // the cost modification functions only on the static controller's turn
-    // (Tithe Taker: "During your turn, spells your opponents cast cost {1} more
-    // to cast ..."). The trailing/`if` scans above miss this because it is a
-    // comma-separated timing prefix, not an "if"/"as long as" clause. The cost
-    // resolver gates on `StaticCondition::DuringYourTurn`, which is evaluated
-    // against the source permanent's controller (CR 102.1: active player).
-    if definition.condition.is_none()
-        && tag::<_, _, OracleError<'_>>("during your turn, ")
-            .parse(lower)
-            .is_ok()
-    {
-        definition.condition = Some(StaticCondition::DuringYourTurn);
+    // CR 102.1 + CR 604.1 + CR 601.2f: Leading "During your turn," / "During turns
+    // other than yours," timing restriction — the cost modification functions only
+    // on (affirmative) or off (negated) the static controller's turn: Tithe Taker
+    // ("During your turn, spells your opponents cast cost {1} more"); Geyser Drake /
+    // Naiad of Hidden Coves ("During turns other than yours, spells you cast cost
+    // {1} less"). The trailing/`if` scans above miss this because it is a
+    // comma-separated timing prefix, not an "if"/"as long as" clause. A single
+    // authority for every cost-mod branch (self-spell, first-qualified, generic):
+    // the cost resolver gates on the resulting StaticCondition
+    // (`DuringYourTurn` / `Not(DuringYourTurn)`), evaluated against the source
+    // permanent's controller (CR 102.1: active player).
+    if definition.condition.is_none() {
+        if let Ok((_, cond)) = parse_leading_turn_scope(lower.trim_start()) {
+            definition.condition = Some(cond);
+        }
     }
 
     // CR 601.2f + CR 702.34a: Caller-proven casting variant (e.g. Flashback from

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6262,6 +6262,59 @@ fn static_opponent_spells_cost_more_during_your_turn() {
     ));
 }
 
+/// CR 604.1: a LEADING "during turns other than yours, " / "during your turn, "
+/// timing clause on a cost modifier lowers to the negated / affirmative
+/// `StaticCondition` instead of being dropped (Geyser Drake, Naiad of Hidden
+/// Coves reduced EVERY spell — including on the controller's own turn). Shares the
+/// negated-turn vocabulary of the CDA / dispatch / type-change static parsers and
+/// mirrors the trailing "during your turn" suffix arm.
+#[test]
+fn cost_mod_leading_turn_scope_negated_and_affirmative() {
+    // "During turns other than yours, spells you cast cost {1} less" → Not(DuringYourTurn).
+    let def =
+        parse_static_line("During turns other than yours, spells you cast cost {1} less to cast.")
+            .expect("cost reduction should parse");
+    assert!(matches!(
+        def.mode,
+        StaticMode::ModifyCost {
+            mode: CostModifyMode::Reduce,
+            ..
+        }
+    ));
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::Not {
+            condition: Box::new(StaticCondition::DuringYourTurn),
+        }),
+        "leading negated-turn clause must gate the reducer, got {:?}",
+        def.condition,
+    );
+
+    // Affirmative leading form → DuringYourTurn.
+    let def = parse_static_line("During your turn, spells you cast cost {1} less to cast.")
+        .expect("cost reduction should parse");
+    assert_eq!(def.condition, Some(StaticCondition::DuringYourTurn));
+
+    // Regression: a plain cost mod with no timing clause is unconditioned.
+    let def = parse_static_line("Spells you cast cost {1} less to cast.")
+        .expect("cost reduction should parse");
+    assert_eq!(def.condition, None);
+
+    // Branch symmetry: the shared leading-clause authority gates a SELF-spell cost
+    // modifier too, not only the generic "spells you cast" branch.
+    let def =
+        parse_static_line("During turns other than yours, this spell costs {1} less to cast.")
+            .expect("self-spell cost reduction should parse");
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::Not {
+            condition: Box::new(StaticCondition::DuringYourTurn),
+        }),
+        "the negated leading clause must gate the self-spell branch too, got {:?}",
+        def.condition,
+    );
+}
+
 #[test]
 fn static_opponent_creature_spells_cost_more_during_your_turn() {
     let def = parse_static_line(

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -6313,6 +6313,37 @@ fn cost_mod_leading_turn_scope_negated_and_affirmative() {
         "the negated leading clause must gate the self-spell branch too, got {:?}",
         def.condition,
     );
+    assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
+    assert_eq!(
+        def.active_zones,
+        crate::types::zones::self_spell_cost_mod_active_zones(),
+        "the leading scope must be peeled before self-spell detection so the modifier works from hand and stack",
+    );
+
+    // The leading scope must also reach the first-qualified branch before its
+    // grammar runs, then compose with (rather than replace) the first-spell gate.
+    let def = parse_static_line(
+        "During turns other than yours, the first spell you cast each turn costs {1} less to cast.",
+    )
+    .expect("first-spell cost reduction should parse");
+    let Some(StaticCondition::And { conditions }) = def.condition else {
+        panic!(
+            "leading turn scope and first-spell gate must compose, got {:?}",
+            def.condition
+        );
+    };
+    assert_eq!(conditions.len(), 2);
+    assert_eq!(
+        &conditions[0],
+        &StaticCondition::Not {
+            condition: Box::new(StaticCondition::DuringYourTurn),
+        }
+    );
+    assert!(
+        matches!(&conditions[1], StaticCondition::QuantityComparison { .. }),
+        "the first-spell condition must survive alongside the leading scope: {:?}",
+        conditions,
+    );
 }
 
 #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -660,6 +660,7 @@ mod mystic_forge_regression;
 mod narset_jeskai_waymaster_draw_spells_cast;
 mod natural_balance;
 mod necrodominance_pay_any_life_draw;
+mod negated_turn_spell_cost_reduction;
 mod nether_spirit_only_creature_card_intervening_if;
 mod nettling_imp_continuity_target;
 mod niko_light_of_hope;

--- a/crates/engine/tests/integration/negated_turn_spell_cost_reduction.rs
+++ b/crates/engine/tests/integration/negated_turn_spell_cost_reduction.rs
@@ -99,12 +99,17 @@ fn hurkyls_pending_cost_mana_value(active_player: PlayerId) -> u32 {
     }
 
     let card_id = runner.state().objects[&spell_id].card_id;
+    // Manual payment mode surfaces `WaitingFor::ManaPayment` and pauses at the
+    // locked-cost boundary WITHOUT auto-tapping; the pending cast retains the
+    // battlefield-modified cost so we can read its mana value before payment.
+    // Auto mode would instead try to pay immediately and fail here because this
+    // scenario seeds no mana sources ("Cannot pay mana cost").
     runner
         .act(GameAction::CastSpell {
             object_id: spell_id,
             card_id,
             targets: vec![],
-            payment_mode: CastPaymentMode::Auto,
+            payment_mode: CastPaymentMode::Manual,
         })
         .expect("casting Hurkyl's Final Meditation should begin");
     assert!(matches!(

--- a/crates/engine/tests/integration/negated_turn_spell_cost_reduction.rs
+++ b/crates/engine/tests/integration/negated_turn_spell_cost_reduction.rs
@@ -1,0 +1,112 @@
+//! CR 604.1 + CR 601.2f regression (runtime cast pipeline): a "During turns other
+//! than yours, spells you cast cost {N} less" reducer (Geyser Drake, Naiad of
+//! Hidden Coves) must reduce the controller's spells ONLY on turns that are not
+//! the controller's — the leading negated-turn clause maps to
+//! `StaticCondition::Not(DuringYourTurn)`.
+//!
+//! Before the fix, the leading "During turns other than yours," clause was not
+//! recognized by the cost-modifier scope stripper, so the static parsed with
+//! `condition: None` and the reducer applied on EVERY turn (including the
+//! controller's own). CR 102.1: the active player is the player whose turn it is;
+//! the gate is evaluated against the source permanent's controller.
+//!
+//! Drives the real cost pipeline: `GameAction::CastSpell` computes the
+//! battlefield-modified cost at `WaitingFor::TargetSelection` (before payment),
+//! so `pending_cast.cost.mana_value()` reads the actual reduction the resolver
+//! applied. On revert the reduction applies on the controller's own turn too and
+//! the "not reduced on your turn" assertion (mv == 2) fails.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle_static::parse_static_line;
+use engine::types::ability::StaticCondition;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const GEYSER: &str = "During turns other than yours, spells you cast cost {1} less to cast.";
+
+/// Begin casting P0's {2}-generic instant and return the total mana value of the
+/// battlefield-modified cost the engine resolved (surfaced at `TargetSelection`
+/// before payment). No reduction → 2; the {1} reduction → 1.
+fn resolved_cost_mana_value(runner: &mut GameRunner, spell_id: ObjectId) -> u32 {
+    let card_id = runner.state().objects[&spell_id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the instant should begin (cost is checked at payment, not here)");
+    match &runner.state().waiting_for {
+        WaitingFor::TargetSelection { pending_cast, .. } => pending_cast.cost.mana_value(),
+        other => panic!("expected TargetSelection after casting the instant, got {other:?}"),
+    }
+}
+
+fn scenario_with_geyser() -> (GameScenario, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain); // active player = P0
+    scenario
+        .add_creature(P0, "Geyser Source", 2, 2)
+        .with_static_definition(parse_static_line(GEYSER).expect("Geyser static should parse"));
+    let spell_id = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Test Blast",
+            true,
+            "Test Blast deals 3 damage to any target.",
+        )
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    (scenario, spell_id)
+}
+
+#[test]
+fn geyser_static_parses_with_not_during_your_turn_condition() {
+    // CR 604.1: the leading "During turns other than yours," clause must lower to
+    // `Not(DuringYourTurn)` — not be silently dropped (which left condition: None).
+    let def = parse_static_line(GEYSER).expect("Geyser static should parse");
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::Not {
+            condition: Box::new(StaticCondition::DuringYourTurn),
+        }),
+        "\"During turns other than yours,\" must gate the reducer, got {:?}",
+        def.condition,
+    );
+}
+
+#[test]
+fn geyser_does_not_reduce_on_its_controllers_own_turn() {
+    // On P0's OWN turn, Not(DuringYourTurn) is false → no reduction → full {2}.
+    // Before the fix the dropped gate reduced it on every turn (mv would be 1).
+    let (scenario, spell_id) = scenario_with_geyser();
+    let mut runner = scenario.build();
+    assert_eq!(
+        resolved_cost_mana_value(&mut runner, spell_id),
+        2,
+        "on the controller's own turn the reducer is OFF; the {{2}} spell stays {{2}}",
+    );
+}
+
+#[test]
+fn geyser_reduces_during_turns_other_than_the_controllers() {
+    // On P1's turn, Not(DuringYourTurn) is true → the {2} spell is reduced to {1}.
+    let (scenario, spell_id) = scenario_with_geyser();
+    let mut runner = scenario.build();
+    // Move to P1's turn and hand P0 priority to cast its instant.
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P0;
+        state.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+    assert_eq!(
+        resolved_cost_mana_value(&mut runner, spell_id),
+        1,
+        "during a turn that is not the controller's, the {{2}} spell is reduced to {{1}}",
+    );
+}

--- a/crates/engine/tests/integration/negated_turn_spell_cost_reduction.rs
+++ b/crates/engine/tests/integration/negated_turn_spell_cost_reduction.rs
@@ -22,10 +22,13 @@ use engine::types::ability::StaticCondition;
 use engine::types::actions::GameAction;
 use engine::types::game_state::{CastPaymentMode, WaitingFor};
 use engine::types::identifiers::ObjectId;
-use engine::types::mana::ManaCost;
+use engine::types::mana::{ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
 
 const GEYSER: &str = "During turns other than yours, spells you cast cost {1} less to cast.";
+const HURKYLS_FINAL_MEDITATION: &str =
+    "During turns other than yours, this spell costs {3} more to cast.";
 
 /// Begin casting P0's {2}-generic instant and return the total mana value of the
 /// battlefield-modified cost the engine resolved (surfaced at `TargetSelection`
@@ -62,6 +65,59 @@ fn scenario_with_geyser() -> (GameScenario, ObjectId) {
         .with_mana_cost(ManaCost::generic(2))
         .id();
     (scenario, spell_id)
+}
+
+/// Cast the real Hurkyl's Final Meditation self-cost static from hand and read
+/// the locked pending-cast cost at the mana-payment boundary. This is the
+/// production path that requires the static's self-spell active zones; a
+/// battlefield-only generic reducer cannot exercise it.
+fn hurkyls_pending_cost_mana_value(active_player: PlayerId) -> u32 {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell_id = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Hurkyl's Final Meditation",
+            true,
+            HURKYLS_FINAL_MEDITATION,
+        )
+        .with_mana_cost(ManaCost::Cost {
+            generic: 4,
+            shards: vec![
+                ManaCostShard::Blue,
+                ManaCostShard::Blue,
+                ManaCostShard::Blue,
+            ],
+        })
+        .id();
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = active_player;
+        state.priority_player = P0;
+        state.waiting_for = WaitingFor::Priority { player: P0 };
+    }
+
+    let card_id = runner.state().objects[&spell_id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Hurkyl's Final Meditation should begin");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment { .. }
+    ));
+    runner
+        .state()
+        .pending_cast
+        .as_ref()
+        .expect("ManaPayment must retain the pending Hurkyl's cast")
+        .cost
+        .mana_value()
 }
 
 #[test]
@@ -108,5 +164,22 @@ fn geyser_reduces_during_turns_other_than_the_controllers() {
         resolved_cost_mana_value(&mut runner, spell_id),
         1,
         "during a turn that is not the controller's, the {{2}} spell is reduced to {{1}}",
+    );
+}
+
+/// CR 601.2f: Hurkyl's Final Meditation is a real self-spell cost modifier,
+/// not a battlefield reducer. Its `SelfRef` static must be active from hand
+/// while the engine locks the pending cast cost.
+#[test]
+fn hurkyls_final_meditation_self_cost_tracks_controller_turn() {
+    assert_eq!(
+        hurkyls_pending_cost_mana_value(P0),
+        7,
+        "on its controller's turn, Hurkyl's keeps its printed {{4}}{{U}}{{U}}{{U}} cost",
+    );
+    assert_eq!(
+        hurkyls_pending_cost_mana_value(P1),
+        10,
+        "on another player's turn, Hurkyl's self modifier adds {{3}} to the pending cast cost",
     );
 }


### PR DESCRIPTION
## Summary

"During turns other than yours, spells you cast cost {1} less to cast" (**Geyser
Drake**, **Naiad of Hidden Coves**) parsed with `condition: None` — the leading
negated-turn timing clause was not recognized by the cost-modifier scope stripper,
so the reducer applied on **every** turn, including the controller's own.

Root cause: `strip_cost_mod_during_your_turn_scope` (static_helpers.rs) only
handled a *trailing* " during your turn" suffix (Paladin Class). A *leading*
"During turns other than yours," / "During your turn," clause — the form these
reducers print — fell through and dropped the timing restriction.

Fix: add `parse_leading_turn_scope`, mapping the leading clause to the same
`StaticCondition` the CDA / dispatch / type-change static parsers already use for
this vocabulary — `Not(DuringYourTurn)` for "turns other than yours",
`DuringYourTurn` for the affirmative form — and route the **single** shared
leading-clause fallback in `try_parse_cost_modification` through it, so every
cost-mod branch (self-spell, first-qualified, generic) gates the negated form
symmetrically with the affirmative one (previously only the affirmative
"During your turn," was recognized). **Parse-only**: the cost-mod condition
resolver already evaluates `StaticCondition::Not` and `DuringYourTurn`
(`evaluate_cost_mod_static_condition`), gating against the source controller
(CR 102.1).

## Files changed

- `crates/engine/src/parser/oracle_static/static_helpers.rs` — new `parse_leading_turn_scope` combinator; the shared leading-clause fallback now recognizes both the affirmative and negated forms (single authority for all branches).
- `crates/engine/src/parser/oracle_static/tests.rs` — parser unit test over the leading negated + affirmative forms, a plain-unconditioned regression, and a self-spell branch-symmetry case.
- `crates/engine/tests/integration/negated_turn_spell_cost_reduction.rs` (new, registered) — runtime cast-pipeline regression.

## CR references

- **CR 604.1** — continuous-effect duration/condition (the timing gate).
- **CR 601.2f** — total cost determination (where the reducer applies).
- **CR 102.1** — the active player is the player whose turn it is (the gate is evaluated against the source controller).

## Implementation method (required)

Found in the same fresh cost-modifier live-parse audit that surfaced the ordinal
fix; live-verified against HEAD (`condition: None`). The `Not(DuringYourTurn)`
mapping reuses the negated-turn vocabulary already present in cda.rs / dispatch.rs
/ type_change.rs — a building-block reuse, not a new condition.

## Track

Developer / misparse fix.

## LLM

Claude Opus 4.8 (1M context).

## Verification

- `cargo fmt --all` — clean.
- `cargo clippy -p engine --all-targets --features proptest -- -D warnings` — 0 warnings.
- `cargo test -p engine --lib parser::oracle_static` — green (incl. the new leading-scope unit test).
- `cargo test -p engine --test integration negated_turn_spell_cost_reduction` — **3/3 pass**: a {2} spell stays {2} on the controller's own turn and is reduced to {1} on other turns (cost read at `WaitingFor::TargetSelection`; reverting the parser fix reduces on the controller's turn too and fails the test).

## Gate A

Tilt was down; ran checks directly. clippy 0 warnings; parser lib suite green;
integration regression 3/3.

## Anchored on

upstream/main @ `11cc01581`.

## Final review-impl

Independent fresh-context review (diff + CLAUDE.md + review-impl skill only, no
prior conversation) ran clean on all lenses — correct seam, nom-mandate (pure
`alt`/`value`/`tag`), regression safety (trailing "during your turn" suffix and
plain cost mods unchanged; the comma in `tag("during your turn, ")` can't mis-fire
on the comma-less trailing form), realizability (`evaluate_cost_mod_static_condition`
handles `Not` + `DuringYourTurn`, gated against the source controller), and a
discriminating runtime test (flips on revert). It raised one **LOW** finding: the
negated form was initially handled only in the generic branch, leaving the
self-spell / first-qualified branches asymmetric. **Addressed in this PR** by
routing the negated form through the single shared leading-clause authority so all
three branches are symmetric (covered by the added self-spell unit-test case). No
real card exercised the asymmetric subclass, but the fix is now correct for it.

## Claimed parse impact

2 cards move from an unconditioned every-turn reducer to a correctly negated-turn-
gated reducer: Geyser Drake, Naiad of Hidden Coves. No card regresses — the
trailing " during your turn" suffix path (Paladin Class) and plain unconditioned
cost mods are unchanged (covered by the parser unit test's regression asserts).

## Validation Failures

None.

## CI Failures

None expected.
