### PR TITLE
docs(skills): note deadline guards are inert under ai-gate measurement mode

### DIFF
--- a/.claude/skills/add-ai-feature-policy/SKILL.md
+++ b/.claude/skills/add-ai-feature-policy/SKILL.md
@@ -94,6 +94,8 @@ Rules:
 
 4. **`cargo ai-gate` is blind to latency, and `cargo ai-perf-gate` is blind to un-instrumented calls.** `ai-gate` measures win-rate only. `ai-perf-gate` (`crates/phase-ai/src/bin/ai_perf_gate.rs`) field-wise sums engine `PerfCounterSnapshot` fields (`crates/engine/src/game/perf_counters.rs`) against `crates/phase-ai/baselines/perf-baseline.json` — but it only sees paths that bump a counter. `max_x_value` / `feasible_mana_capacity` bump none, so BOTH gates missed the regression above; a manual wall-clock A/B caught it. Therefore, if your policy adds a board-wide/affordability engine call that is not already counter-instrumented, EITHER add a `PerfCounterSnapshot` field for it (and refresh the perf baseline) so `ai-perf-gate` can see it, OR run and attach a wall-clock A/B on a large late-game board showing no material regression. A 0-flip `ai-gate` is necessary but NOT sufficient.
 
+5. **Wall-clock / deadline guards are inert under `ai-gate` — a 0-diff is *expected*, not a no-op signal.** If any code you add gates on `self.deadline.expired()`, measurement mode nulls the deadline (`Deadline::none()`), so the guard is a dead branch during `ai-gate` and the run is byte-identical by construction. Never refresh baselines to absorb a divergence from a deadline-only change — a divergence there is a bug (a guard fired on a live path), not a baseline event. See `ai-duel`'s **Measurement And Gates** section for the mechanism and the `with_deadline`-on-a-non-measurement-config test requirement.
+
 ---
 
 ## 3. AST type table — where things live

--- a/.claude/skills/ai-duel/SKILL.md
+++ b/.claude/skills/ai-duel/SKILL.md
@@ -72,6 +72,23 @@ rtk ./scripts/refresh-ai-baseline.sh
 rtk cargo ai-gate
 ```
 
+**Exception — deadline / wall-clock-budget changes are inert under the gate; do
+NOT refresh the baseline for them.** Because measurement mode nulls the
+wall-clock budget (`PlannerServices::with_deadline` forces `Deadline::none()`
+whenever `execution_mode.is_measurement()`, and `Deadline::none().expired()` is
+always `false`), any code guarded by `self.deadline.expired()` is a dead branch
+during `ai-gate`, so the run is byte-identical and **zero baseline movement is
+the *expected* result** — not evidence the change did nothing. If `ai-gate`
+diverges after a deadline-only change, that is a bug (a guard fired on a live
+path), not a baseline event: fix the guard, don't refresh baselines to silence
+it. Unit-test such guards by injecting
+`with_deadline(..., Some(Deadline::after(0)))` on a **non-measurement** config —
+a `.into_measurement()` config nulls the injected deadline, so the guard never
+fires and the test passes vacuously — and assert `services.deadline.expired()`
+as a witness before the negative assertion. Example: PR #6255 bounded the
+`quiesce` / `sample_backfilled_continuations` search apply-loops this way with
+no baseline change.
+
 ## Performance Guide
 
 All times are release mode (`--release`). Debug mode is 5-10x slower.


### PR DESCRIPTION
Measurement mode nulls the search wall-clock budget
(with_deadline forces Deadline::none() under is_measurement()), so any
code guarded by self.deadline.expired() is a dead branch during
cargo ai-gate. Document that a 0-diff is the EXPECTED result for a
deadline-only change, that a divergence is a bug rather than a baseline
event (never refresh baselines to silence it), and that such guards must
be unit-tested via with_deadline(..., Some(Deadline::after(0))) on a
non-measurement config to avoid a vacuous pass.

Substantive caveat in ai-duel's Measurement And Gates section; short
pointer as Performance rule 5 in add-ai-feature-policy. Follow-up to
the search apply-loop bounds in #6255.
