### PR TITLE
fix(tilt): stop card-data self-triggering on its own generated outputs

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -209,7 +209,18 @@ local_resource('check-frontend',
 local_resource('card-data',
     cmd = './scripts/gen-card-data.sh',
     deps = ENGINE_SRC,
-    ignore = TMP_IGNORE,
+    # gen-card-data.sh promotes these tracked files under crates/engine/data/, which is
+    # in ENGINE_SRC (deps). Watching card-data's own generated outputs makes every
+    # promote re-trigger card-data -> an infinite regen loop. The script already stages
+    # via a `.tmp.` infix (covered by TMP_IGNORE), but the final promote writes the real
+    # tracked file, which TMP_IGNORE can't mask. Ignoring the outputs here breaks the
+    # self-trigger without touching the engine resources, which still watch
+    # crates/engine/data/ in full so a genuine data change still rebuilds the engine.
+    ignore = TMP_IGNORE + [
+        'crates/engine/data/known-tokens.toml',
+        'crates/engine/data/oracle-subtypes.json',
+        'crates/engine/data/mtgjson-vintage',
+    ],
     auto_init = True,
     labels = ['data'],
 )


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Tilt's `card-data` resource watches `crates/engine/data/` (via `ENGINE_SRC` in its `deps`), but `gen-card-data.sh` **promotes** three tracked files into that directory — `known-tokens.toml`, `oracle-subtypes.json`, and `mtgjson-vintage`. Each promote changes a watched dep, which re-fires `card-data`, which regenerates and promotes again: an infinite regen loop that also rebuilds the engine on every iteration. This adds those three generated outputs to `card-data`'s `ignore` list (extending the existing `TMP_IGNORE` self-restart guard) so the resource no longer triggers on its own output.

The `.tmp.` infix the script already uses (covered by `TMP_IGNORE`) silences the *staging* writes, but the final promote writes the real tracked file, which `TMP_IGNORE` can't mask — hence the explicit output paths here.

## Implementation method (required)

Method: not-applicable — Tilt dev-loop watch configuration (build tooling); no engine, parser, or game-logic change.

## CR references

None — no rules code touched.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `scripts/check-parser-combinators.sh` — Gate A PASS (no parser file in the diff; Tiltfile-only change).
- `git ls-files crates/engine/data/` → `known-tokens.toml`, `oracle-subtypes.json`, `mtgjson-vintage` — confirms the three ignored paths are exactly the tracked files `gen-card-data.sh` promotes there (script: `TOKENS_FILE` L240, `--write-subtypes` oracle-subtypes L278, `MTGJSON_VINTAGE_FILE` L119).
- `ignore` is per-resource: the engine resources (`clippy`, `test-engine`, `wasm`, `build-native`) keep `deps = ENGINE_SRC` with `ignore = TMP_IGNORE` unchanged, so a genuine `crates/engine/data/` change still rebuilds the engine.

Final review-impl: not run — non-engine build-tooling change with no `/review-impl` engine surface. Flagged honestly rather than emitting a placeholder PASS.

## Gate A

Gate A PASS head=d886ee7af49a8bb48ebca5d99af49d023ea18e5b base=836ff312ae2073c99af28d286b0c4915faa8a458

## Anchored on

- Tiltfile:23 — `TMP_IGNORE`, the existing per-resource self-restart guard this fix extends (same failure mode: a resource's own writes re-triggering it).
- Tiltfile:230 — `draft-pools`, the sibling data resource already wired correctly: `deps = DRAFT_CORE_SRC + ['data/mtgjson/sets/']` watches its *input*, not its output directory.

## Claimed parse impact

None.
