### PR TITLE
fix(engine): stamp real occurrence refs on self-owned trigger installs

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -3127,13 +3127,11 @@ pub(crate) fn ensure_evoke_etb_sac_trigger(obj: &mut crate::game::game_object::G
             .iter_all()
             .any(|entry| is_evoke_sac(entry.definition()))
         {
-            obj.trigger_definitions.push(build_evoke_etb_sac_trigger());
+            obj.relive_printed_trigger(is_evoke_sac);
         }
         return;
     }
-    let trigger = build_evoke_etb_sac_trigger();
-    std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trigger.clone());
-    obj.trigger_definitions.push(trigger);
+    obj.push_printed_trigger(build_evoke_etb_sac_trigger());
 }
 
 fn offspring_etb_copy_trigger_for_ordinal(origin_ordinal: u32) -> TriggerDefinition {
@@ -3224,15 +3222,14 @@ pub(crate) fn ensure_paid_offspring_etb_copy_triggers(
             if !obj.trigger_definitions.iter_all().any(|entry| {
                 is_offspring_etb_copy_trigger_for_ordinal(entry.definition(), origin_ordinal)
             }) {
-                obj.trigger_definitions
-                    .push(offspring_etb_copy_trigger_for_ordinal(origin_ordinal));
+                obj.relive_printed_trigger(|trigger| {
+                    is_offspring_etb_copy_trigger_for_ordinal(trigger, origin_ordinal)
+                });
             }
             continue;
         }
 
-        let trigger = offspring_etb_copy_trigger_for_ordinal(origin_ordinal);
-        std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trigger.clone());
-        obj.trigger_definitions.push(trigger);
+        obj.push_printed_trigger(offspring_etb_copy_trigger_for_ordinal(origin_ordinal));
     }
 }
 

--- a/crates/engine/src/game/blitz.rs
+++ b/crates/engine/src/game/blitz.rs
@@ -93,12 +93,11 @@ fn grant_dies_draw_trigger(obj: &mut GameObject) {
             .iter_all()
             .any(|entry| is_blitz_dies_draw(entry.definition()))
         {
-            obj.trigger_definitions.push(build_dies_draw_trigger());
+            obj.relive_printed_trigger(is_blitz_dies_draw);
         }
         return;
     }
-    let trigger = build_dies_draw_trigger();
-    std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(trigger.clone());
+    std::sync::Arc::make_mut(&mut obj.base_trigger_definitions).push(build_dies_draw_trigger());
     obj.materialize_base_trigger_definitions();
 }
 

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -304,9 +304,7 @@ fn apply_spell_copy_modifications(
             // Stamp base + live (mirroring blitz's dies-trigger seeding) so the
             // trigger persists once the copy becomes a token permanent.
             ContinuousModification::GrantTrigger { trigger } => {
-                std::sync::Arc::make_mut(&mut copy_obj.base_trigger_definitions)
-                    .push((**trigger).clone());
-                copy_obj.trigger_definitions.push((**trigger).clone());
+                copy_obj.push_printed_trigger((**trigger).clone());
             }
             _ => {}
         }

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -3067,10 +3067,16 @@ fn apply_token_ability_payload(obj: &mut GameObject, materialized: TokenAbilityM
         obj.static_definitions.push(static_def);
     }
     if !materialized.trigger_definitions.is_empty() {
-        Arc::make_mut(&mut obj.base_trigger_definitions)
-            .extend(materialized.trigger_definitions.iter().cloned());
+        // CR 111.3: A token's abilities are defined as it is created, so these
+        // entries are printed slots of the token's own base set — not grants.
+        // They must carry a real `Printed` occurrence ref: pushing the bare
+        // `TriggerDefinition` would go through `From<TriggerDefinition>` and
+        // stamp `TriggerDefinitionOccurrenceRef::Unmaterialized`, which
+        // `validate_trigger_definitions` rejects from an observable state and
+        // which `#[serde(skip_serializing)]` turns into a hard serialization
+        // failure the moment the state crosses the WASM bridge.
         for trigger in materialized.trigger_definitions {
-            obj.trigger_definitions.push(trigger);
+            obj.push_printed_trigger(trigger);
         }
     }
     if !materialized.abilities.is_empty() {
@@ -4406,6 +4412,70 @@ mod tests {
             vec![Zone::Battlefield],
             "CR 603.10a LKI scans a dying token as a Battlefield source"
         );
+    }
+
+    /// CR 111.3: A catalog-materialized token ability is a printed slot of the
+    /// token's own base set, so its live entry must carry a real `Printed`
+    /// occurrence ref.
+    ///
+    /// RED before the fix: `apply_token_ability_payload` pushed the bare
+    /// `TriggerDefinition`, which `Definitions::push<U: Into<T>>` routed through
+    /// `From<TriggerDefinition> for TriggerEntry` and stamped
+    /// `TriggerDefinitionOccurrenceRef::Unmaterialized`. That variant is
+    /// `#[serde(skip_serializing)]`, so the first time the state crossed the
+    /// WASM bridge `to_js` panicked ("the enum variant
+    /// `TriggerDefinitionOccurrenceRef::Unmaterialized` cannot be serialized"),
+    /// killing the worker — the engine computed the right tokens and then died
+    /// handing them to the UI. No in-process test caught it because engine tests
+    /// never serialize.
+    #[test]
+    fn catalog_token_trigger_carries_printed_occurrence_and_serializes() {
+        use crate::types::ability::TriggerDefinitionOccurrenceRef;
+
+        let preset = crate::game::token_presets::known_token_preset_by_id(
+            "14c28cbd-1740-5c17-98ea-4aea094067f1",
+        )
+        .expect("BLC Pest preset");
+
+        let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 2, 42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(0),
+            PlayerId(0),
+            "Pest".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&obj_id).unwrap();
+            obj.is_token = true;
+            obj.token_image_ref = preset.token_image_ref.clone();
+        }
+        inject_catalog_token_abilities(&mut state, obj_id);
+
+        let obj = &state.objects[&obj_id];
+        assert_eq!(obj.trigger_definitions.len(), 1);
+
+        let entry = obj.trigger_definitions.iter_all().next().unwrap();
+        assert!(
+            matches!(
+                entry.occurrence,
+                TriggerDefinitionOccurrenceRef::Printed { .. }
+            ),
+            "CR 111.3: a catalog token trigger is a printed slot of the token's own \
+             base set, got {:?}",
+            entry.occurrence
+        );
+
+        // The object-local provenance invariant must hold: `Unmaterialized` is
+        // explicitly rejected from an observable game state.
+        obj.validate_trigger_definitions()
+            .expect("catalog token trigger must have observable occurrence provenance");
+
+        // The bridge check. `engine-wasm`'s `to_js` panics on serialization
+        // failure, so an unserializable entry is fatal, not degraded.
+        serde_json::to_string(obj)
+            .expect("catalog token object must serialize for the WASM bridge");
+        serde_json::to_string(&state).expect("full game state must serialize for the WASM bridge");
     }
 
     #[test]

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1250,8 +1250,7 @@ fn apply_token_modifications(
             // as their source.
             ContinuousModification::GrantTrigger { trigger } => {
                 if let Some(token) = state.objects.get_mut(&token_id) {
-                    token.trigger_definitions.push((**trigger).clone());
-                    Arc::make_mut(&mut token.base_trigger_definitions).push((**trigger).clone());
+                    token.push_printed_trigger((**trigger).clone());
                 }
             }
             // CR 707.9a: "except it has \"<activated/static ability>\"" — the
@@ -1429,8 +1428,7 @@ pub(crate) fn apply_immediate_copy_token_modifications_to_object(
                 token.loyalty = Some(*value);
             }
             ContinuousModification::GrantTrigger { trigger } => {
-                token.trigger_definitions.push((**trigger).clone());
-                Arc::make_mut(&mut token.base_trigger_definitions).push((**trigger).clone());
+                token.push_printed_trigger((**trigger).clone());
             }
             ContinuousModification::GrantAbility { definition } => {
                 Arc::make_mut(&mut token.abilities).push((**definition).clone());

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1271,6 +1271,57 @@ impl GameObject {
         Ok(())
     }
 
+    /// Appends one trigger that belongs to this object's own printed/base set,
+    /// keeping `base_trigger_definitions` and the live list in lockstep and
+    /// stamping a real `Printed` occurrence ref for the new slot.
+    ///
+    /// This is the single authority for "this object gains a trigger that is
+    /// part of what it *is*" (CR 111.3 token abilities, CR 707.9a copiable
+    /// values, synthesized printed riders). It exists so callers never push a
+    /// bare `TriggerDefinition` into the live list: that conversion stamps
+    /// `TriggerDefinitionOccurrenceRef::Unmaterialized`, which
+    /// [`Self::validate_trigger_definitions`] rejects from an observable state
+    /// and which `#[serde(skip_serializing)]` turns into a hard serialization
+    /// failure at the WASM bridge.
+    ///
+    /// Grants from a *separate* source are not printed slots — those go through
+    /// the grant authority (`install_trigger_candidate`) so they carry a
+    /// `Granted`/`ExpandedGrant` producer key instead.
+    pub fn push_printed_trigger(&mut self, definition: TriggerDefinition) {
+        let base_set = self.trigger_base_set_instance;
+        let printed_index = {
+            let base = Arc::make_mut(&mut self.base_trigger_definitions);
+            let index = base.len();
+            base.push(definition.clone());
+            index
+        };
+        self.trigger_definitions.push(TriggerEntry::new(
+            TriggerDefinitionOccurrenceRef::Printed {
+                base_set,
+                printed_index,
+            },
+            definition,
+        ));
+    }
+
+    /// Refreshes the live entry for a printed slot that already exists in
+    /// `base_trigger_definitions`, reusing that slot's index so the occurrence
+    /// ref stays provable. Returns `false` when no matching base slot exists.
+    pub fn relive_printed_trigger(&mut self, matches: impl Fn(&TriggerDefinition) -> bool) -> bool {
+        let Some(printed_index) = self.base_trigger_definitions.iter().position(matches) else {
+            return false;
+        };
+        let definition = self.base_trigger_definitions[printed_index].clone();
+        self.trigger_definitions.push(TriggerEntry::new(
+            TriggerDefinitionOccurrenceRef::Printed {
+                base_set: self.trigger_base_set_instance,
+                printed_index,
+            },
+            definition,
+        ));
+        true
+    }
+
     /// Re-materializes the live base slots without changing their generation.
     /// Ordinary full/incremental layer resets and same-face rehydration use this
     /// path, preserving each printed slot's occurrence identity.

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1311,10 +1311,22 @@ impl GameObject {
         let Some(printed_index) = self.base_trigger_definitions.iter().position(matches) else {
             return false;
         };
+        let base_set = self.trigger_base_set_instance;
+        if self.trigger_definitions.iter_all().any(|entry| {
+            matches!(
+                &entry.occurrence,
+                TriggerDefinitionOccurrenceRef::Printed {
+                    base_set: entry_base_set,
+                    printed_index: entry_printed_index,
+                } if *entry_base_set == base_set && *entry_printed_index == printed_index
+            )
+        }) {
+            return true;
+        }
         let definition = self.base_trigger_definitions[printed_index].clone();
         self.trigger_definitions.push(TriggerEntry::new(
             TriggerDefinitionOccurrenceRef::Printed {
-                base_set: self.trigger_base_set_instance,
+                base_set,
                 printed_index,
             },
             definition,
@@ -2838,6 +2850,27 @@ mod tests {
         assert_ne!(
             object.trigger_definitions[0].occurrence, object.trigger_definitions[1].occurrence,
             "repeated final slots must not collapse because their payloads match"
+        );
+    }
+
+    #[test]
+    fn reliving_a_materialized_printed_slot_does_not_duplicate_it() {
+        let mut object = trigger_test_object();
+        let trigger = TriggerDefinition::new(TriggerMode::Phase);
+        object.push_printed_trigger(trigger.clone());
+
+        assert!(object.relive_printed_trigger(|definition| definition == &trigger));
+        assert_eq!(
+            object.trigger_definitions.len(),
+            1,
+            "re-materializing an already-live printed slot must not duplicate its trigger"
+        );
+        assert_eq!(
+            object.trigger_definitions[0].occurrence,
+            TriggerDefinitionOccurrenceRef::Printed {
+                base_set: TriggerBaseSetInstanceRef::INITIAL,
+                printed_index: 0,
+            }
         );
     }
 

--- a/crates/engine/src/game/stickers.rs
+++ b/crates/engine/src/game/stickers.rs
@@ -477,7 +477,18 @@ fn apply_ability_stickers(obj: &mut GameObject) {
         }
         Arc::make_mut(&mut obj.abilities).extend(parsed.abilities);
         for trigger in parsed.triggers {
-            obj.trigger_definitions.push(trigger);
+            // FIXME(stickers): needs a real occurrence ref. Unlike the other
+            // sites in this change, a sticker-granted trigger is NOT a printed
+            // slot — `rebuild_public_zone_stickers` reverts to base and
+            // re-applies, so pushing to `base_trigger_definitions` would make
+            // the sticker permanent. It wants a Layer-6 grant producer key, but
+            // neither `TriggerProducerOrigin::Static` (no owning static
+            // definition) nor `Transient` (no continuous-effect id) describes a
+            // sticker without a design decision. Left explicit rather than
+            // guessed; a stickered object still fails to serialize.
+            obj.trigger_definitions.push(
+                crate::types::ability::TriggerEntry::unmaterialized_legacy(trigger),
+            );
         }
         for replacement in parsed.replacements {
             obj.replacement_definitions.push(replacement);

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -18941,8 +18941,18 @@ impl TriggerEntry {
     }
 }
 
+#[cfg(any(test, feature = "test-support"))]
 impl From<TriggerDefinition> for TriggerEntry {
     fn from(definition: TriggerDefinition) -> Self {
+        Self::new(TriggerDefinitionOccurrenceRef::Unmaterialized, definition)
+    }
+}
+
+impl TriggerEntry {
+    /// Legacy wire bridge: a payload-only entry with no occurrence provenance.
+    /// Only the deserializer may mint one; a later normalization pass migrates
+    /// it to a provable printed slot or rejects the state.
+    pub(crate) fn unmaterialized_legacy(definition: TriggerDefinition) -> Self {
         Self::new(TriggerDefinitionOccurrenceRef::Unmaterialized, definition)
     }
 }
@@ -18971,7 +18981,9 @@ impl<'de> Deserialize<'de> for TriggerEntry {
             // provable printed/base slot. Keeping the marker here preserves the
             // distinction instead of guessing copied/granted provenance from
             // definition bytes at the serde boundary.
-            TriggerEntryWire::LegacyPayload(definition) => Ok(definition.into()),
+            TriggerEntryWire::LegacyPayload(definition) => {
+                Ok(Self::unmaterialized_legacy(definition))
+            }
         }
     }
 }

--- a/scripts/draw-replacement-corpus.tsv
+++ b/scripts/draw-replacement-corpus.tsv
@@ -27,6 +27,7 @@ abundance	Draw	Optional	none	Choose	-	IndividualDraw
 alhammarret's archive	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 archmage ascension	Draw	Optional	none	SearchLibrary	-	IndividualDraw
 asmodeus the archfiend	Draw	Mandatory	none	ExileTop	-	IndividualDraw
+bard, king of dale	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 blood scrivener	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 breathstealer's crypt	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 chains of mephistopheles	Draw	Mandatory	none	Discard	nested-draw	IndividualDraw


### PR DESCRIPTION
## The crash

A token created from a catalog preset carried its rules-text trigger as a bare `TriggerDefinition`. `Definitions::push<U: Into<T>>` routes that through `From<TriggerDefinition> for TriggerEntry`, which stamps `TriggerDefinitionOccurrenceRef::Unmaterialized` — a variant marked `#[serde(skip_serializing)]` and explicitly rejected from an observable state by `validate_trigger_definitions`.

The engine computed the right result and then died handing it to the UI. `engine-wasm`'s `to_js` panics on serialization failure, so the first state send after such a token was created killed the worker:

```
panicked at crates/engine-wasm/src/lib.rs:75:29:
serde_json serialization failed: the enum variant
TriggerDefinitionOccurrenceRef::Unmaterialized cannot be serialized
```

## User-visible symptom

Reported as "Mitotic Slime's tokens don't work." Sacrificing the Slime put its dies-trigger on the stack correctly, but resolving it created Ooze tokens whose live trigger entries could not serialize — so the worker died before the tokens reached the client. The trigger stayed on the stack forever, and reloading restored the same pre-resolution checkpoint and panicked again ("Engine connection lost", immediately recurring).

Debug-spawning the same Ooze tokens worked, which made this look like a token-ability parser gap. It isn't: debug spawn marks layers dirty, so a layer pass rebuilds live entries from base with proper `Printed` refs before anything serializes. Tokens created mid-resolution get serialized inside that window.

**No engine test caught this because in-process tests never serialize.**

## The fix

Adds `GameObject::push_printed_trigger` / `relive_printed_trigger` as the single authority for *"this object gains a trigger that is part of what it is"* (CR 111.3 token abilities, CR 707.9a copiable values, synthesized printed riders). It keeps `base_trigger_definitions` and the live list in lockstep and stamps a real `Printed` occurrence ref, so callers never do index math or push bare definitions.

Grants from a *separate* source are unchanged — those still go through `install_trigger_candidate` and its `Granted`/`ExpandedGrant` producer key.

Converted, all self-owned installs:

| Site | |
|---|---|
| `effects/token.rs` | catalog token materialization ← **the reported crash** |
| `effects/token_copy.rs` | ×2 |
| `effects/copy_spell.rs` | |
| `game/blitz.rs` | dies-draw trigger |
| `database/synthesis.rs` | evoke + offspring |

## Compiler gate

`From<TriggerDefinition> for TriggerEntry` is now `#[cfg(any(test, feature = "test-support"))]`, matching the sibling `Definitions` conversions in `definitions.rs`. A future raw push into a live list is a **compile error** instead of a runtime engine-kill. The deserializer's legitimate legacy-payload path calls an explicit `unmaterialized_legacy` constructor.

The gate is also how the site list above was proven complete — the compiler enumerated all 9 rather than me asserting I had found them.

## Stickers: deliberately not converted

`game/stickers.rs` is the 9th site and is left on the explicit legacy constructor with a `FIXME`. A sticker-granted trigger is **not** a printed slot: `rebuild_public_zone_stickers` reverts to base and re-applies, so writing to base would make the sticker permanent. It wants a Layer-6 grant producer key, but neither `TriggerProducerOrigin::Static` (no owning static definition) nor `Transient` (no continuous-effect id) describes a sticker without a design decision.

**A stickered object with an ability sticker still fails to serialize.** That is pre-existing, and this change makes it explicit and greppable rather than silent. Worth filing separately rather than guessing at CR 123 semantics.

## Evidence

- The **token** fix is backed by a reproducer from a real crashed session (state dump + console trace) and a red/green regression test.
- The other **7** are pattern-matched to the same defect class. They compile and the suite is green, but there is no gameplay reproducer for blitz/copy/evoke the way there was for the token path. Worth a reviewer's eye on the occurrence semantics at each.

## Verification

- `cargo test -p engine --lib` — 17,260 passed, 0 failed
- `cargo test -p engine --test integration` — 3,574 passed, 0 failed
- `cargo clippy -p engine` — clean
- `cargo fmt --all`
- New test verified **red** without the fix (`got Unmaterialized`)

The regression test asserts the occurrence ref, runs `validate_trigger_definitions`, **and serializes both the object and the full state** — the check whose absence let this ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
