### PR TITLE
test(ai): widen zero-floor projection test deadline to kill wall-clock flake

### DIFF
--- a/crates/phase-ai/src/policies/context.rs
+++ b/crates/phase-ai/src/policies/context.rs
@@ -653,8 +653,10 @@ mod tests {
         config.search.projection_min_budget_ms = 0;
 
         let mut ai_ctx = crate::context::AiContext::empty(&config.weights);
-        // Tight but not expired — 1ms remaining.
-        ai_ctx.deadline = engine::util::Deadline::after(1);
+        // Large budget keeps this deterministic under parallel test load —
+        // with floor=0 the remaining time is never read, so any non-expired
+        // deadline exercises the same branch.
+        ai_ctx.deadline = engine::util::Deadline::after(60_000);
 
         let ability = ResolvedAbility::new(
             Effect::Pump {
@@ -690,8 +692,9 @@ mod tests {
         };
         let ctx = deadline_test_ctx(&state, &decision, &candidate, &config, &ai_ctx);
 
-        // With floor=0, even 1ms remaining allows projection. Only an
-        // already-expired deadline blocks.
+        // With floor=0, any non-expired deadline allows projection; only an
+        // already-expired one blocks (covered by
+        // `deadline_expired_gates_projection`).
         assert!(ctx.can_afford_projection());
     }
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Fixes a wall-clock flake in `policies::context::tests::zero_projection_floor_always_allows`: the test set a 1 ms deadline that could expire between construction and the assert under parallel nextest load, tripping the `expired()` short-circuit in `can_afford_projection()` before the `floor == 0` escape hatch. With `floor = 0` the remaining time is never read, so a 60 s budget exercises the identical branch with no flake surface; the expired path stays covered by the sibling test `deadline_expired_gates_projection`.

## Implementation method (required)

Method: not-applicable — test-only deadline widening in a `phase-ai` `#[cfg(test)]` module; no engine game logic, parser, effects, resolver, or targeting touched.

## CR references

None (AI test infrastructure, no rules behavior).

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head — not run; see note under Final review-impl.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean, no diff.
- `cargo nextest run -p phase-ai -E 'test(zero_projection_floor_always_allows) + test(deadline_expired_gates_projection) + test(fresh_deadline_allows_projection)'` (rerun after rebase onto `upstream/main`) — `3 tests run: 3 passed, 1441 skipped`.
- Discriminating-test probe (non-vacuity evidence): temporarily set the deadline to `Deadline::after(0)` + 5 ms sleep → `FAIL ... assertion failed: ctx.can_afford_projection()` (`1 test run: 0 passed, 1 failed`); reverted the probe → `1 test run: 1 passed`. The assertion still discriminates expired vs. non-expired deadlines.
- `./scripts/check-parser-combinators.sh` — Gate G PASS, Gate A PASS (line below).

## Gate A

Gate A PASS head=4c3fedf6d2056ffe4b50b16afa9452913d64d919 base=836ff312ae2073c99af28d286b0c4915faa8a458

## Anchored on

- crates/phase-ai/src/policies/context.rs:545 — `deadline_expired_gates_projection`, the sibling test that owns the expired-deadline path this test no longer needs to skirt
- crates/phase-ai/src/policies/context.rs:598 — `fresh_deadline_allows_projection`, the same-seam large-budget (`Deadline::after(5_000)`) pattern this change mirrors

## Final review-impl

Not run for this head — 7-line test-only change (one constant + two comments in a single `#[cfg(test)]` module); the discriminating probe FAIL→revert→PASS above is the correctness evidence.

## Claimed parse impact

None (no parser or card-data change).
