### PR TITLE
chore(card-data): re-freeze draw-replacement corpus for Bard, King of Dale (HOB set unlock)

### DIFF
--- a/scripts/draw-replacement-corpus.tsv
+++ b/scripts/draw-replacement-corpus.tsv
@@ -27,6 +27,7 @@ abundance	Draw	Optional	none	Choose	-	IndividualDraw
 alhammarret's archive	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 archmage ascension	Draw	Optional	none	SearchLibrary	-	IndividualDraw
 asmodeus the archfiend	Draw	Mandatory	none	ExileTop	-	IndividualDraw
+bard, king of dale	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 blood scrivener	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 breathstealer's crypt	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
 chains of mephistopheles	Draw	Mandatory	none	Discard	nested-draw	IndividualDraw


### PR DESCRIPTION
## What

Re-freezes the Plan 03 draw-replacement corpus baseline (`scripts/draw-replacement-corpus.tsv`) with exactly one new row:

```
bard, king of dale	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
```

One line, no parser or engine change. Regenerated with `scripts/draw_replacement_census.py --corpus --write`; `--corpus --check` passes afterward (51 rows).

## Why every PR is red

The CI step "Draw replacement corpus freeze (Plan 03 / CR 121.2)" has failed on main and every PR since 2026-07-20T00:00Z. The trigger is **wall-clock, not any merged commit**: the card-data job caches `AtomicCards.json` under the ISO-week key `mtgjson-atomic-$(date +%Y-W%V)` (exact-match, no restore-keys — see `ci.yml`), so at Monday 00:00 UTC the key rolled to the new week and forced a fresh MTGJSON download that now carries The Hobbit (HOB) spoiler data, including Bard, King of Dale, whose draw-replacement row the frozen corpus had never seen.

Tonight's merges are exonerated — including #6174, which touched only the swallow-detector. Note the #4365 release-date gate did **not** engage: `GATED_SETS` is unset in CI (gating is a documented no-op when unset), and HOB's MTGJSON releaseDate is 2026-08-14 (`isPartialPreview: true`). The single-row failure reproduces locally with no gating configured. The gating gap is filed separately as #6221.

Failing runs:
- PR #6195: [Card data job 88256861966](https://github.com/phase-rs/phase/actions/runs/29711854779/job/88256861966)
- PR #6214: [Card data job 88254786623](https://github.com/phase-rs/phase/actions/runs/29710999164/job/88254786623)
- main's own post-midnight push CI is red the same way: [Card data job 88249911454](https://github.com/phase-rs/phase/actions/runs/29708804507/job/88249911454)

## Why the row is correct (CR 121.2, not CR 121.2a)

Bard, King of Dale (The Hobbit, HOB #144): "If you would draw a card except the first one you draw in each of your draw steps, draw two cards instead." This is an individual-draw replacement per CR 121.2 (cards are drawn one at a time): fixed substitute count, no `EventContextAmount` read — so it is *not* a CR 121.2a instruction-count modifier. Its census shape and classification are identical to the already-blessed precedent rows:

```
alhammarret's archive	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
teferi's ageless insight	Draw	Mandatory	none	Draw	nested-draw	IndividualDraw
```

Engine-emitted `draw_scope` and the census's independently derived scope agree (`IndividualDraw`) — a disagreement would have raised `ClassificationError`, not a diff row.

## This blesses PREVIEW text

HOB is `isPartialPreview: true` and releases 2026-08-14, so this row freezes spoiler-season text. If Bard's Oracle text changes before release, the exact-match freeze goes red again and forces a re-review — by design, that is the gate doing its job, not a regression. Current Scryfall preview text matches the parsed row exactly.

## Effect of merging

- Unblocks #6195, #6214, main, and every other open PR.
- Observational, **not addressed here**: the same set-unlock event moved coverage ratios (card pool 34653 → 34702; 20 HOB-only preview cards entered the export), which is the likely cause of main's separate post-midnight "Rust (fmt, clippy, test, coverage-gate)" failure ([job 88250786912](https://github.com/phase-rs/phase/actions/runs/29708804507/job/88250786912)). Left to a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
