### PR TITLE
fix(client): avoid duplicate card data on iOS

### DIFF
--- a/client/src/adapter/__tests__/boundary-guardrails.test.ts
+++ b/client/src/adapter/__tests__/boundary-guardrails.test.ts
@@ -71,6 +71,31 @@ describe("adapter boundary guardrails", () => {
     }
   });
 
+  it("keeps gameplay card-data ownership in the shared engine worker", () => {
+    const root = repoRoot();
+    const gameProvider = readFileSync(
+      resolve(root, "client/src/providers/GameProvider.tsx"),
+      "utf8",
+    );
+
+    // The shared WasmAdapter loads the corpus before game creation/restoration.
+    // Importing the main-thread card-data service here would allocate a second
+    // WASM module and full corpus whenever gameplay mounts or resumes.
+    expect(gameProvider).not.toMatch(/from ["']\.\.\/services\/cardData["']/);
+
+    const cardDataHook = readFileSync(
+      resolve(root, "client/src/hooks/useEngineCardData.ts"),
+      "utf8",
+    );
+    const mainThreadRuntimeImport = cardDataHook.match(
+      /import\s*{([^}]*)}\s*from ["']\.\.\/services\/engineRuntime["']/,
+    );
+    expect(mainThreadRuntimeImport?.[1] ?? "").not.toMatch(
+      /getCardFaceData|getCardParseDetails|getCardRulings/,
+    );
+    expect(cardDataHook).toContain('import { getSharedAdapter } from "../adapter/wasm-adapter";');
+  });
+
   it("keeps the frontend WaitingFor union in lockstep with the engine enum", () => {
     const root = repoRoot();
     const rustSource = readFileSync(

--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -13,6 +13,9 @@ const mockWorkerClient = {
   evaluateDeckCompatibility: vi
     .fn()
     .mockResolvedValue({ standard: { compatible: true, reasons: [] } }),
+  getCardFaceData: vi.fn().mockResolvedValue({ name: "Lightning Bolt" }),
+  getCardParseDetails: vi.fn().mockResolvedValue([{ category: "ability" }]),
+  getCardRulings: vi.fn().mockResolvedValue([{ date: "2020-01-01", text: "Test" }]),
   initializeGame: vi
     .fn()
     .mockResolvedValue({ events: [{ type: "GameStarted" }], log_entries: [] }),
@@ -99,6 +102,25 @@ describe("WasmAdapter", () => {
       expect(mockWorkerClient.loadCardDbFromUrl).toHaveBeenCalledOnce();
       expect(mockWorkerClient.evaluateDeckCompatibility).toHaveBeenCalledWith(request);
       expect(result).toEqual({ standard: { compatible: true, reasons: [] } });
+    });
+  });
+
+  describe("card display queries", () => {
+    it("loads the DB once and routes every query through the shared worker", async () => {
+      await expect(adapter.getCardFaceData("Lightning Bolt")).resolves.toEqual({
+        name: "Lightning Bolt",
+      });
+      await expect(adapter.getCardParseDetails("Lightning Bolt")).resolves.toEqual([
+        { category: "ability" },
+      ]);
+      await expect(adapter.getCardRulings("Lightning Bolt")).resolves.toEqual([
+        { date: "2020-01-01", text: "Test" },
+      ]);
+
+      expect(mockWorkerClient.loadCardDbFromUrl).toHaveBeenCalledOnce();
+      expect(mockWorkerClient.getCardFaceData).toHaveBeenCalledWith("Lightning Bolt");
+      expect(mockWorkerClient.getCardParseDetails).toHaveBeenCalledWith("Lightning Bolt");
+      expect(mockWorkerClient.getCardRulings).toHaveBeenCalledWith("Lightning Bolt");
     });
   });
 

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -167,6 +167,18 @@ export class EngineWorkerClient {
     return this.request<unknown>({ type: "evaluateDeckCompatibility", request });
   }
 
+  async getCardFaceData(cardName: string): Promise<unknown> {
+    return this.request<unknown>({ type: "getCardFaceData", cardName });
+  }
+
+  async getCardParseDetails(cardName: string): Promise<unknown> {
+    return this.request<unknown>({ type: "getCardParseDetails", cardName });
+  }
+
+  async getCardRulings(cardName: string): Promise<unknown> {
+    return this.request<unknown>({ type: "getCardRulings", cardName });
+  }
+
   /**
    * Build the game-scoped AI card-DB subset for THIS game. Returns the
    * serialized `AiCardSubsetResult` tagged union (parse with `JSON.parse`).

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -37,6 +37,9 @@ import init, {
   replay_seek_js,
   clear_replay_playback,
   preview_mana_payment_js,
+  get_card_face_data,
+  get_card_parse_details,
+  get_card_rulings,
 } from "@wasm/engine";
 
 import type { GameAction } from "./types";
@@ -86,6 +89,9 @@ type EngineRequest =
   | { type: "loadCardDbFromUrl"; id: number }
   | { type: "buildAiCardSubset"; id: number }
   | { type: "evaluateDeckCompatibility"; id: number; request: unknown }
+  | { type: "getCardFaceData"; id: number; cardName: string }
+  | { type: "getCardParseDetails"; id: number; cardName: string }
+  | { type: "getCardRulings"; id: number; cardName: string }
   | { type: "resetGame"; id: number }
   | { type: "setMultiplayerMode"; id: number; enabled: boolean }
   | { type: "ping"; id: number }
@@ -183,6 +189,21 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
         }
         const data = evaluate_deck_compatibility_js(msg.request);
         result(msg.id, data);
+        break;
+      }
+
+      case "getCardFaceData": {
+        result(msg.id, get_card_face_data(msg.cardName));
+        break;
+      }
+
+      case "getCardParseDetails": {
+        result(msg.id, get_card_parse_details(msg.cardName));
+        break;
+      }
+
+      case "getCardRulings": {
+        result(msg.id, get_card_rulings(msg.cardName));
         break;
       }
 

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -669,6 +669,32 @@ export class WasmAdapter implements EngineAdapter {
     return this.fallback!.evaluateDeckCompatibility(request);
   }
 
+  /**
+   * Display-only card queries share the authoritative engine worker and its
+   * resident card database. Keeping these off the main-thread runtime avoids a
+   * second WASM module + corpus allocation when card UI mounts during gameplay.
+   */
+  async getCardFaceData(cardName: string): Promise<unknown> {
+    await this.initialize();
+    await this.ensureCardDb();
+    if (this.engine) return this.engine.getCardFaceData(cardName);
+    return this.fallback!.getCardFaceData(cardName);
+  }
+
+  async getCardParseDetails(cardName: string): Promise<unknown> {
+    await this.initialize();
+    await this.ensureCardDb();
+    if (this.engine) return this.engine.getCardParseDetails(cardName);
+    return this.fallback!.getCardParseDetails(cardName);
+  }
+
+  async getCardRulings(cardName: string): Promise<unknown> {
+    await this.initialize();
+    await this.ensureCardDb();
+    if (this.engine) return this.engine.getCardRulings(cardName);
+    return this.fallback!.getCardRulings(cardName);
+  }
+
   dispose(): void {
     // Clear the singleton reference so getSharedAdapter() creates a fresh
     // instance if called after dispose (e.g., error recovery code paths).
@@ -773,6 +799,9 @@ interface MainThreadFallback {
   ): Promise<SubmitResult>;
   estimateBracketForDeck(deck: BracketDeckRequest): Promise<BracketEstimate | null>;
   evaluateDeckCompatibility(request: unknown): Promise<unknown>;
+  getCardFaceData(cardName: string): Promise<unknown>;
+  getCardParseDetails(cardName: string): Promise<unknown>;
+  getCardRulings(cardName: string): Promise<unknown>;
 }
 
 async function createMainThreadFallback(): Promise<MainThreadFallback> {
@@ -934,5 +963,14 @@ async function createMainThreadFallback(): Promise<MainThreadFallback> {
     // `ensureCardDatabase` (engineRuntime), so the query reads it directly.
     evaluateDeckCompatibility: (request: unknown) =>
       enqueue(() => wasm.evaluate_deck_compatibility_js(request)),
+
+    getCardFaceData: (cardName: string) =>
+      enqueue(() => wasm.get_card_face_data(cardName)),
+
+    getCardParseDetails: (cardName: string) =>
+      enqueue(() => wasm.get_card_parse_details(cardName)),
+
+    getCardRulings: (cardName: string) =>
+      enqueue(() => wasm.get_card_rulings(cardName)),
   };
 }

--- a/client/src/components/card/CardImage.tsx
+++ b/client/src/components/card/CardImage.tsx
@@ -75,7 +75,14 @@ export function CardImage({
   // face up or a DFC transforming, and would otherwise stay latched on the text
   // tile forever. Mirrors `CardPreview.tsx`'s `useEffect(… , [src])`.
   useEffect(() => setImageError(false), [src]);
-  const fallbackData = useEngineCardData(!faceDown && oracleText === undefined ? cardName : null);
+  // Only resolve rules text when the art lookup has definitively failed. On the
+  // first render `src` is null for every card while useCardImage is loading; an
+  // eager fallback lookup here used to make all seven mulligan cards initialize
+  // card-data queries even though their artwork resolved a moment later.
+  const showArtFallback = !faceDown && !isLoading && (imageError || !src);
+  const fallbackData = useEngineCardData(
+    showArtFallback && oracleText === undefined ? cardName : null,
+  );
   const resolvedOracleText = oracleText ?? fallbackData?.oracle_text ?? undefined;
 
   const tappedStyle = tapped ? "rotate-[90deg] origin-center" : "";
@@ -104,8 +111,6 @@ export function CardImage({
   //   - `imageError`: the resolved `<img>` failed to load.
   // Both render the card/token name (and Oracle text when known) so every artless
   // card or token — not just one hard-coded name — stays identifiable.
-  const showArtFallback = !faceDown && (imageError || !src);
-
   const renderedSrc = faceDown ? CARD_BACK_URL : (src ?? "");
   const renderedAlt = faceDown ? t("card.faceDownName") : cardName;
 

--- a/client/src/components/card/__tests__/CardImage.test.tsx
+++ b/client/src/components/card/__tests__/CardImage.test.tsx
@@ -5,6 +5,8 @@ import { useCardImage } from "../../../hooks/useCardImage.ts";
 import { CARD_BACK_URL } from "../../../services/scryfall.ts";
 import { CardImage } from "../CardImage.tsx";
 
+const mockUseEngineCardData = vi.hoisted(() => vi.fn(() => null));
+
 vi.mock("../../../hooks/useCardImage.ts", () => ({
   useCardImage: vi.fn(() => ({
     src: null,
@@ -18,7 +20,7 @@ vi.mock("../../../hooks/useCardImage.ts", () => ({
 // the component's own Oracle-text lookup returns nothing; tests pass Oracle text
 // explicitly via the prop when they want to exercise that branch.
 vi.mock("../../../hooks/useEngineCardData.ts", () => ({
-  useEngineCardData: () => null,
+  useEngineCardData: mockUseEngineCardData,
 }));
 
 const mockUseCardImage = vi.mocked(useCardImage);
@@ -39,6 +41,7 @@ describe("CardImage art fallback (issue #6156)", () => {
 
     render(<CardImage cardName="Banana" isToken />);
 
+    expect(mockUseEngineCardData).toHaveBeenCalledWith(null);
     // Positive guard first: the pulse element must actually be in the document.
     // Without this the two negative assertions below would also pass if the
     // loading branch rendered nothing at all, or threw.
@@ -60,6 +63,7 @@ describe("CardImage art fallback (issue #6156)", () => {
 
     render(<CardImage cardName="Banana" isToken />);
 
+    expect(mockUseEngineCardData).toHaveBeenCalledWith("Banana");
     const tile = screen.getByRole("img", { name: "Banana" });
     expect(tile).toBeInTheDocument();
     expect(screen.getByText("Banana")).toBeInTheDocument();

--- a/client/src/hooks/useEngineCardData.ts
+++ b/client/src/hooks/useEngineCardData.ts
@@ -3,10 +3,8 @@ import { useEffect, useState } from "react";
 import {
   type CardRuling,
   ensureCardLocale,
-  getCardFaceData,
-  getCardParseDetails,
-  getCardRulings,
 } from "../services/engineRuntime";
+import { getSharedAdapter } from "../adapter/wasm-adapter";
 import { usePreferencesStore } from "../stores/preferencesStore";
 
 /**
@@ -64,7 +62,7 @@ export function useEngineCardData(cardName: string | null): EngineCardFace | nul
     let cancelled = false;
 
     void (async () => {
-      const result = (await getCardFaceData(cardName)) as EngineCardFace | null;
+      const result = (await getSharedAdapter().getCardFaceData(cardName)) as EngineCardFace | null;
       if (cancelled) return;
       if (!result || language === "en") {
         setData(result ?? null);
@@ -145,10 +143,10 @@ export function useCardParseDetails(cardName: string | null): ParsedItem[] | nul
 
     let cancelled = false;
 
-    getCardParseDetails(cardName)
+    getSharedAdapter().getCardParseDetails(cardName)
       .then((result) => {
         if (cancelled) return;
-        setItems(result ?? null);
+        setItems((result as ParsedItem[] | null) ?? null);
       })
       .catch(() => {
         if (cancelled) return;
@@ -177,10 +175,10 @@ export function useCardRulings(cardName: string | null): CardRuling[] {
 
     let cancelled = false;
 
-    getCardRulings(cardName)
+    getSharedAdapter().getCardRulings(cardName)
       .then((result) => {
         if (cancelled) return;
-        setRulings(result);
+        setRulings((result as CardRuling[] | null) ?? []);
       })
       .catch(() => {
         if (cancelled) return;

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -39,7 +39,6 @@ import { loadP2PSession } from "../services/p2pSession";
 import { expandParsedDeck, type ExpandedDeck, type ParsedDeck } from "../services/deckParser";
 import { formatSuppliesDeck } from "../data/formatRegistry";
 import { consumeRecentAutoUpdateMarker } from "../pwa/updateMarker";
-import { ensureCardDatabase } from "../services/cardData";
 import { loadDraftRun } from "../services/quickDraftPersistence";
 import { SPECTATOR_PLAYER_ID } from "../constants/game";
 import { clearWsSession, loadWsSession, saveWsSession } from "../services/multiplayerSession";
@@ -1156,10 +1155,10 @@ export function GameProvider({
 
       if (savedState) {
         try {
-          // Load card DB before restore so the engine can rehydrate objects
-          // and handle token creation / effects after resume.
-          await ensureCardDatabase().catch(() => {/* card DB is best-effort */});
-          if (cancelled) return;
+          // WasmAdapter.restoreState() loads the card DB into its shared worker
+          // before rehydrating. Do not also initialize the main-thread runtime:
+          // that duplicates both the WASM module and full card corpus, which can
+          // exceed the WebContent memory budget on iOS.
           await resumeGame(gameId, adapter, savedState);
           if (cancelled) return;
           // Derive player count from the restored state — the URL param may be


### PR DESCRIPTION
## Summary

- keep saved-game restoration on the shared engine worker instead of loading a second main-thread WASM/card corpus
- delay `CardImage` fallback data lookup until artwork definitively fails
- route card face, parse-detail, and ruling queries through the shared worker
- add memory-ownership guardrails and focused regression tests

## Root cause

`GameProvider` loaded the full card database through the main-thread runtime before `WasmAdapter` restored via the worker. At the same time, every initial `CardImage` mount queried that main-thread runtime while artwork was still resolving. On memory-constrained iOS WebKit, this duplicated the WASM module and full card corpus and could terminate the WebContent process around game startup or mulligan.

These paths were present on upstream `main` before the hand-preview work and are independent of it.

## User impact

Mobile Safari and the installed PWA can enter games and pass mulligan without falling into the “A problem repeatedly occurred” reload loop. Desktop behavior is unchanged.

## Validation

- physical iPhone manual verification: startup crash no longer reproduced
- TypeScript build (`tsc -b --noEmit`)
- ESLint (0 errors; 18 pre-existing warnings)
- 44 focused Vitest tests
- production PWA build
- full pre-push Rust, parser, AI, card-data, coverage, lint, and type-check gates
