### PR TITLE
ship/native server pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,8 +32,16 @@ jobs:
     if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      actions: write
+      contents: read
     outputs:
       card_data_filename: ${{ steps.card-data-hash.outputs.filename }}
+      card_data_sha256: ${{ steps.card-data-hash.outputs.card_data_sha256 }}
+      card_data_hash16: ${{ steps.card-data-hash.outputs.hash }}
+      draft_pools_sha256: ${{ steps.card-data-hash.outputs.draft_pools_sha256 }}
+      draft_pools_hash16: ${{ steps.card-data-hash.outputs.draft_pools_hash16 }}
+      engine_fingerprint: ${{ steps.engine-fingerprint.outputs.fingerprint }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -132,11 +140,30 @@ jobs:
         # immutable card-data-<hash>.json URL baked into the JS bundle. New
         # deploys publish a new hash; old browser caches keep resolving theirs.
         run: |
-          HASH=$(sha256sum data/card-data.json | awk '{print substr($1, 1, 16)}')
-          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
-          echo "filename=card-data-$HASH.json" >> "$GITHUB_OUTPUT"
-          cp "data/card-data.json" "client/public/card-data-$HASH.json"
-          echo "Content-addressed card-data: card-data-$HASH.json"
+          CARD_DATA_SHA256=$(sha256sum data/card-data.json | awk '{print $1}')
+          CARD_DATA_HASH16=${CARD_DATA_SHA256:0:16}
+          DRAFT_POOLS_SHA256=$(sha256sum client/public/draft-pools.json | awk '{print $1}')
+          DRAFT_POOLS_HASH16=${DRAFT_POOLS_SHA256:0:16}
+          echo "card_data_sha256=$CARD_DATA_SHA256" >> "$GITHUB_OUTPUT"
+          echo "hash=$CARD_DATA_HASH16" >> "$GITHUB_OUTPUT"
+          echo "filename=card-data-$CARD_DATA_HASH16.json" >> "$GITHUB_OUTPUT"
+          echo "draft_pools_sha256=$DRAFT_POOLS_SHA256" >> "$GITHUB_OUTPUT"
+          echo "draft_pools_hash16=$DRAFT_POOLS_HASH16" >> "$GITHUB_OUTPUT"
+          echo "draft_pools_filename=draft-pools-$DRAFT_POOLS_HASH16.json" >> "$GITHUB_OUTPUT"
+          cp data/card-data.json "client/public/card-data-$CARD_DATA_HASH16.json"
+          echo "Content-addressed data: card-data-$CARD_DATA_HASH16.json, draft-pools-$DRAFT_POOLS_HASH16.json"
+
+      - name: Compute engine fingerprint
+        id: engine-fingerprint
+        # The fingerprint is computed exactly once, after both generated data
+        # files exist. It keys preview native artifacts and the frontend define.
+        run: |
+          FINGERPRINT=$(./scripts/engine-fingerprint.sh \
+            "$DEPLOY_SHA" \
+            data/card-data.json \
+            client/public/draft-pools.json)
+          echo "fingerprint=$FINGERPRINT" >> "$GITHUB_OUTPUT"
+          echo "Engine fingerprint: $FINGERPRINT"
 
       - name: Generate Scryfall data
         run: |
@@ -175,6 +202,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
+          DRAFT_POOLS_FILENAME: draft-pools-${{ steps.card-data-hash.outputs.draft_pools_hash16 }}.json
         run: |
           # The r2.dev public endpoint does NOT compress on the fly, so these
           # JSONs were served raw (~77 MB of scryfall data per cold game load).
@@ -185,10 +213,8 @@ jobs:
           # reduction at a fraction of q11's CPU, which matters on an
           # every-merge path.
           #
-          # Compress into a temp dir, never client/public: card-data.json and
-          # draft-pools.json are re-read AFTER this step (Stage server data
-          # artifact) and baked UNCOMPRESSED into the server image, which loads
-          # them from disk — a stray .br or in-place overwrite would break it.
+          # Compress into a temp dir, never client/public: content hashes and
+          # native manifests are over the original uncompressed bytes.
           command -v brotli >/dev/null || { sudo apt-get update && sudo apt-get install -y brotli; }
           BRDIR="$(mktemp -d)"
 
@@ -196,6 +222,11 @@ jobs:
           # over the uncompressed file, so the URL stays a valid content key.
           brotli -q 9 -c "client/public/$CARD_DATA_FILENAME" > "$BRDIR/card-data.br"
           npx wrangler r2 object put "phase-rs-data/staging/$CARD_DATA_FILENAME" --file "$BRDIR/card-data.br" --remote --content-type application/json --content-encoding br --cache-control "public, max-age=31536000, immutable"
+
+          # Draft pools are a second immutable input to native/server data
+          # manifests. Keep the mutable draft-pools.json below for web clients.
+          brotli -q 9 -c client/public/draft-pools.json > "$BRDIR/draft-pools.br"
+          npx wrangler r2 object put "phase-rs-data/staging/$DRAFT_POOLS_FILENAME" --file "$BRDIR/draft-pools.br" --remote --content-type application/json --content-encoding br --cache-control "public, max-age=31536000, immutable"
 
           # Mutable shared JSONs. Loop over the manifest.
           while IFS= read -r f; do
@@ -220,6 +251,7 @@ jobs:
         # actually reachable. Reads from data-files.json — same source as upload.
         env:
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
+          DRAFT_POOLS_FILENAME: draft-pools-${{ steps.card-data-hash.outputs.draft_pools_hash16 }}.json
         run: |
           BASE="https://data.phase-rs.dev/staging"
           fail=0
@@ -240,6 +272,7 @@ jobs:
             fi
           }
           check "$CARD_DATA_FILENAME"
+          check "$DRAFT_POOLS_FILENAME"
           while IFS= read -r f; do check "$f"; done < <(jq -r '.[]' data-files.json)
           # Prove the brotli round-trip end-to-end on one small file: --compressed
           # requests + decodes br, jq confirms it decoded to valid JSON. The 200
@@ -248,24 +281,26 @@ jobs:
             || { echo "::error::brotli round-trip failed for scryfall-sets.json"; fail=1; }
           [ "$fail" = "0" ]
 
-      - name: Stage server data artifact
-        # card-data.json + draft-pools.json are baked into the server image by
-        # push-server-image. They are NOT in data-files.json (the server reads them
-        # from disk, not R2), so they ship via artifact instead.
+      - name: Dispatch preview server artifact build
+        # A dispatch miss self-heals on the next deploy for this fingerprint;
+        # never cancel the content deploy over a transient GitHub API failure.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FINGERPRINT: ${{ steps.engine-fingerprint.outputs.fingerprint }}
+          CARD_DATA_SHA256: ${{ steps.card-data-hash.outputs.card_data_sha256 }}
+          CARD_DATA_HASH16: ${{ steps.card-data-hash.outputs.hash }}
+          DRAFT_POOLS_SHA256: ${{ steps.card-data-hash.outputs.draft_pools_sha256 }}
+          DRAFT_POOLS_HASH16: ${{ steps.card-data-hash.outputs.draft_pools_hash16 }}
         run: |
-          mkdir -p server-data
-          cp data/card-data.json server-data/card-data.json
-          cp client/public/draft-pools.json server-data/draft-pools.json
-          test -s server-data/card-data.json
-          test -s server-data/draft-pools.json
-
-      - name: Upload server data artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: server-data
-          path: server-data/*
-          if-no-files-found: error
-          retention-days: 1
+          if ! gh workflow run preview-server.yml --ref "$DEPLOY_SHA" \
+            -f "fingerprint=$FINGERPRINT" \
+            -f "commit=$DEPLOY_SHA" \
+            -f "card_data_sha256=$CARD_DATA_SHA256" \
+            -f "card_data_hash16=$CARD_DATA_HASH16" \
+            -f "draft_pools_sha256=$DRAFT_POOLS_SHA256" \
+            -f "draft_pools_hash16=$DRAFT_POOLS_HASH16"; then
+            echo "::warning::Could not dispatch preview-server.yml for $FINGERPRINT; a later deploy will retry."
+          fi
 
   # ── WASM build (parallel with card-data) ────────────────────────────────────
   # Compiles the engine + draft WASM bundles. Depends on nothing the data
@@ -374,6 +409,7 @@ jobs:
           # card-data it was built against (filename from the card-data job).
           DATA_BASE_URL: "https://data.phase-rs.dev/staging"
           CARD_DATA_URL: "https://data.phase-rs.dev/staging/${{ needs.card-data.outputs.card_data_filename }}"
+          ENGINE_FINGERPRINT: ${{ needs.card-data.outputs.engine_fingerprint }}
           AUDIO_BASE_URL: "https://data.phase-rs.dev/audio"
           # Cloud-sync config. The anon/publishable key is client-safe (RLS is the
           # access control), so it's baked into the bundle. Empty (secret unset) →
@@ -425,9 +461,9 @@ jobs:
 
   # ── Server binary compile (parallel with card-data) ─────────────────────────
   # phase-server is compiled NATIVELY as a static musl binary, then uploaded as
-  # an artifact for push-server-image to bake into the runtime image. The compile
-  # needs nothing the data pipeline produces, so it deliberately has no `needs:`
-  # and overlaps card-data's ~10min run instead of serializing behind it.
+  # an artifact for push-server-image. The compile needs nothing the data
+  # pipeline produces, so it deliberately has no `needs:` and overlaps card-data's
+  # ~10min run instead of serializing behind it.
   #
   # NOTE: this is a cold ~10min compile every run. Swatinem's rust-cache (via
   # setup-rust-toolchain) caches registry/git deps but prunes the workspace
@@ -477,13 +513,12 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # ── Server image push (needs binary + data) ─────────────────────────────────
-  # Pure packaging step: pulls the prebuilt musl binary and the server data,
-  # then BINARY_STAGE=prebuilt makes Docker just apt + COPY (no compile). Gated
-  # on both producers so it starts the moment the slower of the two finishes.
+  # ── Server image push (needs binary) ────────────────────────────────────────
+  # Pure packaging step: pulls the prebuilt musl binary, then BINARY_STAGE=prebuilt
+  # makes Docker just apt + COPY (no compile). Server data bootstraps at runtime.
   push-server-image:
     name: Build & push server image
-    needs: [build-server-binary, card-data]
+    needs: [build-server-binary]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -500,18 +535,10 @@ jobs:
           name: server-binary
           path: .
 
-      - name: Download server data artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: server-data
-          path: data
-
       - name: Verify build context
         run: |
           test -s phase-server
           chmod +x phase-server
-          test -s data/card-data.json
-          test -s data/draft-pools.json
 
       - name: Compute image tags
         id: image

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -292,7 +292,10 @@ jobs:
           DRAFT_POOLS_SHA256: ${{ steps.card-data-hash.outputs.draft_pools_sha256 }}
           DRAFT_POOLS_HASH16: ${{ steps.card-data-hash.outputs.draft_pools_hash16 }}
         run: |
-          if ! gh workflow run preview-server.yml --ref "$DEPLOY_SHA" \
+          # Dispatch from main (workflow_dispatch refs must be a branch/tag,
+          # never a bare SHA — same pattern as nightly-release.yml); the exact
+          # source tree is pinned separately by the `commit` input below.
+          if ! gh workflow run preview-server.yml --ref main \
             -f "fingerprint=$FINGERPRINT" \
             -f "commit=$DEPLOY_SHA" \
             -f "card_data_sha256=$CARD_DATA_SHA256" \
@@ -515,7 +518,16 @@ jobs:
 
   # ── Server image push (needs binary) ────────────────────────────────────────
   # Pure packaging step: pulls the prebuilt musl binary, then BINARY_STAGE=prebuilt
-  # makes Docker just apt + COPY (no compile). Server data bootstraps at runtime.
+  # makes Docker just apt + COPY (no compile).
+  #
+  # NOTE: this binary is compiled WITHOUT a PHASE_CHANNEL identity (it builds in
+  # parallel with card-data, so the fingerprint cannot exist yet), which means
+  # the image cannot self-bootstrap its data: booting it against an empty
+  # PHASE_DATA_DIR is a clear fatal error. Any consumer must either
+  # pre-provision the data volume or set PHASE_DATA_MANIFEST_URL to a signed
+  # release-shaped data manifest. No in-repo deployment currently runs this
+  # image (beebs deploy-server is disabled); see GH #6287 for publishing a
+  # signed staging data manifest before re-enabling one.
   push-server-image:
     name: Build & push server image
     needs: [build-server-binary]

--- a/.github/workflows/preview-server.yml
+++ b/.github/workflows/preview-server.yml
@@ -1,0 +1,365 @@
+name: Preview Server Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      fingerprint:
+        description: Engine fingerprint (16 hex characters)
+        required: true
+        type: string
+      commit:
+        description: Commit whose server source is compiled
+        required: true
+        type: string
+      card_data_sha256:
+        description: SHA-256 of uncompressed card-data.json
+        required: true
+        type: string
+      card_data_hash16:
+        description: First 16 hex characters of card-data.json SHA-256
+        required: true
+        type: string
+      draft_pools_sha256:
+        description: SHA-256 of uncompressed draft-pools.json
+        required: true
+        type: string
+      draft_pools_hash16:
+        description: First 16 hex characters of draft-pools.json SHA-256
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preview-server-${{ inputs.fingerprint }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    name: Skip published fingerprint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      already_published: ${{ steps.gate.outputs.already_published }}
+    steps:
+      - name: Check manifest membership
+        id: gate
+        env:
+          FINGERPRINT: ${{ inputs.fingerprint }}
+          COMMIT: ${{ inputs.commit }}
+          CARD_DATA_SHA256: ${{ inputs.card_data_sha256 }}
+          CARD_DATA_HASH16: ${{ inputs.card_data_hash16 }}
+          DRAFT_POOLS_SHA256: ${{ inputs.draft_pools_sha256 }}
+          DRAFT_POOLS_HASH16: ${{ inputs.draft_pools_hash16 }}
+        run: |
+          set -euo pipefail
+
+          for value in "$FINGERPRINT" "$CARD_DATA_HASH16" "$DRAFT_POOLS_HASH16"; do
+            if ! [[ "$value" =~ ^[0-9a-f]{16}$ ]]; then
+              echo "::error::Expected a 16-character lowercase hex fingerprint, got: $value"
+              exit 1
+            fi
+          done
+          for value in "$CARD_DATA_SHA256" "$DRAFT_POOLS_SHA256"; do
+            if ! [[ "$value" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "::error::Expected a 64-character lowercase SHA-256, got: $value"
+              exit 1
+            fi
+          done
+          if ! [[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Expected a 40-character lowercase commit SHA, got: $COMMIT"
+            exit 1
+          fi
+
+          manifest=$(mktemp)
+          status=$(curl -sS -o "$manifest" -w '%{http_code}' \
+            --connect-timeout 5 --max-time 30 \
+            https://data.phase-rs.dev/desktop/preview-server.json || true)
+          case "$status" in
+            200)
+              jq -e 'type == "object" and (.fingerprints | type == "object")' "$manifest" >/dev/null
+              if jq -e --arg fingerprint "$FINGERPRINT" '.fingerprints | has($fingerprint)' "$manifest" >/dev/null; then
+                echo "already_published=true" >> "$GITHUB_OUTPUT"
+                echo "Preview fingerprint $FINGERPRINT is already published."
+              else
+                echo "already_published=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            404)
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              echo "Preview manifest does not exist yet."
+              ;;
+            *)
+              echo "::error::Could not fetch preview manifest (HTTP ${status:-curl failure})."
+              exit 1
+              ;;
+          esac
+
+  build:
+    name: Build preview server (${{ matrix.os }})
+    needs: [gate]
+    if: needs.gate.outputs.already_published != 'true'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 55
+    env:
+      PHASE_CHANNEL: preview
+      PHASE_ENGINE_FINGERPRINT: ${{ inputs.fingerprint }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            runner: ubuntu-latest
+            triple: x86_64-unknown-linux-musl
+            extension: ""
+          - os: macos
+            runner: macos-latest
+            triple: aarch64-apple-darwin
+            extension: ""
+          - os: windows
+            runner: windows-latest
+            triple: x86_64-pc-windows-msvc
+            extension: .exe
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-shared-key: rust-server-${{ matrix.os }}
+
+      - name: Install musl tools and target
+        if: matrix.triple == 'x86_64-unknown-linux-musl'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
+
+      - name: Build phase-server
+        run: cargo build --profile server-release --bin phase-server --target ${{ matrix.triple }}
+
+      - name: Prepare preview server binary (Unix)
+        if: matrix.os != 'windows'
+        run: |
+          cp "target/${{ matrix.triple }}/server-release/phase-server" "phase-server-${{ matrix.triple }}"
+          chmod +x "phase-server-${{ matrix.triple }}"
+        shell: bash
+
+      - name: Prepare preview server binary (Windows)
+        if: matrix.os == 'windows'
+        run: |
+          Copy-Item "target/${{ matrix.triple }}/server-release/phase-server.exe" "phase-server-${{ matrix.triple }}.exe"
+        shell: pwsh
+
+      - name: Upload preview server binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-server-${{ matrix.triple }}
+          path: phase-server-${{ matrix.triple }}${{ matrix.extension }}
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Sign, publish, and retain preview servers
+    needs: [gate, build]
+    if: needs.gate.outputs.already_published != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FINGERPRINT: ${{ inputs.fingerprint }}
+      COMMIT: ${{ inputs.commit }}
+      CARD_DATA_SHA256: ${{ inputs.card_data_sha256 }}
+      CARD_DATA_HASH16: ${{ inputs.card_data_hash16 }}
+      DRAFT_POOLS_SHA256: ${{ inputs.draft_pools_sha256 }}
+      DRAFT_POOLS_HASH16: ${{ inputs.draft_pools_hash16 }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY: ${{ secrets.SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Download Linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-server-x86_64-unknown-linux-musl
+          path: artifacts/x86_64-unknown-linux-musl
+
+      - name: Download macOS binary
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-server-aarch64-apple-darwin
+          path: artifacts/aarch64-apple-darwin
+
+      - name: Download Windows binary
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-server-x86_64-pc-windows-msvc
+          path: artifacts/x86_64-pc-windows-msvc
+
+      - name: Sign binaries, publish manifest, and garbage-collect old pairs
+        # The manifest is written last: nothing refers to a binary until its
+        # detached signature exists. R2 retention tracks exactly its current and
+        # previous fingerprint entries.
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+          umask 077
+          key_file=$(mktemp)
+          trap 'rm -f "$key_file"' EXIT
+          printf '%s' "$SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY" > "$key_file"
+
+          sign() {
+            printf '\n' | minisign -S -s "$key_file" -m "$1" -x "$1.minisig"
+          }
+
+          binaries=(
+            artifacts/x86_64-unknown-linux-musl/phase-server-x86_64-unknown-linux-musl
+            artifacts/aarch64-apple-darwin/phase-server-aarch64-apple-darwin
+            artifacts/x86_64-pc-windows-msvc/phase-server-x86_64-pc-windows-msvc.exe
+          )
+          for binary in "${binaries[@]}"; do
+            test -s "$binary"
+            sign "$binary"
+          done
+
+          prefix="desktop/preview-server/$FINGERPRINT"
+          for binary in "${binaries[@]}"; do
+            name=$(basename "$binary")
+            npx wrangler r2 object put "phase-rs-data/$prefix/$name" --file "$binary" --remote --content-type application/octet-stream --cache-control "public, max-age=31536000, immutable"
+            npx wrangler r2 object put "phase-rs-data/$prefix/$name.minisig" --file "$binary.minisig" --remote --content-type application/octet-stream --cache-control "public, max-age=31536000, immutable"
+          done
+
+          existing_manifest=$(mktemp)
+          status=$(curl -sS -o "$existing_manifest" -w '%{http_code}' \
+            --connect-timeout 5 --max-time 30 \
+            https://data.phase-rs.dev/desktop/preview-server.json || true)
+          case "$status" in
+            200)
+              jq -e 'type == "object" and (.fingerprints | type == "object")' "$existing_manifest" >/dev/null
+              ;;
+            404)
+              printf '{}\n' > "$existing_manifest"
+              ;;
+            *)
+              echo "::error::Could not fetch preview manifest for update (HTTP ${status:-curl failure})."
+              exit 1
+              ;;
+          esac
+
+          manifest=preview-server.json
+          generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq -n \
+            --slurpfile existing "$existing_manifest" \
+            --arg fingerprint "$FINGERPRINT" \
+            --arg commit "$COMMIT" \
+            --arg generated_at "$generated_at" \
+            --arg card_data_sha256 "$CARD_DATA_SHA256" \
+            --arg card_data_hash16 "$CARD_DATA_HASH16" \
+            --arg draft_pools_sha256 "$DRAFT_POOLS_SHA256" \
+            --arg draft_pools_hash16 "$DRAFT_POOLS_HASH16" \
+            '($existing[0] // {}) as $old
+             | ($old.current // null) as $old_current
+             | (if $old_current != null and ($old.fingerprints[$old_current] != null)
+                then $old_current
+                else null
+                end) as $previous
+             | {
+                 schema: 1,
+                 channel: "preview",
+                 generated_at: $generated_at,
+                 current: $fingerprint,
+                 previous: $previous,
+                 fingerprints: (
+                   {
+                     ($fingerprint): {
+                       commit: $commit,
+                       binaries: {
+                         "x86_64-unknown-linux-musl": {
+                           url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-unknown-linux-musl",
+                           sig_url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-unknown-linux-musl.minisig"
+                         },
+                         "aarch64-apple-darwin": {
+                           url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-aarch64-apple-darwin",
+                           sig_url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-aarch64-apple-darwin.minisig"
+                         },
+                         "x86_64-pc-windows-msvc": {
+                           url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-pc-windows-msvc.exe",
+                           sig_url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-pc-windows-msvc.exe.minisig"
+                         }
+                       },
+                       data: [
+                         {
+                           name: "card-data.json",
+                           sha256: $card_data_sha256,
+                           url: "https://data.phase-rs.dev/staging/card-data-" + $card_data_hash16 + ".json"
+                         },
+                         {
+                           name: "draft-pools.json",
+                           sha256: $draft_pools_sha256,
+                           url: "https://data.phase-rs.dev/staging/draft-pools-" + $draft_pools_hash16 + ".json"
+                         }
+                       ]
+                     }
+                   }
+                   + if $previous == null then {} else {($previous): $old.fingerprints[$previous]} end
+                 )
+               }' > "$manifest"
+          sign "$manifest"
+
+          # Signature first; the JSON manifest PUT is the atomic publish point.
+          npx wrangler r2 object put "phase-rs-data/desktop/preview-server.json.minisig" --file "$manifest.minisig" --remote --content-type application/octet-stream --cache-control "max-age=60, must-revalidate"
+          npx wrangler r2 object put "phase-rs-data/desktop/preview-server.json" --file "$manifest" --remote --content-type application/json --cache-control "max-age=60, must-revalidate"
+
+          # Wrangler supports individual object deletion but not prefix listing;
+          # list through Cloudflare's R2 API, then delete each unreferenced key
+          # with the same Wrangler/R2 credentials used for publication.
+          list_prefix='desktop/preview-server/'
+          api_url="https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/r2/buckets/phase-rs-data/objects"
+          object_keys=$(mktemp)
+          cursor=''
+          while :; do
+            curl_args=(
+              --fail --silent --show-error --get "$api_url"
+              -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+              --data-urlencode "prefix=$list_prefix"
+              --data-urlencode 'per_page=1000'
+            )
+            if [ -n "$cursor" ]; then
+              curl_args+=(--data-urlencode "cursor=$cursor")
+            fi
+            page=$(curl "${curl_args[@]}")
+            jq -e '.success == true and (.result | type == "array")' <<<"$page" >/dev/null
+            jq -r '.result[]?.key' <<<"$page" >> "$object_keys"
+            if [ "$(jq -r '.result_info.is_truncated // false' <<<"$page")" != true ]; then
+              break
+            fi
+            cursor=$(jq -r '.result_info.cursor // empty' <<<"$page")
+            test -n "$cursor"
+          done
+
+          keep_prefixes=("$list_prefix$FINGERPRINT/")
+          previous=$(jq -r '.previous // empty' "$manifest")
+          if [ -n "$previous" ]; then
+            keep_prefixes+=("$list_prefix$previous/")
+          fi
+
+          while IFS= read -r key; do
+            keep=false
+            for keep_prefix in "${keep_prefixes[@]}"; do
+              if [[ "$key" == "$keep_prefix"* ]]; then
+                keep=true
+                break
+              fi
+            done
+            if [ "$keep" = false ]; then
+              echo "Deleting expired preview binary object: $key"
+              npx wrangler r2 object delete "phase-rs-data/$key" --remote --force
+            fi
+          done < "$object_keys"

--- a/.github/workflows/preview-server.yml
+++ b/.github/workflows/preview-server.yml
@@ -167,6 +167,9 @@ jobs:
     if: needs.gate.outputs.already_published != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    concurrency:
+      group: preview-server-manifest
+      cancel-in-progress: false
     env:
       FINGERPRINT: ${{ inputs.fingerprint }}
       COMMIT: ${{ inputs.commit }}
@@ -178,29 +181,63 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY: ${{ secrets.SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY }}
     steps:
+      - name: Re-check manifest membership under publication lock
+        id: publication-gate
+        run: |
+          set -euo pipefail
+
+          manifest=$(mktemp)
+          trap 'rm -f "$manifest"' EXIT
+          status=$(curl -sS -o "$manifest" -w '%{http_code}' \
+            --connect-timeout 5 --max-time 30 \
+            https://data.phase-rs.dev/desktop/preview-server.json || true)
+          case "$status" in
+            200)
+              jq -e 'type == "object" and (.fingerprints | type == "object")' "$manifest" >/dev/null
+              if jq -e --arg fingerprint "$FINGERPRINT" '.fingerprints | has($fingerprint)' "$manifest" >/dev/null; then
+                echo "already_published=true" >> "$GITHUB_OUTPUT"
+                echo "Preview fingerprint $FINGERPRINT was published while this job waited for the publication lock."
+              else
+                echo "already_published=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            404)
+              echo "already_published=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Could not fetch preview manifest after acquiring publication lock (HTTP ${status:-curl failure})."
+              exit 1
+              ;;
+          esac
+
       - uses: actions/setup-node@v4
+        if: steps.publication-gate.outputs.already_published != 'true'
         with:
           node-version: 22
 
       - name: Download Linux binary
+        if: steps.publication-gate.outputs.already_published != 'true'
         uses: actions/download-artifact@v4
         with:
           name: preview-server-x86_64-unknown-linux-musl
           path: artifacts/x86_64-unknown-linux-musl
 
       - name: Download macOS binary
+        if: steps.publication-gate.outputs.already_published != 'true'
         uses: actions/download-artifact@v4
         with:
           name: preview-server-aarch64-apple-darwin
           path: artifacts/aarch64-apple-darwin
 
       - name: Download Windows binary
+        if: steps.publication-gate.outputs.already_published != 'true'
         uses: actions/download-artifact@v4
         with:
           name: preview-server-x86_64-pc-windows-msvc
           path: artifacts/x86_64-pc-windows-msvc
 
       - name: Sign binaries, publish manifest, and garbage-collect old pairs
+        if: steps.publication-gate.outputs.already_published != 'true'
         # The manifest is written last: nothing refers to a binary until its
         # detached signature exists. R2 retention tracks exactly its current and
         # previous fingerprint entries.
@@ -255,6 +292,7 @@ jobs:
 
           manifest=preview-server.json
           generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # sha256 is over UNCOMPRESSED bytes; R2 serves these objects with Content-Encoding: br unconditionally — consumers MUST brotli-decode before hashing.
           jq -n \
             --slurpfile existing "$existing_manifest" \
             --arg fingerprint "$FINGERPRINT" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,11 @@ jobs:
     # build, stranding the release). Raised to 60m for headroom — the ceiling
     # only bills the failure case, so a normal ~30m run still ends at ~30m.
     timeout-minutes: 60
+    outputs:
+      card_data_sha256: ${{ steps.card-data-hash.outputs.card_data_sha256 }}
+      card_data_hash16: ${{ steps.card-data-hash.outputs.hash }}
+      draft_pools_sha256: ${{ steps.card-data-hash.outputs.draft_pools_sha256 }}
+      draft_pools_hash16: ${{ steps.card-data-hash.outputs.draft_pools_hash16 }}
     env:
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
     steps:
@@ -201,10 +206,18 @@ jobs:
         # `card-data-<hash>.json` URL baked into the JS bundle. Old browser
         # caches keep resolving their old hash even after a new release.
         run: |
-          HASH=$(sha256sum client/public/card-data.json | awk '{print substr($1, 1, 16)}')
-          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
-          echo "filename=card-data-$HASH.json" >> "$GITHUB_OUTPUT"
-          cp client/public/card-data.json "client/public/card-data-$HASH.json"
+          CARD_DATA_SHA256=$(sha256sum client/public/card-data.json | awk '{print $1}')
+          CARD_DATA_HASH16=${CARD_DATA_SHA256:0:16}
+          DRAFT_POOLS_SHA256=$(sha256sum client/public/draft-pools.json | awk '{print $1}')
+          DRAFT_POOLS_HASH16=${DRAFT_POOLS_SHA256:0:16}
+          echo "card_data_sha256=$CARD_DATA_SHA256" >> "$GITHUB_OUTPUT"
+          echo "hash=$CARD_DATA_HASH16" >> "$GITHUB_OUTPUT"
+          echo "filename=card-data-$CARD_DATA_HASH16.json" >> "$GITHUB_OUTPUT"
+          echo "draft_pools_sha256=$DRAFT_POOLS_SHA256" >> "$GITHUB_OUTPUT"
+          echo "draft_pools_hash16=$DRAFT_POOLS_HASH16" >> "$GITHUB_OUTPUT"
+          echo "draft_pools_filename=draft-pools-$DRAFT_POOLS_HASH16.json" >> "$GITHUB_OUTPUT"
+          cp client/public/card-data.json "client/public/card-data-$CARD_DATA_HASH16.json"
+          echo "Content-addressed data: card-data-$CARD_DATA_HASH16.json, draft-pools-$DRAFT_POOLS_HASH16.json"
 
       - name: Generate Scryfall data
         run: |
@@ -269,6 +282,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
+          DRAFT_POOLS_FILENAME: draft-pools-${{ steps.card-data-hash.outputs.draft_pools_hash16 }}.json
         run: |
           # The r2.dev public endpoint does NOT compress on the fly, so these
           # JSONs were served raw. Pre-compress with brotli and store
@@ -276,9 +290,8 @@ jobs:
           # fetch(), which decodes br transparently. q9: ~90% reduction at a
           # fraction of q11's CPU.
           #
-          # Compress into a temp dir, never client/public: card-data.json /
-          # draft-pools.json are re-read after this step and baked UNCOMPRESSED
-          # into the server image (loaded from disk).
+          # Compress into a temp dir, never client/public: content hashes and
+          # release data manifests are over the original uncompressed bytes.
           command -v brotli >/dev/null || { sudo apt-get update && sudo apt-get install -y brotli; }
           BRDIR="$(mktemp -d)"
 
@@ -286,6 +299,11 @@ jobs:
           # over the uncompressed file, so the URL stays a valid content key.
           brotli -q 9 -c "client/public/$CARD_DATA_FILENAME" > "$BRDIR/card-data.br"
           npx wrangler r2 object put "phase-rs-data/$CARD_DATA_FILENAME" --file "$BRDIR/card-data.br" --remote --content-type application/json --content-encoding br --cache-control "public, max-age=31536000, immutable"
+
+          # Native/server manifests must pin draft pools to immutable content,
+          # while the mutable draft-pools.json remains in the shared-file loop.
+          brotli -q 9 -c client/public/draft-pools.json > "$BRDIR/draft-pools.br"
+          npx wrangler r2 object put "phase-rs-data/$DRAFT_POOLS_FILENAME" --file "$BRDIR/draft-pools.br" --remote --content-type application/json --content-encoding br --cache-control "public, max-age=31536000, immutable"
 
           # Mutable shared JSONs. Loop over the manifest.
           while IFS= read -r f; do
@@ -300,6 +318,7 @@ jobs:
       - name: Verify R2 uploads landed
         env:
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
+          DRAFT_POOLS_FILENAME: draft-pools-${{ steps.card-data-hash.outputs.draft_pools_hash16 }}.json
         run: |
           BASE="https://data.phase-rs.dev"
           fail=0
@@ -320,6 +339,7 @@ jobs:
             fi
           }
           check "$CARD_DATA_FILENAME"
+          check "$DRAFT_POOLS_FILENAME"
           while IFS= read -r f; do check "$f"; done < <(jq -r '.[]' data-files.json)
           # Prove the brotli round-trip end-to-end on one small file: --compressed
           # requests + decodes br, jq confirms it decoded to valid JSON.
@@ -359,24 +379,10 @@ jobs:
           path: client/dist
           retention-days: 90
 
-      - name: Upload card data artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: card-data
-          path: client/public/card-data.json
-          retention-days: 1
-
-      - name: Upload draft pools artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: draft-pools
-          path: client/public/draft-pools.json
-          retention-days: 1
-
   # ── Server binary compile (linux musl, shared) ──────────────────────────────
   # Compiles the static musl binary ONCE per release run. Consumed by both
   # build-server-image (prebuilt Docker image) and build-server's linux leg
-  # (release archive), so neither pays a redundant ~10min compile. Needs nothing
+  # (slim server asset), so neither pays a redundant ~10min compile. Needs nothing
   # the data pipeline produces, so it starts immediately.
   build-server-binary:
     name: Build Server Binary (linux)
@@ -387,6 +393,7 @@ jobs:
       contents: read
     env:
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
+      PHASE_CHANNEL: release
     steps:
       - uses: actions/checkout@v4
         with:
@@ -404,7 +411,7 @@ jobs:
 
       - name: Build phase-server (static musl)
         # No chmod here: upload-artifact strips the executable bit anyway; both
-        # consumers (image build, archive packaging) re-apply it.
+        # consumers (image build, slim-asset packaging) re-apply it.
         run: |
           cargo build --profile server-release --bin phase-server --target x86_64-unknown-linux-musl
           cp target/x86_64-unknown-linux-musl/server-release/phase-server ./phase-server
@@ -419,7 +426,7 @@ jobs:
 
   build-server-image:
     name: Build Server Image
-    needs: [resolve-release-ref, build-wasm, build-server-binary]
+    needs: [resolve-release-ref, build-server-binary]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -434,18 +441,6 @@ jobs:
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - name: Download card data
-        uses: actions/download-artifact@v4
-        with:
-          name: card-data
-          path: data
-
-      - name: Download draft pools
-        uses: actions/download-artifact@v4
-        with:
-          name: draft-pools
-          path: data
-
       - name: Download server binary
         uses: actions/download-artifact@v4
         with:
@@ -456,8 +451,6 @@ jobs:
         run: |
           test -s phase-server
           chmod +x phase-server
-          test -s data/card-data.json
-          test -s data/draft-pools.json
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -580,7 +573,7 @@ jobs:
 
   build-server:
     name: Build Server (${{ matrix.os }})
-    needs: [resolve-release-ref, build-wasm, build-server-binary]
+    needs: [resolve-release-ref, build-server-binary]
     runs-on: ${{ matrix.runner }}
     # The Windows leg ran ~33-34 min warm against a 35-min ceiling, so any cache
     # miss tripped the timeout and cancelled the release (a timed-out job reports
@@ -591,6 +584,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs.resolve-release-ref.outputs.release_tag }}
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
+      PHASE_CHANNEL: release
     strategy:
       fail-fast: false
       matrix:
@@ -598,18 +592,15 @@ jobs:
           - os: linux
             runner: ubuntu-latest
             triple: x86_64-unknown-linux-musl
-            artifact: phase-server-linux-x86_64
-            archive_ext: tar.gz
+            extension: ""
           - os: macos
             runner: macos-latest
             triple: aarch64-apple-darwin
-            artifact: phase-server-macos-arm64
-            archive_ext: tar.gz
+            extension: ""
           - os: windows
             runner: windows-latest
             triple: x86_64-pc-windows-msvc
-            artifact: phase-server-windows-x86_64
-            archive_ext: zip
+            extension: .exe
     steps:
       - uses: actions/checkout@v4
         with:
@@ -634,55 +625,25 @@ jobs:
           name: server-binary-linux
           path: target/x86_64-unknown-linux-musl/server-release
 
-      - name: Download card data
-        uses: actions/download-artifact@v4
-        with:
-          name: card-data
-          path: staging/data
-
-      - name: Download draft pools
-        uses: actions/download-artifact@v4
-        with:
-          name: draft-pools
-          path: staging/data
-
-      - name: Package server archive (Unix)
+      - name: Prepare slim server binary (Unix)
         if: matrix.os != 'windows'
         run: |
-          TAG="$RELEASE_TAG"
-          mkdir -p staging
-          cp "target/${{ matrix.triple }}/server-release/phase-server" staging/
-          chmod +x staging/phase-server
-          cd staging
-          tar czf ../${{ matrix.artifact }}.tar.gz phase-server data/card-data.json data/draft-pools.json
+          cp "target/${{ matrix.triple }}/server-release/phase-server" "phase-server-slim-${{ matrix.triple }}"
+          chmod +x "phase-server-slim-${{ matrix.triple }}"
         shell: bash
 
-      - name: Package server archive (Windows)
+      - name: Prepare slim server binary (Windows)
         if: matrix.os == 'windows'
         run: |
-          $Tag = $env:RELEASE_TAG
-          Copy-Item "target/${{ matrix.triple }}/server-release/phase-server.exe" "staging/"
-          Compress-Archive -Path "staging/phase-server.exe","staging/data/card-data.json","staging/data/draft-pools.json" -DestinationPath "${{ matrix.artifact }}.zip"
+          Copy-Item "target/${{ matrix.triple }}/server-release/phase-server.exe" "phase-server-slim-${{ matrix.triple }}.exe"
         shell: pwsh
 
-      - name: Generate checksum (Unix)
-        if: matrix.os != 'windows'
-        run: shasum -a 256 ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.tar.gz.sha256
-
-      - name: Generate checksum (Windows)
-        if: matrix.os == 'windows'
-        run: |
-          $hash = (Get-FileHash "${{ matrix.artifact }}.zip" -Algorithm SHA256).Hash.ToLower()
-          "$hash  ${{ matrix.artifact }}.zip" | Out-File -Encoding utf8 "${{ matrix.artifact }}.zip.sha256"
-        shell: pwsh
-
-      - name: Upload server archive
+      - name: Upload slim server binary
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: |
-            ${{ matrix.artifact }}.${{ matrix.archive_ext }}
-            ${{ matrix.artifact }}.${{ matrix.archive_ext }}.sha256
+          name: phase-server-slim-${{ matrix.triple }}
+          path: phase-server-slim-${{ matrix.triple }}${{ matrix.extension }}
+          if-no-files-found: error
           retention-days: 90
 
   deploy-server:
@@ -756,10 +717,17 @@ jobs:
       needs.build-server.result == 'success' &&
       needs.build-server-image.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       RELEASE_TAG: ${{ needs.resolve-release-ref.outputs.release_tag }}
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
+      CARD_DATA_SHA256: ${{ needs.build-wasm.outputs.card_data_sha256 }}
+      CARD_DATA_HASH16: ${{ needs.build-wasm.outputs.card_data_hash16 }}
+      DRAFT_POOLS_SHA256: ${{ needs.build-wasm.outputs.draft_pools_sha256 }}
+      DRAFT_POOLS_HASH16: ${{ needs.build-wasm.outputs.draft_pools_hash16 }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY: ${{ secrets.SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -770,6 +738,77 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Sign slim server artifacts and publish release data manifest
+        # Sign in this Ubuntu finisher so all three OS binaries use one trusted
+        # signing path. The versioned manifest is immutable; its final PUT is
+        # performed after its detached signature exists.
+        run: |
+          set -euo pipefail
+
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+          WORKSPACE_VERSION=$(awk '
+            /^\[workspace\.package\]/ { in_workspace_package = 1; next }
+            /^\[/ { in_workspace_package = 0 }
+            in_workspace_package && /^version = "/ {
+              gsub(/version = "|"/, "")
+              print
+              exit
+            }
+          ' Cargo.toml)
+          test -n "$WORKSPACE_VERSION"
+          test "$RELEASE_TAG" = "v$WORKSPACE_VERSION"
+
+          umask 077
+          key_file=$(mktemp)
+          trap 'rm -f "$key_file"' EXIT
+          printf '%s' "$SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY" > "$key_file"
+
+          sign() {
+            printf '\n' | minisign -S -s "$key_file" -m "$1" -x "$1.minisig"
+          }
+
+          for triple in \
+            x86_64-unknown-linux-musl \
+            aarch64-apple-darwin \
+            x86_64-pc-windows-msvc; do
+            binary="artifacts/phase-server-slim-$triple/phase-server-slim-$triple"
+            if [ "$triple" = x86_64-pc-windows-msvc ]; then
+              binary="$binary.exe"
+            fi
+            test -s "$binary"
+            sign "$binary"
+          done
+
+          manifest="release-server-v$WORKSPACE_VERSION.json"
+          generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq -n \
+            --arg version "$WORKSPACE_VERSION" \
+            --arg generated_at "$generated_at" \
+            --arg card_data_sha256 "$CARD_DATA_SHA256" \
+            --arg card_data_url "https://data.phase-rs.dev/card-data-$CARD_DATA_HASH16.json" \
+            --arg draft_pools_sha256 "$DRAFT_POOLS_SHA256" \
+            --arg draft_pools_url "https://data.phase-rs.dev/draft-pools-$DRAFT_POOLS_HASH16.json" \
+            '{
+              schema: 1,
+              channel: "release",
+              version: $version,
+              generated_at: $generated_at,
+              data: [
+                {name: "card-data.json", sha256: $card_data_sha256, url: $card_data_url},
+                {name: "draft-pools.json", sha256: $draft_pools_sha256, url: $draft_pools_url}
+              ]
+            }' > "$manifest"
+          sign "$manifest"
+
+          npx wrangler r2 object put "phase-rs-data/desktop/$manifest.minisig" --file "$manifest.minisig" --remote --content-type application/octet-stream --cache-control "public, max-age=31536000, immutable"
+          npx wrangler r2 object put "phase-rs-data/desktop/$manifest" --file "$manifest" --remote --content-type application/json --cache-control "public, max-age=31536000, immutable"
 
       - name: Download shell updater migration bridge
         id: shell-updater-bridge
@@ -828,12 +867,14 @@ jobs:
           body_path: changelog.md
           fail_on_unmatched_files: true
           files: |
-            artifacts/phase-server-linux-x86_64/*.tar.gz
-            artifacts/phase-server-linux-x86_64/*.sha256
-            artifacts/phase-server-macos-arm64/*.tar.gz
-            artifacts/phase-server-macos-arm64/*.sha256
-            artifacts/phase-server-windows-x86_64/*.zip
-            artifacts/phase-server-windows-x86_64/*.sha256
+            artifacts/phase-server-slim-x86_64-unknown-linux-musl/phase-server-slim-x86_64-unknown-linux-musl
+            artifacts/phase-server-slim-x86_64-unknown-linux-musl/phase-server-slim-x86_64-unknown-linux-musl.minisig
+            artifacts/phase-server-slim-aarch64-apple-darwin/phase-server-slim-aarch64-apple-darwin
+            artifacts/phase-server-slim-aarch64-apple-darwin/phase-server-slim-aarch64-apple-darwin.minisig
+            artifacts/phase-server-slim-x86_64-pc-windows-msvc/phase-server-slim-x86_64-pc-windows-msvc.exe
+            artifacts/phase-server-slim-x86_64-pc-windows-msvc/phase-server-slim-x86_64-pc-windows-msvc.exe.minisig
+            release-server-${{ needs.resolve-release-ref.outputs.release_tag }}.json
+            release-server-${{ needs.resolve-release-ref.outputs.release_tag }}.json.minisig
 
       - name: Attach shell updater migration bridge
         if: steps.shell-updater-bridge.outputs.available == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -788,6 +788,7 @@ jobs:
 
           manifest="release-server-v$WORKSPACE_VERSION.json"
           generated_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          # sha256 is over UNCOMPRESSED bytes; R2 serves these objects with Content-Encoding: br unconditionally — consumers MUST brotli-decode before hashing.
           jq -n \
             --arg version "$WORKSPACE_VERSION" \
             --arg generated_at "$generated_at" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +123,18 @@ name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -299,6 +326,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +390,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -420,6 +474,22 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
@@ -1062,8 +1132,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1087,11 +1159,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1312,6 +1386,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1652,6 +1727,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1805,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2000,14 +2087,17 @@ dependencies = [
  "futures-util",
  "http",
  "lobby-broker",
+ "minisign-verify",
  "ngrok",
  "phase-ai",
  "rand 0.9.4",
+ "reqwest",
  "rusqlite",
  "seat-reducer",
  "serde",
  "serde_json",
  "server-core",
+ "sha2",
  "tempfile",
  "tokio",
  "tokio-tungstenite",
@@ -2197,6 +2287,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2292,6 +2438,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -2415,6 +2570,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2422,6 +2579,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2429,6 +2587,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2487,6 +2646,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2533,6 +2693,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2857,6 +3018,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3393,12 +3565,17 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3770,6 +3947,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,15 +47,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=binary /phase-server /usr/local/bin/phase-server
 COPY docker/phase-server-entrypoint.sh /usr/local/bin/phase-server-entrypoint
 
-RUN --mount=type=bind,source=data,target=/context-data,readonly \
-    mkdir -p /usr/share/phase-server \
-    && cp /context-data/card-data.json /usr/share/phase-server/card-data.json \
-    && if [ -f /context-data/draft-pools.json ]; then \
-        cp /context-data/draft-pools.json /usr/share/phase-server/draft-pools.json; \
-    else \
-        printf '{}\n' > /usr/share/phase-server/draft-pools.json; \
-    fi
-
 RUN mkdir -p /var/lib/phase-server \
     && chown -R phase:phase /var/lib/phase-server \
     && chmod +x /usr/local/bin/phase-server /usr/local/bin/phase-server-entrypoint

--- a/crates/phase-server/Cargo.toml
+++ b/crates/phase-server/Cargo.toml
@@ -20,7 +20,7 @@ axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4", features = ["derive", "env"] }
 http = "1"
 minisign-verify = "0.2"
-reqwest = { version = "0.12", default-features = false, features = ["brotli", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["brotli", "rustls-tls-webpki-roots"] }
 sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }

--- a/crates/phase-server/Cargo.toml
+++ b/crates/phase-server/Cargo.toml
@@ -19,10 +19,14 @@ rand = "0.9"
 axum = { version = "0.8", features = ["ws"] }
 clap = { version = "4", features = ["derive", "env"] }
 http = "1"
+minisign-verify = "0.2"
+reqwest = { version = "0.12", default-features = false, features = ["brotli", "rustls-tls"] }
+sha2 = "0.10"
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors"] }
 serde = { workspace = true }
 serde_json = "1"
+tempfile = "3"
 tracing = { workspace = true }
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
@@ -38,5 +42,4 @@ ngrok = ["dep:ngrok"]
 
 [dev-dependencies]
 futures-util = "0.3"
-tempfile = "3"
 tokio-tungstenite = "0.29"

--- a/crates/phase-server/src/data_bootstrap.rs
+++ b/crates/phase-server/src/data_bootstrap.rs
@@ -1,18 +1,21 @@
 use std::fmt;
 use std::io::Write;
 use std::path::{Component, Path};
+use std::time::Duration;
 
 use minisign_verify::{PublicKey, Signature};
 use reqwest::Client;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
+use tracing::warn;
 use url::Url;
 
 pub const PINNED_DATA_MANIFEST_PUBLIC_KEY: &str =
     "RWRDZxG2otNoKLblrgD00kM0a8U0CRZUGHpNCr3W+3ik1E84XHcB6hZe";
 const RELEASE_MANIFEST_BASE_URL: &str = "https://data.phase-rs.dev/desktop";
 const PREVIEW_MANIFEST_URL: &str = "https://data.phase-rs.dev/desktop/preview-server.json";
-const REQUIRED_DATA_FILES: [&str; 2] = ["card-data.json", "draft-pools.json"];
+const REQUIRED_DATA_FILES: [&str; 1] = ["card-data.json"];
+const BEST_EFFORT_DATA_FILES: [&str; 1] = ["draft-pools.json"];
 
 #[derive(Debug)]
 pub struct BootstrapError(String);
@@ -111,6 +114,11 @@ fn resolve_manifest(
     identity: Option<&ChannelIdentity>,
 ) -> Result<ManifestResolution, BootstrapError> {
     if let Some(url) = manifest_url_override {
+        if url.scheme() != "https" {
+            return Err(BootstrapError::new(format!(
+                "data manifest URL must use HTTPS, got {url}"
+            )));
+        }
         return Ok(ManifestResolution::Override(url));
     }
 
@@ -127,7 +135,7 @@ fn resolve_manifest(
             Url::parse(PREVIEW_MANIFEST_URL).expect("preview manifest URL is a valid constant"),
         )),
         None => Err(BootstrapError::new(
-            "card-data.json or draft-pools.json is missing and this binary has no PHASE_CHANNEL identity; pre-provision PHASE_DATA_DIR or pass --data-manifest-url <url>",
+            "card-data.json is missing and this binary has no PHASE_CHANNEL identity; pre-provision PHASE_DATA_DIR or pass --data-manifest-url <url>",
         )),
     }
 }
@@ -249,9 +257,15 @@ fn validate_manifest_data(data: &[DataFile]) -> Result<(), BootstrapError> {
                 file.name, file.sha256
             )));
         }
-        if let Err(error) = Url::parse(&file.url) {
-            return Err(BootstrapError::new(format!(
+        let url = Url::parse(&file.url).map_err(|error| {
+            BootstrapError::new(format!(
                 "data manifest has invalid URL for {}: {} ({error})",
+                file.name, file.url
+            ))
+        })?;
+        if url.scheme() != "https" {
+            return Err(BootstrapError::new(format!(
+                "data manifest URL for {} must use HTTPS, got {}",
                 file.name, file.url
             )));
         }
@@ -276,9 +290,10 @@ fn is_sha256(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
-fn missing_required_data_files(data_dir: &Path) -> Vec<&'static str> {
-    REQUIRED_DATA_FILES
-        .into_iter()
+fn missing_data_files(data_dir: &Path, names: &[&'static str]) -> Vec<&'static str> {
+    names
+        .iter()
+        .copied()
         .filter(|name| !data_dir.join(name).is_file())
         .collect()
 }
@@ -298,21 +313,45 @@ async fn bootstrap_missing_data_with_key(
     identity: Option<&ChannelIdentity>,
     public_key: &str,
 ) -> Result<(), BootstrapError> {
-    let missing = missing_required_data_files(data_dir);
-    if missing.is_empty() {
+    let missing_required = missing_data_files(data_dir, &REQUIRED_DATA_FILES);
+    let missing_best_effort = missing_data_files(data_dir, &BEST_EFFORT_DATA_FILES);
+    if missing_required.is_empty() && missing_best_effort.is_empty() {
         return Ok(());
     }
 
-    let resolution = resolve_manifest(options.manifest_url_override.clone(), identity)?;
     if options.no_data_download {
+        if missing_required.is_empty() {
+            warn!(
+                files = ?missing_best_effort,
+                "optional data files are missing; server-hosted drafts will remain disabled"
+            );
+            return Ok(());
+        }
+
+        let resolution = resolve_manifest(options.manifest_url_override.clone(), identity)?;
         return Err(BootstrapError::new(format!(
             "missing data files {}; --no-data-download prevents fetching them. Pre-provision PHASE_DATA_DIR or retry without --no-data-download (manifest: {})",
-            missing.join(", "),
+            missing_required.join(", "),
             resolution.url()
         )));
     }
 
+    let resolution = match resolve_manifest(options.manifest_url_override.clone(), identity) {
+        Ok(resolution) => resolution,
+        Err(error) if missing_required.is_empty() => {
+            warn!(
+                files = ?missing_best_effort,
+                error = %error,
+                "optional data files are missing but no manifest is available; server-hosted drafts will remain disabled"
+            );
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
+
     let client = Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(120))
         .build()
         .map_err(|error| BootstrapError::new(format!("failed to build HTTP client: {error}")))?;
     let manifest_url = resolution.url();
@@ -326,22 +365,24 @@ async fn bootstrap_missing_data_with_key(
     verify_manifest_signature(&manifest_bytes, &signature_bytes, public_key)?;
 
     let data = parse_manifest_data(&manifest_bytes, identity)?;
-    for file in data
-        .iter()
-        .filter(|file| missing.iter().any(|name| *name == file.name))
-    {
-        let url = Url::parse(&file.url).map_err(|error| {
-            BootstrapError::new(format!(
-                "data manifest has invalid URL for {}: {} ({error})",
-                file.name, file.url
-            ))
-        })?;
-        let bytes = fetch_bytes(&client, &url, &format!("data file {}", file.name)).await?;
-        verify_sha256(&bytes, &file.sha256, &file.name, &url)?;
-        write_verified_data_file(data_dir, &file.name, &bytes).await?;
+    for file in data.iter().filter(|file| {
+        missing_required.iter().any(|name| *name == file.name)
+            || missing_best_effort.iter().any(|name| *name == file.name)
+    }) {
+        if BEST_EFFORT_DATA_FILES.contains(&file.name.as_str()) {
+            if let Err(error) = download_data_file(&client, data_dir, file).await {
+                warn!(
+                    file = %file.name,
+                    error = %error,
+                    "optional data file could not be bootstrapped; server-hosted drafts will remain disabled"
+                );
+            }
+        } else {
+            download_data_file(&client, data_dir, file).await?;
+        }
     }
 
-    let still_missing = missing_required_data_files(data_dir);
+    let still_missing = missing_data_files(data_dir, &REQUIRED_DATA_FILES);
     if !still_missing.is_empty() {
         return Err(BootstrapError::new(format!(
             "data bootstrap did not create required files {} from manifest {}",
@@ -350,6 +391,22 @@ async fn bootstrap_missing_data_with_key(
         )));
     }
     Ok(())
+}
+
+async fn download_data_file(
+    client: &Client,
+    data_dir: &Path,
+    file: &DataFile,
+) -> Result<(), BootstrapError> {
+    let url = Url::parse(&file.url).map_err(|error| {
+        BootstrapError::new(format!(
+            "data manifest has invalid URL for {}: {} ({error})",
+            file.name, file.url
+        ))
+    })?;
+    let bytes = fetch_bytes(client, &url, &format!("data file {}", file.name)).await?;
+    verify_sha256(&bytes, &file.sha256, &file.name, &url)?;
+    write_verified_data_file(data_dir, &file.name, &bytes).await
 }
 
 async fn fetch_bytes(
@@ -474,8 +531,8 @@ fn write_verified_data_file_blocking(
 mod tests {
     use super::{
         bootstrap_missing_data_with_key, identity_from_markers, parse_manifest_data,
-        verify_manifest_signature, verify_sha256, write_verified_data_file, BootstrapOptions,
-        ChannelIdentity,
+        resolve_manifest, verify_manifest_signature, verify_sha256, write_verified_data_file,
+        BootstrapOptions, ChannelIdentity,
     };
     use sha2::{Digest, Sha256};
     use url::Url;
@@ -546,6 +603,47 @@ mod tests {
     }
 
     #[test]
+    fn rejects_non_https_manifest_data_urls() {
+        let manifest = br#"{
+            "schema": 1,
+            "channel": "release",
+            "version": "test",
+            "data": [
+                {"name": "card-data.json", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "url": "http://example.test/card-data.json"}
+            ]
+        }"#;
+
+        let error = parse_manifest_data(manifest, None).expect_err("HTTP data URL must fail");
+
+        assert!(error.to_string().contains("must use HTTPS"));
+    }
+
+    #[test]
+    fn release_manifest_allows_missing_optional_draft_pools() {
+        let manifest = br#"{
+            "schema": 1,
+            "channel": "release",
+            "version": "test",
+            "data": [
+                {"name": "card-data.json", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "url": "https://example.test/card-data.json"}
+            ]
+        }"#;
+
+        parse_manifest_data(manifest, None).expect("draft pools are optional manifest data");
+    }
+
+    #[test]
+    fn rejects_non_https_manifest_override() {
+        let error = resolve_manifest(
+            Some(Url::parse("http://example.test/manifest.json").expect("URL")),
+            None,
+        )
+        .expect_err("HTTP manifest override must fail");
+
+        assert!(error.to_string().contains("must use HTTPS"));
+    }
+
+    #[test]
     fn signature_verification_accepts_signed_fixture_and_rejects_tampering() {
         verify_manifest_signature(
             SIGNED_TEST_MANIFEST,
@@ -602,9 +700,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn only_missing_draft_pools_without_identity_is_best_effort() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::fs::write(temp.path().join("card-data.json"), "self-hosted data")
+            .expect("write card data");
+        let options = BootstrapOptions {
+            manifest_url_override: None,
+            no_data_download: false,
+        };
+
+        bootstrap_missing_data_with_key(temp.path(), &options, None, TEST_PUBLIC_KEY)
+            .await
+            .expect("missing optional draft pools must not prevent startup");
+    }
+
+    #[tokio::test]
+    async fn only_missing_draft_pools_with_no_data_download_is_best_effort() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::fs::write(temp.path().join("card-data.json"), "self-hosted data")
+            .expect("write card data");
+        let options = BootstrapOptions {
+            manifest_url_override: None,
+            no_data_download: true,
+        };
+
+        bootstrap_missing_data_with_key(temp.path(), &options, None, TEST_PUBLIC_KEY)
+            .await
+            .expect("--no-data-download must not prevent startup for optional draft pools");
+    }
+
+    #[tokio::test]
     async fn no_data_download_fails_before_network_access() {
         let temp = tempfile::tempdir().expect("temp dir");
-        let manifest_url = Url::parse("http://127.0.0.1:1/manifest.json").expect("URL");
+        std::fs::write(temp.path().join("draft-pools.json"), "self-hosted data")
+            .expect("write draft pools");
+        let manifest_url = Url::parse("https://127.0.0.1:1/manifest.json").expect("URL");
         let options = BootstrapOptions {
             manifest_url_override: Some(manifest_url.clone()),
             no_data_download: true,
@@ -614,10 +744,29 @@ mod tests {
             .await
             .expect_err("missing data must fail without a download");
 
-        assert!(error
+        assert!(error.to_string().contains("card-data.json"));
+        assert!(!error
             .to_string()
             .contains("card-data.json, draft-pools.json"));
         assert!(error.to_string().contains(manifest_url.as_str()));
+    }
+
+    #[tokio::test]
+    async fn missing_card_data_without_identity_remains_fatal() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        std::fs::write(temp.path().join("draft-pools.json"), "self-hosted data")
+            .expect("write draft pools");
+        let options = BootstrapOptions {
+            manifest_url_override: None,
+            no_data_download: false,
+        };
+
+        let error = bootstrap_missing_data_with_key(temp.path(), &options, None, TEST_PUBLIC_KEY)
+            .await
+            .expect_err("missing card data without an identity must fail");
+
+        assert!(error.to_string().contains("card-data.json"));
+        assert!(error.to_string().contains("no PHASE_CHANNEL identity"));
     }
 
     #[test]

--- a/crates/phase-server/src/data_bootstrap.rs
+++ b/crates/phase-server/src/data_bootstrap.rs
@@ -1,0 +1,636 @@
+use std::fmt;
+use std::io::Write;
+use std::path::{Component, Path};
+
+use minisign_verify::{PublicKey, Signature};
+use reqwest::Client;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use url::Url;
+
+pub const PINNED_DATA_MANIFEST_PUBLIC_KEY: &str =
+    "RWRDZxG2otNoKLblrgD00kM0a8U0CRZUGHpNCr3W+3ik1E84XHcB6hZe";
+const RELEASE_MANIFEST_BASE_URL: &str = "https://data.phase-rs.dev/desktop";
+const PREVIEW_MANIFEST_URL: &str = "https://data.phase-rs.dev/desktop/preview-server.json";
+const REQUIRED_DATA_FILES: [&str; 2] = ["card-data.json", "draft-pools.json"];
+
+#[derive(Debug)]
+pub struct BootstrapError(String);
+
+impl BootstrapError {
+    fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for BootstrapError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for BootstrapError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChannelIdentity {
+    Release,
+    Preview { fingerprint: String },
+}
+
+impl ChannelIdentity {
+    pub fn embedded() -> Result<Option<Self>, BootstrapError> {
+        identity_from_markers(
+            option_env!("PHASE_CHANNEL"),
+            option_env!("PHASE_ENGINE_FINGERPRINT"),
+        )
+    }
+}
+
+fn identity_from_markers(
+    channel: Option<&str>,
+    fingerprint: Option<&str>,
+) -> Result<Option<ChannelIdentity>, BootstrapError> {
+    match channel {
+        None => Ok(None),
+        Some("release") => {
+            if fingerprint.is_some() {
+                return Err(BootstrapError::new(
+                    "PHASE_ENGINE_FINGERPRINT is only valid for PHASE_CHANNEL=preview",
+                ));
+            }
+            Ok(Some(ChannelIdentity::Release))
+        }
+        Some("preview") => {
+            let fingerprint = fingerprint.ok_or_else(|| {
+                BootstrapError::new(
+                    "PHASE_CHANNEL=preview requires a 16-hex PHASE_ENGINE_FINGERPRINT",
+                )
+            })?;
+            if !is_fingerprint(fingerprint) {
+                return Err(BootstrapError::new(format!(
+                    "PHASE_ENGINE_FINGERPRINT must be 16 hexadecimal characters, got {fingerprint:?}"
+                )));
+            }
+            Ok(Some(ChannelIdentity::Preview {
+                fingerprint: fingerprint.to_string(),
+            }))
+        }
+        Some(channel) => Err(BootstrapError::new(format!(
+            "PHASE_CHANNEL must be release or preview, got {channel:?}"
+        ))),
+    }
+}
+
+fn is_fingerprint(value: &str) -> bool {
+    value.len() == 16 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Debug, Clone)]
+pub struct BootstrapOptions {
+    pub manifest_url_override: Option<Url>,
+    pub no_data_download: bool,
+}
+
+#[derive(Debug, Clone)]
+enum ManifestResolution {
+    Override(Url),
+    Release(Url),
+    Preview(Url),
+}
+
+impl ManifestResolution {
+    fn url(&self) -> &Url {
+        match self {
+            Self::Override(url) | Self::Release(url) | Self::Preview(url) => url,
+        }
+    }
+}
+
+fn resolve_manifest(
+    manifest_url_override: Option<Url>,
+    identity: Option<&ChannelIdentity>,
+) -> Result<ManifestResolution, BootstrapError> {
+    if let Some(url) = manifest_url_override {
+        return Ok(ManifestResolution::Override(url));
+    }
+
+    match identity {
+        Some(ChannelIdentity::Release) => {
+            let version = env!("CARGO_PKG_VERSION");
+            let url = Url::parse(&format!(
+                "{RELEASE_MANIFEST_BASE_URL}/release-server-v{version}.json"
+            ))
+            .expect("release manifest URL is a valid constant");
+            Ok(ManifestResolution::Release(url))
+        }
+        Some(ChannelIdentity::Preview { .. }) => Ok(ManifestResolution::Preview(
+            Url::parse(PREVIEW_MANIFEST_URL).expect("preview manifest URL is a valid constant"),
+        )),
+        None => Err(BootstrapError::new(
+            "card-data.json or draft-pools.json is missing and this binary has no PHASE_CHANNEL identity; pre-provision PHASE_DATA_DIR or pass --data-manifest-url <url>",
+        )),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DataFile {
+    name: String,
+    sha256: String,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestEnvelope {
+    schema: u32,
+    channel: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseManifest {
+    schema: u32,
+    channel: String,
+    version: String,
+    data: Vec<DataFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PreviewManifest {
+    schema: u32,
+    channel: String,
+    fingerprints: std::collections::BTreeMap<String, PreviewFingerprint>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PreviewFingerprint {
+    data: Vec<DataFile>,
+}
+
+fn parse_manifest_data(
+    bytes: &[u8],
+    identity: Option<&ChannelIdentity>,
+) -> Result<Vec<DataFile>, BootstrapError> {
+    let envelope: ManifestEnvelope = serde_json::from_slice(bytes)
+        .map_err(|error| BootstrapError::new(format!("invalid data manifest JSON: {error}")))?;
+    if envelope.schema != 1 {
+        return Err(BootstrapError::new(format!(
+            "unsupported data manifest schema {}; expected schema 1",
+            envelope.schema
+        )));
+    }
+
+    let data = match envelope.channel.as_str() {
+        "release" => {
+            let manifest: ReleaseManifest = serde_json::from_slice(bytes).map_err(|error| {
+                BootstrapError::new(format!("invalid release data manifest JSON: {error}"))
+            })?;
+            if manifest.schema != 1 || manifest.channel != "release" {
+                return Err(BootstrapError::new(
+                    "release data manifest does not declare schema 1 and channel release",
+                ));
+            }
+            if matches!(identity, Some(ChannelIdentity::Release))
+                && manifest.version != env!("CARGO_PKG_VERSION")
+            {
+                return Err(BootstrapError::new(format!(
+                    "release data manifest version {} does not match this server version {}",
+                    manifest.version,
+                    env!("CARGO_PKG_VERSION")
+                )));
+            }
+            manifest.data
+        }
+        "preview" => {
+            let manifest: PreviewManifest = serde_json::from_slice(bytes).map_err(|error| {
+                BootstrapError::new(format!("invalid preview data manifest JSON: {error}"))
+            })?;
+            if manifest.schema != 1 || manifest.channel != "preview" {
+                return Err(BootstrapError::new(
+                    "preview data manifest does not declare schema 1 and channel preview",
+                ));
+            }
+            let Some(ChannelIdentity::Preview { fingerprint }) = identity else {
+                return Err(BootstrapError::new(
+                    "preview data manifest requires a binary built with PHASE_CHANNEL=preview and PHASE_ENGINE_FINGERPRINT",
+                ));
+            };
+            manifest
+                .fingerprints
+                .get(fingerprint)
+                .ok_or_else(|| {
+                    BootstrapError::new(format!(
+                        "preview data manifest has no entry for this binary fingerprint {fingerprint}"
+                    ))
+                })?
+                .data
+                .clone()
+        }
+        channel => {
+            return Err(BootstrapError::new(format!(
+                "data manifest has unsupported channel {channel:?}"
+            )));
+        }
+    };
+
+    validate_manifest_data(&data)?;
+    Ok(data)
+}
+
+fn validate_manifest_data(data: &[DataFile]) -> Result<(), BootstrapError> {
+    for file in data {
+        if !is_safe_data_file_name(&file.name) {
+            return Err(BootstrapError::new(format!(
+                "data manifest has unsafe file name {:?}",
+                file.name
+            )));
+        }
+        if !is_sha256(&file.sha256) {
+            return Err(BootstrapError::new(format!(
+                "data manifest has invalid sha256 for {}: {}",
+                file.name, file.sha256
+            )));
+        }
+        if let Err(error) = Url::parse(&file.url) {
+            return Err(BootstrapError::new(format!(
+                "data manifest has invalid URL for {}: {} ({error})",
+                file.name, file.url
+            )));
+        }
+    }
+
+    for required in REQUIRED_DATA_FILES {
+        if !data.iter().any(|file| file.name == required) {
+            return Err(BootstrapError::new(format!(
+                "data manifest is missing required file {required}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn is_safe_data_file_name(name: &str) -> bool {
+    let mut components = Path::new(name).components();
+    matches!(components.next(), Some(Component::Normal(_))) && components.next().is_none()
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn missing_required_data_files(data_dir: &Path) -> Vec<&'static str> {
+    REQUIRED_DATA_FILES
+        .into_iter()
+        .filter(|name| !data_dir.join(name).is_file())
+        .collect()
+}
+
+pub async fn bootstrap_missing_data(
+    data_dir: &Path,
+    options: &BootstrapOptions,
+    identity: Option<&ChannelIdentity>,
+) -> Result<(), BootstrapError> {
+    bootstrap_missing_data_with_key(data_dir, options, identity, PINNED_DATA_MANIFEST_PUBLIC_KEY)
+        .await
+}
+
+async fn bootstrap_missing_data_with_key(
+    data_dir: &Path,
+    options: &BootstrapOptions,
+    identity: Option<&ChannelIdentity>,
+    public_key: &str,
+) -> Result<(), BootstrapError> {
+    let missing = missing_required_data_files(data_dir);
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let resolution = resolve_manifest(options.manifest_url_override.clone(), identity)?;
+    if options.no_data_download {
+        return Err(BootstrapError::new(format!(
+            "missing data files {}; --no-data-download prevents fetching them. Pre-provision PHASE_DATA_DIR or retry without --no-data-download (manifest: {})",
+            missing.join(", "),
+            resolution.url()
+        )));
+    }
+
+    let client = Client::builder()
+        .build()
+        .map_err(|error| BootstrapError::new(format!("failed to build HTTP client: {error}")))?;
+    let manifest_url = resolution.url();
+    let manifest_bytes = fetch_bytes(&client, manifest_url, "data manifest").await?;
+    let signature_url = Url::parse(&format!("{manifest_url}.minisig")).map_err(|error| {
+        BootstrapError::new(format!(
+            "could not construct minisign URL for manifest {manifest_url}: {error}"
+        ))
+    })?;
+    let signature_bytes = fetch_bytes(&client, &signature_url, "data manifest signature").await?;
+    verify_manifest_signature(&manifest_bytes, &signature_bytes, public_key)?;
+
+    let data = parse_manifest_data(&manifest_bytes, identity)?;
+    for file in data
+        .iter()
+        .filter(|file| missing.iter().any(|name| *name == file.name))
+    {
+        let url = Url::parse(&file.url).map_err(|error| {
+            BootstrapError::new(format!(
+                "data manifest has invalid URL for {}: {} ({error})",
+                file.name, file.url
+            ))
+        })?;
+        let bytes = fetch_bytes(&client, &url, &format!("data file {}", file.name)).await?;
+        verify_sha256(&bytes, &file.sha256, &file.name, &url)?;
+        write_verified_data_file(data_dir, &file.name, &bytes).await?;
+    }
+
+    let still_missing = missing_required_data_files(data_dir);
+    if !still_missing.is_empty() {
+        return Err(BootstrapError::new(format!(
+            "data bootstrap did not create required files {} from manifest {}",
+            still_missing.join(", "),
+            manifest_url
+        )));
+    }
+    Ok(())
+}
+
+async fn fetch_bytes(
+    client: &Client,
+    url: &Url,
+    resource: &str,
+) -> Result<Vec<u8>, BootstrapError> {
+    let response = client.get(url.clone()).send().await.map_err(|error| {
+        BootstrapError::new(format!("failed to fetch {resource} from {url}: {error}"))
+    })?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(BootstrapError::new(format!(
+            "failed to fetch {resource} from {url}: HTTP {status}"
+        )));
+    }
+    response
+        .bytes()
+        .await
+        .map(|bytes| bytes.to_vec())
+        .map_err(|error| {
+            BootstrapError::new(format!("failed to read {resource} from {url}: {error}"))
+        })
+}
+
+fn verify_manifest_signature(
+    manifest: &[u8],
+    signature: &[u8],
+    public_key_base64: &str,
+) -> Result<(), BootstrapError> {
+    let public_key = PublicKey::from_base64(public_key_base64).map_err(|error| {
+        BootstrapError::new(format!("invalid pinned minisign public key: {error}"))
+    })?;
+    let signature_text = std::str::from_utf8(signature).map_err(|error| {
+        BootstrapError::new(format!("manifest signature is not UTF-8: {error}"))
+    })?;
+    let signature = Signature::decode(signature_text).map_err(|error| {
+        BootstrapError::new(format!("invalid manifest minisign signature: {error}"))
+    })?;
+    public_key
+        .verify(manifest, &signature, false)
+        .map_err(|error| {
+            BootstrapError::new(format!(
+                "data manifest signature verification failed: {error}"
+            ))
+        })
+}
+
+fn verify_sha256(
+    bytes: &[u8],
+    expected: &str,
+    name: &str,
+    url: &Url,
+) -> Result<(), BootstrapError> {
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(BootstrapError::new(format!(
+            "sha256 mismatch for {name} from {url}: expected {expected}, got {actual}"
+        )))
+    }
+}
+
+async fn write_verified_data_file(
+    data_dir: &Path,
+    name: &str,
+    bytes: &[u8],
+) -> Result<(), BootstrapError> {
+    let data_dir = data_dir.to_path_buf();
+    let name = name.to_string();
+    let bytes = bytes.to_vec();
+    tokio::task::spawn_blocking(move || write_verified_data_file_blocking(&data_dir, &name, &bytes))
+        .await
+        .map_err(|error| BootstrapError::new(format!("data-file write task failed: {error}")))?
+}
+
+fn write_verified_data_file_blocking(
+    data_dir: &Path,
+    name: &str,
+    bytes: &[u8],
+) -> Result<(), BootstrapError> {
+    std::fs::create_dir_all(data_dir).map_err(|error| {
+        BootstrapError::new(format!(
+            "failed to create data directory {}: {error}",
+            data_dir.display()
+        ))
+    })?;
+    let destination = data_dir.join(name);
+    let mut temporary = tempfile::Builder::new()
+        .prefix(&format!(".{name}."))
+        .tempfile_in(data_dir)
+        .map_err(|error| {
+            BootstrapError::new(format!(
+                "failed to create temporary file for {}: {error}",
+                destination.display()
+            ))
+        })?;
+    temporary.write_all(bytes).map_err(|error| {
+        BootstrapError::new(format!(
+            "failed to write temporary data file for {}: {error}",
+            destination.display()
+        ))
+    })?;
+    temporary.as_file().sync_all().map_err(|error| {
+        BootstrapError::new(format!(
+            "failed to sync temporary data file for {}: {error}",
+            destination.display()
+        ))
+    })?;
+    temporary.persist(&destination).map_err(|error| {
+        BootstrapError::new(format!(
+            "failed to atomically install data file {}: {}",
+            destination.display(),
+            error.error
+        ))
+    })?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        bootstrap_missing_data_with_key, identity_from_markers, parse_manifest_data,
+        verify_manifest_signature, verify_sha256, write_verified_data_file, BootstrapOptions,
+        ChannelIdentity,
+    };
+    use sha2::{Digest, Sha256};
+    use url::Url;
+
+    const TEST_PUBLIC_KEY: &str = "RWSRzbuJXEhfwLu1bCNndDifYla7GFbotc6t1tcuytze2q5NjXbWEmG5";
+    const SIGNED_TEST_MANIFEST: &[u8] =
+        br#"{"schema":1,"channel":"release","version":"test","data":[]}"#;
+    const SIGNED_TEST_SIGNATURE: &str = "untrusted comment: signature from minisign secret key\nRUSRzbuJXEhfwAxxkkM8a0M+p0N9xX6VelN8cNVVk9DmUmIUAK7Ga87HN5vjnQn7R4VP1/Lb2DwG8kOI6dj99fNMqYqkpT5DTwM=\ntrusted comment: timestamp:1784645957\tfile:manifest.json\thashed\no9B8aeyirZqbDD1N2/k4voUfPunqsm7iWKqMm6kCOLGrZlx+s5ePOk8m7DejRy/Vg0KsTAsRsg4MNt7ICyICDA==\n";
+
+    #[test]
+    fn parses_release_manifest_and_ignores_unknown_fields() {
+        let manifest = br#"{
+            "schema": 1,
+            "channel": "release",
+            "version": "test",
+            "generated_at": "2026-07-21T00:00:00Z",
+            "data": [
+                {"name": "card-data.json", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "url": "https://example.test/card-data.json", "future": true},
+                {"name": "draft-pools.json", "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "url": "https://example.test/draft-pools.json"}
+            ],
+            "future": "ignored"
+        }"#;
+
+        let data = parse_manifest_data(manifest, None).expect("release manifest parses");
+
+        assert_eq!(data.len(), 2);
+        assert_eq!(data[0].name, "card-data.json");
+    }
+
+    #[test]
+    fn parses_preview_manifest_and_selects_embedded_fingerprint() {
+        let manifest = br#"{
+            "schema": 1,
+            "channel": "preview",
+            "generated_at": "2026-07-21T00:00:00Z",
+            "current": "0123456789abcdef",
+            "previous": null,
+            "fingerprints": {
+                "0123456789abcdef": {
+                    "commit": "abc",
+                    "binaries": {},
+                    "data": [
+                        {"name": "card-data.json", "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "url": "https://example.test/card-data.json"},
+                        {"name": "draft-pools.json", "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "url": "https://example.test/draft-pools.json"}
+                    ],
+                    "future": "ignored"
+                }
+            },
+            "future": true
+        }"#;
+        let identity = ChannelIdentity::Preview {
+            fingerprint: "0123456789abcdef".to_string(),
+        };
+
+        let data = parse_manifest_data(manifest, Some(&identity)).expect("preview manifest parses");
+
+        assert_eq!(data.len(), 2);
+        assert_eq!(data[1].name, "draft-pools.json");
+    }
+
+    #[test]
+    fn rejects_unsupported_manifest_schema() {
+        let manifest = br#"{"schema":2,"channel":"release","version":"test","data":[]}"#;
+
+        let error = parse_manifest_data(manifest, None).expect_err("schema 2 must fail");
+
+        assert!(error.to_string().contains("schema 2"));
+    }
+
+    #[test]
+    fn signature_verification_accepts_signed_fixture_and_rejects_tampering() {
+        verify_manifest_signature(
+            SIGNED_TEST_MANIFEST,
+            SIGNED_TEST_SIGNATURE.as_bytes(),
+            TEST_PUBLIC_KEY,
+        )
+        .expect("throwaway minisign fixture verifies");
+
+        let error = verify_manifest_signature(
+            b"tampered",
+            SIGNED_TEST_SIGNATURE.as_bytes(),
+            TEST_PUBLIC_KEY,
+        )
+        .expect_err("tampered manifest must not verify");
+
+        assert!(error.to_string().contains("verification failed"));
+    }
+
+    #[tokio::test]
+    async fn verifies_sha256_and_writes_with_atomic_replace() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let bytes = b"verified data";
+        let sha256 = format!("{:x}", Sha256::digest(bytes));
+        let url = Url::parse("https://example.test/data.json").expect("URL");
+
+        verify_sha256(bytes, &sha256, "card-data.json", &url).expect("hash matches");
+        write_verified_data_file(temp.path(), "card-data.json", bytes)
+            .await
+            .expect("atomic write");
+
+        assert_eq!(
+            std::fs::read(temp.path().join("card-data.json")).expect("read written file"),
+            bytes
+        );
+        assert!(verify_sha256(b"wrong", &sha256, "card-data.json", &url).is_err());
+    }
+
+    #[tokio::test]
+    async fn present_files_skip_manifest_fetch() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        for name in ["card-data.json", "draft-pools.json"] {
+            std::fs::write(temp.path().join(name), "self-hosted data").expect("write data");
+        }
+        let options = BootstrapOptions {
+            manifest_url_override: Some(
+                Url::parse("http://127.0.0.1:1/manifest.json").expect("URL"),
+            ),
+            no_data_download: false,
+        };
+
+        bootstrap_missing_data_with_key(temp.path(), &options, None, TEST_PUBLIC_KEY)
+            .await
+            .expect("present files avoid all network access");
+    }
+
+    #[tokio::test]
+    async fn no_data_download_fails_before_network_access() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let manifest_url = Url::parse("http://127.0.0.1:1/manifest.json").expect("URL");
+        let options = BootstrapOptions {
+            manifest_url_override: Some(manifest_url.clone()),
+            no_data_download: true,
+        };
+
+        let error = bootstrap_missing_data_with_key(temp.path(), &options, None, TEST_PUBLIC_KEY)
+            .await
+            .expect_err("missing data must fail without a download");
+
+        assert!(error
+            .to_string()
+            .contains("card-data.json, draft-pools.json"));
+        assert!(error.to_string().contains(manifest_url.as_str()));
+    }
+
+    #[test]
+    fn channel_markers_require_preview_fingerprint() {
+        assert_eq!(
+            identity_from_markers(Some("release"), None).expect("release identity"),
+            Some(ChannelIdentity::Release)
+        );
+        assert!(identity_from_markers(Some("preview"), None).is_err());
+        assert!(identity_from_markers(Some("preview"), Some("too-short")).is_err());
+        assert_eq!(
+            identity_from_markers(None, None).expect("no identity"),
+            None
+        );
+    }
+}

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1,10 +1,12 @@
 mod admin;
+mod data_bootstrap;
 mod draft_pools;
 mod logging;
 mod persistence;
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
@@ -27,7 +29,7 @@ use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
 use engine::types::GameLogEntry;
-use http::HeaderValue;
+use http::{HeaderMap, HeaderValue};
 use lobby_broker::{
     check_build_commit, conn_holds_reservation, Broker, BrokerEnv, BuildCommitCheck, ConnState,
     Outbound, NOT_OWNED_RESERVATION,
@@ -67,7 +69,8 @@ use server_core::spectator_wire_guard::{
     guard_spectator_join,
 };
 use std::time::Duration;
-use tokio::sync::{mpsc, Mutex};
+use tokio::io::AsyncReadExt;
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tower_http::cors::CorsLayer;
 use tracing::{debug, error, info, info_span, warn, Instrument};
 use url::Url;
@@ -478,9 +481,33 @@ struct Cli {
     #[arg(short, long, default_value = "9374", env = "PORT")]
     port: u16,
 
+    /// Address to bind. Defaults to all interfaces for LAN and tunnel hosting.
+    #[arg(long, default_value = "0.0.0.0")]
+    bind: IpAddr,
+
+    /// Exit cleanly when stdin closes. Used by the desktop shell so an orphaned
+    /// native server terminates after its parent process dies.
+    #[arg(long)]
+    exit_on_stdin_close: bool,
+
+    /// Accept WebSocket handshakes only from this Origin when one is supplied.
+    /// Clients without an Origin header remain accepted for self-hosted tooling.
+    #[arg(long)]
+    allowed_origin: Option<String>,
+
     /// Path to card data directory (must contain card-data.json)
     #[arg(short, long, default_value = "data", env = "PHASE_DATA_DIR")]
-    data_dir: String,
+    data_dir: PathBuf,
+
+    /// Signed data-manifest URL for bootstrapping a missing PHASE_DATA_DIR.
+    /// This overrides the manifest resolved from the binary's embedded channel.
+    #[arg(long, env = "PHASE_DATA_MANIFEST_URL")]
+    data_manifest_url: Option<Url>,
+
+    /// Refuse to download missing startup data. Intended for air-gapped hosts
+    /// with a pre-provisioned PHASE_DATA_DIR.
+    #[arg(long)]
+    no_data_download: bool,
 
     /// Allowed CORS origin (use '*' for permissive, or a specific URL)
     #[arg(long, env = "PHASE_CORS_ORIGIN")]
@@ -511,6 +538,41 @@ struct Cli {
     /// `NGROK_AUTHTOKEN` is set, the live tunnel URL is used when this is unset.
     #[arg(long, env = "PUBLIC_URL")]
     public_url: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CardDataSource {
+    Export(PathBuf),
+    DevFixture(PathBuf),
+}
+
+fn dev_fixture_enabled() -> bool {
+    matches!(std::env::var("PHASE_DEV_FIXTURE"), Ok(value) if value == "1")
+}
+
+fn select_card_data_source(data_dir: &Path, dev_fixture: bool) -> Result<CardDataSource, String> {
+    let export_path = data_dir.join("card-data.json");
+    if export_path.is_file() {
+        return Ok(CardDataSource::Export(export_path));
+    }
+    if dev_fixture {
+        return Ok(CardDataSource::DevFixture(
+            data_dir.join("mtgjson/test_fixture.json"),
+        ));
+    }
+    Err(format!(
+        "card-data.json is missing from {}; startup data bootstrap did not provide it",
+        data_dir.display()
+    ))
+}
+
+fn bootstrap_required(data_dir: &Path, dev_fixture: bool) -> bool {
+    !dev_fixture || data_dir.join("card-data.json").is_file()
+}
+
+fn fatal_startup(message: impl std::fmt::Display) -> ! {
+    eprintln!("phase-server startup failed: {message}");
+    std::process::exit(1);
 }
 
 /// Per-socket state tracking which game/player this connection belongs to.
@@ -790,13 +852,40 @@ async fn main() {
         ServerMode::Full
     };
     info!(?mode, "server mode selected");
-    let data_path = Path::new(&cli.data_dir);
-    let export_path = data_path.join("card-data.json");
-    let card_db = if export_path.exists() {
-        CardDatabase::from_export(&export_path).expect("Failed to load card-data.json")
+    let data_path = cli.data_dir.as_path();
+    let dev_fixture = dev_fixture_enabled();
+    if bootstrap_required(data_path, dev_fixture) {
+        let identity = data_bootstrap::ChannelIdentity::embedded()
+            .unwrap_or_else(|error| fatal_startup(error));
+        let options = data_bootstrap::BootstrapOptions {
+            manifest_url_override: cli.data_manifest_url.clone(),
+            no_data_download: cli.no_data_download,
+        };
+        if let Err(error) =
+            data_bootstrap::bootstrap_missing_data(data_path, &options, identity.as_ref()).await
+        {
+            fatal_startup(error);
+        }
     } else {
-        CardDatabase::from_mtgjson(&data_path.join("mtgjson/test_fixture.json"))
-            .expect("Failed to load card database")
+        warn!(
+            path = %data_path.display(),
+            "using PHASE_DEV_FIXTURE=1 test fixture; startup data bootstrap is disabled"
+        );
+    }
+    let card_data_source = select_card_data_source(data_path, dev_fixture)
+        .unwrap_or_else(|message| fatal_startup(message));
+    let card_db = match card_data_source {
+        CardDataSource::Export(path) => CardDatabase::from_export(&path).unwrap_or_else(|error| {
+            fatal_startup(format!("failed to load {}: {error}", path.display()))
+        }),
+        CardDataSource::DevFixture(path) => {
+            CardDatabase::from_mtgjson(&path).unwrap_or_else(|error| {
+                fatal_startup(format!(
+                    "PHASE_DEV_FIXTURE=1 was set but failed to load {}: {error}",
+                    path.display()
+                ))
+            })
+        }
     };
     info!(cards = card_db.card_count(), "card database loaded");
     let db: SharedDb = Arc::new(card_db);
@@ -1188,14 +1277,15 @@ async fn main() {
         game_spectators,
         mode,
         public_url: advertised_public_url,
+        allowed_origin: cli.allowed_origin.clone(),
     });
 
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", cli.port))
+    let listener = tokio::net::TcpListener::bind((cli.bind, cli.port))
         .await
         .expect("failed to bind");
-    info!(port = %cli.port, "phase-server listening");
+    info!(bind = %cli.bind, port = %cli.port, "phase-server listening");
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(shutdown_signal(cli.exit_on_stdin_close))
         .await
         .expect("server error");
 
@@ -1250,8 +1340,45 @@ async fn main() {
     }
 }
 
-async fn shutdown_signal() {
+fn stdin_close_watchdog(enabled: bool) -> Option<oneshot::Receiver<()>> {
+    enabled.then(|| {
+        let (sender, receiver) = oneshot::channel();
+        let _stdin_watchdog = tokio::spawn(async move {
+            let mut stdin = tokio::io::stdin();
+            let mut buffer = [0_u8; 1024];
+            loop {
+                match stdin.read(&mut buffer).await {
+                    Ok(0) => {
+                        info!("stdin closed; shutting down");
+                        let _ = sender.send(());
+                        return;
+                    }
+                    Ok(_) => {}
+                    Err(error) => {
+                        warn!(error = %error, "stdin watchdog stopped without EOF");
+                        return;
+                    }
+                }
+            }
+        });
+        receiver
+    })
+}
+
+async fn wait_for_stdin_close(mut watchdog: Option<oneshot::Receiver<()>>) {
+    match watchdog.as_mut() {
+        Some(receiver) => {
+            if receiver.await.is_err() {
+                std::future::pending::<()>().await;
+            }
+        }
+        None => std::future::pending::<()>().await,
+    }
+}
+
+async fn shutdown_signal(exit_on_stdin_close: bool) {
     let ctrl_c = tokio::signal::ctrl_c();
+    let stdin_close = wait_for_stdin_close(stdin_close_watchdog(exit_on_stdin_close));
     #[cfg(unix)]
     {
         let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
@@ -1259,17 +1386,76 @@ async fn shutdown_signal() {
         tokio::select! {
             _ = ctrl_c => info!("received Ctrl+C, shutting down"),
             _ = sigterm.recv() => info!("received SIGTERM, shutting down"),
+            _ = stdin_close => info!("stdin-close watchdog requested shutdown"),
         }
     }
     #[cfg(not(unix))]
     {
-        ctrl_c.await.expect("failed to listen for Ctrl+C");
-        info!("received Ctrl+C, shutting down");
+        tokio::select! {
+            result = ctrl_c => {
+                result.expect("failed to listen for Ctrl+C");
+                info!("received Ctrl+C, shutting down");
+            }
+            _ = stdin_close => info!("stdin-close watchdog requested shutdown"),
+        }
     }
 }
 
 async fn health() -> &'static str {
     "ok"
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use axum::http::{header::ORIGIN, HeaderMap, HeaderValue};
+    use clap::Parser;
+
+    use super::{
+        bootstrap_required, origin_is_allowed, select_card_data_source, CardDataSource, Cli,
+    };
+
+    #[test]
+    fn bind_flag_defaults_to_lan_and_accepts_loopback() {
+        let default = Cli::try_parse_from(["phase-server"]).expect("default CLI parses");
+        assert_eq!(default.bind.to_string(), "0.0.0.0");
+
+        let loopback = Cli::try_parse_from(["phase-server", "--bind", "127.0.0.1"])
+            .expect("loopback bind parses");
+        assert_eq!(loopback.bind.to_string(), "127.0.0.1");
+    }
+
+    #[test]
+    fn allowed_origin_accepts_matching_and_originless_clients() {
+        let mut matching = HeaderMap::new();
+        matching.insert(ORIGIN, HeaderValue::from_static("https://phase-rs.dev"));
+        assert!(origin_is_allowed(&matching, Some("https://phase-rs.dev")));
+
+        let mut mismatched = HeaderMap::new();
+        mismatched.insert(ORIGIN, HeaderValue::from_static("https://attacker.example"));
+        assert!(!origin_is_allowed(
+            &mismatched,
+            Some("https://phase-rs.dev")
+        ));
+
+        assert!(origin_is_allowed(
+            &HeaderMap::new(),
+            Some("https://phase-rs.dev")
+        ));
+        assert!(origin_is_allowed(&mismatched, None));
+    }
+
+    #[test]
+    fn fixture_fallback_requires_the_explicit_dev_opt_in() {
+        let temp = tempfile::tempdir().expect("temp dir");
+
+        assert!(bootstrap_required(temp.path(), false));
+        assert!(select_card_data_source(temp.path(), false).is_err());
+        assert!(!bootstrap_required(temp.path(), true));
+        assert_eq!(
+            select_card_data_source(temp.path(), true).expect("explicit fixture source"),
+            CardDataSource::DevFixture(temp.path().join("mtgjson/test_fixture.json"))
+        );
+    }
 }
 
 /// Constant-time byte comparison so admin-token validation does not leak the
@@ -1417,9 +1603,34 @@ struct AppState {
     /// embedded ngrok tunnel), or `None` when the server has no reachable
     /// address to share. Cloned per connection at greet time only.
     public_url: Option<String>,
+    /// Origin allowed to upgrade WebSocket handshakes. `None` preserves the
+    /// self-hosted permissive behavior; origin-less non-browser clients are
+    /// always allowed.
+    allowed_origin: Option<String>,
 }
 
-async fn ws_handler(ws: WebSocketUpgrade, State(app_state): State<AppState>) -> impl IntoResponse {
+fn origin_is_allowed(headers: &HeaderMap, allowed_origin: Option<&str>) -> bool {
+    let Some(allowed_origin) = allowed_origin else {
+        return true;
+    };
+    match headers.get(http::header::ORIGIN) {
+        None => true,
+        Some(origin) => origin.to_str().is_ok_and(|origin| origin == allowed_origin),
+    }
+}
+
+async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(app_state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if !origin_is_allowed(&headers, app_state.allowed_origin.as_deref()) {
+        warn!(
+            origin = ?headers.get(http::header::ORIGIN),
+            "rejecting WebSocket handshake from disallowed Origin"
+        );
+        return (http::StatusCode::FORBIDDEN, "WebSocket Origin not allowed").into_response();
+    }
     let current = app_state.player_count.load(Ordering::Relaxed);
     if current >= MAX_CONNECTIONS {
         warn!(
@@ -6551,6 +6762,7 @@ mod issue_4548_full_create_tests {
                 game_spectators: Arc::new(Mutex::new(HashMap::new())),
                 mode: ServerMode::Full,
                 public_url: None,
+                allowed_origin: None,
             });
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -7349,6 +7561,7 @@ mod admin_auth_tests {
             game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
             mode: ServerMode::Full,
             public_url: None,
+            allowed_origin: None,
         }
     }
 
@@ -7514,6 +7727,7 @@ mod p2p_backup_delete_tests {
             game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
             mode: ServerMode::Full,
             public_url: None,
+            allowed_origin: None,
         }
     }
 

--- a/docker/phase-server-entrypoint.sh
+++ b/docker/phase-server-entrypoint.sh
@@ -6,9 +6,6 @@ export PHASE_DATA_DIR
 
 mkdir -p "$PHASE_DATA_DIR"
 chown phase:phase "$PHASE_DATA_DIR"
-cp /usr/share/phase-server/card-data.json "$PHASE_DATA_DIR/card-data.json"
-cp /usr/share/phase-server/draft-pools.json "$PHASE_DATA_DIR/draft-pools.json"
-chown phase:phase "$PHASE_DATA_DIR/card-data.json" "$PHASE_DATA_DIR/draft-pools.json"
 
 if [ $# -eq 0 ]; then
     set -- phase-server

--- a/scripts/engine-fingerprint.sh
+++ b/scripts/engine-fingerprint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Computes the preview-native engine compatibility key from source and data.
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+    echo "usage: $0 <commit-sha> <card-data.json path> <draft-pools.json path>" >&2
+    exit 2
+fi
+
+commit_sha="$1"
+card_data_path="$2"
+draft_pools_path="$3"
+
+card_data_sha256=$(sha256sum "$card_data_path" | awk '{print $1}')
+draft_pools_sha256=$(sha256sum "$draft_pools_path" | awk '{print $1}')
+
+{
+    git ls-tree --full-tree -r "$commit_sha" -- crates Cargo.lock rust-toolchain.toml
+    printf '%s\n' "$card_data_sha256"
+    printf '%s\n' "$draft_pools_sha256"
+} | sha256sum | awk '{print substr($1, 1, 16)}'


### PR DESCRIPTION
- **feat(server): channel-aware startup data bootstrap and shell lifecycle flags**
- **fix(server): best-effort draft-pools bootstrap, HTTP timeouts, https-only manifests**
- **ci: slim signed server artifacts, content-addressed data, and continuous preview server pipeline**
- **fix(ci): globally serialize preview manifest publication**
