### PR TITLE
feat(client): mobile current-phase chip with tap-to-open phase stop sheet

### DIFF
--- a/client/src/components/controls/MobilePhaseChip.tsx
+++ b/client/src/components/controls/MobilePhaseChip.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { Phase, PhaseStopScope } from "../../adapter/types";
+import { useSeatColor } from "../../hooks/useSeatColor.ts";
+import { useGameStore } from "../../stores/gameStore";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import { DialogShell } from "../modal/DialogShell.tsx";
+import {
+  PHASE_ICONS,
+  PHASE_KEY,
+  SCOPE_DOT_CLASS,
+  usePhaseStopCycle,
+} from "./PhaseStopBar.tsx";
+
+// CR 500.1: full turn order. The desktop indicators split this list across
+// three components for layout reasons; the sheet has room to show every
+// stoppable step in sequence.
+const ALL_PHASES: Phase[] = [
+  "Untap",
+  "Upkeep",
+  "Draw",
+  "PreCombatMain",
+  "BeginCombat",
+  "DeclareAttackers",
+  "DeclareBlockers",
+  "CombatDamage",
+  "EndCombat",
+  "PostCombatMain",
+  "End",
+  "Cleanup",
+];
+
+const SCOPE_SHORT_KEY: Record<PhaseStopScope, string> = {
+  AllTurns: "phaseStop.scopeShortAllTurns",
+  OwnTurn: "phaseStop.scopeShortOwnTurn",
+  OpponentsTurns: "phaseStop.scopeShortOpponentsTurns",
+};
+
+// Same hue axis as SCOPE_DOT_CLASS in PhaseStopBar.tsx (keep in sync): amber =
+// all turns, emerald = own turns, rose = opponents' turns. Full class strings
+// because Tailwind only sees statically analyzable names. The pill always
+// carries its text label, so color reinforces the scope rather than encoding
+// it alone.
+const SCOPE_PILL_CLASS: Record<PhaseStopScope, string> = {
+  AllTurns: "border-amber-400/40 bg-amber-400/10 text-amber-300",
+  OwnTurn: "border-emerald-400/40 bg-emerald-400/10 text-emerald-300",
+  OpponentsTurns: "border-rose-400/40 bg-rose-400/10 text-rose-300",
+};
+
+/**
+ * Compact persistent phase display for mobile, where the desktop PhaseDot
+ * strips are hidden (their 24px stop-toggle targets are untappable and crowd
+ * the HUD). Splits the dots' two jobs across a disclosure: the chip shows the
+ * current phase (icon + name, seat-color dot for whose turn), and tapping it
+ * opens the phase-stop sheet with full-size per-step stop controls.
+ */
+export function MobilePhaseChip({ className }: { className?: string } = {}) {
+  const { t } = useTranslation("game");
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const phase = useGameStore((s) => s.gameState?.phase);
+  const activePlayer = useGameStore((s) => s.gameState?.active_player);
+  const phaseStops = usePreferencesStore((s) => s.phaseStops);
+  // Unconditional hook call (before the early return); resolves NEUTRAL for
+  // an absent player, which is never rendered thanks to the guard below.
+  const turnSeatColor = useSeatColor(activePlayer);
+
+  if (phase === undefined) return null;
+
+  // The chip is the current phase's row, collapsed: its stop mark mirrors the
+  // desktop PhaseDot exactly — shown only when THIS phase has an armed stop,
+  // in that stop's scope color. Stops on other phases surface in the sheet.
+  const currentStop = phaseStops.find((s) => s.phase === phase);
+
+  const phaseLabel = t(`phaseName.${phase}`);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setSheetOpen(true)}
+        aria-label={t("phaseStop.chipAria", { phase: phaseLabel })}
+        aria-haspopup="dialog"
+        aria-expanded={sheetOpen}
+        className={`relative flex items-center justify-center gap-1.5 rounded-full border border-cyan-400/20 bg-slate-950/64 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-300 ring-1 ring-cyan-400/15 backdrop-blur-xl transition-all duration-200 hover:border-cyan-300/40 hover:text-white hover:ring-cyan-300/30 ${className ?? ""}`}
+      >
+        {/* Seat-color dot: whose turn it is, mirroring the HUD plate's
+            dot+label identity convention. */}
+        <span
+          aria-hidden
+          className="h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{ backgroundColor: turnSeatColor }}
+        />
+        <span aria-hidden className="text-cyan-300 [&>svg]:h-3 [&>svg]:w-3">
+          {PHASE_ICONS[phase]}
+        </span>
+        <span className="truncate">{phaseLabel}</span>
+        {currentStop && (
+          <span
+            aria-hidden
+            className={`absolute -bottom-0.5 left-1/2 h-1 w-1 -translate-x-1/2 rounded-full ${SCOPE_DOT_CLASS[currentStop.scope]}`}
+          />
+        )}
+      </button>
+      {sheetOpen && <PhaseStopSheet onClose={() => setSheetOpen(false)} />}
+    </>
+  );
+}
+
+/** Full-turn phase list with per-step auto-pass stop controls, at touch-size
+ *  targets. The scope is shown as visible text (not a hover tooltip, which
+ *  doesn't exist on touch) so cycling a row is self-explanatory. */
+function PhaseStopSheet({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation("game");
+  return (
+    <DialogShell
+      title={t("phaseStop.sheetTitle")}
+      subtitle={t("phaseStop.sheetSubtitle")}
+      size="sm"
+      scrollable
+      onClose={onClose}
+    >
+      <ul className="flex flex-col px-2 py-2">
+        {ALL_PHASES.map((phase) => (
+          <PhaseStopRow key={phase} phase={phase} />
+        ))}
+      </ul>
+    </DialogShell>
+  );
+}
+
+function PhaseStopRow({ phase }: { phase: Phase }) {
+  const { t } = useTranslation("game");
+  const currentPhase = useGameStore((s) => s.gameState?.phase);
+  const { stop, cyclePhase } = usePhaseStopCycle(phase);
+
+  const isActive = phase === currentPhase;
+  const hasStop = stop !== undefined;
+  const key = PHASE_KEY[phase];
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={cyclePhase}
+        aria-pressed={hasStop}
+        className={`flex w-full items-center gap-3 rounded-[10px] border px-3 py-2 text-left transition-colors duration-150 ${
+          isActive
+            ? "border-cyan-300/45 bg-cyan-950/60"
+            : "border-transparent hover:bg-white/5"
+        }`}
+      >
+        <span
+          aria-hidden
+          className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-[7px] border ${
+            isActive
+              ? "border-cyan-300/45 bg-cyan-950/82 text-white"
+              : "border-white/10 bg-white/5 text-slate-400"
+          } [&>svg]:h-3.5 [&>svg]:w-3.5`}
+        >
+          {PHASE_ICONS[phase]}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium text-slate-100">
+            {t(`phaseStop.${key}Label`)}
+          </span>
+          <span className="block truncate text-[11px] text-slate-400">
+            {t(`phaseStop.${key}Description`)}
+          </span>
+        </span>
+        <span
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+            stop ? SCOPE_PILL_CLASS[stop.scope] : "border-white/10 text-slate-500"
+          }`}
+        >
+          {stop ? t(SCOPE_SHORT_KEY[stop.scope]) : t("phaseStop.scopeShortOff")}
+        </span>
+      </button>
+    </li>
+  );
+}

--- a/client/src/components/controls/PhaseStopBar.tsx
+++ b/client/src/components/controls/PhaseStopBar.tsx
@@ -1,4 +1,4 @@
-import type { Phase, PhaseStopScope } from "../../adapter/types";
+import type { Phase, PhaseStop, PhaseStopScope } from "../../adapter/types";
 import { useId, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
@@ -6,8 +6,10 @@ import { useGameStore } from "../../stores/gameStore";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
 
-// MTGA-style phase icons as inline SVGs (14x14)
-const PHASE_ICONS: Record<Phase, ReactNode> = {
+// MTGA-style phase icons as inline SVGs (14x14). Shared with the mobile
+// phase chip/sheet (MobilePhaseChip.tsx), which renders the same glyphs at
+// touch-friendly sizes.
+export const PHASE_ICONS: Record<Phase, ReactNode> = {
   // Sun — untap
   Untap: (
     <svg viewBox="0 0 14 14" className="h-2.5 w-2.5 lg:h-3.5 lg:w-3.5" fill="currentColor">
@@ -100,7 +102,7 @@ const COMBAT_PHASES: Phase[] = [
 
 // i18n key suffix per phase, used to look up the localized label/description
 // from the `phaseStop` group in game.json (e.g. `phaseStop.untapLabel`).
-const PHASE_KEY: Record<Phase, string> = {
+export const PHASE_KEY: Record<Phase, string> = {
   Untap: "untap",
   Upkeep: "upkeep",
   Draw: "draw",
@@ -123,6 +125,18 @@ const SCOPE_TOOLTIP_KEY: Record<PhaseStopScope, string> = {
   OpponentsTurns: "phaseStop.scopeOpponentsTurns",
 };
 
+// Scope hue, shared with the mobile sheet's scope pills (MobilePhaseChip.tsx —
+// keep the two maps' hues in sync): amber = all turns (the established "stop
+// armed" color), emerald = own turns (TurnStatusLine's "you act" tone), rose =
+// opponents' turns. Deliberately NOT seat colors: a scope is a standing
+// preference over many games and (in multiplayer) many opponents, so it must
+// not borrow any one seat's identity color.
+export const SCOPE_DOT_CLASS: Record<PhaseStopScope, string> = {
+  AllTurns: "bg-amber-400",
+  OwnTurn: "bg-emerald-400",
+  OpponentsTurns: "bg-rose-400",
+};
+
 function getPhaseTooltip(
   t: PhaseTranslate,
   phase: Phase,
@@ -138,22 +152,23 @@ function getPhaseTooltip(
   });
 }
 
-function PhaseDot({ phase }: { phase: Phase }) {
-  const { t } = useTranslation("game");
-  const tooltipId = useId();
-  const currentPhase = useGameStore((s) => s.gameState?.phase);
+/**
+ * Single authority for reading and cycling one phase's stop:
+ * off → AllTurns → OwnTurn → OpponentsTurns → off. Shared by the desktop
+ * PhaseDot buttons and the mobile phase-stop sheet rows.
+ *
+ * Updates in place so array order is preserved — `useGameplayPreferencesSync`
+ * dedupes by positional comparison, so appending would reorder and force a
+ * redundant engine dispatch even when the set of stops is unchanged.
+ */
+export function usePhaseStopCycle(phase: Phase): {
+  stop: PhaseStop | undefined;
+  cyclePhase: () => void;
+} {
   const phaseStops = usePreferencesStore((s) => s.phaseStops);
   const setPhaseStops = usePreferencesStore((s) => s.setPhaseStops);
-
-  const isActive = phase === currentPhase;
   const stop = phaseStops.find((s) => s.phase === phase);
-  const hasStop = stop !== undefined;
-  const tooltip = getPhaseTooltip(t, phase, stop?.scope, isActive);
 
-  // Cycle the stop for this phase: off → AllTurns → OwnTurn → OpponentsTurns → off.
-  // Update in place so array order is preserved — `useGameplayPreferencesSync` dedupes by
-  // positional comparison, so appending would reorder and force a redundant
-  // engine dispatch even when the set of stops is unchanged.
   const cyclePhase = () => {
     if (stop === undefined) {
       setPhaseStops([...phaseStops, { phase, scope: "AllTurns" }]);
@@ -171,6 +186,19 @@ function PhaseDot({ phase }: { phase: Phase }) {
         : phaseStops.map((s) => (s.phase === phase ? { phase, scope: next } : s)),
     );
   };
+
+  return { stop, cyclePhase };
+}
+
+function PhaseDot({ phase }: { phase: Phase }) {
+  const { t } = useTranslation("game");
+  const tooltipId = useId();
+  const currentPhase = useGameStore((s) => s.gameState?.phase);
+  const { stop, cyclePhase } = usePhaseStopCycle(phase);
+
+  const isActive = phase === currentPhase;
+  const hasStop = stop !== undefined;
+  const tooltip = getPhaseTooltip(t, phase, stop?.scope, isActive);
 
   return (
     <button
@@ -191,8 +219,10 @@ function PhaseDot({ phase }: { phase: Phase }) {
         <span className="absolute -top-1 left-1/2 h-1 w-3 -translate-x-1/2 rounded-[2px] bg-amber-300" />
       )}
       {PHASE_ICONS[phase]}
-      {hasStop && (
-        <span className="absolute -bottom-0.5 left-1/2 h-1 w-1 -translate-x-1/2 rounded-full bg-amber-400" />
+      {stop && (
+        <span
+          className={`absolute -bottom-0.5 left-1/2 h-1 w-1 -translate-x-1/2 rounded-full ${SCOPE_DOT_CLASS[stop.scope]}`}
+        />
       )}
       <GameplayTooltip id={tooltipId}>
         {tooltip}
@@ -229,7 +259,7 @@ export function PhaseIndicatorRight() {
 export function CombatPhaseIndicator() {
   const isCompactHeight = useIsCompactHeight();
   // Hide on landscape phones — non-essential and eats horizontal real estate
-  // next to the ActionButton. The phase pills along the top still convey phase.
+  // next to the ActionButton. MobilePhaseChip conveys the current phase there.
   if (isCompactHeight) return null;
   return (
     <div

--- a/client/src/components/controls/__tests__/MobilePhaseChip.test.tsx
+++ b/client/src/components/controls/__tests__/MobilePhaseChip.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
+import { buildGameState } from "../../../test/factories/gameStateFactory.ts";
+import { MobilePhaseChip } from "../MobilePhaseChip.tsx";
+
+describe("MobilePhaseChip", () => {
+  beforeEach(() => {
+    // Factory default: phase PreCombatMain, active_player 0.
+    useGameStore.setState({ gameState: buildGameState() });
+    usePreferencesStore.setState({ phaseStops: [] });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the current phase name", () => {
+    render(<MobilePhaseChip />);
+
+    expect(
+      screen.getByRole("button", { name: /Current phase: Main Phase 1\./ }),
+    ).toHaveTextContent("Main Phase 1");
+  });
+
+  it("opens a sheet listing every turn step, including ones absent from the desktop strips", () => {
+    render(<MobilePhaseChip />);
+    fireEvent.click(screen.getByRole("button", { name: /Current phase/ }));
+
+    expect(screen.getByText("Turn phases")).toBeInTheDocument();
+    // Untap and Cleanup have no desktop PhaseDot — the sheet must still offer them.
+    expect(screen.getByRole("button", { name: /Untap step/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Cleanup step/ })).toBeInTheDocument();
+  });
+
+  it("cycles a step's stop scope from the sheet and shows the scope as text", () => {
+    render(<MobilePhaseChip />);
+    fireEvent.click(screen.getByRole("button", { name: /Current phase/ }));
+
+    const row = screen.getByRole("button", { name: /First main phase/ });
+    expect(row).toHaveAttribute("aria-pressed", "false");
+    expect(row).toHaveTextContent("Off");
+
+    // off → AllTurns
+    fireEvent.click(row);
+    expect(usePreferencesStore.getState().phaseStops).toEqual([
+      { phase: "PreCombatMain", scope: "AllTurns" },
+    ]);
+    expect(row).toHaveAttribute("aria-pressed", "true");
+    expect(row).toHaveTextContent("All turns");
+
+    // AllTurns → OwnTurn → OpponentsTurns → off
+    fireEvent.click(row);
+    expect(row).toHaveTextContent("My turns");
+    fireEvent.click(row);
+    expect(row).toHaveTextContent("Opponents' turns");
+    fireEvent.click(row);
+    expect(usePreferencesStore.getState().phaseStops).toEqual([]);
+    expect(row).toHaveTextContent("Off");
+  });
+
+  it("marks the chip with the current phase's stop, colored by scope", () => {
+    // Factory default phase is PreCombatMain — arm a stop on it.
+    usePreferencesStore.setState({
+      phaseStops: [{ phase: "PreCombatMain", scope: "OwnTurn" }],
+    });
+    const { container } = render(<MobilePhaseChip />);
+
+    expect(container.querySelector(".bg-emerald-400")).not.toBeNull();
+  });
+
+  it("does not mark the chip for stops on other phases", () => {
+    usePreferencesStore.setState({
+      phaseStops: [{ phase: "End", scope: "AllTurns" }],
+    });
+    const { container } = render(<MobilePhaseChip />);
+
+    expect(container.querySelector(".bg-amber-400")).toBeNull();
+  });
+});

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -373,7 +373,14 @@
     "scopeOwnTurn": "Stoppt nur in deinen Zügen.",
     "scopeOpponentsTurns": "Stoppt nur in den Zügen der Gegner.",
     "tooltipCurrentPhase": "Aktuelle Phase.",
-    "tooltip": "Phasenstopp: {{label}}. {{description}} {{stopText}}{{activeText}}"
+    "tooltip": "Phasenstopp: {{label}}. {{description}} {{stopText}}{{activeText}}",
+    "chipAria": "Aktuelle Phase: {{phase}}. Phasenstopp-Einstellungen öffnen.",
+    "sheetTitle": "Zugphasen",
+    "sheetSubtitle": "Tippe auf einen Schritt, um festzulegen, wann das automatische Passen dort stoppt.",
+    "scopeShortOff": "Aus",
+    "scopeShortAllTurns": "Alle Züge",
+    "scopeShortOwnTurn": "Deine Züge",
+    "scopeShortOpponentsTurns": "Gegnerzüge"
   },
   "phaseTracker": {
     "turn": "Zug {{number}}"
@@ -2074,6 +2081,7 @@
     "fromSideboard": "Aus dem Sideboard"
   },
   "phaseName": {
+    "Untap": "Enttappen",
     "Upkeep": "Versorgung",
     "Draw": "Ziehen",
     "PreCombatMain": "Hauptphase 1",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -405,7 +405,14 @@
     "scopeOwnTurn": "Stops only on your turns.",
     "scopeOpponentsTurns": "Stops only on opponents' turns.",
     "tooltipCurrentPhase": "Current phase.",
-    "tooltip": "Phase stop: {{label}}. {{description}} {{stopText}}{{activeText}}"
+    "tooltip": "Phase stop: {{label}}. {{description}} {{stopText}}{{activeText}}",
+    "chipAria": "Current phase: {{phase}}. Open phase stop settings.",
+    "sheetTitle": "Turn phases",
+    "sheetSubtitle": "Tap a step to change when auto-pass stops there.",
+    "scopeShortOff": "Off",
+    "scopeShortAllTurns": "All turns",
+    "scopeShortOwnTurn": "My turns",
+    "scopeShortOpponentsTurns": "Opponents' turns"
   },
   "phaseTracker": {
     "turn": "Turn {{number}}"
@@ -2111,6 +2118,7 @@
     "fromSideboard": "From sideboard"
   },
   "phaseName": {
+    "Untap": "Untap",
     "Upkeep": "Upkeep",
     "Draw": "Draw",
     "PreCombatMain": "Main Phase 1",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -373,7 +373,14 @@
     "scopeOwnTurn": "Se detiene solo en tus turnos.",
     "scopeOpponentsTurns": "Se detiene solo en los turnos de los oponentes.",
     "tooltipCurrentPhase": "Fase actual.",
-    "tooltip": "Parada de fase: {{label}}. {{description}} {{stopText}}{{activeText}}"
+    "tooltip": "Parada de fase: {{label}}. {{description}} {{stopText}}{{activeText}}",
+    "chipAria": "Fase actual: {{phase}}. Abrir ajustes de paradas de fase.",
+    "sheetTitle": "Fases del turno",
+    "sheetSubtitle": "Toca un paso para cambiar cuándo se detiene el pase automático.",
+    "scopeShortOff": "Desactivado",
+    "scopeShortAllTurns": "Todos los turnos",
+    "scopeShortOwnTurn": "Tus turnos",
+    "scopeShortOpponentsTurns": "Turnos de oponentes"
   },
   "phaseTracker": {
     "turn": "Turno {{number}}"
@@ -2074,6 +2081,7 @@
     "fromSideboard": "Desde el banquillo"
   },
   "phaseName": {
+    "Untap": "Enderezar",
     "Upkeep": "Mantenimiento",
     "Draw": "Robar",
     "PreCombatMain": "Fase principal 1",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -373,7 +373,14 @@
     "scopeOwnTurn": "S'arrête uniquement lors de vos tours.",
     "scopeOpponentsTurns": "S'arrête uniquement lors des tours des adversaires.",
     "tooltipCurrentPhase": "Phase actuelle.",
-    "tooltip": "Arrêt de phase : {{label}}. {{description}} {{stopText}}{{activeText}}"
+    "tooltip": "Arrêt de phase : {{label}}. {{description}} {{stopText}}{{activeText}}",
+    "chipAria": "Phase actuelle : {{phase}}. Ouvrir les réglages d'arrêts de phase.",
+    "sheetTitle": "Phases du tour",
+    "sheetSubtitle": "Touchez une étape pour changer quand la passe automatique s'y arrête.",
+    "scopeShortOff": "Désactivé",
+    "scopeShortAllTurns": "Tous les tours",
+    "scopeShortOwnTurn": "Vos tours",
+    "scopeShortOpponentsTurns": "Tours adverses"
   },
   "phaseTracker": {
     "turn": "Tour {{number}}"
@@ -2074,6 +2081,7 @@
     "fromSideboard": "Depuis la réserve"
   },
   "phaseName": {
+    "Untap": "Dégagement",
     "Upkeep": "Entretien",
     "Draw": "Pioche",
     "PreCombatMain": "Phase principale 1",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -373,7 +373,14 @@
     "scopeOwnTurn": "Si ferma solo nei tuoi turni.",
     "scopeOpponentsTurns": "Si ferma solo nei turni degli avversari.",
     "tooltipCurrentPhase": "Fase corrente.",
-    "tooltip": "Stop di fase: {{label}}. {{description}} {{stopText}}{{activeText}}"
+    "tooltip": "Stop di fase: {{label}}. {{description}} {{stopText}}{{activeText}}",
+    "chipAria": "Fase attuale: {{phase}}. Apri le impostazioni degli stop di fase.",
+    "sheetTitle": "Fasi del turno",
+    "sheetSubtitle": "Tocca un passo per cambiare quando il passaggio automatico si ferma lì.",
+    "scopeShortOff": "Disattivato",
+    "scopeShortAllTurns": "Tutti i turni",
+    "scopeShortOwnTurn": "I tuoi turni",
+    "scopeShortOpponentsTurns": "Turni avversari"
   },
   "phaseTracker": {
     "turn": "Turno {{number}}"
@@ -2074,6 +2081,7 @@
     "fromSideboard": "Dalla sideboard"
   },
   "phaseName": {
+    "Untap": "STAP",
     "Upkeep": "Mantenimento",
     "Draw": "Pesca",
     "PreCombatMain": "Fase principale 1",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -373,7 +373,14 @@
     "scopeOwnTurn": "Zatrzymuje się tylko w twoich turach.",
     "scopeOpponentsTurns": "Zatrzymuje się tylko w turach przeciwników.",
     "tooltipCurrentPhase": "Bieżąca faza.",
-    "tooltip": "Zatrzymanie fazy: {{label}}. {{description}} {{stopText}}{{activeText}}"
+    "tooltip": "Zatrzymanie fazy: {{label}}. {{description}} {{stopText}}{{activeText}}",
+    "chipAria": "Bieżąca faza: {{phase}}. Otwórz ustawienia zatrzymań faz.",
+    "sheetTitle": "Fazy tury",
+    "sheetSubtitle": "Dotknij kroku, aby zmienić, kiedy automatyczne pasowanie się tam zatrzymuje.",
+    "scopeShortOff": "Wył.",
+    "scopeShortAllTurns": "Wszystkie tury",
+    "scopeShortOwnTurn": "Twoje tury",
+    "scopeShortOpponentsTurns": "Tury przeciwników"
   },
   "phaseTracker": {
     "turn": "Tura {{number}}"
@@ -2074,6 +2081,7 @@
     "fromSideboard": "Z zaplecza"
   },
   "phaseName": {
+    "Untap": "Odwracanie",
     "Upkeep": "Utrzymanie",
     "Draw": "Dobieranie",
     "PreCombatMain": "Główna faza 1",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -373,7 +373,14 @@
     "scopeOwnTurn": "Para apenas nos seus turnos.",
     "scopeOpponentsTurns": "Para apenas nos turnos dos oponentes.",
     "tooltipCurrentPhase": "Fase atual.",
-    "tooltip": "Parada de fase: {{label}}. {{description}} {{stopText}}{{activeText}}"
+    "tooltip": "Parada de fase: {{label}}. {{description}} {{stopText}}{{activeText}}",
+    "chipAria": "Fase atual: {{phase}}. Abrir configurações de paradas de fase.",
+    "sheetTitle": "Fases do turno",
+    "sheetSubtitle": "Toque em uma etapa para mudar quando o passe automático para ali.",
+    "scopeShortOff": "Desativado",
+    "scopeShortAllTurns": "Todos os turnos",
+    "scopeShortOwnTurn": "Seus turnos",
+    "scopeShortOpponentsTurns": "Turnos dos oponentes"
   },
   "phaseTracker": {
     "turn": "Turno {{number}}"
@@ -2074,6 +2081,7 @@
     "fromSideboard": "Do sideboard"
   },
   "phaseName": {
+    "Untap": "Desvirar",
     "Upkeep": "Manutenção",
     "Draw": "Compra",
     "PreCombatMain": "Fase principal 1",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -51,6 +51,7 @@ import { CardReportDialog } from "../components/card/CardReportDialog.tsx";
 import { ActionButton } from "../components/board/ActionButton.tsx";
 import { FullControlToggle } from "../components/controls/FullControlToggle.tsx";
 import { CombatPhaseIndicator } from "../components/controls/PhaseStopBar.tsx";
+import { MobilePhaseChip } from "../components/controls/MobilePhaseChip.tsx";
 import { MayTriggerAutoChoiceList } from "../components/board/MayTriggerAutoChoiceList.tsx";
 import { PriorityYieldList } from "../components/board/PriorityYieldList.tsx";
 import { OpponentHand } from "../components/hand/OpponentHand.tsx";
@@ -1443,7 +1444,7 @@ function GamePageContent({
             className="hidden flex-col gap-1 max-lg:portrait:flex max-lg:portrait:min-w-0"
           >
             <div className="flex flex-col gap-1 max-lg:gap-1">
-              <CombatPhaseIndicator />
+              <MobilePhaseChip className="w-full" />
               <HandBadge className="w-full" />
             </div>
             <div className="flex items-center gap-1.5">
@@ -1471,6 +1472,9 @@ function GamePageContent({
                 <TurnStatusLine />
               </div>
               <div className="hidden flex-row items-center gap-1.5 max-lg:landscape:flex lg:flex">
+                {/* <lg only: desktop conveys phase via the PhaseDot strips in
+                    PlayerHud, which are hidden on mobile. */}
+                <MobilePhaseChip className="lg:hidden" />
                 <TurnStatusLine />
                 <HandBadge />
                 {/* CR 117.3d: standing priority-yield summary chip, beside the


### PR DESCRIPTION
Mobile had no phase display outside combat (portrait showed only the combat
sub-step dots; landscape phones had none) and no way to set phase stops at
all, since the desktop PhaseDot strips are hidden below lg for tap-size
reasons.

- MobilePhaseChip: persistent pill in the mobile action rail showing the
  current phase icon + name (CR 500.1 turn order), a seat-color dot for
  whose turn, and the current phase's armed stop as a scope-colored mark.
  Tapping opens a DialogShell sheet listing all 12 turn steps with
  touch-size stop controls whose scope reads as visible text.
- usePhaseStopCycle: cycle logic extracted from PhaseDot as the single
  authority (preserves the in-place update that useGameplayPreferencesSync's
  positional dedupe depends on); shared by desktop dots and sheet rows.
- Scope color axis (amber=all turns, emerald=own turns, rose=opponents')
  applied to sheet pills, desktop PhaseDot marks, and the chip.
- i18n: phaseName.Untap, sheet strings, and short scope labels across all
  7 locales, derived from each locale's existing phase vocabulary.
