### PR TITLE
feat(engine): offer free-vs-printed casting choice under Omniscience

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -570,9 +570,13 @@ export type CastingVariant =
   | { type: "Foretell" }
   | { type: "Overload" }
   | { type: "Bestow" }
+  | { type: "Mutate" }
   | { type: "Awaken" }
   | { type: "Cleave" }
+  | { type: "Impending" }
   | { type: "MoreThanMeetsTheEye" }
+  | { type: "Prototype" }
+  | { type: "FaceDown" }
   | { type: "Freerunning" }
   | { type: "Fuse" };
 

--- a/client/src/components/modal/CastingVariantModal.tsx
+++ b/client/src/components/modal/CastingVariantModal.tsx
@@ -35,6 +35,13 @@ const VARIANT_KEYS: Partial<Record<CastingVariant["type"], string>> = {
   Foretell: "variantForetell",
   Overload: "variantOverload",
   Bestow: "variantBestow",
+  Mutate: "variantMutate",
+  Awaken: "variantAwaken",
+  Cleave: "variantCleave",
+  Impending: "variantImpending",
+  MoreThanMeetsTheEye: "variantMoreThanMeetsTheEye",
+  Prototype: "variantPrototype",
+  FaceDown: "variantFaceDown",
   Freerunning: "variantFreerunning",
   Fuse: "variantFuse",
 };

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1765,6 +1765,13 @@
     "variantBestow": "Mit Verleihen wirken",
     "variantFreerunning": "Mit Freerunning wirken",
     "variantFuse": "Mit Verschmelzen wirken",
+    "variantMutate": "Mit Mutate wirken",
+    "variantAwaken": "Mit Erwecken wirken",
+    "variantCleave": "Mit Abspalten wirken",
+    "variantImpending": "Mit Drohend wirken",
+    "variantMoreThanMeetsTheEye": "Cast Converted",
+    "variantPrototype": "Mit Prototyp wirken",
+    "variantFaceDown": "Verdeckt wirken",
     "variantFallback": "Mit {{type}} wirken"
   },
   "categoryChoice": {

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1802,6 +1802,13 @@
     "variantBestow": "Cast with Bestow",
     "variantFreerunning": "Cast with Freerunning",
     "variantFuse": "Cast with Fuse",
+    "variantMutate": "Cast with Mutate",
+    "variantAwaken": "Cast with Awaken",
+    "variantCleave": "Cast with Cleave",
+    "variantImpending": "Cast with Impending",
+    "variantMoreThanMeetsTheEye": "Cast Converted",
+    "variantPrototype": "Cast with Prototype",
+    "variantFaceDown": "Cast Face Down",
     "variantFallback": "Cast with {{type}}"
   },
   "categoryChoice": {

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1765,6 +1765,13 @@
     "variantBestow": "Lanzar con Otorgar",
     "variantFreerunning": "Lanzar con Freerunning",
     "variantFuse": "Lanzar con Fusión",
+    "variantMutate": "Lanzar con Mutate",
+    "variantAwaken": "Lanzar con Despertar",
+    "variantCleave": "Lanzar con Recortar",
+    "variantImpending": "Lanzar con Inminencia",
+    "variantMoreThanMeetsTheEye": "Cast Converted",
+    "variantPrototype": "Lanzar con Prototipo",
+    "variantFaceDown": "Lanzar boca abajo",
     "variantFallback": "Lanzar con {{type}}"
   },
   "categoryChoice": {

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1765,6 +1765,13 @@
     "variantBestow": "Lancer avec Don",
     "variantFreerunning": "Lancer avec Freerunning",
     "variantFuse": "Lancer avec Fusion",
+    "variantMutate": "Lancer avec Mutate",
+    "variantAwaken": "Lancer avec Éveil",
+    "variantCleave": "Lancer avec Tranchage",
+    "variantImpending": "Lancer avec Imminence",
+    "variantMoreThanMeetsTheEye": "Cast Converted",
+    "variantPrototype": "Lancer avec Prototype",
+    "variantFaceDown": "Lancer face cachée",
     "variantFallback": "Lancer avec {{type}}"
   },
   "categoryChoice": {

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1765,6 +1765,13 @@
     "variantBestow": "Lancia con Conferire",
     "variantFreerunning": "Lancia con Freerunning",
     "variantFuse": "Lancia con Fusione",
+    "variantMutate": "Lancia con Mutate",
+    "variantAwaken": "Lancia con Risveglio",
+    "variantCleave": "Lancia con Fendere",
+    "variantImpending": "Lancia con Incombere",
+    "variantMoreThanMeetsTheEye": "Cast Converted",
+    "variantPrototype": "Lancia con Prototipo",
+    "variantFaceDown": "Lancia a faccia in giù",
     "variantFallback": "Lancia con {{type}}"
   },
   "categoryChoice": {

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1765,6 +1765,13 @@
     "variantBestow": "Rzuć z Bestow",
     "variantFreerunning": "Rzuć z Freerunning",
     "variantFuse": "Rzuć z Fuse",
+    "variantMutate": "Rzuć z Mutate",
+    "variantAwaken": "Rzuć z Awaken",
+    "variantCleave": "Rzuć z Cleave",
+    "variantImpending": "Rzuć z Impending",
+    "variantMoreThanMeetsTheEye": "Cast Converted",
+    "variantPrototype": "Rzuć z Prototype",
+    "variantFaceDown": "Rzuć zakrytą",
     "variantFallback": "Rzuć z {{type}}"
   },
   "categoryChoice": {

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1765,6 +1765,13 @@
     "variantBestow": "Conjurar com Conceder",
     "variantFreerunning": "Conjurar com Freerunning",
     "variantFuse": "Conjurar com Fusão",
+    "variantMutate": "Conjurar com Mutate",
+    "variantAwaken": "Conjurar com Despertar",
+    "variantCleave": "Conjurar com Remover",
+    "variantImpending": "Conjurar com Iminente",
+    "variantMoreThanMeetsTheEye": "Cast Converted",
+    "variantPrototype": "Conjurar com Protótipo",
+    "variantFaceDown": "Conjurar Virada para Baixo",
     "variantFallback": "Conjurar com {{type}}"
   },
   "categoryChoice": {

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -4894,6 +4894,134 @@ mod tests {
         );
     }
 
+    /// CR 118.9a + decision D1: the frontend's `spellCosts` map (from
+    /// `legal_actions_full`) must report a hand spell as `NoCost` while Omniscience
+    /// is on the battlefield, so the UI can overlay a {0} pip. The cost overlay is
+    /// the CHEAPEST-legal-cast floor (Display mode), independent of whether the
+    /// printed cost is affordable — the free-vs-printed election lives in the
+    /// `CastingVariantChoice` menu at cast time, not in the overlay. This test pins
+    /// both the zero-mana case and (as the discriminating extension) the ample-mana
+    /// case, so the Display-mode floor cannot silently regress to the printed cost
+    /// once a real cast becomes affordable.
+    #[test]
+    fn spell_costs_report_nocost_for_hand_spell_under_omniscience() {
+        use crate::types::ability::{AbilityKind, Effect, TargetFilter};
+        use crate::types::mana::ManaCostShard;
+        use crate::types::statics::{CastFreeOrigin, CastFrequency, StaticMode};
+        use crate::types::StaticDefinition;
+
+        let mut state = setup_priority();
+
+        let omniscience_id = create_object(
+            &mut state,
+            CardId(4200),
+            PlayerId(0),
+            "Omniscience".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&omniscience_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Enchantment);
+            let def = StaticDefinition {
+                mode: StaticMode::CastFromHandFree {
+                    frequency: CastFrequency::Unlimited,
+                    origin: CastFreeOrigin::Hand,
+                },
+                affected: Some(TargetFilter::Any),
+                modifications: vec![],
+                condition: None,
+                per_player_condition: None,
+                affected_zone: None,
+                effect_zone: None,
+                active_zones: vec![],
+                characteristic_defining: false,
+                description: Some(
+                    "You may cast spells from your hand without paying their mana costs."
+                        .to_string(),
+                ),
+                attack_defended: None,
+                source_controller: None,
+                source_object: None,
+                bypass_beneficiary: None,
+            };
+            obj.static_definitions = vec![def].into();
+        }
+
+        // A 7UUU spell in hand — the exact class the display overlay should zero.
+        let spell_id = create_object(
+            &mut state,
+            CardId(4201),
+            PlayerId(0),
+            "Test Spell".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Sorcery);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![
+                    ManaCostShard::Blue,
+                    ManaCostShard::Blue,
+                    ManaCostShard::Blue,
+                ],
+                generic: 7,
+            };
+            Arc::make_mut(&mut obj.abilities).push(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::unimplemented("Test Spell", "test spell"),
+            ));
+        }
+
+        let (_actions, spell_costs, _grouped) = legal_actions_full(&state);
+        let displayed = spell_costs
+            .get(&spell_id)
+            .expect("spell_costs must surface the Omniscience free-cast hand spell");
+        assert!(
+            matches!(displayed, ManaCost::NoCost),
+            "Omniscience must display the hand spell as NoCost, got {displayed:?}"
+        );
+
+        // Discriminating extension (decision D1): give the caster ample mana to
+        // afford the printed {7}{U}{U}{U}. The Display-mode overlay must STILL floor
+        // to NoCost — the affordable printed cost is only surfaced as a menu option
+        // at cast time, never in the overlay. Under the Actual-mode election logic
+        // this same board would offer {Normal(printed), HandPermission({0})}; the
+        // overlay deliberately does not.
+        for _ in 0..7 {
+            state.players[0].mana_pool.add(ManaUnit {
+                color: ManaType::Colorless,
+                source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
+                supertype: None,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: Vec::new(),
+                grants: vec![],
+                expiry: None,
+            });
+        }
+        for _ in 0..3 {
+            state.players[0].mana_pool.add(ManaUnit {
+                color: ManaType::Blue,
+                source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
+                supertype: None,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: Vec::new(),
+                grants: vec![],
+                expiry: None,
+            });
+        }
+        let (_actions, spell_costs, _grouped) = legal_actions_full(&state);
+        let displayed = spell_costs
+            .get(&spell_id)
+            .expect("spell_costs must surface the Omniscience free-cast hand spell");
+        assert!(
+            matches!(displayed, ManaCost::NoCost),
+            "Omniscience overlay must stay NoCost even when the printed cost is \
+             affordable (Display-mode floor), got {displayed:?}"
+        );
+    }
+
     /// Issue #1542: Emergence Zone must expose TapLandForMana alongside its
     /// sacrifice-for-flash activated ability.
     #[test]

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -4356,6 +4356,11 @@ fn cast_free_permission_from_source(
     })
 }
 
+/// First-match (any-frequency) `CastFromHandFree` source lookup. Production code
+/// uses the Unlimited-preferring `unlimited_hand_cast_free_source` (CR 601.2b
+/// order-bug fix); this raw first-match helper is retained only for the two
+/// permission-provenance tests (Tamiyo emblem / Omniscience source assertions).
+#[cfg(test)]
 pub(crate) fn hand_cast_free_permission_source(
     state: &GameState,
     player: PlayerId,
@@ -4367,9 +4372,39 @@ pub(crate) fn hand_cast_free_permission_source(
     })
 }
 
-/// CR 601.2b + CR 118.9a: `Unlimited` `CastFromHandFree` that zeroes mana cost on
-/// the normal `CastSpell` path (Omniscience from hand; Dracogenesis from hand or
-/// command-zone commanders).
+/// CR 601.2b + CR 118.9a: The `Unlimited` `CastFromHandFree` source (Omniscience,
+/// Dracogenesis, Tamiyo emblem) admitting `obj` for `player`. Unlike
+/// `hand_cast_free_permission_source` (first-match over any frequency), this scans
+/// specifically for an `Unlimited` grant, so a battlefield-earlier `OncePerTurn`
+/// source (Zaffai) cannot hide Omniscience — fixing the first-match order bug and
+/// giving the free-cast menu the correct granting `ObjectId` to latch.
+fn unlimited_hand_cast_free_source(
+    state: &GameState,
+    player: PlayerId,
+    obj: &crate::game::game_object::GameObject,
+) -> Option<ObjectId> {
+    iter_cast_free_permission_source_ids(state).find(|&src_id| {
+        cast_free_permission_from_source(state, player, obj, src_id)
+            == Some(CastFrequency::Unlimited)
+    })
+}
+
+/// CR 601.2b + CR 118.9a: Whether an `Unlimited` `CastFromHandFree` permission
+/// (Omniscience) admits this object for a non-`HandPermission` cast. This is the
+/// "a free cast is available" predicate consulted by the three NoCost-gated guard
+/// sites (the dispatch gate, `normal_cast_choice_cost_and_affordability`, and the
+/// candidate-feasibility gate). Whether the mana cost is actually ZEROED on a
+/// given prepare is decided separately at the prepare call site (see the
+/// `hand_cast_free` binding), which additionally consults `CastingMode` and the
+/// explicit `variant_override` so the menu's printed `Normal` option keeps its
+/// printed cost while the default/overlay cast floors to free.
+///
+/// The first conjunct is preserved verbatim (Revision-3 implementer note): it
+/// prevents re-firing on a prepare that is ALREADY a `HandPermission` election
+/// (the `.or()` cost chain zeroes those independently via
+/// `is_hand_permission_variant`). Rebuilt onto the Unlimited-preferring
+/// `unlimited_hand_cast_free_source` so a battlefield-earlier `OncePerTurn` source
+/// (Zaffai) can no longer hide Omniscience (order-bug fix, test 10).
 fn unlimited_hand_cast_free_applies(
     state: &GameState,
     player: PlayerId,
@@ -4377,8 +4412,7 @@ fn unlimited_hand_cast_free_applies(
     casting_variant: CastingVariant,
 ) -> bool {
     !matches!(casting_variant, CastingVariant::HandPermission { .. })
-        && hand_cast_free_permission_source(state, player, obj)
-            .is_some_and(|(_, frequency)| frequency == CastFrequency::Unlimited)
+        && unlimited_hand_cast_free_source(state, player, obj).is_some()
 }
 
 /// CR 601.2f: Whether `spell_id` matches a pending next-spell modifier's optional
@@ -4891,6 +4925,133 @@ fn casting_variant_candidates(
     if has_fuse_candidate {
         candidates.push(CastingVariant::Normal);
         candidates.push(CastingVariant::Fuse);
+    }
+
+    // CR 118.9 + CR 118.9a + CR 601.2b: When an `Unlimited` `CastFromHandFree`
+    // permission (Omniscience) admits this hand object, the casting-method
+    // election IS the existing N-way `CastingVariantChoice` prompt — free, printed,
+    // and each keyword alternative cost are one mutually-exclusive announcement
+    // (CR 118.9a), not a chain of two-slot modals. Gate every push on that
+    // permission being active: without it this block adds nothing, so every
+    // no-permission board is byte-identical to prior behavior (containment).
+    if obj.zone == Zone::Hand {
+        if let Some(source) = unlimited_hand_cast_free_source(state, player, obj) {
+            // CR 118.9: the effect-applied free alternative cost (X = 0 per
+            // CR 107.3b, resolved by the NoCost prepare — no mana spent).
+            candidates.push(CastingVariant::HandPermission {
+                source,
+                frequency: CastFrequency::Unlimited,
+            });
+            // CR 601.2b: the printed-cost path (mana announced, X electable). The
+            // prepare keeps the printed cost (not force-zeroed), and
+            // `casting_variant_choice_set` drops it via `can_cast_prepared_now` when
+            // unaffordable — implementing "auto-free when the printed cost can't be
+            // paid" by leaving `HandPermission` as the sole surviving option.
+            // Guard: the Fuse block (above) already pushed `Normal` for a fusable
+            // split card, and that push is NON-adjacent to this one (Fuse +
+            // HandPermission sit between them). `casting_variant_choice_set` dedups
+            // with consecutive-only `Vec::dedup` (no preceding sort), so pushing
+            // `Normal` again here would leave two identical "Cast Normally" options
+            // in the menu. Only offer `Normal` when the Fuse block didn't.
+            if !has_fuse_candidate {
+                candidates.push(CastingVariant::Normal);
+            }
+
+            let effective_keywords = effective_spell_keywords(state, player, object_id);
+
+            // CR 702.185a: Warp (keyword presence — mirrors the Warp offer block).
+            if obj
+                .keywords
+                .iter()
+                .any(|k| matches!(k, crate::types::keywords::Keyword::Warp(_)))
+            {
+                candidates.push(CastingVariant::Warp);
+            }
+            // CR 702.103a + CR 303.4a: Bestow — offered only when the bestow keyword
+            // is present AND a legal creature target exists (parity with the Bestow
+            // offer block's `has_legal_creature_target` gate).
+            if effective_keywords
+                .iter()
+                .any(|k| matches!(k, crate::types::keywords::Keyword::Bestow(_)))
+            {
+                let creature_filter =
+                    TargetFilter::Typed(crate::types::ability::TypedFilter::creature());
+                if !targeting::find_legal_targets(state, &creature_filter, player, object_id)
+                    .is_empty()
+                {
+                    candidates.push(CastingVariant::Bestow);
+                }
+            }
+            // CR 702.140a: Mutate — keyword present AND a legal "non-Human creature
+            // you own" merge target exists (parity with the Mutate offer block).
+            if obj
+                .keywords
+                .iter()
+                .any(|k| matches!(k, crate::types::keywords::Keyword::Mutate(_)))
+                && !targeting::find_legal_targets(state, &mutate_target_filter(), player, object_id)
+                    .is_empty()
+            {
+                candidates.push(CastingVariant::Mutate);
+            }
+            // CR 702.113a + CR 702.113b: Awaken — keyword present AND a land you
+            // control exists for the awaken land target (parity with the Awaken
+            // offer block's `has_legal_land` gate).
+            if obj
+                .keywords
+                .iter()
+                .any(|k| matches!(k, crate::types::keywords::Keyword::Awaken { .. }))
+            {
+                let land_filter = TargetFilter::Typed(
+                    crate::types::ability::TypedFilter::land()
+                        .controller(crate::types::ability::ControllerRef::You),
+                );
+                if !targeting::find_legal_targets(state, &land_filter, player, object_id).is_empty()
+                {
+                    candidates.push(CastingVariant::Awaken);
+                }
+            }
+            // CR 702.148a: Cleave — keyword present AND the bracket-removed ability
+            // set was parsed (parity with the Cleave offer block's
+            // `obj.cleave_variant.is_some()` gate).
+            if obj.cleave_variant.is_some()
+                && obj
+                    .keywords
+                    .iter()
+                    .any(|k| matches!(k, crate::types::keywords::Keyword::Cleave(_)))
+            {
+                candidates.push(CastingVariant::Cleave);
+            }
+            // CR 702.176a: Impending (keyword presence).
+            if obj
+                .keywords
+                .iter()
+                .any(|k| matches!(k, crate::types::keywords::Keyword::Impending { .. }))
+            {
+                candidates.push(CastingVariant::Impending);
+            }
+            // CR 702.162a: More Than Meets the Eye (keyword presence).
+            if obj
+                .keywords
+                .iter()
+                .any(|k| matches!(k, crate::types::keywords::Keyword::MoreThanMeetsTheEye(_)))
+            {
+                candidates.push(CastingVariant::MoreThanMeetsTheEye);
+            }
+            // CR 702.160a: Prototype — offered only when the secondary
+            // characteristics are complete (parity with `prototype_form_from_object`).
+            if prototype_form_from_object(obj).is_some() {
+                candidates.push(CastingVariant::Prototype);
+            }
+            // CR 702.37c / CR 702.168b + CR 708.4: Morph / Megamorph / Disguise
+            // face-down cast — offered when an effective face-down keyword is present
+            // and the face-down cast is permitted (parity with the FaceDown offer
+            // block; the fixed {3} affordability is checked by `can_cast_prepared_now`).
+            if object_has_effective_face_down_keyword(state, object_id)
+                && face_down_cast_is_permitted(state, player, object_id)
+            {
+                candidates.push(CastingVariant::FaceDown);
+            }
+        }
     }
 
     candidates
@@ -5635,7 +5796,27 @@ fn prepare_spell_cast_with_variant_override_inner(
     // Dracogenesis); `OncePerTurn` sources (Zaffai) must be opted into
     // explicitly via a dedicated action to preserve the player's "may cast"
     // choice and make per-turn slot consumption visible at the action layer.
-    let hand_cast_free = unlimited_hand_cast_free_applies(state, player, obj, casting_variant);
+    // CR 601.2b + CR 118.9a: Decide whether THIS prepare zeroes the mana cost under
+    // an active `Unlimited` `CastFromHandFree` permission. The free cast is now an
+    // explicit `CastingVariantChoice` menu option (CR 118.9), so zeroing here is the
+    // residual auto-free path:
+    // - `Display`: the hand overlay shows the cheapest legal cast, so an active
+    //   permission always floors the displayed cost to `NoCost` (decision D1).
+    // - `Actual` with `variant_override == None`: the DEFAULT cast (probes,
+    //   `effective_spell_cost`, `can_cast_object_now`) — the cheapest legal cast is
+    //   free, so zero it (keeps affordability/AI castability correct).
+    // - `Actual` with an explicit `variant_override` (the menu's per-candidate
+    //   prepare): NOT zeroed here. The menu's `Normal` candidate keeps its printed
+    //   cost (dropped by `can_cast_prepared_now` when unaffordable — single-method
+    //   degrade, §3.5), and keyword candidates keep their alternative cost, so the
+    //   election is a real free-vs-printed-vs-keyword choice rather than a menu of
+    //   duplicate `{0}` options. An explicit `HandPermission` election is already
+    //   zeroed by `is_hand_permission_variant` below, independent of this flag.
+    let hand_cast_free = unlimited_hand_cast_free_applies(state, player, obj, casting_variant)
+        && match mode {
+            CastingMode::Display => true,
+            CastingMode::Actual => variant_override.is_none(),
+        };
 
     // CR 118.9: Energy replaces mana cost entirely when casting with ExileWithEnergyCost.
     // CR 702.34a: Non-mana flashback costs use NoCost for mana (cost is paid separately).
@@ -9153,6 +9334,78 @@ fn continue_cast_with_variant(
                 Ok(prepared) => prepared,
                 Err(err) => {
                     revert_bestow_form(state, object_id);
+                    return Err(err);
+                }
+            };
+        prepared.payment_mode = payment_mode;
+        return continue_with_prepared(state, player, prepared, events);
+    }
+
+    // CR 702.140a: Mutate marks the spell BEFORE prepare so the
+    // `continue_with_prepared` target-attachment branch requests the non-Human
+    // creature target — the generic prepare-by-variant path skips this pre-stack
+    // mutation, so an elected Mutate variant needs this dedicated arm (mirrors
+    // Bestow). Reverted on a preparation error (CR 702.140b).
+    if variant == CastingVariant::Mutate {
+        if let Some(obj) = state.objects.get_mut(&object_id) {
+            apply_mutate_form(obj);
+        }
+        let mut prepared =
+            match prepare_spell_cast_with_variant_override(state, player, object_id, Some(variant))
+            {
+                Ok(prepared) => prepared,
+                Err(err) => {
+                    revert_mutate_form(state, object_id);
+                    return Err(err);
+                }
+            };
+        prepared.payment_mode = payment_mode;
+        return continue_with_prepared(state, player, prepared, events);
+    }
+
+    // CR 702.148a-b + CR 612: Cleave swaps in the bracket-removed ability set
+    // BEFORE prepare so `combined_spell_ability_def` reads the cleaved text — a
+    // pre-stack mutation the generic path skips. Reverted on a preparation error.
+    if variant == CastingVariant::Cleave {
+        if let Some(obj) = state.objects.get_mut(&object_id) {
+            apply_cleave_text_change(obj);
+        }
+        let mut prepared =
+            match prepare_spell_cast_with_variant_override(state, player, object_id, Some(variant))
+            {
+                Ok(prepared) => prepared,
+                Err(err) => {
+                    if let Some(obj) = state.objects.get_mut(&object_id) {
+                        revert_cleave_text_change(obj);
+                    }
+                    return Err(err);
+                }
+            };
+        prepared.payment_mode = payment_mode;
+        return continue_with_prepared(state, player, prepared, events);
+    }
+
+    // CR 702.160a: Prototype applies the secondary mana cost and P/T BEFORE prepare
+    // so the announced stack spell already has prototype characteristics — a
+    // pre-stack mutation the generic path skips. Restored on a preparation error.
+    if variant == CastingVariant::Prototype {
+        if !state
+            .objects
+            .get_mut(&object_id)
+            .is_some_and(apply_prototype_form)
+        {
+            return Err(EngineError::InvalidAction(
+                "Prototype characteristics are unavailable for this object".to_string(),
+            ));
+        }
+        let mut prepared =
+            match prepare_spell_cast_with_variant_override(state, player, object_id, Some(variant))
+            {
+                Ok(prepared) => prepared,
+                Err(err) => {
+                    if let Some(obj) = state.objects.get_mut(&object_id) {
+                        clear_prototype_form(obj);
+                    }
                     return Err(err);
                 }
             };

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -2173,6 +2173,71 @@ fn non_fuse_alt_cost_candidate_enumeration_uses_front_half() {
     );
 }
 
+/// Regression: a fusable split card in hand under an ACTIVE Unlimited free-cast
+/// permission (Omniscience) must offer EXACTLY ONE `Normal` option. The Fuse
+/// block pushes `Normal` (front-half printed) and the Omniscience block also
+/// pushes `Normal`; those two pushes are NON-adjacent (Fuse + HandPermission sit
+/// between them), and `casting_variant_choice_set` dedups with consecutive-only
+/// `Vec::dedup` (no preceding sort), so before the guard both identical `Normal`
+/// options survived — a malformed "two Cast Normally buttons" menu. The
+/// `!has_fuse_candidate` guard on the Omniscience-block push suppresses the
+/// duplicate. This asserts `count() == 1` (not `>= 1`), so it fails on the
+/// unfixed code (count 2) and passes after the guard; the `HandPermission` and
+/// `Fuse` presence checks prove the guard didn't drop the free or fused options.
+#[test]
+fn fuse_split_under_unlimited_free_cast_offers_single_normal_option() {
+    use crate::game::scenario::{GameScenario, P0};
+    use crate::game::scenario_db::GameScenarioDbExt;
+
+    let db = crate::test_support::shared_card_db();
+
+    let mut sc = GameScenario::new();
+    sc.at_phase(Phase::PreCombatMain);
+    // Breaking // Entering: a real Fuse split card (front Breaking {U}{B}, back
+    // Entering Split half) — `has_fuse_candidate` fires for it.
+    let breaking = sc.add_real_card(P0, "Breaking", Zone::Hand, db);
+    // Enough mana that both the front-half Normal cast and the fused cast are
+    // affordable — so no option is dropped by `can_cast_prepared_now`; the free
+    // (NoCost) HandPermission option is always affordable.
+    fill_mana_for_fused_cast(&mut sc, P0);
+    // Install the real Omniscience static (Unlimited CastFromHandFree) via the
+    // same Oracle text the sibling omniscience menu tests use, so
+    // `unlimited_hand_cast_free_source` recognizes it identically.
+    add_static_permanent(
+        &mut sc,
+        P0,
+        parse_static_line("You may cast spells from your hand without paying their mana costs.")
+            .expect("Omniscience static should parse"),
+    );
+
+    let set = casting_variant_choice_set(&sc.state, P0, breaking, None);
+    let variants: Vec<CastingVariant> = set.options.iter().map(|o| o.variant).collect();
+
+    let normal_count = set
+        .options
+        .iter()
+        .filter(|o| o.variant == CastingVariant::Normal)
+        .count();
+    assert_eq!(
+        normal_count, 1,
+        "a fusable split card under an Unlimited free-cast permission must offer EXACTLY ONE \
+         Normal option; the non-adjacent Fuse-block + Omniscience-block Normal pushes survive \
+         consecutive-only dedup without the guard. Offered: {variants:?}"
+    );
+    assert!(
+        set.options
+            .iter()
+            .any(|o| matches!(o.variant, CastingVariant::HandPermission { .. })),
+        "the free HandPermission option must still be offered. Offered: {variants:?}"
+    );
+    assert!(
+        set.options
+            .iter()
+            .any(|o| o.variant == CastingVariant::Fuse),
+        "the Fuse option must still be offered — the guard must not drop it. Offered: {variants:?}"
+    );
+}
+
 #[test]
 fn foretell_cast_uses_foretell_cost_only_after_current_turn() {
     let mut state = setup_game_at_main_phase();
@@ -14026,11 +14091,12 @@ fn tamiyo_emblem_does_not_free_cast_commander_from_command_zone() {
 /// printed mana cost is unaffordable but whose alternative cost is payable.
 mod omniscience_alt_cost_2432 {
     use super::*;
-    use crate::types::game_state::AlternativeCastKeyword;
+    use crate::types::ability::TargetFilter;
     use crate::types::keywords::{EvokeCost, Keyword};
     use crate::types::mana::{ManaCost, ManaCostShard};
+    use crate::types::statics::{CastFreeOrigin, CastFrequency};
 
-    fn install_omniscience(state: &mut GameState) {
+    fn install_omniscience(state: &mut GameState) -> ObjectId {
         let id = create_object(
             state,
             CardId(2_432_001),
@@ -14044,6 +14110,31 @@ mod omniscience_alt_cost_2432 {
             )
             .expect("Omniscience static should parse"),
         );
+        id
+    }
+
+    /// A plain {1}{U} creature with no alternative-cost keyword.
+    fn create_plain_creature(state: &mut GameState) -> ObjectId {
+        let obj_id = create_object(
+            state,
+            CardId(2_432_010),
+            PlayerId(0),
+            "Plain Creature".to_string(),
+            Zone::Hand,
+        );
+        let obj = state.objects.get_mut(&obj_id).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 1,
+        };
+        obj.base_mana_cost = obj.mana_cost.clone();
+        obj_id
+    }
+
+    fn ample_blue_mana(state: &mut GameState) {
+        add_mana(state, PlayerId(0), ManaType::Colorless, 6);
+        add_mana(state, PlayerId(0), ManaType::Blue, 2);
     }
 
     /// Quantum Riddler class: printed {3}{U}{U}, Warp {1}{U}.
@@ -14100,12 +14191,19 @@ mod omniscience_alt_cost_2432 {
         obj_id
     }
 
+    // Reconciliation (issue #2432, free-cast-election tranche): under an ACTIVE
+    // Unlimited CastFromHandFree permission the casting-method election is the
+    // single N-way `CastingVariantChoice` menu (CR 118.9a — one mutually-exclusive
+    // announcement), NOT the legacy two-slot `AlternativeCastChoice`. These tests
+    // assert the modernized menu shape; semantics (free vs keyword vs printed) are
+    // unchanged.
+
     #[test]
-    fn omniscience_offers_free_normal_when_warp_affordable_but_printed_is_not() {
+    fn omniscience_menu_offers_free_and_warp_when_printed_unaffordable() {
         let mut state = setup_game_at_main_phase();
         install_omniscience(&mut state);
         let riddler = create_quantum_riddler(&mut state);
-        // Enough for Warp {1}{U}, not for {3}{U}{U}.
+        // Enough for Warp {1}{U}, not for printed {3}{U}{U}.
         add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
         add_mana(&mut state, PlayerId(0), ManaType::Blue, 1);
 
@@ -14119,34 +14217,39 @@ mod omniscience_alt_cost_2432 {
         )
         .unwrap();
 
-        match wf {
-            WaitingFor::AlternativeCastChoice {
-                keyword: AlternativeCastKeyword::Warp,
-                normal_cost,
-                alternative_cost,
-                ..
-            } => {
-                assert_eq!(
-                    normal_cost,
-                    ManaCost::NoCost,
-                    "Omniscience must surface NoCost as the normal option"
-                );
-                assert_eq!(
-                    alternative_cost,
-                    Some(ManaCost::Cost {
-                        shards: vec![ManaCostShard::Blue],
-                        generic: 1,
-                    })
-                );
+        let WaitingFor::CastingVariantChoice { options, .. } = wf else {
+            panic!("expected N-way CastingVariantChoice under Omniscience, got {wf:?}");
+        };
+        // CR 118.9: the free option carries the printed-NoCost display and the
+        // Omniscience source id.
+        let free = options
+            .iter()
+            .find(|o| matches!(o.variant, CastingVariant::HandPermission { .. }))
+            .expect("free HandPermission option must be offered");
+        assert_eq!(free.mana_cost, ManaCost::NoCost);
+        // CR 601.2b: the Warp alternative cost path is offered at {1}{U}.
+        let warp = options
+            .iter()
+            .find(|o| o.variant == CastingVariant::Warp)
+            .expect("Warp option must be offered");
+        assert_eq!(
+            warp.mana_cost,
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 1,
             }
-            other => {
-                panic!("expected Warp choice with free normal under Omniscience, got {other:?}")
-            }
-        }
+        );
+        // Single-method degrade: the printed {3}{U}{U} Normal cast is unaffordable
+        // and MUST be dropped (revert of the printed-cost prepare would surface a
+        // spurious free {0} Normal duplicate here).
+        assert!(
+            !options.iter().any(|o| o.variant == CastingVariant::Normal),
+            "unaffordable printed Normal must be dropped, got {options:?}"
+        );
     }
 
     #[test]
-    fn omniscience_offers_free_normal_when_evoke_affordable_but_printed_is_not() {
+    fn omniscience_menu_offers_free_and_evoke_when_printed_unaffordable() {
         let mut state = setup_game_at_main_phase();
         install_omniscience(&mut state);
         let mulldrifter = create_mulldrifter(&mut state);
@@ -14164,75 +14267,234 @@ mod omniscience_alt_cost_2432 {
         )
         .unwrap();
 
-        match wf {
-            WaitingFor::AlternativeCastChoice {
-                keyword: AlternativeCastKeyword::Evoke,
-                normal_cost,
-                alternative_cost,
-                ..
-            } => {
-                assert_eq!(
-                    normal_cost,
-                    ManaCost::NoCost,
-                    "Omniscience must surface NoCost as the normal option"
-                );
-                assert_eq!(
-                    alternative_cost,
-                    Some(ManaCost::Cost {
-                        shards: vec![ManaCostShard::Blue],
-                        generic: 2,
-                    })
-                );
+        let WaitingFor::CastingVariantChoice { options, .. } = wf else {
+            panic!("expected N-way CastingVariantChoice under Omniscience, got {wf:?}");
+        };
+        let free = options
+            .iter()
+            .find(|o| matches!(o.variant, CastingVariant::HandPermission { .. }))
+            .expect("free HandPermission option must be offered");
+        assert_eq!(free.mana_cost, ManaCost::NoCost);
+        let evoke = options
+            .iter()
+            .find(|o| o.variant == CastingVariant::Evoke)
+            .expect("Evoke option must be offered");
+        assert_eq!(
+            evoke.mana_cost,
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 2,
             }
-            other => {
-                panic!("expected Evoke choice with free normal under Omniscience, got {other:?}")
-            }
-        }
+        );
+        assert!(
+            !options.iter().any(|o| o.variant == CastingVariant::Normal),
+            "unaffordable printed Normal must be dropped, got {options:?}"
+        );
     }
 
     #[test]
-    fn omniscience_warp_spell_normal_choice_proceeds_without_mana_payment() {
+    fn omniscience_free_election_proceeds_without_mana_payment() {
         let mut state = setup_game_at_main_phase();
         install_omniscience(&mut state);
         let riddler = create_quantum_riddler(&mut state);
         add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
         add_mana(&mut state, PlayerId(0), ManaType::Blue, 1);
+        let card_id = CardId(2_432_002);
 
         let mut events = Vec::new();
-        let wf = handle_cast_spell(
-            &mut state,
-            PlayerId(0),
-            riddler,
-            CardId(2_432_002),
-            &mut events,
-        )
-        .unwrap();
-        assert!(matches!(
-            wf,
-            WaitingFor::AlternativeCastChoice {
-                keyword: AlternativeCastKeyword::Warp,
-                ..
-            }
-        ));
+        let wf = handle_cast_spell(&mut state, PlayerId(0), riddler, card_id, &mut events).unwrap();
+        let WaitingFor::CastingVariantChoice { options, .. } = wf else {
+            panic!("expected N-way CastingVariantChoice under Omniscience, got {wf:?}");
+        };
+        // Reach-guard: the free option must be present so the election is real.
+        let free_index = options
+            .iter()
+            .position(|o| matches!(o.variant, CastingVariant::HandPermission { .. }))
+            .expect("free HandPermission option must be offered");
 
-        let wf = handle_warp_cost_choice(
+        let wf = handle_casting_variant_choice(
             &mut state,
             PlayerId(0),
             riddler,
-            CardId(2_432_002),
-            crate::types::actions::AlternativeCastDecision::Normal,
+            card_id,
+            &options,
+            free_index,
             &mut events,
         )
         .unwrap();
 
         assert!(
-            !matches!(wf, WaitingFor::AlternativeCastChoice { .. }),
-            "normal choice under Omniscience must not re-prompt; got {wf:?}"
+            !matches!(wf, WaitingFor::CastingVariantChoice { .. }),
+            "free election under Omniscience must not re-prompt; got {wf:?}"
         );
         assert!(
             !matches!(wf, WaitingFor::ManaPayment { .. }),
-            "Omniscience normal cast must skip mana payment; got {wf:?}"
+            "Omniscience free cast must skip mana payment; got {wf:?}"
         );
+    }
+
+    /// Test 1: when the printed cost is affordable the menu offers BOTH the free
+    /// option and the printed `Normal` option (at its printed cost, not a second
+    /// {0}). Reverting the printed-cost prepare would collapse `Normal` to {0} or
+    /// drop it — this option-set equality catches both.
+    #[test]
+    fn menu_offers_free_and_printed_when_affordable() {
+        let mut state = setup_game_at_main_phase();
+        install_omniscience(&mut state);
+        let spell = create_plain_creature(&mut state);
+        ample_blue_mana(&mut state);
+
+        let set = casting_variant_choice_set(&state, PlayerId(0), spell, None);
+        let free = set
+            .options
+            .iter()
+            .find(|o| matches!(o.variant, CastingVariant::HandPermission { .. }))
+            .expect("free HandPermission option must be offered");
+        assert_eq!(free.mana_cost, ManaCost::NoCost);
+        let normal = set
+            .options
+            .iter()
+            .find(|o| o.variant == CastingVariant::Normal)
+            .expect("printed Normal option must be offered when affordable");
+        assert_eq!(
+            normal.mana_cost,
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 1,
+            },
+            "the Normal option must display the printed {{1}}{{U}}, not a duplicate {{0}}"
+        );
+        assert_eq!(
+            set.options.len(),
+            2,
+            "a plain creature under Omniscience offers exactly free + printed, got {:?}",
+            set.options
+        );
+    }
+
+    /// Test 7: Mulldrifter three-way — all three methods affordable produce three
+    /// options with DISTINCT costs (printed {4}{U}, evoke {2}{U}, free {0}).
+    #[test]
+    fn menu_offers_three_distinct_costs_for_mulldrifter_when_all_affordable() {
+        let mut state = setup_game_at_main_phase();
+        install_omniscience(&mut state);
+        let mulldrifter = create_mulldrifter(&mut state);
+        ample_blue_mana(&mut state);
+
+        let set = casting_variant_choice_set(&state, PlayerId(0), mulldrifter, None);
+        let cost_of = |variant: CastingVariant| {
+            set.options
+                .iter()
+                .find(|o| o.variant == variant)
+                .unwrap_or_else(|| {
+                    panic!("option {variant:?} must be present in {:?}", set.options)
+                })
+                .mana_cost
+                .clone()
+        };
+        let free = set
+            .options
+            .iter()
+            .find(|o| matches!(o.variant, CastingVariant::HandPermission { .. }))
+            .expect("free option must be present");
+        assert_eq!(free.mana_cost, ManaCost::NoCost);
+        assert_eq!(
+            cost_of(CastingVariant::Normal),
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 4,
+            }
+        );
+        assert_eq!(
+            cost_of(CastingVariant::Evoke),
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 2,
+            }
+        );
+    }
+
+    /// Test 8 (engine side): the newly menu-gated keyword variants surface as
+    /// options under Omniscience when affordable (Warp here). The FE label
+    /// coverage for these is gated by check-frontend.
+    #[test]
+    fn menu_offers_warp_keyword_option_under_omniscience() {
+        let mut state = setup_game_at_main_phase();
+        install_omniscience(&mut state);
+        let riddler = create_quantum_riddler(&mut state);
+        ample_blue_mana(&mut state);
+
+        let set = casting_variant_choice_set(&state, PlayerId(0), riddler, None);
+        assert!(
+            set.options
+                .iter()
+                .any(|o| matches!(o.variant, CastingVariant::HandPermission { .. })),
+            "free option must be present"
+        );
+        let warp = set
+            .options
+            .iter()
+            .find(|o| o.variant == CastingVariant::Warp)
+            .expect("Warp keyword option must join the menu under Omniscience");
+        assert_eq!(
+            warp.mana_cost,
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 1,
+            }
+        );
+    }
+
+    /// Test 10: multi-authority order bug. A OncePerTurn (Zaffai-class) permission
+    /// created EARLIER in battlefield order than Omniscience must not hide the
+    /// Unlimited source — the free option must latch the Omniscience id and carry
+    /// `Unlimited` frequency (so electing it records no once-per-turn slot). The
+    /// pre-fix first-match scan would have returned the Zaffai id here.
+    #[test]
+    fn free_option_latches_unlimited_source_over_earlier_once_per_turn() {
+        let mut state = setup_game_at_main_phase();
+
+        // Earlier-in-battlefield OncePerTurn CastFromHandFree source (Zaffai-class).
+        let zaffai = create_object(
+            &mut state,
+            CardId(2_432_020),
+            PlayerId(0),
+            "Zaffai (test)".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&zaffai)
+            .unwrap()
+            .static_definitions
+            .push(
+                StaticDefinition::new(StaticMode::CastFromHandFree {
+                    frequency: CastFrequency::OncePerTurn,
+                    origin: CastFreeOrigin::Hand,
+                })
+                .affected(TargetFilter::Any),
+            );
+
+        // Omniscience appended AFTER Zaffai (later in battlefield order).
+        let omniscience = install_omniscience(&mut state);
+        let spell = create_plain_creature(&mut state);
+        ample_blue_mana(&mut state);
+
+        let set = casting_variant_choice_set(&state, PlayerId(0), spell, None);
+        let free = set
+            .options
+            .iter()
+            .find(|o| matches!(o.variant, CastingVariant::HandPermission { .. }))
+            .expect("free option must be present");
+        let CastingVariant::HandPermission { source, frequency } = free.variant else {
+            unreachable!()
+        };
+        assert_eq!(
+            source, omniscience,
+            "the free option must latch the Unlimited (Omniscience) source, not the \
+             earlier OncePerTurn Zaffai source"
+        );
+        assert_eq!(frequency, CastFrequency::Unlimited);
     }
 }
 

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1864,6 +1864,7 @@ pub struct SpellCast<'a> {
     alternative_cast: Option<AlternativeCastDecision>,
     adventure_creature: Option<bool>,
     casting_variant: Option<CastingVariant>,
+    free_cast: bool,
     modes: Option<Vec<usize>>,
     x: Option<u32>,
     target_players: Vec<PlayerId>,
@@ -1891,6 +1892,7 @@ impl<'a> SpellCast<'a> {
             alternative_cast: None,
             adventure_creature: None,
             casting_variant: None,
+            free_cast: false,
             modes: None,
             x: None,
             target_players: Vec::new(),
@@ -1956,6 +1958,15 @@ impl<'a> SpellCast<'a> {
     /// surfaces a variant choice without an explicit test intent.
     pub fn casting_variant(mut self, variant: CastingVariant) -> Self {
         self.casting_variant = Some(variant);
+        self
+    }
+
+    /// Elect the free `HandPermission` option at a `CastingVariantChoice` without
+    /// having to name the granting source's `ObjectId` (CR 118.9 / CR 118.9a). The
+    /// driver picks the first `CastingVariant::HandPermission` option the menu
+    /// offers — the Omniscience-class "cast without paying its mana cost" branch.
+    pub fn free_cast(mut self) -> Self {
+        self.free_cast = true;
         self
     }
 
@@ -2100,6 +2111,7 @@ impl<'a> SpellCast<'a> {
             alternative_cast,
             adventure_creature,
             casting_variant,
+            free_cast,
             modes,
             x,
             target_players,
@@ -2200,21 +2212,38 @@ impl<'a> SpellCast<'a> {
                     )?;
                 }
                 WaitingFor::CastingVariantChoice { options, .. } => {
-                    let variant = casting_variant.unwrap_or_else(|| {
-                        panic!(
-                            "SpellCast reached WaitingFor::CastingVariantChoice but no \
-                             .casting_variant(..) was declared — declare the intended cast variant"
-                        )
-                    });
-                    let index = options
-                        .iter()
-                        .position(|option| option.variant == variant)
-                        .unwrap_or_else(|| {
+                    // CR 118.9 / CR 118.9a: `.free_cast()` elects the first
+                    // `HandPermission` option without naming the source id;
+                    // otherwise match the explicitly declared `.casting_variant(..)`.
+                    let index = if free_cast {
+                        options
+                            .iter()
+                            .position(|option| {
+                                matches!(option.variant, CastingVariant::HandPermission { .. })
+                            })
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "SpellCast .free_cast() found no HandPermission option in {:?}",
+                                    options
+                                )
+                            })
+                    } else {
+                        let variant = casting_variant.unwrap_or_else(|| {
                             panic!(
-                                "SpellCast could not find requested cast variant {:?} in options {:?}",
-                                variant, options
+                                "SpellCast reached WaitingFor::CastingVariantChoice but no \
+                                 .casting_variant(..) was declared — declare the intended cast variant"
                             )
                         });
+                        options
+                            .iter()
+                            .position(|option| option.variant == variant)
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "SpellCast could not find requested cast variant {:?} in options {:?}",
+                                    variant, options
+                                )
+                            })
+                    };
                     selected_casting_variant = Some(options[index].clone());
                     act_collect(
                         runner,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -682,6 +682,8 @@ mod obeka_splitter_additional_phases;
 mod obliterate_regression;
 mod officious_interrogation_bare_strive_surcharge;
 mod old_growth_troll_return_as_aura;
+mod omniscience_free_cast_chalice_x;
+mod omniscience_free_cast_vexing_bauble;
 mod omo_queen_of_vesuva;
 mod oracle_parser;
 mod overload_no_legal_target;

--- a/crates/engine/tests/integration/omniscience_free_cast_chalice_x.rs
+++ b/crates/engine/tests/integration/omniscience_free_cast_chalice_x.rs
@@ -1,0 +1,90 @@
+//! CR 107.3b + CR 601.2b: The free election of an {X} spell under Omniscience
+//! locks X to 0 (no mana spent), so its mana value is 0 and Chalice of the Void
+//! with zero charge counters counters it. The printed election of the same spell
+//! announces X=2 (mana value 2), which Chalice@0 does NOT counter — the spell
+//! resolves. This proves the two branches produce different mana values through
+//! the real cast pipeline.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::game_state::CastingVariant;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const OMNISCIENCE: &str = "You may cast spells from your hand without paying their mana costs.";
+// Verbatim Oracle text (card-data.json, 2026-07-20).
+const CHALICE: &str =
+    "This artifact enters with X charge counters on it.\nWhenever a player casts \
+a spell with mana value equal to the number of charge counters on this artifact, counter that \
+spell.";
+
+/// Casts an {X} creature under Omniscience + Chalice-of-the-Void-at-zero. `free`
+/// elects the free option (X locked to 0); otherwise the printed cost is paid
+/// with X=2. Returns the spell's final zone.
+fn cast_x_spell_under_chalice(free: bool) -> Zone {
+    let mut sc = GameScenario::new();
+    sc.at_phase(Phase::PreCombatMain);
+
+    sc.add_creature(P0, "Omniscience", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(OMNISCIENCE);
+    // Placed directly on the battlefield, so the "enters with X charge counters"
+    // replacement never fires — Chalice sits at 0 charge counters (Chalice@0),
+    // countering only mana-value-0 spells.
+    sc.add_creature(P0, "Chalice of the Void", 0, 0)
+        .as_artifact()
+        .from_oracle_text(CHALICE);
+
+    let spell = sc
+        .add_creature_to_hand(P0, "X Wurm", 3, 3)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::X],
+            generic: 0,
+        })
+        .id();
+
+    // Fund {2} on both branches so the menu offers free AND printed and the paid
+    // X=2 announcement is affordable.
+    sc.with_mana_pool(
+        P0,
+        (0..2)
+            .map(|_| ManaUnit::new(ManaType::Colorless, spell, false, Vec::new()))
+            .collect(),
+    );
+
+    let mut runner = sc.build();
+    let outcome = if free {
+        runner.cast(spell).free_cast().resolve()
+    } else {
+        runner
+            .cast(spell)
+            .casting_variant(CastingVariant::Normal)
+            .x(2)
+            .resolve()
+    };
+    outcome.zone_of(spell)
+}
+
+#[test]
+fn free_x_spell_is_mana_value_zero_and_countered_by_chalice_at_zero() {
+    // CR 107.3b: no alternative cost includes X, so the only legal X is 0 → MV 0 →
+    // Chalice@0 counters the spell into the graveyard.
+    assert_eq!(
+        cast_x_spell_under_chalice(true),
+        Zone::Graveyard,
+        "a free {{X}} cast has X=0 (MV 0), which Chalice@0 must counter"
+    );
+}
+
+#[test]
+fn paid_x_spell_announces_x_and_dodges_chalice_at_zero() {
+    // CR 601.2b: the printed election announces X=2 (MV 2). Chalice@0 counters only
+    // MV-0 spells, so this resolves onto the battlefield. Reach-guard: `.x(2)` is
+    // consumed only if the ChooseX flow actually surfaced (proving the printed
+    // branch spent mana and announced X, not the free branch).
+    assert_eq!(
+        cast_x_spell_under_chalice(false),
+        Zone::Battlefield,
+        "the printed X=2 cast has MV 2, which Chalice@0 must NOT counter"
+    );
+}

--- a/crates/engine/tests/integration/omniscience_free_cast_vexing_bauble.rs
+++ b/crates/engine/tests/integration/omniscience_free_cast_vexing_bauble.rs
@@ -1,0 +1,87 @@
+//! CR 118.9 + CR 118.9a: Electing the Omniscience free-cast option is the
+//! no-mana-spent branch. Vexing Bauble ("Whenever a player casts a spell, if no
+//! mana was spent to cast it, counter that spell.") therefore counters a spell
+//! cast for free, but NOT the same spell cast for its printed cost (mana spent).
+//! This is the production-path proof that the free election spends zero mana and
+//! the printed election spends mana — the exact dodge the plan requires.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::game_state::CastingVariant;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const OMNISCIENCE: &str = "You may cast spells from your hand without paying their mana costs.";
+// Verbatim MH3 Oracle text (card-data.json, 2026-07-20).
+const VEXING_BAUBLE: &str = "Whenever a player casts a spell, if no mana was spent to cast it, \
+counter that spell.\n{1}, {T}, Sacrifice this artifact: Draw a card.";
+
+/// Casts a {1}{G} bear under Omniscience + Vexing Bauble on a board that can
+/// afford the printed cost. `free` elects the free `HandPermission` option;
+/// otherwise the printed `Normal` option is paid. Returns the bear's final zone.
+fn cast_bear_under_bauble(free: bool) -> Zone {
+    let mut sc = GameScenario::new();
+    sc.at_phase(Phase::PreCombatMain);
+
+    // Omniscience: the Unlimited CastFromHandFree permission.
+    sc.add_creature(P0, "Omniscience", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(OMNISCIENCE);
+    // Vexing Bauble: counters any spell cast with no mana spent.
+    sc.add_creature(P0, "Vexing Bauble", 0, 0)
+        .as_artifact()
+        .from_oracle_text(VEXING_BAUBLE);
+
+    let bear = sc
+        .add_creature_to_hand(P0, "Test Bear", 2, 2)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        })
+        .id();
+
+    // Fund the printed {1}{G} on BOTH branches so the menu offers free AND
+    // printed — the election (not affordability) is the only difference.
+    sc.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Green, bear, false, Vec::new()),
+            ManaUnit::new(ManaType::Colorless, bear, false, Vec::new()),
+        ],
+    );
+
+    let mut runner = sc.build();
+    let outcome = if free {
+        runner.cast(bear).free_cast().resolve()
+    } else {
+        runner
+            .cast(bear)
+            .casting_variant(CastingVariant::Normal)
+            .resolve()
+    };
+    outcome.zone_of(bear)
+}
+
+#[test]
+fn free_election_is_countered_by_vexing_bauble() {
+    // CR 118.9a + CR 107.3b: the free election spends no mana, so Vexing Bauble's
+    // "if no mana was spent" trigger counters the spell into the graveyard.
+    assert_eq!(
+        cast_bear_under_bauble(true),
+        Zone::Graveyard,
+        "a free (no-mana-spent) cast under Omniscience must be countered by Vexing Bauble"
+    );
+}
+
+#[test]
+fn printed_election_dodges_vexing_bauble() {
+    // Reach-guard + discriminator: paying the printed {1}{G} spends mana, so the
+    // trigger's intervening-if fails and the spell resolves onto the battlefield.
+    // If the "free" branch had also spent no mana this would be vacuous — it does
+    // not, because THIS branch spends mana and resolves.
+    assert_eq!(
+        cast_bear_under_bauble(false),
+        Zone::Battlefield,
+        "casting for the printed cost spends mana, so Vexing Bauble must NOT counter it"
+    );
+}

--- a/crates/engine/tests/integration/rules/casting.rs
+++ b/crates/engine/tests/integration/rules/casting.rs
@@ -1951,6 +1951,21 @@ fn tamiyo_emblem_allows_free_cast_from_hand() {
     let bolt_id = scenario.add_bolt_to_hand(P0);
 
     let mut runner = scenario.build();
+    // CR 118.9a: the free cast is now an explicit election in the
+    // `CastingVariantChoice` menu. Give the bolt a real {R} printed cost with no
+    // red mana available so the printed `Normal` option is unaffordable and
+    // dropped — leaving the free `HandPermission` option as the sole survivor,
+    // which the menu auto-elects with no prompt (single-method degrade). This
+    // exercises the CR 118.9a free branch and keeps mana untouched.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&bolt_id)
+        .unwrap()
+        .mana_cost = ManaCost::Cost {
+        shards: vec![ManaCostShard::Red],
+        generic: 0,
+    };
     let emblem_static = engine::parser::oracle_static::parse_static_line(
         "You may cast spells from your hand without paying their mana costs.",
     )


### PR DESCRIPTION
Make the "cast without paying its mana cost" free permission (Omniscience
and the general Unlimited CastFromHandFree path) an optional, offered
choice instead of a forced auto-free override. When two or more casting
methods are legal and affordable (free {0} vs printed cost vs Evoke/Warp/
etc.), a single N-way CastingVariantChoice prompt enumerates every method
with its resolved cost; when only one is legal/affordable it auto-applies
with no prompt.

The free branch forces X=0 (CR 107.3b) and spends no mana; additional and
conditional costs (targets, timing, discard/sacrifice) still apply. The
printed branch lets the player announce X (CR 601.2b) and pays; mana is
spent. This routes the election through the engine's existing N-way
CastingVariantChoice infrastructure (CR 118.9a: one announcement among
mutually-exclusive alternative costs), so no engine type, serde, or adapter
shape changes are needed.

Enables the player to choose to pay in order to:
- dodge Vexing Bauble ("if no mana was spent to cast it, counter that
  spell") — the free option spends no mana and is countered; paying
  survives.
- pick X>0 against Chalice of the Void — free forces X=0 (MV 0); paying
  lets the player announce a higher X.

The frontend is display-only: the CastingVariantModal renders each offered
method's engine-provided label and cost. Adds the four missing CastingVariant
union members and their labels across all seven locales.
