### PR TITLE
feat(client): show the unimplemented-mechanics badge on stack spells

### DIFF
--- a/client/src/components/card/CardImage.tsx
+++ b/client/src/components/card/CardImage.tsx
@@ -7,6 +7,7 @@ import type { TokenImageRef } from "../../adapter/types.ts";
 import { CARD_BACK_URL } from "../../services/scryfall.ts";
 import { getBevelBorderStyle } from "./cardFrame.ts";
 import { CardArtFallback } from "./CardArtFallback.tsx";
+import { UnimplementedMechanicsBadge } from "./UnimplementedMechanicsBadge.tsx";
 import { ManaSymbol } from "../mana/ManaSymbol.tsx";
 
 interface CardImageProps {
@@ -131,14 +132,7 @@ export function CardImage({
           style={borderStyle ?? { border: "1px solid #4b5563" }}
         />
       )}
-      {unimplementedMechanics && unimplementedMechanics.length > 0 && (
-        <span
-          className="absolute top-0.5 left-0.5 bg-amber-500 text-black text-[8px] font-bold rounded-sm px-0.5 leading-tight"
-          title={t("card.unimplemented", { mechanics: unimplementedMechanics.join(", ") })}
-        >
-          !
-        </span>
-      )}
+      <UnimplementedMechanicsBadge mechanics={unimplementedMechanics} variant="overlay" />
       {tapIndicator && (
         <span
           className="absolute top-1 right-1 flex items-center justify-center rounded-full bg-black/70 p-1 shadow-md ring-1 ring-white/20"

--- a/client/src/components/card/UnimplementedMechanicsBadge.tsx
+++ b/client/src/components/card/UnimplementedMechanicsBadge.tsx
@@ -1,0 +1,61 @@
+import { useTranslation } from "react-i18next";
+
+/**
+ * Render scale for the badge. Mirrors the `artCrop` / `fullCard` variant
+ * vocabulary `CardArtFallback` already uses, so every card-surface component in
+ * this directory names its render modes the same way.
+ *
+ * - `overlay` — pinned inside the art of a hand/battlefield card, where the
+ *   badge shares the corner with the tap indicator and must stay unobtrusive.
+ * - `corner` — hung outside the border of a stack entry, matching the ×N and
+ *   status pills that already sit on that surface.
+ */
+export type UnimplementedMechanicsBadgeVariant = "overlay" | "corner";
+
+export interface UnimplementedMechanicsBadgeProps {
+  /**
+   * Engine-provided `unimplemented_mechanics` for the object. The badge is the
+   * single authority on when the warning shows: it renders nothing when this is
+   * absent or empty, so no call site has to repeat the emptiness guard.
+   */
+  mechanics?: string[];
+  variant?: UnimplementedMechanicsBadgeVariant;
+}
+
+const VARIANT_CLASSES: Record<UnimplementedMechanicsBadgeVariant, string> = {
+  overlay: "absolute top-0.5 left-0.5 text-[8px] px-0.5 rounded-sm leading-tight",
+  // Bottom-right is the stack entry's only free corner: ×N and the chosen-X
+  // pill sit top-left, "Casting…"/"Next" top-right, and the auto-pass yield
+  // pill bottom-left. Verified visually — a bottom-left badge overlapped the
+  // yield pill, which no DOM assertion would have caught.
+  corner: "absolute -bottom-2 -right-2 z-10 text-[11px] px-2 py-0.5 rounded-full shadow-md",
+};
+
+/**
+ * Amber `!` warning shown on a card surface whose printed abilities include
+ * mechanics the engine does not implement yet.
+ *
+ * Extracted from `CardImage` so hand, battlefield and stack surfaces render one
+ * badge instead of three drifting copies (issue #4711). Display-only: the
+ * `unimplemented_mechanics` projection is computed by the engine and forwarded
+ * verbatim — this component neither derives nor filters it.
+ */
+export function UnimplementedMechanicsBadge({
+  mechanics,
+  variant = "overlay",
+}: UnimplementedMechanicsBadgeProps) {
+  const { t } = useTranslation("game");
+  if (!mechanics || mechanics.length === 0) return null;
+
+  const label = t("card.unimplemented", { mechanics: mechanics.join(", ") });
+  return (
+    <span
+      className={`${VARIANT_CLASSES[variant]} bg-amber-500 font-bold text-black`}
+      title={label}
+      aria-label={label}
+      data-testid="unimplemented-mechanics-badge"
+    >
+      !
+    </span>
+  );
+}

--- a/client/src/components/card/__tests__/UnimplementedMechanicsBadge.test.tsx
+++ b/client/src/components/card/__tests__/UnimplementedMechanicsBadge.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { UnimplementedMechanicsBadge } from "../UnimplementedMechanicsBadge.tsx";
+
+const BADGE = "unimplemented-mechanics-badge";
+
+describe("UnimplementedMechanicsBadge", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // The badge owns the emptiness guard so no call site has to repeat it — that
+  // duplicated `mechanics.length > 0` check across surfaces is what issue #4711
+  // exists to remove. Both "no field" and "empty array" must stay silent: the
+  // engine omits the projection entirely for fully-supported cards, and serde
+  // can also round-trip it as `[]`.
+  it("renders nothing when the engine reports no unimplemented mechanics", () => {
+    render(<UnimplementedMechanicsBadge />);
+    expect(screen.queryByTestId(BADGE)).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for an empty mechanics list", () => {
+    render(<UnimplementedMechanicsBadge mechanics={[]} />);
+    expect(screen.queryByTestId(BADGE)).not.toBeInTheDocument();
+  });
+
+  it("renders the warning when at least one mechanic is unimplemented", () => {
+    render(<UnimplementedMechanicsBadge mechanics={["cascade"]} />);
+    expect(screen.getByTestId(BADGE)).toBeInTheDocument();
+  });
+
+  it("names every unimplemented mechanic in its accessible label, comma-joined", () => {
+    // The label is the only place the mechanic names are legible — the glyph is
+    // a bare "!", so a screen-reader user and a hover user get the detail here
+    // or not at all.
+    render(<UnimplementedMechanicsBadge mechanics={["cascade", "storm"]} />);
+    const badge = screen.getByTestId(BADGE);
+    expect(badge).toHaveAttribute("title", "Unimplemented: cascade, storm");
+    expect(badge).toHaveAccessibleName("Unimplemented: cascade, storm");
+  });
+
+  it("keeps the amber warning identity in both variants, changing only placement", () => {
+    // Shared identity is the point of extracting the component: a stack entry
+    // and a hand card must read as the SAME warning, differing only in where it
+    // is pinned. `corner` hangs outside the border; `overlay` sits inside the art.
+    const { rerender } = render(
+      <UnimplementedMechanicsBadge mechanics={["cascade"]} variant="overlay" />,
+    );
+    const overlay = screen.getByTestId(BADGE).className;
+    expect(overlay).toContain("bg-amber-500");
+    expect(overlay).toContain("top-0.5");
+
+    rerender(<UnimplementedMechanicsBadge mechanics={["cascade"]} variant="corner" />);
+    const corner = screen.getByTestId(BADGE).className;
+    expect(corner).toContain("bg-amber-500");
+    expect(corner).toContain("-bottom-2");
+    expect(corner).toContain("-right-2");
+  });
+
+  it("defaults to the overlay variant so existing card surfaces are unchanged", () => {
+    render(<UnimplementedMechanicsBadge mechanics={["cascade"]} />);
+    expect(screen.getByTestId(BADGE).className).toContain("top-0.5");
+  });
+});

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 
 import { CardArtFallback } from "../card/CardArtFallback.tsx";
+import { UnimplementedMechanicsBadge } from "../card/UnimplementedMechanicsBadge.tsx";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useLongPress } from "../../hooks/useLongPress.ts";
@@ -251,6 +252,12 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
           <ManaCostPips cost={displayManaCost} size="xs" className="absolute right-[5%] top-[2.5%]" />
         )}
       </div>
+
+      {/* Badge: unimplemented-mechanics warning (issue #4711). Hand and
+          battlefield cards already surface this through CardImage; a spell is
+          most consequential while it is on the stack about to resolve, so the
+          same badge is shown here from the same engine-provided projection. */}
+      <UnimplementedMechanicsBadge mechanics={sourceObj?.unimplemented_mechanics} variant="corner" />
 
       {/* Badge: ×N coalesce count for engine-grouped mass triggers. */}
       {groupCount > 1 && (

--- a/client/src/components/stack/__tests__/StackEntry.test.tsx
+++ b/client/src/components/stack/__tests__/StackEntry.test.tsx
@@ -309,4 +309,63 @@ describe("StackEntry", () => {
     );
     expect(screen.queryByRole("region", { name: "Selected modes" })).not.toBeInTheDocument();
   });
+
+  // Issue #4711: the warning already shows on hand and battlefield cards via
+  // CardImage; a spell matters most while it is on the stack about to resolve,
+  // and that was the one surface that skipped it.
+  it("surfaces the unimplemented-mechanics warning for a spell on the stack", () => {
+    const entry: StackEntryType = buildStackEntry({
+      id: 77,
+      source_id: 50,
+      controller: 0,
+      kind: { type: "Spell", data: { card_id: 9, actual_mana_spent: 0 } },
+    });
+    const gameState = createGameState({
+      objects: buildObjectMap(
+        buildGameObject({
+          id: 50,
+          card_id: 9,
+          name: "Bloodghast",
+          zone: "Stack",
+          unimplemented_mechanics: ["cascade"],
+        }),
+      ),
+      stack: [entry],
+    });
+
+    act(() => {
+      useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+    });
+
+    render(<StackEntry entry={entry} index={0} isTop cardSize={{ width: 120, height: 168 }} />);
+
+    const badge = screen.getByTestId("unimplemented-mechanics-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "Unimplemented: cascade");
+  });
+
+  it("shows no warning for a fully-supported spell on the stack", () => {
+    // Discriminating guard: without it the test above would still pass if the
+    // badge were rendered unconditionally for every stack entry.
+    const entry: StackEntryType = buildStackEntry({
+      id: 78,
+      source_id: 51,
+      controller: 0,
+      kind: { type: "Spell", data: { card_id: 9, actual_mana_spent: 0 } },
+    });
+    const gameState = createGameState({
+      objects: buildObjectMap(
+        buildGameObject({ id: 51, card_id: 9, name: "Grizzly Bears", zone: "Stack" }),
+      ),
+      stack: [entry],
+    });
+
+    act(() => {
+      useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+    });
+
+    render(<StackEntry entry={entry} index={0} isTop cardSize={{ width: 120, height: 168 }} />);
+
+    expect(screen.queryByTestId("unimplemented-mechanics-badge")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

Hand cards and battlefield permanents already show the amber `!` when the engine reports `unimplemented_mechanics`. Stack entries skipped it — and that is the surface where it matters most, since a spell on the stack is about to resolve and is the last moment a player can respond to it.

Extracts the badge out of `CardImage` into a shared `UnimplementedMechanicsBadge` and renders it on both surfaces, so the two cannot drift apart.

Closes #4711

## Screenshot

Both entries are the real `StackEntry` component. Left: a spell whose printed abilities include unimplemented mechanics (`cascade`, `storm`) — amber `!` at bottom-right. Right: a fully-supported spell — no badge.

![unimplemented-mechanics badge on stack spells](https://raw.githubusercontent.com/minion1227/phase/assets/pr-4711-screenshot/badge_4711.png)

Rendered in headless Chrome against a real `gameStore` state. Disclosure: the harness stubs `@wasm/engine`, because building the WASM bundle needs `wasm-pack`, which I could not install in a network-restricted sandbox. That is why the **card art is blank** — every other element (badge, yield pill, "Next", borders, layout) is the genuine component output. Happy to redo this as a live in-game capture if you want one; I just can't produce it from here.

## The screenshot caught a real placement bug

Worth recording, because it justifies the screenshot requirement. My first pass put the badge **bottom-left**, having checked that top-left (coalesce `×N`, chosen `X=`) and top-right (`Casting…` / `Next`) were occupied. Rendering it showed the badge **overlapping the auto-pass yield pill**, which also lives bottom-left.

Bottom-right is the stack entry's only genuinely free corner. No DOM assertion would have caught the overlap — both elements render, both are in the document, and both pass every query. Only pixels show it.

## Fix

- **New** `client/src/components/card/UnimplementedMechanicsBadge.tsx`.
  - Owns the emptiness guard: renders `null` for an absent field *or* an empty array, so no call site repeats `mechanics.length > 0`. That duplicated guard across surfaces is what this issue exists to remove.
  - Takes a typed `variant` (`"overlay"` inside card art, `"corner"` hung off a stack entry) rather than a raw `className`, so placement is a closed set rather than stringly-typed styling.
- `CardImage.tsx` — inline span replaced by the component; visual output unchanged (`overlay` is the default variant and reproduces the previous classes).
- `StackEntry.tsx` — renders the badge from `sourceObj?.unimplemented_mechanics`.

Display-only, as scoped in the issue. `unimplemented_mechanics` is an engine-computed projection forwarded verbatim; nothing here derives, filters, or re-interprets it, and there are no engine changes.

## Anchored on

`CardArtFallback` in the same directory — the component I extracted from `CardImage` in #6214 for the same reason (one shared surface instead of per-caller copies). This follows its conventions deliberately: exported props interface, doc comments on the props, and a named `variant` union for render scale rather than passing classes down.

## Test plan

`client/src/components/card/__tests__/UnimplementedMechanicsBadge.test.tsx` — building-block coverage across the component's whole input range, not a single call site:

- renders nothing when the field is absent, and nothing for an empty list (the engine omits the projection for supported cards, but serde can also round-trip `[]`)
- renders when at least one mechanic is unimplemented
- names every mechanic in `title` and the accessible name, comma-joined — the glyph is a bare `!`, so that label is the only place the detail is legible
- keeps the amber identity across both variants, changing only placement
- defaults to `overlay`, pinning that existing card surfaces are unchanged

`client/src/components/stack/__tests__/StackEntry.test.tsx` — two paired cases: a partially-supported spell shows the warning; a fully-supported one does not. The second is the discriminating guard — without it the first would still pass if the badge rendered unconditionally.

Verified locally: **2116 tests pass** (245 files, full client suite), `tsc -b --noEmit` exit 0, `eslint` exit 0 on all five changed files.

## Credit

#4712 by @jsdevninja proposed this same extraction and was closed for inactivity after the screenshot request went unanswered. I arrived at the same shape independently from the issue text; the placement fix, typed `variant`, building-block tests, and screenshot are new here.

## AI-contributor disclosure

Authored with an LLM (Claude). Frontend-only; no engine, parser, or rules logic is touched, so no CR annotations apply. The badge consumes an existing engine projection and adds no derived state to the client, per the display-layer rule in CLAUDE.md.

Unlike my previous frontend PRs (#6214, #6215), I was able to run the frontend suite, type-check, and lint locally this time, so those results are measured rather than deferred to CI. Happy to rework anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
