### PR TITLE
feat(telemetry): report format on game_start

### DIFF
--- a/client/src/services/telemetryEvents.ts
+++ b/client/src/services/telemetryEvents.ts
@@ -172,6 +172,7 @@ function installGameStartTracking(): void {
 
       trackEvent("game_start", {
         game_mode: gameMode,
+        format: gameState.format_config?.format,
         player_count: gameState.players.length,
         ai_count: aiSeatIds.length,
       });

--- a/lobby-worker/src/telemetry.ts
+++ b/lobby-worker/src/telemetry.ts
@@ -68,7 +68,9 @@ export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] 
     doubles: ["turn", "supported", "total"],
   },
   session_start: { blobs: ["route"], doubles: [] },
-  game_start: { blobs: ["game_mode"], doubles: ["player_count", "ai_count"] },
+  // `format` appended 2026-07: the engine `GameFormat` variant name (e.g.
+  // "Commander", "HistoricBrawl"); "" from clients predating the field.
+  game_start: { blobs: ["game_mode", "format"], doubles: ["player_count", "ai_count"] },
   route_view: { blobs: ["route"], doubles: [] },
 };
 

--- a/lobby-worker/test/telemetry.test.mjs
+++ b/lobby-worker/test/telemetry.test.mjs
@@ -45,7 +45,7 @@ test("sanitizeTelemetryBatch accepts the Tier 2 report/usage events with their c
     batch([
       { event: "card_report", oracle_id: "abc", face_name: "Front", name: "Colossal Dreadmaw", zone: "Battlefield", game_mode: "ai", turn: 5, supported: 2, total: 3 },
       { event: "session_start", route: "/game" },
-      { event: "game_start", game_mode: "ai", player_count: 2, ai_count: 1 },
+      { event: "game_start", game_mode: "ai", format: "HistoricBrawl", player_count: 2, ai_count: 1 },
       { event: "route_view", route: "/deck-builder" },
     ]),
   );
@@ -60,7 +60,7 @@ test("sanitizeTelemetryBatch accepts the Tier 2 report/usage events with their c
   assert.deepEqual(report.doubles, [5, 2, 3]);
   assert.deepEqual(session.blobs, ["/game"]);
   assert.deepEqual(session.doubles, []);
-  assert.deepEqual(gameStart.blobs, ["ai"]);
+  assert.deepEqual(gameStart.blobs, ["ai", "HistoricBrawl"]);
   assert.deepEqual(gameStart.doubles, [2, 1]);
   assert.deepEqual(route.blobs, ["/deck-builder"]);
   assert.deepEqual(route.doubles, []);


### PR DESCRIPTION
Adds the engine GameFormat variant name to the game_start event
(appended AE blob column; old clients project as "") so format
popularity and seat counts are queryable. player_count/ai_count
already existed.
