### PR TITLE
fix(parser): route "different kinds of counters" quantity to DistinctCounterKindsAmong

### DIFF
--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1468,7 +1468,16 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
         // generic controlled-type/type-filter arms whose leading token would
         // otherwise commit. Nested together to stay within nom's top-level `alt`
         // arity (nom 8.0 max: 21 items).
-        alt((parse_distinct_subtypes_among, parse_turns_taken_this_game)),
+        //
+        // CR 122.1: "different kind[s] of counters {on|among} <filter>" — the
+        // dynamic-quantity reading of the counter-kind cardinality (Perrie, the
+        // Pulverizer: "X is the number of different kinds of counters among
+        // permanents you control") — shares this nest for the same reason.
+        alt((
+            parse_distinct_subtypes_among,
+            parse_turns_taken_this_game,
+            parse_distinct_counter_kinds_among_tail,
+        )),
         // CR 201.2 + CR 603.4: "differently named <type-phrase>" (distinct-by-name)
         // and "different <power|mana value> among <type>" (distinct-by-quality —
         // Celebrate the Harvest's "the number of different powers among ..."
@@ -2254,6 +2263,32 @@ fn parse_distinct_subtypes_objects_source(input: &str) -> OracleResult<'_, CardT
     // difference of their lengths — no pointer arithmetic needed.
     let consumed = type_text.len() - remainder.len();
     Ok((&input[consumed..], CardTypeSetSource::Objects { filter }))
+}
+
+/// CR 122.1: Parse "different kind[s] of counters {on|among} <filter>" after
+/// "the number of" → [`QuantityRef::DistinctCounterKindsAmong`].
+///
+/// Dynamic-quantity counterpart to `parse_for_each_distinct_counter_kinds_among`
+/// (which covers the "for each kind of counter on/among <filter>" repeat-source
+/// reading): same counter-kind cardinality, reached from the "where X is the
+/// number of …" CDA quantity path instead of a `repeat_for` loop. Perrie, the
+/// Pulverizer: "X is the number of different kinds of counters among permanents
+/// you control". Combinator-composed — no string dispatch.
+fn parse_distinct_counter_kinds_among_tail(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, _) = tag("different kind").parse(input)?;
+    let (rest, _) = opt(tag("s")).parse(rest)?;
+    let (rest, _) = tag(" of counter").parse(rest)?;
+    let (rest, _) = opt(tag("s")).parse(rest)?;
+    let (rest, _) = tag(" ").parse(rest)?;
+    let (rest, _) = alt((tag("on "), tag("among "))).parse(rest)?;
+    let (filter, remainder) = parse_type_phrase(rest);
+    if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    Ok(("", QuantityRef::DistinctCounterKindsAmong { filter }))
 }
 
 /// CR 500: "turns you've taken this game" → [`QuantityRef::TurnsTaken`] (Control
@@ -7104,6 +7139,38 @@ mod tests {
         // "among" surface form + a non-permanent type phrase.
         let (rest, q) =
             parse_for_each_clause_ref("kind of counter among creatures you control").unwrap();
+        assert_eq!(rest, "");
+        assert!(matches!(q, QuantityRef::DistinctCounterKindsAmong { .. }));
+    }
+
+    #[test]
+    fn test_parse_the_number_of_different_kinds_of_counters_among() {
+        // CR 122.1: Perrie, the Pulverizer — "the number of different kinds of
+        // counters among permanents you control" (dynamic-quantity reading, not
+        // a repeat_for iteration source).
+        let (rest, q) = parse_quantity_ref(
+            "the number of different kinds of counters among permanents you control",
+        )
+        .unwrap();
+        assert_eq!(rest, "");
+        match q {
+            QuantityRef::DistinctCounterKindsAmong { filter } => match filter {
+                TargetFilter::Typed(tf) => {
+                    assert_eq!(tf.type_filters, vec![TypeFilter::Permanent]);
+                    assert_eq!(tf.controller, Some(ControllerRef::You));
+                }
+                other => panic!("expected typed permanent filter, got {other:?}"),
+            },
+            other => panic!("expected DistinctCounterKindsAmong, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_the_number_of_different_kind_of_counter_on_singular() {
+        // Singular "kind of counter on" surface form.
+        let (rest, q) =
+            parse_quantity_ref("the number of different kind of counter on creatures you control")
+                .unwrap();
         assert_eq!(rest, "");
         assert!(matches!(q, QuantityRef::DistinctCounterKindsAmong { .. }));
     }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -690,6 +690,7 @@ mod palisade_giant_redirect;
 mod panther_habit_equipped_prevention_scope;
 mod peer_into_the_abyss;
 mod pendrell_flux_unless_pay_own_cost;
+mod perrie_the_pulverizer_attack_trigger_6219;
 mod peter_parker_modal_back_face_cast;
 mod phantom_general_token_anthem;
 mod phyrexian_fleshgorger_ward;

--- a/crates/engine/tests/integration/perrie_the_pulverizer_attack_trigger_6219.rs
+++ b/crates/engine/tests/integration/perrie_the_pulverizer_attack_trigger_6219.rs
@@ -1,0 +1,137 @@
+//! Regression for issue #6219: Perrie, the Pulverizer's attack trigger.
+//!
+//! https://github.com/phase-rs/phase/issues/6219
+//!
+//! Oracle: "Whenever Perrie attacks, target creature you control gains trample
+//! and gets +X/+X until end of turn, where X is the number of different kinds
+//! of counters among permanents you control."
+//!
+//! The quantity parser lowered "the number of different kinds of counters
+//! among <filter>" through the generic "the number of [counter type] counters
+//! among <filter>" arm, treating "different kinds of" as a literal counter
+//! type name instead of routing to the dedicated `DistinctCounterKindsAmong`
+//! quantity (CR 122.1). No real permanent ever carries a counter literally
+//! named "different kinds of", so X always resolved to 0 — the trample grant
+//! landed but the +X/+X boost was silently a no-op.
+//!
+//! Discriminating observable: P0 controls Perrie (printed 3/3) carrying a
+//! shield counter and a lore counter — two distinct counter kinds that don't
+//! themselves modify power/toughness. After Perrie attacks and its trigger
+//! auto-targets itself (the lone legal "creature you control"), X must
+//! resolve to 2, so Perrie's effective power/toughness becomes 5/5 with
+//! trample. Reverting the parser fix collapses X to 0, so the final assertion
+//! flips to 3/3 with no trample.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+const PERRIE_ORACLE: &str = "When Perrie enters, put a shield counter on target creature. (If it would be dealt damage or destroyed, remove a shield counter from it instead.)\nWhenever Perrie attacks, target creature you control gains trample and gets +X/+X until end of turn, where X is the number of different kinds of counters among permanents you control.";
+
+/// Effective (post-layer) power/toughness of an object.
+fn power_toughness(runner: &GameRunner, id: ObjectId) -> (i32, i32) {
+    let obj = runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("object still present");
+    (obj.power.unwrap_or(0), obj.toughness.unwrap_or(0))
+}
+
+fn has_trample(runner: &GameRunner, id: ObjectId) -> bool {
+    runner
+        .state()
+        .objects
+        .get(&id)
+        .expect("object still present")
+        .keywords
+        .iter()
+        .any(|k| matches!(k, Keyword::Trample))
+}
+
+#[test]
+fn perrie_attack_trigger_counts_distinct_counter_kinds() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0 controls Perrie, printed 3/3 (NCC). `add_creature_from_oracle` places
+    // the object directly on the battlefield without an "enters" event, so the
+    // ETB shield-counter trigger does not fire here — only the attack trigger
+    // under test does.
+    let perrie = scenario
+        .add_creature_from_oracle(P0, "Perrie, the Pulverizer", 3, 3, PERRIE_ORACLE)
+        .id();
+
+    // Seed two distinct counter kinds directly on Perrie: a shield counter and
+    // a lore counter. CR 122.1: counters with different names/descriptions are
+    // distinct kinds, so this makes X resolve to 2. Neither kind modifies P/T
+    // on its own (unlike a +1/+1 counter), so the trigger's +X/+X is the only
+    // source of the P/T change this test observes.
+    scenario.with_counter(perrie, CounterType::Shield, 1);
+    scenario.with_counter(perrie, CounterType::Lore, 1);
+
+    let mut runner = scenario.build();
+
+    // Sanity: printed 3/3 before combat, no trample.
+    assert_eq!(power_toughness(&runner, perrie), (3, 3), "printed P/T");
+    assert!(
+        !has_trample(&runner, perrie),
+        "no trample before the attack"
+    );
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(perrie, AttackTarget::Player(P1))])
+        .expect("declare Perrie as attacker");
+
+    // Drive the trigger through the real trigger -> stack -> resolution
+    // pipeline: Perrie is the only legal "creature you control" target, so
+    // the engine auto-selects it without a TriggerTargetSelection prompt.
+    // Pass priority (and order the trigger, if prompted) until the buff
+    // lands or the loop exhausts.
+    for _ in 0..300 {
+        if power_toughness(&runner, perrie) == (5, 5) && has_trample(&runner, perrie) {
+            break;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .or_else(|_| runner.act(GameAction::OrderTriggers { order: vec![] }))
+                    .expect("order the single attack trigger");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break;
+                }
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("no blocks");
+            }
+            _ => break,
+        }
+    }
+
+    // CR 122.1 + CR 702.19: X must count the two distinct counter kinds
+    // (shield, lore) among permanents P0 controls, so Perrie's effective P/T
+    // becomes 5/5 with trample for the turn.
+    assert_eq!(
+        power_toughness(&runner, perrie),
+        (5, 5),
+        "Perrie's attack trigger must add +2/+2 for the two distinct counter kinds it carries"
+    );
+    assert!(
+        has_trample(&runner, perrie),
+        "Perrie's attack trigger must grant trample to the targeted creature"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #6219: Perrie, the Pulverizer's attack trigger ("Whenever Perrie
attacks, target creature you control gains trample and gets +X/+X until end
of turn, where X is the number of different kinds of counters among
permanents you control") never applied the +X/+X boost. Trample landed fine,
but X always resolved to 0.

Root cause: the "the number of [counter type] counters among <filter>"
generic quantity arm treated "different kinds of" as a literal counter type
name. Since no real counter is ever named that, `CountersOnObjects` always
counted zero. The engine already has the correct primitive for this —
`QuantityRef::DistinctCounterKindsAmong` — used by the "for each kind of
counter on/among <filter>" `repeat_for` reading (Bribe Taker), but nothing
routed the "the number of different kinds of counters among <filter>"
dynamic-quantity surface form to it.

Added `parse_distinct_counter_kinds_among_tail` to
`oracle_nom/quantity.rs`, a nom combinator that recognizes "different
kind[s] of counters {on|among} <filter>" and emits
`QuantityRef::DistinctCounterKindsAmong { filter }`, nested alongside
`parse_distinct_subtypes_among` in `parse_number_of_inner` so it's tried
before the generic controlled-type/counter-type fallback.

## Files changed

- `crates/engine/src/parser/oracle_nom/quantity.rs` — new combinator +
  registration + 2 parser unit tests (plural/singular surface forms).
- `crates/engine/tests/integration/perrie_the_pulverizer_attack_trigger_6219.rs`
  — new runtime regression driving the real attack trigger through
  declare-attackers → stack → resolution, asserting the +2/+2 pump and
  trample grant land on Perrie.
- `crates/engine/tests/integration/main.rs` — registers the new test module.

## CR references

- CR 122.1 (counters, distinct kinds by name/description)

## Implementation method

Method: manual (parser combinator + runtime regression), traced through
the existing `DistinctCounterKindsAmong` primitive and its `for each`
sibling before writing the fix.

## Track

Developer

## LLM

Model: Claude (Sonnet 5) / Thinking: standard / Tier: n/a

## Verification

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy -p engine --all-targets --features engine/proptest -- -D warnings` — 0 warnings
- [x] `cargo test -p engine --lib` — 17301 passed, 0 failed, 6 ignored
- [x] `cargo test -p engine --test integration` — 3585 passed, 0 failed, 2 ignored (includes the new Perrie regression)
- [x] `./scripts/check-parser-combinators.sh origin/main` — `Gate A PASS head=df13846e3c03fa29902d4bd93e8f4eefd84972f7 base=2f4608051c4d694d3ec3fd59c3e68c26d3746559`
- [x] Revert check: `git apply -R` on the parser-fix hunk flips the new integration test red (X resolves to 0, P/T stays 3/3); re-applying turns it green (5/5 + trample) — confirms the test actually pins the fix.

## Gate A

Gate A PASS head=df13846e3c03fa29902d4bd93e8f4eefd84972f7 base=2f4608051c4d694d3ec3fd59c3e68c26d3746559

## Anchored on

- `crates/engine/src/parser/oracle_nom/quantity.rs:1626` — `parse_for_each_distinct_counter_kinds_among` (the `repeat_for` sibling reading of the same `DistinctCounterKindsAmong` primitive)
- `crates/engine/src/parser/oracle_nom/quantity.rs:1595` — `parse_number_of_distinct_colors_among_permanents_tail` (the same "the number of `<distinct-X>` among `<filter>`" CDA-quantity shape, colors side)

## Final review-impl PASS head=df13846e3c03fa29902d4bd93e8f4eefd84972f7

## Claimed parse impact

1 card (Perrie, the Pulverizer) moves from `supported_aspect_defect` (X
always 0) to fully correct. No other card's Oracle text begins with
"different kind of counter" / "different kinds of counters" in a way the
prior generic arm would have handled differently — this arm is nested
strictly before the generic controlled-type fallback and only fires on
that literal adjective prefix, so no existing `supported:true` card
regresses.

Scope Expansion: None.
Validation Failures: None.
CI Failures: None.
