### PR TITLE
feat(review): guard against redundant reviews when a repo member commented last

### DIFF
--- a/.claude/skills/pr-review-loop/SKILL.md
+++ b/.claude/skills/pr-review-loop/SKILL.md
@@ -89,6 +89,8 @@ The CLI models freshness using:
 - CI status as evidence only, not as a pre-review or merge-when-ready gate;
 - labels and merge-queue membership.
 
+**Redundant-review guard.** The converse of the freshness invariant: when the most recent comment or review on the PR was authored by a repository member (GitHub `authorAssociation` of `OWNER`, `MEMBER`, or `COLLABORATOR` — including the acting login), the ball is in the contributor's court and there is no unacknowledged follow-up to respond to. Do not dispatch a redundant review of the same head. This guard suppresses only redundancy: it never overrides the mandatory re-review triggers below (changed head, queue drop, stale approval, edited author activity), which act on state, not on who spoke last.
+
 **Freshness invariant.** Before accepting `held`, `blocked`, `queued`, or a previously approved no-action result, the sweep must compare the current `headRefOid` with the most recent locally recorded head. A different head is a mandatory re-review candidate (or `update_branch_for_handler` when it conflicts), never an inherited hold. Likewise, an author comment/review created **or edited** after the latest GitHub-visible maintainer comment/review is an unacknowledged follow-up even if a later local event recorded a hold. Local event timestamps are observations, not contributor responses. If the scanner cannot prove that it has the relevant recent comment history, it must surface the PR for review rather than preserve the state. Explicit capability-policy deferrals and self/standing skips remain policy decisions, not inherited review states.
 
 ## Maintainer-Caused Staleness

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -66,6 +66,10 @@ DASHBOARD_DEFAULT_TERMINAL_LIMIT = 200
 SUCCESS_STATES = {"accepted", "merged"}
 BLOCK_STATES = {"blocked", "changes_requested"}
 HOLD_STATES = {"held", "held_ci"}
+# GitHub authorAssociation values that identify a repository member. The
+# redundant-review guard treats a comment/review from any of these as "the ball
+# is in the contributor's court" — see the pr-review-loop SKILL.md guard doc.
+MEMBER_AUTHOR_ASSOCIATIONS = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 # Local events that mean "this head is blocked". Single authority for both the
 # routing decision and the requested-changes expiry anchor — two copies would drift.
 LOCAL_BLOCK_EVENT_TYPES = {"review_blocked", "changes_requested", "blocked"}
@@ -2523,6 +2527,34 @@ def latest_maintainer_activity_timestamp(pr: dict[str, Any], acting_login: str |
     )
 
 
+def member_commented_last(pr: dict[str, Any]) -> bool:
+    """Whether the most recent comment or review on the PR is from a repo member.
+
+    The redundant-review guard (see pr-review-loop SKILL.md): when a repository
+    member (GitHub ``authorAssociation`` of OWNER/MEMBER/COLLABORATOR, including
+    the acting maintainer) authored the latest activity, the ball is in the
+    contributor's court and re-reviewing the same head is redundant. Activity
+    whose authorAssociation is absent (bots, older cached payloads) counts as
+    non-member, so the guard never suppresses on missing data.
+    """
+    activities = [
+        (activity_timestamp(comment, "createdAt", "updatedAt"), comment)
+        for comment in pr.get("comments", [])
+    ] + [
+        (activity_timestamp(review, "submittedAt"), review)
+        for review in pr.get("reviews", [])
+    ]
+    dated = [
+        (parsed, activity)
+        for timestamp, activity in activities
+        if (parsed := parse_event_datetime(timestamp)) is not None
+    ]
+    if not dated:
+        return False
+    _, latest = max(dated, key=lambda pair: pair[0])
+    return latest.get("authorAssociation") in MEMBER_AUTHOR_ASSOCIATIONS
+
+
 def review_freshness(
     pr: dict[str, Any],
     acting_login: str | None,
@@ -2548,6 +2580,7 @@ def review_freshness(
         "author_followup_after_maintainer_activity": author_followup_after_maintainer_activity,
         "author_followup_after_local_event": author_activity_after(pr, local_timestamp),
         "comment_history_incomplete": pr.get("commentsComplete") is False,
+        "member_activity_is_latest": member_commented_last(pr),
     }
 
 
@@ -2691,6 +2724,10 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     )
     head_changed_since_local_event = freshness.get("head_changed_since_local_event", False)
     comment_history_incomplete = freshness.get("comment_history_incomplete", False)
+    member_activity_is_latest = freshness.get(
+        "member_activity_is_latest",
+        member_commented_last(pr),
+    )
     parse_diff = packet.get("parse_diff") or {}
     parse_diff_after_local_event = timestamp_after(
         parse_diff.get("updated_at"), local_event_timestamp
@@ -2844,6 +2881,14 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     elif review_decision == "APPROVED":
         action = "approve_ready_for_handler"
         reason = "approved_needs_live_queue_check"
+    elif member_activity_is_latest:
+        # Redundant-review guard: reaching this branch means no state-based
+        # trigger fired above (head unchanged, no author follow-up, not
+        # queue-stale, no pending decision). If a repository member spoke last,
+        # the ball is in the contributor's court, so re-reviewing the same head
+        # would be redundant. State triggers above always take precedence.
+        action = "hold"
+        reason = "redundant_review_member_commented_last"
     else:
         action = "review"
         reason = "needs_review"
@@ -3160,7 +3205,7 @@ def pr_node_fields(
     review_body = " body" if include_review_body else ""
     comment_body = " body" if include_comment_body else ""
     full_reviews = (
-        f"reviews(first:50){{nodes{{author{{login}} state submittedAt commit{{oid}}{review_body}}}}} "
+        f"reviews(first:50){{nodes{{author{{login}} authorAssociation state submittedAt commit{{oid}}{review_body}}}}} "
         if include_full_reviews
         else ""
     )
@@ -3179,7 +3224,7 @@ def pr_node_fields(
     )
     comments = (
         f"comments(last:{comments_last})"
-        + "{totalCount pageInfo{hasNextPage endCursor} nodes{author{login} createdAt updatedAt"
+        + "{totalCount pageInfo{hasNextPage endCursor} nodes{author{login} authorAssociation createdAt updatedAt"
         + comment_body
         + "}} "
     )
@@ -3192,7 +3237,7 @@ def pr_node_fields(
         "assignees(first:10){nodes{login}} "
         "isInMergeQueue mergeQueueEntry{position state} autoMergeRequest{enabledAt} "
         "files(first:100){totalCount pageInfo{hasNextPage endCursor} nodes{path}} "
-        f"latestReviews(first:20){{nodes{{author{{login}} state submittedAt commit{{oid}}{review_body}}}}} "
+        f"latestReviews(first:20){{nodes{{author{{login}} authorAssociation state submittedAt commit{{oid}}{review_body}}}}} "
         f"{full_reviews}"
         f"{comments}"
         f"{status_rollup}"
@@ -3339,6 +3384,7 @@ def graphql_reviews(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [
         {
             "author": {"login": (review.get("author") or {}).get("login")},
+            "authorAssociation": review.get("authorAssociation"),
             "state": review.get("state"),
             "submittedAt": review.get("submittedAt"),
             "commit": review.get("commit"),
@@ -3425,6 +3471,7 @@ def normalize_graphql_pr(node: dict[str, Any]) -> dict[str, Any]:
         "comments": [
             {
                 "author": {"login": (c.get("author") or {}).get("login")},
+                "authorAssociation": c.get("authorAssociation"),
                 "createdAt": c.get("createdAt"),
                 "updatedAt": c.get("updatedAt"),
                 "body": c.get("body"),

--- a/scripts/pr_review.py
+++ b/scripts/pr_review.py
@@ -2750,6 +2750,12 @@ def recommend_from_packet(packet: dict[str, Any]) -> dict[str, Any]:
     elif local_hold and conflicts_with_base:
         action = "blocked"
         reason = "local_hold_current_head"
+    elif local_hold and parse_diff_after_local_event:
+        action = "review"
+        reason = "parse_diff_after_local_hold"
+    elif local_hold:
+        action = "hold"
+        reason = "local_hold_current_head"
     elif local_block and author_followup_after_maintainer_activity and conflicts_with_base:
         action = "update_branch_for_handler"
         reason = "conflicting_after_author_followup"

--- a/scripts/pr_review_tests.py
+++ b/scripts/pr_review_tests.py
@@ -1230,7 +1230,11 @@ class PrReviewTests(unittest.TestCase):
         self.assertEqual(recommendation["advisory_action"], "defer")
         self.assertEqual(recommendation["reason"], "frontend_policy")
 
-    def test_current_head_hold_does_not_suppress_green_review(self) -> None:
+    def test_current_head_bare_hold_is_honored(self) -> None:
+        # A recorded hold on the current head with nothing new — green CI, no
+        # author follow-up, no parse-diff — is honored rather than re-reviewed.
+        # (Resurfacing on a real change is covered by the parse-diff and
+        # head-change tests below.)
         packet = {
             "pr": {
                 "number": 4574,
@@ -1252,8 +1256,188 @@ class PrReviewTests(unittest.TestCase):
 
         recommendation = pr_review.recommend_from_packet(packet)
 
+        self.assertEqual(recommendation["advisory_action"], "hold")
+        self.assertEqual(recommendation["reason"], "local_hold_current_head")
+
+    def test_bare_local_hold_resurfaces_on_parse_diff(self) -> None:
+        # A parse-diff update landing after the hold re-surfaces the same head.
+        packet = {
+            "pr": {
+                "number": 4575,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "reviewDecision": "",
+                "isInMergeQueue": False,
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": None,
+            "local_current_event": {
+                "event_type": "held",
+                "outcome": "held",
+                "head_sha": "head",
+                "timestamp": self._minutes_ago(5),
+            },
+            "parse_diff": {"updated_at": self._minutes_ago(1)},
+            "policy_trace": [],
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "review")
+        self.assertEqual(recommendation["reason"], "parse_diff_after_local_hold")
+
+    def test_member_commented_last_helper(self) -> None:
+        # A review outranks an older comment; a member review last -> True.
+        self.assertTrue(
+            pr_review.member_commented_last(
+                {
+                    "comments": [
+                        {"authorAssociation": "CONTRIBUTOR", "createdAt": self._days_ago(1)},
+                    ],
+                    "reviews": [
+                        {"authorAssociation": "MEMBER", "submittedAt": self._minutes_ago(1)},
+                    ],
+                }
+            )
+        )
+        # Missing authorAssociation (e.g. a bot or cached payload) is not a
+        # member, so the guard never suppresses on absent data.
+        self.assertFalse(
+            pr_review.member_commented_last(
+                {
+                    "comments": [
+                        {"createdAt": self._minutes_ago(1)},
+                    ],
+                    "reviews": [],
+                }
+            )
+        )
+        # No dated activity at all -> False.
+        self.assertFalse(pr_review.member_commented_last({"comments": [], "reviews": []}))
+
+    def test_member_commented_last_holds_redundant_review(self) -> None:
+        # No state trigger fires and a repo member spoke last -> hold, so the
+        # sweep does not dispatch a redundant review of the same head.
+        packet = {
+            "pr": {
+                "number": 6262,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "author_login": "contributor",
+                "reviewDecision": "",
+                "isInMergeQueue": False,
+                "commentsComplete": True,
+                "comments": [
+                    {
+                        "author": "contributor",
+                        "authorAssociation": "CONTRIBUTOR",
+                        "createdAt": self._days_ago(2),
+                        "updatedAt": self._days_ago(2),
+                    },
+                    {
+                        "author": "maintainer",
+                        "authorAssociation": "MEMBER",
+                        "createdAt": self._minutes_ago(5),
+                        "updatedAt": self._minutes_ago(5),
+                    },
+                ],
+                "reviews": [],
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": "head",
+            "policy_trace": [],
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "hold")
+        self.assertEqual(
+            recommendation["reason"], "redundant_review_member_commented_last"
+        )
+
+    def test_contributor_commented_last_still_reviews(self) -> None:
+        # The converse of the guard: the contributor spoke last, so there is an
+        # unacknowledged follow-up and the PR must still surface for review.
+        packet = {
+            "pr": {
+                "number": 6263,
+                "state": "OPEN",
+                "headRefOid": "head",
+                "author_login": "contributor",
+                "reviewDecision": "",
+                "isInMergeQueue": False,
+                "commentsComplete": True,
+                "comments": [
+                    {
+                        "author": "maintainer",
+                        "authorAssociation": "MEMBER",
+                        "createdAt": self._days_ago(2),
+                        "updatedAt": self._days_ago(2),
+                    },
+                    {
+                        "author": "contributor",
+                        "authorAssociation": "CONTRIBUTOR",
+                        "createdAt": self._minutes_ago(5),
+                        "updatedAt": self._minutes_ago(5),
+                    },
+                ],
+                "reviews": [],
+            },
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": "head",
+            "policy_trace": [],
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
         self.assertEqual(recommendation["advisory_action"], "review")
         self.assertEqual(recommendation["reason"], "needs_review")
+
+    def test_member_guard_never_overrides_head_change(self) -> None:
+        # A member spoke last, but the head advanced since the recorded event: a
+        # mandatory state trigger must win over the redundancy guard.
+        previous_event = {
+            "event_type": "reviewed",
+            "outcome": "reviewed",
+            "head_sha": "old-head",
+            "timestamp": self._minutes_ago(10),
+        }
+        pr = {
+            "number": 6264,
+            "state": "OPEN",
+            "headRefOid": "new-head",
+            "author_login": "contributor",
+            "reviewDecision": "",
+            "isInMergeQueue": False,
+            "commentsComplete": True,
+            "comments": [
+                {
+                    "author": "maintainer",
+                    "authorAssociation": "MEMBER",
+                    "createdAt": self._minutes_ago(5),
+                    "updatedAt": self._minutes_ago(5),
+                },
+            ],
+            "reviews": [],
+        }
+        packet = {
+            "pr": pr,
+            "acting_login": "maintainer",
+            "ci": {"state": "green"},
+            "classification": {"hard_stop_paths": [], "surface": "backend"},
+            "latest_maintainer_review_commit": "old-head",
+            "local_current_event": None,
+            "freshness": pr_review.review_freshness(pr, "maintainer", None, previous_event),
+            "policy_trace": [],
+        }
+
+        recommendation = pr_review.recommend_from_packet(packet)
+
+        self.assertEqual(recommendation["advisory_action"], "review")
+        self.assertEqual(recommendation["reason"], "head_changed_since_local_event")
 
     def test_author_followup_after_local_block_resurfaces_same_head(self) -> None:
         packet = {


### PR DESCRIPTION
Add a redundant-review guard to the pr-review-loop skill: when the most
recent comment or review is from a repository member (OWNER/MEMBER/
COLLABORATOR), the ball is in the contributor's court — do not dispatch
a redundant review of the same head. State-based re-review triggers
(changed head, queue drop, stale approval) are unaffected.

In pr_review.py recommend routing, honor a local hold on the current
head: bare local_hold now routes to hold instead of falling through,
and a parse-diff update arriving after the hold re-surfaces the PR
for review.
