### PR TITLE
fix(parser): parse "play up to <n> additional lands this turn" (Summer Bloom #5979)

### DIFF
--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -453,13 +453,18 @@ fn is_specialized_duration_carrier(text_lower: &str) -> bool {
 fn parse_additional_land_head(input: &str) -> nom::IResult<&str, (), OracleError<'_>> {
     use nom::branch::alt;
     use nom::bytes::complete::tag;
-    use nom::combinator::value;
+    use nom::combinator::{opt, value};
     alt((
         value((), tag("play an additional land")),
+        // CR 305.2: "play <n> additional lands" and the equivalent
+        // "play up to <n> additional lands" (Summer Bloom) — the "up to" is
+        // redundant grammar (land plays are already optional), so it grants the
+        // same +n land-play allowance.
         value(
             (),
             (
                 tag("play "),
+                opt(tag("up to ")),
                 crate::parser::oracle_nom::primitives::parse_number,
                 tag(" additional lands"),
             ),

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -11814,12 +11814,19 @@ fn try_parse_additional_land_this_turn(tp: TextPair) -> Option<ParsedEffectClaus
     let (count, rest_orig) = nom_on_lower(tp.original, tp.lower, |input| {
         let (input, _) = opt(alt((tag("you may "), tag("may ")))).parse(input)?;
         let (input, _) = tag("play ").parse(input)?;
-        // "an additional land" (count 1) or "<number> additional lands".
+        // "an additional land" (count 1) or "[up to ]<number> additional lands".
+        // CR 305.2: "up to <n>" grants the same +n land-play allowance as a bare
+        // "<n>" — playing lands is already optional, so the "up to" hedge (Summer
+        // Bloom) is functionally identical to the fixed count.
         let (input, count) = alt((
             value(1u8, tag("an additional land")),
             map(
-                (nom_primitives::parse_number, tag(" additional lands")),
-                |(n, _)| n as u8,
+                (
+                    opt(tag("up to ")),
+                    nom_primitives::parse_number,
+                    tag(" additional lands"),
+                ),
+                |(_, n, _)| n as u8,
             ),
         ))
         .parse(input)?;

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -22145,6 +22145,45 @@ fn play_two_additional_lands_this_turn_parses_count() {
     }
 }
 
+/// Issue #5979: "play up to <n> additional lands this turn" (Summer Bloom) is
+/// functionally identical to the bare "<n> additional lands" grant — the "up to"
+/// hedge is redundant because land plays are already optional (CR 305.2). It must
+/// carry `AdditionalLandDrop { count: 3 }`, not fall through to Unimplemented.
+#[test]
+fn summer_bloom_up_to_three_additional_lands_parses_count() {
+    let def = parse_effect_chain(
+        "You may play up to three additional lands this turn.",
+        AbilityKind::Spell,
+    );
+    assert!(
+        !def.optional,
+        "permission grant must not become an optional resolution choice"
+    );
+    match &*def.effect {
+        Effect::GenericEffect {
+            static_abilities,
+            duration,
+            ..
+        } => {
+            assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+            let s = &static_abilities[0];
+            assert_eq!(s.mode, StaticMode::AdditionalLandDrop { count: 3 });
+            assert_eq!(s.affected, Some(TargetFilter::Controller));
+            assert!(
+                s.modifications.iter().any(|m| matches!(
+                    m,
+                    ContinuousModification::AddStaticMode {
+                        mode: StaticMode::AdditionalLandDrop { count: 3 }
+                    }
+                )),
+                "expected AddStaticMode(AdditionalLandDrop count 3), got {:?}",
+                s.modifications
+            );
+        }
+        other => panic!("expected GenericEffect, got {other:?}"),
+    }
+}
+
 /// Issue #2879: the complete Escape to the Wilds oracle text parses to a
 /// 3-link chain (ExileTop -> PlayFromExile grant -> additional-land
 /// GenericEffect) with no Unimplemented / CastFromZone{Any}.

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -3767,6 +3767,51 @@ fn modal_spell_block_keeps_mode_branches_separate() {
     ));
 }
 
+/// Issue #5979 (modal-card context): "play up to <n> additional lands this
+/// turn" also reaches the additional-land grammar as a modal mode bullet, not
+/// only as a standalone sentence. Journey of Discovery's second mode ("You may
+/// play up to two additional lands this turn.") must parse — through the
+/// production card parser — to the `AdditionalLandDrop { count: 2 }` grant, not
+/// misroute to `CastFromZone`. Entwine is a keyword line and adds no mode.
+#[test]
+fn journey_of_discovery_modal_up_to_two_additional_lands() {
+    use crate::types::statics::StaticMode;
+    let r = parse(
+        "Choose one —\n• Search your library for up to two basic land cards, reveal them, put them into your hand, then shuffle.\n• You may play up to two additional lands this turn.\nEntwine {2}{G}",
+        "Journey of Discovery",
+        &[],
+        &["Sorcery"],
+        &[],
+    );
+
+    let modal = r.modal.expect("Journey of Discovery is a modal spell");
+    assert_eq!(
+        modal.mode_count, 2,
+        "Entwine must not register as a third mode"
+    );
+    assert_eq!(
+        r.abilities.len(),
+        2,
+        "one ability per mode: {:?}",
+        r.abilities
+    );
+
+    // Second mode: the turn-scoped additional-land grant (count 2).
+    match &*r.abilities[1].effect {
+        Effect::GenericEffect {
+            static_abilities, ..
+        } => assert!(
+            static_abilities
+                .iter()
+                .any(|d| d.mode == StaticMode::AdditionalLandDrop { count: 2 }),
+            "expected AdditionalLandDrop {{ count: 2 }} in second mode, got {static_abilities:?}"
+        ),
+        other => {
+            panic!("expected GenericEffect additional-land grant as second mode, got {other:?}")
+        }
+    }
+}
+
 #[test]
 fn non_spell_permanent_resolution_like_lines_do_not_merge() {
     let r = parse(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -754,6 +754,7 @@ mod std_s07_damage_doublers;
 mod steadfast_armasaur_lki_toughness;
 mod steelform_sliver_toughness_anthem;
 mod stensian_sanguinist_prepare;
+mod summer_bloom_5979;
 mod sun_droplet_remove_counter_infeasible_4776;
 mod support;
 mod suppressor_skyguard_prevent_2924;

--- a/crates/engine/tests/integration/summer_bloom_5979.rs
+++ b/crates/engine/tests/integration/summer_bloom_5979.rs
@@ -1,0 +1,41 @@
+//! Regression test for issue #5979 — Summer Bloom's "You may play up to three
+//! additional lands this turn." must not only parse to the `AdditionalLandDrop`
+//! grant but actually reach `additional_land_drops` through cast + stack
+//! resolution (the pre-fix parser misrouted it to `CastFromZone`, so no
+//! land-play allowance was ever registered).
+//!
+//! Mirrors the runtime pattern in `explore_spell_3315.rs`: cast the real Oracle
+//! text via `GameScenario` + `GameRunner::cast(...).resolve()` and observe the
+//! transient continuous effect the production resolver registers.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::static_abilities::additional_land_drops;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+/// CR 305.2: "play up to three additional lands this turn" grants the same +3
+/// land-play allowance as a bare "three additional lands" — the "up to" hedge is
+/// redundant because land plays are already optional.
+#[test]
+fn summer_bloom_grants_three_additional_land_drops_at_runtime() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Summer Bloom",
+            false, // sorcery
+            "You may play up to three additional lands this turn.",
+        )
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let outcome = scenario.build().cast(spell).resolve();
+
+    assert_eq!(
+        additional_land_drops(outcome.state(), P0),
+        3,
+        "Summer Bloom must grant 3 additional land drops after resolving"
+    );
+}


### PR DESCRIPTION
Fixes #5979.

## Summary

Summer Bloom (`{1}{G}` sorcery — "You may play up to three additional lands this turn.") never granted its extra land plays. The turn-scoped additional-land grant parser recognized `play an additional land` and `play <n> additional lands` but not the **"up to"** hedge form.

Root cause is a two-site interaction:

1. `parse_additional_land_head` (used by `is_specialized_duration_carrier`) did not match `play up to <n> additional lands`, so the shell treated the clause as a *non*-duration-carrier and stripped the trailing ` this turn` into the clause duration.
2. `try_parse_additional_land_this_turn` then required a literal ` this turn` tag that was already gone, so the clause fell through instead of becoming an `AdditionalLandDrop` grant.

Both parse sites now accept an optional `up to ` before the count.

## Rules

CR 305.2: a "play up to `<n>` additional lands this turn" grant is functionally identical to a bare "`<n>` additional lands" grant — playing lands is already optional, so the "up to" hedge grants the same `+n` land-play allowance. It therefore maps to `AdditionalLandDrop { count: n }`, matching the existing count-`n` branch.

## Class, not card

The fix is grammar-level: any "play up to `<n>` additional lands this turn" card is now covered, not just Summer Bloom. The `opt(tag("up to "))` composes into the existing count `alt()` — no new AST shape, no per-card branch.

## Anchored on
- crates/engine/src/parser/oracle_effect/mod.rs:11818 — existing `alt()` count branch (`(parse_number, tag(" additional lands"))`) that I extended with `opt(tag("up to "))`.
- crates/engine/src/parser/clause_shell.rs:459 — existing `parse_additional_land_head` `alt()` (`("play ", parse_number, " additional lands")`) extended the same way, keeping the duration-carrier detector in sync with the effect parser.

Same nom combinator family (`alt`/`tag`/`opt`/`value`), same naming, same modules.

## Test

Added `summer_bloom_up_to_three_additional_lands_parses_count` in `oracle_effect/tests.rs`, mirroring the existing `play_two_additional_lands_this_turn_parses_count`: asserts the clause parses to a `GenericEffect` carrying `AdditionalLandDrop { count: 3 }` affecting the controller, `UntilEndOfTurn`, non-optional.

## Verification

- **Gate A (parser combinator purity):** PASS — see below. New code uses only nom combinators (`alt`/`tag`/`opt`/`value`/`map`).
- **Track:** Non-developer. This sandbox has no C toolchain (`cc`/`ld` absent) and no root to install one, so a local `cargo`/`clippy`/`test` build is not possible here. CI will run the full suite. The change is a two-line grammar extension using combinators already in scope, and the added test is a near-exact copy of the existing, passing `play_two_additional_lands_this_turn_parses_count` (same asserts, count 3 instead of 2, `up to ` in the input).
- `cargo fmt --all` run clean (no diff).

## Gate A
```
Gate A PASS head=04d731fa398abc659dc974463e01fb2aa0cb2320 base=51cff6adbb783c64559f2c004a206fc4f0968f40
```

Model: claude-opus-4-8
Thinking: High
Tier: Frontier
