### PR TITLE
fix(ai): populate all_card_names in ai_commander so NamedChoice{CardName} choices aren't a permanent stall

### DIFF
--- a/crates/phase-ai/src/bin/ai_commander.rs
+++ b/crates/phase-ai/src/bin/ai_commander.rs
@@ -203,8 +203,7 @@ fn main() {
     }
     println!();
 
-    let mut state = GameState::new(FormatConfig::commander(), 4, seed);
-    load_deck_into_state(&mut state, &payload);
+    let mut state = build_game_state(&db, &payload, seed);
 
     engine::game::engine::start_game(&mut state);
     println!();
@@ -545,9 +544,124 @@ fn classify_run_outcome(aborted: bool, waiting_for: &WaitingFor) -> RunOutcome {
     }
 }
 
+/// Builds the 4-player commander `GameState` this driver plays, from a
+/// resolved deck payload. Single authority for this bin's setup sequence —
+/// `main()` and the setup regression test below both call this, so the two
+/// can never drift apart.
+///
+/// Populates `state.all_card_names` (a `#[serde(skip)]` field, so it is never
+/// restored by deserialization) right after deck loading, mirroring every
+/// other game-construction site (`engine-wasm/src/lib.rs`, `replay.rs`,
+/// `server-core/src/session.rs`). Without it, `NamedChoice { choice_type:
+/// CardName, .. }` candidate generation (`ai_support::candidate_actions` ->
+/// `card_name_choice_candidates`) sees an empty `all_card_names` and returns
+/// zero legal actions — a permanent AI stall the first time an opponent's
+/// card triggers a "name a card" choice.
+fn build_game_state(db: &CardDatabase, payload: &DeckPayload, seed: u64) -> GameState {
+    let mut state = GameState::new(FormatConfig::commander(), 4, seed);
+    load_deck_into_state(&mut state, payload);
+    state.all_card_names = db.card_names().into();
+    state
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use engine::ai_support::candidate_actions;
+    use engine::types::ability::ChoiceType;
+
+    /// Minimal two-card fixture (one legendary creature, one basic land) so the
+    /// setup-path regression test below doesn't depend on the full card-data.json
+    /// corpus. Mirrors the schema used by `deck_loading`'s own `snow_basics_db`
+    /// test fixture.
+    fn fixture_db() -> CardDatabase {
+        let json = serde_json::json!({
+            "test commander": {
+                "name": "Test Commander",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": {
+                    "supertypes": ["Legendary"],
+                    "core_types": ["Creature"],
+                    "subtypes": ["Human"]
+                },
+                "power": { "type": "Fixed", "value": 2 },
+                "toughness": { "type": "Fixed", "value": 2 },
+                "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [],
+                "color_override": null, "scryfall_oracle_id": null
+            },
+            "test land": {
+                "name": "Test Land",
+                "mana_cost": { "type": "NoCost" },
+                "card_type": {
+                    "supertypes": ["Basic"],
+                    "core_types": ["Land"],
+                    "subtypes": ["Plains"]
+                },
+                "power": null, "toughness": null, "loyalty": null, "defense": null,
+                "oracle_text": null, "non_ability_text": null, "flavor_name": null,
+                "keywords": [], "abilities": [], "triggers": [],
+                "static_abilities": [], "replacements": [],
+                "color_override": null, "scryfall_oracle_id": null
+            }
+        })
+        .to_string();
+        CardDatabase::from_json_str(&json).expect("ai_commander test fixture parses")
+    }
+
+    /// Regression test for the gap fixed alongside this test: `build_game_state`
+    /// (called by `main()`) builds a 4-player commander `GameState` from a
+    /// resolved deck payload and must set `state.all_card_names`, the
+    /// `#[serde(skip)]` field `NamedChoice { choice_type: CardName, .. }`
+    /// candidate generation reads (see
+    /// `ai_support::candidates::card_name_choice_candidates`, which returns an
+    /// empty candidate list — a permanent AI stall — whenever `all_card_names`
+    /// is empty). This calls the bin's actual setup function (not a duplicated
+    /// copy of it) and asserts a `NamedChoice{CardName}` prompt yields a
+    /// non-empty candidate set afterward, mirroring `candidates.rs`'s
+    /// `named_card_choice_uses_bounded_in_game_names` test and the restore-path
+    /// guard in `printed_cards.rs`.
+    #[test]
+    fn setup_populates_all_card_names_for_named_choice_candidates() {
+        let db = fixture_db();
+        let seat = PlayerDeckList {
+            main_deck: vec!["Test Land".to_string(); 10],
+            commander: vec!["Test Commander".to_string()],
+            ..Default::default()
+        };
+        let deck_list = DeckList {
+            player: seat.clone(),
+            opponent: seat.clone(),
+            ai_decks: vec![seat.clone(), seat],
+            ..Default::default()
+        };
+        let payload: DeckPayload = resolve_deck_list(&db, &deck_list);
+
+        // Calls the same setup function `main()` uses — if the
+        // `all_card_names` assignment is ever removed from `build_game_state`,
+        // this test fails instead of silently passing against a duplicated copy.
+        let mut state = build_game_state(&db, &payload, 42);
+
+        assert!(
+            !state.all_card_names.is_empty(),
+            "setup must populate all_card_names right after deck loading"
+        );
+
+        state.waiting_for = WaitingFor::NamedChoice {
+            player: PlayerId(1),
+            choice_type: ChoiceType::CardName,
+            options: Vec::new(),
+            source: None,
+            persist_player: None,
+        };
+        let actions = candidate_actions(&state);
+        assert!(
+            !actions.is_empty(),
+            "NamedChoice{{CardName}} must yield candidates once all_card_names is populated"
+        );
+    }
 
     #[test]
     fn parse_action_cap_accepts_positive_integer() {


### PR DESCRIPTION
## Summary

`crates/phase-ai/src/bin/ai_commander.rs` is a standalone 4-player AI-vs-AI test driver. It builds a `GameState` and loads decks into it, but never set `state.all_card_names` — the `#[serde(skip)]` field the engine uses to enumerate/validate `NamedChoice { choice_type: CardName, .. }` choices (e.g. "name a card" effects).

Every other game-construction site in the repo sets this right after deck loading:
- `crates/engine-wasm/src/lib.rs` (after `load_and_hydrate_decks`)
- `crates/engine/src/game/replay.rs` (same pattern)
- `crates/server-core/src/session.rs` (two call sites, same pattern)

`ai_commander.rs` was the one place that skipped it. `candidates.rs::card_name_choice_candidates` returns an empty candidate list whenever `state.all_card_names` is empty (`if state.all_card_names.is_empty() { return Vec::new(); }`), so any opponent-controlled card that triggers a "name a card" choice against this driver produces zero legal actions — a permanent stall.

This gap was found during investigation of a related, now-closed issue (unrelated `OptionalCostChoice` root cause) — it is not the same bug, just discovered along the way. A 4-player AI gauntlet corpus run against this driver showed 27+ stalls with exactly this `NamedChoice{CardName, options: []}` shape.

## Changes

- Extracts the bin's setup sequence (`GameState::new` + `load_deck_into_state` + the `all_card_names` assignment) into a single `build_game_state()` function, so `main()` and the new regression test share one authority and can't drift apart.
- Adds `state.all_card_names = db.card_names().into();` right after deck loading inside `build_game_state()`, mirroring the other four call sites.
- Adds a regression test (`setup_populates_all_card_names_for_named_choice_candidates`) that builds a minimal in-memory card-database fixture, calls the actual `build_game_state()` setup path, and asserts a `NamedChoice{CardName}` prompt yields a non-empty candidate set — mirroring `candidates.rs`'s existing `named_card_choice_uses_bounded_in_game_names` test and the restore-path guard in `printed_cards.rs`.

## Test plan

- [x] `cargo build --release --bin ai-commander -p phase-ai` — compiles clean
- [x] `cargo test -p phase-ai --bin ai-commander` — 10/10 tests pass, including the new regression test
- [x] `cargo clippy -p phase-ai --bin ai-commander --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — no changes needed beyond the edit
- [x] Full pre-push hook suite (workspace clippy, engine parser tests, coverage regression check, frontend lint/type-check) passed

Diff is scoped entirely to `crates/phase-ai/src/bin/ai_commander.rs` — no card-parsing or card-data files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)