### PR TITLE
Fix Thrumming Stone

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1240,7 +1240,13 @@ pub(super) fn drain_deferred_triggers_after_stack_object_announcement(
     events: &mut Vec<GameEvent>,
     waiting_for: WaitingFor,
 ) -> WaitingFor {
-    if !matches!(waiting_for, WaitingFor::Priority { .. }) {
+    // CR 603.3b + CR 608.2g: a terminal Ripple completion waits for the
+    // *current* final cast's SpellCast event to join the earlier parked casts.
+    // The ordinary post-announcement helper would otherwise drain B here,
+    // before the reducer's priority pipeline has collected C.
+    if !matches!(waiting_for, WaitingFor::Priority { .. })
+        || state.pending_resolution_completion.is_some()
+    {
         return waiting_for;
     }
     crate::game::triggers::drain_deferred_triggers_after_stack_object_announcement(state, events)
@@ -8897,11 +8903,28 @@ fn handle_resolution_cast_success(
             if remaining_hits.is_empty() {
                 // CR 702.60a: after the last accepted hit, put the revealed
                 // cards not cast this way on the library bottom.
+                //
+                // This marker is installed before the replacement-aware batch
+                // because that batch can pause. The resumed cast must still
+                // collect its eventual SpellCast trigger with the earlier
+                // accepted hits, rather than drain them during the prompt.
+                state.pending_resolution_completion =
+                    Some(crate::types::game_state::PendingResolutionCompletion {
+                        player,
+                        source_id,
+                        final_cast: Some(cast_object),
+                    });
                 match crate::game::effects::cascade::shuffle_to_bottom(
                     state,
                     &exiled_misses,
                     source_id,
-                    None,
+                    Some(
+                        crate::types::game_state::BatchCompletion::RippleTerminalComplete {
+                            player,
+                            source_id,
+                            final_cast: Some(cast_object),
+                        },
+                    ),
                     events,
                 ) {
                     crate::game::zone_pipeline::BatchMoveResult::Done => None,

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -582,6 +582,17 @@ fn cast_stack_spell_copy_during_resolution(
         )));
     }
 
+    // CR 113.2c + CR 601.2i + CR 608.2g: this copy is now being CAST, so
+    // snapshot its effective spell keywords before recording SpellCast. This
+    // mirrors `casting_costs::finalize_cast_with_phyrexian_choices_inner` and
+    // preserves the selected static-grant instances/provenance for cast-trigger
+    // synthesis (notably multiple Ripple grants) after the event is recorded.
+    let cast_spell_keywords =
+        crate::game::casting::effective_spell_keyword_instances(state, ability.controller, copy_id);
+    if let Some(copy) = state.objects.get_mut(&copy_id) {
+        copy.cast_spell_keywords = cast_spell_keywords;
+    }
+
     let origin = obj.cast_from_zone.unwrap_or(Zone::Exile);
     events.push(GameEvent::SpellCast {
         card_id: obj.card_id,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7202,6 +7202,26 @@ fn apply_action(
         });
     }
 
+    // CR 603.2 + CR 603.3b + CR 608.2g: a cast made during an unresolved
+    // effect can leave the reducer at that effect's next choice (not Priority).
+    // Park its SpellCast observers now; they are drained only when the parent
+    // resolution reaches a genuine priority boundary.
+    if let Some(waiting_for) =
+        engine_resolution_choices::park_cast_during_resolution_cast_observers(
+            state,
+            &mut events,
+            0,
+            &waiting_for,
+        )?
+    {
+        state.waiting_for = waiting_for.clone();
+        return Ok(ActionResult {
+            events,
+            waiting_for,
+            log_entries: vec![],
+        });
+    }
+
     // CR 704.3 / CR 800.4: SBAs may have ended the game during phase auto-advance (e.g.,
     // combat damage step) before we reach this point. state.waiting_for is the authoritative
     // result — written directly by eliminate_player → check_game_over. Guard against

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -59,7 +59,7 @@ pub(crate) fn run_post_action_pipeline_from(
     // `collect_triggers_into_deferred` when `waiting_for` is `NamedChoice`)
     // and fired a second time by the replay, causing double-fire for ETB
     // observers like Soul Warden (issue #830).
-    // A terminal resolution completion can be installed while a
+    // CR 603.3b + CR 608.2g: A terminal resolution completion can be installed while a
     // replacement-resume action is finalizing its deferred free cast. That
     // action may have already handled ordinary zone-event triggers, but its
     // just-emitted `SpellCast` still has to join the terminal batch before B's

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -1,5 +1,6 @@
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::identifiers::ObjectId;
 
 use super::engine::{begin_pending_trigger_target_selection, check_exile_returns, EngineError};
 use super::match_flow;
@@ -58,7 +59,12 @@ pub(crate) fn run_post_action_pipeline_from(
     // `collect_triggers_into_deferred` when `waiting_for` is `NamedChoice`)
     // and fired a second time by the replay, causing double-fire for ETB
     // observers like Soul Warden (issue #830).
-    if !skip_trigger_scan {
+    // A terminal resolution completion can be installed while a
+    // replacement-resume action is finalizing its deferred free cast. That
+    // action may have already handled ordinary zone-event triggers, but its
+    // just-emitted `SpellCast` still has to join the terminal batch before B's
+    // parked trigger drains.
+    if !skip_trigger_scan || state.pending_resolution_completion.is_some() {
         // A paused logical zone-change owner has already Segment-collected its
         // retained ZoneChanged occurrences into deferred trigger contexts. Do
         // not rediscover those records through the generic post-action scan;
@@ -99,11 +105,12 @@ pub(crate) fn run_post_action_pipeline_from(
             .flat_map(|context| context.trigger_events.iter())
             .filter(|event| matches!(event, GameEvent::ZoneChanged { .. }))
             .collect();
-        let unconsumed_events = triggers::filter_consumed_trigger_events(
-            &events[event_start..],
+        let unconsumed_events = triggers::filter_consumed_trigger_events_from(
+            events,
+            event_start,
             &consumed_trigger_events,
         );
-        let filtered_events: Vec<_> = unconsumed_events
+        let mut filtered_events: Vec<_> = unconsumed_events
             .iter()
             .filter(|event| {
                 !matches!(event, GameEvent::PhaseChanged { .. })
@@ -113,6 +120,9 @@ pub(crate) fn run_post_action_pipeline_from(
             })
             .cloned()
             .collect();
+        if skip_trigger_scan {
+            filtered_events.retain(|event| matches!(event, GameEvent::SpellCast { .. }));
+        }
         // CR 603.3b: If the resolution step that just ran paused for a player
         // resolution-choice (Scry/Surveil/Dig/Search/...), the triggered
         // abilities it generated (e.g. "whenever you scry, ...") must NOT be
@@ -121,7 +131,9 @@ pub(crate) fn run_post_action_pipeline_from(
         // `ScryChoice` when 2+ same-controller triggers fire). Park them in
         // `deferred_triggers`; they are drained below once the action settles
         // back to Priority. Mirrors `batch_or_drain_observer_triggers`' B2 branch.
-        if super::engine_resolution_choices::handles(&state.waiting_for) {
+        if super::engine_resolution_choices::handles(&state.waiting_for)
+            || state.pending_resolution_completion.is_some()
+        {
             triggers::collect_triggers_into_deferred(state, &filtered_events);
         } else {
             triggers::process_triggers(state, &filtered_events);
@@ -166,7 +178,11 @@ pub(crate) fn run_post_action_pipeline_from(
         }
         if events.len() > events_before {
             let sba_events: Vec<_> = events[events_before..].to_vec();
-            triggers::process_triggers(state, &sba_events);
+            if state.pending_resolution_completion.is_some() {
+                triggers::collect_triggers_into_deferred(state, &sba_events);
+            } else {
+                triggers::process_triggers(state, &sba_events);
+            }
             // CR 603.3d: SBA-generated zone changes (e.g. lethal damage) may put
             // death triggers on the stack that need target/mode prompts before the
             // next SBA pass.
@@ -199,7 +215,9 @@ pub(crate) fn run_post_action_pipeline_from(
             &exile_return_events,
             &consumed_exile_return_events,
         );
-        if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+        if !matches!(state.waiting_for, WaitingFor::Priority { .. })
+            || state.pending_resolution_completion.is_some()
+        {
             triggers::collect_triggers_into_deferred(state, &unconsumed_exile_return_events);
         } else {
             let mut normal_pending = state
@@ -230,7 +248,13 @@ pub(crate) fn run_post_action_pipeline_from(
     // / mid-spell settles; same-controller groups get `OrderTriggers` first).
     // A drained trigger that itself needs input returns its own WaitingFor,
     // handled by the check below.
-    if matches!(state.waiting_for, WaitingFor::Priority { .. })
+    if settle_pending_resolution_completion(state) {
+        if let Some(wf) =
+            triggers::drain_deferred_triggers_after_stack_object_announcement(state, events)
+        {
+            state.waiting_for = wf;
+        }
+    } else if matches!(state.waiting_for, WaitingFor::Priority { .. })
         && !state.deferred_triggers.is_empty()
         && !skip_deferred_trigger_drain
     {
@@ -301,6 +325,72 @@ pub(crate) fn run_post_action_pipeline_from(
         default_wf.clone(),
         default_wf.acting_player(),
     ))
+}
+
+/// CR 603.3b + CR 608.2g: settles a terminal resolution marker only after its
+/// final free cast has actually been announced. The drain uses the
+/// stack-announcement boundary so B/C's triggers may be ordered above their
+/// still-stacked spells, rather than the ordinary resolution drain's spell guard.
+fn settle_pending_resolution_completion(state: &mut GameState) -> bool {
+    let Some(completion) = state.pending_resolution_completion.as_ref() else {
+        return false;
+    };
+    let final_cast = completion.final_cast;
+    if !matches!(state.waiting_for, WaitingFor::Priority { .. })
+        || !triggers::resolution_completion_can_settle(state)
+    {
+        return false;
+    }
+    if final_cast.is_some_and(|object_id| {
+        !state
+            .objects
+            .get(&object_id)
+            .is_some_and(|object| object.zone == crate::types::zones::Zone::Stack)
+    }) {
+        return false;
+    }
+
+    ensure_terminal_cast_spell_triggers_collected(state, final_cast);
+
+    // The source check at batch completion proved this is the active Ripple
+    // resolution. Now its terminal instruction has completed, so clear the
+    // resolution-only LKI before the explicit post-announcement drain.
+    state.pending_resolution_completion = None;
+    state.resolving_stack_entry = None;
+    state.resolution_source_relatch = None;
+    true
+}
+
+/// CR 603.2 + CR 603.3b + CR 608.2g: replacement-resume casts can complete
+/// below the ordinary event-scan seam. At terminal Ripple settlement, recover
+/// the one authoritative SpellCast event from the fully announced spell if it
+/// has not already been collected into this ordering batch.
+fn ensure_terminal_cast_spell_triggers_collected(
+    state: &mut GameState,
+    final_cast: Option<ObjectId>,
+) {
+    let Some(object_id) = final_cast else {
+        return;
+    };
+    let already_collected = state.deferred_triggers.iter().any(|context| {
+        context.pending.source_id == object_id
+            && matches!(
+                context.pending.trigger_event.as_ref(),
+                Some(GameEvent::SpellCast { object_id: event_id, .. }) if *event_id == object_id
+            )
+    });
+    if already_collected {
+        return;
+    }
+    let Some(object) = state.objects.get(&object_id) else {
+        return;
+    };
+    let event = GameEvent::SpellCast {
+        card_id: object.card_id,
+        controller: object.controller,
+        object_id,
+    };
+    triggers::collect_triggers_into_deferred(state, &[event]);
 }
 
 fn flush_pending_priority_intercepts(

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -131,6 +131,8 @@ pub(crate) fn run_post_action_pipeline_from(
         // `ScryChoice` when 2+ same-controller triggers fire). Park them in
         // `deferred_triggers`; they are drained below once the action settles
         // back to Priority. Mirrors `batch_or_drain_observer_triggers`' B2 branch.
+        // CR 603.3b: Terminal-resolution observers join the deferred batch so
+        // they are ordered only after the resolving ability has completed.
         if super::engine_resolution_choices::handles(&state.waiting_for)
             || state.pending_resolution_completion.is_some()
         {
@@ -178,6 +180,8 @@ pub(crate) fn run_post_action_pipeline_from(
         }
         if events.len() > events_before {
             let sba_events: Vec<_> = events[events_before..].to_vec();
+            // CR 603.3b: SBA-generated triggers join the terminal batch rather
+            // than being ordered before its final cast trigger is collected.
             if state.pending_resolution_completion.is_some() {
                 triggers::collect_triggers_into_deferred(state, &sba_events);
             } else {
@@ -215,6 +219,8 @@ pub(crate) fn run_post_action_pipeline_from(
             &exile_return_events,
             &consumed_exile_return_events,
         );
+        // CR 603.3b: Exile-return triggers also join a terminal batch so they
+        // cannot be ordered before the final cast trigger is collected.
         if !matches!(state.waiting_for, WaitingFor::Priority { .. })
             || state.pending_resolution_completion.is_some()
         {
@@ -373,11 +379,10 @@ fn ensure_terminal_cast_spell_triggers_collected(
         return;
     };
     let already_collected = state.deferred_triggers.iter().any(|context| {
-        context.pending.source_id == object_id
-            && matches!(
-                context.pending.trigger_event.as_ref(),
-                Some(GameEvent::SpellCast { object_id: event_id, .. }) if *event_id == object_id
-            )
+        matches!(
+            context.pending.trigger_event.as_ref(),
+            Some(GameEvent::SpellCast { object_id: event_id, .. }) if *event_id == object_id
+        )
     });
     if already_collected {
         return;

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -6479,7 +6479,7 @@ pub(crate) fn run_batch_completion(
             source_id,
             final_cast,
         } => {
-            // The final accepted Ripple cast has not yet emitted SpellCast: this
+            // CR 702.60a + CR 603.3b: The final accepted Ripple cast has not yet emitted SpellCast: this
             // batch completion runs inside its pre-finalization cleanup. Mark the
             // terminal settlement now, but leave both the resolver LKI and parked
             // triggers intact until that spell finishes announcement.

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -511,6 +511,45 @@ pub(super) enum ResolutionChoiceOutcome {
     ActionResult(ActionResult),
 }
 
+/// CR 603.2 + CR 603.3b + CR 608.2g: A spell cast while an effect is
+/// resolving can finish its announcement at another resolution prompt (for
+/// example, Ripple's next revealed-card offer) rather than at Priority. Its
+/// `SpellCast` event nevertheless happened and must be collected exactly once;
+/// it merely cannot be put onto the stack until the parent resolution finishes.
+///
+/// This is the single paused cast-during-resolution settlement seam. It covers
+/// free casts, casts that pause for targets or payment, and continuation offers
+/// uniformly because the final reducer calls it after every successful action.
+pub(super) fn park_cast_during_resolution_cast_observers(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+    event_start: usize,
+    waiting_for: &WaitingFor,
+) -> Result<Option<WaitingFor>, EngineError> {
+    let cast_announced = events[event_start..]
+        .iter()
+        .any(|event| matches!(event, GameEvent::SpellCast { .. }));
+    let paused_resolution_cast =
+        handles(waiting_for) || matches!(waiting_for, WaitingFor::CopyRetarget { .. });
+    if state.resolving_stack_entry.is_none() || !paused_resolution_cast || !cast_announced {
+        return Ok(None);
+    }
+
+    // `run_post_action_pipeline_from` recognizes the non-Priority resolution
+    // choice and parks the suffix's observers in `deferred_triggers`; it does
+    // not drain them while the parent continuation is still active.
+    state.waiting_for = waiting_for.clone();
+    let settled = super::engine_priority::run_post_action_pipeline_from(
+        state,
+        events,
+        event_start,
+        waiting_for,
+        false,
+        true,
+    )?;
+    Ok(Some(settled))
+}
+
 /// CR 603.2 + CR 603.3b: After a resolution-choice handler has moved objects
 /// (sacrifice, change-zone, bounce, discard) and resolved any reflexive
 /// continuation, dispatch the observer triggers (dies-, discarded-, etc.)
@@ -1860,13 +1899,17 @@ pub(super) fn handle_resolution_choice(
                     state,
                     &all_to_bottom,
                     source_id,
-                    None,
+                    Some(
+                        crate::types::game_state::BatchCompletion::RippleTerminalComplete {
+                            player,
+                            source_id,
+                            final_cast: None,
+                        },
+                    ),
                     events,
                 ) {
                     crate::game::zone_pipeline::BatchMoveResult::Done => {
-                        ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(
-                            state, player, events,
-                        ))
+                        ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
                     }
                     crate::game::zone_pipeline::BatchMoveResult::NeedsChoice => {
                         ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
@@ -6429,6 +6472,41 @@ pub(crate) fn run_batch_completion(
                 source_id,
                 subject: None,
             });
+            crate::game::zone_pipeline::BatchMoveResult::Done
+        }
+        BatchCompletion::RippleTerminalComplete {
+            player,
+            source_id,
+            final_cast,
+        } => {
+            // The final accepted Ripple cast has not yet emitted SpellCast: this
+            // batch completion runs inside its pre-finalization cleanup. Mark the
+            // terminal settlement now, but leave both the resolver LKI and parked
+            // triggers intact until that spell finishes announcement.
+            let matches_resolving_ripple =
+                state.resolving_stack_entry.as_ref().is_some_and(|entry| {
+                    entry.source_id == source_id
+                        && entry.controller == player
+                        && matches!(
+                            &entry.kind,
+                            crate::types::game_state::StackEntryKind::TriggeredAbility {
+                                ability, ..
+                            } if matches!(ability.effect, Effect::Ripple { .. })
+                        )
+                });
+            if matches_resolving_ripple {
+                state.pending_resolution_completion =
+                    Some(crate::types::game_state::PendingResolutionCompletion {
+                        player,
+                        source_id,
+                        final_cast,
+                    });
+                // CR 608.2c: the terminal Ripple instruction is complete. The
+                // post-action pipeline owns collecting and ordering the parked
+                // cast observers; it will keep the marker through any final-cast
+                // announcement or replacement tail.
+                state.waiting_for = WaitingFor::Priority { player };
+            }
             crate::game::zone_pipeline::BatchMoveResult::Done
         }
         BatchCompletion::DiscoverBottomComplete { source_id } => {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3435,19 +3435,27 @@ fn collect_pending_triggers_with_collection(
             // CR 702.60a + CR 702.60b: Ripple — synthesized "when you cast this
             // spell" trigger off the just-cast spell, one per Ripple instance,
             // each carrying that instance's N. Mirrors the Cascade synthesis above.
-            let ripple_instances: Vec<u32> =
-                super::casting::effective_spell_keywords(state, *caster, *cast_obj_id)
-                    .into_iter()
-                    .filter_map(|k| match k {
-                        Keyword::Ripple(n) => Some(n),
-                        _ => None,
-                    })
-                    .collect();
-            let ripple_controller = state
+            // CR 113.2c + CR 702.60b: use the cast-time keyword snapshot, not
+            // a live static-ability query. This is the same authority as
+            // Cascade above: the spell's abilities are fixed as it is cast, and
+            // each separately-functioning Ripple instance produces its own
+            // triggered ability.
+            let (ripple_instances, ripple_controller): (Vec<u32>, PlayerId) = state
                 .objects
                 .get(cast_obj_id)
-                .map(|o| o.controller)
-                .unwrap_or(*caster);
+                .map(|obj| {
+                    (
+                        obj.cast_spell_keywords
+                            .iter()
+                            .filter_map(|keyword| match keyword {
+                                Keyword::Ripple(n) => Some(*n),
+                                _ => None,
+                            })
+                            .collect(),
+                        obj.controller,
+                    )
+                })
+                .unwrap_or_default();
             for n in ripple_instances {
                 let ripple_trig_def = TriggerDefinition::new(TriggerMode::SpellCast)
                     .description("Ripple".to_string())
@@ -6386,10 +6394,11 @@ fn dispatch_pending_trigger_context(
 /// `deferred_triggers`. Mid-resolution `Priority` from player-scope iteration,
 /// `repeat_for`, or replacement continuations must not drain (or offer CR
 /// 603.3b ordering) until those continuations finish.
-fn can_drain_deferred_triggers(state: &GameState, allow_spell_on_stack: bool) -> bool {
-    if state.deferred_triggers.is_empty() {
-        return false;
-    }
+/// CR 603.3b + CR 608.2g: whether a paused resolution has reached a real
+/// post-announcement settlement boundary. This intentionally permits spells on
+/// the stack: cast triggers go above the spells that caused them once the parent
+/// resolution is complete.
+pub(crate) fn resolution_completion_can_settle(state: &GameState) -> bool {
     if is_pending_trigger_construction_active(state) {
         return false;
     }
@@ -6403,6 +6412,21 @@ fn can_drain_deferred_triggers(state: &GameState, allow_spell_on_stack: bool) ->
         return false;
     }
     if state.pending_change_zone_iteration.is_some() {
+        return false;
+    }
+    if state.pending_replacement.is_some()
+        || state.pending_batch_deliveries.is_some()
+        || state.pending_counter_additions.is_some()
+        || state.pending_counter_moves.is_some()
+        || state.pending_counter_removals.is_some()
+    {
+        return false;
+    }
+    true
+}
+
+fn can_drain_deferred_triggers(state: &GameState, allow_spell_on_stack: bool) -> bool {
+    if state.deferred_triggers.is_empty() || !resolution_completion_can_settle(state) {
         return false;
     }
     // CR 603.3b + issue #1793: observer triggers parked during a spell's
@@ -6456,6 +6480,14 @@ pub(crate) fn drain_deferred_triggers_after_stack_object_announcement(
     state: &mut GameState,
     events_out: &mut Vec<GameEvent>,
 ) -> Option<crate::types::game_state::WaitingFor> {
+    // CR 603.3b + CR 608.2g: terminal Ripple settlement owns this exact
+    // post-announcement boundary. It must first collect the current final
+    // cast's SpellCast event with earlier accepted casts, then drain one batch.
+    // Callers that finalize an announcement before that reducer seam therefore
+    // leave the queue intact while the typed marker is live.
+    if state.pending_resolution_completion.is_some() {
+        return None;
+    }
     if !can_drain_deferred_triggers(state, true) {
         return None;
     }
@@ -6960,30 +6992,37 @@ fn trigger_event_occurrence(events: &[GameEvent], event_index: usize) -> usize {
         .count()
 }
 
+/// Filter a suffix while comparing consumed occurrence identities against the
+/// complete action event buffer. An occurrence is an identity within the full
+/// buffer, not within a later continuation slice: rebasing it at `event_start`
+/// can consume an equal-looking event from the wrong resolution segment.
+pub(crate) fn filter_consumed_trigger_events_from(
+    events: &[GameEvent],
+    event_start: usize,
+    consumed: &[ConsumedTriggerEventOccurrence],
+) -> Vec<GameEvent> {
+    events[event_start..]
+        .iter()
+        .enumerate()
+        .filter_map(|(offset, event)| {
+            let occurrence = trigger_event_occurrence(events, event_start + offset);
+            if !consumed
+                .iter()
+                .any(|consumed| consumed.event == *event && consumed.occurrence == occurrence)
+            {
+                Some(event.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
 pub(crate) fn filter_consumed_trigger_events(
     events: &[GameEvent],
     consumed: &[ConsumedTriggerEventOccurrence],
 ) -> Vec<GameEvent> {
-    let mut seen: Vec<(GameEvent, usize)> = Vec::new();
-    let mut filtered = Vec::new();
-    for event in events {
-        let occurrence =
-            if let Some((_, count)) = seen.iter_mut().find(|(seen_event, _)| seen_event == event) {
-                let occurrence = *count;
-                *count += 1;
-                occurrence
-            } else {
-                seen.push((event.clone(), 1));
-                0
-            };
-        if !consumed
-            .iter()
-            .any(|consumed| consumed.event == *event && consumed.occurrence == occurrence)
-        {
-            filtered.push(event.clone());
-        }
-    }
-    filtered
+    filter_consumed_trigger_events_from(events, 0, consumed)
 }
 
 fn delayed_trigger_to_context(
@@ -15679,6 +15718,33 @@ pub mod tests {
         );
 
         assert_eq!(filtered, vec![events[0].clone(), events[2].clone()]);
+    }
+
+    #[test]
+    fn filter_consumed_trigger_events_from_keeps_prefix_occurrence_identity() {
+        let events = vec![
+            GameEvent::PhaseChanged {
+                phase: Phase::Upkeep,
+            },
+            GameEvent::PhaseChanged {
+                phase: Phase::Upkeep,
+            },
+            GameEvent::PhaseChanged { phase: Phase::Draw },
+        ];
+        let filtered = filter_consumed_trigger_events_from(
+            &events,
+            1,
+            &[ConsumedTriggerEventOccurrence {
+                event: events[1].clone(),
+                occurrence: 1,
+            }],
+        );
+
+        assert_eq!(
+            filtered,
+            vec![events[2].clone()],
+            "the suffix-local first upkeep is globally the second occurrence"
+        );
     }
 
     /// Issue #1304 — RUNTIME: Keeper of the Accord's intervening-if must compare

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -4367,6 +4367,15 @@ pub enum BatchCompletion {
         source_id: ObjectId,
         exiled_count: u32,
     },
+    /// CR 702.60a + CR 603.3b + CR 616.1: A terminal Ripple bottom batch
+    /// settled after a replacement-choice pause. Only now may the resolving
+    /// trigger's deferred cast observers be placed above their spells.
+    RippleTerminalComplete {
+        player: PlayerId,
+        source_id: ObjectId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        final_cast: Option<ObjectId>,
+    },
     /// CR 701.57a + CR 616.1: A no-hit Discover's randomized bottom batch has
     /// settled, so the discover resolution completes exactly once.
     DiscoverBottomComplete { source_id: ObjectId },
@@ -4625,6 +4634,22 @@ pub enum BatchCompletion {
     /// second physical card has completed its independently replaceable move,
     /// carrying the originating event's applied-set through every pause.
     MeldRedirect { source_id: ObjectId },
+}
+
+/// CR 603.3b + CR 608.2g: terminal settlement that must wait until the
+/// resolution-cast spell has completed its announcement. `source_id` proves
+/// the terminal batch belongs to the still-stashed resolving Ripple ability;
+/// the post-announcement boundary then combines this cast's triggers with the
+/// earlier accepted casts' parked observers before ordering the one batch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingResolutionCompletion {
+    pub player: PlayerId,
+    pub source_id: ObjectId,
+    /// `Some` for a terminal accepted Ripple hit. The marker cannot settle
+    /// until this spell has actually reached the stack, which prevents a
+    /// replacement-choice pause in its bottom batch from draining earlier casts.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_cast: Option<ObjectId>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -12275,6 +12300,12 @@ pub struct GameState {
     /// `current_trigger_event`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolving_stack_entry: Option<StackEntry>,
+    /// CR 603.3b + CR 608.2g: a terminal resolution batch (currently Ripple)
+    /// has settled, but its final spell is still completing announcement. Keep
+    /// the provenance until the post-announcement priority pipeline can collect
+    /// that spell's cast triggers into the same deferred ordering batch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_resolution_completion: Option<PendingResolutionCompletion>,
     /// CR 107.3i: the X announced for an in-flight COST, keyed by the object whose cost
     /// it is. CR 107.3i: "Normally, all instances of X on an object have the same value
     /// at any given time" — so a triggered ability of that SAME object which fires
@@ -13924,6 +13955,7 @@ impl GameState {
             announced_source_x: None,
             current_trigger_match_count: None,
             resolving_stack_entry: None,
+            pending_resolution_completion: None,
             resolution_source_relatch: None,
             last_recast_context: None,
             current_trigger_events: Vec::new(),
@@ -15046,6 +15078,7 @@ fn _gamestate_partition_is_total(s: &GameState) {
         // per-cycle accumulator and PartialEq does not compare it.
         announced_source_x: _,
         resolving_stack_entry: _,
+        pending_resolution_completion: _,
         current_trigger_events: _,
         stack_trigger_event_batches: _,
         lki_cache: _,
@@ -15288,6 +15321,7 @@ impl PartialEq for GameState {
             && self.revealed_cards == other.revealed_cards
             && self.public_revealed_cards == other.public_revealed_cards
             && self.pending_continuation == other.pending_continuation
+            && self.pending_resolution_completion == other.pending_resolution_completion
             && self.pending_repeat_iteration == other.pending_repeat_iteration
             && self.pending_repeated_optional_payment == other.pending_repeated_optional_payment
             && self.pending_change_zone_iteration == other.pending_change_zone_iteration

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -1755,8 +1755,9 @@ impl Keyword {
     /// the parser must not emit a duplicate `CastWithKeyword` grant the merge would
     /// silently drop.
     ///
-    /// - Cascade (CR 702.85c): each granted instance triggers separately, counted
-    ///   via `effective_spell_keyword_instances` in `game/triggers.rs`.
+    /// - Cascade (CR 702.85c) and Ripple (CR 702.60b): each granted instance
+    ///   triggers separately, counted via `cast_spell_keywords` in
+    ///   `game/triggers.rs`.
     /// - Casualty (CR 702.153b) / Squad (CR 702.157b): each instance is paid and
     ///   triggers separately.
     ///
@@ -1772,7 +1773,10 @@ impl Keyword {
     pub fn cast_merge_preserves_instances(&self) -> bool {
         matches!(
             self,
-            Keyword::Cascade | Keyword::Casualty(_) | Keyword::Squad(_)
+            // CR 113.2c + CR 702.60b: multiple instances of Ripple function
+            // independently, so a spell's cast-time snapshot must retain each
+            // static grant for trigger synthesis.
+            Keyword::Cascade | Keyword::Ripple(_) | Keyword::Casualty(_) | Keyword::Squad(_)
         )
     }
 }

--- a/crates/engine/tests/integration/cast_during_resolution_pipeline.rs
+++ b/crates/engine/tests/integration/cast_during_resolution_pipeline.rs
@@ -15,7 +15,9 @@
 //! reason this class of bug shipped.
 
 use engine::game::scenario::{GameScenario, P0, P1};
-use engine::types::ability::{CastingPermission, Effect};
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, CastingPermission, Effect, ReplacementDefinition, TargetFilter,
+};
 use engine::types::actions::{CastChoice, GameAction};
 use engine::types::game_state::{
     CastOfferKind, CastPaymentMode, GameState, StackEntryKind, WaitingFor,
@@ -23,7 +25,36 @@ use engine::types::game_state::{
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
-use engine::types::zones::Zone;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::{EtbTapState, Zone};
+
+const THRUMMING_STONE_ORACLE: &str = "Spells you cast have ripple 4. (When you cast a spell, you may reveal the top four cards of your library. You may cast any revealed cards with the same name as the cast spell without paying their mana costs. Put the rest on the bottom of your library in any order.)";
+const RAT_COLONY_ORACLE: &str = "Rat Colony gets +1/+0 for each other Rat you control named Rat Colony.\nA deck can have any number of cards named Rat Colony.";
+
+/// CR 614.1a: a synthetic global Library-destination redirect used to force a
+/// genuine CR 616.1 ordering choice in the terminal Ripple bottom batch.
+fn redirect_library_move_to(destination: Zone) -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(Zone::Library)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                destination,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        ))
+}
 
 fn red_pool(scenario: &mut GameScenario, count: usize) {
     let units: Vec<ManaUnit> = (0..count)
@@ -49,6 +80,387 @@ fn has_exile_alt_cost(state: &GameState, id: ObjectId) -> bool {
         .casting_permissions
         .iter()
         .any(|p| matches!(p, CastingPermission::ExileWithAltCost { .. }))
+}
+
+/// CR 702.60a-b + CR 603.3b: a Ripple-found Rat Colony is cast while the
+/// parent Ripple still has another offer open. Its own Ripple trigger must be
+/// deferred, then put above the newly cast spell after that parent finishes.
+#[test]
+fn thrumming_stone_ripple_retriggers_for_each_cast_rat_colony() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    red_pool(&mut scenario, 2);
+
+    let stone = scenario
+        .add_creature_from_oracle(P0, "Thrumming Stone", 1, 1, THRUMMING_STONE_ORACLE)
+        .id();
+    let rat_a = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    // Add bottom first: Ripple reveals B then C, leaving C available for B's
+    // own trigger after A's outstanding offer is declined.
+    let rat_c = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let rat_b = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        engine::game::zones::remove_from_zone(state, rat_b, Zone::Hand, P0);
+        engine::game::zones::add_to_zone(state, rat_b, Zone::Library, P0);
+        state.objects.get_mut(&rat_b).expect("rat B").zone = Zone::Library;
+        engine::game::zones::remove_from_zone(state, rat_c, Zone::Hand, P0);
+        engine::game::zones::add_to_zone(state, rat_c, Zone::Library, P0);
+        state.objects.get_mut(&rat_c).expect("rat C").zone = Zone::Library;
+    }
+    assert!(
+        !runner.state().objects[&stone].static_definitions.is_empty(),
+        "exact Thrumming Stone Oracle text must parse to its static Ripple grant"
+    );
+    assert!(
+        !runner.state().objects[&rat_a].static_definitions.is_empty(),
+        "exact Rat Colony Oracle text must parse both of its static abilities"
+    );
+    assert!(
+        runner.state().objects[&rat_a]
+            .abilities
+            .iter()
+            .all(|ability| { !matches!(ability.effect.as_ref(), Effect::Unimplemented { .. }) }),
+        "exact Rat Colony Oracle text must not leak an unimplemented spell ability"
+    );
+
+    let card_id = runner.state().objects[&rat_a].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: rat_a,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast first Rat Colony");
+    runner.act(GameAction::PassPriority).expect("p0 pass");
+    runner.act(GameAction::PassPriority).expect("p1 pass");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::CastOffer {
+            kind: CastOfferKind::Ripple { hit_card, .. },
+            ..
+        } if hit_card == rat_b
+    ));
+    runner
+        .act(GameAction::RippleChoice {
+            choice: CastChoice::Cast,
+        })
+        .expect("cast first revealed Rat Colony");
+
+    // B was announced, but A's Ripple resolution is still offering C. B's
+    // trigger must be parked rather than lost or placed early.
+    assert_eq!(runner.state().objects[&rat_b].zone, Zone::Stack);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::CastOffer {
+            kind: CastOfferKind::Ripple { hit_card, .. },
+            ..
+        } if hit_card == rat_c
+    ));
+    assert!(
+        !runner.state().stack.iter().any(|entry| matches!(
+            &entry.kind,
+            StackEntryKind::TriggeredAbility { source_id, ability, .. }
+                if *source_id == rat_b && matches!(ability.effect, Effect::Ripple { .. })
+        )),
+        "B's Ripple trigger cannot be put on the stack before A's Ripple finishes"
+    );
+
+    runner
+        .act(GameAction::RippleChoice {
+            choice: CastChoice::Cast,
+        })
+        .expect("cast A's final revealed Rat Colony");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::OrderTriggers { ref triggers, .. } if triggers.len() == 2
+    ));
+    runner
+        .act(GameAction::OrderTriggers { order: vec![0, 1] })
+        .expect("order the combined B/C Ripple trigger batch");
+    let retrigger_sources: Vec<_> = runner
+        .state()
+        .stack
+        .iter()
+        .filter_map(|entry| match &entry.kind {
+            StackEntryKind::TriggeredAbility {
+                source_id, ability, ..
+            } if matches!(ability.effect, Effect::Ripple { .. }) => Some(*source_id),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        retrigger_sources.iter().filter(|&&id| id == rat_b).count(),
+        1,
+        "B's parked Ripple must join the terminal cast batch exactly once"
+    );
+    assert_eq!(
+        retrigger_sources.iter().filter(|&&id| id == rat_c).count(),
+        1,
+        "C's SpellCast Ripple must join B's parked trigger before either is ordered"
+    );
+    assert!(
+        runner.state().deferred_triggers.is_empty(),
+        "the terminal accepted cast must settle the one deferred trigger batch"
+    );
+    assert!(
+        runner.state().pending_resolution_completion.is_none(),
+        "the terminal settlement marker must clear only after C is announced"
+    );
+    let b_stack_index = runner
+        .state()
+        .stack
+        .iter()
+        .position(|entry| entry.id == rat_b)
+        .expect("B remains on the stack beneath its trigger");
+    let c_stack_index = runner
+        .state()
+        .stack
+        .iter()
+        .position(|entry| entry.id == rat_c)
+        .expect("C remains on the stack beneath its trigger");
+    let first_retrigger_index = runner
+        .state()
+        .stack
+        .iter()
+        .position(|entry| {
+            matches!(
+                &entry.kind,
+                StackEntryKind::TriggeredAbility { source_id, ability, .. }
+                    if (*source_id == rat_b || *source_id == rat_c)
+                        && matches!(ability.effect, Effect::Ripple { .. })
+            )
+        })
+        .expect("the combined Ripple trigger batch is on the stack");
+    assert!(
+        first_retrigger_index > b_stack_index && first_retrigger_index > c_stack_index,
+        "the combined B/C trigger batch must be above both cast Rat Colonies"
+    );
+    assert_eq!(runner.state().objects[&rat_c].zone, Zone::Stack);
+}
+
+/// CR 702.60a + CR 603.3b + CR 616.1: a terminal accepted Ripple cast whose
+/// miss bottom batch pauses for competing replacements keeps the typed terminal
+/// completion through the prompt, then puts B/C's exactly-once Ripple triggers
+/// above both spells after the final cast actually completes.
+#[test]
+fn thrumming_stone_terminal_ripple_waits_through_bottom_replacement_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    red_pool(&mut scenario, 2);
+    scenario.add_creature_from_oracle(P0, "Thrumming Stone", 1, 1, THRUMMING_STONE_ORACLE);
+    let rat_a = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let rat_c = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let miss = scenario
+        .add_spell_to_hand_from_oracle(P0, "Terminal Ripple Miss", true, "Draw a card.")
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+    let rat_b = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    for (name, destination) in [
+        ("Ripple Library Redirect to Hand", Zone::Hand),
+        ("Ripple Library Redirect to Graveyard", Zone::Graveyard),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_library_move_to(destination));
+    }
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        for id in [rat_b, miss, rat_c] {
+            engine::game::zones::remove_from_zone(state, id, Zone::Hand, P0);
+            engine::game::zones::add_to_zone(state, id, Zone::Library, P0);
+            state.objects.get_mut(&id).expect("library card").zone = Zone::Library;
+        }
+    }
+
+    let card_id = runner.state().objects[&rat_a].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: rat_a,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast first Rat Colony");
+    runner.act(GameAction::PassPriority).expect("p0 pass");
+    runner.act(GameAction::PassPriority).expect("p1 pass");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::CastOffer {
+            kind: CastOfferKind::Ripple { hit_card, .. },
+            ..
+        } if hit_card == rat_b
+    ));
+    runner
+        .act(GameAction::RippleChoice {
+            choice: CastChoice::Cast,
+        })
+        .expect("accept B");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::CastOffer {
+            kind: CastOfferKind::Ripple { hit_card, .. },
+            ..
+        } if hit_card == rat_c
+    ));
+
+    runner
+        .act(GameAction::RippleChoice {
+            choice: CastChoice::Cast,
+        })
+        .expect("accept terminal C until bottom replacement choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(
+        matches!(
+            runner
+                .state()
+                .pending_batch_deliveries
+                .as_ref()
+                .and_then(|batch| batch.completion.as_ref()),
+            Some(engine::types::game_state::BatchCompletion::RippleTerminalComplete {
+                player: P0,
+                source_id: _,
+                final_cast: Some(id),
+            }) if *id == rat_c
+        ),
+        "the terminal batch completion must survive the replacement prompt"
+    );
+    assert!(
+        matches!(
+            runner.state().pending_resolution_completion,
+            Some(engine::types::game_state::PendingResolutionCompletion {
+                player: P0,
+                final_cast: Some(id),
+                ..
+            }) if id == rat_c
+        ),
+        "the terminal marker must survive the replacement prompt until C reaches the stack"
+    );
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("resolve terminal bottom replacement");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::OrderTriggers { ref triggers, .. } if triggers.len() == 2
+    ));
+    runner
+        .act(GameAction::OrderTriggers { order: vec![0, 1] })
+        .expect("order the combined B/C Ripple trigger batch");
+    let retrigger_sources: Vec<_> = runner
+        .state()
+        .stack
+        .iter()
+        .filter_map(|entry| match &entry.kind {
+            StackEntryKind::TriggeredAbility {
+                source_id, ability, ..
+            } if matches!(ability.effect, Effect::Ripple { .. }) => Some(*source_id),
+            _ => None,
+        })
+        .collect();
+    for id in [rat_b, rat_c] {
+        assert_eq!(
+            retrigger_sources
+                .iter()
+                .filter(|&&source| source == id)
+                .count(),
+            1,
+            "each accepted Ripple cast must contribute exactly one trigger after the pause"
+        );
+        let spell_index = runner
+            .state()
+            .stack
+            .iter()
+            .position(|entry| entry.id == id)
+            .expect("accepted Rat remains on the stack");
+        let trigger_index = runner
+            .state()
+            .stack
+            .iter()
+            .position(|entry| {
+                matches!(
+                    &entry.kind,
+                    StackEntryKind::TriggeredAbility { source_id, ability, .. }
+                        if *source_id == id && matches!(ability.effect, Effect::Ripple { .. })
+                )
+            })
+            .expect("accepted Rat's Ripple trigger is on the stack");
+        assert!(
+            trigger_index > spell_index,
+            "trigger must be above its spell"
+        );
+    }
+    assert!(runner.state().deferred_triggers.is_empty());
+    assert!(runner.state().pending_resolution_completion.is_none());
+    assert!(runner.state().pending_batch_deliveries.is_none());
+}
+
+/// CR 113.2c + CR 702.60b: two independent Thrumming Stones grant two Ripple
+/// instances, each of which must become a distinct trigger when a Rat is cast.
+#[test]
+fn two_thrumming_stones_preserve_two_ripple_instances() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    red_pool(&mut scenario, 2);
+    scenario.add_creature_from_oracle(P0, "Thrumming Stone", 1, 1, THRUMMING_STONE_ORACLE);
+    scenario.add_creature_from_oracle(P0, "Thrumming Stone", 1, 1, THRUMMING_STONE_ORACLE);
+    let rat = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&rat].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: rat,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Rat Colony");
+    let ripple_triggers = runner
+        .state()
+        .stack
+        .iter()
+        .filter(|entry| {
+            matches!(
+                &entry.kind,
+                StackEntryKind::TriggeredAbility { source_id, ability, .. }
+                    if *source_id == rat && matches!(ability.effect, Effect::Ripple { count: 4 })
+            )
+        })
+        .count();
+    assert_eq!(
+        ripple_triggers, 2,
+        "two Stones must create two Ripple triggers"
+    );
 }
 
 /// CR 608.2g + CR 702.85a: accepting a cascade offer casts the hit DURING

--- a/crates/engine/tests/integration/cast_during_resolution_pipeline.rs
+++ b/crates/engine/tests/integration/cast_during_resolution_pipeline.rs
@@ -30,6 +30,7 @@ use engine::types::zones::{EtbTapState, Zone};
 
 const THRUMMING_STONE_ORACLE: &str = "Spells you cast have ripple 4. (When you cast a spell, you may reveal the top four cards of your library. You may cast any revealed cards with the same name as the cast spell without paying their mana costs. Put the rest on the bottom of your library in any order.)";
 const RAT_COLONY_ORACLE: &str = "Rat Colony gets +1/+0 for each other Rat you control named Rat Colony.\nA deck can have any number of cards named Rat Colony.";
+const AETHERFLUX_RESERVOIR_ORACLE: &str = "Whenever you cast a spell, you gain 1 life for each spell you've cast this turn.\nPay 50 life: This artifact deals 50 damage to any target.";
 
 /// CR 614.1a: a synthetic global Library-destination redirect used to force a
 /// genuine CR 616.1 ordering choice in the terminal Ripple bottom batch.
@@ -419,6 +420,179 @@ fn thrumming_stone_terminal_ripple_waits_through_bottom_replacement_choice() {
     assert!(runner.state().deferred_triggers.is_empty());
     assert!(runner.state().pending_resolution_completion.is_none());
     assert!(runner.state().pending_batch_deliveries.is_none());
+}
+
+/// CR 603.2 + CR 603.3b + CR 608.2g + CR 616.1: terminal Ripple settlement
+/// must not re-collect the resumed final cast merely because the earlier,
+/// parked observer is a different source. Aetherflux Reservoir is a distinct
+/// battlefield source, so its exactly-once B/C triggers prove the synthetic
+/// terminal SpellCast collector keys on the event, not `source_id == final_cast`.
+#[test]
+fn terminal_ripple_replacement_resume_collects_distinct_spell_cast_observer() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    red_pool(&mut scenario, 2);
+    let observer = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Aetherflux Reservoir",
+            0,
+            0,
+            AETHERFLUX_RESERVOIR_ORACLE,
+        )
+        .as_enchantment()
+        .id();
+    let rat_a = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .with_keyword(engine::types::keywords::Keyword::Ripple(4))
+        .id();
+    let rat_c = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let miss = scenario
+        .add_spell_to_hand_from_oracle(P0, "Terminal Observer Miss", true, "Draw a card.")
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+    let rat_b = scenario
+        .add_creature_to_hand_from_oracle(P0, "Rat Colony", 2, 1, RAT_COLONY_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    for (name, destination) in [
+        ("Observer Library Redirect to Hand", Zone::Hand),
+        ("Observer Library Redirect to Graveyard", Zone::Graveyard),
+    ] {
+        scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(redirect_library_move_to(destination));
+    }
+
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        for id in [rat_b, miss, rat_c] {
+            engine::game::zones::remove_from_zone(state, id, Zone::Hand, P0);
+            engine::game::zones::add_to_zone(state, id, Zone::Library, P0);
+            state.objects.get_mut(&id).expect("library card").zone = Zone::Library;
+        }
+    }
+    assert!(
+        runner.state().objects[&observer]
+            .trigger_definitions
+            .as_slice()
+            .iter()
+            .any(|trigger| matches!(
+                trigger.definition.mode,
+                engine::types::triggers::TriggerMode::SpellCast
+            )),
+        "exact Aetherflux Reservoir Oracle text must parse to its SpellCast observer"
+    );
+    assert_ne!(
+        observer, rat_c,
+        "the observer must be a distinct battlefield object from the terminal Rat"
+    );
+
+    let card_id = runner.state().objects[&rat_a].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: rat_a,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast first Rat Colony");
+
+    // Put Aetherflux's initial-cast trigger below A's Ripple so it remains a
+    // live, distinct observer while Ripple performs the terminal free cast.
+    let initial_order = match &runner.state().waiting_for {
+        WaitingFor::OrderTriggers { triggers, .. } => {
+            let observer_index = triggers
+                .iter()
+                .position(|trigger| trigger.source_id == observer)
+                .expect("Aetherflux observes the initial Rat cast");
+            let ripple_index = triggers
+                .iter()
+                .position(|trigger| trigger.source_id == rat_a)
+                .expect("Rat A's granted Ripple observes its own cast");
+            vec![observer_index, ripple_index]
+        }
+        waiting_for => panic!("expected initial observer/Ripple ordering, got {waiting_for:?}"),
+    };
+    runner
+        .act(GameAction::OrderTriggers {
+            order: initial_order,
+        })
+        .expect("place initial observer below Ripple");
+    runner.act(GameAction::PassPriority).expect("p0 pass");
+    runner.act(GameAction::PassPriority).expect("p1 pass");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::CastOffer {
+            kind: CastOfferKind::Ripple { hit_card, .. },
+            ..
+        } if hit_card == rat_b
+    ));
+
+    runner
+        .act(GameAction::RippleChoice {
+            choice: CastChoice::Cast,
+        })
+        .expect("accept B while A's Ripple still offers C");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::CastOffer {
+            kind: CastOfferKind::Ripple { hit_card, .. },
+            ..
+        } if hit_card == rat_c
+    ));
+    assert_eq!(
+        runner
+            .state()
+            .deferred_triggers
+            .iter()
+            .filter(|context| context.pending.source_id == observer)
+            .count(),
+        1,
+        "B's observer trigger must park while A's Ripple keeps offering cards"
+    );
+
+    runner
+        .act(GameAction::RippleChoice {
+            choice: CastChoice::Cast,
+        })
+        .expect("accept terminal C until bottom replacement choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("resolve the terminal bottom replacement");
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+
+    let first_accepted_rat_index = runner
+        .state()
+        .stack
+        .iter()
+        .position(|entry| entry.id == rat_b)
+        .expect("B remains on the stack");
+    assert_eq!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .skip(first_accepted_rat_index + 1)
+            .filter(|entry| entry.source_id == observer)
+            .count(),
+        2,
+        "Aetherflux contributes exactly one observer trigger for each accepted B/C cast"
+    );
 }
 
 /// CR 113.2c + CR 702.60b: two independent Thrumming Stones grant two Ripple

--- a/crates/engine/tests/integration/issue_4792_isochron_scepter.rs
+++ b/crates/engine/tests/integration/issue_4792_isochron_scepter.rs
@@ -3,8 +3,9 @@
 use engine::game::rehydrate_game_from_card_db;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::game::scenario_db::GameScenarioDbExt;
+use engine::types::ability::Effect;
 use engine::types::actions::GameAction;
-use engine::types::game_state::{ExileLink, ExileLinkKind, WaitingFor};
+use engine::types::game_state::{ExileLink, ExileLinkKind, StackEntryKind, WaitingFor};
 use engine::types::identifiers::TrackedSetId;
 use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -115,6 +116,70 @@ fn isochron_scepter_copies_and_casts_imprinted_instant() {
         runner.state().objects.get(&shock).map(|o| o.zone),
         Some(Zone::Exile),
         "imprinted Shock stays exiled after copying"
+    );
+}
+
+/// CR 608.2g + CR 113.2c + CR 702.60b: Isochron's copied spell is cast through
+/// the production `CopySpell` → `CastFromZone { ParentTarget }` reducer path.
+/// Its cast-time snapshot must include Thrumming Stone's Ripple grant so the
+/// synthesized trigger reaches the stack after the copy's retarget choice.
+#[test]
+fn isochron_cast_copy_snapshots_thrumming_stone_ripple() {
+    let Some(db) = load_db() else {
+        return;
+    };
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(
+        P0,
+        "Thrumming Stone",
+        1,
+        1,
+        "Spells you cast have ripple 4. (When you cast a spell, you may reveal the top four cards of your library. You may cast any revealed cards with the same name as the cast spell without paying their mana costs. Put the rest on the bottom of your library in any order.)",
+    );
+    let scepter = scenario.add_real_card(P0, "Isochron Scepter", Zone::Battlefield, db);
+    let shock = scenario.add_real_card(P0, "Shock", Zone::Exile, db);
+    let mut runner = scenario.build();
+    rehydrate_game_from_card_db(runner.state_mut(), db);
+    link_imprinted_instant(&mut runner, scepter, shock);
+    fund_generic(&mut runner, 2);
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: scepter,
+            ability_index: 0,
+        })
+        .expect("activate Isochron Scepter");
+    let copy_id = (0..20)
+        .find_map(|_| match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept Isochron copy/cast choice");
+                None
+            }
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass priority");
+                None
+            }
+            WaitingFor::CopyRetarget { copy_id, .. } => Some(copy_id),
+            other => panic!("unexpected Isochron cast state: {other:?}"),
+        })
+        .expect("copied Shock must request a target");
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(engine::types::ability::TargetRef::Player(P1)),
+        })
+        .expect("target copied Shock");
+
+    assert!(
+        runner.state().stack.iter().any(|entry| matches!(
+            &entry.kind,
+            StackEntryKind::TriggeredAbility { source_id, ability, .. }
+                if *source_id == copy_id && matches!(ability.effect, Effect::Ripple { count: 4 })
+        )),
+        "the cast copy must create Thrumming Stone's Ripple trigger"
     );
 }
 


### PR DESCRIPTION
## Summary
Fixes **Thrumming Stone** so Ripple cast triggers are preserved and ordered correctly when revealed spells are cast during a resolving Ripple ability. The class-wide fix also covers nested Cascade/Discover-style cast offers, spell copies, multiple Ripple grants, terminal accepts, and replacement-paused library moves.

## Files changed
- crates/engine/src/game/casting_costs.rs
- crates/engine/src/game/effects/cast_from_zone.rs
- crates/engine/src/game/engine.rs
- crates/engine/src/game/engine_priority.rs
- crates/engine/src/game/engine_resolution_choices.rs
- crates/engine/src/game/triggers.rs
- crates/engine/src/types/game_state.rs
- crates/engine/src/types/keywords.rs
- crates/engine/tests/integration/cast_during_resolution_pipeline.rs
- crates/engine/tests/integration/issue_4792_isochron_scepter.rs

## CR references
- CR 113.2c
- CR 601.2a, CR 601.2i
- CR 603.2, CR 603.3b
- CR 608.2g
- CR 616.1
- CR 702.60a-b

## Implementation method (required)
Method: /engine-implementer

## Track
Developer

## LLM
Model: gpt-5
Thinking: high
Tier: Standard

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — passed.
- `cargo test -p engine --test integration cast_during_resolution_pipeline` — 10 passed.
- Rust, parser, AI, card-data export, validation, and coverage checks from the pre-push suite — passed.
- Independent final implementation review — passed.

## Gate A
Gate A PASS head=2791ce7968cdbdd0d9353f58e5b8ade426c1c171 base=6dffff1b35b4c0c498dc515ee4c8bc6537b109f7

## Anchored on
- crates/engine/src/game/triggers.rs:2511 — Cascade reads cast-time keyword snapshots when synthesizing cast triggers; Ripple follows that same provenance authority.
- crates/engine/src/game/triggers.rs:5597 — existing deferred-trigger drain after a stack object is announced; terminal Ripple settlement reuses this ordering-capable path.

## Final review-impl
Final review-impl PASS head=2791ce7968cdbdd0d9353f58e5b8ade426c1c171

## Claimed parse impact
None.

## Validation Failures
None.

## CI Failures
The pre-push frontend lint reports parser errors in generated `client/src-tauri/target/...` assets containing ANSI escape characters. This engine-only branch does not modify those assets; the branch was pushed after the relevant Rust and card-data checks completed.