### PR TITLE
perf(engine): structural sharing for zone-change history and LKI caches

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -48208,7 +48208,7 @@ fn push_cards_to_graveyard_this_turn(state: &mut GameState, owner: PlayerId, cou
     for i in 0..count {
         state
             .zone_changes_this_turn
-            .push(crate::types::game_state::ZoneChangeRecord {
+            .push_back(crate::types::game_state::ZoneChangeRecord {
                 name: format!("Milled Card {i}"),
                 core_types: vec![CoreType::Creature],
                 mana_value: 1,

--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -2255,7 +2255,7 @@ mod tests {
         let old_equipment = spawn_with_subtype(&mut state, "Old Sword", "Equipment");
         let new_equipment = spawn_with_subtype(&mut state, "New Sword", "Equipment");
 
-        state.zone_changes_this_turn.push(ZoneChangeRecord {
+        state.zone_changes_this_turn.push_back(ZoneChangeRecord {
             attachments: vec![AttachmentSnapshot {
                 object_id: old_equipment,
                 identity: None,
@@ -2264,7 +2264,7 @@ mod tests {
             }],
             ..ZoneChangeRecord::test_minimal(zack, Some(Zone::Battlefield), Zone::Graveyard)
         });
-        state.zone_changes_this_turn.push(ZoneChangeRecord {
+        state.zone_changes_this_turn.push_back(ZoneChangeRecord {
             attachments: vec![AttachmentSnapshot {
                 object_id: new_equipment,
                 identity: None,

--- a/crates/engine/src/game/effects/conjure.rs
+++ b/crates/engine/src/game/effects/conjure.rs
@@ -209,7 +209,7 @@ pub fn resolve(
                         .snapshot_for_zone_change(obj_id, None, Zone::Battlefield);
                     state
                         .zone_changes_this_turn
-                        .push(zone_change_record.clone());
+                        .push_back(zone_change_record.clone());
                     events.push(GameEvent::ZoneChanged {
                         object_id: obj_id,
                         from: None,

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -431,7 +431,7 @@ fn apply_pending_counter_post_action(
             }) {
                 state
                     .zone_changes_this_turn
-                    .push(zone_change_record.clone());
+                    .push_back(zone_change_record.clone());
                 events.push(GameEvent::ZoneChanged {
                     object_id,
                     from: None,

--- a/crates/engine/src/game/effects/incubate.rs
+++ b/crates/engine/src/game/effects/incubate.rs
@@ -116,7 +116,7 @@ pub fn resolve(
         .snapshot_for_zone_change(obj_id, None, Zone::Battlefield);
     state
         .zone_changes_this_turn
-        .push(zone_change_record.clone());
+        .push_back(zone_change_record.clone());
     events.push(GameEvent::ZoneChanged {
         object_id: obj_id,
         from: None,

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -4759,7 +4759,7 @@ mod tests {
         // Only `milled` carries a Library->Graveyard record this turn.
         state
             .zone_changes_this_turn
-            .push(ZoneChangeRecord::test_minimal(
+            .push_back(ZoneChangeRecord::test_minimal(
                 milled,
                 Some(Zone::Library),
                 Zone::Graveyard,

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -11898,7 +11898,7 @@ mod tests {
             .push(CoreType::Artifact);
         state
             .zone_changes_this_turn
-            .push(ZoneChangeRecord::test_minimal(
+            .push_back(ZoneChangeRecord::test_minimal(
                 card,
                 Some(Zone::Battlefield),
                 Zone::Graveyard,

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -6148,14 +6148,14 @@ mod tests {
             .core_types
             .push(CoreType::Creature);
 
-        state.sacrificed_permanents_this_turn.push(
+        state.sacrificed_permanents_this_turn.push_back(
             state.objects[&artifact].snapshot_for_zone_change(
                 artifact,
                 Some(Zone::Battlefield),
                 Zone::Graveyard,
             ),
         );
-        state.sacrificed_permanents_this_turn.push(
+        state.sacrificed_permanents_this_turn.push_back(
             state.objects[&creature].snapshot_for_zone_change(
                 creature,
                 Some(Zone::Battlefield),

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -371,7 +371,7 @@ pub fn record_token_created(state: &mut crate::types::game_state::GameState, obj
             .insert(obj.controller);
         state
             .created_tokens_this_turn
-            .push(obj.snapshot_for_zone_change(object_id, None, Zone::Battlefield));
+            .push_back(obj.snapshot_for_zone_change(object_id, None, Zone::Battlefield));
     }
 }
 
@@ -385,7 +385,11 @@ pub fn record_sacrifice(
     };
     state
         .sacrificed_permanents_this_turn
-        .push(obj.snapshot_for_zone_change(object_id, Some(Zone::Battlefield), Zone::Graveyard));
+        .push_back(obj.snapshot_for_zone_change(
+            object_id,
+            Some(Zone::Battlefield),
+            Zone::Graveyard,
+        ));
     if obj.card_types.core_types.contains(&CoreType::Artifact) {
         state
             .players_who_sacrificed_artifact_this_turn
@@ -527,7 +531,7 @@ pub fn record_zone_change(
     let to_zone = record.to_zone;
     let turn_zone_change_index = state.zone_changes_this_turn.len();
     record.turn_zone_change_index = turn_zone_change_index;
-    state.zone_changes_this_turn.push(record);
+    state.zone_changes_this_turn.push_back(record);
 
     if to_zone == Zone::Battlefield {
         record_battlefield_entry(state, object_id);
@@ -3207,7 +3211,7 @@ mod tests {
         let mut state = crate::types::game_state::GameState::new_two_player(42);
         state
             .zone_changes_this_turn
-            .push(crate::types::game_state::ZoneChangeRecord {
+            .push_back(crate::types::game_state::ZoneChangeRecord {
                 name: "Grizzly Bears".to_string(),
                 core_types: vec![CoreType::Creature],
                 ..crate::types::game_state::ZoneChangeRecord::test_minimal(
@@ -3326,7 +3330,7 @@ mod tests {
         let mut state = crate::types::game_state::GameState::new_two_player(42);
         state
             .zone_changes_this_turn
-            .push(crate::types::game_state::ZoneChangeRecord {
+            .push_back(crate::types::game_state::ZoneChangeRecord {
                 name: "Skeleton".to_string(),
                 core_types: vec![CoreType::Creature],
                 subtypes: vec!["Skeleton".to_string()],
@@ -3347,7 +3351,7 @@ mod tests {
 
         state
             .zone_changes_this_turn
-            .push(crate::types::game_state::ZoneChangeRecord {
+            .push_back(crate::types::game_state::ZoneChangeRecord {
                 name: "Vampire".to_string(),
                 core_types: vec![CoreType::Creature],
                 subtypes: vec!["Vampire".to_string()],
@@ -3401,7 +3405,7 @@ mod tests {
         for i in 0..3 {
             state
                 .zone_changes_this_turn
-                .push(crate::types::game_state::ZoneChangeRecord {
+                .push_back(crate::types::game_state::ZoneChangeRecord {
                     name: format!("Card {}", i),
                     ..crate::types::game_state::ZoneChangeRecord::test_minimal(
                         ObjectId(100 + i),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -11688,8 +11688,8 @@ pub struct GameState {
     pub players_who_created_token_this_turn: HashSet<PlayerId>,
     /// CR 111.2: Token creation snapshots this turn, preserving creation-time
     /// characteristics for filtered "tokens you created this turn" quantities.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub created_tokens_this_turn: Vec<ZoneChangeRecord>,
+    #[serde(default, skip_serializing_if = "im::Vector::is_empty")]
+    pub created_tokens_this_turn: im::Vector<ZoneChangeRecord>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub counter_added_this_turn: Vec<CounterAddedRecord>,
     #[serde(default)]
@@ -11701,11 +11701,11 @@ pub struct GameState {
     /// CR 701.21a: Sacrificed permanent snapshots this turn, preserving
     /// event-time characteristics for filtered "you sacrificed [quality] this
     /// turn" conditions and quantities.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub sacrificed_permanents_this_turn: Vec<ZoneChangeRecord>,
+    #[serde(default, skip_serializing_if = "im::Vector::is_empty")]
+    pub sacrificed_permanents_this_turn: im::Vector<ZoneChangeRecord>,
     /// CR 400.7: Zone-change snapshots this turn, enabling data-driven condition queries.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub zone_changes_this_turn: Vec<ZoneChangeRecord>,
+    #[serde(default, skip_serializing_if = "im::Vector::is_empty")]
+    pub zone_changes_this_turn: im::Vector<ZoneChangeRecord>,
     /// CR 603.2c: Batched zone-change triggers already collected for
     /// `(definition_ref, turn_zone_change_index)`. Prevents a second
     /// `process_triggers` pass over the same `ZoneChanged` events from
@@ -12506,8 +12506,8 @@ pub struct GameState {
     /// CR 400.7: Last Known Information cache.
     /// Populated before zone changes for objects leaving the battlefield.
     /// Cleared on phase/step transitions via `advance_phase()`.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub lki_cache: HashMap<ObjectId, LKISnapshot>,
+    #[serde(default, skip_serializing_if = "im::HashMap::is_empty")]
+    pub lki_cache: im::HashMap<ObjectId, LKISnapshot>,
     /// CR 608.2h + CR 707.2: Full copiable-values LKI for objects that leave a
     /// public zone. Ordinary `LKISnapshot` is intentionally filter-shaped and
     /// does not carry ability definitions; copy effects need the complete
@@ -12520,8 +12520,8 @@ pub struct GameState {
     /// resolution paths that carry an incarnation use this history so a later
     /// departure of a re-entered object cannot overwrite the earlier object's LKI.
     /// Cleared with `lki_cache` on phase/step transitions.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub lki_by_incarnation: HashMap<ObjectId, HashMap<u64, LKISnapshot>>,
+    #[serde(default, skip_serializing_if = "im::HashMap::is_empty")]
+    pub lki_by_incarnation: im::HashMap<ObjectId, im::HashMap<u64, LKISnapshot>>,
 
     /// CR 607.2b + CR 603.10e: Last-known "cards exiled with [source]" linkage,
     /// captured when a source with `TrackedBySource` exile links leaves the
@@ -14218,13 +14218,13 @@ impl GameState {
             attacker_declarations_this_turn: Vec::new(),
             creatures_blocked_this_turn: HashSet::new(),
             players_who_created_token_this_turn: HashSet::new(),
-            created_tokens_this_turn: Vec::new(),
+            created_tokens_this_turn: im::Vector::new(),
             counter_added_this_turn: Vec::new(),
             players_who_discarded_card_this_turn: HashSet::new(),
             cards_discarded_this_turn_by_player: HashMap::new(),
             players_who_sacrificed_artifact_this_turn: HashSet::new(),
-            sacrificed_permanents_this_turn: Vec::new(),
-            zone_changes_this_turn: Vec::new(),
+            sacrificed_permanents_this_turn: im::Vector::new(),
+            zone_changes_this_turn: im::Vector::new(),
             batched_zone_change_trigger_fired: HashSet::new(),
             battlefield_entries_this_turn: Vec::new(),
             damage_dealt_this_turn: im::Vector::new(),
@@ -14318,9 +14318,9 @@ impl GameState {
             current_trigger_events: Vec::new(),
             last_discover_value: None,
             stack_trigger_event_batches: HashMap::new(),
-            lki_cache: HashMap::new(),
+            lki_cache: im::HashMap::new(),
             lki_copiable_values: HashMap::new(),
-            lki_by_incarnation: HashMap::new(),
+            lki_by_incarnation: im::HashMap::new(),
             linked_exile_lki: HashMap::new(),
             cost_payment_failed_flag: false,
             pending_taps_for_mana_overrides: std::collections::HashMap::new(),
@@ -15008,12 +15008,15 @@ impl GameState {
             }
         }
 
-        clone.lki_by_incarnation.retain(|object_id, history| {
-            history.retain(|incarnation, _| {
-                referenced_lki.contains(&ObjectIncarnationRef::of(*object_id, *incarnation))
-            });
-            !history.is_empty()
-        });
+        clone.lki_by_incarnation = std::mem::take(&mut clone.lki_by_incarnation)
+            .into_iter()
+            .filter_map(|(object_id, mut history)| {
+                history.retain(|incarnation, _| {
+                    referenced_lki.contains(&ObjectIncarnationRef::of(object_id, *incarnation))
+                });
+                (!history.is_empty()).then_some((object_id, history))
+            })
+            .collect();
         clone
     }
 

--- a/crates/engine/tests/integration/issue_3277_captain_nghathrod_eliminated_opponent.rs
+++ b/crates/engine/tests/integration/issue_3277_captain_nghathrod_eliminated_opponent.rs
@@ -76,7 +76,7 @@ fn captain_nghathrod_end_step_skips_eliminated_opponent_graveyard() {
     runner
         .state_mut()
         .zone_changes_this_turn
-        .push(ZoneChangeRecord {
+        .push_back(ZoneChangeRecord {
             object_id: milled_creature,
             name: "Milled Bear".to_string(),
             core_types: vec![CoreType::Creature],

--- a/crates/engine/tests/integration/issue_879_obsessive_pursuit.rs
+++ b/crates/engine/tests/integration/issue_879_obsessive_pursuit.rs
@@ -21,7 +21,7 @@ fn record_sacrifice(runner: &mut engine::game::scenario::GameRunner, id: ObjectI
     let state = runner.state_mut();
     let record =
         state.objects[&id].snapshot_for_zone_change(id, Some(Zone::Battlefield), Zone::Graveyard);
-    state.sacrificed_permanents_this_turn.push(record);
+    state.sacrificed_permanents_this_turn.push_back(record);
 }
 
 fn p1p1_counters(runner: &engine::game::scenario::GameRunner, id: ObjectId) -> u32 {

--- a/crates/engine/tests/integration/l02_bb1_activation_conditions.rs
+++ b/crates/engine/tests/integration/l02_bb1_activation_conditions.rs
@@ -184,7 +184,7 @@ fn s1_bonecache_runtime_false_when_neither_disjunct() {
     // Only 2 cards left the graveyard this turn, no Food sacrificed.
     for &m in &motes[..2] {
         let rec = push_gy_left(runner.state(), m);
-        runner.state_mut().zone_changes_this_turn.push(rec);
+        runner.state_mut().zone_changes_this_turn.push_back(rec);
     }
     assert!(
         !condition_gate_ok(runner.state(), overseer),
@@ -198,7 +198,7 @@ fn s1_bonecache_runtime_true_via_graveyard_disjunct() {
     let mut runner = scenario.build();
     for &m in &motes {
         let rec = push_gy_left(runner.state(), m);
-        runner.state_mut().zone_changes_this_turn.push(rec);
+        runner.state_mut().zone_changes_this_turn.push_back(rec);
     }
     assert!(
         condition_gate_ok(runner.state(), overseer),
@@ -214,7 +214,10 @@ fn s1_bonecache_runtime_true_via_food_disjunct() {
     let mut runner = scenario.build();
     make_food(runner.state_mut(), food);
     let rec = push_sacrificed(runner.state(), food);
-    runner.state_mut().sacrificed_permanents_this_turn.push(rec);
+    runner
+        .state_mut()
+        .sacrificed_permanents_this_turn
+        .push_back(rec);
     assert!(
         condition_gate_ok(runner.state(), overseer),
         "a sacrificed Food this turn must satisfy the second disjunct"

--- a/crates/engine/tests/integration/l02_bb6_conditional_enters_with_counter.rs
+++ b/crates/engine/tests/integration/l02_bb6_conditional_enters_with_counter.rs
@@ -462,7 +462,7 @@ fn push_death(runner: &mut engine::game::scenario::GameRunner, obj: ObjectId) {
         Some(Zone::Battlefield),
         Zone::Graveyard,
     );
-    runner.state_mut().zone_changes_this_turn.push(rec);
+    runner.state_mut().zone_changes_this_turn.push_back(rec);
 }
 
 /// Test 7(a) + 7(i) — Undead Sprinter runtime: with a non-Zombie creature dead

--- a/crates/engine/tests/integration/purged_source_matches_filter_lki.rs
+++ b/crates/engine/tests/integration/purged_source_matches_filter_lki.rs
@@ -547,7 +547,7 @@ fn lki_attachment_ids_are_identity_only_and_survive_a_purged_aura() {
 
 /// RIDER — SAVE-COMPAT ROUND TRIP, BOTH DIRECTIONS.
 ///
-/// `GameState` is `Serialize`/`Deserialize` and owns `lki_cache: HashMap<ObjectId, LKISnapshot>`,
+/// `GameState` is `Serialize`/`Deserialize` and owns `lki_cache: im::HashMap<ObjectId, LKISnapshot>`,
 /// so `LKISnapshot` IS persisted into saves. The new field therefore needs `#[serde(default)]`
 /// (it has it) and a two-way round-trip proof:
 ///


### PR DESCRIPTION
AI search deep-clones GameState per node; sample profiles of hung ai-gate
runs showed 89-94% of GameState::clone time in Vec<ZoneChangeRecord>::clone
(zone_changes_this_turn / created_tokens_this_turn /
sacrificed_permanents_this_turn) plus ~9% in the LKI cache HashMaps. History
grows monotonically within a turn, so per-node clone cost grew with game
length: niv-mirror duel-suite rows livelocked past 3600s at 9-17GB RSS.

Convert the three history vectors to im::Vector and the two LKI caches to
im::HashMap (structural sharing, O(1) clone), following the existing
spells_cast_this_game_by_player precedent. Pure representation swap: the LKI
maps are never iterated (keyed access + one retain), im::Vector preserves
Vec iteration order, and serde wire format is unchanged.

A/B at 65f0a3ac on the suite host (seed 10573729, Medium, 100 games/row):
- affinity/elves/lands controls: play byte-identical (only duration fields
  differ), 13-18% faster per game
- niv-mirror: hang at base (9.1GB peak in 30min, fingerprint-identical
  census) -> completes in 18s/game with the fix (46/47/7, 28.8 avg turns)
- landfall-vs-niv: livelocked at base era -> completes (73/25/2)
- equipment-mirror peak RSS 2.4GB -> <1GB (its timeout is a separate
  candidate-generation hotspot, tracked separately)
