### PR TITLE
feat(client): scale hand and stack mana pips to card size

### DIFF
--- a/client/src/components/hand/MobileHandDrawer.tsx
+++ b/client/src/components/hand/MobileHandDrawer.tsx
@@ -292,7 +292,11 @@ const DrawerCard = memo(function DrawerCard({
       ) : (
         <div className="h-full w-full bg-gray-700" />
       )}
-      <ManaCostPips cost={displayCost} isReduced={isReduced} className="absolute right-[4%] top-[2%]" />
+      {/* @container overlay sized to the card so the pips scale in cqi with the
+          drawer card's width instead of a fixed px size. */}
+      <div className="pointer-events-none absolute inset-0 @container">
+        <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" className="absolute right-[4%] top-[2%]" />
+      </div>
     </button>
   );
 });

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -925,7 +925,12 @@ const HandCard = memo(function HandCard({
           className="pointer-events-none absolute inset-y-0 right-0 w-[3px] rounded-full bg-ember-bright shadow-[0_0_10px_3px_rgba(251,146,60,0.85)]"
           style={{ opacity: rightEdgeOpacity }}
         />
-        <ManaCostPips cost={displayCost} isReduced={isReduced} className="absolute right-[4%] top-[2%]" />
+        {/* @container overlay sized to the card (absolute inset-0 takes width
+            from the card wrapper, so container-type can't collapse it); lets the
+            pips scale in cqi with --hand-card-w instead of a fixed px size. */}
+        <div className="pointer-events-none absolute inset-0 @container">
+          <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" className="absolute right-[4%] top-[2%]" />
+        </div>
       </motion.div>
     </motion.div>
   );
@@ -1055,7 +1060,11 @@ const ZoneFanCard = memo(function ZoneFanCard({
       </div>
       {/* Per-zone castable glow ring (sibling of the clipped image so it isn't cropped). */}
       <div className={`pointer-events-none absolute inset-0 rounded-lg ${theme.ring}`} />
-      <ManaCostPips cost={displayCost} isReduced={isReduced} className="absolute right-[4%] top-[2%]" />
+      {/* @container overlay sized to the card so the pips scale in cqi with
+          --hand-card-w (see the hand-card render above). */}
+      <div className="pointer-events-none absolute inset-0 @container">
+        <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" className="absolute right-[4%] top-[2%]" />
+      </div>
     </motion.div>
   );
 });

--- a/client/src/components/mana/ManaCostPips.tsx
+++ b/client/src/components/mana/ManaCostPips.tsx
@@ -2,7 +2,7 @@ import type { ManaCost } from "../../adapter/types.ts";
 import { manaCostToShards } from "../../viewmodel/costLabel.ts";
 import { ManaSymbol } from "./ManaSymbol.tsx";
 
-type PipSize = "2xs" | "xs" | "sm" | "md" | "lg";
+type PipSize = "2xs" | "xs" | "sm" | "md" | "lg" | "fluid";
 
 const PIP_SIZES: Record<PipSize, { container: string; gap: string; backdrop: string }> = {
   "2xs": { container: "w-[10px] h-[10px] p-[0px]", gap: "gap-[0.5px]", backdrop: "-inset-x-[1px] top-[2px] -bottom-[3px]" },
@@ -10,6 +10,14 @@ const PIP_SIZES: Record<PipSize, { container: string; gap: string; backdrop: str
   sm: { container: "w-[18px] h-[18px] p-[0px]", gap: "gap-[1px]", backdrop: "-inset-x-[2px] top-[4px] -bottom-[8px]" },
   md: { container: "w-[22px] h-[22px] p-[2px]", gap: "gap-[1px]", backdrop: "-inset-x-[3px] -top-[2px] -bottom-[4px]" },
   lg: { container: "w-[28px] h-[28px] py-[2px] px-[2.5px]", gap: "gap-[0.5px]", backdrop: "-inset-x-[3px] -top-[2px] -bottom-[4px]" },
+  // Card-relative sizing in container-query inline units (1cqi = 1% of the
+  // nearest `@container` ancestor's width). Consumers that pass `size="fluid"`
+  // MUST wrap the pips in an element with `container-type: inline-size` sized to
+  // the card (e.g. an `absolute inset-0 @container` overlay). 15cqi matches the
+  // fixed `md` (22px) pip on a ~145px desktop hand card, then scales down with
+  // the card so pips never look oversized on smaller layouts. Secondary
+  // dimensions use the same md ratios (p 9.1%, gap 4.5%, backdrop 13.6/9.1/18.2%).
+  fluid: { container: "w-[15cqi] h-[15cqi] p-[1.4cqi]", gap: "gap-[0.7cqi]", backdrop: "-inset-x-[2cqi] -top-[1.4cqi] -bottom-[2.7cqi]" },
 };
 
 interface ManaCostPipsProps {

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -248,10 +248,17 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
             onError={() => setArtError(true)}
           />
         )}
-        {isSpell && displayManaCost && (
-          <ManaCostPips cost={displayManaCost} size="xs" className="absolute right-[5%] top-[2.5%]" />
-        )}
       </div>
+      {/* @container overlay sized to the card (sibling of the overflow-hidden
+          image wrapper, so the pip backdrop isn't clipped at the card edge).
+          absolute inset-0 takes its width from the relative outer wrapper, so
+          container-type can't collapse it; pips scale in cqi with the stack
+          card's width instead of a fixed px size. */}
+      {isSpell && displayManaCost && (
+        <div className="pointer-events-none absolute inset-0 @container">
+          <ManaCostPips cost={displayManaCost} size="fluid" className="absolute right-[5%] top-[2.5%]" />
+        </div>
+      )}
 
       {/* Badge: unimplemented-mechanics warning (issue #4711). Hand and
           battlefield cards already surface this through CardImage; a spell is


### PR DESCRIPTION
The mana-cost pips rendered a fixed 22px (hand) / 12px (stack) regardless
of the card's actual rendered width, so they looked oversized as cards
shrank on smaller layouts (a 22px pip is ~15% of a desktop hand card but
~30% of a compact one).

Add a `fluid` PipSize to ManaCostPips whose dimensions are expressed in
container-query inline units (1cqi = 1% of the nearest @container ancestor's
width), calibrated so a pip is ~15% of the card width — matching today's
desktop appearance while scaling down proportionally on smaller cards.

Each hand/stack pip render is wrapped in a `pointer-events-none absolute
inset-0 @container` overlay. Because inset-0 sizes the overlay from the
card wrapper (external sizing), marking it container-type: inline-size can't
collapse it, and the card wrapper itself is untouched — so fan geometry and
hover measurement in PlayerHand are unaffected. Applied to the desktop hand
card, the zone-fan (castable-from-elsewhere) card, the mobile hand drawer,
and stack spell cards. On the stack the pips also move out of the card's
overflow-hidden wrapper, so the pip backdrop is no longer clipped at the
card's corner.
