### PR TITLE
fix(parser): bind "twice its power" damage subject to the target, not the spell (#6208)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19104,7 +19104,21 @@ fn damage_clause_has_self_ref_recipient(effect: &Effect) -> bool {
 /// amount must be retargeted to `Anaphoric` (resolved to `targets[0]` by the
 /// runtime one-sided-fight fallback in `game/quantity.rs`), keeping the export
 /// in sync with the Oracle "its".
-fn rebind_source_ref(qty: &mut QuantityRef, target: ObjectScope) {
+#[derive(Clone, Copy)]
+enum SourceRefRebind {
+    AllObjectRefs,
+    PowerOrToughness,
+}
+
+fn rebind_source_ref(qty: &mut QuantityRef, target: ObjectScope, rebind: SourceRefRebind) {
+    if matches!(rebind, SourceRefRebind::PowerOrToughness)
+        && !matches!(
+            qty,
+            QuantityRef::Power { .. } | QuantityRef::Toughness { .. }
+        )
+    {
+        return;
+    }
     let scope = match qty {
         QuantityRef::Power { scope }
         | QuantityRef::Toughness { scope }
@@ -19123,9 +19137,9 @@ fn rebind_source_ref(qty: &mut QuantityRef, target: ObjectScope) {
 
 /// `QuantityExpr` walker for `rebind_source_ref` (mirrors
 /// `rebind_anaphoric_object_scope`'s recursion).
-fn rebind_source_amount(expr: &mut QuantityExpr, target: ObjectScope) {
+fn rebind_source_amount(expr: &mut QuantityExpr, target: ObjectScope, rebind: SourceRefRebind) {
     match expr {
-        QuantityExpr::Ref { qty } => rebind_source_ref(qty, target),
+        QuantityExpr::Ref { qty } => rebind_source_ref(qty, target, rebind),
         QuantityExpr::DivideRounded { inner, .. }
         | QuantityExpr::Multiply { inner, .. }
         | QuantityExpr::ClampMin { inner, .. }
@@ -19133,15 +19147,15 @@ fn rebind_source_amount(expr: &mut QuantityExpr, target: ObjectScope) {
         | QuantityExpr::UpTo { max: inner }
         | QuantityExpr::Power {
             exponent: inner, ..
-        } => rebind_source_amount(inner, target),
+        } => rebind_source_amount(inner, target, rebind),
         QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
             for inner in exprs {
-                rebind_source_amount(inner, target);
+                rebind_source_amount(inner, target, rebind);
             }
         }
         QuantityExpr::Difference { left, right } => {
-            rebind_source_amount(left, target);
-            rebind_source_amount(right, target);
+            rebind_source_amount(left, target, rebind);
+            rebind_source_amount(right, target, rebind);
         }
         QuantityExpr::Fixed { .. } => {}
     }
@@ -19173,7 +19187,11 @@ fn rebind_source_amount(expr: &mut QuantityExpr, target: ObjectScope) {
 fn restore_this_way_trigger_anaphor(effect: &mut Effect) {
     match effect {
         Effect::DealDamage { amount, .. } | Effect::DamageEachPlayer { amount, .. } => {
-            rebind_source_amount(amount, ObjectScope::Anaphoric);
+            rebind_source_amount(
+                amount,
+                ObjectScope::Anaphoric,
+                SourceRefRebind::AllObjectRefs,
+            );
         }
         _ => {}
     }
@@ -19238,7 +19256,11 @@ fn bind_anaphoric_damage_subject_keep_recipient(effect: &mut Effect) -> bool {
     // gated inside this fresh-opponent branch so it can't touch unrelated
     // Source-amount cards. Anaphoric amounts are already correct and untouched.
     if let Effect::DealDamage { amount, .. } | Effect::DamageAll { amount, .. } = effect {
-        rebind_source_amount(amount, ObjectScope::Anaphoric);
+        rebind_source_amount(
+            amount,
+            ObjectScope::Anaphoric,
+            SourceRefRebind::AllObjectRefs,
+        );
     }
     true
 }
@@ -20838,50 +20860,6 @@ fn rebind_anaphoric_ref(qty: &mut QuantityRef, target: ObjectScope) {
     }
 }
 
-/// CR 208.1 + issue #6208: Retarget a residual `Source`-scoped "its power" /
-/// "its toughness" leaf to `target`. Only the target-subject damage path uses
-/// this: "target creature deals damage equal to TWICE its power" lowers "its
-/// power" via the multiplier CDA path to `Power{Source}` (unlike the singular
-/// form's rebindable `Anaphoric`), which reads the spell — power 0 — so the
-/// clause deals nothing. In that path the subject is the target creature, never
-/// the spell, so the source-scoped characteristic must follow the subject.
-///
-/// Restricted to `Power`/`Toughness` (the "its power/toughness" anaphor) so a
-/// legitimate `ObjectManaValue{Source}` / color-count "this spell's ..." ref is
-/// left intact. Self-subject damage (Duggan) is a bare `DealDamage` never routed
-/// through the target-subject wrapper, so its `Power{Source}` is never reached.
-fn retarget_source_power_toughness(expr: &mut QuantityExpr, target: ObjectScope) {
-    match expr {
-        QuantityExpr::Ref { qty } => {
-            if let QuantityRef::Power { scope } | QuantityRef::Toughness { scope } = qty {
-                if *scope == ObjectScope::Source {
-                    *scope = target;
-                }
-            }
-        }
-        QuantityExpr::DivideRounded { inner, .. }
-        | QuantityExpr::Multiply { inner, .. }
-        | QuantityExpr::ClampMin { inner, .. }
-        | QuantityExpr::Offset { inner, .. }
-        | QuantityExpr::UpTo { max: inner }
-        | QuantityExpr::Power {
-            exponent: inner, ..
-        } => {
-            retarget_source_power_toughness(inner, target);
-        }
-        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
-            for inner in exprs {
-                retarget_source_power_toughness(inner, target);
-            }
-        }
-        QuantityExpr::Difference { left, right } => {
-            retarget_source_power_toughness(left, target);
-            retarget_source_power_toughness(right, target);
-        }
-        QuantityExpr::Fixed { .. } => {}
-    }
-}
-
 /// CR 120.1: True when a damage clause already carries the multi-source
 /// `EachTarget` marker (set by the parser for "their power" forms). Used to keep
 /// `wrap_target_subject_damage` from collapsing it to the single-source `Target`.
@@ -21077,7 +21055,11 @@ fn wrap_target_subject_damage(
         if let Effect::DealDamage { amount, .. } | Effect::DamageAll { amount, .. } =
             &mut clause.effect
         {
-            retarget_source_power_toughness(amount, ObjectScope::Target);
+            rebind_source_amount(
+                amount,
+                ObjectScope::Target,
+                SourceRefRebind::PowerOrToughness,
+            );
         }
     } else {
         return None;

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20838,6 +20838,50 @@ fn rebind_anaphoric_ref(qty: &mut QuantityRef, target: ObjectScope) {
     }
 }
 
+/// CR 208.1 + issue #6208: Retarget a residual `Source`-scoped "its power" /
+/// "its toughness" leaf to `target`. Only the target-subject damage path uses
+/// this: "target creature deals damage equal to TWICE its power" lowers "its
+/// power" via the multiplier CDA path to `Power{Source}` (unlike the singular
+/// form's rebindable `Anaphoric`), which reads the spell — power 0 — so the
+/// clause deals nothing. In that path the subject is the target creature, never
+/// the spell, so the source-scoped characteristic must follow the subject.
+///
+/// Restricted to `Power`/`Toughness` (the "its power/toughness" anaphor) so a
+/// legitimate `ObjectManaValue{Source}` / color-count "this spell's ..." ref is
+/// left intact. Self-subject damage (Duggan) is a bare `DealDamage` never routed
+/// through the target-subject wrapper, so its `Power{Source}` is never reached.
+fn retarget_source_power_toughness(expr: &mut QuantityExpr, target: ObjectScope) {
+    match expr {
+        QuantityExpr::Ref { qty } => {
+            if let QuantityRef::Power { scope } | QuantityRef::Toughness { scope } = qty {
+                if *scope == ObjectScope::Source {
+                    *scope = target;
+                }
+            }
+        }
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Multiply { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Offset { inner, .. }
+        | QuantityExpr::UpTo { max: inner }
+        | QuantityExpr::Power {
+            exponent: inner, ..
+        } => {
+            retarget_source_power_toughness(inner, target);
+        }
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => {
+            for inner in exprs {
+                retarget_source_power_toughness(inner, target);
+            }
+        }
+        QuantityExpr::Difference { left, right } => {
+            retarget_source_power_toughness(left, target);
+            retarget_source_power_toughness(right, target);
+        }
+        QuantityExpr::Fixed { .. } => {}
+    }
+}
+
 /// CR 120.1: True when a damage clause already carries the multi-source
 /// `EachTarget` marker (set by the parser for "their power" forms). Used to keep
 /// `wrap_target_subject_damage` from collapsing it to the single-source `Target`.
@@ -21010,7 +21054,7 @@ fn wrap_target_subject_damage(
     // flows onto the outer `TargetOnly` picker below.
     if damage_clause_is_each_target(&clause.effect) {
         rebind_each_target_damage_amount(&mut clause.effect, ObjectScope::Target);
-    } else if !bind_damage_clause_source(
+    } else if bind_damage_clause_source(
         // CR 608.2c + CR 120.1: "target creature deals damage equal to its
         // power..." (single source) makes the chosen object, not the spell card,
         // deal the damage. "Its power" is therefore the first target's current
@@ -21025,6 +21069,17 @@ fn wrap_target_subject_damage(
         DamageSource::Target,
         ObjectScope::Target,
     ) {
+        // CR 208.1 + issue #6208: `bind_damage_clause_source` only rebinds an
+        // `Anaphoric` amount leaf. The "twice its power" multiplier form lowers
+        // "its power" to `Power{Source}` (reads the spell — power 0), so retarget
+        // that residual source-scoped power/toughness to the target subject too.
+        // Fixes Punishing Punch, Animist's Might, Polliwallop, Thing Swing.
+        if let Effect::DealDamage { amount, .. } | Effect::DamageAll { amount, .. } =
+            &mut clause.effect
+        {
+            retarget_source_power_toughness(amount, ObjectScope::Target);
+        }
+    } else {
         return None;
     }
     if let Effect::DealDamage { amount, .. } | Effect::DamageAll { amount, .. } = &mut clause.effect

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -4979,6 +4979,60 @@ fn target_subject_damage_equal_to_its_power_uses_target_source_power() {
     );
 }
 
+#[test]
+fn source_power_toughness_rebind_preserves_other_source_refs() {
+    let mut amount = QuantityExpr::Sum {
+        exprs: vec![
+            QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::Source,
+                },
+            },
+            QuantityExpr::Ref {
+                qty: QuantityRef::Toughness {
+                    scope: ObjectScope::Source,
+                },
+            },
+            QuantityExpr::Ref {
+                qty: QuantityRef::ObjectManaValue {
+                    scope: ObjectScope::Source,
+                },
+            },
+        ],
+    };
+
+    rebind_source_amount(
+        &mut amount,
+        ObjectScope::Target,
+        SourceRefRebind::PowerOrToughness,
+    );
+
+    assert!(matches!(
+        amount,
+        QuantityExpr::Sum { exprs }
+            if matches!(
+                exprs.as_slice(),
+                [
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Power {
+                            scope: ObjectScope::Target,
+                        },
+                    },
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Toughness {
+                            scope: ObjectScope::Target,
+                        },
+                    },
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectManaValue {
+                            scope: ObjectScope::Source,
+                        },
+                    },
+                ]
+            )
+    ));
+}
+
 /// Self-Destruct's second damage instruction inherits the target creature from
 /// the first subject clause; it must not resolve against the spell source.
 #[test]

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -5075,6 +5075,54 @@ fn named_damage_source_multi_recipient_chain_keeps_cant_block_rider() {
     );
 }
 
+/// CR 208.1 + issue #6208: Punishing Punch — "Target creature you control deals
+/// damage equal to TWICE its power to target creature an opponent controls." The
+/// multiplier form lowered "its power" via the CDA path to `Power{Source}` (which
+/// reads the spell — power 0 — so it dealt nothing); it must bind to the target
+/// subject exactly like the singular form above. Self-subject "twice its power"
+/// (Duggan, a bare `DealDamage`) is unaffected and keeps `Power{Source}` — see
+/// `duggan_private_detective_full_kit_parses` as the regression guard.
+#[test]
+fn target_subject_damage_twice_its_power_uses_target_source_power() {
+    let clause = parse_effect_clause(
+        "target creature you control deals damage equal to twice its power to target creature an opponent controls",
+        &mut ParseContext::default(),
+    );
+    let Effect::TargetOnly { target } = &clause.effect else {
+        panic!(
+            "expected TargetOnly source wrapper, got {:?}",
+            clause.effect
+        );
+    };
+    assert!(matches!(target, TargetFilter::Typed(_)));
+    let sub = clause
+        .sub_ability
+        .as_ref()
+        .expect("damage should be in sub-ability after source target");
+    let Effect::DealDamage {
+        amount,
+        damage_source,
+        ..
+    } = sub.effect.as_ref()
+    else {
+        panic!("expected DealDamage sub-effect, got {:?}", sub.effect);
+    };
+    assert_eq!(*damage_source, Some(DamageSource::Target));
+    assert!(
+        matches!(
+            amount,
+            QuantityExpr::Multiply { factor: 2, inner }
+                if matches!(
+                    inner.as_ref(),
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::Power { scope: ObjectScope::Target }
+                    }
+                )
+        ),
+        "amount must be 2 x TARGET power (not Source, which reads the spell), got {amount:?}"
+    );
+}
+
 /// Issue #607 — Chandra's Ignition. "Target creature you control deals
 /// damage equal to its power to each other creature and each opponent"
 /// must lower to:

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -809,6 +809,7 @@ mod precast_copy_shortcut;
 mod primo_unbounded_fractal_counters;
 mod printed_ability_order;
 mod proliferate_zero_counter;
+mod punishing_punch_twice_subject_power;
 mod purged_source_attachment_count_lki;
 mod purged_source_attacked_this_turn_lki;
 mod purged_source_intervening_if_lki;

--- a/crates/engine/tests/integration/punishing_punch_twice_subject_power.rs
+++ b/crates/engine/tests/integration/punishing_punch_twice_subject_power.rs
@@ -1,0 +1,56 @@
+//! Runtime regression for issue #6208 — Punishing Punch.
+//!
+//! Oracle: "Target creature you control deals damage equal to twice its power to
+//! target creature an opponent controls."
+//!
+//! "Its power" names the first target (the creature you control that deals the
+//! damage). The multiplier form lowered it to `Multiply{2, Power{Source}}`, and
+//! `Source` reads the SPELL (power 0), so the clause dealt 0 damage. The parser
+//! now retargets the source-scoped power to the target subject, mirroring the
+//! singular "its power" form. This drives the real cast pipeline (live-parsed,
+//! no card-data dependency) and asserts the damage equals twice the SUBJECT's
+//! power — not 0 (dropped referent) and not the recipient's own power.
+//!
+//! Distinct from Duggan (`duggan_private_detective_punch`): there the subject is
+//! the source itself, so `Power{Source}` is correct and stays. Here the subject
+//! is a separate target, so the source-scoped power must follow it.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const PUNISHING_PUNCH: &str = "Target creature you control deals damage equal to twice its power \
+to target creature an opponent controls.";
+
+#[test]
+fn punishing_punch_deals_twice_the_subject_creatures_power() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Subject: P0's creature, power 3 → deals 2 x 3 = 6.
+    let subject = scenario.add_vanilla(P0, 3, 3);
+    // Recipient: P1's creature, toughness 10 (survives 6 so `damage_marked` stays
+    // observable) and power 4 (differs from 6, so a wrong referent cannot pass).
+    let recipient = scenario.add_vanilla(P1, 4, 10);
+    let punch = scenario
+        .add_spell_to_hand(P0, "Punishing Punch", true)
+        .from_oracle_text(PUNISHING_PUNCH)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().debug_mode = true;
+
+    let outcome = runner
+        .cast(punch)
+        .target_object(subject)
+        .target_object(recipient)
+        .resolve();
+
+    assert_eq!(
+        outcome.state().objects[&recipient].damage_marked,
+        6,
+        "Punishing Punch deals twice the SUBJECT's power (2 x 3 = 6), not 0 (the \
+         dropped Source referent reads the spell) and not the recipient's own power (4)"
+    );
+}


### PR DESCRIPTION
Fixes #6208

## Problem

Punishing Punch — *"Target creature you control deals damage equal to **twice its power** to target creature an opponent controls."* — dealt 0 damage.

"Its power" names the first target (the creature you control that deals the damage). The **singular** form ("deals damage equal to its power") lowers "its power" to `Power{Anaphoric}`, which `bind_damage_clause_source` rebinds to `Power{Target}` in the target-subject path. But the **multiplier** form ("twice its power") lowers it via the CDA path to `Multiply{2, Power{Source}}`, and the rebind only rewrites `Anaphoric` leaves — so `Power{Source}` survived, read the **spell** (power 0), and the clause dealt nothing.

## Fix

In the target-subject damage path (`wrap_target_subject_damage`, `oracle_effect/mod.rs`), after binding `damage_source = Target`, retarget any residual `Source`-scoped `Power`/`Toughness` leaf in the amount to `Target`. In that path the subject is the target creature, never the spell, so its self-referential characteristic must follow the subject. Restricted to power/toughness so a legitimate `ObjectManaValue{Source}` ("this spell's mana value") is left intact.

Scoping: **Duggan, Private Detective** ("Duggan deals damage equal to twice its power") is self-subject — a bare `DealDamage` that is *never* routed through the target-subject wrapper — so its `Power{Source}` is untouched (its existing full-kit test is the regression guard). Blast radius is exactly the 4 target-subject cards that share the pattern: Punishing Punch, Animist's Might, Polliwallop, Thing Swing.

Runtime is already supported: the singular `Power{Target}` + `damage_source: Some(Target)` form (Rabid Bite, Chandra's Ignition #607) and `Multiply{2, Power{…}}` damage (Duggan's runtime test) both resolve today — this fix just combines them, no runtime change.

## Tests

- **Parser** (`target_subject_damage_twice_its_power_uses_target_source_power`): the amount is `Multiply{2, Power{Target}}` with `damage_source: Some(Target)`, not `Power{Source}`. The singular test and Duggan's full-kit test (`Power{Source}` self-subject) are the regression guards.
- **Runtime** (`punishing_punch_twice_subject_power.rs`): casts Punishing Punch with a power-3 subject at a toughness-10 opponent creature — `damage_marked == 6` (2 × 3), not 0 and not the recipient's own power.

CR: 208.1, 120.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected damage calculations for effects that deal damage based on a targeted creature’s power or toughness.
  * Ensured calculated damage uses the intended target’s characteristics rather than the spell source or recipient.

* **Tests**
  * Added regression coverage for “Punishing Punch,” confirming damage equal to twice the subject creature’s power is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->