### PR TITLE
fix(engine,client): address review findings on CR 732.2a loop-collapse

### DIFF
--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -919,7 +919,12 @@ export const PermanentCard = memo(function PermanentCard({
               // counter unboundedly — render ∞ instead of the (still-finite) real count.
               const isUnbounded = unboundedCounterTypes.includes(type);
               return (
-                <CounterTooltip key={type} type={type} count={count}>
+                <CounterTooltip
+                  key={type}
+                  type={type}
+                  count={count}
+                  isUnbounded={isUnbounded}
+                >
                   <span
                     className={`flex items-center gap-0.5 rounded px-1 text-[10px] font-bold text-white ${COUNTER_COLORS[type] ?? "bg-purple-600"}`}
                   >

--- a/client/src/components/card/ArtCropCard.tsx
+++ b/client/src/components/card/ArtCropCard.tsx
@@ -214,7 +214,12 @@ export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardPr
                   // counter unboundedly — render ∞ instead of the (still-finite) real count.
                   const isUnbounded = unboundedCounterTypes.includes(type);
                   return (
-                    <CounterTooltip key={type} type={type} count={count}>
+                    <CounterTooltip
+                      key={type}
+                      type={type}
+                      count={count}
+                      isUnbounded={isUnbounded}
+                    >
                       <span
                         className={`rounded-full flex items-center justify-center font-bold text-white shadow-md border border-black/50 ${COUNTER_COLORS[type] ?? "bg-purple-600"}`}
                         style={counterStyle}

--- a/client/src/components/card/__tests__/ArtCropCard.test.tsx
+++ b/client/src/components/card/__tests__/ArtCropCard.test.tsx
@@ -346,4 +346,40 @@ describe("ArtCropCard", () => {
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.queryByText("∞")).not.toBeInTheDocument();
   });
+
+  // LOW-4 (CR 732.2a / CR 701.34a): the ∞ pill and its TOOLTIP must agree. Before the fix the
+  // badge showed ∞ while the tooltip interpolated the raw finite count ("… : 2"), contradicting
+  // the pill. The tooltip summary must say ∞, not leak the count.
+  it("tooltip renders ∞ and hides the finite count when the counter is unbounded", () => {
+    mockUseCardImage.mockReturnValue({ src: "card.png", isLoading: false, isRotated: false, isFlip: false });
+    const permanent = pentadWithCharge();
+    useGameStore.setState({
+      gameState: {
+        objects: { [permanent.id]: permanent },
+        derived: { unbounded_counters: { [permanent.id]: ["charge"] } },
+      } as never,
+    });
+
+    render(<ArtCropCard objectId={101} />);
+
+    // The tooltip summary line reads "∞ <label> counters", never the finite "2 <label> counters".
+    expect(screen.getByText(/∞ \S+ counters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/2 \S+ counters/i)).not.toBeInTheDocument();
+  });
+
+  it("tooltip shows the finite count when the counter is NOT unbounded (matched pair)", () => {
+    mockUseCardImage.mockReturnValue({ src: "card.png", isLoading: false, isRotated: false, isFlip: false });
+    const permanent = pentadWithCharge();
+    useGameStore.setState({
+      gameState: {
+        objects: { [permanent.id]: permanent },
+        derived: { unbounded_counters: {} },
+      } as never,
+    });
+
+    render(<ArtCropCard objectId={101} />);
+
+    expect(screen.getByText(/2 \S+ counters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/∞ \S+ counters/i)).not.toBeInTheDocument();
+  });
 });

--- a/client/src/components/mana/PayAmountChoiceUI.tsx
+++ b/client/src/components/mana/PayAmountChoiceUI.tsx
@@ -107,7 +107,13 @@ export function PayAmountChoiceUI() {
               className={gameButtonClass({ tone: "emerald", size: "md" })}
             >
               {loopCollapseAxis
-                ? t(`mana.loopCollapseAmount${loopCollapseAxis}`, { value })
+                ? // `count` drives i18next pluralization for the Tokens axis
+                  // (loopCollapseAmountTokens_one/_other); the ×N-framed
+                  // Counters/Life/Mixed keys keep reading `value`.
+                  t(`mana.loopCollapseAmount${loopCollapseAxis}`, {
+                    value,
+                    count: value,
+                  })
                 : t("mana.payAmount", { value, resource: resourceLabel })}
             </button>
           </div>

--- a/client/src/components/mana/__tests__/PayAmountChoiceUI.test.tsx
+++ b/client/src/components/mana/__tests__/PayAmountChoiceUI.test.tsx
@@ -9,13 +9,14 @@ import { PayAmountChoiceUI } from "../PayAmountChoiceUI.tsx";
 
 // CR 732.2a: the LoopCollapse prompt must name the axis the loop collapses. The
 // counter/life labels are iteration-framed (×N), never a raw token count.
-function loopCollapseWaitingFor(axis: LoopCollapseAxis): WaitingFor {
+function loopCollapseWaitingFor(axis: LoopCollapseAxis, min = 0): WaitingFor {
   return {
     type: "PayAmountChoice",
     data: {
       player: 0,
       resource: { type: "LoopCollapse", data: { axis } },
-      min: 0,
+      // The stepper initializes `value` to `min`, so `min` pins the rendered count.
+      min,
       max: 1000,
       source_id: 0,
     },
@@ -25,8 +26,8 @@ function loopCollapseWaitingFor(axis: LoopCollapseAxis): WaitingFor {
 // player 0 == local PLAYER_ID, and turn_decision_controller/active_player are the
 // local seat, so `useCanActForWaitingState` returns true and the prompt renders
 // (else it renders null and every text query passes VACUOUSLY).
-function renderWithAxis(axis: LoopCollapseAxis) {
-  const waitingFor = loopCollapseWaitingFor(axis);
+function renderWithAxis(axis: LoopCollapseAxis, min = 0) {
+  const waitingFor = loopCollapseWaitingFor(axis, min);
   setGameStoreForTest({
     gameState: buildGameState({
       waiting_for: waitingFor,
@@ -62,6 +63,27 @@ describe("PayAmountChoiceUI — LoopCollapse axis label", () => {
     renderWithAxis("Tokens");
     expect(
       screen.getByRole("button", { name: /create .* tokens/i }),
+    ).toBeInTheDocument();
+  });
+
+  // LOW-5 (i18next plural): the Tokens label must agree in number with the count. The old
+  // hardcoded "Create {{value}} tokens" rendered "Create 1 tokens" at value=1; the `_one`/`_other`
+  // keys keyed on `count` fix the singular.
+  it("renders the SINGULAR token label at value=1", () => {
+    renderWithAxis("Tokens", 1);
+    // Revert-flip: restore the hardcoded plural key ⇒ "Create 1 tokens" ⇒ this /token$/ fails.
+    expect(
+      screen.getByRole("button", { name: /create 1 token$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create 1 tokens/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the PLURAL token label at value=2 (matched-pair reach-guard)", () => {
+    renderWithAxis("Tokens", 2);
+    expect(
+      screen.getByRole("button", { name: /create 2 tokens$/i }),
     ).toBeInTheDocument();
   });
 });

--- a/client/src/components/ui/CounterTooltip.tsx
+++ b/client/src/components/ui/CounterTooltip.tsx
@@ -9,6 +9,13 @@ interface CounterTooltipProps {
   count: number;
   children: ReactNode;
   className?: string;
+  /**
+   * CR 732.2a / CR 701.34a: when the counter belongs to an accepted counter-growth
+   * loop, the badge renders `∞` — so the tooltip summary must say "unbounded" instead
+   * of leaking the (still-finite) real `count`. Optional so the callers that draw no
+   * `∞` pill compile unchanged and keep the numeric summary.
+   */
+  isUnbounded?: boolean;
 }
 
 export function CounterTooltip({
@@ -16,9 +23,10 @@ export function CounterTooltip({
   count,
   children,
   className,
+  isUnbounded,
 }: CounterTooltipProps) {
   const { t } = useTranslation("game");
-  const lines = formatCounterTooltip(type, count, t).split("\n");
+  const lines = formatCounterTooltip(type, count, t, isUnbounded).split("\n");
 
   return (
     <span className="group relative inline-flex">

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -413,6 +413,7 @@
   "counterTooltip": {
     "summary_one": "1 {{label}}-Marke\n{{description}}",
     "summary_other": "{{count}} {{label}}-Marken\n{{description}}",
+    "summaryUnbounded": "∞ {{label}}-Marken\n{{description}}",
     "descriptions": {
       "p1p1": "Jede +1/+1-Marke gibt der bleibenden Karte +1/+1.",
       "m1m1": "Jede -1/-1-Marke gibt der bleibenden Karte -1/-1.",
@@ -580,7 +581,8 @@
     "loopCollapseTitleCounters": "Wähle, wie oft Marken hinzugefügt werden",
     "loopCollapseTitleLife": "Wähle, wie oft Leben dazugewonnen wird",
     "loopCollapseTitleMixed": "Wähle, wie oft die Schleife wiederholt wird",
-    "loopCollapseAmountTokens": "{{value}} Spielsteine erzeugen",
+    "loopCollapseAmountTokens_one": "{{count}} Spielstein erzeugen",
+    "loopCollapseAmountTokens_other": "{{count}} Spielsteine erzeugen",
     "loopCollapseAmountCounters": "Marken hinzufügen {{value}}×",
     "loopCollapseAmountLife": "Leben dazugewinnen {{value}}×",
     "loopCollapseAmountMixed": "Schleife wiederholen {{value}}×",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -445,6 +445,7 @@
   "counterTooltip": {
     "summary_one": "1 {{label}} counter\n{{description}}",
     "summary_other": "{{count}} {{label}} counters\n{{description}}",
+    "summaryUnbounded": "∞ {{label}} counters\n{{description}}",
     "descriptions": {
       "p1p1": "Each +1/+1 counter gives the permanent +1/+1.",
       "m1m1": "Each -1/-1 counter gives the permanent -1/-1.",
@@ -612,7 +613,8 @@
     "loopCollapseTitleCounters": "Choose how many times to add counters",
     "loopCollapseTitleLife": "Choose how many times to gain life",
     "loopCollapseTitleMixed": "Choose how many times to repeat the loop",
-    "loopCollapseAmountTokens": "Create {{value}} tokens",
+    "loopCollapseAmountTokens_one": "Create {{count}} token",
+    "loopCollapseAmountTokens_other": "Create {{count}} tokens",
     "loopCollapseAmountCounters": "Add counters {{value}}×",
     "loopCollapseAmountLife": "Gain life {{value}}×",
     "loopCollapseAmountMixed": "Repeat loop {{value}}×",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -413,6 +413,7 @@
   "counterTooltip": {
     "summary_one": "1 contador {{label}}\n{{description}}",
     "summary_other": "{{count}} contadores {{label}}\n{{description}}",
+    "summaryUnbounded": "∞ contadores {{label}}\n{{description}}",
     "descriptions": {
       "p1p1": "Cada contador +1/+1 da +1/+1 al permanente.",
       "m1m1": "Cada contador -1/-1 da -1/-1 al permanente.",
@@ -580,7 +581,8 @@
     "loopCollapseTitleCounters": "Elige cuántas veces añadir contadores",
     "loopCollapseTitleLife": "Elige cuántas veces ganar vida",
     "loopCollapseTitleMixed": "Elige cuántas veces repetir el bucle",
-    "loopCollapseAmountTokens": "Crear {{value}} fichas",
+    "loopCollapseAmountTokens_one": "Crear {{count}} ficha",
+    "loopCollapseAmountTokens_other": "Crear {{count}} fichas",
     "loopCollapseAmountCounters": "Añadir contadores {{value}}×",
     "loopCollapseAmountLife": "Ganar vida {{value}}×",
     "loopCollapseAmountMixed": "Repetir el bucle {{value}}×",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -413,6 +413,7 @@
   "counterTooltip": {
     "summary_one": "1 marqueur {{label}}\n{{description}}",
     "summary_other": "{{count}} marqueurs {{label}}\n{{description}}",
+    "summaryUnbounded": "∞ marqueurs {{label}}\n{{description}}",
     "descriptions": {
       "p1p1": "Chaque marqueur +1/+1 donne +1/+1 au permanent.",
       "m1m1": "Chaque marqueur -1/-1 donne -1/-1 au permanent.",
@@ -580,7 +581,8 @@
     "loopCollapseTitleCounters": "Choisissez combien de fois ajouter des marqueurs",
     "loopCollapseTitleLife": "Choisissez combien de fois gagner des points de vie",
     "loopCollapseTitleMixed": "Choisissez combien de fois répéter la boucle",
-    "loopCollapseAmountTokens": "Créer {{value}} jetons",
+    "loopCollapseAmountTokens_one": "Créer {{count}} jeton",
+    "loopCollapseAmountTokens_other": "Créer {{count}} jetons",
     "loopCollapseAmountCounters": "Ajouter des marqueurs {{value}}×",
     "loopCollapseAmountLife": "Gagner des points de vie {{value}}×",
     "loopCollapseAmountMixed": "Répéter la boucle {{value}}×",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -413,6 +413,7 @@
   "counterTooltip": {
     "summary_one": "1 segnalino {{label}}\n{{description}}",
     "summary_other": "{{count}} segnalini {{label}}\n{{description}}",
+    "summaryUnbounded": "∞ segnalini {{label}}\n{{description}}",
     "descriptions": {
       "p1p1": "Ogni segnalino +1/+1 dà +1/+1 al permanente.",
       "m1m1": "Ogni segnalino -1/-1 dà -1/-1 al permanente.",
@@ -580,7 +581,8 @@
     "loopCollapseTitleCounters": "Scegli quante volte aggiungere segnalini",
     "loopCollapseTitleLife": "Scegli quante volte guadagnare punti vita",
     "loopCollapseTitleMixed": "Scegli quante volte ripetere il ciclo",
-    "loopCollapseAmountTokens": "Crea {{value}} pedine",
+    "loopCollapseAmountTokens_one": "Crea {{count}} pedina",
+    "loopCollapseAmountTokens_other": "Crea {{count}} pedine",
     "loopCollapseAmountCounters": "Aggiungi segnalini {{value}}×",
     "loopCollapseAmountLife": "Guadagna punti vita {{value}}×",
     "loopCollapseAmountMixed": "Ripeti il ciclo {{value}}×",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -413,6 +413,7 @@
   "counterTooltip": {
     "summary_one": "1 znacznik {{label}}\n{{description}}",
     "summary_other": "{{count}} znaczników {{label}}\n{{description}}",
+    "summaryUnbounded": "∞ znaczników {{label}}\n{{description}}",
     "descriptions": {
       "p1p1": "Każdy znacznik +1/+1 daje permanentowi +1/+1.",
       "m1m1": "Każdy znacznik -1/-1 daje permanentowi -1/-1.",
@@ -580,7 +581,8 @@
     "loopCollapseTitleCounters": "Wybierz, ile razy dodać liczniki",
     "loopCollapseTitleLife": "Wybierz, ile razy zyskać życie",
     "loopCollapseTitleMixed": "Wybierz, ile razy powtórzyć pętlę",
-    "loopCollapseAmountTokens": "Stwórz {{value}} żetonów",
+    "loopCollapseAmountTokens_one": "Stwórz {{count}} żeton",
+    "loopCollapseAmountTokens_other": "Stwórz {{count}} żetonów",
     "loopCollapseAmountCounters": "Dodaj liczniki {{value}}×",
     "loopCollapseAmountLife": "Zyskaj życie {{value}}×",
     "loopCollapseAmountMixed": "Powtórz pętlę {{value}}×",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -413,6 +413,7 @@
   "counterTooltip": {
     "summary_one": "1 marcador {{label}}\n{{description}}",
     "summary_other": "{{count}} marcadores {{label}}\n{{description}}",
+    "summaryUnbounded": "∞ marcadores {{label}}\n{{description}}",
     "descriptions": {
       "p1p1": "Cada marcador +1/+1 dá +1/+1 à permanente.",
       "m1m1": "Cada marcador -1/-1 dá -1/-1 à permanente.",
@@ -580,7 +581,8 @@
     "loopCollapseTitleCounters": "Escolha quantas vezes adicionar marcadores",
     "loopCollapseTitleLife": "Escolha quantas vezes ganhar vida",
     "loopCollapseTitleMixed": "Escolha quantas vezes repetir o ciclo",
-    "loopCollapseAmountTokens": "Criar {{value}} fichas",
+    "loopCollapseAmountTokens_one": "Criar {{count}} ficha",
+    "loopCollapseAmountTokens_other": "Criar {{count}} fichas",
     "loopCollapseAmountCounters": "Adicionar marcadores {{value}}×",
     "loopCollapseAmountLife": "Ganhar vida {{value}}×",
     "loopCollapseAmountMixed": "Repetir o ciclo {{value}}×",

--- a/client/src/viewmodel/__tests__/cardProps.test.ts
+++ b/client/src/viewmodel/__tests__/cardProps.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { GameObject } from "../../adapter/types";
-import { toCardProps, toRoman } from "../cardProps";
+import { formatCounterTooltip, toCardProps, toRoman } from "../cardProps";
 
 function makeGameObject(overrides: Partial<GameObject> = {}): GameObject {
   return {
@@ -184,5 +184,48 @@ describe("toRoman", () => {
 
   it("falls back to the arabic numeral for a Class level beyond V", () => {
     expect(toRoman(6)).toBe("6");
+  });
+});
+
+// LOW-4 (CR 732.2a / CR 701.34a): while an accepted counter-growth loop pumps a counter, the
+// badge renders `∞` — the tooltip summary must say "unbounded" and NOT leak the still-finite
+// count. `isUnbounded` is the display-only flag threaded from the engine's `unbounded_counters`
+// membership set (never computed in the frontend).
+describe("formatCounterTooltip — unbounded summary", () => {
+  it("says ∞ and hides the finite count when unbounded (fallback, no translator)", () => {
+    const summary = formatCounterTooltip("charge", 4, undefined, true);
+    expect(summary).toContain("∞");
+    expect(summary).not.toContain("4");
+  });
+
+  it("shows the finite count when bounded (fallback, no translator) — matched pair", () => {
+    const summary = formatCounterTooltip("charge", 4, undefined, false);
+    expect(summary).toContain("4");
+    expect(summary).not.toContain("∞");
+  });
+
+  it("routes to the summaryUnbounded key WITHOUT forwarding the finite count (translator path)", () => {
+    const calls: Array<{ key: string; opts: Record<string, unknown> }> = [];
+    const translate = ((key: string, opts: Record<string, unknown>) => {
+      calls.push({ key, opts });
+      return key;
+    }) as never;
+    formatCounterTooltip("charge", 4, translate, true);
+    const call = calls.find((c) => c.key === "counterTooltip.summaryUnbounded");
+    expect(call, "the unbounded flag must select the summaryUnbounded key").toBeDefined();
+    // The finite `count` is NOT interpolated into the unbounded summary (no leak).
+    expect(call?.opts).not.toHaveProperty("count");
+  });
+
+  it("routes to the plural summary key WITH the count when bounded (revert-flip matched pair)", () => {
+    const calls: Array<{ key: string; opts: Record<string, unknown> }> = [];
+    const translate = ((key: string, opts: Record<string, unknown>) => {
+      calls.push({ key, opts });
+      return key;
+    }) as never;
+    formatCounterTooltip("charge", 4, translate, false);
+    const call = calls.find((c) => c.key === "counterTooltip.summary");
+    expect(call, "the bounded path must select the numeric summary key").toBeDefined();
+    expect(call?.opts).toMatchObject({ count: 4 });
   });
 });

--- a/client/src/viewmodel/cardProps.ts
+++ b/client/src/viewmodel/cardProps.ts
@@ -172,14 +172,26 @@ export function formatCounterTooltip(
   type: string,
   count: number,
   translate?: CounterTooltipTranslator,
+  isUnbounded?: boolean,
 ): string {
   const label = formatCounterType(type);
   if (translate) {
+    // CR 732.2a / CR 701.34a: an unbounded counter renders `∞` on the badge, so its
+    // tooltip summary must say "unbounded" rather than interpolate the finite count.
+    if (isUnbounded) {
+      return translate("counterTooltip.summaryUnbounded", {
+        label,
+        description: formatCounterDescription(type, translate),
+      });
+    }
     return translate("counterTooltip.summary", {
       count,
       label,
       description: formatCounterDescription(type, translate),
     });
+  }
+  if (isUnbounded) {
+    return `${label} counters: ∞`;
   }
   return `${label} counter${count !== 1 ? "s" : ""}: ${count}`;
 }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -11268,4 +11268,59 @@ mod kilo_interruptibility_tests {
             "without the pins the drive aborts at the unpinned tap cost ⇒ NO offer"
         );
     }
+
+    /// [LOW-1] declined-axis ∞ lifecycle — characterization/regression guard (memory:
+    /// combo-interruptibility-acceptance-criterion). A declined `Counters`/`Life` axis leaves its
+    /// ∞ capability marker in `unbounded_resources` intentionally (CR 732.2b never forces a
+    /// shortcut). This test guards the MEASURED retirement path (a) documented at the boundary
+    /// seam: the empty-stack offer hook `try_offer_object_growth_shortcut` (engine.rs:472) is NOT
+    /// gated by existing ∞ marks, so a later genuine re-detection RE-OFFERS the loop and can
+    /// re-collapse the declined axis once the observer is gone.
+    ///
+    /// DISCRIMINATING LEG (the re-offer assertion): with a pre-existing declined ∞ mark injected
+    /// for P0, the offer STILL fires. If a future regression ∞-gated the offer hook (e.g. to
+    /// suppress re-offering a declined axis), this flips to `None`. Positive control / reach-guard:
+    /// the SAME state WITHOUT the mark also offers (proving the mark is what the assertion isolates,
+    /// and the recorded 2-step period is intact — a `None` would be a drive-abort, not a missing
+    /// sequence).
+    #[test]
+    fn declined_infinity_mark_does_not_suppress_reoffer() {
+        use crate::analysis::resource::ResourceAxis;
+
+        let mut driven = load_migrated_dump();
+        drive_one_live_cycle(&mut driven);
+        let base = at_priority_window(driven);
+
+        // Reach-guard anchor: the recorded period is present (a `None` below is a real gating
+        // decision, never an empty-sequence artifact).
+        assert_eq!(
+            base.last_loop_action_sequence.len(),
+            2,
+            "reach-guard: the live cycle recorded the clean 2-step pinned period"
+        );
+        // Positive control: without any ∞ mark the intact loop re-derives the offer.
+        assert!(
+            try_offer_object_growth_shortcut(&base).is_some(),
+            "positive control: the intact loop offers when no ∞ mark is present"
+        );
+
+        // Inject a pre-existing DECLINED ∞ axis for P0 (as if an earlier boundary declined the life
+        // axis and left it ∞-marked for manual play). The offer hook reads `waiting_for` + stack +
+        // `samples()` + `last_loop_action_sequence` — never `unbounded_resources` — so the mark
+        // must NOT suppress the re-offer.
+        let mut marked = base.clone();
+        marked.mark_unbounded_loop(P0, &[ResourceAxis::Life(P0)]);
+        assert!(
+            marked
+                .unbounded_resources
+                .get(&P0)
+                .is_some_and(|axes| axes.contains(&ResourceAxis::Life(P0))),
+            "reach-guard: the declined ∞ Life mark is present on the probed state"
+        );
+        assert!(
+            try_offer_object_growth_shortcut(&marked).is_some(),
+            "the empty-stack offer hook is NOT ∞-gated: a persisted declined ∞ axis does not \
+             suppress a genuine re-detection re-offering the loop (CR 732.2a / CR 732.2b)"
+        );
+    }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2165,11 +2165,21 @@ pub(super) fn handle_resolution_choice(
                     // early-return above. `take_` removes the whole stash even on the
                     // error path so the boundary fixpoint terminates rather than
                     // re-prompting forever.
-                    let Some(items) = state.take_pending_materialization(player) else {
+                    let Some(mut items) = state.take_pending_materialization(player) else {
                         return Err(EngineError::InvalidAction(format!(
                             "LoopCollapse pay-amount for {player:?} has no pending materialization stash"
                         )));
                     };
+                    // CR 732.2a pause-safety: process the ONLY pause-prone axis (`Tokens` — its
+                    // per-cycle fodder mint can raise an ETB replacement `NeedsChoice`, unlike
+                    // the deterministic Counters/Life/DriveSequence axes) LAST. A mixed loop
+                    // stashes multiple axes at once (Guide of Souls + Sprout Swarm =
+                    // tokens+life; Witherbloom + Sprout Swarm = tokens+counters). Committing the
+                    // deterministic axes first means a `Tokens` pause leaves the finite
+                    // non-token effects applied exactly once and only the paused `Tokens` axis
+                    // ∞ — order-independent of how the stash was registered. Stable: relative
+                    // order of the non-Tokens axes is preserved.
+                    items.sort_by_key(|i| matches!(i, PersistentAxisMaterialization::Tokens(_)));
                     // FINDING #4 (accept→boundary observer-drift): the observed-growth
                     // firewall ran at ACCEPT, but the controller held priority between
                     // accept and this boundary and could have cast an observer (Heliod /
@@ -2249,6 +2259,14 @@ pub(super) fn handle_resolution_choice(
                                 // the ∞ marks are not cleared). No `debug_assert!` — the defensive
                                 // test deliberately drives this pause, which a debug_assert would panic.
                                 if state.pending_copy_token_resolution.is_some() {
+                                    // CR 732.2a pause-safe transaction: cash out the axes already
+                                    // applied THIS pass (a mixed stash, Edit 1 puts Tokens last) so
+                                    // no finite-applied Counters/Life axis is left with a stale ∞
+                                    // mark. The still-paused Tokens axis is NOT in `collapsed`, so
+                                    // its ∞ axis/pile is preserved for manual play (CR 732.2b never
+                                    // forces a shortcut). Do NOT drain the phase — the mint is
+                                    // mid-flight.
+                                    state.clear_collapsed_materializations(player, &collapsed);
                                     return Ok(ResolutionChoiceOutcome::WaitingFor(
                                         state.waiting_for.clone(),
                                     ));

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2197,6 +2197,19 @@ pub(super) fn handle_resolution_choice(
                                 // CR 707.2 (+ CR 111.10): mint N tapped copy-tokens of the
                                 // fodder profile — a source-less mint, so route through
                                 // `drive_copy_token_batches` (`ObjectId(0)` sentinel source).
+                                //
+                                // CR 732.2a k≡1 INVARIANT: this mints `count: amount` == k·amount
+                                // with the per-cycle fodder count k STRUCTURALLY ≡ 1. A `Tokens`
+                                // stash is only registered under `if let Some(profile)` in
+                                // `materialize_object_growth_shortcut` (engine.rs), whose
+                                // `current_period_fodder` derives the profile from
+                                // `derived_fodder_class` (engine.rs:1991-2005), which returns `None`
+                                // unless EXACTLY one new battlefield object appeared per period
+                                // (`let id = new_ids.next()?; if new_ids.next().is_some() { None }`).
+                                // A k>1 period (two+ new objects/cycle) fails that gate ⇒ no `Tokens`
+                                // stash ⇒ this arm is never reached for k≠1. So `count: amount` is
+                                // EXACT, not a k·N undercount. (Counters/Life instead carry a measured
+                                // `per_cycle_delta`, so those axes handle k>1 by construction.)
                                 let batch = crate::types::game_state::PendingCopyTokenBatch {
                                     owner: player,
                                     count: amount,
@@ -2222,6 +2235,24 @@ pub(super) fn handle_resolution_choice(
                                     ObjectId(0),
                                     events,
                                 );
+                                // CR 732.2a defense-in-depth: the offer firewall (the exhaustive
+                                // fail-closed `_ => Err(RecastAbort)` in `drive_loop_action_iteration`,
+                                // engine.rs:1871-1873, has no replacement-/target-choice arm)
+                                // guarantees a certified shortcut's per-cycle fodder mint cannot
+                                // pause, so this mint is unreachable-paused today. The boundary copies
+                                // the SAME fodder class (CR 707.2), so a mint that would pause implies
+                                // a certification that would have aborted. If that invariant ever
+                                // weakens, DO NOT advance the phase / mark the axis collapsed /
+                                // overwrite the replacement `waiting_for`: preserve the paused
+                                // copy-resolution and hand the replacement choice back (CR 732.2b
+                                // leaves the ∞ axes for manual play; game totals stay correct because
+                                // the ∞ marks are not cleared). No `debug_assert!` — the defensive
+                                // test deliberately drives this pause, which a debug_assert would panic.
+                                if state.pending_copy_token_resolution.is_some() {
+                                    return Ok(ResolutionChoiceOutcome::WaitingFor(
+                                        state.waiting_for.clone(),
+                                    ));
+                                }
                                 collapsed.push(item.clone());
                             }
                             PersistentAxisMaterialization::Counters(growths) => {
@@ -2284,6 +2315,27 @@ pub(super) fn handle_resolution_choice(
                     // end their ∞ status + stash + pile, PRESERVING any coexisting axis (a
                     // debug infinite-mana capability, or a finding-#4-declined axis). The ∞
                     // display collapses to an ordinary ×N for the collapsed axes (§9).
+                    //
+                    // FINDING #4 DECLINED-AXIS ∞ LIFECYCLE (CR 732.2b): a declined `Counters`/`Life`
+                    // axis (`continue`d above without `collapsed.push`) is absent from `collapsed`,
+                    // so `clear_collapsed_materializations` — which iterates ONLY `collapsed`
+                    // (game_state.rs) — never removes its `unbounded_resources` /
+                    // `unbounded_counter_targets` entry. That ∞ mark is an INTENTIONAL capability
+                    // marker that PERSISTS (the loop machinery still exists, so the capability is
+                    // real), with game totals correct (the declined axis was not applied — no double
+                    // count). It is retired by exactly TWO LIVE paths:
+                    //   (a) a later GENUINE re-detection re-collapsing it — the empty-stack offer
+                    //       hook `try_offer_object_growth_shortcut` (engine.rs:472), which is NOT
+                    //       ∞-gated, so a fresh manual re-loop re-offers and re-registers a stash; and
+                    //   (b) debug toggle-off — `clear_unbounded_loop` via `engine_debug.rs:417`.
+                    // NOTE: the enabler-departure clear (`clear_unbounded_loop` from
+                    // `zones.rs:544-554`) is INERT for this object-growth ∞-mark class, because
+                    // `materialize_object_growth_shortcut` (engine.rs) never calls
+                    // `register_unbounded_loop_enablers` (only the Interactive Path-C arm at
+                    // engine.rs:682 does), so `zones.rs`'s `unbounded_loop_enablers.contains(id)`
+                    // gate never matches an object-growth mark. Registering enablers for the
+                    // object-growth path is a PRE-EXISTING, broader gap (deferred follow-up F2), not
+                    // introduced by this declined-axis handling.
                     state.clear_collapsed_materializations(player, &collapsed);
                     // Continue the boundary fixpoint (§7): re-draining either prompts the
                     // next APNAP player with a stash or restores Priority now.

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -10298,3 +10298,57 @@ fn morph_casts_face_down_under_multiple_name_prohibitions() {
         "CR 708.2a: a face-down spell has no name"
     );
 }
+
+/// LOW-2 (CR 732.2a / CR 111.10): `derived_fodder_class` is the single-new-object gate that
+/// guarantees the boundary Tokens mint's per-cycle fodder count k ≡ 1. It returns `Some(class)`
+/// for a period that reproduced EXACTLY one new battlefield object, and `None` for a period that
+/// reproduced two+ (a non-certifiable multi-fodder shape ⇒ no `Tokens` stash ⇒ no k·N undercount).
+/// This is the structural proof behind the k≡1 annotation at the boundary mint and on the
+/// `PersistentAxisMaterialization::Tokens` variant.
+///
+/// REVERT-FAILING assertion: delete `if new_ids.next().is_some() { return None }` in
+/// `derived_fodder_class` (engine.rs) ⇒ the two-new-object case returns `Some(first)` ⇒ the
+/// `is_none()` assert below flips to FAIL. Non-vacuity: the paired one-new-object `Some` case is
+/// the positive reach-guard (the gate genuinely admits the k≡1 shape).
+#[test]
+fn derived_fodder_class_is_single_new_object_gate() {
+    let before = GameState::new_two_player(7);
+
+    // One new battlefield object across the period ⇒ Some(class) (the k≡1 certifiable shape).
+    let mut after_one = before.clone();
+    let saproling = create_object(
+        &mut after_one,
+        CardId(1),
+        PlayerId(0),
+        "Saproling".to_string(),
+        Zone::Battlefield,
+    );
+    let class = derived_fodder_class(&before, &after_one);
+    assert!(
+        class.as_ref().is_some_and(|o| o.id == saproling),
+        "reach-guard: one new battlefield object ⇒ the reproduced fodder class; got {class:?}"
+    );
+
+    // Two new battlefield objects across the period ⇒ None: a multi-fodder period is not this
+    // shape, so no `Tokens` stash is registered and the k>1 undercount is unreachable.
+    let mut after_two = before.clone();
+    create_object(
+        &mut after_two,
+        CardId(1),
+        PlayerId(0),
+        "Saproling".to_string(),
+        Zone::Battlefield,
+    );
+    create_object(
+        &mut after_two,
+        CardId(2),
+        PlayerId(0),
+        "Saproling".to_string(),
+        Zone::Battlefield,
+    );
+    assert!(
+        derived_fodder_class(&before, &after_two).is_none(),
+        "single-new-object gate: two new battlefield objects ⇒ None (delete the second-`next` \
+         guard and this flips to Some)"
+    );
+}

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3379,7 +3379,13 @@ pub struct PendingCopyTokenBatch {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum PersistentAxisMaterialization {
     /// CR 707.2 + CR 111.1: mint N tapped copy-tokens of this fodder profile
-    /// (the `TokensCreated` axis).
+    /// (the `TokensCreated` axis). Carries NO per-cycle count because the per-cycle
+    /// fodder count k is STRUCTURALLY ≡ 1: this stash is only registered when
+    /// `materialize_object_growth_shortcut`'s `derived_fodder_class`
+    /// (engine.rs:1991-2005) found EXACTLY one new battlefield object per period
+    /// (a two+-object period returns `None` ⇒ no `Tokens` stash), so the boundary
+    /// mint of `count: amount` == k·amount is EXACT. (Contrast `Counters`/`Life`,
+    /// which carry a measured `per_cycle_delta` to handle k>1.)
     Tokens(Box<CopiableValues>),
     /// CR 122.1 / CR 701.34a: apply `per_cycle_delta × N` counters to each captured
     /// target (the beneficial-growable counter axis: Generic / +1/+1 / loyalty / defense).

--- a/crates/engine/tests/integration/combo_infinite_pile.rs
+++ b/crates/engine/tests/integration/combo_infinite_pile.rs
@@ -35,7 +35,7 @@ use engine::game::deck_loading::{
 use engine::game::derived_views::derive_views;
 use engine::game::engine::{apply, start_game};
 use engine::game::layers::{flush_layers, mark_layers_full};
-use engine::game::scenario::GameRunner;
+use engine::game::scenario::{GameRunner, GameScenario};
 use engine::game::zones::{add_to_zone, create_object, remove_from_zone};
 use engine::types::actions::{GameAction, MulliganChoice};
 use engine::types::card_type::CoreType;
@@ -2059,5 +2059,292 @@ fn loop_collapse_axis_from_materializations_maps_each_shape() {
     assert_eq!(
         LoopCollapseAxis::from_materializations(&drive_mana),
         LoopCollapseAxis::Mixed
+    );
+}
+
+/// [MED] (CR 732.2a defense-in-depth): the `Tokens` boundary-mint arm must early-return when the
+/// copy-token mint PAUSES for a replacement choice, preserving the replacement `waiting_for` and
+/// the paused `pending_copy_token_resolution` instead of advancing the phase / overwriting
+/// `waiting_for = Priority`.
+///
+/// DELIBERATELY FIREWALL-UNREACHABLE: the offer firewall (`drive_loop_action_iteration`'s
+/// exhaustive fail-closed `_ => Err(RecastAbort)`, engine.rs:1871-1873) guarantees a certified
+/// shortcut's per-cycle fodder mint cannot pause, so this state cannot arise in real play. The test
+/// constructs it directly — installing an OPTIONAL token-creation replacement (CR 616.1 single
+/// optional candidate → `replace_event` returns `NeedsChoice`, replacement.rs:8191-8214) on a P0
+/// battlefield object AFTER accept — to exercise the defensive guard. (Two IDENTICAL replacements
+/// would be immaterially ordered and auto-resolve with NO pause, making the test vacuous; a single
+/// MANDATORY replacement applies without a pause — hence a single OPTIONAL candidate.)
+///
+/// NON-VACUITY REACH-GUARD: the first assertion checks the mint actually paused
+/// (`pending_copy_token_resolution.is_some()`), so a fizzled/auto-resolved mint (non-matching or
+/// immaterial replacement) fails loudly rather than passing vacuously.
+///
+/// REVERT-FAILING assertion (MEASURED, implementer-run revert-probe): delete the guard → the arm
+/// falls through to `collapsed.push(Tokens)` + `clear_collapsed_materializations`, which cashes out
+/// the Tokens ∞ axis (`TokensCreated`) and DROPS the ∞ token pile — even though the paused mint
+/// created ZERO tokens. So the guard's load-bearing effect is PRESERVING the ∞ axis/pile on a
+/// paused mint; the revert-probe flips the `unbounded_resources`/`unbounded_loop_pile` assertions
+/// below (the phase-drain is a no-op while a replacement choice is pending, so `waiting_for` stays
+/// `ReplacementChoice` either way — that is a correctness sanity check, not the discriminator).
+#[test]
+fn med_tokens_boundary_mint_pause_preserves_replacement_choice() {
+    use engine::analysis::resource::ResourceAxis;
+    use engine::types::ability::{QuantityModification, ReplacementDefinition, ReplacementMode};
+    use engine::types::replacements::ReplacementEvent;
+    use std::sync::Arc;
+
+    let mut state: GameState = serde_json::from_str(&OFFER_STATE)
+        .expect("the real 4p offer dump must deserialize into the current GameState");
+    drive_all_accept(&mut state);
+
+    // Install an OPTIONAL token-count-doubling replacement ("you may create twice that many tokens
+    // instead", CR 616.1) on a fresh P0 battlefield permanent — AFTER accept, so it never perturbs
+    // the accept-time fodder-derivation clone-drive (installing it before accept would abort
+    // certification at the firewall, which is exactly the invariant this guard backstops). At the
+    // boundary Tokens mint, `replace_event` sees ONE optional candidate for the copy-token
+    // `CreateToken` event → returns `NeedsChoice` → `drive_copy_token_batches` sets
+    // `pending_copy_token_resolution` AND `waiting_for = ReplacementChoice`.
+    let doubler = create_object(
+        &mut state,
+        CardId(9001),
+        P0,
+        "Optional Token Doubler".to_string(),
+        Zone::Battlefield,
+    );
+    let mut def = ReplacementDefinition::new(ReplacementEvent::CreateToken);
+    def.mode = ReplacementMode::Optional { decline: None };
+    def.quantity_modification = Some(QuantityModification::DOUBLE);
+    let reps = vec![def];
+    let obj = state.objects.get_mut(&doubler).unwrap();
+    obj.replacement_definitions = reps.clone().into();
+    obj.base_replacement_definitions = Arc::new(reps);
+
+    drive_priority_to_next_boundary(&mut state);
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::PayAmountChoice { player, resource: PayableResource::LoopCollapse { .. }, .. }
+                if player == P0
+        ),
+        "the boundary must prompt P0 for the Tokens LoopCollapse count, got {:?}",
+        state.waiting_for
+    );
+    // Pre-submit reach-guards: the accepted token loop marked the Tokens ∞ axis + a non-empty ∞
+    // pile — the capability the paused mint must NOT cash out. (Non-vacuity: if these were absent
+    // the preservation assertions below would be trivially satisfiable.)
+    assert!(
+        state
+            .unbounded_resources
+            .get(&P0)
+            .is_some_and(|a| a.contains(&ResourceAxis::TokensCreated)),
+        "pre-submit reach-guard: the accepted token loop marks the TokensCreated ∞ axis"
+    );
+    assert!(
+        state
+            .unbounded_loop_pile
+            .get(&P0)
+            .is_some_and(|p| !p.is_empty()),
+        "pre-submit reach-guard: the accepted token loop has a non-empty ∞ pile"
+    );
+
+    apply(&mut state, P0, GameAction::SubmitPayAmount { amount: 3 })
+        .expect("P0 submits the finite token loop-collapse count");
+
+    // Non-vacuity reach-guard: the mint actually paused for the replacement (proves the OPTIONAL
+    // replacement matched the synthetic mint; a non-matching / auto-resolving construction leaves
+    // this None and fails the test loudly).
+    assert!(
+        state.pending_copy_token_resolution.is_some(),
+        "reach-guard: the boundary Tokens mint paused on the optional replacement \
+         (pending_copy_token_resolution set)"
+    );
+    // Correctness sanity (holds with AND without the guard — the phase-drain no-ops while a
+    // replacement choice is pending): the replacement prompt is surfaced, not clobbered to Priority.
+    assert!(
+        matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }),
+        "the paused replacement choice is surfaced, got {:?}",
+        state.waiting_for
+    );
+    // DISCRIMINATOR (revert-flip): the paused mint created ZERO tokens, so it must NOT cash out
+    // the Tokens ∞ capability. Without the guard, `collapsed.push(Tokens)` +
+    // `clear_collapsed_materializations` remove the TokensCreated axis and drop the ∞ pile ⇒ both
+    // assertions FLIP to FAIL (measured via implementer revert-probe).
+    assert!(
+        state
+            .unbounded_resources
+            .get(&P0)
+            .is_some_and(|a| a.contains(&ResourceAxis::TokensCreated)),
+        "REVERT-FLIP: the paused mint must preserve the Tokens ∞ axis, not cash it out for a \
+         batch that minted zero tokens"
+    );
+    assert!(
+        state
+            .unbounded_loop_pile
+            .get(&P0)
+            .is_some_and(|p| !p.is_empty()),
+        "REVERT-FLIP: the paused mint must preserve the ∞ token pile, not drop it"
+    );
+}
+
+/// Activate `ability_index` on `source`, then pass priority until the stack settles empty at a
+/// `Priority` window OR a `LoopShortcut` offer surfaces (mirrors the mana-engine harness).
+fn low3_activate_and_settle(runner: &mut GameRunner, source: ObjectId, ability_index: usize) {
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index,
+        })
+        .expect("activation is legal");
+    for _ in 0..60 {
+        match &runner.state().waiting_for {
+            WaitingFor::LoopShortcut { .. } => break,
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            _ => {}
+        }
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+}
+
+/// [LOW-3] E2E: accepting a REAL UNOBSERVED life-growth loop drives the accept-time production
+/// routing in `materialize_object_growth_shortcut` (engine.rs) into the BATCHED `Life` branch —
+/// the branch every prior Counters/Life collapse test GRAFTS via `register_pending_materialization`
+/// (bypassing the real δ-capture + `life_growth_is_observed` decision). The OBSERVED (DriveSequence)
+/// counter route is already covered by `kilo_accept_collapses_at_boundary_to_exactly_n_counters`
+/// (kilo_live_offer_from_real_dump.rs); this closes the UNOBSERVED batched gap.
+///
+/// CONSTRUCTION (self-contained, no dump): a synthetic creature with an off-stack mana ability
+/// (CR 605.3b — the only activation class that SEEDS a loop period, engine.rs:4141-4173), plus a
+/// free gain-life and a free untap. Ordered [mana, gain-life, untap] so the 2-step prefix leaves
+/// the creature TAPPED — the offer's re-drive can't re-tap it, aborting any premature pure-mana
+/// offer and forcing the life beat into the certified 3-step period. No `LifeChanged` trigger /
+/// `GainLife` replacement / life-total reader is on the board ⇒ `life_growth_is_observed == false`
+/// ⇒ the accept routes to the BATCHED `Life` stash.
+///
+/// REVERT-FAILING assertion: break the routing predicate — force the observed branch, or drop the
+/// `else`/`if !life.is_empty()` batched registration in `materialize_object_growth_shortcut` — and
+/// the produced stash shape changes (a `DriveSequence`, or an empty stash) ⇒ the batched-`Life`
+/// assertion FLIPS. Non-vacuity reach-guards: the recorded 3-step period, the surfaced offer, and
+/// the non-empty post-accept stash all gate the shape assertion.
+#[test]
+fn low3_unobserved_life_growth_accept_registers_batched_life() {
+    use engine::analysis::resource::ResourceAxis;
+    use engine::game::mana_abilities::is_mana_ability;
+    use engine::types::ability::{Effect, TapStateChange};
+
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    let engine_id = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Lifedynamo",
+            2,
+            2,
+            "{T}: Add {C}.\n{0}: You gain 1 life.\n{0}: Untap Lifedynamo.",
+        )
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().loop_detection = LoopDetectionMode::Interactive;
+
+    // Derive the ability indices off the layer-built object (robust to parser ordering).
+    let (mana_idx, life_idx, untap_idx) = {
+        let abilities = &runner.state().objects[&engine_id].abilities;
+        let mana_idx = abilities
+            .iter()
+            .position(is_mana_ability)
+            .expect("the {T}: Add {C} mana ability");
+        let life_idx = abilities
+            .iter()
+            .position(|d| matches!(&*d.effect, Effect::GainLife { .. }))
+            .expect("the {0}: You gain 1 life ability");
+        let untap_idx = abilities
+            .iter()
+            .position(|d| {
+                matches!(
+                    &*d.effect,
+                    Effect::SetTapState {
+                        state: TapStateChange::Untap,
+                        ..
+                    }
+                )
+            })
+            .expect("the {0}: Untap ability");
+        (mana_idx, life_idx, untap_idx)
+    };
+
+    // Drive one period [mana, gain-life, untap], settling each beat; the offer surfaces after the
+    // untap beat closes the 3-step certified period.
+    low3_activate_and_settle(&mut runner, engine_id, mana_idx);
+    low3_activate_and_settle(&mut runner, engine_id, life_idx);
+    low3_activate_and_settle(&mut runner, engine_id, untap_idx);
+
+    // Reach-guard: the 3-step period recorded (non-vacuous — a shorter seq would be a different
+    // loop / a drive artifact).
+    assert_eq!(
+        runner.state().last_loop_action_sequence.len(),
+        3,
+        "the certified period is the 3-step [mana, gain-life, untap] sequence, got {:?}",
+        runner.state().last_loop_action_sequence
+    );
+    // Reach-guard: the CR 732.2a offer surfaced for P0.
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::LoopShortcut { proposer, .. } if proposer == P0),
+        "the unobserved life engine must surface a LoopShortcut offer for P0, got {:?}",
+        runner.state().waiting_for
+    );
+
+    // Accept through the REAL APNAP pipeline → materialize_object_growth_shortcut routing.
+    runner
+        .act(GameAction::DeclareShortcut {
+            count: IterationCount::Fixed(1),
+            template: None,
+        })
+        .expect("P0 declares the shortcut");
+    runner
+        .act(GameAction::RespondToShortcut {
+            response: ShortcutResponse::Accept,
+        })
+        .expect("the single opponent accepts");
+
+    // Reach-guard: the accept produced a non-empty deferred stash (not a no-op).
+    let stash = runner
+        .state()
+        .pending_unbounded_materialization
+        .get(&P0)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !stash.is_empty(),
+        "reach-guard: the accept must register a deferred materialization stash for P0"
+    );
+    // DISCRIMINATOR: the UNOBSERVED life growth routes to a BATCHED `Life` item carrying the
+    // per-cycle δ — produced by the real accept-time routing, never grafted.
+    assert!(
+        stash.iter().any(|m| matches!(
+            m,
+            PersistentAxisMaterialization::Life { player, per_cycle_delta }
+                if *player == P0 && *per_cycle_delta >= 1
+        )),
+        "the unobserved life loop must register a BATCHED Life stash (per_cycle_delta captured), \
+         got {stash:?}"
+    );
+    // DISCRIMINATOR: an UNOBSERVED loop BATCHES — it must NOT register a DriveSequence (that is the
+    // observed route; forcing the observed branch flips this).
+    assert!(
+        !stash
+            .iter()
+            .any(|m| matches!(m, PersistentAxisMaterialization::DriveSequence { .. })),
+        "an unobserved life loop batches; it must not register a DriveSequence, got {stash:?}"
+    );
+    // The life axis is ∞-marked (the mana axis is too; both are real unbounded axes here).
+    assert!(
+        runner
+            .state()
+            .unbounded_resources
+            .get(&P0)
+            .is_some_and(|axes| axes.contains(&ResourceAxis::Life(P0))),
+        "the accepted loop marks the Life axis ∞ for P0"
     );
 }

--- a/crates/engine/tests/integration/combo_infinite_pile.rs
+++ b/crates/engine/tests/integration/combo_infinite_pile.rs
@@ -2187,6 +2187,173 @@ fn med_tokens_boundary_mint_pause_preserves_replacement_choice() {
     );
 }
 
+/// [BLOCKER] (#6259 review, CR 732.2a pause-safety): a MIXED stash pausing on the `Tokens`
+/// axis must NOT strand a finite-applied `Counters` axis with a stale ∞ mark, and must not
+/// skip the deterministic `Counters` axis depending on stash registration order. Before this
+/// fix, production registers `Tokens` before `Counters` (Tokens→Counters→Life in
+/// `materialize_object_growth_shortcut`), so the `for item in &items` loop hit `Tokens` FIRST —
+/// a pausing Tokens mint early-returned before `Counters` ever ran on this pass, and whatever
+/// HAD already landed in `collapsed` was never cashed out, leaving stale ∞ marks.
+///
+/// FIX: Edit 1 sorts `items` so the ONLY pause-prone axis (`Tokens`) runs LAST regardless of
+/// registration order. Edit 2 calls `clear_collapsed_materializations(player, &collapsed)` at
+/// the `Tokens` pause guard, cashing out whatever finite axes DID commit before the pause.
+///
+/// CONSTRUCTION: real 4p offer dump → real accept (registers the `Tokens` stash for P0) →
+/// graft an UNOBSERVED `Counters` axis onto a P0 Saproling (the same single-authority
+/// `mark_unbounded_loop` + `register_pending_materialization` writers the accept path uses, per
+/// `real_4p_boundary_collapse_batches_unobserved_counter_and_declines_observed_life`) → install
+/// the OPTIONAL token-doubler replacement AFTER accept (per
+/// `med_tokens_boundary_mint_pause_preserves_replacement_choice`) so the boundary `Tokens` mint
+/// PAUSES on a `NeedsChoice` replacement choice → drive to the boundary → `SubmitPayAmount{4}`.
+///
+/// REVERT-FLIPS (MEASURED, implementer-run revert-probe — see report):
+///  - delete Edit 2's `clear_collapsed_materializations` call at the pause guard ⇒ the
+///    collapsed `Counters` axis is never cashed out ⇒ assertion (3)'s "Counter axis gone"
+///    FLIPS to FAIL (stale ∞ left on the applied counter axis).
+///  - delete Edit 1's `sort_by_key` ⇒ `Tokens` (registered by the accept path before this
+///    test's `Counters` graft) processes FIRST, pauses at index 0, and `Counters` is NEVER
+///    reached ⇒ assertion (2) FLIPS to FAIL (counter stays at base, unchanged).
+#[test]
+fn med_mixed_counter_tokens_pause_commits_finite_counter_and_keeps_only_tokens_unbounded() {
+    use engine::analysis::resource::{CounterClass, ObjectClass, ResourceAxis};
+    use engine::types::ability::{QuantityModification, ReplacementDefinition, ReplacementMode};
+    use engine::types::counter::CounterType;
+    use engine::types::game_state::CounterGrowth;
+    use engine::types::replacements::ReplacementEvent;
+    use std::sync::Arc;
+
+    let mut state: GameState = serde_json::from_str(&OFFER_STATE)
+        .expect("the real 4p offer dump must deserialize into the current GameState");
+    drive_all_accept(&mut state);
+
+    // Graft an UNOBSERVED +1/+1 counter axis onto a P0 Saproling — the same single-authority
+    // writers the accept path uses (mirrors
+    // real_4p_boundary_collapse_batches_unobserved_counter_and_declines_observed_life).
+    let creature = *p0_saproling_ids(&state)
+        .iter()
+        .next()
+        .expect("P0 controls at least one Saproling to bear a +1/+1 counter");
+    let base_counters = 1u32;
+    state
+        .objects
+        .get_mut(&creature)
+        .unwrap()
+        .counters
+        .insert(CounterType::Plus1Plus1, base_counters);
+    state.mark_unbounded_loop(
+        P0,
+        &[ResourceAxis::Counter(
+            CounterClass::Plus1Plus1,
+            ObjectClass::Creature,
+        )],
+    );
+    state.register_pending_materialization(
+        P0,
+        PersistentAxisMaterialization::Counters(vec![CounterGrowth {
+            object: creature,
+            counter: CounterType::Plus1Plus1,
+            per_cycle_delta: 2,
+        }]),
+    );
+
+    // Install the OPTIONAL token-doubler replacement AFTER accept (mirrors
+    // med_tokens_boundary_mint_pause_preserves_replacement_choice) so the boundary Tokens mint
+    // pauses on a NeedsChoice replacement instead of completing.
+    let doubler = create_object(
+        &mut state,
+        CardId(9002),
+        P0,
+        "Optional Token Doubler".to_string(),
+        Zone::Battlefield,
+    );
+    let mut def = ReplacementDefinition::new(ReplacementEvent::CreateToken);
+    def.mode = ReplacementMode::Optional { decline: None };
+    def.quantity_modification = Some(QuantityModification::DOUBLE);
+    let reps = vec![def];
+    let obj = state.objects.get_mut(&doubler).unwrap();
+    obj.replacement_definitions = reps.clone().into();
+    obj.base_replacement_definitions = Arc::new(reps);
+
+    drive_priority_to_next_boundary(&mut state);
+    assert!(
+        matches!(
+            state.waiting_for,
+            WaitingFor::PayAmountChoice { player, resource: PayableResource::LoopCollapse { .. }, .. }
+                if player == P0
+        ),
+        "the boundary must prompt P0 for the mixed Counters+Tokens LoopCollapse count, got {:?}",
+        state.waiting_for
+    );
+
+    apply(&mut state, P0, GameAction::SubmitPayAmount { amount: 4 })
+        .expect("P0 submits the finite mixed-axis loop-collapse count");
+
+    // (1) Reach-guard: the Tokens mint actually paused (proves the submit ran past the
+    //     Counters axis and into the Tokens axis, not a fizzled/auto-resolved mint).
+    assert!(
+        state.pending_copy_token_resolution.is_some(),
+        "reach-guard: the boundary Tokens mint paused on the optional replacement"
+    );
+    assert!(
+        matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }),
+        "the paused replacement choice is surfaced, not clobbered, got {:?}",
+        state.waiting_for
+    );
+
+    // (2) FINITE PRIOR EFFECT ONCE: the grafted counter axis committed exactly once — 4×2 = 8 —
+    //     which only holds because Edit 1 processes Counters BEFORE the Tokens pause.
+    assert_eq!(
+        state
+            .objects
+            .get(&creature)
+            .unwrap()
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        base_counters + 4 * 2,
+        "SubmitPayAmount{{4}} commits the Counters axis exactly once (4×2 = 8) despite the \
+         Tokens axis pausing later in the same pass"
+    );
+
+    // (3) ONLY Tokens ∞: the collapsed Counters axis is cashed out (Edit 2), the still-paused
+    //     Tokens axis is NOT (its ∞ axis + pile survive for the eventual resume/manual play).
+    assert!(
+        !state
+            .unbounded_resources
+            .get(&P0)
+            .is_some_and(|a| a.contains(&ResourceAxis::Counter(
+                CounterClass::Plus1Plus1,
+                ObjectClass::Creature
+            ))),
+        "REVERT-FLIP: the committed Counters axis must cash out of the ∞ status, not strand a \
+         stale ∞ mark on a finite-applied axis"
+    );
+    assert!(
+        state
+            .unbounded_resources
+            .get(&P0)
+            .is_some_and(|a| a.contains(&ResourceAxis::TokensCreated)),
+        "the still-paused Tokens axis stays ∞-marked (not yet collapsed)"
+    );
+    assert!(
+        state
+            .unbounded_loop_pile
+            .get(&P0)
+            .is_some_and(|p| !p.is_empty()),
+        "the still-paused Tokens axis keeps its ∞ pile (not dropped mid-pause)"
+    );
+
+    // (4) Phase NOT advanced: the boundary drain is skipped while the replacement is pending —
+    //     the paused prompt stays surfaced, not clobbered to Priority.
+    assert!(
+        !matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "the phase drain must not run while the Tokens mint is mid-pause, got {:?}",
+        state.waiting_for
+    );
+}
+
 /// Activate `ability_index` on `source`, then pass priority until the stack settles empty at a
 /// `Priority` window OR a `LoopShortcut` offer surfaces (mirrors the mana-engine harness).
 fn low3_activate_and_settle(runner: &mut GameRunner, source: ObjectId, ability_index: usize) {


### PR DESCRIPTION
Play-tested at `247ffb7` (rebased to `b211832`) and combo detection works in live games. Will check again after addressing blockers.
Play-tested at `1ed7cfd` (rebased to `e6ebd63`) and combo detection works in live games with blockers addressed.

:robot: _AI text below_ :robot:

## Summary

Follow-up to **#6238** (merged) addressing the 1 MED + 5 LOW findings from the maintainer's independent `review-impl` on the CR 732.2a loop-collapse feature: a defense-in-depth boundary-mint pause guard, the declined-axis `∞` lifecycle documentation + regression test, the single-fodder invariant assertion + unit test, an accept-time production-routing E2E test, and two frontend display fixes (the `∞` counter tooltip and an i18next plural). No behavior change to the certified/offer path; the MED guard is unreachable today (firewall-gated) and the rest are coverage/docs/display.

## Implementation method (required)

Method: /engine-implementer

(plan → review-engine-plan [2 rounds to clean] → implement → review-impl [clean, every finding's revert-flip observed]. Two findings changed fix after code-probing: LOW-1 both reviewer options proven wrong/impossible → document + test; LOW-2 k>1 proven structurally impossible → assert + unit test, not capture-and-multiply.)

## CR references

`CR 732.2a` (offer firewall / no-conditional-actions), `CR 732.2b` (loop shortcut never forced — declined-axis capability marker), `CR 707.2` (token-copy surface identity), `CR 616.1` (2+ materially-ordered replacements → controller orders; the MED test's pausing construction), `CR 111.10` (predefined-token creation), `CR 605.3b` (off-stack mana ability — the LOW-3 test's loop-seeding activation class). All grepped against `docs/MagicCompRules.txt`.

## Verification

- [x] Required checks ran clean locally (Tilt does not watch this worktree; run directly), post-rebase on the current head.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean (the reviewed diff is byte-identical to this head except the #6254 import union, re-verified green post-rebase).
- [x] Both anchors cite existing analogous code at the same seam.

Rebased onto `upstream/main` (`6817abeb4`, which now contains #6238's squash `549582524`) — one content conflict in `combo_infinite_pile.rs` resolved as a union import (`mark_layers_full` from #6254 + `GameScenario` from this PR). Measured post-rebase on head `247ffb761`:

- `cargo test -p engine --test integration combo_infinite_pile` — **21 passed / 0 failed**
- `cargo test -p engine --lib derived_fodder_class` — **1 passed** (the LOW-2 single-new-object gate)
- `cargo check --workspace` — **clean** (Finished, 2m26s)
- `cargo clippy -p engine --all-targets` — **clean, 0 warnings / 0 errors** (16m06s)
- `pnpm type-check` — **exit 0** · `pnpm test` — **2138 passed / 246 files** (18 todo, 4 skipped; i18n locale parity green)
- `cargo fmt --all --check` — **clean**

Each new test carries an observed revert-flip: removing the MED guard fails the "preserve the Tokens `∞` axis" assertion; forcing the LOW-3 routing branch changes the registered stash shape; deleting the LOW-2 single-new-object gate flips the `is_none()` assertion; ∞-gating the LOW-1 re-offer fails; neutralizing `isUnbounded` leaks the finite count; reverting the LOW-5 plural key renders "Create 1 tokens" at value=1.

## Gate A

Gate A PASS head=247ffb76188651139168f03f3f629c8188b327bf base=836ff312ae2073c99af28d286b0c4915faa8a458

## Anchored on

- `crates/engine/src/game/engine_resolution_choices.rs` — the existing `pending_mana_ability` early-return in the same `SubmitPayAmount` handler; the MED guard mirrors that pause-aware `WaitingFor` idiom for the copy-token mint.
- `client/src/viewmodel/cardProps.ts` + the render sites' existing `isUnbounded` membership read from engine `derived.unbounded_counters` (`PermanentCard.tsx` / `ArtCropCard.tsx`); the LOW-4 tooltip fix threads that same engine-provided flag (display-only, no new frontend logic).

## Final review-impl

Final review-impl PASS head=247ffb76188651139168f03f3f629c8188b327bf

## Claimed parse impact

None — engine game-logic (a defensive boundary guard, docs, tests) + frontend display/i18n; no parser or card-data change. (Coverage parse-diff on #6238 already read "No card-parse changes".)

## Combo-detector series

| Pos | PR | Delivers |
|-----|----|----------|
| PR-7 | #5672 | Loop shortcut **offer** + APNAP accept-or-shorten window (CR 732.2a–c). |
| PR-8 | #6238 (merged) | Loop-shortcut **acceptance + phase-boundary collapse/materialization** (tokens/counters/life/mana → `∞`). |
| **this PR** | (this PR) | **Review follow-up** on #6238 — boundary-mint pause guard, declined-axis `∞` lifecycle doc + test, single-fodder invariant, accept-time routing E2E, `∞` tooltip + plural i18n. |

**Predecessor: #6238 — https://github.com/phase-rs/phase/pull/6238 (MERGED)** — this PR addresses its post-merge review findings.

## Deferred (disclosed)

- **Declined-axis `∞` lifecycle (answering the reviewer's LOW-1 question):** a declined axis's `∞` mark is kept as an intentional **capability marker** (CR 732.2b never forces a shortcut; the axis was not applied, so game totals stay correct) and is retired by a later genuine re-detection re-collapse or the debug toggle. Collapse-to-finite was rejected as rules-wrong (it would hide a still-usable capability). If you'd prefer different UX here, say so and I'll adjust.
- **Object-growth enabler-registration gap (F2):** `materialize_object_growth_shortcut` never calls `register_unbounded_loop_enablers`, so `zones.rs`'s enabler-departure auto-revoke is inert for object-growth `∞` marks. This is **pre-existing** (predates this PR) and class-wide — deferred to a separate follow-up rather than widened here.
