### PR TITLE
feat(client): centralize spell cost display in a spellCostDisplay viewmodel helper

### DIFF
--- a/client/src/components/hand/MobileHandDrawer.tsx
+++ b/client/src/components/hand/MobileHandDrawer.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
+import { spellCostDisplay } from "../../viewmodel/costLabel.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
@@ -235,9 +236,7 @@ const DrawerCard = memo(function DrawerCard({
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
   const effectiveCost = useGameStore((s) => s.spellCosts[String(objectId)]);
   const { src } = useCardImage(cardName, { size: "normal" });
-  const displayCost = effectiveCost ?? manaCost;
-  const isReduced = effectiveCost?.type === "Cost" && manaCost.type === "Cost"
-    && (effectiveCost.generic < manaCost.generic || effectiveCost.shards.length < manaCost.shards.length);
+  const { displayCost, isReduced } = spellCostDisplay(effectiveCost, manaCost);
 
   // Mouse hover (desktop) + long-press (touch) both open the card preview, and
   // the hook tags the element with `data-card-hover` so usePreviewDismiss's

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { CardImage } from "../card/CardImage.tsx";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
+import { spellCostDisplay } from "../../viewmodel/costLabel.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
@@ -815,13 +816,10 @@ const HandCard = memo(function HandCard({
         : 0,
   );
 
-  // Use effective spell cost from engine if available (reflects reductions),
-  // otherwise fall back to printed mana cost.
+  // Effective spell cost from the engine (reflects cost reductions and
+  // free-cast permissions such as Omniscience); falls back to the printed cost.
   const effectiveCost = useGameStore((s) => s.spellCosts[String(objectId)]);
-  const displayCost = effectiveCost ?? manaCost;
-  // Detect cost reduction by comparing effective vs printed generic mana
-  const isReduced = effectiveCost?.type === "Cost" && manaCost.type === "Cost"
-    && (effectiveCost.generic < manaCost.generic || effectiveCost.shards.length < manaCost.shards.length);
+  const { displayCost, isReduced } = spellCostDisplay(effectiveCost, manaCost);
   const playedRef = useRef(false);
 
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
@@ -993,9 +991,7 @@ const ZoneFanCard = memo(function ZoneFanCard({
   });
 
   const effectiveCost = useGameStore((s) => s.spellCosts[String(objectId)]);
-  const displayCost = effectiveCost ?? manaCost;
-  const isReduced = effectiveCost?.type === "Cost" && manaCost.type === "Cost"
-    && (effectiveCost.generic < manaCost.generic || effectiveCost.shards.length < manaCost.shards.length);
+  const { displayCost, isReduced } = spellCostDisplay(effectiveCost, manaCost);
   // Suppress dragSnapToOrigin only when the flick actually cast the card, so a
   // short/sideways drag springs back into the wing instead of flying off.
   const playedRef = useRef(false);

--- a/client/src/viewmodel/__tests__/costLabel.test.ts
+++ b/client/src/viewmodel/__tests__/costLabel.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { AdditionalCost, GameAction, GameObject, Keyword } from "../../adapter/types.ts";
+import type { AdditionalCost, GameAction, GameObject, Keyword, ManaCost } from "../../adapter/types.ts";
 import { buildGameObject } from "../../test/factories/gameObjectFactory.ts";
 import {
   abilityChoiceLabel,
@@ -8,6 +8,7 @@ import {
   additionalCostChoices,
   formatAbilityCost,
   formatCost,
+  spellCostDisplay,
 } from "../costLabel.ts";
 
 function makeObject(overrides: Partial<GameObject> = {}): GameObject {
@@ -273,5 +274,47 @@ describe("formatAbilityCost", () => {
         { type: "PayLife", amount: { type: "Fixed", value: 2 } },
       ],
     })).toBe("{1} or Pay 2 life");
+  });
+});
+
+describe("spellCostDisplay", () => {
+  const cost = (generic: number, shards: string[] = []): ManaCost => ({
+    type: "Cost",
+    generic,
+    shards,
+  });
+  const noCost: ManaCost = { type: "NoCost" };
+
+  it("shows the printed cost, not reduced, when the engine reports no override", () => {
+    const printed = cost(7, ["Blue", "Blue", "Blue"]);
+    const { displayCost, isReduced } = spellCostDisplay(undefined, printed);
+    expect(displayCost).toBe(printed);
+    expect(isReduced).toBe(false);
+  });
+
+  it("flags a smaller effective Cost as reduced", () => {
+    const { displayCost, isReduced } = spellCostDisplay(cost(3, ["Blue"]), cost(5, ["Blue"]));
+    expect(displayCost).toEqual(cost(3, ["Blue"]));
+    expect(isReduced).toBe(true);
+  });
+
+  // CR 118.9: Omniscience reports the effective cost as NoCost against a real
+  // printed cost — a reduction to {0}, so the pips must render (green {0}).
+  it("flags a NoCost effective cost against a real printed cost as reduced (Omniscience)", () => {
+    const { displayCost, isReduced } = spellCostDisplay(noCost, cost(7, ["Blue", "Blue", "Blue"]));
+    expect(displayCost).toEqual(noCost);
+    expect(isReduced).toBe(true);
+  });
+
+  // A naturally-free card (token, Ancestral Vision) has no printed cost and must
+  // never be flagged reduced — no {0} overlay.
+  it("does not flag a naturally-free card (no printed cost) as reduced", () => {
+    const { isReduced } = spellCostDisplay(noCost, noCost);
+    expect(isReduced).toBe(false);
+  });
+
+  it("does not flag an unchanged effective cost as reduced", () => {
+    const { isReduced } = spellCostDisplay(cost(5, ["Blue"]), cost(5, ["Blue"]));
+    expect(isReduced).toBe(false);
   });
 });

--- a/client/src/viewmodel/costLabel.ts
+++ b/client/src/viewmodel/costLabel.ts
@@ -45,6 +45,37 @@ export function manaCostToShards(cost: ManaCost): string[] {
   return shards;
 }
 
+/**
+ * Decide which mana cost to overlay on a castable card and whether to flag it
+ * as cost-reduced. The engine is the sole authority on the effective cost
+ * (`spellCosts[id]`, from `display_spell_cost`); this only chooses the DISPLAY
+ * value and its styling.
+ *
+ * A card with no printed mana cost (token, Ancestral Vision) is naturally free
+ * and is never flagged reduced. A real printed `Cost` that the engine lowered —
+ * to a smaller `Cost`, or all the way to `NoCost` via a "cast without paying its
+ * mana cost" permission (Omniscience, CR 118.9) — IS reduced, so `ManaCostPips`
+ * forces a green-ringed {0} rather than rendering nothing.
+ */
+export function spellCostDisplay(
+  effectiveCost: ManaCost | undefined,
+  printedCost: ManaCost,
+): { displayCost: ManaCost; isReduced: boolean } {
+  const displayCost = effectiveCost ?? printedCost;
+  const printedIsRealCost = printedCost.type === "Cost";
+  const reducedToSmaller =
+    effectiveCost?.type === "Cost" &&
+    printedIsRealCost &&
+    (effectiveCost.generic < printedCost.generic ||
+      effectiveCost.shards.length < printedCost.shards.length);
+  // CR 118.9: "cast without paying its mana cost" (Omniscience) is an
+  // alternative cost, reported here as NoCost. CR 118.9c: it doesn't change the
+  // printed mana cost, so against a real printed cost this is a reduction to
+  // {0}, not a naturally-free card.
+  const reducedToFree = effectiveCost?.type === "NoCost" && printedIsRealCost;
+  return { displayCost, isReduced: reducedToSmaller || reducedToFree };
+}
+
 /** Extract the mana component of an activation/additional ability cost for payment UI. */
 export function abilityCostToManaShards(cost: SerializedAbilityCost | undefined): string[] | null {
   if (!cost) return null;


### PR DESCRIPTION
Extract the duplicated effective-vs-printed cost logic from HandCard,
ZoneFanCard, and DrawerCard into a single spellCostDisplay() helper in
the costLabel viewmodel. The three call sites previously each inlined the
same reduction-detection comparison.

Also handle the free-cast case: a NoCost effective cost against a real
printed cost (Omniscience, CR 118.9a) is a reduction to {0}, so the pips
render a green-ringed {0} rather than nothing, while a naturally-free
card (token, Ancestral Vision) is never flagged reduced. Covered by new
spellCostDisplay unit tests.
