### PR TITLE
feat(engine,client): badge permanents that a copy effect turned into copies

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2574,6 +2574,14 @@ export interface DerivedViews {
    * matters on the battlefield. Keyed by ObjectId-as-string.
    */
   battlefield_keyword_badges?: Record<string, Keyword[]>;
+  /**
+   * CR 613.2a + CR 707.2: battlefield permanents whose copiable values are
+   * currently supplied by a copy effect (Clone, Phantasmal Image, Vesuvan
+   * Doppelganger). Such a permanent renders identically to what it copied, so
+   * the engine classifies it here rather than leaving the client to guess.
+   * Face-down permanents are excluded per CR 708.2. Absent when empty.
+   */
+  copied_permanents?: ObjectId[];
   /** Keyed by attacking commander's current controller (PlayerId as string). */
   commander_damage_by_attacker?: Record<string, CommanderDamageView[]>;
   /**

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -261,6 +261,13 @@ export const PermanentCard = memo(function PermanentCard({
       s.gameState?.derived?.battlefield_keyword_badges?.[String(objectId)]
       ?? EMPTY_KEYWORD_BADGES,
   );
+  // CR 613.2a + CR 707.2: whether a live copy effect supplies this permanent's
+  // copiable values. Engine-classified because a copy of a permanent lives in a
+  // Layer 1a continuous effect, not on the object — and the copy overrides
+  // `printed_ref` too, so a copy is pixel-identical to its source here.
+  const isCopiedPermanent = useGameStore((s) =>
+    (s.gameState?.derived?.copied_permanents ?? []).includes(objectId),
+  );
   // CR 732.2a / CR 701.34a: the counter-type keys the engine marks as ∞ (unbounded
   // counter-growth loop) for this object. Values match the object's `counters` map keys
   // (e.g. "charge"); the pill renders ∞ instead of ×N for any type in this set.
@@ -552,7 +559,16 @@ export const PermanentCard = memo(function PermanentCard({
   // CR 708.2: a face-down permanent has no characteristics other than those
   // its face-down rule grants, so never surface "Copy" on it — that would leak
   // that it's a token-copy (matches the `!face_down` guard on the keyword strip).
-  const isCopy = obj.is_token === true && obj.display_source !== "Token" && !obj.face_down;
+  // Two independent ways a permanent is a copy, unioned so the badge covers the
+  // whole class rather than only the token half (issue #5932):
+  //   - a token minted as a copy (`is_token` + card art), and
+  //   - a real card under a live copy effect (`copied_permanents`) — Clone,
+  //     Phantasmal Image, Vesuvan Doppelganger. These were previously missed
+  //     entirely, so two Reveillarks were indistinguishable on the board.
+  // Both stay subject to the same face-down guard below.
+  const isCopy =
+    (obj.is_token === true && obj.display_source !== "Token" && !obj.face_down)
+    || (isCopiedPermanent && !obj.face_down);
 
   // Filter out loyalty counters — shown separately as the loyalty badge
   const counters = Object.entries(obj.counters).filter((entry): entry is [string, number] => entry[1] != null && entry[0] !== "loyalty");

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -565,10 +565,12 @@ export const PermanentCard = memo(function PermanentCard({
   //   - a real card under a live copy effect (`copied_permanents`) — Clone,
   //     Phantasmal Image, Vesuvan Doppelganger. These were previously missed
   //     entirely, so two Reveillarks were indistinguishable on the board.
-  // Both stay subject to the same face-down guard below.
+  // CR 708.2: the face-down guard leads, so it covers BOTH sources — a
+  // face-down permanent has only the characteristics its face-down rules grant,
+  // and surfacing "Copy" on one would leak what it really is.
   const isCopy =
-    (obj.is_token === true && obj.display_source !== "Token" && !obj.face_down)
-    || (isCopiedPermanent && !obj.face_down);
+    !obj.face_down
+    && ((obj.is_token === true && obj.display_source !== "Token") || isCopiedPermanent);
 
   // Filter out loyalty counters — shown separately as the loyalty badge
   const counters = Object.entries(obj.counters).filter((entry): entry is [string, number] => entry[1] != null && entry[0] !== "loyalty");

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -181,6 +181,47 @@ describe("PermanentCard", () => {
     cleanup();
   });
 
+  // Issue #5932: a Phantasmal Image copying a Reveillark rendered identically to
+  // the real one. The board's copy badge was gated on a TOKEN-copy heuristic
+  // (`is_token`), so a real card under a copy effect never qualified. The engine
+  // now classifies it (CR 613.2a Layer 1a + CR 707.2) and this reads that.
+  it("badges a real card that a copy effect turned into a copy", () => {
+    const gameState = makeState();
+    gameState.derived = { copied_permanents: [1] };
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    renderPermanent();
+
+    expect(screen.getByText("Copy")).toBeInTheDocument();
+  });
+
+  it("shows no copy badge on an ordinary permanent", () => {
+    // Discriminating guard: without it the test above would still pass if the
+    // badge rendered unconditionally.
+    const gameState = makeState();
+    gameState.derived = { copied_permanents: [] };
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    renderPermanent();
+
+    expect(screen.queryByText("Copy")).not.toBeInTheDocument();
+  });
+
+  it("never badges a face-down permanent as a copy (CR 708.2)", () => {
+    // A face-down permanent has only the characteristics its face-down rules
+    // grant, so surfacing "Copy" would leak what it really is. The engine omits
+    // it from the projection; the client keeps its own guard so neither side
+    // alone can leak it.
+    const gameState = makeState();
+    gameState.objects[1].face_down = true;
+    gameState.derived = { copied_permanents: [1] };
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    renderPermanent();
+
+    expect(screen.queryByText("Copy")).not.toBeInTheDocument();
+  });
+
   it("renders only the engine-classified battlefield keyword badges", () => {
     const gameState = makeState();
     gameState.objects[1].keywords = ["Flying", "Ravenous", "Evoke"];

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -1493,17 +1493,46 @@ mod tests {
             &mut events,
         );
 
+        let merge_effect_id = state
+            .objects
+            .get(&host)
+            .and_then(|object| object.merge_layer_effect_id);
         assert!(
-            state
-                .objects
-                .get(&host)
-                .and_then(|object| object.merge_layer_effect_id)
-                .is_some(),
+            merge_effect_id.is_some(),
             "precondition: merge is represented by a CopyValues layer effect"
         );
         assert!(
             derive_views(&state, None).copied_permanents.is_empty(),
             "a merge representation must not produce a Copy badge"
+        );
+
+        // The exclusion is effect-scoped, not object-scoped: a merged
+        // permanent can still acquire an independent copy effect.
+        let values = crate::game::printed_cards::intrinsic_copiable_values(
+            state.objects.get(&host).unwrap(),
+        );
+        let independent_copy_effect_id = state.add_transient_continuous_effect(
+            host,
+            PlayerId(0),
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: host },
+            vec![ContinuousModification::CopyValues {
+                values: Box::new(values),
+                display_source: DisplaySource::Card,
+                printed_ref: None,
+                token_image_ref: None,
+            }],
+            None,
+        );
+        assert_ne!(
+            Some(independent_copy_effect_id),
+            merge_effect_id,
+            "precondition: the independent copy effect is distinct from merge's representation"
+        );
+        assert_eq!(
+            derive_views(&state, None).copied_permanents,
+            vec![host],
+            "a later independent copy effect on a merged permanent must still produce a badge"
         );
     }
 

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -16,11 +16,12 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use crate::analysis::resource::ResourceAxis;
 use crate::game::ability_utils::flatten_targets_in_chain;
+use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::game_object::AttachTarget;
 use crate::game::stack::{effective_stack_ability, stack_display_groups, StackDisplayGroup};
 use crate::types::ability::{
-    GameRestriction, KeywordAction, ProhibitedActivity, RestrictionExpiry, RestrictionPlayerScope,
-    TargetRef,
+    ContinuousModification, GameRestriction, KeywordAction, ProhibitedActivity, RestrictionExpiry,
+    RestrictionPlayerScope, TargetRef,
 };
 use crate::types::card::TokenImageRef;
 use crate::types::counter::CounterType;
@@ -209,6 +210,27 @@ pub struct DerivedViews {
     /// keyword.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub battlefield_keyword_badges: HashMap<ObjectId, Vec<Keyword>>,
+
+    /// CR 613.2a + CR 707.2: battlefield permanents whose copiable values are
+    /// currently supplied by a copy effect (Layer 1a) — Clone, Phantasmal
+    /// Image, Vesuvan Doppelganger, and every "enters as a copy" permanent.
+    ///
+    /// Such a permanent renders pixel-identical to what it copied (the copy
+    /// effect overrides `printed_ref`, so even image lookup follows the copied
+    /// card), leaving the player unable to tell the copy from the original on
+    /// the board. Nothing already serialized distinguishes them: `is_copy`
+    /// means "not represented by a card" (CR 707.10) and is cleared once a copy
+    /// resolves onto the battlefield, and the copy modification lives on a
+    /// transient continuous effect rather than the object. So the engine
+    /// classifies it here rather than leaving the client to infer it.
+    ///
+    /// CR 708.2: face-down permanents are excluded — their characteristics are
+    /// only those the face-down rules grant, so surfacing "copy" on one would
+    /// leak hidden information.
+    ///
+    /// Sorted for stable serialization; absent when nothing is a copy.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub copied_permanents: Vec<ObjectId>,
 
     /// Commander damage grouped by the attacking commander's current
     /// controller. Each inner entry preserves per-commander identity so
@@ -444,6 +466,31 @@ fn pending_payment_remaining(state: &GameState, viewer: PlayerId) -> Option<Mana
     ))
 }
 
+/// CR 613.2a + CR 707.2: true when a live copy effect is currently supplying
+/// `object_id`'s copiable values.
+///
+/// A copy of a permanent is expressed as a transient continuous effect carrying
+/// `ContinuousModification::CopyValues`, applied in Layer 1a — never as a flag
+/// on the object — so membership is decided by asking the same question the
+/// layer engine asks: does this effect's `affected` filter match the object?
+/// Reusing `matches_target_filter` (rather than special-casing the
+/// `SpecificObject` filter copy effects usually carry) keeps the projection
+/// correct for any filter shape a future copy effect might use.
+fn object_has_copy_effect(state: &GameState, object_id: ObjectId) -> bool {
+    state.transient_continuous_effects.iter().any(|effect| {
+        effect
+            .modifications
+            .iter()
+            .any(|m| matches!(m, ContinuousModification::CopyValues { .. }))
+            && matches_target_filter(
+                state,
+                object_id,
+                &effect.affected,
+                &FilterContext::from_source(state, effect.source_id),
+            )
+    })
+}
+
 pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews {
     let mut views = DerivedViews {
         unique_authorized_submitter: unique_authorized_submitter(state),
@@ -480,6 +527,14 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
             .collect();
         if !badges.is_empty() {
             views.battlefield_keyword_badges.insert(obj_id, badges);
+        }
+        // CR 613.2a + CR 707.2 / CR 708.2: see `copied_permanents`. Matched
+        // through the same `matches_target_filter` the layer engine uses to
+        // pick a continuous effect's recipients, so this projection and the
+        // effect that actually rewrote the object's characteristics can never
+        // disagree about who is a copy.
+        if !obj.face_down && object_has_copy_effect(state, obj_id) {
+            views.copied_permanents.push(obj_id);
         }
         if let Some(AttachTarget::Player(host)) = obj.attached_to {
             views
@@ -1205,9 +1260,10 @@ fn zone_label(zone: Option<Zone>) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::game::game_object::DisplaySource;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        Effect, ModalChoice, ResolvedAbility, RestrictionExpiry, TargetRef,
+        Duration, Effect, ModalChoice, ResolvedAbility, RestrictionExpiry, TargetFilter, TargetRef,
     };
     use crate::types::card_type::CoreType;
     use crate::types::format::FormatConfig;
@@ -1257,6 +1313,108 @@ mod tests {
             views.commander_damage_by_attacker.is_empty(),
             "non-Commander format must short-circuit regardless of stored damage entries"
         );
+    }
+
+    #[test]
+    fn derive_views_flags_a_permanent_under_a_live_copy_effect() {
+        // CR 613.2a + CR 707.2: a copy of a permanent is expressed as a Layer 1a
+        // `CopyValues` continuous effect, not a flag on the object — so the
+        // projection has to read the effect list. Issue #5932: a Phantasmal
+        // Image copying a Reveillark renders identically to the real one, and
+        // nothing already serialized told the client which was which.
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let original = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Reveillark".into(),
+            Zone::Battlefield,
+        );
+        let clone = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Phantasmal Image".into(),
+            Zone::Battlefield,
+        );
+
+        let values = crate::game::printed_cards::intrinsic_copiable_values(
+            state.objects.get(&original).unwrap(),
+        );
+        state.add_transient_continuous_effect(
+            clone,
+            PlayerId(0),
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: clone },
+            vec![ContinuousModification::CopyValues {
+                values: Box::new(values),
+                display_source: DisplaySource::Card,
+                printed_ref: None,
+                token_image_ref: None,
+            }],
+            None,
+        );
+
+        let views = derive_views(&state, None);
+
+        assert_eq!(
+            views.copied_permanents,
+            vec![clone],
+            "only the permanent the copy effect applies to is a copy; the \
+             original it copied is not"
+        );
+    }
+
+    #[test]
+    fn derive_views_omits_copy_flag_for_a_face_down_permanent() {
+        // CR 708.2: a face-down permanent's characteristics are only those the
+        // face-down rules grant. Surfacing "copy" on one would leak hidden
+        // information about what it really is.
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let hidden = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Face-Down Copy".into(),
+            Zone::Battlefield,
+        );
+        let values = crate::game::printed_cards::intrinsic_copiable_values(
+            state.objects.get(&hidden).unwrap(),
+        );
+        state.objects.get_mut(&hidden).unwrap().face_down = true;
+        state.add_transient_continuous_effect(
+            hidden,
+            PlayerId(0),
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: hidden },
+            vec![ContinuousModification::CopyValues {
+                values: Box::new(values),
+                display_source: DisplaySource::Card,
+                printed_ref: None,
+                token_image_ref: None,
+            }],
+            None,
+        );
+
+        assert!(
+            derive_views(&state, None).copied_permanents.is_empty(),
+            "a face-down permanent must never be reported as a copy (CR 708.2)"
+        );
+    }
+
+    #[test]
+    fn derive_views_omits_copy_flag_when_no_copy_effect_is_live() {
+        // Discriminating guard: an ordinary board must report nothing, so the
+        // projection cannot degenerate into "every permanent is a copy".
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Grizzly Bears".into(),
+            Zone::Battlefield,
+        );
+        assert!(derive_views(&state, None).copied_permanents.is_empty());
     }
 
     #[test]

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -477,6 +477,11 @@ fn pending_payment_remaining(state: &GameState, viewer: PlayerId) -> Option<Mana
 /// `SpecificObject` filter copy effects usually carry) keeps the projection
 /// correct for any filter shape a future copy effect might use.
 fn object_has_copy_effect(state: &GameState, object_id: ObjectId) -> bool {
+    let merge_layer_effect_id = state
+        .objects
+        .get(&object_id)
+        .and_then(|object| object.merge_layer_effect_id);
+
     state.transient_continuous_effects.iter().any(|effect| {
         // A lapsed effect stays stored until it is swept, so "is it in the list"
         // is not the same question as "is it applying". Zygon Infiltrator's copy
@@ -485,6 +490,11 @@ fn object_has_copy_effect(state: &GameState, object_id: ObjectId) -> bool {
         // stopped applying. Gated on the layer engine's own predicate so the two
         // cannot drift apart.
         crate::game::layers::transient_effect_is_live(state, effect)
+            // CR 730.2a: merge uses a private Layer 1 `CopyValues` effect to
+            // represent its top component, but a merged permanent is not a
+            // copy. Exclude only that recorded representation: a merged object
+            // may still acquire an independent copy effect.
+            && Some(effect.id) != merge_layer_effect_id
             && effect
                 .modifications
                 .iter()
@@ -1450,6 +1460,50 @@ mod tests {
         assert!(
             derive_views(&state, None).copied_permanents.is_empty(),
             "a lapsed copy must not keep the badge (CR 611.2b)"
+        );
+    }
+
+    #[test]
+    fn derive_views_does_not_flag_a_merged_permanent_as_a_copy() {
+        // CR 730.2a: merge represents the top component with a private
+        // `CopyValues` Layer-1 effect, but the resulting permanent is merged,
+        // not a copy. The projection must exclude that exact effect while
+        // continuing to admit independent copy effects on the same object.
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let host = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Host".into(),
+            Zone::Battlefield,
+        );
+        let rider = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Rider".into(),
+            Zone::Battlefield,
+        );
+        let mut events = Vec::new();
+        crate::game::merge::merge_object_onto(
+            &mut state,
+            rider,
+            host,
+            crate::game::merge::MergeSide::Top,
+            &mut events,
+        );
+
+        assert!(
+            state
+                .objects
+                .get(&host)
+                .and_then(|object| object.merge_layer_effect_id)
+                .is_some(),
+            "precondition: merge is represented by a CopyValues layer effect"
+        );
+        assert!(
+            derive_views(&state, None).copied_permanents.is_empty(),
+            "a merge representation must not produce a Copy badge"
         );
     }
 

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -478,10 +478,17 @@ fn pending_payment_remaining(state: &GameState, viewer: PlayerId) -> Option<Mana
 /// correct for any filter shape a future copy effect might use.
 fn object_has_copy_effect(state: &GameState, object_id: ObjectId) -> bool {
     state.transient_continuous_effects.iter().any(|effect| {
-        effect
-            .modifications
-            .iter()
-            .any(|m| matches!(m, ContinuousModification::CopyValues { .. }))
+        // A lapsed effect stays stored until it is swept, so "is it in the list"
+        // is not the same question as "is it applying". Zygon Infiltrator's copy
+        // ends the instant its target untaps while the effect remains stored —
+        // badging that permanent would claim a copy the layer engine has already
+        // stopped applying. Gated on the layer engine's own predicate so the two
+        // cannot drift apart.
+        crate::game::layers::transient_effect_is_live(state, effect)
+            && effect
+                .modifications
+                .iter()
+                .any(|m| matches!(m, ContinuousModification::CopyValues { .. }))
             && matches_target_filter(
                 state,
                 object_id,
@@ -544,6 +551,11 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
                 .push(obj_id);
         }
     }
+    // Collected in `state.battlefield` order above, which reorders as permanents
+    // enter and leave; sort so the serialized payload depends only on WHICH
+    // permanents are copies, not on battlefield churn that never changed the
+    // answer.
+    views.copied_permanents.sort_unstable();
 
     // CR 702.188a + 604.1: viewer-scoped web-slinging costs (own hand only → leak-proof).
     if let Some(viewer) = viewer {
@@ -1263,7 +1275,8 @@ mod tests {
     use crate::game::game_object::DisplaySource;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        Duration, Effect, ModalChoice, ResolvedAbility, RestrictionExpiry, TargetFilter, TargetRef,
+        Duration, Effect, ModalChoice, ResolvedAbility, RestrictionExpiry, StaticCondition,
+        TargetFilter, TargetRef,
     };
     use crate::types::card_type::CoreType;
     use crate::types::format::FormatConfig;
@@ -1362,6 +1375,81 @@ mod tests {
             vec![clone],
             "only the permanent the copy effect applies to is a copy; the \
              original it copied is not"
+        );
+    }
+
+    #[test]
+    fn derive_views_drops_the_copy_flag_once_a_temporary_copy_effect_lapses() {
+        // CR 611.2b: a `ForAsLongAs` copy ends the moment its condition goes
+        // false, but the effect stays STORED until it is swept. Zygon
+        // Infiltrator copies "for as long as that creature remains tapped", so
+        // untapping the target ends the copy while the TCE is still in the list.
+        // Reading membership alone would keep badging a permanent that is no
+        // longer a copy, so the projection asks the layer engine's own
+        // liveness predicate instead.
+        use crate::types::ability::ObjectScope;
+
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let target = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Tapped Bear".into(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&target).unwrap().tapped = true;
+        let source = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Zygon".into(),
+            Zone::Battlefield,
+        );
+
+        let values = crate::game::printed_cards::intrinsic_copiable_values(
+            state.objects.get(&target).unwrap(),
+        );
+        let tce_id = state.add_transient_continuous_effect(
+            source,
+            PlayerId(0),
+            Duration::ForAsLongAs {
+                condition: StaticCondition::IsTapped {
+                    scope: ObjectScope::Target,
+                },
+            },
+            TargetFilter::SpecificObject { id: source },
+            vec![ContinuousModification::CopyValues {
+                values: Box::new(values),
+                display_source: DisplaySource::Card,
+                printed_ref: None,
+                token_image_ref: None,
+            }],
+            None,
+        );
+        // CR 611.2b: the duration tracks the copy TARGET's tap state, not the
+        // source's — the same binding the layer engine uses.
+        state.set_transient_duration_subject(tce_id, target);
+
+        assert_eq!(
+            derive_views(&state, None).copied_permanents,
+            vec![source],
+            "while the target is tapped the copy applies, so the badge shows"
+        );
+
+        // Untap the target: the duration ends and the copy lapses, but the
+        // effect is still stored.
+        state.objects.get_mut(&target).unwrap().tapped = false;
+        assert!(
+            state
+                .transient_continuous_effects
+                .iter()
+                .any(|t| t.id == tce_id),
+            "precondition: the lapsed effect is still stored, so this test is \
+             exercising liveness rather than removal"
+        );
+        assert!(
+            derive_views(&state, None).copied_permanents.is_empty(),
+            "a lapsed copy must not keep the badge (CR 611.2b)"
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -4583,33 +4583,54 @@ fn expand_granted_triggered_abilities(
 }
 
 /// Collect active transient effects, filtering out expired host-bound effects.
+/// CR 611.2 + CR 613.1: whether a stored transient continuous effect is still
+/// APPLYING, as opposed to merely still being stored.
+///
+/// A lapsed effect stays in `transient_continuous_effects` until it is swept, so
+/// presence in that list means nothing on its own: the host may have left the
+/// battlefield, a `ForAsLongAs` duration may have ended (Zygon Infiltrator's copy
+/// lapses the moment its target untaps), or the source condition may have gone
+/// false. This is the single authority for that question — `derive_views`
+/// consults it too, so a display projection can never claim an effect is live
+/// after the layer engine has stopped applying it.
+pub(crate) fn transient_effect_is_live(state: &GameState, tce: &TransientContinuousEffect) -> bool {
+    // UntilHostLeavesPlay: skip if source is no longer on the battlefield
+    if tce.duration == Duration::UntilHostLeavesPlay
+        && !state
+            .objects
+            .get(&tce.source_id)
+            .is_some_and(|obj| obj.zone == crate::types::zones::Zone::Battlefield)
+    {
+        return false;
+    }
+
+    if !transient_duration_holds(state, tce) {
+        return false;
+    }
+
+    if let Some(condition) = &tce.condition {
+        if !source_condition_gate_passes(state, condition, tce.controller, tce.source_id) {
+            return false;
+        }
+    }
+
+    true
+}
+
 pub(crate) fn gather_transient_continuous_effects(
     state: &GameState,
     effects: &mut Vec<ActiveContinuousEffect>,
 ) {
     for tce in &state.transient_continuous_effects {
-        // UntilHostLeavesPlay: skip if source is no longer on the battlefield
-        if tce.duration == Duration::UntilHostLeavesPlay
-            && !state
-                .objects
-                .get(&tce.source_id)
-                .is_some_and(|obj| obj.zone == crate::types::zones::Zone::Battlefield)
-        {
+        if !transient_effect_is_live(state, tce) {
             continue;
         }
 
-        if !transient_duration_holds(state, tce) {
-            continue;
-        }
-
-        let retained_condition = if let Some(condition) = &tce.condition {
-            if !source_condition_gate_passes(state, condition, tce.controller, tce.source_id) {
-                continue;
-            }
-            condition_uses_recipient_context(condition).then(|| condition.clone())
-        } else {
-            None
-        };
+        let retained_condition = tce
+            .condition
+            .as_ref()
+            .filter(|condition| condition_uses_recipient_context(condition))
+            .cloned();
 
         for (mod_index, modification) in tce.modifications.iter().enumerate() {
             if is_combat_assignment_rule_modification(modification) {


### PR DESCRIPTION
## Summary

A Phantasmal Image that entered as a copy of Reveillark rendered identically to the real Reveillark — same art, same name, same P/T — so the board gave no way to tell them apart.

Closes #5932

## Root cause

The board already has a "Copy" badge, but it was gated on a **token-copy** heuristic:

```ts
const isCopy = obj.is_token === true && obj.display_source !== "Token" && !obj.face_down;
```

A real card under a copy effect is not a token, so it never qualified.

There was no serialized signal the frontend could use instead — I checked the two obvious candidates and both are dead ends:

- **`GameObject.is_copy`** means "not represented by a card" (CR 707.10) and is deliberately cleared when a copy resolves onto the battlefield (`game/stack.rs:835-836`, `game/sba.rs:4869`). For Phantasmal Image it is correctly `false`.
- **`copy_modifications`** lives on `CopyChosenSelection` (a `WaitingFor` payload), not on `GameObject`.

The copy itself is a Layer 1a `CopyValues` continuous effect (CR 613.2a + CR 707.2), not a property of the object — and it overrides `printed_ref`, which is why even image lookup follows the copied card.

## Fix

The engine classifies it, since the client cannot and should not derive it (display-layer rule).

**Engine** — `DerivedViews::copied_permanents`: battlefield permanents whose copiable values a live copy effect currently supplies. Membership is decided with the same `matches_target_filter` the layer engine uses to pick a continuous effect's recipients, so the projection and the effect that actually rewrote the object's characteristics can never disagree. Using the shared matcher (rather than special-casing the `SpecificObject` filter copy effects usually carry) also keeps it correct for any filter shape a future copy effect might use.

**Client** — `PermanentCard` unions the projection with the existing token-copy case, so the badge now covers the whole class — Clone, Vesuvan Doppelganger, and every "enters as a copy" permanent — instead of only the token half.

**CR 708.2** — face-down permanents are excluded on **both** sides. Their characteristics are only those the face-down rules grant, so surfacing "Copy" would leak what one really is. Keeping the guard on each side means neither alone can leak it.

## Anchored on

`DerivedViews::battlefield_keyword_badges` — the existing per-object display projection where the engine classifies something the client would otherwise have to reinterpret, keyed by `ObjectId` and consumed through a `useGameStore` selector. This follows that shape exactly: same struct, same serde `skip_serializing_if` treatment, same selector pattern in `PermanentCard`.

## Test plan

**Engine** (`derived_views.rs`) — three cases:
- flags the permanent a live `CopyValues` effect applies to, and *not* the original it copied
- reports nothing on an ordinary board (discriminating guard against "every permanent is a copy")
- never reports a face-down permanent (CR 708.2)

**Client** (`PermanentCard.test.tsx`) — badge appears for a permanent in `copied_permanents`, is absent on an ordinary permanent, and is absent when that permanent is face-down.

**Fail-on-revert verified**: restoring the old token-only condition makes `badges a real card that a copy effect turned into a copy` fail (1 failed / 37 passed) while both guards stay green — so the positive test is discriminating rather than vacuous.

Verified locally: `cargo fmt --all` clean; `cargo clippy -p engine --all-targets --features proptest -- -D warnings` exit 0; engine `derive_views` tests pass; **2163 client tests pass** (251 files); `tsc -b --noEmit` exit 0; `eslint` exit 0.

## AI-contributor disclosure

Authored with an LLM (Claude). Every CR number was verified against `docs/MagicCompRules.txt` before use: 613.2a (line 2976, Layer 1a copiable effects), 707.2 (line 5610, copiable values), 708.2 (line 5701, face-down characteristics). No parser changes, so the combinator-purity gate is not engaged.

I deliberately did not have the client infer copy-ness from what it can see (e.g. a name/`printed_ref` mismatch): that would be deriving game state the engine owns, and the copy effect overrides `printed_ref` anyway, so there is nothing left to compare. Happy to rework anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
