### PR TITLE
feat(engine): typed resolution frame stack + versioned wire codec (P04 Phase 2 + riders)

### DIFF
--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -39,6 +39,8 @@ export interface DeckData {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 19 — Connive exact subject snapshots and resident paused post-replacement
+ *      drains changed the serialized full-game state.
  * 17 — Dedicated companion deck slot and typed companion-reveal choices.
  * 16 — Meld pair/attacking-entry choices after the mana-payment preview variants.
  * 15 — Mana-payment preview request/response variants.
@@ -47,7 +49,7 @@ export interface DeckData {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 18;
+export const PROTOCOL_VERSION = 19;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -61,6 +61,8 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *   3 — Planechase state and action payloads in game_setup/reconnect snapshots
  *   4 — Archenemy derived view and scheme deck payloads
  *   5 — CardPredicateGuessMade game event shape
+ *  12 — Connive exact subject snapshots and resident paused post-replacement
+ *       drains changed P2P GameState snapshots.
  *  11 — Serialized GameState trigger provenance and paused logical zone-change owners.
  *  10 — Dedicated companion deck slot and typed companion-reveal choices.
  *   9 — Meld pair and attacking-entry choices after mana-payment preview variants.
@@ -70,7 +72,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 11 as const;
+export const WIRE_PROTOCOL_VERSION = 12 as const;
 
 export type P2PMessage =
   | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string }

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -6031,10 +6031,24 @@ mod tests {
     #[test]
     fn exact_selection_count_above_pool_cap_keeps_progress_candidate() {
         let mut state = GameState::new_two_player(42);
+        let conniver_id = ObjectId(100);
+        state.objects.insert(
+            conniver_id,
+            crate::game::game_object::GameObject::new(
+                conniver_id,
+                crate::types::identifiers::CardId(100),
+                PlayerId(0),
+                "Conniver".to_string(),
+                Zone::Battlefield,
+            ),
+        );
+        state.battlefield.push_back(conniver_id);
         let cards: Vec<ObjectId> = (1..=20).map(ObjectId).collect();
         state.waiting_for = WaitingFor::ConniveDiscard {
             player: PlayerId(0),
-            conniver_id: ObjectId(100),
+            conniver: state
+                .capture_connive_subject(conniver_id)
+                .expect("fixture conniver exists"),
             source_id: ObjectId(100),
             cards,
             count: SELECTION_POOL_CAP + 1,

--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -69,6 +69,7 @@ pub(crate) fn propose_connive(
 ) -> Result<(), EffectError> {
     let proposed = ProposedEvent::Connive {
         object_id: conniver.object_id(),
+        subject: Box::new(conniver.snapshot.clone()),
         count,
         applied,
     };
@@ -128,7 +129,10 @@ pub(crate) fn resolve_connive_effect(
         controller,
         count,
         HashSet::new(),
-        crate::types::game_state::DrawSequenceOrigin::ConniveTail { conniver, count },
+        crate::types::game_state::DrawSequenceOrigin::ConniveTail {
+            conniver: Box::new(conniver),
+            count,
+        },
         events,
     ) {
         ReplacementResult::Execute(_) | ReplacementResult::Prevented => {}

--- a/crates/engine/src/game/effects/connive.rs
+++ b/crates/engine/src/game/effects/connive.rs
@@ -5,9 +5,8 @@ use crate::game::replacement::{self, ReplacementResult};
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetRef};
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, WaitingFor};
+use crate::types::game_state::{ConniveSubject, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
-use crate::types::player::PlayerId;
 use crate::types::proposed_event::{AppliedReplacementKey, CounterPlacement, ProposedEvent};
 use crate::types::zones::Zone;
 
@@ -48,7 +47,10 @@ pub fn resolve(
     // Super-Genius — "If a creature you control would connive, instead you draw
     // a card, then that creature connives") before the draw/discard/counter
     // pipeline runs. The top-level resolve seeds an empty `applied` set.
-    propose_connive(state, conniver_id, count, HashSet::new(), events)
+    let conniver = state
+        .capture_connive_subject(conniver_id)
+        .ok_or(EffectError::ObjectNotFound(conniver_id))?;
+    propose_connive(state, conniver, count, HashSet::new(), events)
 }
 
 /// CR 701.50a + CR 614.1a + CR 616.1f: Propose a connive action through the
@@ -60,27 +62,25 @@ pub fn resolve(
 /// still-applicable connive replacements (CR 616.1f) without self-invoking.
 pub(crate) fn propose_connive(
     state: &mut GameState,
-    conniver_id: ObjectId,
+    conniver: ConniveSubject,
     count: u32,
     applied: HashSet<AppliedReplacementKey>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
     let proposed = ProposedEvent::Connive {
-        object_id: conniver_id,
+        object_id: conniver.object_id(),
         count,
         applied,
     };
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(ProposedEvent::Connive {
-            object_id,
-            count: final_count,
-            ..
-        }) => resolve_connive_effect(state, object_id, final_count, events),
+            count: final_count, ..
+        }) => resolve_connive_effect(state, conniver, final_count, events),
         ReplacementResult::Execute(_) => {
             // Defensive: a non-Connive survivor cannot occur (the pipeline only
             // substitutes same-variant survivor events for count-modifier
             // replacements). Fall back to the original count.
-            resolve_connive_effect(state, conniver_id, count, events)
+            resolve_connive_effect(state, conniver, count, events)
         }
         ReplacementResult::Prevented => {
             // CR 701.50f + CR 701.50b: A replacement fully replaced the connive
@@ -102,7 +102,7 @@ pub(crate) fn propose_connive(
 /// replacement pipeline — CR 614.5).
 pub(crate) fn resolve_connive_effect(
     state: &mut GameState,
-    conniver_id: ObjectId,
+    conniver: ConniveSubject,
     count: u32,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
@@ -119,11 +119,7 @@ pub(crate) fn resolve_connive_effect(
     }
 
     // CR 701.50a: The conviving permanent's controller draws and discards.
-    let controller = state
-        .objects
-        .get(&conniver_id)
-        .map(|obj| obj.controller)
-        .unwrap_or(PlayerId(0));
+    let controller = conniver.snapshot.controller;
 
     // Step 1: Draw `count` cards for the controller. The frame retains the
     // connive tail through any per-unit replacement pause.
@@ -132,10 +128,7 @@ pub(crate) fn resolve_connive_effect(
         controller,
         count,
         HashSet::new(),
-        crate::types::game_state::DrawSequenceOrigin::ConniveTail {
-            conniver: conniver_id,
-            count,
-        },
+        crate::types::game_state::DrawSequenceOrigin::ConniveTail { conniver, count },
         events,
     ) {
         ReplacementResult::Execute(_) | ReplacementResult::Prevented => {}
@@ -151,15 +144,11 @@ pub(crate) fn resolve_connive_effect(
 /// actually drawn; a partial or replaced draw still discards up to that count.
 pub(crate) fn apply_connive_tail(
     state: &mut GameState,
-    conniver_id: ObjectId,
+    conniver: ConniveSubject,
     count: u32,
     events: &mut Vec<GameEvent>,
 ) {
-    let controller = state
-        .objects
-        .get(&conniver_id)
-        .map(|obj| obj.controller)
-        .unwrap_or(PlayerId(0));
+    let controller = conniver.snapshot.controller;
 
     let hand_cards: Vec<ObjectId> = state
         .players
@@ -180,15 +169,16 @@ pub(crate) fn apply_connive_tail(
             // Replacement choice interrupted the discard loop — waiting_for already set.
             return;
         };
-        add_connive_counters(state, conniver_id, nonland_count, events);
+        add_connive_counters(state, &conniver, nonland_count, events);
     } else {
         // Player must choose which cards to discard
+        let source_id = conniver.object_id();
         state.waiting_for = WaitingFor::ConniveDiscard {
             player: controller,
-            conniver_id,
+            conniver,
             // CR 701.50b: metadata only (the discard handler ignores this field);
             // the conniving permanent is the natural source reference here.
-            source_id: conniver_id,
+            source_id,
             cards: hand_cards,
             count: discard_count,
         };
@@ -201,8 +191,8 @@ pub(crate) fn apply_connive_tail(
     // matches the conniving permanent, not the causing source.
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::Connive,
-        source_id: conniver_id,
-        subject: None,
+        source_id: conniver.object_id(),
+        subject: Some(Box::new(conniver.snapshot)),
     });
 }
 
@@ -247,7 +237,7 @@ fn is_nonland_card(state: &GameState, object_id: ObjectId) -> bool {
 /// CR 701.50b: If the creature left the battlefield, skip the counter.
 pub(crate) fn add_connive_counters(
     state: &mut GameState,
-    conniver_id: ObjectId,
+    conniver: &ConniveSubject,
     count: u32,
     events: &mut Vec<GameEvent>,
 ) {
@@ -255,22 +245,20 @@ pub(crate) fn add_connive_counters(
         return;
     }
     // CR 701.50b: Skip if the conniver has left the battlefield
-    let on_battlefield = state
-        .objects
-        .get(&conniver_id)
-        .is_some_and(|o| o.zone == Zone::Battlefield);
-    if !on_battlefield {
+    let Some(conniver_object) = state.objects.get(&conniver.object_id()) else {
+        return;
+    };
+    if conniver_object.zone != Zone::Battlefield
+        || crate::types::identifiers::ObjectIncarnationRef::from_object(conniver_object)
+            != conniver.identity()
+    {
         return;
     }
 
     let proposed = ProposedEvent::AddCounter {
         placement: CounterPlacement::Object {
-            actor: state
-                .objects
-                .get(&conniver_id)
-                .map(|obj| obj.controller)
-                .unwrap_or(crate::types::player::PlayerId(0)),
-            object_id: conniver_id,
+            actor: conniver_object.controller,
+            object_id: conniver.object_id(),
             counter_type: CounterType::Plus1Plus1,
         },
         count,
@@ -717,13 +705,13 @@ mod tests {
         match &waiting {
             WaitingFor::ConniveDiscard {
                 player,
-                conniver_id,
+                conniver: pending_conniver,
                 cards,
                 count,
                 ..
             } => {
                 assert_eq!(*player, PlayerId(0));
-                assert_eq!(*conniver_id, conniver);
+                assert_eq!(pending_conniver.object_id(), conniver);
                 assert_eq!(*count, 1);
                 let hand_cards: HashSet<ObjectId> = cards.iter().copied().collect();
                 let expected: HashSet<ObjectId> = [extra, connive_draw].into_iter().collect();
@@ -985,13 +973,13 @@ mod tests {
         match state.waiting_for.clone() {
             WaitingFor::ConniveDiscard {
                 player,
-                conniver_id,
+                conniver: pending_conniver,
                 count,
                 cards,
                 ..
             } => {
                 assert_eq!(player, PlayerId(0));
-                assert_eq!(conniver_id, conniver);
+                assert_eq!(pending_conniver.object_id(), conniver);
                 assert_eq!(count, 1, "the plain connive discards exactly 1");
                 let hand_cards: HashSet<ObjectId> = cards.iter().copied().collect();
                 let expected: HashSet<ObjectId> =
@@ -1190,13 +1178,13 @@ mod tests {
         match state.waiting_for.clone() {
             WaitingFor::ConniveDiscard {
                 player,
-                conniver_id,
+                conniver: pending_conniver,
                 count,
                 cards,
                 ..
             } => {
                 assert_eq!(player, PlayerId(0));
-                assert_eq!(conniver_id, conniver);
+                assert_eq!(pending_conniver.object_id(), conniver);
                 assert_eq!(count, 1, "the plain connive discards exactly 1");
                 let hand_cards: HashSet<ObjectId> = cards.iter().copied().collect();
                 let expected: HashSet<ObjectId> =
@@ -1498,12 +1486,12 @@ mod tests {
         match state.waiting_for.clone() {
             WaitingFor::ConniveDiscard {
                 player,
-                conniver_id,
+                conniver: pending_conniver,
                 count,
                 ..
             } => {
                 assert_eq!(player, PlayerId(0));
-                assert_eq!(conniver_id, conniver);
+                assert_eq!(pending_conniver.object_id(), conniver);
                 assert_eq!(count, 1, "the resumed plain connive discards exactly 1");
             }
             other => {
@@ -1555,14 +1543,9 @@ mod tests {
         );
     }
 
-    /// Phase-0 G1 red baseline. CR 400.7 says the returning permanent is a new
-    /// object; CR 701.50b/f nevertheless requires the original conniver's LKI
-    /// to finish the connive. Today `PendingConniveReentry` stores only an
-    /// `ObjectId`, so this deliberately pins the current wrong behavior: a
-    /// battlefield -> graveyard -> battlefield round trip under the same id lets
-    /// the deferred tail put a counter on the return. Phase 1 must carry exact
-    /// identity for the connive subject: the original completes by LKI and this
-    /// return remains untouched.
+    /// G1 regression: the original conniver completes by exact identity/LKI;
+    /// a battlefield -> graveyard -> battlefield round trip under the same
+    /// storage id must not put a counter on the returned object.
     #[test]
     fn phase0_g1_pending_connive_reentry_rebinds_same_id_return() {
         use crate::game::engine::apply_as_current;
@@ -1574,6 +1557,10 @@ mod tests {
         let mut state = GameState::new_two_player(42);
         let _leader = install_leader_replacement(&mut state, PlayerId(0));
         let conniver = make_battlefield_creature(&mut state, PlayerId(0));
+        let original_identity = state
+            .capture_connive_subject(conniver)
+            .expect("fixture conniver exists")
+            .identity();
 
         // Two one-shot draw replacements make Leader's replacement draw pause
         // on a real CR 616.1 choice, leaving its connive tail in the dedicated
@@ -1642,8 +1629,21 @@ mod tests {
                 .get(&CounterType::Plus1Plus1)
                 .copied()
                 .unwrap_or(0),
-            1,
-            "CURRENT (wrong): raw PendingConniveReentry::conniver rebinds the connive tail to the same-id return; Phase 1 must leave the return at zero counters"
+            0,
+            "the deferred connive belongs to the departed incarnation; a same-id return must remain untouched"
+        );
+        assert!(
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    GameEvent::EffectResolved {
+                        kind: EffectKind::Connive,
+                        subject: Some(subject),
+                        ..
+                    } if subject.identity == original_identity
+                )
+            }),
+            "the original conniver's exact event snapshot must complete the parked connive"
         );
     }
 

--- a/crates/engine/src/game/effects/draw.rs
+++ b/crates/engine/src/game/effects/draw.rs
@@ -301,6 +301,7 @@ pub(crate) fn resume_draw_sequence(
         return ReplacementResult::Prevented;
     };
     state.last_effect_count = Some(frame.accumulated as i32);
+    let post_replacement_drain_owner = frame.post_replacement_drain_owner;
 
     match frame.origin {
         DrawSequenceOrigin::Plain => {
@@ -317,6 +318,10 @@ pub(crate) fn resume_draw_sequence(
                 subject: None,
             });
         }
+    }
+
+    if post_replacement_drain_owner.is_some() && !state.park_post_replacement_drain_dispatch() {
+        state.finish_post_replacement_drain_dispatch();
     }
 
     ReplacementResult::Execute(ProposedEvent::Draw {

--- a/crates/engine/src/game/effects/draw.rs
+++ b/crates/engine/src/game/effects/draw.rs
@@ -282,11 +282,23 @@ pub(crate) fn resume_draw_sequence(
         );
         match result {
             ReplacementResult::Execute(_) | ReplacementResult::Prevented => {
-                // The unit's delivery may itself have pushed and popped a nested
-                // instruction, so re-address this frame by ID rather than assuming
-                // it is still whatever `active_mut()` returns.
-                if let Some(frame) = state.draw_sequences.active_if(frame_id) {
+                // The unit's delivery may itself have pushed a nested instruction.
+                // Credit this exact frame by identity, but never resume it while
+                // the nested frame remains active.
+                if let Some(frame) = state.draw_sequences.frame_mut(frame_id) {
                     frame.accumulated += unit_drawn;
+                }
+                if state
+                    .draw_sequences
+                    .active()
+                    .is_none_or(|frame| frame.frame_id != frame_id)
+                {
+                    return ReplacementResult::NeedsChoice(
+                        state
+                            .waiting_for
+                            .acting_player()
+                            .unwrap_or(state.active_player),
+                    );
                 }
             }
             // The frame stays parked on the stack; the choice resumes it.
@@ -301,15 +313,13 @@ pub(crate) fn resume_draw_sequence(
         return ReplacementResult::Prevented;
     };
     state.last_effect_count = Some(frame.accumulated as i32);
-    let post_replacement_drain_owner = frame.post_replacement_drain_owner;
-
     match frame.origin {
         DrawSequenceOrigin::Plain => {
             // Intentionally no `EffectResolved { Draw }`: no trigger matcher consumes
             // `EffectKind::Draw` today, so wiring that event is out of scope here.
         }
         DrawSequenceOrigin::ConniveTail { conniver, count } => {
-            super::connive::apply_connive_tail(state, conniver, count, events);
+            super::connive::apply_connive_tail(state, *conniver, count, events);
         }
         DrawSequenceOrigin::ScryCompletion { source_id } => {
             events.push(GameEvent::EffectResolved {
@@ -320,8 +330,15 @@ pub(crate) fn resume_draw_sequence(
         }
     }
 
-    if post_replacement_drain_owner.is_some() && !state.park_post_replacement_drain_dispatch() {
-        state.finish_post_replacement_drain_dispatch();
+    // CR 615.5: A `Draw` with a chained follow-up leaves that follow-up in the
+    // normal pending-continuation slot. Keep this paused drain resident until
+    // that chain runs: its `PostReplacementSourceController` read still needs
+    // the prevented-event context. A draw without a parked follow-up is the
+    // terminal action of this dispatch and can retire the exact top entry now.
+    // Nested replacement dispatches retain their own stack entries, so this
+    // never pops an outer paused event context.
+    if state.pending_continuation.is_none() {
+        state.post_replacement_drains.finish_paused_dispatch();
     }
 
     ReplacementResult::Execute(ProposedEvent::Draw {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -29,6 +29,7 @@ use crate::types::game_state::{
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::mana::ManaCost;
 use crate::types::player::{Player, PlayerId};
+use crate::types::resolution::{ResolutionFrame, ResolutionStack};
 use crate::types::zones::Zone;
 
 pub mod adapt;
@@ -792,6 +793,110 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
         // full-drain lifetime — clear it alongside the applied seed so it never
         // leaks into a later, unrelated `EventContextAmount` read.
         state.post_replacement_token_substitution_count = None;
+    }
+}
+
+/// Resume the active typed resolution-frame view through its established legacy
+/// authority while Phase 2 still keeps the mutable runtime slots in `GameState`.
+///
+/// The dispatcher reads only `frames.last()`. The one shipped coupled shape is
+/// represented structurally: a `MultiDraw` whose immediate predecessor is a
+/// paused `PostReplacement` drain is a paired child; all other `MultiDraw`
+/// frames are independent roots. Both delegate to `draw::resume_draw_sequence`,
+/// whose existing resident-drain cleanup preserves the paused parent. No frame
+/// is popped here, and the central legacy drains remain authoritative until
+/// Phase 3 owns the stack at runtime.
+pub(crate) fn resume_resolution_frames(
+    state: &mut GameState,
+    frames: &ResolutionStack,
+    events: &mut Vec<GameEvent>,
+) {
+    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+        return;
+    }
+
+    let Some(frame) = frames.last() else {
+        return;
+    };
+
+    match frame {
+        ResolutionFrame::AbilityContinuation(_)
+        | ResolutionFrame::RepeatFor(_)
+        | ResolutionFrame::RepeatUntil(_)
+        | ResolutionFrame::ChangeZone(_) => drain_pending_continuation(state, events),
+        ResolutionFrame::RepeatedOptionalPayment(_) => {
+            // The optional-effect action owns both the next payment prompt and
+            // its reflexive tail; a priority boundary has nothing to resume.
+        }
+        ResolutionFrame::BatchDelivery(_) => {
+            crate::game::zone_pipeline::drain_pending_batch_deliveries(state, events);
+        }
+        ResolutionFrame::CounterMoves(_) => counters::drain_pending_counter_moves(state, events),
+        ResolutionFrame::CounterRemovals(_) => {
+            counters::drain_pending_counter_removals(state, events);
+        }
+        ResolutionFrame::CounterAdditions(_) => {
+            counters::drain_pending_counter_additions(state, events);
+        }
+        ResolutionFrame::CopyToken(_) => {
+            token_copy::drain_pending_copy_token_resolution(state, events);
+        }
+        ResolutionFrame::EachPlayerCopyChosen(_) => {
+            each_player_copy_chosen::drain_pending(state, events);
+        }
+        ResolutionFrame::ChooseOneOf(_) => choose_one_of::resume_pending(state, events),
+        ResolutionFrame::VoteBallot(_) => {
+            vote::drain_pending_vote_ballot_iteration(state, events);
+        }
+        ResolutionFrame::PerPlayerZoneChoice(_) => {
+            choose_from_zone::drain_pending_per_player_zone_choice(state, &[], events);
+        }
+        ResolutionFrame::PerCategoryZoneChoice(_) => {
+            let _ = choose_from_zone::drain_pending_per_category_zone_choice(state, &[], events);
+        }
+        ResolutionFrame::OptionalEffect(_)
+        | ResolutionFrame::CoinFlip(_)
+        | ResolutionFrame::Proliferate(_)
+        | ResolutionFrame::MutateMerge(_) => {
+            // Direct-choice frames resume only through their corresponding
+            // action handlers, never by a priority-time drain.
+        }
+        ResolutionFrame::MultiDraw(_) => {
+            let paired_parent = matches!(
+                frames.active_predecessor(),
+                Some(ResolutionFrame::PostReplacement(drains))
+                    if matches!(
+                        drains.resident().map(|drain| &drain.status),
+                        Some(crate::types::game_state::DrainStatus::Paused)
+                    )
+            );
+            if paired_parent {
+                // The resident drain is retained and retired only by the
+                // existing typed dispatch lifecycle inside the draw authority.
+                debug_assert!(state.post_replacement_drains.resident().is_some());
+            }
+            if let Some(frame_id) = state.draw_sequences.active().map(|draw| draw.frame_id) {
+                let _ = draw::resume_draw_sequence(state, frame_id, events);
+            }
+        }
+        ResolutionFrame::ConniveReentry(_) => {
+            let _ = crate::game::engine_replacement::drain_pending_connive_reentry(state, events);
+        }
+        ResolutionFrame::LifeTotalAssignment(_) => {
+            life::drain_pending_life_total_assignment(state, events);
+        }
+        ResolutionFrame::SpellResolution(_) => {
+            if let Some(pending) = state.pending_spell_resolution.clone() {
+                crate::game::engine_replacement::apply_pending_spell_resolution(
+                    state, &pending, events,
+                );
+            }
+        }
+        ResolutionFrame::PostReplacement(_) => {
+            let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
+                state, None, None, None, events,
+            );
+        }
     }
 }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -719,6 +719,7 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
                 parent_kind,
                 search_attach_host,
                 trigger_context,
+                post_replacement_drain_owner,
             } = cont;
             state.search_continuation_attach_host = search_attach_host;
             let source_id = chain.source_id;
@@ -739,6 +740,11 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
                     source_id,
                     subject: None,
                 });
+            }
+            if post_replacement_drain_owner.is_some()
+                && !state.park_post_replacement_drain_dispatch()
+            {
+                state.finish_post_replacement_drain_dispatch();
             }
         }
     }
@@ -1324,6 +1330,7 @@ fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbil
             parent_kind,
             search_attach_host,
             trigger_context,
+            post_replacement_drain_owner,
         } = existing;
         super::ability_utils::append_to_sub_chain(&mut head, *chain);
         state.pending_continuation = Some(PendingContinuation {
@@ -1334,6 +1341,7 @@ fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbil
             // ability's resolution is anchored to its earliest pause, not
             // re-latched to whatever is live at splice time.
             trigger_context,
+            post_replacement_drain_owner,
         });
     } else {
         state.pending_continuation = Some(PendingContinuation::new(Box::new(head), state));

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -719,7 +719,6 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
                 parent_kind,
                 search_attach_host,
                 trigger_context,
-                post_replacement_drain_owner,
             } = cont;
             state.search_continuation_attach_host = search_attach_host;
             let source_id = chain.source_id;
@@ -741,10 +740,10 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
                     subject: None,
                 });
             }
-            if post_replacement_drain_owner.is_some()
-                && !state.park_post_replacement_drain_dispatch()
-            {
-                state.finish_post_replacement_drain_dispatch();
+            if !waits_for_resolution_choice(&state.waiting_for) {
+                // CR 615.5: a resumed continuation completes its own paused
+                // resident drain only after it has not raised another choice.
+                state.post_replacement_drains.finish_paused_dispatch();
             }
         }
     }
@@ -1330,7 +1329,6 @@ fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbil
             parent_kind,
             search_attach_host,
             trigger_context,
-            post_replacement_drain_owner,
         } = existing;
         super::ability_utils::append_to_sub_chain(&mut head, *chain);
         state.pending_continuation = Some(PendingContinuation {
@@ -1341,7 +1339,6 @@ fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbil
             // ability's resolution is anchored to its earliest pause, not
             // re-latched to whatever is live at splice time.
             trigger_context,
-            post_replacement_drain_owner,
         });
     } else {
         state.pending_continuation = Some(PendingContinuation::new(Box::new(head), state));

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -2283,7 +2283,9 @@ mod tests {
             crate::types::proposed_event::AppliedReplacementKey::object(o, 0),
         ]));
         state.pending_connive_reentry = Some(PendingConniveReentry {
-            conniver: o,
+            conniver: state
+                .capture_connive_subject(o)
+                .expect("fixture conniver exists"),
             count: 1,
             applied: HashSet::new(),
         });

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -19,6 +19,8 @@ use crate::types::match_config::MatchType;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
 use crate::types::resolution::canonicalize_legacy_resolution_state;
+#[cfg(debug_assertions)]
+use crate::types::resolution::debug_assert_runtime_resolution_invariants;
 use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
@@ -273,6 +275,8 @@ pub(super) fn apply_action_boundary_with_stack_limit(
         finalize_display_state(state);
     }
     result.log_entries = super::log::resolve_log_entries(&result.events, state);
+    #[cfg(debug_assertions)]
+    debug_assert_runtime_resolution_invariants(state);
     Ok(result)
 }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -18,6 +18,7 @@ use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::match_config::MatchType;
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
+use crate::types::resolution::canonicalize_legacy_resolution_state;
 use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
@@ -2293,6 +2294,11 @@ pub(super) fn resume_pending_continuation_if_priority(
 ) -> Result<(), EngineError> {
     if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
         effects::drain_pending_continuation(state, events);
+        if matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+            let frames =
+                canonicalize_legacy_resolution_state(state).map_err(EngineError::InvalidAction)?;
+            effects::resume_resolution_frames(state, &frames, events);
+        }
         // CR 605.3b + CR 616.1: A post-replacement prompt reaches this common
         // boundary only after ordinary continuations drain. The shared typed
         // dispatcher owns the remaining eligible payment roots.

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -525,14 +525,13 @@ pub(super) fn handle_replacement_choice(
                 // already repeated over and exhausted every applicable connive
                 // replacement, so no connive replacement remains to apply here and
                 // a direct `resolve_connive_effect` is correct.
-                ProposedEvent::Connive {
-                    object_id, count, ..
-                } => {
-                    if let Some(conniver) = state.capture_connive_subject(object_id) {
-                        let _ = crate::game::effects::connive::resolve_connive_effect(
-                            state, conniver, count, events,
-                        );
-                    }
+                ProposedEvent::Connive { subject, count, .. } => {
+                    let _ = crate::game::effects::connive::resolve_connive_effect(
+                        state,
+                        crate::types::game_state::ConniveSubject { snapshot: *subject },
+                        count,
+                        events,
+                    );
                 }
                 // CR 701.34a: Proliferate accepted after replacement choice.
                 proliferate @ ProposedEvent::Proliferate { .. } => {
@@ -841,13 +840,23 @@ pub(super) fn handle_replacement_choice(
             // if the next unit surfaces its own choice, so an arbitrary number of
             // sequential re-pauses compose — each resume re-addresses the same
             // frame by ID.
-            if matches!(waiting_for, WaitingFor::Priority { .. }) {
-                if let Some(frame_id) = state.draw_sequences.active().map(|f| f.frame_id) {
-                    let _ =
-                        crate::game::effects::draw::resume_draw_sequence(state, frame_id, events);
-                    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
-                        waiting_for = state.waiting_for.clone();
-                    }
+            while matches!(waiting_for, WaitingFor::Priority { .. }) {
+                let Some(frame_id) = state.draw_sequences.active().map(|frame| frame.frame_id)
+                else {
+                    break;
+                };
+                let _ = crate::game::effects::draw::resume_draw_sequence(state, frame_id, events);
+                if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+                    waiting_for = state.waiting_for.clone();
+                    break;
+                }
+                if state
+                    .draw_sequences
+                    .active()
+                    .is_some_and(|frame| frame.frame_id == frame_id)
+                {
+                    // No frame completed or paused; avoid retrying a stalled frame.
+                    break;
                 }
             }
 
@@ -1969,7 +1978,9 @@ pub(crate) fn apply_pending_post_replacement_effect(
     //   * the effect can still read this drain's event context (CR 615.5), which is
     //     how `PostReplacementSourceController` resolves "the source's controller
     //     draws cards" for Swans of Bryn Argoll.
-    // The drain is popped after the dispatch returns.
+    // The typed dispatch handle keeps cleanup attached to that exact resident
+    // entry. A nested replacement can push its own drain above it, but cannot
+    // cause the outer post-dispatch cleanup to mark or pop the nested top.
     //
     // `Resolved` carries captured targets (prevention follow-ups); `Template` is an
     // AST that resolves against `source` for ETB / Optional accept.
@@ -1980,11 +1991,12 @@ pub(crate) fn apply_pending_post_replacement_effect(
         .map(|drain| std::mem::take(&mut drain.applied))
         .unwrap_or_default();
 
-    let waiting_for = match state.post_replacement_drains.begin_dispatch() {
-        Some(PostReplacementContinuation::Resolved(resolved)) => {
+    let (continuation, dispatch) = state.post_replacement_drains.begin_dispatch()?;
+    let waiting_for = match continuation {
+        PostReplacementContinuation::Resolved(resolved) => {
             apply_post_replacement_resolved_effect(state, &resolved, replacement_applied, events)
         }
-        Some(PostReplacementContinuation::Template(effect_def)) => apply_post_replacement_effect(
+        PostReplacementContinuation::Template(effect_def) => apply_post_replacement_effect(
             state,
             &effect_def,
             source,
@@ -1993,15 +2005,18 @@ pub(crate) fn apply_pending_post_replacement_effect(
             replacement_applied,
             events,
         ),
-        None => None,
     };
-    // CR 615.5: a pausing draw or its parked continuation owns this dispatch.
-    // Keep the drain resident so the resumed chain can still read the prevented
-    // event's source and target; otherwise the synchronous dispatch is complete.
-    if waiting_for.is_some() && state.park_post_replacement_drain_dispatch() {
-        // The typed pause owner retires the resident drain at true completion.
+    // CR 615.5: a direct pause retains this dispatch's context on its own entry.
+    // If a nested drain owns the prompt instead, this continuation has completed;
+    // retire its exact `Dispatching` entry below the nested top.
+    if waiting_for.is_some()
+        && state
+            .post_replacement_drains
+            .dispatch_is_resident_top(dispatch)
+    {
+        state.post_replacement_drains.pause_dispatch(dispatch);
     } else {
-        state.finish_post_replacement_drain_dispatch();
+        state.post_replacement_drains.finish_dispatch(dispatch);
     }
     // NOTE: the inherited token-choice applied seed is intentionally NOT cleared
     // here. This drain runs for EVERY replacement continuation — including a
@@ -2391,6 +2406,8 @@ pub(super) fn find_copy_targets(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::super::game_object::GameObject;
     use super::*;
     use crate::game::engine::apply_as_current;
@@ -2404,7 +2421,7 @@ mod tests {
     use crate::types::counter::CounterType;
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
-    use crate::types::proposed_event::ProposedEvent;
+    use crate::types::proposed_event::{ProposedEvent, ReplacementId};
     use crate::types::replacements::ReplacementEvent;
 
     /// Helper: install an Optional replacement on a battlefield object so the
@@ -2440,6 +2457,89 @@ mod tests {
         let obj = state.objects.get_mut(&id).unwrap();
         obj.card_types.core_types.push(CoreType::Creature);
         id
+    }
+
+    /// CR 400.7 + CR 616.1: A Connive event parked for replacement ordering
+    /// carries the original subject snapshot. Its terminal delivery must not
+    /// recapture a returned object that reused the same storage id.
+    #[test]
+    fn connive_replacement_ordering_keeps_original_subject_after_same_id_return() {
+        let mut state = GameState::new_two_player(42);
+        let conniver = make_creature(&mut state, PlayerId(0), "Original conniver");
+        let original_subject = state
+            .capture_connive_subject(conniver)
+            .expect("fixture conniver exists before the ordering pause");
+
+        // A real zone round trip creates a new object incarnation while
+        // preserving the engine's storage ObjectId.
+        crate::game::zones::move_to_zone(&mut state, conniver, Zone::Graveyard, &mut Vec::new());
+        crate::game::zones::move_to_zone(&mut state, conniver, Zone::Battlefield, &mut Vec::new());
+        assert_ne!(
+            original_subject.identity(),
+            crate::types::identifiers::ObjectIncarnationRef::from_object(&state.objects[&conniver]),
+            "reach guard: the battlefield return must be a new CR 400.7 incarnation"
+        );
+
+        // The candidate deliberately has no execute payload. Choosing it takes
+        // the actual `continue_replacement` path, marks it applied, and delivers
+        // the terminal Connive survivor through `handle_replacement_choice`.
+        let candidate = install_optional_replacement(&mut state, ReplacementEvent::Connive);
+        state.pending_replacement = Some(crate::types::game_state::PendingReplacement {
+            proposed: ProposedEvent::Connive {
+                object_id: conniver,
+                subject: Box::new(original_subject.snapshot.clone()),
+                count: 1,
+                applied: HashSet::new(),
+            },
+            sacrifice_provenance: None,
+            candidates: vec![ReplacementId {
+                source: candidate,
+                index: 0,
+            }],
+            search_found_candidates: Vec::new(),
+            depth: 0,
+            is_optional: true,
+            library_placement: None,
+            excess_recipient: None,
+            lifelink_bonus: 0,
+            may_cost_paid: false,
+            may_cost_remaining: None,
+        });
+        state.waiting_for = replacement_mod::replacement_choice_waiting_for(PlayerId(0), &state);
+
+        let draw_card_id = CardId(state.next_object_id);
+        let draw = create_object(
+            &mut state,
+            draw_card_id,
+            PlayerId(0),
+            "Discarded by the original connive".to_string(),
+            Zone::Library,
+        );
+        let mut events = Vec::new();
+        handle_replacement_choice(&mut state, 0, &mut events)
+            .expect("resume the parked Connive replacement choice");
+
+        assert!(state.players[0].graveyard.contains(&draw));
+        assert_eq!(
+            state.objects[&conniver]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            0,
+            "the same-id return is not the original conniver and receives no counter"
+        );
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: crate::types::ability::EffectKind::Connive,
+                    subject: Some(subject),
+                    ..
+                } if subject.identity == original_subject.identity()
+            )),
+            "completion event retains the original exact subject for Connive triggers"
+        );
     }
 
     /// CR 805.4b + CR 616.1: regression for a review-flagged bug where the
@@ -5139,11 +5239,11 @@ mod tests {
             matches!(
                 state.post_replacement_drains.resident(),
                 Some(crate::types::game_state::PostReplacementDrain {
-                    status: crate::types::game_state::DrainStatus::Dispatching,
+                    status: crate::types::game_state::DrainStatus::Paused,
                     ..
                 })
             ),
-            "the dispatching drain must own its event context across the paused draw"
+            "the paused drain must own its event context across the paused draw"
         );
 
         let serialized = serde_json::to_string(&state).expect("save paused state");
@@ -5165,6 +5265,116 @@ mod tests {
         assert!(
             restored.post_replacement_drains.is_empty(),
             "the drain is retired only after its resumed continuation completes"
+        );
+    }
+
+    /// CR 615.5 + CR 616.1g: an outer post-replacement draw can install and
+    /// immediately dispatch an inner post-replacement draw. If the inner draw
+    /// pauses on its own replacement choice, the completed outer drain must be
+    /// retired by its typed dispatch handle rather than stranding below the
+    /// inner pause.
+    #[test]
+    fn nested_post_replacement_draw_pause_retires_completed_outer_drain() {
+        use crate::types::ability::{
+            AbilityDefinition, AbilityKind, DrawReplacementScope, Effect,
+            PostReplacementContinuation, QuantityModification, ReplacementDefinition,
+            ReplacementPlayerScope, TargetFilter,
+        };
+
+        let mut state = GameState::new_two_player(42);
+        let outer_source = make_creature(&mut state, PlayerId(0), "Outer draw source");
+        for player in [PlayerId(0), PlayerId(1)] {
+            for index in 0..4 {
+                let card_id = CardId(state.next_object_id);
+                create_object(
+                    &mut state,
+                    card_id,
+                    player,
+                    format!("P{} nested library {index}", player.0),
+                    Zone::Library,
+                );
+            }
+        }
+
+        // P0's outer draw is replaced by an equivalent draw plus a P1 draw in
+        // its post-replacement tail. The first replacement therefore installs
+        // and dispatches an inner drain while the outer drain is still running.
+        let replacement_host = make_creature(&mut state, PlayerId(1), "Nested draw host");
+        let nested_draw = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        let mut outer_draw_replacement = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        outer_draw_replacement.sub_ability = Some(Box::new(nested_draw));
+        let mut replacement = ReplacementDefinition::new(ReplacementEvent::Draw)
+            .draw_scope(DrawReplacementScope::IndividualDraw)
+            .execute(outer_draw_replacement);
+        replacement.valid_player = Some(ReplacementPlayerScope::Opponent);
+        state.objects[&replacement_host]
+            .replacement_definitions
+            .push(replacement);
+
+        // Only the inner P1 draw sees these two modifiers, so it alone pauses
+        // on CR 616.1 ordering while the completed P0 outer draw is unwinding.
+        for modification in [
+            QuantityModification::Times { factor: 2 },
+            QuantityModification::Plus { value: 1 },
+        ] {
+            let host = make_creature(&mut state, PlayerId(1), "Inner draw modifier");
+            let mut modifier = ReplacementDefinition::new(ReplacementEvent::Draw)
+                .draw_scope(DrawReplacementScope::IndividualDraw);
+            modifier.valid_player = Some(ReplacementPlayerScope::You);
+            modifier.quantity_modification = Some(modification);
+            modifier.consume_on_apply = true;
+            state.objects[&host].replacement_definitions.push(modifier);
+        }
+
+        state.install_ready_continuation(PostReplacementContinuation::Template(Box::new(
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+            ),
+        )));
+        let mut events = Vec::new();
+        let waiting = apply_pending_post_replacement_effect(
+            &mut state,
+            Some(outer_source),
+            None,
+            Some(ReplacementEvent::DamageDone),
+            &mut events,
+        );
+        assert!(
+            matches!(waiting, Some(WaitingFor::ReplacementChoice { .. })),
+            "reach guard: the inner P1 draw pauses while the outer drain unwinds"
+        );
+        assert!(
+            matches!(
+                state.post_replacement_drains.resident(),
+                Some(crate::types::game_state::PostReplacementDrain {
+                    status: crate::types::game_state::DrainStatus::Paused,
+                    ..
+                })
+            ),
+            "the inner draw owns the sole resident paused context"
+        );
+
+        apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+            .expect("resume the inner draw replacement choice");
+        assert!(
+            state.post_replacement_drains.is_empty(),
+            "resuming the inner draw retires it without leaving the completed outer drain"
         );
     }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -1995,10 +1995,14 @@ pub(crate) fn apply_pending_post_replacement_effect(
         ),
         None => None,
     };
-    // The dispatch is over: retire the drain, taking its event context with it.
-    // This replaces the hand-clearing of `post_replacement_event_source` /
-    // `_event_target` that used to sit below.
-    state.post_replacement_drains.finish_dispatch();
+    // CR 615.5: a pausing draw or its parked continuation owns this dispatch.
+    // Keep the drain resident so the resumed chain can still read the prevented
+    // event's source and target; otherwise the synchronous dispatch is complete.
+    if waiting_for.is_some() && state.park_post_replacement_drain_dispatch() {
+        // The typed pause owner retires the resident drain at true completion.
+    } else {
+        state.finish_post_replacement_drain_dispatch();
+    }
     // NOTE: the inherited token-choice applied seed is intentionally NOT cleared
     // here. This drain runs for EVERY replacement continuation — including a
     // nested one that pauses inside an outer token-choice ChooseOneOf (issue
@@ -5048,12 +5052,9 @@ mod tests {
         assert_eq!(state.players[1].life, initial_life - 3);
     }
 
-    /// Phase-0 G4 baseline. A general post-replacement drain begins a true draw
-    /// that pauses on a replacement consult, the paused state is saved/reloaded,
-    /// and a continuation then reads `PostReplacementSourceController`. Today
-    /// `finish_dispatch` pops the resident drain before that continuation resumes,
-    /// so the event-source context is lost. Phase 1 must retain typed ownership
-    /// across this pause: P1 must draw the second card instead of P0.
+    /// G4 regression: a general post-replacement drain that begins a true draw
+    /// retains its event context across a save/reload at a replacement pause,
+    /// through its context-dependent follow-up.
     #[test]
     fn phase0_g4_general_drain_loses_event_context_across_pausing_draw_resume() {
         use crate::types::ability::{
@@ -5135,8 +5136,14 @@ mod tests {
             "reach guard: general drain's first draw must pause on a replacement consult"
         );
         assert!(
-            state.post_replacement_drains.is_empty(),
-            "CURRENT behavior: finish_dispatch already popped the dispatching drain at the pause"
+            matches!(
+                state.post_replacement_drains.resident(),
+                Some(crate::types::game_state::PostReplacementDrain {
+                    status: crate::types::game_state::DrainStatus::Dispatching,
+                    ..
+                })
+            ),
+            "the dispatching drain must own its event context across the paused draw"
         );
 
         let serialized = serde_json::to_string(&state).expect("save paused state");
@@ -5152,8 +5159,12 @@ mod tests {
         );
         assert_eq!(
             restored.players[1].hand.len(),
-            0,
-            "CURRENT (wrong): the post-resume PostReplacementSourceController read has no resident drain context, so P1 draws zero; Phase 1 must make P1 draw one"
+            1,
+            "the resumed PostReplacementSourceController follow-up must draw for P1 from the persisted drain context"
+        );
+        assert!(
+            restored.post_replacement_drains.is_empty(),
+            "the drain is retired only after its resumed continuation completes"
         );
     }
 

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -528,9 +528,11 @@ pub(super) fn handle_replacement_choice(
                 ProposedEvent::Connive {
                     object_id, count, ..
                 } => {
-                    let _ = crate::game::effects::connive::resolve_connive_effect(
-                        state, object_id, count, events,
-                    );
+                    if let Some(conniver) = state.capture_connive_subject(object_id) {
+                        let _ = crate::game::effects::connive::resolve_connive_effect(
+                            state, conniver, count, events,
+                        );
+                    }
                 }
                 // CR 701.34a: Proliferate accepted after replacement choice.
                 proliferate @ ProposedEvent::Proliferate { .. } => {

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -94,7 +94,7 @@ pub(crate) fn object_has_devour_replacement(state: &GameState, id: ObjectId) -> 
 /// THEN that creature connives" still runs the connive step — the prevention
 /// replaced only the draw). Returns the parked `WaitingFor` (ConniveDiscard /
 /// fresh ReplacementChoice) if `propose_connive` parked one, else `None`.
-fn drain_pending_connive_reentry(
+pub(crate) fn drain_pending_connive_reentry(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
 ) -> Option<WaitingFor> {
@@ -2176,7 +2176,7 @@ fn apply_post_replacement_resolved_effect(
 /// CR 608.3: Complete post-resolution work for a permanent spell whose ETB
 /// went through the replacement pipeline and required a player choice.
 /// Applies cast_from_zone, aura attachment, and warp delayed triggers.
-fn apply_pending_spell_resolution(
+pub(crate) fn apply_pending_spell_resolution(
     state: &mut GameState,
     ctx: &crate::types::game_state::PendingSpellResolution,
     events: &mut Vec<GameEvent>,

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3721,7 +3721,7 @@ pub(super) fn handle_resolution_choice(
         (
             WaitingFor::ConniveDiscard {
                 player,
-                conniver_id,
+                conniver,
                 source_id: _,
                 cards,
                 count,
@@ -3762,14 +3762,14 @@ pub(super) fn handle_resolution_choice(
                 return Ok(action_result_outcome(events, state.waiting_for.clone()));
             };
 
-            effects::connive::add_connive_counters(state, conniver_id, nonland_count, events);
+            effects::connive::add_connive_counters(state, &conniver, nonland_count, events);
             // CR 701.50f + CR 701.50b: the EffectResolved carries the CONNIVER's
             // id (LKI if it left the battlefield) so "whenever a creature you
             // control connives" matches the conniving permanent, not the source.
             events.push(GameEvent::EffectResolved {
                 kind: EffectKind::Connive,
-                source_id: conniver_id,
-                subject: None,
+                source_id: conniver.object_id(),
+                subject: Some(Box::new(conniver.snapshot)),
             });
             ResolutionChoiceOutcome::WaitingFor(finish_with_continuation(state, player, events))
         }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -18,6 +18,7 @@ use crate::types::ability::{
 use crate::types::card::CardFace;
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterMatch;
+use crate::types::events::EventObjectSnapshot;
 use crate::types::game_state::{
     AttackDeclarationRecord, CounterAddedRecord, DamageRecord, GameState, LKISnapshot,
     SpellCastRecord, StackEntryKind, TriggerSourceContext, ZoneChangeRecord,
@@ -1659,6 +1660,75 @@ pub fn matches_target_filter_on_lki_snapshot(
         is_suspected: lki.is_suspected,
     };
     matches_target_filter_on_zone_change_record(state, &record, filter, ctx)
+}
+
+/// CR 400.7 + CR 603.10a: Match an event subject from its captured facts,
+/// never by re-reading the live object at the same storage id. Connive uses
+/// this for its exact completion snapshot after a replacement-ordering pause.
+pub(crate) fn matches_target_filter_on_event_snapshot(
+    state: &GameState,
+    snapshot: &EventObjectSnapshot,
+    filter: &TargetFilter,
+    ctx: &FilterContext<'_>,
+) -> bool {
+    let mut object = GameObject::new(
+        snapshot.identity.object_id,
+        CardId(0),
+        snapshot.owner,
+        snapshot.name.clone(),
+        snapshot.zone,
+    );
+    object.controller = snapshot.controller;
+    object.power = snapshot.power;
+    object.toughness = snapshot.toughness;
+    object.base_power = snapshot.base_power;
+    object.base_toughness = snapshot.base_toughness;
+    object.card_types.core_types = snapshot.core_types.clone();
+    object.card_types.subtypes = snapshot.subtypes.clone();
+    object.card_types.supertypes = snapshot.supertypes.clone();
+    object.mana_cost = ManaCost::generic(snapshot.mana_value);
+    object.keywords = snapshot.keywords.clone();
+    object.color = snapshot.colors.clone();
+    object.counters = snapshot.counters.clone();
+    object.is_token = snapshot.is_token;
+    object.is_commander = snapshot.is_commander;
+    object.tapped = snapshot.tapped;
+    object.face_down = snapshot.face_down;
+    object.transformed = snapshot.transformed;
+    object.is_suspected = snapshot.is_suspected;
+    object.is_renowned = snapshot.is_renowned;
+    object.is_saddled = snapshot.is_saddled;
+    object.attachments = snapshot
+        .attachments
+        .iter()
+        .map(|attachment| attachment.identity.object_id)
+        .collect();
+    object.saddled_by = snapshot
+        .relations
+        .saddled_sources
+        .iter()
+        .map(|identity| identity.object_id)
+        .collect();
+    object.convoked_creatures = snapshot
+        .relations
+        .convoked_sources
+        .iter()
+        .map(|identity| identity.object_id)
+        .collect();
+
+    filter_inner_for_object(
+        state,
+        &object,
+        snapshot.identity.object_id,
+        filter,
+        ctx.source_id,
+        ctx.source_controller,
+        ctx.ability,
+        ctx.trigger_source,
+        ctx.recipient_id,
+        ctx.scoped_iteration_player,
+        ControllerLookup::LiveOnly,
+    )
 }
 
 /// CR 603.4 + CR 603.6 + CR 603.10: Evaluate a trigger condition whose

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4958,7 +4958,7 @@ fn stack_entry_targets_satisfy(
     }
 }
 
-fn object_has_no_abilities(obj: &GameObject) -> bool {
+pub(crate) fn object_has_no_abilities(obj: &GameObject) -> bool {
     obj.keywords.is_empty()
         && obj.abilities.is_empty()
         && obj.trigger_definitions.is_empty()

--- a/crates/engine/src/game/public_state.rs
+++ b/crates/engine/src/game/public_state.rs
@@ -17,13 +17,9 @@ use super::turn_control;
 /// is split into [`finalize_display_state`] so engine-owned fast-forward loops
 /// can keep rules state current while batching expensive display recomputes.
 pub fn finalize_rules_state(state: &mut GameState) {
-    // Backward-compat for the 2026-05-09 audit M4
-    // post-replacement-continuation slot fold. Idempotent on already-migrated
-    // states; cheap on every other invocation.
-    state.migrate_post_replacement_continuation();
-    // CR 121.2: Backward-compat for the single-slot `pending_multi_draw` →
-    // `draw_sequences` stack conversion. Idempotent on already-migrated states.
-    state.migrate_pending_multi_draw();
+    // Persistence conversion is performed by ResolutionStateWire at the first
+    // deserialize boundary. This action-boundary finalizer must not mutate a
+    // restored legacy shape into a different runtime state.
     normalize_legacy_attach_waiting_for(state);
     sync_priority_player_from_waiting_for(state);
     flush_layers(state);

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -15,7 +15,8 @@ use crate::types::counter::CounterType;
 
 use super::filter::{
     matches_target_filter, matches_target_filter_on_battlefield_entry,
-    matches_target_filter_on_damage_record_source, FilterContext,
+    matches_target_filter_on_damage_record_source, matches_target_filter_on_event_snapshot,
+    FilterContext,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
@@ -2538,6 +2539,7 @@ fn connive_applier(
 ) -> ApplyResult {
     let ProposedEvent::Connive {
         object_id,
+        subject,
         count,
         applied,
     } = event
@@ -2550,6 +2552,7 @@ fn connive_applier(
         // the fallback survivor event cannot re-apply the same replacement.
         return ApplyResult::Modified(ProposedEvent::Connive {
             object_id,
+            subject,
             count,
             applied,
         });
@@ -2563,6 +2566,7 @@ fn connive_applier(
         // the fallback survivor event cannot re-apply the same replacement.
         return ApplyResult::Modified(ProposedEvent::Connive {
             object_id,
+            subject,
             count,
             applied,
         });
@@ -2608,15 +2612,15 @@ fn connive_applier(
                 // (Fixed(1)/N) still seeds the re-proposed event, preserving the
                 // count fix. The chain loop may drive multiple links, so clone the
                 // (small) `applied` set per re-entry.
-                if let Some(conniver) = state.capture_connive_subject(object_id) {
-                    let _ = crate::game::effects::connive::propose_connive(
-                        state,
-                        conniver,
-                        connive_count,
-                        applied.clone(),
-                        events,
-                    );
-                }
+                let _ = crate::game::effects::connive::propose_connive(
+                    state,
+                    crate::types::game_state::ConniveSubject {
+                        snapshot: (*subject).clone(),
+                    },
+                    connive_count,
+                    applied.clone(),
+                    events,
+                );
             }
             // CR 701.50a: "you draw a card" and any other modeled effect in the
             // chain resolve against the replacement source / conniving permanent.
@@ -2680,9 +2684,9 @@ fn connive_applier(
                             if state.pending_connive_reentry.is_none() {
                                 state.pending_connive_reentry =
                                     Some(crate::types::game_state::PendingConniveReentry {
-                                        conniver: state.capture_connive_subject(object_id).expect(
-                                            "connive replacement must preserve its live subject",
-                                        ),
+                                        conniver: crate::types::game_state::ConniveSubject {
+                                            snapshot: (*subject).clone(),
+                                        },
                                         count: connive_count,
                                         applied: applied.clone(),
                                     });
@@ -4838,16 +4842,60 @@ fn replacement_condition_quantity_ctx(
     state: &GameState,
     source_id: ObjectId,
     affected_object_id: Option<ObjectId>,
+    event: &ProposedEvent,
 ) -> crate::game::quantity::QuantityContext {
-    let scoped_player = affected_object_id
-        .and_then(|id| state.objects.get(&id))
-        .map(replacement_source_player);
+    let scoped_player = match event {
+        // CR 400.7: Connive's subject may have left and returned while a
+        // replacement ordering choice was pending. Its controller-relative
+        // condition context is frozen on the original subject, never read from
+        // the current object at the reused storage id.
+        ProposedEvent::Connive { subject, .. } => Some(subject.controller),
+        _ => affected_object_id
+            .and_then(|id| state.objects.get(&id))
+            .map(replacement_source_player),
+    };
     crate::game::quantity::QuantityContext {
         entering: None,
         source: source_id,
         trigger_source: None,
         recipient: None,
         scoped_player,
+    }
+}
+
+/// CR 400.7 + CR 614.1d: determine whether a replacement's `valid_card`
+/// predicate matches the event subject. Connive carries its own exact snapshot;
+/// all other events retain their established live or entry-snapshot paths.
+fn replacement_valid_card_matches(
+    repl_def: &ReplacementDefinition,
+    event: &ProposedEvent,
+    state: &GameState,
+    filter: &TargetFilter,
+    ctx: &FilterContext<'_>,
+) -> bool {
+    if let ProposedEvent::Connive { subject, .. } = event {
+        return matches_target_filter_on_event_snapshot(state, subject, filter, ctx);
+    }
+    if repl_def.event == ReplacementEvent::ChangeZone
+        || (matches!(event, ProposedEvent::TokenEntry { .. })
+            && repl_def.event == ReplacementEvent::Moved)
+    {
+        return matches_target_filter_on_battlefield_entry(state, event, filter, ctx);
+    }
+    event
+        .affected_object_id()
+        .map(|oid| matches_target_filter(state, oid, filter, ctx))
+        .unwrap_or(false)
+}
+
+/// CR 400.7: an exact Connive snapshot must not be converted back into a raw
+/// object id for condition evaluation. Conditions that need unavailable facts
+/// fail closed; controller-scoped quantities use the snapshot in
+/// [`replacement_condition_quantity_ctx`].
+fn replacement_condition_affected_object_id(event: &ProposedEvent) -> Option<ObjectId> {
+    match event {
+        ProposedEvent::Connive { .. } => None,
+        _ => event.affected_object_id(),
     }
 }
 
@@ -5017,7 +5065,8 @@ fn evaluate_replacement_condition(
             }
             // CR 608.2c: resolve with the scoped-player context so `ScopedPlayer`
             // filters bind to the entering/affected object's controller.
-            let ctx = replacement_condition_quantity_ctx(state, source_id, affected_object_id);
+            let ctx =
+                replacement_condition_quantity_ctx(state, source_id, affected_object_id, event);
             let lhs_val = crate::game::quantity::resolve_quantity_with_ctx(
                 state,
                 lhs,
@@ -5067,7 +5116,8 @@ fn evaluate_replacement_condition(
             // CR 608.2c: resolve with the scoped-player context so `ScopedPlayer`
             // filters bind to the entering/affected object's controller (Land
             // Equilibrium's LHS "an opponent who controls at least as many lands").
-            let ctx = replacement_condition_quantity_ctx(state, source_id, affected_object_id);
+            let ctx =
+                replacement_condition_quantity_ctx(state, source_id, affected_object_id, event);
             let lhs_val = crate::game::quantity::resolve_quantity_with_ctx(
                 state,
                 lhs,
@@ -5404,17 +5454,7 @@ fn apply_state_level_gates(
     // CR 614.1d: valid_card filter — the event's affected object must match.
     if let Some(ref filter) = repl_def.valid_card {
         let ctx = FilterContext::from_source_with_controller(source, source_controller);
-        let matches = if repl_def.event == ReplacementEvent::ChangeZone
-            || (matches!(event, ProposedEvent::TokenEntry { .. })
-                && repl_def.event == ReplacementEvent::Moved)
-        {
-            matches_target_filter_on_battlefield_entry(state, event, filter, &ctx)
-        } else {
-            event
-                .affected_object_id()
-                .map(|oid| matches_target_filter(state, oid, filter, &ctx))
-                .unwrap_or(false)
-        };
+        let matches = replacement_valid_card_matches(repl_def, event, state, filter, &ctx);
         if !matches {
             return false;
         }
@@ -5445,7 +5485,7 @@ fn apply_state_level_gates(
             source_controller,
             source,
             state,
-            event.affected_object_id(),
+            replacement_condition_affected_object_id(event),
             event,
         ) {
             return false;
@@ -5781,17 +5821,7 @@ fn object_replacement_candidate_applies(
 
     if let Some(ref filter) = repl_def.valid_card {
         let ctx = FilterContext::from_source_with_controller(obj.id, replacement_player);
-        let matches = if repl_def.event == ReplacementEvent::ChangeZone
-            || (matches!(event, ProposedEvent::TokenEntry { .. })
-                && repl_def.event == ReplacementEvent::Moved)
-        {
-            matches_target_filter_on_battlefield_entry(state, event, filter, &ctx)
-        } else {
-            event
-                .affected_object_id()
-                .map(|oid| matches_target_filter(state, oid, filter, &ctx))
-                .unwrap_or(false)
-        };
+        let matches = replacement_valid_card_matches(repl_def, event, state, filter, &ctx);
         if !matches {
             return false;
         }
@@ -5821,7 +5851,7 @@ fn object_replacement_candidate_applies(
             replacement_player,
             obj.id,
             state,
-            event.affected_object_id(),
+            replacement_condition_affected_object_id(event),
             event,
         ) {
             return false;
@@ -8784,7 +8814,9 @@ mod tests {
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
-    use crate::types::game_state::{DamageRecord, LiminalEntry, ManaSpentSourceSnapshot};
+    use crate::types::game_state::{
+        DamageRecord, GameState, LiminalEntry, ManaSpentSourceSnapshot,
+    };
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::keywords::Keyword;
     use crate::types::mana::ManaType;
@@ -9548,6 +9580,23 @@ mod tests {
 
     #[test]
     fn replacement_event_key_taxonomy_matches_supported_proposed_events() {
+        let mut connive_state = GameState::new_two_player(42);
+        let conniver_id = ObjectId(1);
+        connive_state.objects.insert(
+            conniver_id,
+            GameObject::new(
+                conniver_id,
+                CardId(1),
+                PlayerId(0),
+                "Conniver".to_string(),
+                Zone::Battlefield,
+            ),
+        );
+        connive_state.battlefield.push_back(conniver_id);
+        let connive_subject = connive_state
+            .capture_connive_subject(conniver_id)
+            .expect("fixture conniver exists")
+            .snapshot;
         let token_event = ProposedEvent::CreateToken {
             owner: PlayerId(0),
             spec: Box::new(test_token_spec(PlayerId(0), CoreType::Creature)),
@@ -9680,6 +9729,7 @@ mod tests {
             (
                 ProposedEvent::Connive {
                     object_id: ObjectId(1),
+                    subject: Box::new(connive_subject),
                     count: 1,
                     applied: HashSet::new(),
                 },
@@ -12604,6 +12654,53 @@ mod tests {
             subtypes: vec![],
         };
         obj
+    }
+
+    /// CR 400.7 + CR 614.1d: Connive replacement passes keep the original
+    /// subject facts. A same-id return between two replacement checks must not
+    /// make the second check read the returned incarnation's controller.
+    #[test]
+    fn connive_replacement_second_pass_uses_original_subject_snapshot() {
+        let conniver_id = ObjectId(6100);
+        let mut state = GameState::new_two_player(42);
+        state.objects.insert(
+            conniver_id,
+            make_creature(conniver_id, PlayerId(0), Zone::Battlefield),
+        );
+        state.battlefield.push_back(conniver_id);
+        let original = state
+            .capture_connive_subject(conniver_id)
+            .expect("fixture conniver exists before replacement pass one");
+        let event = ProposedEvent::Connive {
+            object_id: conniver_id,
+            subject: Box::new(original.snapshot.clone()),
+            count: 1,
+            applied: HashSet::new(),
+        };
+
+        let first_pass = ReplacementDefinition::new(ReplacementEvent::Connive);
+        assert!(
+            apply_state_level_gates(&first_pass, &event, ObjectId(0), PlayerId(0), &state),
+            "reach guard: the first Connive replacement pass applies"
+        );
+
+        crate::game::zones::move_to_zone(&mut state, conniver_id, Zone::Graveyard, &mut Vec::new());
+        crate::game::zones::move_to_zone(
+            &mut state,
+            conniver_id,
+            Zone::Battlefield,
+            &mut Vec::new(),
+        );
+        state.objects.get_mut(&conniver_id).unwrap().controller = PlayerId(1);
+
+        let mut second_pass = ReplacementDefinition::new(ReplacementEvent::Connive);
+        second_pass.valid_card = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::You),
+        ));
+        assert!(
+            apply_state_level_gates(&second_pass, &event, ObjectId(0), PlayerId(0), &state),
+            "the second pass reads the original P0 creature snapshot, not the P1 same-id return"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -2608,13 +2608,15 @@ fn connive_applier(
                 // (Fixed(1)/N) still seeds the re-proposed event, preserving the
                 // count fix. The chain loop may drive multiple links, so clone the
                 // (small) `applied` set per re-entry.
-                let _ = crate::game::effects::connive::propose_connive(
-                    state,
-                    object_id,
-                    connive_count,
-                    applied.clone(),
-                    events,
-                );
+                if let Some(conniver) = state.capture_connive_subject(object_id) {
+                    let _ = crate::game::effects::connive::propose_connive(
+                        state,
+                        conniver,
+                        connive_count,
+                        applied.clone(),
+                        events,
+                    );
+                }
             }
             // CR 701.50a: "you draw a card" and any other modeled effect in the
             // chain resolve against the replacement source / conniving permanent.
@@ -2678,7 +2680,9 @@ fn connive_applier(
                             if state.pending_connive_reentry.is_none() {
                                 state.pending_connive_reentry =
                                     Some(crate::types::game_state::PendingConniveReentry {
-                                        conniver: object_id,
+                                        conniver: state.capture_connive_subject(object_id).expect(
+                                            "connive replacement must preserve its live subject",
+                                        ),
                                         count: connive_count,
                                         applied: applied.clone(),
                                     });

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -3284,15 +3284,30 @@ pub(super) fn match_connives(
     source_context: &TriggerSourceContext,
     state: &GameState,
 ) -> bool {
-    let source_id = source_event_subject_id(source_context);
     let GameEvent::EffectResolved {
         kind: EffectKind::Connive,
         source_id: conniver_id,
-        ..
+        subject,
     } = event
     else {
         return false;
     };
+    if let Some(subject) = subject {
+        if let Some(filter) = &trigger.valid_card {
+            return super::filter::matches_target_filter_on_event_snapshot(
+                state,
+                subject,
+                filter,
+                &super::filter::FilterContext::from_trigger_source(source_context),
+            );
+        }
+        return subject.identity == source_context.identity.reference;
+    }
+
+    // Legacy events have no exact subject snapshot. They cannot arise from the
+    // current connive pipeline, but retain the prior LKI fallback for archived
+    // test fixtures and historic event logs.
+    let source_id = source_event_subject_id(source_context);
     if trigger.valid_card.is_some() {
         // CR 603.10a + CR 111.7: Connive triggers look back in time. The conniver is
         // routinely gone by the time this event is matched — killed in response while the
@@ -16530,6 +16545,73 @@ mod tests {
         assert!(
             !match_connives(&opp_event, &trigger, &test_trigger_source_context(&state, source), &state),
             "an opponent's conniver must NOT fire the controller's 'creature you control' trigger via LKI"
+        );
+    }
+
+    /// CR 400.7 + CR 701.50f: A Connive completion event owns the incarnation
+    /// that performed the keyword action. A same-id return neither satisfies
+    /// that returned object's self trigger nor changes the typed subject facts
+    /// observed by another permanent's "creature you control connives" trigger.
+    #[test]
+    fn connives_completion_snapshot_does_not_rebind_same_id_return() {
+        let mut state = setup();
+        let observer = create_object(
+            &mut state,
+            CardId(830),
+            PlayerId(0),
+            "Glorious Purpose".to_string(),
+            Zone::Battlefield,
+        );
+        let conniver = create_object(
+            &mut state,
+            CardId(831),
+            PlayerId(0),
+            "Original Conniver".to_string(),
+            Zone::Battlefield,
+        );
+        make_creature(&mut state, conniver);
+        let original = state
+            .capture_connive_subject(conniver)
+            .expect("fixture conniver exists before it leaves");
+
+        crate::game::zones::move_to_zone(&mut state, conniver, Zone::Graveyard, &mut Vec::new());
+        crate::game::zones::move_to_zone(&mut state, conniver, Zone::Battlefield, &mut Vec::new());
+        state.objects.get_mut(&conniver).unwrap().controller = PlayerId(1);
+        assert_ne!(
+            original.identity(),
+            crate::types::identifiers::ObjectIncarnationRef::from_object(&state.objects[&conniver]),
+            "reach guard: the returned object must be a distinct incarnation"
+        );
+
+        let event = GameEvent::EffectResolved {
+            kind: EffectKind::Connive,
+            source_id: conniver,
+            subject: Some(Box::new(original.snapshot.clone())),
+        };
+
+        let self_trigger = make_trigger(TriggerMode::Connives);
+        assert!(
+            !match_connives(
+                &event,
+                &self_trigger,
+                &test_trigger_source_context(&state, conniver),
+                &state
+            ),
+            "the returned permanent is not the object that connived"
+        );
+
+        let typed_trigger = parse_trigger_line(
+            "Whenever a creature you control connives, put a +1/+1 counter on that creature.",
+            "Glorious Purpose",
+        );
+        assert!(
+            match_connives(
+                &event,
+                &typed_trigger,
+                &test_trigger_source_context(&state, observer),
+                &state
+            ),
+            "the typed Connive subject filter reads the original captured controller, not the returned object"
         );
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -41,6 +41,8 @@ use super::proposed_event::{
     AppliedReplacementKey, CopyTokenSpec, ProposedEvent, ReplacementId, TokenSpec,
 };
 use super::replacements::ReplacementEvent;
+#[cfg(debug_assertions)]
+use super::resolution::debug_assert_runtime_resolution_invariants;
 use super::resolution::ResolutionStateWire;
 use super::zones::EtbTapState;
 use super::zones::{ExileCostSourceZone, Zone};
@@ -6846,9 +6848,12 @@ fn decode_persisted_resolution_state(mut value: serde_json::Value) -> Result<Gam
     object
         .entry("resolution_state_version".to_string())
         .or_insert_with(|| serde_json::Value::from(1));
-    serde_json::from_value::<ResolutionStateWire>(value)
+    let state = serde_json::from_value::<ResolutionStateWire>(value)
         .map(ResolutionStateWire::into_game_state)
-        .map_err(|error| error.to_string())
+        .map_err(|error| error.to_string())?;
+    #[cfg(debug_assertions)]
+    debug_assert_runtime_resolution_invariants(&state);
+    Ok(state)
 }
 
 impl Serialize for TrustedGameStateEnvelope {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1807,6 +1807,15 @@ pub struct CommanderDamageEntry {
 /// without the other and break the "pause emits the same event as
 /// non-pause" invariant.
 ///
+/// CR 615.5: typed ownership of a resident post-replacement drain while a
+/// continuation is paused. This is deliberately a marker, not a drain ID or a
+/// reverse reference: the resident top is the sole drain being dispatched, and
+/// the marker only extends that dispatch until its owned continuation finishes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PostReplacementDispatchPauseOwner {
+    Dispatch,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingContinuation {
     pub chain: Box<ResolvedAbility>,
@@ -1824,6 +1833,10 @@ pub struct PendingContinuation {
     /// finished or merely paused.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trigger_context: Option<ResolvingTriggerContext>,
+    /// CR 615.5: a paused post-replacement continuation owns the resident
+    /// drain's event context until the chain truly completes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_replacement_drain_owner: Option<PostReplacementDispatchPauseOwner>,
 }
 
 impl PendingContinuation {
@@ -1836,6 +1849,7 @@ impl PendingContinuation {
             parent_kind: None,
             search_attach_host: None,
             trigger_context: ResolvingTriggerContext::capture(state),
+            post_replacement_drain_owner: None,
         }
     }
 
@@ -1853,6 +1867,7 @@ impl PendingContinuation {
             parent_kind: Some(parent_kind),
             search_attach_host: None,
             trigger_context: ResolvingTriggerContext::capture(state),
+            post_replacement_drain_owner: None,
         }
     }
 }
@@ -12962,6 +12977,11 @@ pub struct DrawSequenceFrame {
     /// The instruction's completion behavior. Old saves default to [`DrawSequenceOrigin::Plain`].
     #[serde(default)]
     pub origin: DrawSequenceOrigin,
+    /// CR 615.5: if a post-replacement continuation pauses directly on this
+    /// draw, this frame keeps the resident drain's event context alive until
+    /// the draw (and any transferred continuation) truly completes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub post_replacement_drain_owner: Option<PostReplacementDispatchPauseOwner>,
     /// CR 121.6b: individual draws of this instruction not yet attempted. "If an
     /// effect replaces a draw within a sequence of card draws, the replacement
     /// effect is completed before resuming the sequence."
@@ -13063,6 +13083,7 @@ impl DrawSequenceStack {
             player,
             applied,
             origin,
+            post_replacement_drain_owner: None,
             remaining: count,
             accumulated: 0,
         });
@@ -13367,6 +13388,29 @@ const _: fn() = || {
 };
 
 impl GameState {
+    /// CR 615.5: Move resident post-replacement dispatch ownership onto the
+    /// concrete paused work. A continuation takes precedence because it owns a
+    /// later chain after the current draw settles; otherwise the active draw
+    /// frame is the pause carrier.
+    pub fn park_post_replacement_drain_dispatch(&mut self) -> bool {
+        if let Some(continuation) = self.pending_continuation.as_mut() {
+            continuation.post_replacement_drain_owner =
+                Some(PostReplacementDispatchPauseOwner::Dispatch);
+            return true;
+        }
+        if let Some(frame) = self.draw_sequences.active_mut() {
+            frame.post_replacement_drain_owner = Some(PostReplacementDispatchPauseOwner::Dispatch);
+            return true;
+        }
+        false
+    }
+
+    /// CR 615.5: Retire a resident dispatch only after the typed owner has no
+    /// paused continuation or draw frame left to resume.
+    pub fn finish_post_replacement_drain_dispatch(&mut self) {
+        self.post_replacement_drains.finish_dispatch();
+    }
+
     /// CR 400.7 + CR 701.50b/f: Capture the original conniver before any
     /// replacement-driven draw can pause its tail. The resulting subject is the
     /// authority for the later discard/counter step; it is never rebound through

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -21,7 +21,10 @@ use super::attribution::ObjectAttribution;
 use super::card::{CardFace, PrintedCardRef, TokenImageRef};
 use super::card_type::{CoreType, Supertype};
 use super::counter::{counter_map_serde, CounterMatch, CounterType};
-use super::events::{GameEvent, PlayerActionKind};
+use super::events::{
+    EventAttachmentSnapshot, EventCombatSnapshot, EventObjectHistorySnapshot,
+    EventObjectRelationSnapshot, EventObjectSnapshot, GameEvent, PlayerActionKind,
+};
 use super::format::FormatConfig;
 use super::identifiers::{
     CardId, LogicalZoneChangeGroupId, ObjectId, ObjectIdentityBinding, ObjectIncarnationRef,
@@ -1803,6 +1806,7 @@ pub struct CommanderDamageEntry {
 /// cannot go out of sync; two parallel `Option`s would let one be set
 /// without the other and break the "pause emits the same event as
 /// non-pause" invariant.
+///
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingContinuation {
     pub chain: Box<ResolvedAbility>,
@@ -7470,7 +7474,7 @@ pub enum WaitingFor {
     /// After discarding, nonland discards add +1/+1 counters to the conniving creature.
     ConniveDiscard {
         player: PlayerId,
-        conniver_id: ObjectId,
+        conniver: ConniveSubject,
         source_id: ObjectId,
         cards: Vec<ObjectId>,
         count: usize,
@@ -12573,9 +12577,33 @@ pub struct TransientContinuousEffect {
 /// (CR 614.5) so the CR 616.1f repeat covers the remaining connive replacements
 /// without self-invoking. (CR 614.11a — completing a replacement's actions before
 /// resuming a draw — is the analogous supporting principle.)
+/// CR 400.7 + CR 701.50b/f: The exact permanent that began a connive action.
+///
+/// This deliberately carries the full event snapshot rather than a bare
+/// [`ObjectId`]. Connive's draw/discard tail can pause and the original permanent
+/// can leave and return before that tail adds counters. The embedded
+/// [`ObjectIncarnationRef`] keeps that returned object from becoming the old
+/// conniver. There is intentionally no serde default or raw-ID compatibility:
+/// an old save cannot reconstruct the original incarnation or LKI, so accepting
+/// it would silently authorize a different object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConniveSubject {
+    pub snapshot: EventObjectSnapshot,
+}
+
+impl ConniveSubject {
+    pub fn identity(&self) -> ObjectIncarnationRef {
+        self.snapshot.identity
+    }
+
+    pub fn object_id(&self) -> ObjectId {
+        self.identity().object_id
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingConniveReentry {
-    pub conniver: ObjectId,
+    pub conniver: ConniveSubject,
     pub count: u32,
     pub applied: HashSet<AppliedReplacementKey>,
 }
@@ -12905,7 +12933,10 @@ pub enum DrawSequenceOrigin {
     Plain,
     /// CR 701.50a/701.50d: after the connive draws settle, discard `count` cards and
     /// put +1/+1 counters equal to nonland cards discarded on `conniver`.
-    ConniveTail { conniver: ObjectId, count: u32 },
+    ConniveTail {
+        conniver: ConniveSubject,
+        count: u32,
+    },
     /// CR 701.22d-adjacent bookkeeping: a scry replaced into a draw completes by
     /// emitting EffectResolved{Scry} for `source_id` once the draws settle.
     ScryCompletion { source_id: ObjectId },
@@ -13336,6 +13367,146 @@ const _: fn() = || {
 };
 
 impl GameState {
+    /// CR 400.7 + CR 701.50b/f: Capture the original conniver before any
+    /// replacement-driven draw can pause its tail. The resulting subject is the
+    /// authority for the later discard/counter step; it is never rebound through
+    /// the stable storage id.
+    pub fn capture_connive_subject(&self, object_id: ObjectId) -> Option<ConniveSubject> {
+        let object = self.objects.get(&object_id)?;
+        let identity = ObjectIncarnationRef::from_object(object);
+        let combat = self.combat.as_ref();
+        let attacker = combat.and_then(|combat| {
+            combat
+                .attackers
+                .iter()
+                .find(|attacker| attacker.object_id == object_id)
+        });
+        let blocking =
+            combat.is_some_and(|combat| combat.blocker_to_attacker.contains_key(&object_id));
+        let related_objects = attacker
+            .into_iter()
+            .flat_map(|attacker| {
+                combat
+                    .and_then(|combat| combat.blocker_assignments.get(&attacker.object_id))
+                    .into_iter()
+                    .flatten()
+            })
+            .chain(
+                combat
+                    .and_then(|combat| combat.blocker_to_attacker.get(&object_id))
+                    .into_iter()
+                    .flatten(),
+            )
+            .filter_map(|related_id| {
+                self.objects
+                    .get(related_id)
+                    .map(ObjectIncarnationRef::from_object)
+            })
+            .collect();
+        let attachments = crate::game::zones::capture_attachment_snapshot(self, object)
+            .into_iter()
+            .filter_map(|attachment| {
+                Some(EventAttachmentSnapshot {
+                    identity: attachment.identity?,
+                    controller: attachment.controller,
+                    kind: attachment.kind,
+                })
+            })
+            .collect();
+        let zone_changes_this_turn = self
+            .zone_changes_this_turn
+            .iter()
+            .filter(|record| {
+                record
+                    .trigger_source_context
+                    .as_ref()
+                    .is_some_and(|context| context.identity.reference == identity)
+            })
+            .map(|record| (record.from_zone, record.to_zone))
+            .collect();
+
+        Some(ConniveSubject {
+            snapshot: EventObjectSnapshot {
+                identity,
+                controller: object.controller,
+                owner: object.owner,
+                zone: object.zone,
+                name: object.name.clone(),
+                core_types: object.card_types.core_types.clone(),
+                subtypes: object.card_types.subtypes.clone(),
+                supertypes: object.card_types.supertypes.clone(),
+                colors: object.effective_colors(),
+                keywords: object.keywords.clone(),
+                power: object.power,
+                toughness: object.toughness,
+                base_power: object.base_power,
+                base_toughness: object.base_toughness,
+                mana_value: object.effective_mana_value(),
+                counters: object.counters.clone(),
+                is_token: object.is_token,
+                is_commander: object.is_commander,
+                tapped: object.tapped,
+                face_down: object.face_down,
+                transformed: object.transformed,
+                is_suspected: object.is_suspected,
+                is_renowned: object.is_renowned,
+                is_saddled: object.is_saddled,
+                has_no_abilities: crate::game::filter::object_has_no_abilities(object),
+                attachments,
+                protector: object.protector(),
+                combat: EventCombatSnapshot {
+                    attacking: attacker.is_some(),
+                    blocking,
+                    blocked: attacker.is_some_and(|attacker| attacker.blocked),
+                    attacking_alone: attacker
+                        .is_some_and(|_| combat.is_some_and(|combat| combat.attackers.len() == 1)),
+                    blocking_alone: blocking
+                        && combat.is_some_and(|combat| combat.blocker_to_attacker.len() == 1),
+                    defending_player: attacker.map(|attacker| attacker.defending_player),
+                    related_objects,
+                },
+                history: EventObjectHistorySnapshot {
+                    was_dealt_damage_this_turn: self.damage_dealt_this_turn.iter().any(|damage| {
+                        matches!(damage.target, TargetRef::Object(target) if target == object_id)
+                            && damage.target_incarnation == Some(identity.incarnation)
+                    }),
+                    entered_this_turn: object.entered_battlefield_turn == Some(self.turn_number),
+                    attacked_defenders_this_turn: self
+                        .creature_attacked_defenders_this_turn
+                        .get(&object_id)
+                        .map(|players| players.iter().copied().collect())
+                        .unwrap_or_default(),
+                    blocked_this_turn: self.creatures_blocked_this_turn.contains(&object_id),
+                    zone_changes_this_turn,
+                    // Counter records predating exact-incarnation support carry
+                    // only an ObjectId. Do not turn that ambiguous history into
+                    // evidence about this subject.
+                    counters_put_on_this_turn: Vec::new(),
+                },
+                relations: EventObjectRelationSnapshot {
+                    saddled_sources: object
+                        .saddled_by
+                        .iter()
+                        .filter_map(|id| {
+                            self.objects.get(id).map(ObjectIncarnationRef::from_object)
+                        })
+                        .collect(),
+                    convoked_sources: object
+                        .convoked_creatures
+                        .iter()
+                        .filter_map(|id| {
+                            self.objects.get(id).map(ObjectIncarnationRef::from_object)
+                        })
+                        .collect(),
+                    // Tracked-set membership is currently raw-ID-only. As with
+                    // counter history above, fail closed until it carries exact
+                    // membership identity.
+                    tracked_sets: Vec::new(),
+                },
+            },
+        })
+    }
+
     /// Builds the exact paused-delivery key from the replacement record before
     /// that record is consumed. Only a `ZoneChange` can belong to either
     /// logical zone-change owner.
@@ -17105,9 +17276,23 @@ mod tests {
         // Leader-style "draw, then connive" carries its tail separately. The
         // connive tail is outer work and the draw remains the active inner work.
         let mut draw_then_connive = GameState::new_two_player(42);
+        let conniver_id = ObjectId(99);
+        draw_then_connive.objects.insert(
+            conniver_id,
+            GameObject::new(
+                conniver_id,
+                CardId(99),
+                PlayerId(0),
+                "Conniver".to_string(),
+                Zone::Battlefield,
+            ),
+        );
+        draw_then_connive.battlefield.push_back(conniver_id);
         draw(&mut draw_then_connive);
         draw_then_connive.pending_connive_reentry = Some(PendingConniveReentry {
-            conniver: ObjectId(99),
+            conniver: draw_then_connive
+                .capture_connive_subject(conniver_id)
+                .expect("fixture conniver exists"),
             count: 1,
             applied: HashSet::new(),
         });
@@ -17316,6 +17501,25 @@ mod tests {
                 alt_cost_grant_source: None,
             })
         }
+
+        let conniver = {
+            let mut state = GameState::new_two_player(42);
+            let id = ObjectId(1);
+            state.objects.insert(
+                id,
+                GameObject::new(
+                    id,
+                    CardId(1),
+                    PlayerId(0),
+                    "Conniver".to_string(),
+                    Zone::Battlefield,
+                ),
+            );
+            state.battlefield.push_back(id);
+            state
+                .capture_connive_subject(id)
+                .expect("fixture conniver exists")
+        };
 
         // Use push to avoid large stack frame from vec! macro expansion.
         let mut variants: Vec<Box<WaitingFor>> = Vec::new();
@@ -17592,7 +17796,7 @@ mod tests {
         }));
         variants.push(Box::new(WaitingFor::ConniveDiscard {
             player: PlayerId(0),
-            conniver_id: ObjectId(1),
+            conniver,
             source_id: ObjectId(1),
             cards: vec![ObjectId(2)],
             count: 1,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1807,15 +1807,6 @@ pub struct CommanderDamageEntry {
 /// without the other and break the "pause emits the same event as
 /// non-pause" invariant.
 ///
-/// CR 615.5: typed ownership of a resident post-replacement drain while a
-/// continuation is paused. This is deliberately a marker, not a drain ID or a
-/// reverse reference: the resident top is the sole drain being dispatched, and
-/// the marker only extends that dispatch until its owned continuation finishes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum PostReplacementDispatchPauseOwner {
-    Dispatch,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingContinuation {
     pub chain: Box<ResolvedAbility>,
@@ -1833,10 +1824,6 @@ pub struct PendingContinuation {
     /// finished or merely paused.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub trigger_context: Option<ResolvingTriggerContext>,
-    /// CR 615.5: a paused post-replacement continuation owns the resident
-    /// drain's event context until the chain truly completes.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub post_replacement_drain_owner: Option<PostReplacementDispatchPauseOwner>,
 }
 
 impl PendingContinuation {
@@ -1849,7 +1836,6 @@ impl PendingContinuation {
             parent_kind: None,
             search_attach_host: None,
             trigger_context: ResolvingTriggerContext::capture(state),
-            post_replacement_drain_owner: None,
         }
     }
 
@@ -1867,7 +1853,6 @@ impl PendingContinuation {
             parent_kind: Some(parent_kind),
             search_attach_host: None,
             trigger_context: ResolvingTriggerContext::capture(state),
-            post_replacement_drain_owner: None,
         }
     }
 }
@@ -12646,7 +12631,7 @@ pub struct PendingConniveReentry {
 /// The old single slot expressed this by taking the continuation early and
 /// clearing the event fields late — an interleaving that no type enforced and
 /// every caller had to respect. Here it is a state transition:
-/// `Ready(work)` → `Dispatching` → popped.
+/// `Ready(work)` → `Dispatching` → `Paused` → popped.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum DrainStatus {
     /// Not yet run. `Template` is an AST resolved against `source`; `Resolved`
@@ -12655,6 +12640,21 @@ pub enum DrainStatus {
     /// Taken and running. The drain stays resident so the running effect can still
     /// read its event context (CR 615.5).
     Dispatching,
+    /// The taken continuation paused. This status lives on the exact stack entry
+    /// that dispatched it, so nested post-replacement draws retain independent
+    /// event contexts without a drain-id graph or a reverse frame reference.
+    Paused,
+}
+
+/// A transient, typed claim on one resident post-replacement drain dispatch.
+///
+/// The drain stack owns the persisted lifecycle status; this handle only lets
+/// the synchronous dispatcher finish or pause the entry it took after a nested
+/// replacement has pushed another drain above it. It is never serialized and
+/// introduces no cross-carrier reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PostReplacementDrainDispatch {
+    depth: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -12812,7 +12812,7 @@ impl PostReplacementDrain {
     ) -> Option<&crate::types::ability::PostReplacementContinuation> {
         match &self.status {
             DrainStatus::Ready(continuation) => Some(continuation),
-            DrainStatus::Dispatching => None,
+            DrainStatus::Dispatching | DrainStatus::Paused => None,
         }
     }
 }
@@ -12899,19 +12899,67 @@ impl PostReplacementDrainStack {
     ///
     /// Returns `None` if there is no resident drain, or its continuation was
     /// already taken.
-    pub fn begin_dispatch(&mut self) -> Option<crate::types::ability::PostReplacementContinuation> {
-        let drain = self.drains.last_mut()?;
+    pub fn begin_dispatch(
+        &mut self,
+    ) -> Option<(
+        crate::types::ability::PostReplacementContinuation,
+        PostReplacementDrainDispatch,
+    )> {
+        let depth = self.drains.len().checked_sub(1)?;
+        let drain = self.drains.get_mut(depth)?;
         match std::mem::replace(&mut drain.status, DrainStatus::Dispatching) {
-            DrainStatus::Ready(continuation) => Some(continuation),
-            // Already dispatching: report no work. The `mem::replace` above has
-            // already written `Dispatching` back, so there is nothing to restore.
+            DrainStatus::Ready(continuation) => {
+                Some((continuation, PostReplacementDrainDispatch { depth }))
+            }
+            // Already dispatching or paused: report no work. The `mem::replace`
+            // above has written `Dispatching` back, so restore a paused owner.
             DrainStatus::Dispatching => None,
+            DrainStatus::Paused => {
+                drain.status = DrainStatus::Paused;
+                None
+            }
         }
     }
 
-    /// Pop the drain whose continuation has finished dispatching.
-    pub fn finish_dispatch(&mut self) -> Option<PostReplacementDrain> {
-        if matches!(self.drains.last()?.status, DrainStatus::Dispatching) {
+    /// Whether this dispatch still owns the resident stack top. A nested
+    /// replacement drain makes this false without invalidating the handle.
+    pub fn dispatch_is_resident_top(&self, dispatch: PostReplacementDrainDispatch) -> bool {
+        dispatch.depth.checked_add(1) == Some(self.drains.len())
+    }
+
+    /// Mark the exact drain whose continuation paused. The typed handle keeps a
+    /// nested dispatch from changing the outer entry by accident.
+    pub fn pause_dispatch(&mut self, dispatch: PostReplacementDrainDispatch) -> bool {
+        let Some(drain) = self.drains.get_mut(dispatch.depth) else {
+            return false;
+        };
+        if !matches!(drain.status, DrainStatus::Dispatching) {
+            return false;
+        }
+        drain.status = DrainStatus::Paused;
+        true
+    }
+
+    /// Pop the exact drain whose continuation has finished dispatching. It may
+    /// sit below a nested paused drain; this retires only that finished owner's
+    /// event context and leaves the nested continuation intact.
+    pub fn finish_dispatch(
+        &mut self,
+        dispatch: PostReplacementDrainDispatch,
+    ) -> Option<PostReplacementDrain> {
+        if matches!(
+            self.drains.get(dispatch.depth)?.status,
+            DrainStatus::Dispatching
+        ) {
+            return Some(self.drains.remove(dispatch.depth));
+        }
+        None
+    }
+
+    /// Pop only the innermost dispatch that itself paused. This preserves the
+    /// outer event context while a contained replacement continuation runs.
+    pub fn finish_paused_dispatch(&mut self) -> Option<PostReplacementDrain> {
+        if matches!(self.drains.last()?.status, DrainStatus::Paused) {
             return self.drains.pop();
         }
         None
@@ -12949,7 +12997,7 @@ pub enum DrawSequenceOrigin {
     /// CR 701.50a/701.50d: after the connive draws settle, discard `count` cards and
     /// put +1/+1 counters equal to nonland cards discarded on `conniver`.
     ConniveTail {
-        conniver: ConniveSubject,
+        conniver: Box<ConniveSubject>,
         count: u32,
     },
     /// CR 701.22d-adjacent bookkeeping: a scry replaced into a draw completes by
@@ -12977,11 +13025,6 @@ pub struct DrawSequenceFrame {
     /// The instruction's completion behavior. Old saves default to [`DrawSequenceOrigin::Plain`].
     #[serde(default)]
     pub origin: DrawSequenceOrigin,
-    /// CR 615.5: if a post-replacement continuation pauses directly on this
-    /// draw, this frame keeps the resident drain's event context alive until
-    /// the draw (and any transferred continuation) truly completes.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub post_replacement_drain_owner: Option<PostReplacementDispatchPauseOwner>,
     /// CR 121.6b: individual draws of this instruction not yet attempted. "If an
     /// effect replaces a draw within a sequence of card draws, the replacement
     /// effect is completed before resuming the sequence."
@@ -13046,6 +13089,17 @@ impl DrawSequenceStack {
             .filter(|frame| frame.frame_id == frame_id)
     }
 
+    /// Locate a still-live frame by its stable identity without making it active.
+    ///
+    /// CR 121.6b: only [`Self::active_if`] may *resume* a frame. Completion
+    /// accounting, however, must still credit an outer unit that delivered just
+    /// before a nested replacement draw pushed its own frame above it.
+    pub fn frame_mut(&mut self, frame_id: DrawSequenceFrameId) -> Option<&mut DrawSequenceFrame> {
+        self.frames
+            .iter_mut()
+            .find(|frame| frame.frame_id == frame_id)
+    }
+
     /// Push a new instruction and return its ID. Monotonic: the allocator never
     /// rewinds, so an ID from a popped frame is never reissued.
     pub fn push(&mut self, player: PlayerId, count: u32) -> DrawSequenceFrameId {
@@ -13083,7 +13137,6 @@ impl DrawSequenceStack {
             player,
             applied,
             origin,
-            post_replacement_drain_owner: None,
             remaining: count,
             accumulated: 0,
         });
@@ -13388,29 +13441,6 @@ const _: fn() = || {
 };
 
 impl GameState {
-    /// CR 615.5: Move resident post-replacement dispatch ownership onto the
-    /// concrete paused work. A continuation takes precedence because it owns a
-    /// later chain after the current draw settles; otherwise the active draw
-    /// frame is the pause carrier.
-    pub fn park_post_replacement_drain_dispatch(&mut self) -> bool {
-        if let Some(continuation) = self.pending_continuation.as_mut() {
-            continuation.post_replacement_drain_owner =
-                Some(PostReplacementDispatchPauseOwner::Dispatch);
-            return true;
-        }
-        if let Some(frame) = self.draw_sequences.active_mut() {
-            frame.post_replacement_drain_owner = Some(PostReplacementDispatchPauseOwner::Dispatch);
-            return true;
-        }
-        false
-    }
-
-    /// CR 615.5: Retire a resident dispatch only after the typed owner has no
-    /// paused continuation or draw frame left to resume.
-    pub fn finish_post_replacement_drain_dispatch(&mut self) {
-        self.post_replacement_drains.finish_dispatch();
-    }
-
     /// CR 400.7 + CR 701.50b/f: Capture the original conniver before any
     /// replacement-driven draw can pause its tail. The resulting subject is the
     /// authority for the later discard/counter step; it is never rebound through
@@ -15797,6 +15827,79 @@ mod drain_stack_reentrancy_tests {
         );
     }
 
+    /// CR 615.5 + CR 616.1g: nested pausing replacement continuations own
+    /// distinct stack entries. Completing the inner draw must not pop or strand
+    /// the outer prevented-event context.
+    #[test]
+    fn nested_paused_dispatches_finish_lifo() {
+        let mut stack = PostReplacementDrainStack::default();
+        assert!(stack.install(ready_drain("outer"), ResidentDrainPolicy::KeepResident));
+        let (_, outer_dispatch) = stack.begin_dispatch().expect("outer dispatch starts");
+        assert!(stack.pause_dispatch(outer_dispatch));
+
+        assert!(stack.install(ready_drain("inner"), ResidentDrainPolicy::KeepResident));
+        let (_, inner_dispatch) = stack.begin_dispatch().expect("inner dispatch starts");
+        assert!(stack.pause_dispatch(inner_dispatch));
+        assert_eq!(
+            stack.drains.len(),
+            2,
+            "both paused contexts remain resident"
+        );
+
+        assert!(stack.finish_paused_dispatch().is_some());
+        assert!(
+            matches!(
+                stack.resident(),
+                Some(PostReplacementDrain {
+                    status: DrainStatus::Paused,
+                    ..
+                })
+            ),
+            "finishing the inner pause must preserve the outer paused context"
+        );
+        assert!(stack.finish_paused_dispatch().is_some());
+        assert!(
+            stack.is_empty(),
+            "the outer pause retires only after its own resume"
+        );
+    }
+
+    /// CR 615.5 + CR 616.1g: if an outer continuation completes by starting an
+    /// inner continuation that pauses, its typed dispatch handle removes the
+    /// outer `Dispatching` entry rather than mistaking the paused inner top for
+    /// its own state. The inner context remains available until its resume.
+    #[test]
+    fn completed_outer_dispatch_does_not_strand_below_nested_pause() {
+        let mut stack = PostReplacementDrainStack::default();
+        assert!(stack.install(ready_drain("outer"), ResidentDrainPolicy::KeepResident));
+        let (_, outer_dispatch) = stack.begin_dispatch().expect("outer dispatch starts");
+
+        assert!(stack.install(ready_drain("inner"), ResidentDrainPolicy::KeepResident));
+        let (_, inner_dispatch) = stack.begin_dispatch().expect("inner dispatch starts");
+        assert!(stack.pause_dispatch(inner_dispatch));
+        assert!(
+            !stack.dispatch_is_resident_top(outer_dispatch),
+            "reach guard: the nested pause now owns the resident top"
+        );
+
+        assert!(stack.finish_dispatch(outer_dispatch).is_some());
+        assert!(
+            matches!(
+                stack.resident(),
+                Some(PostReplacementDrain {
+                    status: DrainStatus::Paused,
+                    ..
+                })
+            ),
+            "retiring the completed outer dispatch preserves the nested pause"
+        );
+        assert!(stack.finish_paused_dispatch().is_some());
+        assert!(
+            stack.is_empty(),
+            "both completed contexts retire exactly once"
+        );
+    }
+
     /// `KeepResident` drops a stash that arrives while a READY drain is pending.
     ///
     /// This pins the drop as a **leak-guard**, which is what it actually is — not,
@@ -15832,7 +15935,7 @@ mod drain_stack_reentrancy_tests {
         stack
             .drains
             .iter()
-            .find(|drain| matches!(drain.status, DrainStatus::Dispatching))
+            .find(|drain| matches!(drain.status, DrainStatus::Dispatching | DrainStatus::Paused))
             .and_then(|drain| drain.event_source)
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -41,6 +41,7 @@ use super::proposed_event::{
     AppliedReplacementKey, CopyTokenSpec, ProposedEvent, ReplacementId, TokenSpec,
 };
 use super::replacements::ReplacementEvent;
+use super::resolution::ResolutionStateWire;
 use super::zones::EtbTapState;
 use super::zones::{ExileCostSourceZone, Zone};
 
@@ -6827,11 +6828,71 @@ pub(crate) struct PrecastShortcutBreakpoint {
 
 /// Trusted-persistence-only envelope for runtime data that must never cross a
 /// raw or public `GameState` serialization boundary.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct TrustedGameStateEnvelope {
     state: GameState,
-    #[serde(default)]
     precast_shortcut_runtime: PrecastShortcutRuntime,
+}
+
+fn decode_persisted_resolution_state(mut value: serde_json::Value) -> Result<GameState, String> {
+    let object = value
+        .as_object_mut()
+        .ok_or_else(|| "persisted game state must be a JSON object".to_string())?;
+    // Historical persistence payloads predate the explicit resolution-state
+    // discriminator. This outer persistence boundary, which already knows it
+    // is reading an old raw GameState shape, gives them the legacy-only v1
+    // marker before the first GameState decode. ResolutionStateWire itself
+    // continues to reject missing/unknown discriminators.
+    object
+        .entry("resolution_state_version".to_string())
+        .or_insert_with(|| serde_json::Value::from(1));
+    serde_json::from_value::<ResolutionStateWire>(value)
+        .map(ResolutionStateWire::into_game_state)
+        .map_err(|error| error.to_string())
+}
+
+impl Serialize for TrustedGameStateEnvelope {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut value = serde_json::Map::new();
+        value.insert(
+            "state".to_string(),
+            serde_json::to_value(ResolutionStateWire::from_game_state(self.state.clone()))
+                .map_err(serde::ser::Error::custom)?,
+        );
+        value.insert(
+            "precast_shortcut_runtime".to_string(),
+            serde_json::to_value(&self.precast_shortcut_runtime)
+                .map_err(serde::ser::Error::custom)?,
+        );
+        serde_json::Value::Object(value).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for TrustedGameStateEnvelope {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let mut value = serde_json::Value::deserialize(deserializer)?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| serde::de::Error::custom("trusted state must be a JSON object"))?;
+        let state = object
+            .remove("state")
+            .ok_or_else(|| serde::de::Error::custom("trusted state is missing state"))?;
+        let precast_shortcut_runtime = match object.remove("precast_shortcut_runtime") {
+            Some(runtime) => serde_json::from_value(runtime).map_err(serde::de::Error::custom)?,
+            None => PrecastShortcutRuntime::default(),
+        };
+        let state = decode_persisted_resolution_state(state).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            state,
+            precast_shortcut_runtime,
+        })
+    }
 }
 
 impl TrustedGameStateEnvelope {
@@ -6857,11 +6918,24 @@ impl TrustedGameStateEnvelope {
 /// Decodes both current trusted snapshots and historical raw `GameState`
 /// snapshots. The raw form has no pre-cast route authority, so restoring it
 /// always drops any protocol wait before it reaches a live game session.
-#[derive(Debug, Clone, Serialize)]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
 pub enum PersistedGameState {
     Raw(Box<GameState>),
     Trusted(Box<TrustedGameStateEnvelope>),
+}
+
+impl Serialize for PersistedGameState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Raw(state) => {
+                ResolutionStateWire::from_game_state((**state).clone()).serialize(serializer)
+            }
+            Self::Trusted(envelope) => envelope.serialize(serializer),
+        }
+    }
 }
 
 /// Rejects the old prompt shape before deserializing a persisted game.
@@ -6906,7 +6980,7 @@ impl<'de> Deserialize<'de> for PersistedGameState {
                 .map(|envelope| Self::Trusted(Box::new(envelope)))
                 .map_err(serde::de::Error::custom)
         } else {
-            serde_json::from_value(value)
+            decode_persisted_resolution_state(value)
                 .map(|state| Self::Raw(Box::new(state)))
                 .map_err(serde::de::Error::custom)
         }
@@ -19095,6 +19169,47 @@ mod tests {
                 }
             ));
         }
+    }
+
+    #[test]
+    fn persisted_state_decodes_v1_at_the_boundary_and_rewrites_v2_only() {
+        let mut legacy = GameState::new_two_player(43);
+        legacy.legacy_pending_multi_draw = Some(PendingMultiDraw {
+            player: PlayerId(0),
+            remaining: 2,
+            accumulated: 1,
+        });
+
+        let v1 = serde_json::to_value(legacy).expect("legacy state serializes without a marker");
+        assert!(v1.get("resolution_state_version").is_none());
+        assert!(v1.get("pending_multi_draw").is_some());
+
+        let restored = serde_json::from_value::<PersistedGameState>(v1)
+            .expect("persistence boundary supplies the v1 discriminator");
+        let resumed = restored.clone().into_game_state();
+        assert!(resumed.legacy_pending_multi_draw.is_none());
+        assert_eq!(
+            resumed.draw_sequences.active().map(|frame| frame.remaining),
+            Some(2)
+        );
+
+        let raw_v2 = serde_json::to_value(restored).expect("restored raw state serializes");
+        assert_eq!(
+            raw_v2["resolution_state_version"],
+            serde_json::Value::from(2)
+        );
+        assert!(raw_v2.get("resolution_frames").is_some());
+        assert!(raw_v2.get("pending_multi_draw").is_none());
+
+        let trusted_v2 = serde_json::to_value(PersistedGameState::capture(resumed))
+            .expect("trusted state serializes");
+        let trusted_state = &trusted_v2["state"];
+        assert_eq!(
+            trusted_state["resolution_state_version"],
+            serde_json::Value::from(2)
+        );
+        assert!(trusted_state.get("resolution_frames").is_some());
+        assert!(trusted_state.get("pending_multi_draw").is_none());
     }
 
     #[test]

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -66,8 +66,9 @@ pub use proposed_event::{AppliedReplacementKey, ProposedEvent, ReplacementId};
 pub use replacements::ReplacementEvent;
 pub use replay::{RecordedAction, ReplayHeader, ReplayLog};
 pub use resolution::{
-    ChangeZoneFrame, FrameGate, FrameKind, MultiDrawFrame, OptionalEffectFrame,
+    ChangeZoneFrame, DirectChoiceGate, FrameGate, FrameKind, MultiDrawFrame, OptionalEffectFrame,
     PerCategoryZoneChoiceFrame, RepeatedOptionalPaymentFrame, ResolutionFrame, ResolutionStack,
+    ResolutionStackError,
 };
 pub use statics::StaticMode;
 pub use stickers::{AppliedSticker, StickerKind, StickerLocator};

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -20,6 +20,7 @@ pub mod player;
 pub mod proposed_event;
 pub mod replacements;
 pub mod replay;
+pub mod resolution;
 pub mod statics;
 pub mod stickers;
 pub mod triggers;
@@ -64,6 +65,10 @@ pub use player::{Player, PlayerId};
 pub use proposed_event::{AppliedReplacementKey, ProposedEvent, ReplacementId};
 pub use replacements::ReplacementEvent;
 pub use replay::{RecordedAction, ReplayHeader, ReplayLog};
+pub use resolution::{
+    ChangeZoneFrame, FrameGate, FrameKind, MultiDrawFrame, OptionalEffectFrame,
+    PerCategoryZoneChoiceFrame, RepeatedOptionalPaymentFrame, ResolutionFrame, ResolutionStack,
+};
 pub use statics::StaticMode;
 pub use stickers::{AppliedSticker, StickerKind, StickerLocator};
 pub use triggers::{TriggerEventKey, TriggerMode};

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -66,9 +66,10 @@ pub use proposed_event::{AppliedReplacementKey, ProposedEvent, ReplacementId};
 pub use replacements::ReplacementEvent;
 pub use replay::{RecordedAction, ReplayHeader, ReplayLog};
 pub use resolution::{
-    ChangeZoneFrame, DirectChoiceGate, FrameGate, FrameKind, MultiDrawFrame, OptionalEffectFrame,
-    PerCategoryZoneChoiceFrame, RepeatedOptionalPaymentFrame, ResolutionFrame, ResolutionStack,
-    ResolutionStackError,
+    AbilityContinuationFrame, ChangeZoneFrame, DirectChoiceGate, FrameGate, FrameKind,
+    MultiDrawFrame, OptionalEffectFrame, PerCategoryZoneChoiceFrame, RepeatedOptionalPaymentFrame,
+    ResolutionFrame, ResolutionStack, ResolutionStackError, ResolutionStateWire,
+    RESOLUTION_STATE_WIRE_VERSION,
 };
 pub use statics::StaticMode;
 pub use stickers::{AppliedSticker, StickerKind, StickerLocator};

--- a/crates/engine/src/types/proposed_event.rs
+++ b/crates/engine/src/types/proposed_event.rs
@@ -11,6 +11,7 @@ use super::ability::{
 };
 use super::card::{PrintedCardRef, TokenImageRef};
 use super::card_type::{CoreType, Supertype};
+use super::events::EventObjectSnapshot;
 use super::identifiers::{ObjectId, ObjectIncarnationRef};
 use super::keywords::Keyword;
 use super::mana::{ManaColor, ManaType, UnitDecision};
@@ -482,6 +483,11 @@ pub enum ProposedEvent {
     /// already resolved from `QuantityExpr` at propose time.
     Connive {
         object_id: ObjectId,
+        /// CR 400.7 + CR 701.50b/f: the exact permanent that proposed this
+        /// action. A replacement-ordering pause must not recapture a later
+        /// incarnation that reused `object_id`. Intentionally no serde default:
+        /// a legacy raw-id-only parked event cannot reconstruct this authority.
+        subject: Box<EventObjectSnapshot>,
         count: u32,
         applied: HashSet<AppliedReplacementKey>,
     },
@@ -910,14 +916,14 @@ impl ProposedEvent {
             | ProposedEvent::TurnFaceUp { object_id, .. }
             | ProposedEvent::Destroy { object_id, .. }
             | ProposedEvent::RemoveCounter { object_id, .. }
-            | ProposedEvent::Explore { object_id, .. }
-            // CR 701.50a: The conniving permanent's controller is the affected
-            // player — they draw/discard and choose the connive replacement order.
-            | ProposedEvent::Connive { object_id, .. } => state
+            | ProposedEvent::Explore { object_id, .. } => state
                 .objects
                 .get(object_id)
                 .map(|o| o.controller)
                 .unwrap_or(PlayerId(0)),
+            // CR 701.50a: The conniving permanent's controller is the affected
+            // player — they draw/discard and choose the connive replacement order.
+            ProposedEvent::Connive { subject, .. } => subject.controller,
             ProposedEvent::AddCounter { placement, .. } => match placement {
                 CounterPlacement::Object { object_id, .. } => state
                     .objects

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -1,0 +1,218 @@
+//! Typed, serializable suspension frames for ability resolution.
+//!
+//! This module deliberately models only suspended resolution work. The legacy
+//! `GameState` slots remain the runtime authority until their individual Phase-3
+//! migrations; Phase 2 uses these payloads at the wire boundary without
+//! introducing a second mutable runtime owner.
+
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::ability::ResolvedAbility;
+use crate::types::events::GameEvent;
+use crate::types::game_state::{
+    DrawSequenceStack, PendingBatchDeliveries, PendingChangeZoneIteration, PendingChooseOneOf,
+    PendingCoinFlip, PendingConniveReentry, PendingContinuation, PendingCopyTokenResolution,
+    PendingCounterAdditionQueue, PendingCounterMoveQueue, PendingCounterRemovalQueue,
+    PendingEachPlayerCopyChosen, PendingLifeTotalAssignment, PendingMutateMerge,
+    PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice, PendingProliferateActions,
+    PendingRepeatIteration, PendingRepeatUntil, PendingRepeatedOptionalPayment,
+    PendingSpellResolution, PendingVoteBallotIteration, PostReplacementDrainStack,
+    ResolvingTriggerContext,
+};
+use crate::types::identifiers::ObjectId;
+
+/// The complete shipped draw authority carried by one `MultiDraw` frame.
+///
+/// The plan's designed `DrawResolutionState` was never shipped. The actual
+/// model is a draw-sequence stack plus the dedicated exact-subject connive
+/// re-entry link. General replacement drains stay in their own adjacent
+/// `PostReplacement` frame, where a `DrainStatus::Paused` entry proves the
+/// parent/child relationship while the draw is active.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiDrawFrame {
+    pub draw_sequences: DrawSequenceStack,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_connive_reentry: Option<PendingConniveReentry>,
+}
+
+/// The persisted payload for a parked repeated optional-payment decision.
+///
+/// The count is a separate legacy runtime register, but it is part of the
+/// same resolution lifetime and therefore travels with this frame on the wire.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepeatedOptionalPaymentFrame {
+    pub pending: Box<PendingRepeatedOptionalPayment>,
+    pub optional_cost_payments_this_resolution: u32,
+}
+
+/// The complete parked optional-effect authority.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OptionalEffectFrame {
+    pub ability: Box<ResolvedAbility>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_event: Option<GameEvent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_match_count: Option<u32>,
+}
+
+/// The ChangeZone owner plus the only sidecar that is not already embedded in
+/// `PendingChangeZoneIteration`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ChangeZoneFrame {
+    pub pending: PendingChangeZoneIteration,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub devour_eligible_snapshot: Option<HashSet<ObjectId>>,
+}
+
+/// The per-category zone-choice owner and its captured trigger context.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PerCategoryZoneChoiceFrame {
+    pub pending: PendingPerCategoryZoneChoice,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_context: Option<ResolvingTriggerContext>,
+}
+
+/// The one place that states every serializable family of suspended
+/// resolution work. The variants intentionally mirror the exhaustive Phase-2
+/// census; a new pause family must be added here before it can cross the wire.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum ResolutionFrame {
+    AbilityContinuation(PendingContinuation),
+    RepeatFor(PendingRepeatIteration),
+    RepeatUntil(PendingRepeatUntil),
+    RepeatedOptionalPayment(RepeatedOptionalPaymentFrame),
+    ChangeZone(ChangeZoneFrame),
+    BatchDelivery(PendingBatchDeliveries),
+    CounterMoves(PendingCounterMoveQueue),
+    CounterRemovals(PendingCounterRemovalQueue),
+    CounterAdditions(PendingCounterAdditionQueue),
+    CopyToken(PendingCopyTokenResolution),
+    EachPlayerCopyChosen(PendingEachPlayerCopyChosen),
+    ChooseOneOf(PendingChooseOneOf),
+    VoteBallot(PendingVoteBallotIteration),
+    PerPlayerZoneChoice(PendingPerPlayerZoneChoice),
+    PerCategoryZoneChoice(PerCategoryZoneChoiceFrame),
+    OptionalEffect(OptionalEffectFrame),
+    CoinFlip(PendingCoinFlip),
+    Proliferate(PendingProliferateActions),
+    MultiDraw(MultiDrawFrame),
+    ConniveReentry(PendingConniveReentry),
+    LifeTotalAssignment(PendingLifeTotalAssignment),
+    SpellResolution(PendingSpellResolution),
+    MutateMerge(PendingMutateMerge),
+    PostReplacement(PostReplacementDrainStack),
+}
+
+/// The discriminant of a [`ResolutionFrame`], used by checked stack
+/// transitions without exposing the backing vector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum FrameKind {
+    AbilityContinuation,
+    RepeatFor,
+    RepeatUntil,
+    RepeatedOptionalPayment,
+    ChangeZone,
+    BatchDelivery,
+    CounterMoves,
+    CounterRemovals,
+    CounterAdditions,
+    CopyToken,
+    EachPlayerCopyChosen,
+    ChooseOneOf,
+    VoteBallot,
+    PerPlayerZoneChoice,
+    PerCategoryZoneChoice,
+    OptionalEffect,
+    CoinFlip,
+    Proliferate,
+    MultiDraw,
+    ConniveReentry,
+    LifeTotalAssignment,
+    SpellResolution,
+    MutateMerge,
+    PostReplacement,
+}
+
+impl ResolutionFrame {
+    pub const fn kind(&self) -> FrameKind {
+        match self {
+            Self::AbilityContinuation(_) => FrameKind::AbilityContinuation,
+            Self::RepeatFor(_) => FrameKind::RepeatFor,
+            Self::RepeatUntil(_) => FrameKind::RepeatUntil,
+            Self::RepeatedOptionalPayment(_) => FrameKind::RepeatedOptionalPayment,
+            Self::ChangeZone(_) => FrameKind::ChangeZone,
+            Self::BatchDelivery(_) => FrameKind::BatchDelivery,
+            Self::CounterMoves(_) => FrameKind::CounterMoves,
+            Self::CounterRemovals(_) => FrameKind::CounterRemovals,
+            Self::CounterAdditions(_) => FrameKind::CounterAdditions,
+            Self::CopyToken(_) => FrameKind::CopyToken,
+            Self::EachPlayerCopyChosen(_) => FrameKind::EachPlayerCopyChosen,
+            Self::ChooseOneOf(_) => FrameKind::ChooseOneOf,
+            Self::VoteBallot(_) => FrameKind::VoteBallot,
+            Self::PerPlayerZoneChoice(_) => FrameKind::PerPlayerZoneChoice,
+            Self::PerCategoryZoneChoice(_) => FrameKind::PerCategoryZoneChoice,
+            Self::OptionalEffect(_) => FrameKind::OptionalEffect,
+            Self::CoinFlip(_) => FrameKind::CoinFlip,
+            Self::Proliferate(_) => FrameKind::Proliferate,
+            Self::MultiDraw(_) => FrameKind::MultiDraw,
+            Self::ConniveReentry(_) => FrameKind::ConniveReentry,
+            Self::LifeTotalAssignment(_) => FrameKind::LifeTotalAssignment,
+            Self::SpellResolution(_) => FrameKind::SpellResolution,
+            Self::MutateMerge(_) => FrameKind::MutateMerge,
+            Self::PostReplacement(_) => FrameKind::PostReplacement,
+        }
+    }
+
+    /// Parent continuations wake only after their child has completed. Direct
+    /// choice frames are the prompt-owning family and will be checked against
+    /// the concrete `WaitingFor` variant by the structural API.
+    pub const fn gate(&self) -> FrameGate {
+        match self {
+            Self::RepeatedOptionalPayment(_)
+            | Self::OptionalEffect(_)
+            | Self::CoinFlip(_)
+            | Self::Proliferate(_)
+            | Self::MutateMerge(_) => FrameGate::DirectChoice,
+            Self::AbilityContinuation(_)
+            | Self::RepeatFor(_)
+            | Self::RepeatUntil(_)
+            | Self::ChangeZone(_)
+            | Self::BatchDelivery(_)
+            | Self::CounterMoves(_)
+            | Self::CounterRemovals(_)
+            | Self::CounterAdditions(_)
+            | Self::CopyToken(_)
+            | Self::EachPlayerCopyChosen(_)
+            | Self::ChooseOneOf(_)
+            | Self::VoteBallot(_)
+            | Self::PerPlayerZoneChoice(_)
+            | Self::PerCategoryZoneChoice(_)
+            | Self::MultiDraw(_)
+            | Self::ConniveReentry(_)
+            | Self::LifeTotalAssignment(_)
+            | Self::SpellResolution(_)
+            | Self::PostReplacement(_) => FrameGate::AfterChild,
+        }
+    }
+}
+
+/// Whether the active frame owns the current direct prompt or waits until its
+/// inner child returns to a resumable boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FrameGate {
+    DirectChoice,
+    AfterChild,
+}
+
+/// An ordered, LIFO stack of suspended resolution work.
+///
+/// Its backing storage is intentionally private: all future mutations must
+/// pass through the checked structural APIs rather than searching for or
+/// removing a non-top parent.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ResolutionStack {
+    frames: Vec<ResolutionFrame>,
+}

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -1077,16 +1077,19 @@ mod tests {
     use crate::game::merge::MergeSide;
     use crate::game::scenario::GameScenario;
     use crate::types::ability::{
-        Effect, EffectKind, PostReplacementContinuation, QuantityExpr, RepeatContinuation,
-        TargetFilter,
+        AbilityDefinition, AbilityKind, CardSelectionMode, Chooser, CopyChooseScope, Effect,
+        EffectKind, ForEachCategoryAction, IterationCategory, PostReplacementContinuation,
+        QuantityExpr, RepeatContinuation, SpellContext, TargetFilter, ZoneOwner,
     };
     use crate::types::actions::GameAction;
     use crate::types::game_state::{
-        DrainStatus, GameState, PendingBatchDeliveries, PendingCoinFlipKind,
-        PendingCopyTokenResolution, PendingCounterAdditionQueue, PendingCounterMoveQueue,
-        PendingCounterRemovalQueue, PendingMutateMerge, PendingProliferateActions,
-        PendingRepeatIteration, PendingRepeatUntil, PendingRepeatedOptionalPayment,
-        PostReplacementDrain, ResidentDrainPolicy, ZoneDeliveryExileTracking,
+        CopyChosenStage, DrainStatus, GameState, PendingBatchDeliveries, PendingChooseOneOf,
+        PendingCoinFlipKind, PendingCopyTokenResolution, PendingCounterAdditionQueue,
+        PendingCounterMoveQueue, PendingCounterRemovalQueue, PendingEachPlayerCopyChosen,
+        PendingMutateMerge, PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice,
+        PendingProliferateActions, PendingRepeatIteration, PendingRepeatUntil,
+        PendingRepeatedOptionalPayment, PendingVoteBallotIteration, PostReplacementDrain,
+        ResidentDrainPolicy, ZoneDeliveryExileTracking,
     };
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
@@ -1103,6 +1106,10 @@ mod tests {
             ObjectId(source_id),
             PlayerId(0),
         )
+    }
+
+    fn resolved_effect(source_id: u64, effect: Effect) -> ResolvedAbility {
+        ResolvedAbility::new(effect, Vec::new(), ObjectId(source_id), PlayerId(0))
     }
 
     fn continuation_frame(source_id: u64) -> ResolutionFrame {
@@ -1828,5 +1835,115 @@ mod tests {
         );
         assert!(copy_token.pending_copy_token_resolution.is_none());
         assert_reserializes_v2_only(copy_token);
+    }
+
+    #[test]
+    fn v1_choice_iteration_fixtures_resume_via_their_production_drains() {
+        let mut each_player_copy = GameState::new_two_player(130);
+        each_player_copy.pending_each_player_copy_chosen = Some(PendingEachPlayerCopyChosen {
+            stage: CopyChosenStage::AwaitingCounters,
+            player: PlayerId(0),
+            chosen: Vec::new(),
+            remaining_choices: Vec::new(),
+            choose_filter: TargetFilter::Controller,
+            min: 0,
+            max: 0,
+            copy_modifications: Vec::new(),
+            scale: None,
+            choose_scope: CopyChooseScope::Chooser,
+            source_id: ObjectId(130),
+            source_controller: PlayerId(0),
+            scoped_players: Vec::new(),
+            trigger_event: None,
+        });
+        let mut each_player_copy = restore_v1_fixture(each_player_copy);
+        crate::game::effects::each_player_copy_chosen::drain_pending(
+            &mut each_player_copy,
+            &mut Vec::new(),
+        );
+        assert!(each_player_copy.pending_each_player_copy_chosen.is_none());
+        assert_reserializes_v2_only(each_player_copy);
+
+        let mut choose_one_of = GameState::new_two_player(131);
+        choose_one_of.pending_choose_one_of = Some(PendingChooseOneOf {
+            controller: PlayerId(0),
+            source_id: ObjectId(131),
+            branches: Vec::new(),
+            parent_targets: Vec::new(),
+            context: SpellContext::default(),
+            replacement_applied: HashSet::new(),
+            remaining_players: Vec::new(),
+        });
+        let mut choose_one_of = restore_v1_fixture(choose_one_of);
+        crate::game::effects::choose_one_of::resume_pending(&mut choose_one_of, &mut Vec::new());
+        assert!(choose_one_of.pending_choose_one_of.is_none());
+        assert_reserializes_v2_only(choose_one_of);
+
+        let mut vote = GameState::new_two_player(132);
+        vote.pending_vote_ballot_iteration = Some(PendingVoteBallotIteration {
+            ability_template: Box::new(AbilityDefinition::new(AbilityKind::Spell, Effect::NoOp)),
+            remaining_voters: Vec::new(),
+            source_id: ObjectId(132),
+            controller: PlayerId(0),
+        });
+        let mut vote = restore_v1_fixture(vote);
+        crate::game::effects::vote::drain_pending_vote_ballot_iteration(&mut vote, &mut Vec::new());
+        assert!(vote.pending_vote_ballot_iteration.is_none());
+        assert_reserializes_v2_only(vote);
+
+        let choose_from_zone = resolved_effect(
+            133,
+            Effect::ChooseFromZone {
+                count: 1,
+                zone: Zone::Graveyard,
+                additional_zones: Vec::new(),
+                zone_owner: ZoneOwner::EachPlayer,
+                filter: None,
+                chooser: Chooser::Controller,
+                up_to: true,
+                selection: CardSelectionMode::Chosen,
+                constraint: None,
+            },
+        );
+        let mut per_player = GameState::new_two_player(133);
+        per_player.pending_per_player_zone_choice = Some(PendingPerPlayerZoneChoice {
+            ability: Box::new(choose_from_zone),
+            remaining_players: Vec::new(),
+            accumulated: false,
+        });
+        let mut per_player = restore_v1_fixture(per_player);
+        crate::game::effects::choose_from_zone::drain_pending_per_player_zone_choice(
+            &mut per_player,
+            &[],
+            &mut Vec::new(),
+        );
+        assert!(per_player.pending_per_player_zone_choice.is_none());
+        assert_reserializes_v2_only(per_player);
+
+        let for_each_category = resolved_effect(
+            134,
+            Effect::ForEachCategory {
+                category: IterationCategory::Color,
+                chooser: Chooser::Controller,
+                action: ForEachCategoryAction::ExileFromPool {
+                    zone: Zone::Graveyard,
+                    up_to: true,
+                },
+            },
+        );
+        let mut per_category = GameState::new_two_player(134);
+        per_category.pending_per_category_zone_choice = Some(PendingPerCategoryZoneChoice {
+            ability: Box::new(for_each_category),
+            pool: Vec::new(),
+            remaining_member_filters: Vec::new(),
+        });
+        let mut per_category = restore_v1_fixture(per_category);
+        let _ = crate::game::effects::choose_from_zone::drain_pending_per_category_zone_choice(
+            &mut per_category,
+            &[],
+            &mut Vec::new(),
+        );
+        assert!(per_category.pending_per_category_zone_choice.is_none());
+        assert_reserializes_v2_only(per_category);
     }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -1082,14 +1082,16 @@ mod tests {
     };
     use crate::types::actions::GameAction;
     use crate::types::game_state::{
-        DrainStatus, GameState, PendingCoinFlipKind, PendingCounterAdditionQueue,
-        PendingCounterMoveQueue, PendingCounterRemovalQueue, PendingMutateMerge,
-        PendingProliferateActions, PendingRepeatIteration, PendingRepeatUntil,
-        PendingRepeatedOptionalPayment, PostReplacementDrain, ResidentDrainPolicy,
+        DrainStatus, GameState, PendingBatchDeliveries, PendingCoinFlipKind,
+        PendingCopyTokenResolution, PendingCounterAdditionQueue, PendingCounterMoveQueue,
+        PendingCounterRemovalQueue, PendingMutateMerge, PendingProliferateActions,
+        PendingRepeatIteration, PendingRepeatUntil, PendingRepeatedOptionalPayment,
+        PostReplacementDrain, ResidentDrainPolicy, ZoneDeliveryExileTracking,
     };
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
     use crate::types::zones::{EtbTapState, Zone};
+    use std::collections::VecDeque;
 
     fn resolved_draw(source_id: u64) -> ResolvedAbility {
         ResolvedAbility::new(
@@ -1782,5 +1784,49 @@ mod tests {
         let counter_additions = resume_priority_fixture(restore_v1_fixture(counter_additions));
         assert!(counter_additions.pending_counter_additions.is_none());
         assert_reserializes_v2_only(counter_additions);
+    }
+
+    #[test]
+    fn v1_batch_and_copy_token_fixtures_resume_via_their_production_drains() {
+        let mut batch = GameState::new_two_player(120);
+        let mut logical_zone_change_group = batch.allocate_logical_zone_change_group(&[]);
+        logical_zone_change_group
+            .latch_immediately_before(Vec::new(), Vec::new())
+            .expect("empty batch group retains its pre-delivery latch");
+        batch.pending_batch_deliveries = Some(PendingBatchDeliveries {
+            logical_zone_change_group,
+            paused_current: None,
+            remaining: Vec::new(),
+            destination: Zone::Graveyard,
+            source_id: None,
+            enter_tapped: EtbTapState::Unspecified,
+            exile_tracking: ZoneDeliveryExileTracking::None,
+            library_placement: None,
+            completion: None,
+            replacement_applied: HashSet::new(),
+            requests: Vec::new(),
+            attempted: Vec::new(),
+            zone_change_record_start: batch.zone_changes_this_turn.len(),
+            deferred_events: Vec::new(),
+        });
+        let mut batch = restore_v1_fixture(batch);
+        crate::game::zone_pipeline::drain_pending_batch_deliveries(&mut batch, &mut Vec::new());
+        assert!(batch.pending_batch_deliveries.is_none());
+        assert_reserializes_v2_only(batch);
+
+        let mut copy_token = GameState::new_two_player(121);
+        copy_token.pending_copy_token_resolution = Some(PendingCopyTokenResolution {
+            created_ids: Vec::new(),
+            remaining: VecDeque::new(),
+            effect_kind: EffectKind::CopyTokenOf,
+            source_id: ObjectId(121),
+        });
+        let mut copy_token = restore_v1_fixture(copy_token);
+        crate::game::effects::token_copy::drain_pending_copy_token_resolution(
+            &mut copy_token,
+            &mut Vec::new(),
+        );
+        assert!(copy_token.pending_copy_token_resolution.is_none());
+        assert_reserializes_v2_only(copy_token);
     }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -7,19 +7,20 @@
 
 use std::collections::HashSet;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map, Value};
 
 use crate::types::ability::ResolvedAbility;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    DrawSequenceStack, PendingBatchDeliveries, PendingChangeZoneIteration, PendingChooseOneOf,
-    PendingCoinFlip, PendingConniveReentry, PendingContinuation, PendingCopyTokenResolution,
-    PendingCounterAdditionQueue, PendingCounterMoveQueue, PendingCounterRemovalQueue,
-    PendingEachPlayerCopyChosen, PendingLifeTotalAssignment, PendingMutateMerge,
-    PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice, PendingProliferateActions,
-    PendingRepeatIteration, PendingRepeatUntil, PendingRepeatedOptionalPayment,
-    PendingSpellResolution, PendingVoteBallotIteration, PostReplacementDrainStack,
-    ResolvingTriggerContext, WaitingFor,
+    DrawSequenceStack, GameState, PendingBatchDeliveries, PendingChangeZoneIteration,
+    PendingChooseOneOf, PendingCoinFlip, PendingConniveReentry, PendingContinuation,
+    PendingCopyTokenResolution, PendingCounterAdditionQueue, PendingCounterMoveQueue,
+    PendingCounterRemovalQueue, PendingEachPlayerCopyChosen, PendingLifeTotalAssignment,
+    PendingMutateMerge, PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice,
+    PendingProliferateActions, PendingRepeatIteration, PendingRepeatUntil,
+    PendingRepeatedOptionalPayment, PendingSpellResolution, PendingVoteBallotIteration,
+    PostReplacementDrainStack, ResolvingTriggerContext, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 
@@ -43,7 +44,8 @@ pub struct MultiDrawFrame {
 /// same resolution lifetime and therefore travels with this frame on the wire.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepeatedOptionalPaymentFrame {
-    pub pending: Box<PendingRepeatedOptionalPayment>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending: Option<Box<PendingRepeatedOptionalPayment>>,
     pub optional_cost_payments_this_resolution: u32,
 }
 
@@ -61,17 +63,29 @@ pub struct OptionalEffectFrame {
 /// `PendingChangeZoneIteration`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChangeZoneFrame {
-    pub pending: PendingChangeZoneIteration,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending: Option<PendingChangeZoneIteration>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub devour_eligible_snapshot: Option<HashSet<ObjectId>>,
 }
 
-/// The per-category zone-choice owner and its captured trigger context.
+/// The complete parked continuation authority.
+///
+/// `ChooseFromZone` stores its narrow trigger-context sidecar beside the
+/// continuation it will drain, not beside the independent per-category
+/// iterator. Keeping it here prevents a v1→v2 conversion from dropping that
+/// sidecar at a save boundary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AbilityContinuationFrame {
+    pub pending: PendingContinuation,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub choose_zone_trigger_context: Option<ResolvingTriggerContext>,
+}
+
+/// The per-category zone-choice owner.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PerCategoryZoneChoiceFrame {
     pub pending: PendingPerCategoryZoneChoice,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub trigger_context: Option<ResolvingTriggerContext>,
 }
 
 /// The one place that states every serializable family of suspended
@@ -80,7 +94,7 @@ pub struct PerCategoryZoneChoiceFrame {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum ResolutionFrame {
-    AbilityContinuation(PendingContinuation),
+    AbilityContinuation(AbilityContinuationFrame),
     RepeatFor(PendingRepeatIteration),
     RepeatUntil(PendingRepeatUntil),
     RepeatedOptionalPayment(RepeatedOptionalPaymentFrame),
@@ -171,15 +185,20 @@ impl ResolutionFrame {
     /// the concrete `WaitingFor` variant by the structural API.
     pub const fn gate(&self) -> FrameGate {
         match self {
-            Self::RepeatedOptionalPayment(_) | Self::OptionalEffect(_) => {
-                FrameGate::DirectChoice(DirectChoiceGate::OptionalEffect)
-            }
+            Self::RepeatedOptionalPayment(RepeatedOptionalPaymentFrame {
+                pending: Some(_),
+                ..
+            })
+            | Self::OptionalEffect(_) => FrameGate::DirectChoice(DirectChoiceGate::OptionalEffect),
             Self::CoinFlip(_) => FrameGate::DirectChoice(DirectChoiceGate::CoinFlipKeep),
             Self::Proliferate(_) => FrameGate::DirectChoice(DirectChoiceGate::Proliferate),
             Self::MutateMerge(_) => FrameGate::DirectChoice(DirectChoiceGate::MutateMerge),
             Self::AbilityContinuation(_)
             | Self::RepeatFor(_)
             | Self::RepeatUntil(_)
+            | Self::RepeatedOptionalPayment(RepeatedOptionalPaymentFrame {
+                pending: None, ..
+            })
             | Self::ChangeZone(_)
             | Self::BatchDelivery(_)
             | Self::CounterMoves(_)
@@ -378,7 +397,11 @@ impl ResolutionStack {
 
     /// Validate stack-local structural and prompt coherence invariants.
     pub fn validate(&self, waiting_for: &WaitingFor) -> Result<(), ResolutionStackError> {
-        for frame in &self.frames {
+        let has_multi_draw = self
+            .frames
+            .iter()
+            .any(|frame| matches!(frame, ResolutionFrame::MultiDraw(_)));
+        for (index, frame) in self.frames.iter().enumerate() {
             if let ResolutionFrame::MultiDraw(draw) = frame {
                 draw.draw_sequences.validate().map_err(|message| {
                     ResolutionStackError::InvalidPayload {
@@ -386,6 +409,29 @@ impl ResolutionStack {
                         message,
                     }
                 })?;
+            }
+            if has_multi_draw
+                && matches!(
+                    frame,
+                    ResolutionFrame::PostReplacement(drains)
+                        if matches!(
+                            drains.resident().map(|drain| &drain.status),
+                            Some(crate::types::game_state::DrainStatus::Paused)
+                        )
+                )
+            {
+                let child =
+                    self.frames
+                        .get(index + 1)
+                        .ok_or(ResolutionStackError::InvalidAdjacentPair(
+                            "a paused post-replacement drain has no immediate multi-draw child",
+                        ))?;
+                validate_shipped_post_replacement_draw_pair(frame, child)?;
+                if index + 2 != self.frames.len() {
+                    return Err(ResolutionStackError::InvalidAdjacentPair(
+                        "a paired multi-draw child is not the active stack top",
+                    ));
+                }
             }
         }
 
@@ -402,6 +448,591 @@ impl ResolutionStack {
         }
         Ok(())
     }
+}
+
+/// The full-state resolution wire protocol version that carries only typed
+/// [`ResolutionStack`] frames for paused resolution work.
+pub const RESOLUTION_STATE_WIRE_VERSION: u64 = 2;
+const LEGACY_RESOLUTION_STATE_WIRE_VERSION: u64 = 1;
+
+/// Versioned wire adapter for full game-state persistence and transport.
+///
+/// `GameState` intentionally retains the legacy runtime slots until their
+/// Phase-3 migrations. This adapter is the only persistence seam that turns
+/// those slots into the typed stack: v1 reads legacy-only state, v2 reads
+/// frame-only state, and v2 writes no legacy resolution field.
+#[derive(Debug, Clone)]
+pub struct ResolutionStateWire {
+    state: GameState,
+}
+
+impl ResolutionStateWire {
+    pub fn from_game_state(state: GameState) -> Self {
+        Self { state }
+    }
+
+    pub fn into_game_state(self) -> GameState {
+        self.state
+    }
+
+    pub fn game_state(&self) -> &GameState {
+        &self.state
+    }
+
+    fn to_value(&self) -> Result<Value, String> {
+        let frames = canonicalize_legacy_resolution_state(&self.state)?;
+        frames
+            .validate(&self.state.waiting_for)
+            .map_err(|error| error.to_string())?;
+
+        let mut value = serde_json::to_value(&self.state).map_err(|error| error.to_string())?;
+        let object = value
+            .as_object_mut()
+            .ok_or_else(|| "GameState must serialize as a JSON object".to_string())?;
+        remove_resolution_wire_fields(object);
+        object.insert(
+            "resolution_state_version".to_string(),
+            Value::from(RESOLUTION_STATE_WIRE_VERSION),
+        );
+        object.insert(
+            "resolution_frames".to_string(),
+            serde_json::to_value(frames).map_err(|error| error.to_string())?,
+        );
+        Ok(value)
+    }
+
+    fn from_value(value: Value) -> Result<Self, String> {
+        let object = value
+            .as_object()
+            .ok_or_else(|| "resolution state wire must be a JSON object".to_string())?;
+        let version = object
+            .get("resolution_state_version")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| {
+                "resolution state wire is missing a numeric resolution_state_version".to_string()
+            })?;
+
+        match version {
+            LEGACY_RESOLUTION_STATE_WIRE_VERSION => {
+                if object.contains_key("resolution_frames") {
+                    return Err("v1 resolution state must not contain resolution_frames".to_string());
+                }
+                let mut legacy: GameState =
+                    serde_json::from_value(value).map_err(|error| error.to_string())?;
+                legacy.migrate_post_replacement_continuation();
+                legacy.migrate_pending_multi_draw();
+                let frames = canonicalize_legacy_resolution_state(&legacy)?;
+                frames
+                    .validate(&legacy.waiting_for)
+                    .map_err(|error| error.to_string())?;
+                Ok(Self {
+                    state: project_frames_into_legacy_state(&legacy, &frames)?,
+                })
+            }
+            RESOLUTION_STATE_WIRE_VERSION => {
+                if legacy_resolution_wire_field(object).is_some() {
+                    return Err("v2 resolution state must not contain a legacy resolution field".to_string());
+                }
+                let frames_value = object
+                    .get("resolution_frames")
+                    .ok_or_else(|| "v2 resolution state is missing resolution_frames".to_string())?;
+                let frames: ResolutionStack = serde_json::from_value(frames_value.clone())
+                    .map_err(|error| error.to_string())?;
+
+                let mut state_value = value;
+                let state_object = state_value.as_object_mut().expect("checked JSON object");
+                state_object.remove("resolution_state_version");
+                state_object.remove("resolution_frames");
+                let state: GameState =
+                    serde_json::from_value(state_value).map_err(|error| error.to_string())?;
+                frames
+                    .validate(&state.waiting_for)
+                    .map_err(|error| error.to_string())?;
+                let projected = project_frames_into_legacy_state(&state, &frames)?;
+                let canonical = canonicalize_legacy_resolution_state(&projected)?;
+                if canonical != frames {
+                    return Err("v2 resolution frames cannot be represented by the legacy runtime slots"
+                        .to_string());
+                }
+                Ok(Self { state: projected })
+            }
+            other => Err(format!(
+                "unsupported resolution_state_version {other}; expected 1 or {RESOLUTION_STATE_WIRE_VERSION}"
+            )),
+        }
+    }
+}
+
+impl Serialize for ResolutionStateWire {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_value()
+            .map_err(serde::ser::Error::custom)?
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ResolutionStateWire {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::from_value(Value::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+enum DrawAndPostConversion {
+    Paired {
+        parent: ResolutionFrame,
+        child: ResolutionFrame,
+    },
+    UnpairedDraw(ResolutionFrame),
+    UnpairedPost(ResolutionFrame),
+}
+
+fn canonicalize_legacy_resolution_state(state: &GameState) -> Result<ResolutionStack, String> {
+    if state.pending_continuation.is_none() && state.pending_choose_zone_trigger_context.is_some() {
+        return Err(
+            "pending choose-from-zone trigger context has no continuation owner".to_string(),
+        );
+    }
+    if state.pending_optional_effect.is_none()
+        && (state.pending_optional_trigger_event.is_some()
+            || state.pending_optional_trigger_match_count.is_some())
+    {
+        return Err(
+            "pending optional-effect trigger context has no optional-effect owner".to_string(),
+        );
+    }
+    let mut frames = ResolutionStack::default();
+
+    push_legacy_after_child_frames(state, &mut frames);
+    if let Some(conversion) = classify_draw_and_post_replacement(state)? {
+        // The paired branch is deliberately first. Once a paused resident drain
+        // proves the adjacency relationship, neither unpaired converter may run.
+        match conversion {
+            DrawAndPostConversion::Paired { parent, child } => frames
+                .install_adjacent_post_replacement_draw(parent, child)
+                .map_err(|error| error.to_string())?,
+            DrawAndPostConversion::UnpairedDraw(frame) => frames.push_inner(frame),
+            DrawAndPostConversion::UnpairedPost(frame) => frames.push_inner(frame),
+        }
+    }
+    if state.draw_sequences.is_empty() {
+        if let Some(pending) = state.pending_connive_reentry.clone() {
+            frames.push_inner(ResolutionFrame::ConniveReentry(pending));
+        }
+    }
+    push_legacy_direct_choice_frames(state, &mut frames)?;
+    Ok(frames)
+}
+
+fn push_legacy_after_child_frames(state: &GameState, frames: &mut ResolutionStack) {
+    if let Some(pending) = state.pending_continuation.clone() {
+        frames.push_inner(ResolutionFrame::AbilityContinuation(
+            AbilityContinuationFrame {
+                pending,
+                choose_zone_trigger_context: state.pending_choose_zone_trigger_context.clone(),
+            },
+        ));
+    }
+    if let Some(pending) = state.pending_repeat_iteration.clone() {
+        frames.push_inner(ResolutionFrame::RepeatFor(pending));
+    }
+    if let Some(pending) = state.pending_repeat_until.clone() {
+        frames.push_inner(ResolutionFrame::RepeatUntil(pending));
+    }
+    if state.pending_change_zone_iteration.is_some() || state.devour_eligible_snapshot.is_some() {
+        frames.push_inner(ResolutionFrame::ChangeZone(ChangeZoneFrame {
+            pending: state.pending_change_zone_iteration.clone(),
+            devour_eligible_snapshot: state.devour_eligible_snapshot.clone(),
+        }));
+    }
+    if let Some(pending) = state.pending_batch_deliveries.clone() {
+        frames.push_inner(ResolutionFrame::BatchDelivery(pending));
+    }
+    if let Some(pending) = state.pending_counter_moves.clone() {
+        frames.push_inner(ResolutionFrame::CounterMoves(pending));
+    }
+    if let Some(pending) = state.pending_counter_removals.clone() {
+        frames.push_inner(ResolutionFrame::CounterRemovals(pending));
+    }
+    if let Some(pending) = state.pending_counter_additions.clone() {
+        frames.push_inner(ResolutionFrame::CounterAdditions(pending));
+    }
+    if let Some(pending) = state.pending_copy_token_resolution.clone() {
+        frames.push_inner(ResolutionFrame::CopyToken(pending));
+    }
+    if let Some(pending) = state.pending_each_player_copy_chosen.clone() {
+        frames.push_inner(ResolutionFrame::EachPlayerCopyChosen(pending));
+    }
+    if let Some(pending) = state.pending_choose_one_of.clone() {
+        frames.push_inner(ResolutionFrame::ChooseOneOf(pending));
+    }
+    if let Some(pending) = state.pending_vote_ballot_iteration.clone() {
+        frames.push_inner(ResolutionFrame::VoteBallot(pending));
+    }
+    if let Some(pending) = state.pending_per_player_zone_choice.clone() {
+        frames.push_inner(ResolutionFrame::PerPlayerZoneChoice(pending));
+    }
+    if let Some(pending) = state.pending_per_category_zone_choice.clone() {
+        frames.push_inner(ResolutionFrame::PerCategoryZoneChoice(
+            PerCategoryZoneChoiceFrame { pending },
+        ));
+    }
+    if let Some(pending) = state.pending_life_total_assignment.clone() {
+        frames.push_inner(ResolutionFrame::LifeTotalAssignment(pending));
+    }
+    if let Some(pending) = state.pending_spell_resolution.clone() {
+        frames.push_inner(ResolutionFrame::SpellResolution(pending));
+    }
+}
+
+fn push_legacy_direct_choice_frames(
+    state: &GameState,
+    frames: &mut ResolutionStack,
+) -> Result<(), String> {
+    let mut direct_choice_count = 0;
+    if state.pending_repeated_optional_payment.is_some()
+        || state.optional_cost_payments_this_resolution != 0
+    {
+        direct_choice_count += 1;
+        frames.push_inner(ResolutionFrame::RepeatedOptionalPayment(
+            RepeatedOptionalPaymentFrame {
+                pending: state.pending_repeated_optional_payment.clone(),
+                optional_cost_payments_this_resolution: state
+                    .optional_cost_payments_this_resolution,
+            },
+        ));
+    }
+    if let Some(ability) = state.pending_optional_effect.clone() {
+        direct_choice_count += 1;
+        frames.push_inner(ResolutionFrame::OptionalEffect(OptionalEffectFrame {
+            ability,
+            trigger_event: state.pending_optional_trigger_event.clone(),
+            trigger_match_count: state.pending_optional_trigger_match_count,
+        }));
+    }
+    if let Some(pending) = state.pending_coin_flip.clone() {
+        direct_choice_count += 1;
+        frames.push_inner(ResolutionFrame::CoinFlip(pending));
+    }
+    if let Some(pending) = state.pending_proliferate_actions.clone() {
+        direct_choice_count += 1;
+        frames.push_inner(ResolutionFrame::Proliferate(pending));
+    }
+    if let Some(pending) = state.pending_mutate_merge.clone() {
+        direct_choice_count += 1;
+        frames.push_inner(ResolutionFrame::MutateMerge(pending));
+    }
+    if direct_choice_count > 1 {
+        return Err("legacy resolution state has multiple direct-choice owners".to_string());
+    }
+    Ok(())
+}
+
+fn classify_draw_and_post_replacement(
+    state: &GameState,
+) -> Result<Option<DrawAndPostConversion>, String> {
+    let draw = (!state.draw_sequences.is_empty()).then(|| {
+        ResolutionFrame::MultiDraw(MultiDrawFrame {
+            draw_sequences: state.draw_sequences.clone(),
+            pending_connive_reentry: state.pending_connive_reentry.clone(),
+        })
+    });
+    let post = (!state.post_replacement_drains.is_empty())
+        .then(|| ResolutionFrame::PostReplacement(state.post_replacement_drains.clone()));
+
+    let conversion = match (post, draw) {
+        (Some(parent), Some(child)) => {
+            let ResolutionFrame::PostReplacement(drains) = &parent else {
+                unreachable!("post frame classifier constructed the wrong frame kind")
+            };
+            if !matches!(
+                drains.resident().map(|drain| &drain.status),
+                Some(crate::types::game_state::DrainStatus::Paused)
+            ) {
+                return Err(
+                    "legacy post-replacement and multi-draw state is ambiguous without a paused resident drain"
+                        .to_string(),
+                );
+            }
+            Some(DrawAndPostConversion::Paired { parent, child })
+        }
+        (None, Some(draw)) => Some(DrawAndPostConversion::UnpairedDraw(draw)),
+        (Some(post), None) => Some(DrawAndPostConversion::UnpairedPost(post)),
+        (None, None) => None,
+    };
+    Ok(conversion)
+}
+
+fn project_frames_into_legacy_state(
+    state: &GameState,
+    frames: &ResolutionStack,
+) -> Result<GameState, String> {
+    let mut projected = state.clone();
+    clear_legacy_resolution_slots(&mut projected);
+    for frame in frames.iter() {
+        match frame {
+            ResolutionFrame::AbilityContinuation(frame) => {
+                set_once(
+                    &mut projected.pending_continuation,
+                    frame.pending.clone(),
+                    "AbilityContinuation",
+                )?;
+                if projected.pending_choose_zone_trigger_context.is_some() {
+                    return Err("duplicate AbilityContinuation trigger context".to_string());
+                }
+                projected.pending_choose_zone_trigger_context =
+                    frame.choose_zone_trigger_context.clone();
+            }
+            ResolutionFrame::RepeatFor(pending) => set_once(
+                &mut projected.pending_repeat_iteration,
+                pending.clone(),
+                "RepeatFor",
+            )?,
+            ResolutionFrame::RepeatUntil(pending) => set_once(
+                &mut projected.pending_repeat_until,
+                pending.clone(),
+                "RepeatUntil",
+            )?,
+            ResolutionFrame::RepeatedOptionalPayment(frame) => {
+                if let Some(pending) = frame.pending.clone() {
+                    set_once(
+                        &mut projected.pending_repeated_optional_payment,
+                        pending,
+                        "RepeatedOptionalPayment",
+                    )?;
+                }
+                projected.optional_cost_payments_this_resolution =
+                    frame.optional_cost_payments_this_resolution;
+            }
+            ResolutionFrame::ChangeZone(frame) => {
+                if let Some(pending) = frame.pending.clone() {
+                    set_once(
+                        &mut projected.pending_change_zone_iteration,
+                        pending,
+                        "ChangeZone",
+                    )?;
+                }
+                if projected.devour_eligible_snapshot.is_some() {
+                    return Err("duplicate ChangeZone devour snapshot".to_string());
+                }
+                projected.devour_eligible_snapshot = frame.devour_eligible_snapshot.clone();
+            }
+            ResolutionFrame::BatchDelivery(pending) => set_once(
+                &mut projected.pending_batch_deliveries,
+                pending.clone(),
+                "BatchDelivery",
+            )?,
+            ResolutionFrame::CounterMoves(pending) => set_once(
+                &mut projected.pending_counter_moves,
+                pending.clone(),
+                "CounterMoves",
+            )?,
+            ResolutionFrame::CounterRemovals(pending) => set_once(
+                &mut projected.pending_counter_removals,
+                pending.clone(),
+                "CounterRemovals",
+            )?,
+            ResolutionFrame::CounterAdditions(pending) => set_once(
+                &mut projected.pending_counter_additions,
+                pending.clone(),
+                "CounterAdditions",
+            )?,
+            ResolutionFrame::CopyToken(pending) => set_once(
+                &mut projected.pending_copy_token_resolution,
+                pending.clone(),
+                "CopyToken",
+            )?,
+            ResolutionFrame::EachPlayerCopyChosen(pending) => set_once(
+                &mut projected.pending_each_player_copy_chosen,
+                pending.clone(),
+                "EachPlayerCopyChosen",
+            )?,
+            ResolutionFrame::ChooseOneOf(pending) => set_once(
+                &mut projected.pending_choose_one_of,
+                pending.clone(),
+                "ChooseOneOf",
+            )?,
+            ResolutionFrame::VoteBallot(pending) => set_once(
+                &mut projected.pending_vote_ballot_iteration,
+                pending.clone(),
+                "VoteBallot",
+            )?,
+            ResolutionFrame::PerPlayerZoneChoice(pending) => set_once(
+                &mut projected.pending_per_player_zone_choice,
+                pending.clone(),
+                "PerPlayerZoneChoice",
+            )?,
+            ResolutionFrame::PerCategoryZoneChoice(frame) => {
+                set_once(
+                    &mut projected.pending_per_category_zone_choice,
+                    frame.pending.clone(),
+                    "PerCategoryZoneChoice",
+                )?;
+            }
+            ResolutionFrame::OptionalEffect(frame) => {
+                set_once(
+                    &mut projected.pending_optional_effect,
+                    frame.ability.clone(),
+                    "OptionalEffect",
+                )?;
+                projected.pending_optional_trigger_event = frame.trigger_event.clone();
+                projected.pending_optional_trigger_match_count = frame.trigger_match_count;
+            }
+            ResolutionFrame::CoinFlip(pending) => set_once(
+                &mut projected.pending_coin_flip,
+                pending.clone(),
+                "CoinFlip",
+            )?,
+            ResolutionFrame::Proliferate(pending) => set_once(
+                &mut projected.pending_proliferate_actions,
+                pending.clone(),
+                "Proliferate",
+            )?,
+            ResolutionFrame::MultiDraw(frame) => {
+                if !projected.draw_sequences.is_empty()
+                    || projected.pending_connive_reentry.is_some()
+                {
+                    return Err("duplicate MultiDraw frame".to_string());
+                }
+                projected.draw_sequences = frame.draw_sequences.clone();
+                projected.pending_connive_reentry = frame.pending_connive_reentry.clone();
+            }
+            ResolutionFrame::ConniveReentry(pending) => set_once(
+                &mut projected.pending_connive_reentry,
+                pending.clone(),
+                "ConniveReentry",
+            )?,
+            ResolutionFrame::LifeTotalAssignment(pending) => set_once(
+                &mut projected.pending_life_total_assignment,
+                pending.clone(),
+                "LifeTotalAssignment",
+            )?,
+            ResolutionFrame::SpellResolution(pending) => set_once(
+                &mut projected.pending_spell_resolution,
+                pending.clone(),
+                "SpellResolution",
+            )?,
+            ResolutionFrame::MutateMerge(pending) => set_once(
+                &mut projected.pending_mutate_merge,
+                pending.clone(),
+                "MutateMerge",
+            )?,
+            ResolutionFrame::PostReplacement(drains) => {
+                if !projected.post_replacement_drains.is_empty() {
+                    return Err("duplicate PostReplacement frame".to_string());
+                }
+                projected.post_replacement_drains = drains.clone();
+            }
+        }
+    }
+    Ok(projected)
+}
+
+fn clear_legacy_resolution_slots(state: &mut GameState) {
+    state.pending_continuation = None;
+    state.pending_repeat_iteration = None;
+    state.pending_repeat_until = None;
+    state.pending_repeated_optional_payment = None;
+    state.optional_cost_payments_this_resolution = 0;
+    state.pending_change_zone_iteration = None;
+    state.devour_eligible_snapshot = None;
+    state.pending_batch_deliveries = None;
+    state.pending_counter_moves = None;
+    state.pending_counter_removals = None;
+    state.pending_counter_additions = None;
+    state.pending_copy_token_resolution = None;
+    state.pending_each_player_copy_chosen = None;
+    state.pending_choose_one_of = None;
+    state.pending_vote_ballot_iteration = None;
+    state.pending_per_player_zone_choice = None;
+    state.pending_per_category_zone_choice = None;
+    state.pending_choose_zone_trigger_context = None;
+    state.pending_optional_effect = None;
+    state.pending_optional_trigger_event = None;
+    state.pending_optional_trigger_match_count = None;
+    state.pending_coin_flip = None;
+    state.pending_proliferate_actions = None;
+    state.draw_sequences = DrawSequenceStack::default();
+    state.legacy_pending_multi_draw = None;
+    state.pending_connive_reentry = None;
+    state.pending_life_total_assignment = None;
+    state.pending_spell_resolution = None;
+    state.pending_mutate_merge = None;
+    state.post_replacement_drains = PostReplacementDrainStack::default();
+    state.legacy_post_replacement_effect = None;
+    state.legacy_post_replacement_resolved_effect = None;
+    state.legacy_post_replacement_continuation = None;
+    state.legacy_post_replacement_source = None;
+    state.legacy_post_replacement_applied.clear();
+    state.legacy_post_replacement_event_source = None;
+    state.legacy_post_replacement_event_target = None;
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T, name: &str) -> Result<(), String> {
+    if slot.replace(value).is_some() {
+        return Err(format!("duplicate {name} frame"));
+    }
+    Ok(())
+}
+
+fn legacy_resolution_wire_field(object: &Map<String, Value>) -> Option<&str> {
+    legacy_resolution_wire_fields()
+        .iter()
+        .copied()
+        .find(|field| object.contains_key(*field))
+}
+
+fn remove_resolution_wire_fields(object: &mut Map<String, Value>) {
+    for field in legacy_resolution_wire_fields() {
+        object.remove(*field);
+    }
+}
+
+fn legacy_resolution_wire_fields() -> &'static [&'static str] {
+    &[
+        "pending_continuation",
+        "pending_repeat_iteration",
+        "pending_repeat_until",
+        "pending_repeated_optional_payment",
+        "optional_cost_payments_this_resolution",
+        "pending_change_zone_iteration",
+        "devour_eligible_snapshot",
+        "pending_batch_deliveries",
+        "pending_counter_moves",
+        "pending_counter_removals",
+        "pending_counter_additions",
+        "pending_copy_token_resolution",
+        "pending_each_player_copy_chosen",
+        "pending_choose_one_of",
+        "pending_vote_ballot_iteration",
+        "pending_per_player_zone_choice",
+        "pending_per_category_zone_choice",
+        "pending_choose_zone_trigger_context",
+        "pending_optional_effect",
+        "pending_optional_trigger_event",
+        "pending_optional_trigger_match_count",
+        "pending_coin_flip",
+        "pending_proliferate_actions",
+        "draw_sequences",
+        "pending_multi_draw",
+        "pending_connive_reentry",
+        "pending_life_total_assignment",
+        "pending_spell_resolution",
+        "pending_mutate_merge",
+        "post_replacement_drains",
+        "post_replacement_effect",
+        "post_replacement_resolved_effect",
+        "post_replacement_continuation",
+        "post_replacement_source",
+        "post_replacement_applied",
+        "post_replacement_event_source",
+        "post_replacement_event_target",
+    ]
 }
 
 fn validate_shipped_post_replacement_draw_pair(
@@ -466,10 +1097,10 @@ mod tests {
 
     fn continuation_frame(source_id: u64) -> ResolutionFrame {
         let state = GameState::new_two_player(source_id);
-        ResolutionFrame::AbilityContinuation(PendingContinuation::new(
-            Box::new(resolved_draw(source_id)),
-            &state,
-        ))
+        ResolutionFrame::AbilityContinuation(AbilityContinuationFrame {
+            pending: PendingContinuation::new(Box::new(resolved_draw(source_id)), &state),
+            choose_zone_trigger_context: None,
+        })
     }
 
     fn change_zone_frame(group_seed: u64) -> ResolutionFrame {
@@ -479,7 +1110,7 @@ mod tests {
             .latch_immediately_before(Vec::new(), Vec::new())
             .expect("empty logical group still needs its pre-delivery latch");
         ResolutionFrame::ChangeZone(ChangeZoneFrame {
-            pending: PendingChangeZoneIteration {
+            pending: Some(PendingChangeZoneIteration {
                 logical_zone_change_group,
                 paused_current: None,
                 remaining: Vec::new(),
@@ -501,7 +1132,7 @@ mod tests {
                 enters_modified_if: None,
                 enter_attached_to: None,
                 effect_kind: EffectKind::ChangeZone,
-            },
+            }),
             devour_eligible_snapshot: None,
         })
     }
@@ -703,5 +1334,193 @@ mod tests {
             )
             .is_err());
         assert_eq!(empty, before, "failed paired installation is atomic");
+    }
+
+    #[test]
+    fn resolution_state_wire_converts_v1_to_v2_without_legacy_projection() {
+        let mut state = GameState::new_two_player(42);
+        state.pending_coin_flip = Some(PendingCoinFlip {
+            source_id: ObjectId(5),
+            controller: PlayerId(0),
+            flipper: PlayerId(0),
+            targets: Vec::new(),
+            win_effect: None,
+            lose_effect: None,
+            kind: PendingCoinFlipKind::Single,
+        });
+        state.waiting_for = WaitingFor::CoinFlipKeepChoice {
+            player: PlayerId(0),
+            results: vec![true, false],
+            keep_count: 1,
+        };
+
+        let mut v1 = serde_json::to_value(&state).expect("legacy state serializes");
+        v1["resolution_state_version"] = Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        let wire: ResolutionStateWire =
+            serde_json::from_value(v1).expect("v1 legacy state converts through frames");
+        assert!(wire.game_state().pending_coin_flip.is_some());
+
+        let v2 = serde_json::to_value(&wire).expect("v2 wire serializes");
+        assert_eq!(
+            v2["resolution_state_version"],
+            Value::from(RESOLUTION_STATE_WIRE_VERSION)
+        );
+        assert!(v2.get("resolution_frames").is_some());
+        assert!(v2.get("pending_coin_flip").is_none());
+
+        let restored: ResolutionStateWire =
+            serde_json::from_value(v2).expect("v2 frame state projects for legacy runtime");
+        assert!(restored.into_game_state().pending_coin_flip.is_some());
+    }
+
+    #[test]
+    fn resolution_state_wire_keeps_choose_from_zone_context_with_its_continuation() {
+        let mut state = GameState::new_two_player(43);
+        state.pending_continuation = Some(PendingContinuation::new(
+            Box::new(resolved_draw(43)),
+            &state,
+        ));
+        let context = ResolvingTriggerContext {
+            event: None,
+            events: Vec::new(),
+            match_count: Some(2),
+            die_result: None,
+        };
+        state.pending_choose_zone_trigger_context = Some(context.clone());
+
+        let mut v1 = serde_json::to_value(&state).expect("legacy state serializes");
+        v1["resolution_state_version"] = Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        let wire: ResolutionStateWire =
+            serde_json::from_value(v1).expect("v1 continuation sidecar converts through frames");
+        let v2 = serde_json::to_value(&wire).expect("v2 wire serializes");
+        assert!(v2.get("pending_choose_zone_trigger_context").is_none());
+
+        let restored: ResolutionStateWire =
+            serde_json::from_value(v2).expect("v2 continuation sidecar projects for runtime");
+        assert_eq!(
+            restored
+                .into_game_state()
+                .pending_choose_zone_trigger_context,
+            Some(context)
+        );
+    }
+
+    #[test]
+    fn resolution_state_wire_keeps_devour_snapshot_without_a_change_zone_iteration() {
+        let mut state = GameState::new_two_player(44);
+        let snapshot = HashSet::from([ObjectId(7), ObjectId(8)]);
+        state.devour_eligible_snapshot = Some(snapshot.clone());
+
+        let mut v1 = serde_json::to_value(&state).expect("legacy state serializes");
+        v1["resolution_state_version"] = Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        let wire: ResolutionStateWire =
+            serde_json::from_value(v1).expect("v1 devour sidecar converts through frames");
+        let v2 = serde_json::to_value(&wire).expect("v2 wire serializes");
+        assert!(v2.get("devour_eligible_snapshot").is_none());
+
+        let restored: ResolutionStateWire =
+            serde_json::from_value(v2).expect("v2 devour sidecar projects for runtime");
+        assert_eq!(
+            restored.into_game_state().devour_eligible_snapshot,
+            Some(snapshot)
+        );
+    }
+
+    #[test]
+    fn resolution_state_wire_keeps_payment_count_after_its_driver_has_finished() {
+        let mut state = GameState::new_two_player(45);
+        state.optional_cost_payments_this_resolution = 2;
+
+        let mut v1 = serde_json::to_value(&state).expect("legacy state serializes");
+        v1["resolution_state_version"] = Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        let wire: ResolutionStateWire =
+            serde_json::from_value(v1).expect("v1 payment count converts through frames");
+        let v2 = serde_json::to_value(&wire).expect("v2 wire serializes");
+        assert!(v2.get("optional_cost_payments_this_resolution").is_none());
+
+        let restored: ResolutionStateWire =
+            serde_json::from_value(v2).expect("v2 payment count projects for runtime");
+        assert_eq!(
+            restored
+                .into_game_state()
+                .optional_cost_payments_this_resolution,
+            2
+        );
+    }
+
+    #[test]
+    fn resolution_state_wire_converts_the_shipped_paused_drain_pair_atomically() {
+        let ResolutionFrame::PostReplacement(drains) = paused_post_replacement_frame() else {
+            unreachable!("test helper constructs a post-replacement frame")
+        };
+        let ResolutionFrame::MultiDraw(draw) = active_multi_draw_frame() else {
+            unreachable!("test helper constructs a multi-draw frame")
+        };
+        let mut state = GameState::new_two_player(42);
+        state.post_replacement_drains = drains;
+        state.draw_sequences = draw.draw_sequences;
+        let mut v1 = serde_json::to_value(&state).expect("legacy paired state serializes");
+        v1["resolution_state_version"] = Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+
+        let wire: ResolutionStateWire =
+            serde_json::from_value(v1).expect("paused drain and draw become one adjacent pair");
+        let v2 = serde_json::to_value(&wire).expect("converted pair serializes");
+        let frames: ResolutionStack =
+            serde_json::from_value(v2["resolution_frames"].clone()).expect("frame payload parses");
+        assert_eq!(
+            frames.iter().map(ResolutionFrame::kind).collect::<Vec<_>>(),
+            vec![FrameKind::PostReplacement, FrameKind::MultiDraw]
+        );
+    }
+
+    #[test]
+    fn resolution_state_wire_rejects_missing_unknown_and_mixed_versions() {
+        let state = GameState::new_two_player(42);
+        let wire = ResolutionStateWire::from_game_state(state);
+        let v2 = serde_json::to_value(wire).expect("v2 wire serializes");
+
+        let mut missing = v2.clone();
+        missing
+            .as_object_mut()
+            .expect("wire is an object")
+            .remove("resolution_state_version");
+        assert!(serde_json::from_value::<ResolutionStateWire>(missing).is_err());
+
+        let mut unknown = v2.clone();
+        unknown["resolution_state_version"] = Value::from(99);
+        assert!(serde_json::from_value::<ResolutionStateWire>(unknown).is_err());
+
+        let mut mixed = v2;
+        mixed["pending_coin_flip"] = Value::Null;
+        assert!(serde_json::from_value::<ResolutionStateWire>(mixed).is_err());
+    }
+
+    #[test]
+    fn validation_rejects_a_paused_drain_pair_buried_below_another_frame() {
+        let mut stack = ResolutionStack::default();
+        stack
+            .install_adjacent_post_replacement_draw(
+                paused_post_replacement_frame(),
+                active_multi_draw_frame(),
+            )
+            .expect("pair installs");
+        stack.push_inner(continuation_frame(9));
+        assert!(matches!(
+            stack.validate(&WaitingFor::Priority {
+                player: PlayerId(0)
+            }),
+            Err(ResolutionStackError::InvalidAdjacentPair(_))
+        ));
+    }
+
+    #[test]
+    fn validation_keeps_an_independent_paused_drain_without_a_draw_frame() {
+        let mut stack = ResolutionStack::default();
+        stack.push_inner(paused_post_replacement_frame());
+        stack
+            .validate(&WaitingFor::Priority {
+                player: PlayerId(0),
+            })
+            .expect("a non-draw paused drain remains an independent post-replacement frame");
     }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -1073,11 +1073,14 @@ fn validate_shipped_post_replacement_draw_pair(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::engine::apply_as_current;
     use crate::types::ability::{
         Effect, EffectKind, PostReplacementContinuation, QuantityExpr, TargetFilter,
     };
+    use crate::types::actions::GameAction;
     use crate::types::game_state::{
-        DrainStatus, GameState, PendingCoinFlipKind, PostReplacementDrain, ResidentDrainPolicy,
+        DrainStatus, GameState, PendingCoinFlipKind, PendingProliferateActions,
+        PendingRepeatedOptionalPayment, PostReplacementDrain, ResidentDrainPolicy,
     };
     use crate::types::identifiers::ObjectId;
     use crate::types::player::PlayerId;
@@ -1164,6 +1167,46 @@ mod tests {
             draw_sequences,
             pending_connive_reentry: None,
         })
+    }
+
+    fn restore_v1_fixture(state: GameState) -> GameState {
+        let mut v1 = serde_json::to_value(state).expect("legacy fixture serializes");
+        v1["resolution_state_version"] = Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+
+        let wire: ResolutionStateWire =
+            serde_json::from_value(v1).expect("v1 fixture converts through the wire");
+        let v2 = serde_json::to_value(&wire).expect("converted fixture serializes as v2");
+        assert_eq!(
+            v2["resolution_state_version"],
+            Value::from(RESOLUTION_STATE_WIRE_VERSION)
+        );
+        assert!(v2.get("resolution_frames").is_some());
+        for field in legacy_resolution_wire_fields() {
+            assert!(
+                v2.get(*field).is_none(),
+                "v2 fixture must not write legacy field {field}"
+            );
+        }
+
+        serde_json::from_value::<ResolutionStateWire>(v2)
+            .expect("v2 fixture restores for the legacy runtime action path")
+            .into_game_state()
+    }
+
+    fn assert_reserializes_v2_only(state: GameState) {
+        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
+            .expect("resumed fixture serializes as v2");
+        assert_eq!(
+            v2["resolution_state_version"],
+            Value::from(RESOLUTION_STATE_WIRE_VERSION)
+        );
+        assert!(v2.get("resolution_frames").is_some());
+        for field in legacy_resolution_wire_fields() {
+            assert!(
+                v2.get(*field).is_none(),
+                "resumed v2 fixture must not write legacy field {field}"
+            );
+        }
     }
 
     #[test]
@@ -1522,5 +1565,94 @@ mod tests {
                 player: PlayerId(0),
             })
             .expect("a non-draw paused drain remains an independent post-replacement frame");
+    }
+
+    #[test]
+    fn v1_direct_choice_fixtures_resume_on_the_real_action_path() {
+        let mut repeated = GameState::new_two_player(100);
+        repeated.pending_repeated_optional_payment =
+            Some(Box::new(PendingRepeatedOptionalPayment {
+                payment_unit: Box::new(resolved_draw(100)),
+                reflexive: Box::new(resolved_draw(101)),
+                remaining: 0,
+            }));
+        repeated.waiting_for = WaitingFor::OptionalEffectChoice {
+            player: PlayerId(0),
+            source_id: ObjectId(100),
+            description: None,
+            may_trigger_key: None,
+        };
+        let mut repeated = restore_v1_fixture(repeated);
+        apply_as_current(
+            &mut repeated,
+            GameAction::DecideOptionalEffect { accept: false },
+        )
+        .expect("repeated-payment fixture resumes through the real optional-choice action");
+        assert!(repeated.pending_repeated_optional_payment.is_none());
+        assert_reserializes_v2_only(repeated);
+
+        let mut optional = GameState::new_two_player(102);
+        optional.pending_optional_effect = Some(Box::new(resolved_draw(102)));
+        optional.waiting_for = WaitingFor::OptionalEffectChoice {
+            player: PlayerId(0),
+            source_id: ObjectId(102),
+            description: None,
+            may_trigger_key: None,
+        };
+        let mut optional = restore_v1_fixture(optional);
+        apply_as_current(
+            &mut optional,
+            GameAction::DecideOptionalEffect { accept: false },
+        )
+        .expect("optional-effect fixture resumes through the real optional-choice action");
+        assert!(optional.pending_optional_effect.is_none());
+        assert_reserializes_v2_only(optional);
+
+        let mut coin = GameState::new_two_player(103);
+        coin.pending_coin_flip = Some(PendingCoinFlip {
+            source_id: ObjectId(103),
+            controller: PlayerId(0),
+            flipper: PlayerId(0),
+            targets: Vec::new(),
+            win_effect: None,
+            lose_effect: None,
+            kind: PendingCoinFlipKind::Single,
+        });
+        coin.waiting_for = WaitingFor::CoinFlipKeepChoice {
+            player: PlayerId(0),
+            results: vec![true, false],
+            keep_count: 1,
+        };
+        let mut coin = restore_v1_fixture(coin);
+        apply_as_current(
+            &mut coin,
+            GameAction::SelectCoinFlips {
+                keep_indices: vec![0],
+            },
+        )
+        .expect("coin-flip fixture resumes through the real keep-choice action");
+        assert!(coin.pending_coin_flip.is_none());
+        assert_reserializes_v2_only(coin);
+
+        let mut proliferate = GameState::new_two_player(104);
+        proliferate.pending_proliferate_actions = Some(PendingProliferateActions {
+            actor: PlayerId(0),
+            source_id: ObjectId(104),
+            remaining: 0,
+        });
+        proliferate.waiting_for = WaitingFor::ProliferateChoice {
+            player: PlayerId(0),
+            eligible: Vec::new(),
+        };
+        let mut proliferate = restore_v1_fixture(proliferate);
+        apply_as_current(
+            &mut proliferate,
+            GameAction::SelectTargets {
+                targets: Vec::new(),
+            },
+        )
+        .expect("proliferate fixture resumes through the real target-choice action");
+        assert!(proliferate.pending_proliferate_actions.is_none());
+        assert_reserializes_v2_only(proliferate);
     }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -1074,12 +1074,14 @@ fn validate_shipped_post_replacement_draw_pair(
 mod tests {
     use super::*;
     use crate::game::engine::apply_as_current;
+    use crate::game::merge::MergeSide;
+    use crate::game::scenario::GameScenario;
     use crate::types::ability::{
         Effect, EffectKind, PostReplacementContinuation, QuantityExpr, TargetFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::game_state::{
-        DrainStatus, GameState, PendingCoinFlipKind, PendingProliferateActions,
+        DrainStatus, GameState, PendingCoinFlipKind, PendingMutateMerge, PendingProliferateActions,
         PendingRepeatedOptionalPayment, PostReplacementDrain, ResidentDrainPolicy,
     };
     use crate::types::identifiers::ObjectId;
@@ -1654,5 +1656,38 @@ mod tests {
         .expect("proliferate fixture resumes through the real target-choice action");
         assert!(proliferate.pending_proliferate_actions.is_none());
         assert_reserializes_v2_only(proliferate);
+
+        let mut scenario = GameScenario::new();
+        let merging_id = scenario.add_creature(PlayerId(0), "Rider", 4, 4).id();
+        let target_id = scenario.add_creature(PlayerId(0), "Host", 2, 2).id();
+        let mut mutate = scenario.state;
+        mutate.pending_mutate_merge = Some(PendingMutateMerge {
+            merging_id,
+            target_id,
+            controller: PlayerId(0),
+        });
+        mutate.waiting_for = WaitingFor::MutateMergeChoice {
+            player: PlayerId(0),
+            merging_id,
+            target_id,
+        };
+        let mut mutate = restore_v1_fixture(mutate);
+        apply_as_current(
+            &mut mutate,
+            GameAction::ChooseMutateMergeSide {
+                side: MergeSide::Top,
+            },
+        )
+        .expect("mutate fixture resumes through the real merge-choice action");
+        assert!(mutate.pending_mutate_merge.is_none());
+        assert_eq!(
+            mutate
+                .objects
+                .get(&target_id)
+                .expect("merged target remains in the object map")
+                .merged_components,
+            vec![merging_id, target_id]
+        );
+        assert_reserializes_v2_only(mutate);
     }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -533,9 +533,10 @@ impl ResolutionStateWire {
                 frames
                     .validate(&legacy.waiting_for)
                     .map_err(|error| error.to_string())?;
-                Ok(Self {
-                    state: project_frames_into_legacy_state(&legacy, &frames)?,
-                })
+                let state = project_frames_into_legacy_state(&legacy, &frames)?;
+                #[cfg(debug_assertions)]
+                debug_assert_runtime_resolution_invariants(&state);
+                Ok(Self { state })
             }
             RESOLUTION_STATE_WIRE_VERSION => {
                 if legacy_resolution_wire_field(object).is_some() {
@@ -562,6 +563,8 @@ impl ResolutionStateWire {
                     return Err("v2 resolution frames cannot be represented by the legacy runtime slots"
                         .to_string());
                 }
+                #[cfg(debug_assertions)]
+                debug_assert_runtime_resolution_invariants(&projected);
                 Ok(Self { state: projected })
             }
             other => Err(format!(
@@ -588,6 +591,40 @@ impl<'de> Deserialize<'de> for ResolutionStateWire {
         D: Deserializer<'de>,
     {
         Self::from_value(Value::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Checks the Phase-2 boundary invariants after a restore and after every
+/// public action. `ResolutionStack` is still a wire-only view in this phase,
+/// so this additionally proves that its v2 representation never carries one
+/// of the legacy runtime families alongside `resolution_frames`.
+#[cfg(debug_assertions)]
+pub(crate) fn debug_assert_runtime_resolution_invariants(state: &GameState) {
+    let frames = canonicalize_legacy_resolution_state(state)
+        .unwrap_or_else(|error| panic!("resolution state must canonicalize: {error}"));
+    frames
+        .validate(&state.waiting_for)
+        .unwrap_or_else(|error| panic!("canonical resolution frames must validate: {error}"));
+    assert!(
+        state.pending_taps_for_mana_overrides.is_empty(),
+        "inline-mana override entries must not survive a public boundary"
+    );
+    assert!(
+        state.current_triggered_mana_override.is_none(),
+        "the active inline-mana override must not survive a public boundary"
+    );
+
+    let v2 = ResolutionStateWire::from_game_state(state.clone())
+        .to_value()
+        .expect("canonical runtime state must have a v2 wire representation");
+    let object = v2
+        .as_object()
+        .expect("resolution wire serialization is always an object");
+    for field in legacy_resolution_wire_fields() {
+        assert!(
+            !object.contains_key(*field),
+            "v2 resolution frames must not co-reside with legacy runtime field {field}"
+        );
     }
 }
 

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -1085,7 +1085,7 @@ mod tests {
     use crate::types::actions::GameAction;
     use crate::types::game_state::{
         CastingVariant, CopyChosenStage, DrainStatus, GameState, PendingBatchDeliveries,
-        PendingChooseOneOf, PendingCoinFlipKind, PendingCopyTokenResolution,
+        PendingChooseOneOf, PendingCoinFlip, PendingCoinFlipKind, PendingCopyTokenResolution,
         PendingCounterAdditionQueue, PendingCounterMoveQueue, PendingCounterRemovalQueue,
         PendingEachPlayerCopyChosen, PendingLifeTotalAssignment, PendingMutateMerge,
         PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice, PendingProliferateActions,
@@ -1225,6 +1225,13 @@ mod tests {
                 "resumed v2 fixture must not write legacy field {field}"
             );
         }
+    }
+
+    fn v2_fixture_with_frames(state: GameState, frames: ResolutionStack) -> Value {
+        let mut v2 = serde_json::to_value(ResolutionStateWire::from_game_state(state))
+            .expect("empty v2 fixture serializes");
+        v2["resolution_frames"] = serde_json::to_value(frames).expect("fixture frames serialize");
+        v2
     }
 
     fn resume_priority_fixture(mut state: GameState) -> GameState {
@@ -2120,5 +2127,150 @@ mod tests {
         assert!(paired.draw_sequences.is_empty());
         assert!(paired.post_replacement_drains.is_empty());
         assert_reserializes_v2_only(paired);
+    }
+
+    #[test]
+    fn resolution_state_wire_rejects_translated_ambiguous_and_invalid_frame_shapes() {
+        let base = GameState::new_two_player(150);
+        let v2 = serde_json::to_value(ResolutionStateWire::from_game_state(base.clone()))
+            .expect("base v2 fixture serializes");
+
+        let mut v2_missing_frames = v2.clone();
+        v2_missing_frames
+            .as_object_mut()
+            .expect("v2 fixture is an object")
+            .remove("resolution_frames");
+        assert!(serde_json::from_value::<ResolutionStateWire>(v2_missing_frames).is_err());
+
+        let mut v2_with_legacy = v2.clone();
+        v2_with_legacy["pending_coin_flip"] = Value::Null;
+        assert!(serde_json::from_value::<ResolutionStateWire>(v2_with_legacy).is_err());
+
+        let mut v1_with_frames = serde_json::to_value(base.clone()).expect("v1 serializes");
+        v1_with_frames["resolution_state_version"] =
+            Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        v1_with_frames["resolution_frames"] = Value::Array(Vec::new());
+        assert!(serde_json::from_value::<ResolutionStateWire>(v1_with_frames).is_err());
+
+        let mut invalid_version_type = v2.clone();
+        invalid_version_type["resolution_state_version"] = Value::from("two");
+        assert!(serde_json::from_value::<ResolutionStateWire>(invalid_version_type).is_err());
+
+        let mut multiple_direct = GameState::new_two_player(151);
+        multiple_direct.pending_coin_flip = Some(PendingCoinFlip {
+            source_id: ObjectId(151),
+            controller: PlayerId(0),
+            flipper: PlayerId(0),
+            targets: Vec::new(),
+            win_effect: None,
+            lose_effect: None,
+            kind: PendingCoinFlipKind::Single,
+        });
+        multiple_direct.pending_proliferate_actions = Some(PendingProliferateActions {
+            actor: PlayerId(0),
+            source_id: ObjectId(151),
+            remaining: 0,
+        });
+        let mut multiple_direct = serde_json::to_value(multiple_direct).expect("v1 serializes");
+        multiple_direct["resolution_state_version"] =
+            Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        assert!(serde_json::from_value::<ResolutionStateWire>(multiple_direct).is_err());
+
+        let mut orphan_choose_context = GameState::new_two_player(152);
+        orphan_choose_context.pending_choose_zone_trigger_context = Some(ResolvingTriggerContext {
+            event: None,
+            events: Vec::new(),
+            match_count: None,
+            die_result: None,
+        });
+        let mut orphan_choose_context =
+            serde_json::to_value(orphan_choose_context).expect("v1 serializes");
+        orphan_choose_context["resolution_state_version"] =
+            Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        assert!(serde_json::from_value::<ResolutionStateWire>(orphan_choose_context).is_err());
+
+        let mut orphan_optional_context = GameState::new_two_player(153);
+        orphan_optional_context.pending_optional_trigger_match_count = Some(1);
+        let mut orphan_optional_context =
+            serde_json::to_value(orphan_optional_context).expect("v1 serializes");
+        orphan_optional_context["resolution_state_version"] =
+            Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        assert!(serde_json::from_value::<ResolutionStateWire>(orphan_optional_context).is_err());
+
+        let mut ambiguous_legacy_pair = GameState::new_two_player(154);
+        let ResolutionFrame::PostReplacement(ready_drains) = ({
+            let mut drains = PostReplacementDrainStack::default();
+            assert!(drains.install(
+                PostReplacementDrain::ready(PostReplacementContinuation::Resolved(Box::new(
+                    resolved_draw(154),
+                ))),
+                ResidentDrainPolicy::KeepResident,
+            ));
+            ResolutionFrame::PostReplacement(drains)
+        }) else {
+            unreachable!("fixture constructs a post-replacement frame")
+        };
+        let ResolutionFrame::MultiDraw(draw) = active_multi_draw_frame() else {
+            unreachable!("fixture constructs a multi-draw frame")
+        };
+        ambiguous_legacy_pair.post_replacement_drains = ready_drains;
+        ambiguous_legacy_pair.draw_sequences = draw.draw_sequences;
+        let mut ambiguous_legacy_pair =
+            serde_json::to_value(ambiguous_legacy_pair).expect("v1 serializes");
+        ambiguous_legacy_pair["resolution_state_version"] =
+            Value::from(LEGACY_RESOLUTION_STATE_WIRE_VERSION);
+        assert!(serde_json::from_value::<ResolutionStateWire>(ambiguous_legacy_pair).is_err());
+
+        let mut duplicate_draw = ResolutionStack::default();
+        duplicate_draw.push_inner(active_multi_draw_frame());
+        duplicate_draw.push_inner(active_multi_draw_frame());
+        assert!(
+            serde_json::from_value::<ResolutionStateWire>(v2_fixture_with_frames(
+                base.clone(),
+                duplicate_draw,
+            ))
+            .is_err()
+        );
+
+        let mut mismatched_gate = ResolutionStack::default();
+        mismatched_gate.push_inner(ResolutionFrame::CoinFlip(PendingCoinFlip {
+            source_id: ObjectId(155),
+            controller: PlayerId(0),
+            flipper: PlayerId(0),
+            targets: Vec::new(),
+            win_effect: None,
+            lose_effect: None,
+            kind: PendingCoinFlipKind::Single,
+        }));
+        assert!(
+            serde_json::from_value::<ResolutionStateWire>(v2_fixture_with_frames(
+                base.clone(),
+                mismatched_gate,
+            ))
+            .is_err()
+        );
+
+        let mut nonadjacent_pair = ResolutionStack::default();
+        nonadjacent_pair.push_inner(paused_post_replacement_frame());
+        nonadjacent_pair.push_inner(continuation_frame(156));
+        nonadjacent_pair.push_inner(active_multi_draw_frame());
+        assert!(
+            serde_json::from_value::<ResolutionStateWire>(v2_fixture_with_frames(
+                base.clone(),
+                nonadjacent_pair,
+            ))
+            .is_err()
+        );
+
+        let mut reordered_pair = ResolutionStack::default();
+        reordered_pair.push_inner(active_multi_draw_frame());
+        reordered_pair.push_inner(paused_post_replacement_frame());
+        assert!(
+            serde_json::from_value::<ResolutionStateWire>(v2_fixture_with_frames(
+                base,
+                reordered_pair,
+            ))
+            .is_err()
+        );
     }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -1077,11 +1077,14 @@ mod tests {
     use crate::game::merge::MergeSide;
     use crate::game::scenario::GameScenario;
     use crate::types::ability::{
-        Effect, EffectKind, PostReplacementContinuation, QuantityExpr, TargetFilter,
+        Effect, EffectKind, PostReplacementContinuation, QuantityExpr, RepeatContinuation,
+        TargetFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::game_state::{
-        DrainStatus, GameState, PendingCoinFlipKind, PendingMutateMerge, PendingProliferateActions,
+        DrainStatus, GameState, PendingCoinFlipKind, PendingCounterAdditionQueue,
+        PendingCounterMoveQueue, PendingCounterRemovalQueue, PendingMutateMerge,
+        PendingProliferateActions, PendingRepeatIteration, PendingRepeatUntil,
         PendingRepeatedOptionalPayment, PostReplacementDrain, ResidentDrainPolicy,
     };
     use crate::types::identifiers::ObjectId;
@@ -1209,6 +1212,12 @@ mod tests {
                 "resumed v2 fixture must not write legacy field {field}"
             );
         }
+    }
+
+    fn resume_priority_fixture(mut state: GameState) -> GameState {
+        apply_as_current(&mut state, GameAction::PassPriority)
+            .expect("priority action resumes the legacy resolution drain");
+        state
     }
 
     #[test]
@@ -1689,5 +1698,89 @@ mod tests {
             vec![merging_id, target_id]
         );
         assert_reserializes_v2_only(mutate);
+    }
+
+    #[test]
+    fn v1_after_child_fixtures_resume_on_the_real_priority_drain() {
+        let mut continuation = GameState::new_two_player(110);
+        continuation.pending_continuation = Some(PendingContinuation::new(
+            Box::new(resolved_draw(110)),
+            &continuation,
+        ));
+        let continuation = resume_priority_fixture(restore_v1_fixture(continuation));
+        assert!(continuation.pending_continuation.is_none());
+        assert_reserializes_v2_only(continuation);
+
+        let mut repeat_for = GameState::new_two_player(111);
+        repeat_for.pending_repeat_iteration = Some(PendingRepeatIteration {
+            ability: Box::new(resolved_draw(111)),
+            tracked_members: Vec::new(),
+            iterated_counter_kinds: Vec::new(),
+            next_iteration: 0,
+            total_iterations: 0,
+        });
+        let repeat_for = resume_priority_fixture(restore_v1_fixture(repeat_for));
+        assert!(repeat_for.pending_repeat_iteration.is_none());
+        assert_reserializes_v2_only(repeat_for);
+
+        let mut repeat_until = GameState::new_two_player(112);
+        let mut repeat_ability = resolved_draw(112);
+        repeat_ability.repeat_until = Some(RepeatContinuation::ControllerChoice);
+        repeat_until.pending_repeat_until = Some(PendingRepeatUntil {
+            ability: Box::new(repeat_ability),
+        });
+        let mut repeat_until = resume_priority_fixture(restore_v1_fixture(repeat_until));
+        assert!(matches!(
+            repeat_until.waiting_for,
+            WaitingFor::RepeatDecision { .. }
+        ));
+        apply_as_current(
+            &mut repeat_until,
+            GameAction::DecideOptionalEffect { accept: false },
+        )
+        .expect("repeat-until fixture resumes through the real repeat decision");
+        assert!(repeat_until.pending_repeat_until.is_none());
+        assert_reserializes_v2_only(repeat_until);
+
+        let ResolutionFrame::ChangeZone(change_zone_frame) = change_zone_frame(113) else {
+            unreachable!("helper constructs a change-zone frame")
+        };
+        let mut change_zone = GameState::new_two_player(113);
+        change_zone.pending_change_zone_iteration = change_zone_frame.pending;
+        change_zone.devour_eligible_snapshot = Some(HashSet::from([ObjectId(113)]));
+        let change_zone = resume_priority_fixture(restore_v1_fixture(change_zone));
+        assert!(change_zone.pending_change_zone_iteration.is_none());
+        assert_reserializes_v2_only(change_zone);
+
+        let mut counter_moves = GameState::new_two_player(114);
+        counter_moves.pending_counter_moves = Some(PendingCounterMoveQueue {
+            remaining: Vec::new(),
+            effect_kind: EffectKind::MoveCounters,
+            source_id: ObjectId(114),
+        });
+        let counter_moves = resume_priority_fixture(restore_v1_fixture(counter_moves));
+        assert!(counter_moves.pending_counter_moves.is_none());
+        assert_reserializes_v2_only(counter_moves);
+
+        let mut counter_removals = GameState::new_two_player(115);
+        counter_removals.pending_counter_removals = Some(PendingCounterRemovalQueue {
+            remaining: Vec::new(),
+            source_id: ObjectId(115),
+            effect_kind: EffectKind::RemoveCounter,
+            source_ability_id: ObjectId(115),
+            total: 0,
+        });
+        let counter_removals = resume_priority_fixture(restore_v1_fixture(counter_removals));
+        assert!(counter_removals.pending_counter_removals.is_none());
+        assert_reserializes_v2_only(counter_removals);
+
+        let mut counter_additions = GameState::new_two_player(116);
+        counter_additions.pending_counter_additions = Some(PendingCounterAdditionQueue {
+            remaining: Vec::new(),
+            completion: None,
+        });
+        let counter_additions = resume_priority_fixture(restore_v1_fixture(counter_additions));
+        assert!(counter_additions.pending_counter_additions.is_none());
+        assert_reserializes_v2_only(counter_additions);
     }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -1079,20 +1079,24 @@ mod tests {
     use crate::types::ability::{
         AbilityDefinition, AbilityKind, CardSelectionMode, Chooser, CopyChooseScope, Effect,
         EffectKind, ForEachCategoryAction, IterationCategory, PostReplacementContinuation,
-        QuantityExpr, RepeatContinuation, SpellContext, TargetFilter, ZoneOwner,
+        QuantityExpr, RepeatContinuation, ReplacementDefinition, SpellContext, TargetFilter,
+        ZoneOwner,
     };
     use crate::types::actions::GameAction;
     use crate::types::game_state::{
-        CopyChosenStage, DrainStatus, GameState, PendingBatchDeliveries, PendingChooseOneOf,
-        PendingCoinFlipKind, PendingCopyTokenResolution, PendingCounterAdditionQueue,
-        PendingCounterMoveQueue, PendingCounterRemovalQueue, PendingEachPlayerCopyChosen,
-        PendingMutateMerge, PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice,
-        PendingProliferateActions, PendingRepeatIteration, PendingRepeatUntil,
-        PendingRepeatedOptionalPayment, PendingVoteBallotIteration, PostReplacementDrain,
+        CastingVariant, CopyChosenStage, DrainStatus, GameState, PendingBatchDeliveries,
+        PendingChooseOneOf, PendingCoinFlipKind, PendingCopyTokenResolution,
+        PendingCounterAdditionQueue, PendingCounterMoveQueue, PendingCounterRemovalQueue,
+        PendingEachPlayerCopyChosen, PendingLifeTotalAssignment, PendingMutateMerge,
+        PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice, PendingProliferateActions,
+        PendingRepeatIteration, PendingRepeatUntil, PendingRepeatedOptionalPayment,
+        PendingSpellResolution, PendingVoteBallotIteration, PostReplacementDrain,
         ResidentDrainPolicy, ZoneDeliveryExileTracking,
     };
-    use crate::types::identifiers::ObjectId;
+    use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::player::PlayerId;
+    use crate::types::proposed_event::{ProposedEvent, ReplacementId};
+    use crate::types::replacements::ReplacementEvent;
     use crate::types::zones::{EtbTapState, Zone};
     use std::collections::VecDeque;
 
@@ -1945,5 +1949,176 @@ mod tests {
         );
         assert!(per_category.pending_per_category_zone_choice.is_none());
         assert_reserializes_v2_only(per_category);
+    }
+
+    #[test]
+    fn v1_remaining_resolution_frames_resume_via_shipped_authorities() {
+        let mut multi_draw = GameState::new_two_player(140);
+        let outer = multi_draw.draw_sequences.push(PlayerId(0), 0);
+        let inner = multi_draw.draw_sequences.push(PlayerId(0), 0);
+        let mut multi_draw = restore_v1_fixture(multi_draw);
+        let _ = crate::game::effects::draw::resume_draw_sequence(
+            &mut multi_draw,
+            inner,
+            &mut Vec::new(),
+        );
+        let _ = crate::game::effects::draw::resume_draw_sequence(
+            &mut multi_draw,
+            outer,
+            &mut Vec::new(),
+        );
+        assert!(multi_draw.draw_sequences.is_empty());
+        assert_reserializes_v2_only(multi_draw);
+
+        let mut connive = GameScenario::new();
+        let conniver = connive.add_creature(PlayerId(0), "Conniver", 1, 1).id();
+        let mut connive = connive.state;
+        connive.pending_connive_reentry = Some(PendingConniveReentry {
+            conniver: connive
+                .capture_connive_subject(conniver)
+                .expect("fixture conniver exists"),
+            count: 0,
+            applied: HashSet::new(),
+        });
+        let mut connive = restore_v1_fixture(connive);
+        let pending = connive
+            .pending_connive_reentry
+            .take()
+            .expect("v1 fixture restores the exact connive subject");
+        crate::game::effects::connive::propose_connive(
+            &mut connive,
+            pending.conniver,
+            pending.count,
+            pending.applied,
+            &mut Vec::new(),
+        )
+        .expect("connive fixture re-enters through the production proposer");
+        assert!(connive.pending_connive_reentry.is_none());
+        assert_reserializes_v2_only(connive);
+
+        let mut life = GameState::new_two_player(141);
+        life.pending_life_total_assignment = Some(PendingLifeTotalAssignment {
+            completion_player: PlayerId(0),
+            remaining: Vec::new(),
+            completion: None,
+        });
+        let mut life = restore_v1_fixture(life);
+        crate::game::effects::life::drain_pending_life_total_assignment(&mut life, &mut Vec::new());
+        assert!(life.pending_life_total_assignment.is_none());
+        assert_reserializes_v2_only(life);
+
+        let mut spell = GameState::new_two_player(142);
+        let spell_id = crate::game::zones::create_object(
+            &mut spell,
+            CardId(142),
+            PlayerId(0),
+            "Paused spell".to_string(),
+            Zone::Stack,
+        );
+        let bear = crate::game::zones::create_object(
+            &mut spell,
+            CardId(143),
+            PlayerId(0),
+            "Regenerating bear".to_string(),
+            Zone::Battlefield,
+        );
+        spell
+            .objects
+            .get_mut(&bear)
+            .expect("fixture bear exists")
+            .replacement_definitions = vec![ReplacementDefinition::new(ReplacementEvent::Destroy)
+            .regeneration_shield()
+            .description("Regenerate".to_string())]
+        .into();
+        spell.pending_spell_resolution = Some(PendingSpellResolution {
+            object_id: spell_id,
+            controller: PlayerId(0),
+            casting_variant: CastingVariant::Normal,
+            cast_from_zone: None,
+            cast_controller: None,
+            cast_timing_permission: None,
+            spell_targets: Vec::new(),
+            actual_mana_spent: 0,
+            kickers_paid: Vec::new(),
+            additional_cost_payment_count: 0,
+            additional_cost_payments: Vec::new(),
+            convoked_creatures: Vec::new(),
+        });
+        spell.pending_replacement = Some(crate::types::game_state::PendingReplacement {
+            proposed: ProposedEvent::Destroy {
+                object_id: bear,
+                source: None,
+                cant_regenerate: false,
+                applied: HashSet::new(),
+            },
+            sacrifice_provenance: None,
+            candidates: vec![ReplacementId {
+                source: bear,
+                index: 0,
+            }],
+            search_found_candidates: Vec::new(),
+            depth: 0,
+            is_optional: false,
+            library_placement: None,
+            excess_recipient: None,
+            lifelink_bonus: 0,
+            may_cost_paid: false,
+            may_cost_remaining: None,
+        });
+        spell.waiting_for =
+            crate::game::replacement::replacement_choice_waiting_for(PlayerId(0), &spell);
+        let mut spell = restore_v1_fixture(spell);
+        apply_as_current(&mut spell, GameAction::ChooseReplacement { index: 0 })
+            .expect("spell fixture resumes through the real replacement action");
+        assert!(spell.pending_spell_resolution.is_none());
+        assert_reserializes_v2_only(spell);
+
+        let mut post_replacement = GameState::new_two_player(144);
+        assert!(post_replacement.post_replacement_drains.install(
+            PostReplacementDrain::ready(PostReplacementContinuation::Resolved(Box::new(
+                resolved_draw(144),
+            ))),
+            ResidentDrainPolicy::KeepResident,
+        ));
+        let mut post_replacement = restore_v1_fixture(post_replacement);
+        assert!(
+            crate::game::engine_replacement::apply_pending_post_replacement_effect(
+                &mut post_replacement,
+                None,
+                None,
+                None,
+                &mut Vec::new(),
+            )
+            .is_none()
+        );
+        assert!(post_replacement.post_replacement_drains.is_empty());
+        assert_reserializes_v2_only(post_replacement);
+    }
+
+    #[test]
+    fn v1_paired_post_replacement_and_multi_draw_fixture_resumes_as_one_resident_pair() {
+        let ResolutionFrame::PostReplacement(drains) = paused_post_replacement_frame() else {
+            unreachable!("helper constructs a post-replacement frame")
+        };
+        let ResolutionFrame::MultiDraw(draw) = active_multi_draw_frame() else {
+            unreachable!("helper constructs a multi-draw frame")
+        };
+        let frame_id = draw
+            .draw_sequences
+            .active()
+            .expect("fixture draw frame is active")
+            .frame_id;
+        let mut paired = GameState::new_two_player(145);
+        paired.post_replacement_drains = drains;
+        paired.draw_sequences = draw.draw_sequences;
+        let mut paired = restore_v1_fixture(paired);
+        let _ = crate::game::effects::draw::resume_draw_sequence(
+            &mut paired,
+            frame_id,
+            &mut Vec::new(),
+        );
+        assert!(paired.draw_sequences.is_empty());
+        assert!(paired.post_replacement_drains.is_empty());
+        assert_reserializes_v2_only(paired);
     }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -19,7 +19,7 @@ use crate::types::game_state::{
     PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice, PendingProliferateActions,
     PendingRepeatIteration, PendingRepeatUntil, PendingRepeatedOptionalPayment,
     PendingSpellResolution, PendingVoteBallotIteration, PostReplacementDrainStack,
-    ResolvingTriggerContext,
+    ResolvingTriggerContext, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 
@@ -171,11 +171,12 @@ impl ResolutionFrame {
     /// the concrete `WaitingFor` variant by the structural API.
     pub const fn gate(&self) -> FrameGate {
         match self {
-            Self::RepeatedOptionalPayment(_)
-            | Self::OptionalEffect(_)
-            | Self::CoinFlip(_)
-            | Self::Proliferate(_)
-            | Self::MutateMerge(_) => FrameGate::DirectChoice,
+            Self::RepeatedOptionalPayment(_) | Self::OptionalEffect(_) => {
+                FrameGate::DirectChoice(DirectChoiceGate::OptionalEffect)
+            }
+            Self::CoinFlip(_) => FrameGate::DirectChoice(DirectChoiceGate::CoinFlipKeep),
+            Self::Proliferate(_) => FrameGate::DirectChoice(DirectChoiceGate::Proliferate),
+            Self::MutateMerge(_) => FrameGate::DirectChoice(DirectChoiceGate::MutateMerge),
             Self::AbilityContinuation(_)
             | Self::RepeatFor(_)
             | Self::RepeatUntil(_)
@@ -203,8 +204,54 @@ impl ResolutionFrame {
 /// inner child returns to a resumable boundary.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum FrameGate {
-    DirectChoice,
+    DirectChoice(DirectChoiceGate),
     AfterChild,
+}
+
+/// A concrete prompt that a direct-choice frame is permitted to consume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DirectChoiceGate {
+    OptionalEffect,
+    CoinFlipKeep,
+    Proliferate,
+    MutateMerge,
+}
+
+impl DirectChoiceGate {
+    const fn matches(self, waiting_for: &WaitingFor) -> bool {
+        matches!(
+            (self, waiting_for),
+            (
+                Self::OptionalEffect,
+                WaitingFor::OptionalEffectChoice { .. }
+            ) | (Self::CoinFlipKeep, WaitingFor::CoinFlipKeepChoice { .. })
+                | (Self::Proliferate, WaitingFor::ProliferateChoice { .. })
+                | (Self::MutateMerge, WaitingFor::MutateMergeChoice { .. })
+        )
+    }
+}
+
+/// A checked structural-stack failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolutionStackError {
+    #[error("resolution stack is empty")]
+    Empty,
+    #[error("resolution stack top is {actual:?}, expected {expected:?}")]
+    UnexpectedTop {
+        expected: FrameKind,
+        actual: FrameKind,
+    },
+    #[error("a parent frame requires an active child")]
+    NoActiveChild,
+    #[error("top frame {frame:?} does not match waiting prompt {waiting_for}")]
+    PromptMismatch {
+        frame: FrameKind,
+        waiting_for: &'static str,
+    },
+    #[error("invalid adjacent post-replacement and multi-draw pair: {0}")]
+    InvalidAdjacentPair(&'static str),
+    #[error("invalid embedded {frame:?} frame: {message}")]
+    InvalidPayload { frame: FrameKind, message: String },
 }
 
 /// An ordered, LIFO stack of suspended resolution work.
@@ -215,4 +262,446 @@ pub enum FrameGate {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ResolutionStack {
     frames: Vec<ResolutionFrame>,
+}
+
+impl ResolutionStack {
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    pub fn last(&self) -> Option<&ResolutionFrame> {
+        self.frames.last()
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &ResolutionFrame> {
+        self.frames.iter()
+    }
+
+    /// Park work that is inside the current active operation.
+    pub fn push_inner(&mut self, frame: ResolutionFrame) {
+        self.frames.push(frame);
+    }
+
+    /// Install an outer continuation immediately below the active child.
+    ///
+    /// There is deliberately no fallback insertion position: callers that do
+    /// not have an active child must first trace the real nesting relationship.
+    pub fn insert_parent_of_active(
+        &mut self,
+        frame: ResolutionFrame,
+    ) -> Result<(), ResolutionStackError> {
+        let active_index = self
+            .frames
+            .len()
+            .checked_sub(1)
+            .ok_or(ResolutionStackError::NoActiveChild)?;
+        self.frames.insert(active_index, frame);
+        Ok(())
+    }
+
+    /// Consume exactly the active frame expected by one direct prompt handler.
+    pub fn pop_expected(
+        &mut self,
+        expected: FrameKind,
+    ) -> Result<ResolutionFrame, ResolutionStackError> {
+        let actual = self
+            .frames
+            .last()
+            .map(ResolutionFrame::kind)
+            .ok_or(ResolutionStackError::Empty)?;
+        if actual != expected {
+            return Err(ResolutionStackError::UnexpectedTop { expected, actual });
+        }
+        Ok(self
+            .frames
+            .pop()
+            .expect("checked resolution stack top must still be present"))
+    }
+
+    /// Re-park the current operation without exposing an empty-stack interval.
+    pub fn replace_active(&mut self, frame: ResolutionFrame) -> Result<(), ResolutionStackError> {
+        let active = self.frames.last_mut().ok_or(ResolutionStackError::Empty)?;
+        *active = frame;
+        Ok(())
+    }
+
+    /// Atomically install the shipped general-drain/draw pair.
+    ///
+    /// The semantic edge is positional: a paused resident drain must be the
+    /// immediate predecessor of the active draw sequence. No designed drain or
+    /// draw reference is reconstructed, and neither half is installed on a
+    /// failed validation.
+    pub fn install_adjacent_post_replacement_draw(
+        &mut self,
+        parent: ResolutionFrame,
+        child: ResolutionFrame,
+    ) -> Result<(), ResolutionStackError> {
+        validate_shipped_post_replacement_draw_pair(&parent, &child)?;
+        self.frames.push(parent);
+        self.frames.push(child);
+        Ok(())
+    }
+
+    /// Consume only the active child of an adjacent shipped drain/draw pair.
+    ///
+    /// The paused drain remains resident and is retired by the existing typed
+    /// dispatch handle after the resumed continuation finishes. This method
+    /// examines only the top and immediate predecessor; it never searches for a
+    /// non-top parent.
+    pub fn complete_adjacent_post_replacement_draw(
+        &mut self,
+    ) -> Result<ResolutionFrame, ResolutionStackError> {
+        let child_index = self
+            .frames
+            .len()
+            .checked_sub(1)
+            .ok_or(ResolutionStackError::Empty)?;
+        let parent_index =
+            child_index
+                .checked_sub(1)
+                .ok_or(ResolutionStackError::InvalidAdjacentPair(
+                    "a multi-draw child has no immediate post-replacement predecessor",
+                ))?;
+        validate_shipped_post_replacement_draw_pair(
+            &self.frames[parent_index],
+            &self.frames[child_index],
+        )?;
+        Ok(self
+            .frames
+            .pop()
+            .expect("checked resolution child must be present"))
+    }
+
+    /// Validate stack-local structural and prompt coherence invariants.
+    pub fn validate(&self, waiting_for: &WaitingFor) -> Result<(), ResolutionStackError> {
+        for frame in &self.frames {
+            if let ResolutionFrame::MultiDraw(draw) = frame {
+                draw.draw_sequences.validate().map_err(|message| {
+                    ResolutionStackError::InvalidPayload {
+                        frame: FrameKind::MultiDraw,
+                        message,
+                    }
+                })?;
+            }
+        }
+
+        let Some(top) = self.frames.last() else {
+            return Ok(());
+        };
+        if let FrameGate::DirectChoice(gate) = top.gate() {
+            if !gate.matches(waiting_for) {
+                return Err(ResolutionStackError::PromptMismatch {
+                    frame: top.kind(),
+                    waiting_for: waiting_for.variant_name(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_shipped_post_replacement_draw_pair(
+    parent: &ResolutionFrame,
+    child: &ResolutionFrame,
+) -> Result<(), ResolutionStackError> {
+    let ResolutionFrame::PostReplacement(drains) = parent else {
+        return Err(ResolutionStackError::InvalidAdjacentPair(
+            "the immediate parent is not a post-replacement frame",
+        ));
+    };
+    let ResolutionFrame::MultiDraw(draw) = child else {
+        return Err(ResolutionStackError::InvalidAdjacentPair(
+            "the immediate child is not a multi-draw frame",
+        ));
+    };
+    if !matches!(
+        drains.resident().map(|drain| &drain.status),
+        Some(crate::types::game_state::DrainStatus::Paused)
+    ) {
+        return Err(ResolutionStackError::InvalidAdjacentPair(
+            "the parent has no paused resident drain",
+        ));
+    }
+    if draw.draw_sequences.active().is_none() {
+        return Err(ResolutionStackError::InvalidAdjacentPair(
+            "the child has no active draw sequence",
+        ));
+    }
+    draw.draw_sequences
+        .validate()
+        .map_err(|message| ResolutionStackError::InvalidPayload {
+            frame: FrameKind::MultiDraw,
+            message,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ability::{
+        Effect, EffectKind, PostReplacementContinuation, QuantityExpr, TargetFilter,
+    };
+    use crate::types::game_state::{
+        DrainStatus, GameState, PendingCoinFlipKind, PostReplacementDrain, ResidentDrainPolicy,
+    };
+    use crate::types::identifiers::ObjectId;
+    use crate::types::player::PlayerId;
+    use crate::types::zones::{EtbTapState, Zone};
+
+    fn resolved_draw(source_id: u64) -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(source_id),
+            PlayerId(0),
+        )
+    }
+
+    fn continuation_frame(source_id: u64) -> ResolutionFrame {
+        let state = GameState::new_two_player(source_id);
+        ResolutionFrame::AbilityContinuation(PendingContinuation::new(
+            Box::new(resolved_draw(source_id)),
+            &state,
+        ))
+    }
+
+    fn change_zone_frame(group_seed: u64) -> ResolutionFrame {
+        let mut state = GameState::new_two_player(group_seed);
+        let mut logical_zone_change_group = state.allocate_logical_zone_change_group(&[]);
+        logical_zone_change_group
+            .latch_immediately_before(Vec::new(), Vec::new())
+            .expect("empty logical group still needs its pre-delivery latch");
+        ResolutionFrame::ChangeZone(ChangeZoneFrame {
+            pending: PendingChangeZoneIteration {
+                logical_zone_change_group,
+                paused_current: None,
+                remaining: Vec::new(),
+                source_id: ObjectId(group_seed),
+                controller: PlayerId(0),
+                origin: None,
+                destination: Zone::Battlefield,
+                enter_transformed: false,
+                enter_tapped: EtbTapState::Unspecified,
+                enters_under_player: None,
+                enters_attacking: false,
+                enter_with_counters: Vec::new(),
+                conditional_enter_with_counters: Vec::new(),
+                duration: None,
+                track_exiled_by_source: false,
+                moved_count: None,
+                face_down_profile: None,
+                library_placement: None,
+                enters_modified_if: None,
+                enter_attached_to: None,
+                effect_kind: EffectKind::ChangeZone,
+            },
+            devour_eligible_snapshot: None,
+        })
+    }
+
+    fn paused_post_replacement_frame() -> ResolutionFrame {
+        let mut drains = PostReplacementDrainStack::default();
+        let installed = drains.install(
+            PostReplacementDrain::ready(PostReplacementContinuation::Resolved(Box::new(
+                resolved_draw(81),
+            ))),
+            ResidentDrainPolicy::KeepResident,
+        );
+        assert!(installed);
+        let (_, dispatch) = drains
+            .begin_dispatch()
+            .expect("ready drain must begin dispatching");
+        assert!(drains.pause_dispatch(dispatch));
+        assert!(matches!(
+            drains.resident().map(|drain| &drain.status),
+            Some(DrainStatus::Paused)
+        ));
+        ResolutionFrame::PostReplacement(drains)
+    }
+
+    fn active_multi_draw_frame() -> ResolutionFrame {
+        let mut draw_sequences = DrawSequenceStack::default();
+        draw_sequences.push(PlayerId(0), 1);
+        ResolutionFrame::MultiDraw(MultiDrawFrame {
+            draw_sequences,
+            pending_connive_reentry: None,
+        })
+    }
+
+    #[test]
+    fn structural_operations_are_top_only_and_full_drain_is_explicit() {
+        let mut stack = ResolutionStack::default();
+        assert!(stack.is_empty());
+        assert_eq!(
+            stack.insert_parent_of_active(continuation_frame(1)),
+            Err(ResolutionStackError::NoActiveChild)
+        );
+
+        stack.push_inner(ResolutionFrame::PostReplacement(
+            PostReplacementDrainStack::default(),
+        ));
+        stack.push_inner(continuation_frame(2));
+        stack
+            .insert_parent_of_active(ResolutionFrame::PostReplacement(
+                PostReplacementDrainStack::default(),
+            ))
+            .expect("active child accepts an immediate parent");
+        assert_eq!(
+            stack.iter().map(ResolutionFrame::kind).collect::<Vec<_>>(),
+            vec![
+                FrameKind::PostReplacement,
+                FrameKind::PostReplacement,
+                FrameKind::AbilityContinuation,
+            ]
+        );
+
+        assert_eq!(
+            stack.pop_expected(FrameKind::CoinFlip),
+            Err(ResolutionStackError::UnexpectedTop {
+                expected: FrameKind::CoinFlip,
+                actual: FrameKind::AbilityContinuation,
+            })
+        );
+        stack
+            .replace_active(ResolutionFrame::PostReplacement(
+                PostReplacementDrainStack::default(),
+            ))
+            .expect("top frame can be re-parked atomically");
+        while !stack.is_empty() {
+            let kind = stack.last().expect("non-empty stack has top").kind();
+            stack
+                .pop_expected(kind)
+                .expect("full drain consumes only the top frame");
+        }
+        assert_eq!(
+            stack.pop_expected(FrameKind::CoinFlip),
+            Err(ResolutionStackError::Empty)
+        );
+    }
+
+    #[test]
+    fn direct_choice_gate_must_match_the_waiting_prompt() {
+        let frame = ResolutionFrame::CoinFlip(PendingCoinFlip {
+            source_id: ObjectId(5),
+            controller: PlayerId(0),
+            flipper: PlayerId(0),
+            targets: Vec::new(),
+            win_effect: None,
+            lose_effect: None,
+            kind: PendingCoinFlipKind::Single,
+        });
+        let mut stack = ResolutionStack::default();
+        stack.push_inner(frame);
+        stack
+            .validate(&WaitingFor::CoinFlipKeepChoice {
+                player: PlayerId(0),
+                results: vec![true, false],
+                keep_count: 1,
+            })
+            .expect("coin-flip frame owns its coin-flip prompt");
+        assert_eq!(
+            stack.validate(&WaitingFor::Priority {
+                player: PlayerId(0),
+            }),
+            Err(ResolutionStackError::PromptMismatch {
+                frame: FrameKind::CoinFlip,
+                waiting_for: "Priority",
+            })
+        );
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_adjacent_and_separated_same_kind_frames() {
+        let mut stack = ResolutionStack::default();
+        stack.push_inner(change_zone_frame(1));
+        stack.push_inner(change_zone_frame(2));
+        stack.push_inner(continuation_frame(3));
+        stack.push_inner(ResolutionFrame::PostReplacement(
+            PostReplacementDrainStack::default(),
+        ));
+        stack.push_inner(continuation_frame(4));
+
+        let encoded = serde_json::to_value(&stack).expect("typed stack serializes");
+        let decoded: ResolutionStack =
+            serde_json::from_value(encoded).expect("typed stack deserializes");
+        assert_eq!(
+            decoded
+                .iter()
+                .map(ResolutionFrame::kind)
+                .collect::<Vec<_>>(),
+            vec![
+                FrameKind::ChangeZone,
+                FrameKind::ChangeZone,
+                FrameKind::AbilityContinuation,
+                FrameKind::PostReplacement,
+                FrameKind::AbilityContinuation,
+            ]
+        );
+        decoded
+            .validate(&WaitingFor::Priority {
+                player: PlayerId(0),
+            })
+            .expect("after-child frames are valid at their resumable boundary");
+    }
+
+    #[test]
+    fn shipped_paused_drain_and_active_draw_install_and_complete_as_an_adjacent_pair() {
+        let parent = paused_post_replacement_frame();
+        let child = active_multi_draw_frame();
+        let mut stack = ResolutionStack::default();
+        stack
+            .install_adjacent_post_replacement_draw(parent, child)
+            .expect("paused drain and active draw form the shipped adjacent pair");
+        assert_eq!(
+            stack.iter().map(ResolutionFrame::kind).collect::<Vec<_>>(),
+            vec![FrameKind::PostReplacement, FrameKind::MultiDraw]
+        );
+        let encoded = serde_json::to_value(&stack).expect("paired stack serializes");
+        let decoded: ResolutionStack =
+            serde_json::from_value(encoded).expect("paired stack deserializes");
+        assert_eq!(decoded, stack);
+
+        let completed = stack
+            .complete_adjacent_post_replacement_draw()
+            .expect("completion inspects only the active child and its predecessor");
+        assert_eq!(completed.kind(), FrameKind::MultiDraw);
+        assert_eq!(
+            stack.last().map(ResolutionFrame::kind),
+            Some(FrameKind::PostReplacement)
+        );
+    }
+
+    #[test]
+    fn adjacent_pair_operations_never_search_for_a_non_top_parent() {
+        let mut stack = ResolutionStack::default();
+        stack.push_inner(paused_post_replacement_frame());
+        stack.push_inner(continuation_frame(9));
+        stack.push_inner(active_multi_draw_frame());
+        let before = stack.clone();
+        let error = stack
+            .complete_adjacent_post_replacement_draw()
+            .expect_err("a non-adjacent parent must not be discovered by search");
+        assert!(matches!(
+            error,
+            ResolutionStackError::InvalidAdjacentPair(_)
+        ));
+        assert_eq!(stack, before, "failed paired completion is atomic");
+
+        let mut empty = ResolutionStack::default();
+        let before = empty.clone();
+        assert!(empty
+            .install_adjacent_post_replacement_draw(
+                ResolutionFrame::PostReplacement(PostReplacementDrainStack::default()),
+                active_multi_draw_frame(),
+            )
+            .is_err());
+        assert_eq!(empty, before, "failed paired installation is atomic");
+    }
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -98,8 +98,8 @@ pub enum ResolutionFrame {
     RepeatFor(PendingRepeatIteration),
     RepeatUntil(PendingRepeatUntil),
     RepeatedOptionalPayment(RepeatedOptionalPaymentFrame),
-    ChangeZone(ChangeZoneFrame),
-    BatchDelivery(PendingBatchDeliveries),
+    ChangeZone(Box<ChangeZoneFrame>),
+    BatchDelivery(Box<PendingBatchDeliveries>),
     CounterMoves(PendingCounterMoveQueue),
     CounterRemovals(PendingCounterRemovalQueue),
     CounterAdditions(PendingCounterAdditionQueue),
@@ -631,7 +631,7 @@ pub(crate) fn debug_assert_runtime_resolution_invariants(state: &GameState) {
 enum DrawAndPostConversion {
     Paired {
         parent: ResolutionFrame,
-        child: ResolutionFrame,
+        child: Box<ResolutionFrame>,
     },
     UnpairedDraw(ResolutionFrame),
     UnpairedPost(ResolutionFrame),
@@ -661,7 +661,7 @@ pub(crate) fn canonicalize_legacy_resolution_state(
         // proves the adjacency relationship, neither unpaired converter may run.
         match conversion {
             DrawAndPostConversion::Paired { parent, child } => frames
-                .install_adjacent_post_replacement_draw(parent, child)
+                .install_adjacent_post_replacement_draw(parent, *child)
                 .map_err(|error| error.to_string())?,
             DrawAndPostConversion::UnpairedDraw(frame) => frames.push_inner(frame),
             DrawAndPostConversion::UnpairedPost(frame) => frames.push_inner(frame),
@@ -692,13 +692,13 @@ fn push_legacy_after_child_frames(state: &GameState, frames: &mut ResolutionStac
         frames.push_inner(ResolutionFrame::RepeatUntil(pending));
     }
     if state.pending_change_zone_iteration.is_some() || state.devour_eligible_snapshot.is_some() {
-        frames.push_inner(ResolutionFrame::ChangeZone(ChangeZoneFrame {
+        frames.push_inner(ResolutionFrame::ChangeZone(Box::new(ChangeZoneFrame {
             pending: state.pending_change_zone_iteration.clone(),
             devour_eligible_snapshot: state.devour_eligible_snapshot.clone(),
-        }));
+        })));
     }
     if let Some(pending) = state.pending_batch_deliveries.clone() {
-        frames.push_inner(ResolutionFrame::BatchDelivery(pending));
+        frames.push_inner(ResolutionFrame::BatchDelivery(Box::new(pending)));
     }
     if let Some(pending) = state.pending_counter_moves.clone() {
         frames.push_inner(ResolutionFrame::CounterMoves(pending));
@@ -806,7 +806,10 @@ fn classify_draw_and_post_replacement(
                         .to_string(),
                 );
             }
-            Some(DrawAndPostConversion::Paired { parent, child })
+            Some(DrawAndPostConversion::Paired {
+                parent,
+                child: Box::new(child),
+            })
         }
         (None, Some(draw)) => Some(DrawAndPostConversion::UnpairedDraw(draw)),
         (Some(post), None) => Some(DrawAndPostConversion::UnpairedPost(post)),
@@ -871,7 +874,7 @@ fn project_frames_into_legacy_state(
             }
             ResolutionFrame::BatchDelivery(pending) => set_once(
                 &mut projected.pending_batch_deliveries,
-                pending.clone(),
+                pending.as_ref().clone(),
                 "BatchDelivery",
             )?,
             ResolutionFrame::CounterMoves(pending) => set_once(
@@ -1177,7 +1180,7 @@ mod tests {
         logical_zone_change_group
             .latch_immediately_before(Vec::new(), Vec::new())
             .expect("empty logical group still needs its pre-delivery latch");
-        ResolutionFrame::ChangeZone(ChangeZoneFrame {
+        ResolutionFrame::ChangeZone(Box::new(ChangeZoneFrame {
             pending: Some(PendingChangeZoneIteration {
                 logical_zone_change_group,
                 paused_current: None,
@@ -1202,7 +1205,7 @@ mod tests {
                 effect_kind: EffectKind::ChangeZone,
             }),
             devour_eligible_snapshot: None,
-        })
+        }))
     }
 
     fn paused_post_replacement_frame() -> ResolutionFrame {

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -296,6 +296,14 @@ impl ResolutionStack {
         self.frames.last()
     }
 
+    /// Returns only the immediate predecessor of the active frame.
+    ///
+    /// This is intentionally narrower than a frame search: the only Phase-2
+    /// parent/child relationship is the shipped paused-drain/draw adjacency.
+    pub fn active_predecessor(&self) -> Option<&ResolutionFrame> {
+        self.frames.get(self.frames.len().checked_sub(2)?)
+    }
+
     pub fn iter(&self) -> impl ExactSizeIterator<Item = &ResolutionFrame> {
         self.frames.iter()
     }
@@ -592,7 +600,9 @@ enum DrawAndPostConversion {
     UnpairedPost(ResolutionFrame),
 }
 
-fn canonicalize_legacy_resolution_state(state: &GameState) -> Result<ResolutionStack, String> {
+pub(crate) fn canonicalize_legacy_resolution_state(
+    state: &GameState,
+) -> Result<ResolutionStack, String> {
     if state.pending_continuation.is_none() && state.pending_choose_zone_trigger_context.is_some() {
         return Err(
             "pending choose-from-zone trigger context has no continuation owner".to_string(),
@@ -1232,6 +1242,65 @@ mod tests {
             .expect("empty v2 fixture serializes");
         v2["resolution_frames"] = serde_json::to_value(frames).expect("fixture frames serialize");
         v2
+    }
+
+    #[test]
+    fn dispatcher_resumes_only_the_active_frame() {
+        let ResolutionFrame::MultiDraw(draw) = active_multi_draw_frame() else {
+            unreachable!("helper constructs a multi-draw frame")
+        };
+        let mut state = GameState::new_two_player(157);
+        state.draw_sequences = draw.draw_sequences.clone();
+        state.pending_continuation = Some(PendingContinuation::new(
+            Box::new(resolved_draw(157)),
+            &state,
+        ));
+
+        let mut frames = ResolutionStack::default();
+        frames.push_inner(continuation_frame(157));
+        frames.push_inner(ResolutionFrame::MultiDraw(draw));
+
+        crate::game::effects::resume_resolution_frames(&mut state, &frames, &mut Vec::new());
+
+        assert!(state.draw_sequences.is_empty());
+        assert!(
+            state.pending_continuation.is_some(),
+            "the dispatcher must not search below the active multi-draw frame"
+        );
+    }
+
+    #[test]
+    fn dispatcher_resumes_the_shipped_paused_draw_pair_without_popping_generically() {
+        let ResolutionFrame::PostReplacement(drains) = paused_post_replacement_frame() else {
+            unreachable!("helper constructs a post-replacement frame")
+        };
+        let ResolutionFrame::MultiDraw(draw) = active_multi_draw_frame() else {
+            unreachable!("helper constructs a multi-draw frame")
+        };
+        let mut state = GameState::new_two_player(158);
+        state.post_replacement_drains = drains.clone();
+        state.draw_sequences = draw.draw_sequences.clone();
+
+        let mut frames = ResolutionStack::default();
+        frames
+            .install_adjacent_post_replacement_draw(
+                ResolutionFrame::PostReplacement(drains),
+                ResolutionFrame::MultiDraw(draw),
+            )
+            .expect("fixture installs the shipped adjacent pair");
+
+        crate::game::effects::resume_resolution_frames(&mut state, &frames, &mut Vec::new());
+
+        assert!(state.draw_sequences.is_empty());
+        assert!(
+            state.post_replacement_drains.is_empty(),
+            "the draw authority, not a generic frame pop, retires the paused resident"
+        );
+        assert_eq!(
+            frames.len(),
+            2,
+            "the transitional dispatcher does not own frames"
+        );
     }
 
     fn resume_priority_fixture(mut state: GameState) -> GameState {

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -243,7 +243,8 @@ impl DirectChoiceGate {
             (
                 Self::OptionalEffect,
                 WaitingFor::OptionalEffectChoice { .. }
-            ) | (Self::CoinFlipKeep, WaitingFor::CoinFlipKeepChoice { .. })
+            ) | (Self::OptionalEffect, WaitingFor::OpponentMayChoice { .. })
+                | (Self::CoinFlipKeep, WaitingFor::CoinFlipKeepChoice { .. })
                 | (Self::Proliferate, WaitingFor::ProliferateChoice { .. })
                 | (Self::MutateMerge, WaitingFor::MutateMergeChoice { .. })
         )
@@ -595,9 +596,10 @@ impl<'de> Deserialize<'de> for ResolutionStateWire {
 }
 
 /// Checks the Phase-2 boundary invariants after a restore and after every
-/// public action. `ResolutionStack` is still a wire-only view in this phase,
-/// so this additionally proves that its v2 representation never carries one
-/// of the legacy runtime families alongside `resolution_frames`.
+/// public action. `ResolutionStack` is still a wire-only view in this phase.
+/// A serializable runtime state must therefore write no legacy family beside
+/// `resolution_frames`; valid in-flight trigger occurrences may intentionally
+/// be non-serializable and are checked only structurally at this boundary.
 #[cfg(debug_assertions)]
 pub(crate) fn debug_assert_runtime_resolution_invariants(state: &GameState) {
     let frames = canonicalize_legacy_resolution_state(state)
@@ -614,17 +616,16 @@ pub(crate) fn debug_assert_runtime_resolution_invariants(state: &GameState) {
         "the active inline-mana override must not survive a public boundary"
     );
 
-    let v2 = ResolutionStateWire::from_game_state(state.clone())
-        .to_value()
-        .expect("canonical runtime state must have a v2 wire representation");
-    let object = v2
-        .as_object()
-        .expect("resolution wire serialization is always an object");
-    for field in legacy_resolution_wire_fields() {
-        assert!(
-            !object.contains_key(*field),
-            "v2 resolution frames must not co-reside with legacy runtime field {field}"
-        );
+    if let Ok(v2) = ResolutionStateWire::from_game_state(state.clone()).to_value() {
+        let object = v2
+            .as_object()
+            .expect("resolution wire serialization is always an object");
+        for field in legacy_resolution_wire_fields() {
+            assert!(
+                !object.contains_key(*field),
+                "v2 resolution frames must not co-reside with legacy runtime field {field}"
+            );
+        }
     }
 }
 
@@ -1429,6 +1430,21 @@ mod tests {
                 waiting_for: "Priority",
             })
         );
+
+        let mut optional_effect = ResolutionStack::default();
+        optional_effect.push_inner(ResolutionFrame::OptionalEffect(OptionalEffectFrame {
+            ability: Box::new(resolved_draw(6)),
+            trigger_event: None,
+            trigger_match_count: None,
+        }));
+        optional_effect
+            .validate(&WaitingFor::OpponentMayChoice {
+                player: PlayerId(1),
+                source_id: ObjectId(6),
+                description: None,
+                remaining: Vec::new(),
+            })
+            .expect("optional-effect frame owns an opponent-may prompt");
     }
 
     #[test]

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -31,6 +31,8 @@ use serde::{Deserialize, Serialize};
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 19 — Connive's exact `EventObjectSnapshot` subject and resident paused
+///      post-replacement drains changed serialized full-game state.
 /// 18 — Serialized GameState trigger provenance and paused logical zone-change
 ///      owners are now wire-visible.
 /// 16 — Meld pair/attacking-entry choices after mana-payment preview variants.
@@ -40,7 +42,7 @@ use serde::{Deserialize, Serialize};
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 18;
+pub const PROTOCOL_VERSION: u32 = 19;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake. Lobby traffic has a one-version rollout window; full game servers
@@ -365,9 +367,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn protocol_version_tracks_trigger_provenance_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 18);
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 17);
+    fn protocol_version_tracks_resolution_state_wire_changes() {
+        assert_eq!(PROTOCOL_VERSION, 19);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 18);
     }
 
     #[test]

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1884,8 +1884,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_18() {
-        assert_eq!(PROTOCOL_VERSION, 18);
+    fn protocol_version_is_19() {
+        assert_eq!(PROTOCOL_VERSION, 19);
     }
 
     #[test]

--- a/scripts/draw-replacement-corpus.tsv
+++ b/scripts/draw-replacement-corpus.tsv
@@ -27,6 +27,7 @@ abundance	Draw	Optional	none	Choose	-	IndividualDraw
 alhammarret's archive	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 archmage ascension	Draw	Optional	none	SearchLibrary	-	IndividualDraw
 asmodeus the archfiend	Draw	Mandatory	none	ExileTop	-	IndividualDraw
+bard, king of dale	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 blood scrivener	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 breathstealer's crypt	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 chains of mephistopheles	Draw	Mandatory	none	Discard	nested-draw	IndividualDraw

--- a/scripts/post-replacement-continuation-baseline.txt
+++ b/scripts/post-replacement-continuation-baseline.txt
@@ -31,6 +31,7 @@ crates/engine/src/game/effects/deal_damage.rs	resolve_each_source_deals_damage	c
 crates/engine/src/game/effects/deal_damage.rs	resolve_each_target_power_damage	consumer	1
 crates/engine/src/game/effects/draw.rs	draw_through_replacement_with_applied	consumer	1
 crates/engine/src/game/effects/life.rs	drain_substitution_continuation	consumer	1
+crates/engine/src/game/effects/mod.rs	resume_resolution_frames	consumer	1
 crates/engine/src/game/effects/scry.rs	resolve	consumer	1
 crates/engine/src/game/effects/token_copy.rs	apply_copy_token_after_replacement_with_created_ids	consumer	1
 crates/engine/src/game/engine.rs	handle_play_land	consumer	1


### PR DESCRIPTION
## Summary

Plan 04 Phase 2 plus its two Amendment-B riders, shipped as one tranche behind a single combined schema bump.

**Riders (Phase 1e):**
- **Connive exact-subject identity**: all connive carriers (`WaitingFor::ConniveDiscard`, `PendingConniveReentry`, `DrawSequenceOrigin::ConniveTail`, in-flight `ProposedEvent::Connive`) now hold a `ConniveSubject { snapshot: EventObjectSnapshot }`. Counter application is gated on battlefield zone AND incarnation equality (CR 400.7 + CR 701.50b no-rebind); controllers read from the snapshot, never live state.
- **Resident paused drains**: `DrainStatus::Paused` keeps a dispatching post-replacement drain resident (and serializable) while its draw pauses for a replacement choice, retired via a typed non-serialized dispatch handle — general drains no longer lose event context across a pausing draw resume.

**Phase 2 (no runtime field removed — removals are Phase 3+):**
- New `types/resolution.rs`: exhaustive 24-family `ResolutionFrame`, private-vector `ResolutionStack` with top-only structural APIs (paired adjacent install/complete inspects only `last()` and its immediate predecessor).
- `ResolutionStateWire`: v1 legacy-only decode (runs the old migrations exactly once at the boundary), v2 frame-only encode/decode, mixed or unknown versions rejected, v2 decode enforces projection round-trip equality (fail-closed).
- Persistence boundaries (`PersistedGameState`, trusted envelope; WASM restore, multiplayer host resume, server sessions) convert at first deserialize; `finalize_rules_state` no longer mutates restored shapes.
- 24-variant v1 fixture matrix + paired PostReplacement(paused)→MultiDraw fixture + invalid-wire reject matrix; every fixture resumes through its real production action path and reserializes v2-only.
- `resume_resolution_frames`: exhaustive last-frame-only dispatcher delegating to existing per-family authorities; central legacy drains retained.
- Debug-only invariants after persistence decode and at the public apply boundary.

**Schema (single combined bump):** rider shapes ride P2P/WS `GameState` snapshots directly, so `PROTOCOL_VERSION` 18→19 (lobby-broker authority + mirrors) and `WIRE_PROTOCOL_VERSION` 11→12.

## Verification
- Workspace clippy `-D warnings`: exit 0. Engine lib 17,257 passed; integration 3,547 passed; Phase-0 baselines 9 passed; server-core, client type-check, protocol-version script all green.
- Independent whole-phase review: PASS (no blockers); rider review: 3 rounds clean.

## CI note: corpus re-freeze rider
The first CI runs failed only the draw-replacement corpus freeze: the weekly MTGJSON refresh (ISO-week key, rolled 2026-07-20 UTC) added **Bard, King of Dale** (The Hobbit preview), whose "If you would draw a card … draw two cards instead" parses to a new corpus row. Pre-existing for any PR regenerating card-data this week; reproduced and root-caused locally. Commit `269e93e6af` re-freezes the baseline with the reviewed row (CR 121.2 IndividualDraw — same class as Alhammarret's Archive; not a CR 121.2a instruction-count modification). No engine/parser change.

Second gate finding: the CI-only post-replacement continuation census correctly flagged `resume_resolution_frames` as a NEW consumer site (the dispatcher's PostReplacement arm delegating to the existing authority — dispatch-only, reviewed in the whole-phase review). Baseline re-frozen in `ae113b5eb8`; the full `check-engine-authorities.sh` suite now passes locally end-to-end.
