### PR TITLE
perf(engine): gate spell-keyword static scans and thread cast probe through variant checks

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1595,28 +1595,31 @@ fn granted_spell_keywords_for(
     let mut keywords = Vec::new();
     // CR 702.26b + CR 604.1: Functioning gate owned by
     // `battlefield_active_statics`; inline `def.condition` check removed.
-    for (source_obj, def) in super::functioning_abilities::game_active_statics(state) {
-        let StaticMode::CastWithKeyword { keyword } = &def.mode else {
-            continue;
-        };
+    if static_kind_present(state, StaticModeKind::CastWithKeyword) {
+        crate::game::perf_counters::record_spell_keyword_grant_scan();
+        for (source_obj, def) in super::functioning_abilities::game_active_statics(state) {
+            let StaticMode::CastWithKeyword { keyword } = &def.mode else {
+                continue;
+            };
 
-        let matches = def.affected.as_ref().is_none_or(|filter| {
-            super::filter::spell_object_matches_filter_from_state_for(
-                state,
-                spell_obj,
-                origin_zone,
-                caster,
-                filter,
-                source_obj.id,
-                &state.all_creature_types,
-                fused,
-            )
-        });
-        if !matches {
-            continue;
+            let matches = def.affected.as_ref().is_none_or(|filter| {
+                super::filter::spell_object_matches_filter_from_state_for(
+                    state,
+                    spell_obj,
+                    origin_zone,
+                    caster,
+                    filter,
+                    source_obj.id,
+                    &state.all_creature_types,
+                    fused,
+                )
+            });
+            if !matches {
+                continue;
+            }
+
+            merge_spell_keyword(&mut keywords, keyword.clone(), false);
         }
-
-        merge_spell_keyword(&mut keywords, keyword.clone(), false);
     }
 
     // CR 611.2c: Player-scoped flash-timing grants applied by activated/triggered
@@ -4591,6 +4594,7 @@ fn casting_variant_choice_set(
     state: &GameState,
     player: PlayerId,
     object_id: ObjectId,
+    probe: Option<&PriorityCastProbe>,
 ) -> CastingVariantChoiceSet {
     let mut candidates = casting_variant_candidates(state, player, object_id);
     candidates.dedup();
@@ -4603,7 +4607,7 @@ fn casting_variant_choice_set(
         else {
             continue;
         };
-        if !can_cast_prepared_now(state, player, &prepared) {
+        if !can_cast_prepared_now_with_probe(state, player, &prepared, probe) {
             continue;
         }
         options.push(CastingVariantChoiceOption {
@@ -9226,7 +9230,7 @@ pub fn handle_casting_variant_choice_with_payment_mode(
     let option = options
         .get(index)
         .ok_or_else(|| EngineError::InvalidAction("Invalid cast variant choice".to_string()))?;
-    let fresh_options = casting_variant_choice_set(state, player, object_id).options;
+    let fresh_options = casting_variant_choice_set(state, player, object_id, None).options;
     if !fresh_options
         .iter()
         .any(|fresh| fresh.variant == option.variant)
@@ -10048,7 +10052,7 @@ pub fn handle_cast_spell_with_payment_mode(
         }
     }
 
-    let variant_choices = casting_variant_choice_set(state, player, object_id);
+    let variant_choices = casting_variant_choice_set(state, player, object_id, None);
     if variant_choices.options.len() > 1 {
         return Ok(WaitingFor::CastingVariantChoice {
             player,
@@ -12128,7 +12132,7 @@ fn legal_target_slots_for_castable_spell_in_flushed_state(
 
     // CR 601.2b: Alternative/additional cost choices are announced before
     // targets, so casts with multiple viable variants are target-ambiguous.
-    let choices = casting_variant_choice_set(state, player, object_id);
+    let choices = casting_variant_choice_set(state, player, object_id, None);
     if choices.options.len() > 1 {
         return Ok(Vec::new());
     }
@@ -12593,11 +12597,11 @@ pub fn can_cast_object_now_with_probe(
         {
             return true;
         }
-        let choices = casting_variant_choice_set(state, player, object_id);
+        let choices = casting_variant_choice_set(state, player, object_id, probe);
         return !choices.options.is_empty();
     };
     can_cast_prepared_now_with_probe(state, player, &prepared, probe)
-        || !casting_variant_choice_set(state, player, object_id)
+        || !casting_variant_choice_set(state, player, object_id, probe)
             .options
             .is_empty()
 }
@@ -12674,14 +12678,6 @@ fn can_feasibly_pay_harmonize_mana_cost_with_probe(
                 None,
             )
         })
-}
-
-fn can_cast_prepared_now(
-    state: &GameState,
-    player: PlayerId,
-    prepared: &PreparedSpellCast,
-) -> bool {
-    can_cast_prepared_now_with_probe(state, player, prepared, None)
 }
 
 fn can_cast_prepared_now_with_probe(

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -1866,7 +1866,7 @@ fn fused_split_spell_blocked_by_combined_mana_value_per_turn_limit_enumeration()
     // Sanity: marker must NOT be set — this exercises the pre-payment path.
     assert!(!sc.state.objects.get(&breaking).unwrap().fused_split_spell);
 
-    let set = casting_variant_choice_set(&sc.state, P0, breaking);
+    let set = casting_variant_choice_set(&sc.state, P0, breaking, None);
     assert!(
         !fuse_option_offered(&set),
         "a fused Breaking // Entering (combined MV 8) must be BLOCKED by a \
@@ -1896,7 +1896,7 @@ fn fused_split_spell_blocked_by_combined_mana_value_per_turn_limit_enumeration()
             spell_filter: Some(cmc_ge(9)),
         }),
     );
-    let set9 = casting_variant_choice_set(&sc9.state, P0, breaking9);
+    let set9 = casting_variant_choice_set(&sc9.state, P0, breaking9, None);
     assert!(
         fuse_option_offered(&set9),
         "under Cmc >= 9 the fused cast (combined MV 8 < 9) is NOT blocked and must be \
@@ -1943,7 +1943,7 @@ fn non_fuse_alt_cost_candidate_uses_front_half_not_combined() {
             .affected(filter),
         );
         assert!(!sc.state.objects.get(&breaking).unwrap().fused_split_spell);
-        casting_variant_choice_set(&sc.state, P0, breaking)
+        casting_variant_choice_set(&sc.state, P0, breaking, None)
             .options
             .iter()
             .any(|o| o.variant == CastingVariant::Dash)
@@ -1999,7 +1999,7 @@ fn fused_split_spell_assist_offer_uses_combined_projection() {
         // Marker must NOT be set — this exercises the pre-payment path.
         assert!(!sc.state.objects.get(&breaking).unwrap().fused_split_spell);
 
-        let set = casting_variant_choice_set(&sc.state, P0, breaking);
+        let set = casting_variant_choice_set(&sc.state, P0, breaking, None);
         let options: Vec<CastingVariantChoiceOption> = set.options.clone();
         let fuse_index = options
             .iter()
@@ -2102,7 +2102,7 @@ fn fused_split_spell_granted_flash_timing_uses_combined_projection() {
         // Marker must NOT be set — this exercises the pre-payment path.
         assert!(!sc.state.objects.get(&breaking).unwrap().fused_split_spell);
 
-        fuse_option_offered(&casting_variant_choice_set(&sc.state, P0, breaking))
+        fuse_option_offered(&casting_variant_choice_set(&sc.state, P0, breaking, None))
     };
 
     assert!(
@@ -14825,7 +14825,7 @@ fn ashling_granted_evoke_offered_and_installs_etb_sac() {
         can_cast_object_now(&state, PlayerId(0), spell),
         "granted evoke {{4}} affordable ⇒ spell must be castable via the gate"
     );
-    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
     assert!(
         choices
             .options
@@ -14923,7 +14923,7 @@ fn blitz_creature_offers_blitz_variant() {
         can_cast_object_now(&state, PlayerId(0), spell),
         "a blitz creature with affordable cost must be castable"
     );
-    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
     assert!(
         choices
             .options
@@ -14995,7 +14995,7 @@ fn granted_blitz_offers_blitz_variant() {
         "recipient must have no printed Blitz — the option must come from the grant"
     );
 
-    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
     assert!(
         choices
             .options
@@ -15066,7 +15066,7 @@ fn granted_blitz_self_mana_cost_surfaces_self_referential_cost() {
         obj.base_mana_cost = spell_cost.clone();
     }
 
-    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
     let blitz = choices
         .options
         .iter()
@@ -15728,7 +15728,7 @@ fn overload_castable_with_no_legal_printed_target() {
     );
 
     // (2) The choice set surfaces the Overload variant.
-    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
     assert!(
         choices
             .options
@@ -15784,7 +15784,7 @@ fn dash_creature_offers_dash_variant() {
         can_cast_object_now(&state, PlayerId(0), spell),
         "a dash creature with affordable cost must be castable"
     );
-    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
     assert!(
         choices
             .options
@@ -15959,7 +15959,7 @@ fn spectacle_offered_only_when_opponent_lost_life() {
     }
 
     // No opponent has lost life this turn ⇒ Spectacle is not offered.
-    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
     assert!(
         !choices
             .options
@@ -15971,7 +15971,7 @@ fn spectacle_offered_only_when_opponent_lost_life() {
 
     // An opponent loses life this turn ⇒ Spectacle becomes available.
     state.players[1].life_lost_this_turn = 2;
-    let choices = casting_variant_choice_set(&state, PlayerId(0), spell);
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
     assert!(
         choices
             .options
@@ -19068,6 +19068,76 @@ fn priority_activation_candidates_share_activation_restriction_static_gate() {
     assert_eq!(
         snapshot.restriction_static_exact_scans, 0,
         "absent ModifyActivationLimit statics must not fall through to exact static scans per candidate"
+    );
+}
+
+#[test]
+fn priority_spell_candidates_without_keyword_grants_skip_static_scans() {
+    let mut state = setup_game_at_main_phase();
+    let spells = [
+        create_generic_creature_in_hand(&mut state, 7_317, PlayerId(0), "Vanilla Spell A", 0),
+        create_generic_creature_in_hand(&mut state, 7_318, PlayerId(0), "Vanilla Spell B", 0),
+        create_generic_creature_in_hand(&mut state, 7_319, PlayerId(0), "Vanilla Spell C", 0),
+    ];
+
+    crate::game::perf_counters::reset();
+    let (actions, _, _) = crate::ai_support::legal_actions_full(&state);
+
+    for spell in spells {
+        assert!(
+            actions.iter().any(|action| matches!(
+                action,
+                GameAction::CastSpell { object_id, .. } if *object_id == spell
+            )),
+            "every castable hand spell must reach production candidate enumeration"
+        );
+    }
+    assert_eq!(
+        crate::game::perf_counters::snapshot().spell_keyword_grant_scans,
+        0,
+        "production spell candidate enumeration must skip CastWithKeyword static scans when none exist"
+    );
+}
+
+#[test]
+fn priority_spell_candidates_scan_and_merge_present_keyword_grants() {
+    let mut state = setup_game_at_main_phase();
+    let spell = create_generic_creature_in_hand(&mut state, 7_320, PlayerId(0), "Vanilla Spell", 0);
+    let grantor = create_object(
+        &mut state,
+        CardId(7_321),
+        PlayerId(0),
+        "Keyword Grantor".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&grantor)
+        .unwrap()
+        .static_definitions
+        .push(StaticDefinition::new(StaticMode::CastWithKeyword {
+            keyword: Keyword::Flash,
+        }));
+
+    crate::game::perf_counters::reset();
+    let (actions, _, _) = crate::ai_support::legal_actions_full(&state);
+
+    assert!(
+        actions.iter().any(|action| matches!(
+            action,
+            GameAction::CastSpell { object_id, .. } if *object_id == spell
+        )),
+        "the granted-keyword spell must remain a production cast candidate"
+    );
+    assert!(
+        crate::game::perf_counters::snapshot().spell_keyword_grant_scans > 0,
+        "present CastWithKeyword statics must fall through to the exact grant scan"
+    );
+    assert!(
+        effective_spell_keywords(&state, PlayerId(0), spell)
+            .iter()
+            .any(|keyword| matches!(keyword, Keyword::Flash)),
+        "the exact scan must still merge the granted keyword"
     );
 }
 
@@ -35258,7 +35328,7 @@ mod alt_cost_reduction_509 {
 
         // The Evoke hand candidate is the only non-Normal variant, so the
         // choice set carries exactly one option and is not flagged multiple.
-        let choices = casting_variant_choice_set(&state, PlayerId(0), obj);
+        let choices = casting_variant_choice_set(&state, PlayerId(0), obj, None);
         assert!(
             choices
                 .options

--- a/crates/engine/src/game/perf_counters.rs
+++ b/crates/engine/src/game/perf_counters.rs
@@ -4,6 +4,7 @@ use std::cell::Cell;
 pub struct PerfCounterSnapshot {
     pub state_clone_for_legality: u64,
     pub static_full_scans: u64,
+    pub spell_keyword_grant_scans: u64,
     pub layers_full_eval: u64,
     pub layers_incremental: u64,
     pub layers_escalated: u64,
@@ -47,6 +48,7 @@ thread_local! {
     static COUNTERS: Cell<PerfCounterSnapshot> = const { Cell::new(PerfCounterSnapshot {
         state_clone_for_legality: 0,
         static_full_scans: 0,
+        spell_keyword_grant_scans: 0,
         layers_full_eval: 0,
         layers_incremental: 0,
         layers_escalated: 0,
@@ -100,6 +102,13 @@ pub fn record_state_clone_for_legality() {
 /// counter stays at 0 across an entire target enumeration.
 pub fn record_static_full_scan() {
     with_mut(|s| s.static_full_scans += 1);
+}
+
+/// Counts full `game_active_statics` scans for `CastWithKeyword` spell grants.
+/// The O(1) `static_kind_present(CastWithKeyword)` gate should keep this at zero
+/// during candidate generation when no functioning spell-keyword grant exists.
+pub fn record_spell_keyword_grant_scan() {
+    with_mut(|s| s.spell_keyword_grant_scans += 1);
 }
 
 /// Counts every full-body execution of `blocker_can_block_shadow` (each a

--- a/crates/phase-ai/src/duel_suite/perf.rs
+++ b/crates/phase-ai/src/duel_suite/perf.rs
@@ -144,6 +144,7 @@ impl PerfCounters {
         let PerfCounterSnapshot {
             state_clone_for_legality,
             static_full_scans,
+            spell_keyword_grant_scans,
             layers_full_eval,
             layers_incremental,
             layers_escalated,
@@ -178,6 +179,10 @@ impl PerfCounters {
             state_clone_for_legality,
         );
         map.insert("static_full_scans".to_string(), static_full_scans);
+        map.insert(
+            "spell_keyword_grant_scans".to_string(),
+            spell_keyword_grant_scans,
+        );
         map.insert("layers_full_eval".to_string(), layers_full_eval);
         map.insert("layers_incremental".to_string(), layers_incremental);
         map.insert("layers_escalated".to_string(), layers_escalated);
@@ -892,6 +897,7 @@ mod tests {
         let snapshot = PerfCounterSnapshot {
             state_clone_for_legality: 1,
             static_full_scans: 2,
+            spell_keyword_grant_scans: 29,
             layers_full_eval: 3,
             layers_incremental: 4,
             layers_escalated: 5,


### PR DESCRIPTION
AI search on equipment-heavy boards livelocked in candidate generation:
can_cast_object_now_with_probe dominated hung-run samples (2090/4257),
split between granted_spell_keywords_for iterating game_active_statics
per hand card per search node, and casting_variant_choice_set re-running
un-probed affordability (fresh auto-tap source discovery) for every
unaffordable card at every node.

Two byte-identical changes:
- Gate the game_active_statics loop in granted_spell_keywords_for behind
  static_kind_present(state, StaticModeKind::CastWithKeyword) — O(1)
  presence query, precise post-flush (same discipline as the existing
  casting.rs caller); loop provably yields nothing when absent.
- Thread probe: Option<&PriorityCastProbe> through
  casting_variant_choice_set so its can_cast_prepared_now recheck reuses
  the probe's cached flushed state + AutoTapSourceCache; all non-probe
  callers pass None (unchanged behavior).

Instrumentation: perf counter spell_keyword_grant_scans + revert-failing
tests driving production legal_actions_full (counter==0 without any
CastWithKeyword static; counter>0 with one present and keyword still
granted).

Evidence (ai-gate Medium, seed 10573729, 100 games/row, A/B at
65f0a3ac8a+fix1): equipment-mirror previously never finished (hung in
B0 and B1); now completes 100 games in 77min (46.4s/game, 43-57-0,
avg 21.7 turns). Controls lands/affinity/elves and niv-mirror all
byte-identical (.results deep-equal except duration fields);
niv-mirror 18058 -> 17393 ms/game.
