### PR TITLE
test(parser): pin Bring the Ending Corrupted "instead" as a branch (#5683 Class B anchor)

### DIFF
--- a/crates/engine/tests/integration/bring_the_ending_corrupted_instead_branch_5683.rs
+++ b/crates/engine/tests/integration/bring_the_ending_corrupted_instead_branch_5683.rs
@@ -1,0 +1,81 @@
+//! Issue #5683 (Class B regression anchor) — CR 614.1a + CR 614.6: a
+//! "Counter that spell **instead** if <cond>" ability-word override is a BRANCH,
+//! not a second sibling ability.
+//!
+//! CR 614.1a: "Effects that use the word 'instead' are replacement effects."
+//! CR 614.6:  "If an event is replaced, it never happens…"
+//!
+//! Witness (Oracle read from the pool export):
+//!   Bring the Ending —
+//!     "Counter target spell unless its controller pays {2}.
+//!      Corrupted — Counter that spell instead if its controller has three or
+//!      more poison counters."
+//!
+//! The #5683 defect class is "instead" clauses lowering to an unconditional
+//! `SequentialSibling` chain (both halves run, condition dropped). This card is
+//! one of the four named regression anchors; it is already lowered CORRECTLY via
+//! the cross-line self-replacement binder (the same path that fixed Anoint with
+//! Affliction) — this test pins that so it cannot regress back to two
+//! unconditional Counter siblings. Drives the real production card parser
+//! (`parse_oracle_text`).
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{AbilityCondition, Effect};
+
+const BRING_THE_ENDING: &str = "Counter target spell unless its controller pays {2}.\nCorrupted — Counter that spell instead if its controller has three or more poison counters.";
+
+#[test]
+fn bring_the_ending_corrupted_instead_is_a_branch_not_a_sibling() {
+    let parsed = parse_oracle_text(
+        BRING_THE_ENDING,
+        "Bring the Ending",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+
+    // CR 614.6: the "instead" override is a conditional sub of the base spell,
+    // NOT a second top-level ability. Two abilities here would mean the Corrupted
+    // Counter runs as an independent unconditional sibling (the #5683 defect).
+    assert_eq!(
+        parsed.abilities.len(),
+        1,
+        "the Corrupted 'instead' override must be a conditional sub, not a second \
+         sibling ability, got {:?}",
+        parsed.abilities
+    );
+
+    let base = &parsed.abilities[0];
+    assert!(
+        matches!(&*base.effect, Effect::Counter { .. }),
+        "base clause is Counter target spell, got {:?}",
+        base.effect
+    );
+    // The base keeps its "unless its controller pays {2}" cost — not overwritten
+    // by the override.
+    assert!(
+        base.unless_pay.is_some(),
+        "base must retain the 'unless … pays {{2}}' cost"
+    );
+
+    let sub = base
+        .sub_ability
+        .as_deref()
+        .expect("the Corrupted override must attach as the base's sub_ability");
+    // CR 614.15: the override is gated by `ConditionInstead` (fires the swap only
+    // when corrupted) — the whole point of the fix. A `None` / non-instead
+    // condition would mean the counter runs unconditionally.
+    assert!(
+        matches!(
+            sub.condition,
+            Some(AbilityCondition::ConditionInstead { .. })
+        ),
+        "the override sub must be gated by ConditionInstead (branch), got {:?}",
+        sub.condition
+    );
+    assert!(
+        matches!(&*sub.effect, Effect::Counter { .. }),
+        "the override effect is 'counter that spell' outright, got {:?}",
+        sub.effect
+    );
+}

--- a/crates/engine/tests/integration/bring_the_ending_corrupted_instead_branch_5683.rs
+++ b/crates/engine/tests/integration/bring_the_ending_corrupted_instead_branch_5683.rs
@@ -30,7 +30,7 @@ fn bring_the_ending_corrupted_instead_is_a_branch_not_a_sibling() {
         BRING_THE_ENDING,
         "Bring the Ending",
         &[],
-        &["Sorcery".to_string()],
+        &["Instant".to_string()],
         &[],
     );
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -50,6 +50,7 @@ mod bound_by_moonsilver_sacrifice_source_relative_6017;
 mod braids_arisen_nightmare_decline;
 mod breeches_blastmaker_coin_flip_copy;
 mod brigid_mana_ability;
+mod bring_the_ending_corrupted_instead_branch_5683;
 mod bring_to_light_free_cast_2880;
 mod calamity_of_the_titans_reveal_cost;
 mod call_damage_control_modal_return;


### PR DESCRIPTION
Part of #5683 (conditional "instead" clauses lowering to unconditional chains).

## Context

#5683 names four regression anchors. I dumped all four through the production parser (`parse_oracle_text`) against current `main`, and **Bring the Ending is already lowered correctly** — the cross-line self-replacement binder (the same path that fixed Anoint with Affliction) produces a single `Counter` ability whose Corrupted override attaches as a `ConditionInstead`-gated `sub_ability`, not two unconditional `Counter` siblings. This PR **locks that anchor** so it can't silently regress back to the double-counter chain while the other three classes (Paragon / Back for Seconds / Anthem of Rakdos) are worked separately.

Verified AST (current `main`):
```
Counter{StackSpell} unless_pay:{2}
  └─ sub: condition = ConditionInstead{ QuantityCheck{ TargetControllerCounter{Poison}, GE, 3 } }
          effect    = Counter
```

## Test

`crates/engine/tests/integration/bring_the_ending_corrupted_instead_branch_5683.rs` (registered in `tests/integration/main.rs`) asserts through `parse_oracle_text`: exactly one ability (not two siblings), base `Counter` retaining its `unless … pays {2}` cost, and the override sub gated by `AbilityCondition::ConditionInstead`. RED if the override ever regresses to an unconditional sibling.

## Verification

Locally verified: I compiled the exact assertion body against the current engine rlib (via a bootstrapped `zig cc` linker) and it passes — this pins **current, real** behavior, not an aspiration. (The full `cargo test` binary OOMs on this host, so CI runs the registered test.)

`Gate A PASS head=01ef81645… base=e259c4c65…` (mirrors the existing `anax_instead_branch_not_chain` regression, CR 614.1a / 614.6 / 614.15).

Model: claude-opus-4-8
Thinking: High
Tier: Frontier