### PR TITLE
fix(parser): scale P/T by opponents below half starting life (Anya, Merciless Angel #5920)

### DIFF
--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -27,7 +27,9 @@ use nom::Parser;
 
 use super::oracle_ir::context::ParseContext;
 use super::oracle_nom::bridge::nom_on_lower;
-use super::oracle_nom::condition::{inject_controller_you, parse_spell_history_filter};
+use super::oracle_nom::condition::{
+    inject_controller_you, parse_life_total_comparator, parse_spell_history_filter,
+};
 use super::oracle_nom::duration::parse_cast_snapshot_suffix;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_nom::quantity as nom_quantity;
@@ -1410,6 +1412,7 @@ fn parse_for_each_opponent_player_attribute_clause(clause: &str) -> Option<Quant
     let ((relation, attr, comparator, value_expr), rest) = nom_on_lower(clause, clause, |input| {
         let (input, relation) = parse_player_population(input)?;
         let (input, (attr, comparator, value_expr)) = alt((
+            parse_life_total_who_attr_clause,
             map(parse_hand_size_who_attr_clause, |(a, c, n)| {
                 (a, c, QuantityExpr::Fixed { value: n })
             }),
@@ -1435,6 +1438,35 @@ fn parse_for_each_opponent_player_attribute_clause(clause: &str) -> Option<Quant
             value: Box::new(value_expr),
         },
     })
+}
+
+/// CR 119: "whose life total is <comparator> <quantity>" → the candidate player's
+/// own life total (CR 119.1), compared under <comparator> to a threshold quantity.
+/// Anya, Merciless Angel: "for each opponent whose life total is less than half
+/// their starting life total" → LifeTotal LT DivideRounded(StartingLifeTotal, 2,
+/// Down). Reuses `parse_life_total_comparator` (the shared life-total ordering
+/// grammar) and `nom_quantity::parse_quantity` (the shared threshold grammar) —
+/// the exact pair the existential "an opponent's life total is <cmp> <qty>" static
+/// condition uses, so this per-candidate predicate's RHS is AST-identical to
+/// Anya's indestructible-ability condition RHS. The `PlayerScope` on the LHS ref
+/// is inert at runtime (the `PlayerAttribute` resolver reads each candidate player
+/// directly); `ScopedPlayer` documents the "each candidate's own life total" read.
+fn parse_life_total_who_attr_clause(
+    input: &str,
+) -> OracleResult<'_, (QuantityRef, Comparator, QuantityExpr)> {
+    let (input, _) = tag("whose life total is ").parse(input)?;
+    let (input, comparator) = parse_life_total_comparator(input)?;
+    let (input, value) = nom_quantity::parse_quantity(input)?;
+    Ok((
+        input,
+        (
+            QuantityRef::LifeTotal {
+                player: PlayerScope::ScopedPlayer,
+            },
+            comparator,
+            value,
+        ),
+    ))
 }
 
 /// CR 402.1: "who has/have N or fewer|more cards in hand" → the candidate's hand

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -14910,6 +14910,74 @@ fn static_parse_for_each_attached_to_self_kellan() {
     }
 }
 
+#[test]
+fn static_for_each_opponent_below_half_starting_life_is_dynamic_anya() {
+    // Issue #5920 — Anya, Merciless Angel: "Anya gets +3/+3 for each opponent
+    // whose life total is less than half their starting life total." Pre-fix the
+    // "whose life total …" arm was missing so the for-each clause failed and the
+    // boost froze at a FIXED +3/+3. It must now emit an `AddDynamicPower` over a
+    // `PlayerCount { PlayerAttribute { LifeTotal LT half-starting } }` so the
+    // boost scales with the number of qualifying opponents (CR 119).
+    let def = parse_static_line(
+        "~ gets +3/+3 for each opponent whose life total is less than half their starting life total.",
+    )
+    .expect("Anya static must parse");
+    assert_eq!(def.mode, StaticMode::Continuous);
+    let value = def
+        .modifications
+        .iter()
+        .find_map(|m| match m {
+            ContinuousModification::AddDynamicPower { value } => Some(value),
+            _ => None,
+        })
+        .expect("expected AddDynamicPower (dynamic, not fixed +3/+3)");
+    let inner = match value {
+        QuantityExpr::Multiply { factor: 3, inner } => inner.as_ref(),
+        other => panic!("expected Multiply by 3, got {other:?}"),
+    };
+    let filter = match inner {
+        QuantityExpr::Ref {
+            qty: QuantityRef::PlayerCount { filter },
+        } => filter,
+        other => panic!("expected PlayerCount ref, got {other:?}"),
+    };
+    match filter {
+        PlayerFilter::PlayerAttribute {
+            relation,
+            attr,
+            comparator,
+            value,
+        } => {
+            assert_eq!(*relation, crate::types::ability::PlayerRelation::Opponent);
+            assert!(
+                matches!(
+                    attr.as_ref(),
+                    QuantityRef::LifeTotal {
+                        player: PlayerScope::ScopedPlayer
+                    }
+                ),
+                "attr must be each candidate's own LifeTotal, got {attr:?}"
+            );
+            assert_eq!(*comparator, Comparator::LT);
+            assert!(
+                matches!(
+                    value.as_ref(),
+                    QuantityExpr::DivideRounded {
+                        divisor: 2,
+                        rounding: RoundingMode::Down,
+                        inner,
+                    } if matches!(
+                        inner.as_ref(),
+                        QuantityExpr::Ref { qty: QuantityRef::StartingLifeTotal }
+                    )
+                ),
+                "threshold must be half (rounded down) their starting life, got {value:?}"
+            );
+        }
+        other => panic!("expected PlayerAttribute filter, got {other:?}"),
+    }
+}
+
 /// Helper: the dynamic-power `QuantityExpr` from a static line's first
 /// `AddDynamicPower` modification, plus whether `keyword` was granted.
 fn dyn_power_and_keyword(

--- a/crates/engine/tests/integration/anya_merciless_angel_5920.rs
+++ b/crates/engine/tests/integration/anya_merciless_angel_5920.rs
@@ -1,0 +1,97 @@
+//! Regression for issue #5920 — Anya, Merciless Angel: "Anya gets +3/+3 for each
+//! opponent whose life total is less than half their starting life total."
+//!
+//! Pre-fix, the "for each opponent whose life total …" dynamic count did not
+//! parse (no life-total arm in `parse_for_each_opponent_player_attribute_clause`),
+//! so the static line fell through to a FIXED +3/+3 and Anya was buffed
+//! unconditionally — the reporter saw +3/+3 while every opponent was well above
+//! half their starting life. The fix routes the clause to
+//! `PlayerCount { PlayerFilter::PlayerAttribute { LifeTotal LT half-starting } }`,
+//! whose runtime is already exercised by shipping cards (Bandit's Talent etc.).
+//!
+//! Drives the real Oracle parse → static synthesis → layer pipeline and asserts
+//! Anya's derived power/toughness scales with the number of qualifying opponents.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::PlayerId;
+
+const ANYA: &str = "Flying\nAnya gets +3/+3 for each opponent whose life total is less than half their starting life total.\nAs long as an opponent's life total is less than half their starting life total, Anya has indestructible.";
+
+fn effective_pt(runner: &mut GameRunner, id: ObjectId) -> (i32, i32) {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    let object = &runner.state().objects[&id];
+    (
+        object.power.expect("creature has power"),
+        object.toughness.expect("creature has toughness"),
+    )
+}
+
+fn set_life(runner: &mut GameRunner, player: PlayerId, life: i32) {
+    runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|p| p.id == player)
+        .expect("player exists")
+        .life = life;
+}
+
+#[test]
+fn anya_gets_plus3_per_opponent_below_half_starting_life() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    // Base 4/4 Anya carrying her real Oracle text (parsed → static synthesis).
+    let anya = scenario
+        .add_creature_from_oracle(P0, "Anya", 4, 4, ANYA)
+        .id();
+    let mut runner = scenario.build();
+
+    let p2 = PlayerId(2);
+    // Initial life == starting life; half is rounded down (CR: DivideRounded Down).
+    let start = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .unwrap()
+        .life;
+    let half = start / 2;
+
+    // No opponent below half → count 0 → base 4/4 (the reporter's bug case).
+    set_life(&mut runner, P1, start);
+    set_life(&mut runner, p2, start);
+    assert_eq!(
+        effective_pt(&mut runner, anya),
+        (4, 4),
+        "Anya must NOT be buffed while every opponent is at/above half their starting life"
+    );
+
+    // One opponent below half → count 1 → +3/+3 → 7/7.
+    set_life(&mut runner, P1, half - 1);
+    assert_eq!(
+        effective_pt(&mut runner, anya),
+        (7, 7),
+        "one qualifying opponent → +3/+3"
+    );
+
+    // Two opponents below half → count 2 → +6/+6 → 10/10.
+    set_life(&mut runner, p2, half - 5);
+    assert_eq!(
+        effective_pt(&mut runner, anya),
+        (10, 10),
+        "two qualifying opponents → +6/+6"
+    );
+
+    // Boundary: an opponent at exactly half is NOT below it (strict LT, not LE).
+    set_life(&mut runner, P1, half);
+    set_life(&mut runner, p2, start);
+    assert_eq!(
+        effective_pt(&mut runner, anya),
+        (4, 4),
+        "life exactly at half their starting life must not count (less than, not <=)"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -16,6 +16,7 @@ mod angels_grace;
 mod angels_grace_2hg;
 mod announce_locked_x_runtime;
 mod another_round_repeat;
+mod anya_merciless_angel_5920;
 mod archmage_ascension_gated_draw_replacement;
 mod arcum_weathervane_supertype_removal;
 mod ark_of_hunger_play_from_graveyard_751;


### PR DESCRIPTION
Fixes #5920.

## Summary

Anya, Merciless Angel (`{3}{R}{W}`, 4/4): "Anya gets +3/+3 **for each opponent whose life total is less than half their starting life total**." She was being buffed **unconditionally** — the reporter saw +3/+3 while every opponent was well above half their starting life.

Root cause: the static "gets +N/+N for each opponent whose …" dynamic-count dispatch (`parse_for_each_opponent_player_attribute_clause`) had **no life-total arm**. The for-each clause failed to parse, so control fell through to `parse_continuous_modifications`, which extracted a **fixed +3/+3** and silently dropped the count scaling.

## Fix (parser-only)

Adds `parse_life_total_who_attr_clause` — the direct sibling of the existing `parse_hand_size_who_attr_clause` — composing two **shared building blocks already used** by the existential "an opponent's life total is `<cmp>` `<qty>`" static condition (i.e. Anya's *own* second/indestructible ability):

- `parse_life_total_comparator` (the shared life-total ordering-comparator grammar)
- `nom_quantity::parse_quantity` (the shared threshold-quantity grammar; `"half their starting life total"` → `DivideRounded(StartingLifeTotal, 2, Down)`)

The clause now lowers to:
```
PlayerCount { PlayerFilter::PlayerAttribute {
  relation: Opponent, attr: LifeTotal(ScopedPlayer),
  comparator: LT, value: DivideRounded(StartingLifeTotal, 2, Down) } }
```

**No new engine variant, no runtime/walker changes.** `PlayerFilter::PlayerAttribute` already exists and its runtime is exercised by shipping cards (Bandit's Talent, Wolfcaller's Howl, Glissa's Retriever). The `add-engine-variant` gate was run and returned "use the existing parameterized slot" — a scope-baked `OpponentLifeBelowHalfStarting` sibling would violate "Parameterize, don't proliferate."

## Class, not card

Covers "for each opponent whose life total is `<comparator>` `<quantity>`" for the full comparator × threshold matrix (via `parse_life_total_comparator` + `parse_quantity`), not just Anya.

## Anchored on
- crates/engine/src/parser/oracle_quantity.rs:1448 — `parse_hand_size_who_attr_clause`, the sibling `tag ∘ comparator ∘ quantity` arm this mirrors (same combinator family, same return tuple `(QuantityRef, Comparator, QuantityExpr)`).
- crates/engine/src/parser/oracle_quantity.rs:1409 — `parse_for_each_opponent_player_attribute_clause`, the existing `alt(...)` this adds one branch to.

## Verification

Local `cargo test` on the full engine test binaries OOMs on this host (7.7 GB; no C toolchain / no root — I link Rust via a bootstrapped `zig cc`). So I verified by building the engine rlib (non-test builds fine) and running standalone binaries against it:

**Parser AST** — `parse_static_line("~ gets +3/+3 for each opponent whose life total is less than half their starting life total.")` produces `AddDynamicPower`/`AddDynamicToughness { Multiply{ 3, PlayerCount{ PlayerAttribute{ Opponent, LifeTotal(ScopedPlayer), LT, DivideRounded(StartingLifeTotal,2,Down) } } } }` (both P and T, affected SelfRef). The sibling `"who has one or fewer cards in hand"` clause still parses (no arm shadowing).

**Runtime P/T** — Anya (base 4/4) on the battlefield, `evaluate_layers`, starting_life 20 (half 10):

| opponents (life) | qualifying | Anya P/T |
|---|---|---|
| both at 20 (≥ half) | 0 | **4/4** ← the reporter's bug case |
| one at 9 (< half) | 1 | **7/7** |
| two below half | 2 | **10/10** |
| one at exactly 10 (= half) | 0 (strict LT) | **4/4** |

## Tests added
- `crates/engine/tests/integration/anya_merciless_angel_5920.rs` — the runtime P/T matrix above through the real Oracle parse → static synthesis → layer pipeline (registered in `tests/integration/main.rs`).
- `oracle_static/tests.rs::static_for_each_opponent_below_half_starting_life_is_dynamic_anya` — asserts the dynamic AST (revert-failing: pre-fix emits a fixed pump).

## Gate A
```
Gate A PASS head=2778441f7a61091d4553f04a06b955b9fbafca7c base=45c6b30b85b046ccf5d28741807c95e91356de01
```

Model: claude-opus-4-8
Thinking: High
Tier: Frontier
