### PR TITLE
fix(engine): commit W30 MTGJSON token catalog and make coverage snapshot vintage-proof

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -11308,11 +11308,13 @@ mod tests {
     fn analyze_token_coverage_treats_source_defined_pt_as_represented() {
         let summary = analyze_token_coverage();
 
-        assert_eq!(summary.total_tokens, 2845);
-        assert_eq!(summary.supported_tokens, 2845);
-        assert_eq!(summary.rules_text_tokens, 1480);
-        assert_eq!(summary.parsed_rules_text_tokens, 1480);
-        assert_eq!(summary.total_tokens - summary.supported_tokens, 0);
+        // The weekly MTGJSON vintage refresh (#6237) makes absolute token counts
+        // data-dependent, so assert invariants (full coverage) plus non-vacuity
+        // floors at the last-known-good baseline (the catalog only grows).
+        assert_eq!(summary.supported_tokens, summary.total_tokens);
+        assert_eq!(summary.parsed_rules_text_tokens, summary.rules_text_tokens);
+        assert!(summary.total_tokens >= 2845);
+        assert!(summary.rules_text_tokens >= 1480);
         assert!(!summary.top_gaps.iter().any(|gap| {
             gap.handler == TOKEN_BODY_DYNAMIC_OR_SOURCE_DEFINED_POWER_TOUGHNESS_LABEL
         }));

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -11315,6 +11315,18 @@ mod tests {
         // 1173 source_card_refs (9810 -> 8637) while the token count GREW, so the ref
         // floor is the only one of the three that catches a partial regen. Raise these
         // with each verified regen; lower one only in the commit that shrank it.
+        //
+        // These floors do not establish provenance — that this catalog is tokens-gen's
+        // output for its declared vintage. No test can: the generator input
+        // (`data/mtgjson/sets`) is gitignored and absent at test time.
+        // `scripts/gen-card-data.sh` regenerates on every run and refuses to promote
+        // when MTGJSON's `.meta.date` predates `crates/engine/data/mtgjson-vintage`, so
+        // the tracked file cannot regress to older inputs; nothing re-derives an
+        // already-committed one. tokens-gen is deterministic, so a clean `cmp` proves it:
+        //
+        //     ./scripts/fetch-token-sets.sh   # populates the gitignored input
+        //     cargo run --bin tokens-gen -- --input data/mtgjson/sets --output /tmp/kt.toml
+        //     cmp /tmp/kt.toml crates/engine/data/known-tokens.toml
         assert_eq!(summary.supported_tokens, summary.total_tokens);
         assert_eq!(summary.parsed_rules_text_tokens, summary.rules_text_tokens);
         assert!(

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -11309,12 +11309,29 @@ mod tests {
         let summary = analyze_token_coverage();
 
         // The weekly MTGJSON vintage refresh (#6237) makes absolute token counts
-        // data-dependent, so assert invariants (full coverage) plus non-vacuity
-        // floors at the last-known-good baseline (the catalog only grows).
+        // data-dependent, so assert invariants (full coverage) plus ratchet floors
+        // pinned to the COMMITTED vintage. `>=` keeps weekly additions green; a
+        // shrink fails, which is the case worth a human look: #6199 silently dropped
+        // 1173 source_card_refs (9810 -> 8637) while the token count GREW, so the ref
+        // floor is the only one of the three that catches a partial regen. Raise these
+        // with each verified regen; lower one only in the commit that shrank it.
         assert_eq!(summary.supported_tokens, summary.total_tokens);
         assert_eq!(summary.parsed_rules_text_tokens, summary.rules_text_tokens);
-        assert!(summary.total_tokens >= 2845);
-        assert!(summary.rules_text_tokens >= 1480);
+        assert!(
+            summary.total_tokens >= 2858,
+            "token catalog shrank: {} presets < 2858",
+            summary.total_tokens
+        );
+        assert!(
+            summary.rules_text_tokens >= 1490,
+            "token catalog shrank: {} rules-text presets < 1490",
+            summary.rules_text_tokens
+        );
+        assert!(
+            summary.source_card_refs >= 9821,
+            "token catalog shrank: {} source_card_refs < 9821",
+            summary.source_card_refs
+        );
         assert!(!summary.top_gaps.iter().any(|gap| {
             gap.handler == TOKEN_BODY_DYNAMIC_OR_SOURCE_DEFINED_POWER_TOUGHNESS_LABEL
         }));


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Commits the 2026-W30 weekly MTGJSON token catalog refresh (deterministic regen: +13 tokens, +1184 `[[token.source_card_refs]]`, "Undercity // The Initiative" → "Undercity" face-name change, 0 removed) and converts the token coverage snapshot test from vintage-pinned absolute counts to invariants (`supported == total`, `parsed_rules_text == rules_text`) with non-vacuity floors, so the weekly refresh introduced by #6237 no longer turns `test-engine` red every time upstream adds tokens at 100% coverage.

## Implementation method (required)

Method: not-applicable — deterministic data-catalog regeneration plus a test-assertion change in an existing coverage snapshot test; no parser, effect, resolver, targeting, or rules behavior touched.

## CR references

None — coverage accounting and generated card data only; no game-rule logic changed.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo build --profile tool --features cli --bin tokens-gen && target/tool/tokens-gen --input data/mtgjson/sets --output crates/engine/data/known-tokens.toml` — `Generated 2858 token presets`; `cmp` against the main checkout's independently promoted catalog: **byte-identical** (determinism re-proven across two checkouts).
- `cargo nextest run -p engine -E 'test(analyze_token_coverage) + test(token_coverage) + test(source_defined_pt) + test(token_rules_text)'` — **5 passed, 0 failed** (final run on the committed tree).
- Measured summary on this head: `total=2858 supported=2858 rules_text=1490 parsed_rules_text=1490` (temporary eprintln, removed before commit).
- **Discriminating-test probe:** temporarily forced `token_rules_text_unparsed_gap` to report a gap for every `SourceDefinedOrDynamic` preset → test **FAILED** (`assertion left == right failed — left: 2743, right: 2858`, parsed_rules_text 1490→1443); probe fully reverted → test **PASSED**; `git diff` clean of probe residue. (First probe attempt at `token_pt_provenance_represents_line` was measured vacuous — no preset currently has `unparsed_rules_text_lines` — hence the probe point one level up.)
- Non-vacuity floors: an empty/truncated catalog passes both equality invariants trivially, but fails `total_tokens >= 2845` / `rules_text_tokens >= 1480`.
- `grep -rn --include="*.rs" --include="*.ts" --include="*.tsx" -E "\b(2845|1480|2858)\b" crates/ client/src` — coverage.rs is the only pin site (remaining hits are unrelated issue #2858 references).
- `grep -rn --include="*.rs" --include="*.ts" --include="*.tsx" "Undercity // The Initiative" crates/ client/src` — no source references the old face name.
- `bash scripts/check-parser-combinators.sh` — Gate G PASS, Gate A PASS on committed head.
- `cargo fmt --all` — clean.

## Gate A

Gate A PASS head=f0ac54354e82e0bd97a5da2a3e41bc6a6655974a base=836ff312ae2073c99af28d286b0c4915faa8a458

## Anchored on

- crates/engine/src/game/coverage.rs:5217 — `analyze_token_coverage()` over `known_token_presets()`, the summary authority the snapshot test measures
- crates/engine/src/game/coverage.rs:5207 — `token_pt_provenance_has_no_materialization_gap`, the source-defined-PT representation path the kept `top_gaps` assert and the probe exercise

## Final review-impl

Final review-impl PASS head=f0ac54354e82e0bd97a5da2a3e41bc6a6655974a

## Claimed parse impact

- None — no parser code changed; catalog additions are data (Food ×8, Treasure, Ooze, Elf Warrior ×2, Goblin Army Token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KY26RoWwb6nYW2up9eFgC9
