### PR TITLE
test(engine): assert token-catalog ordering and image-ref self-consistency

### DIFF
--- a/crates/engine/src/game/token_presets.rs
+++ b/crates/engine/src/game/token_presets.rs
@@ -187,8 +187,11 @@ static PRESETS: LazyLock<Vec<TokenPreset>> = LazyLock::new(|| {
     parsed.token
 });
 
-/// Returns the full set of debug-spawnable token presets, sorted by category
-/// then id for stable display order.
+/// Returns the full set of debug-spawnable token presets, in catalog order:
+/// ascending id, which is what `tokens-gen` emits so that a regen produces a
+/// minimal diff (asserted by `catalog_is_ordered_and_self_consistent`). Ids are
+/// MTGJSON uuids, so this is not a display order — consumers impose their own
+/// (the debug UI groups by category and sorts by power/toughness/name).
 pub fn known_token_presets() -> &'static [TokenPreset] {
     &PRESETS
 }
@@ -564,6 +567,57 @@ mod tests {
     fn catalog_loads_and_validates() {
         let presets = known_token_presets();
         assert!(!presets.is_empty(), "catalog must contain entries");
+    }
+
+    /// Structural properties of `tokens-gen` output, checked against the
+    /// committed catalog. Both are per-entry properties with no pinned totals,
+    /// so a weekly refresh that only adds tokens stays green.
+    ///
+    /// Scope, stated precisely because it is narrow: these catch entries
+    /// *reordered* relative to generator output, and an image ref pointing at a
+    /// different preset. They do NOT catch a body-only rewrite (nothing here
+    /// ties `body`/`fidelity`/`source_card_refs` to an identity) nor a deleted
+    /// entry (removing from the middle keeps the sequence ascending) — a
+    /// deletion is the count floors' job, in
+    /// `analyze_token_coverage_treats_source_defined_pt_as_represented`.
+    ///
+    /// And none of it establishes provenance — that the catalog is tokens-gen's
+    /// output for its declared vintage — which needs the gitignored generator
+    /// input, absent at test time. See the comment on that coverage test for
+    /// the by-hand `tokens-gen`/`cmp` recipe.
+    #[test]
+    fn catalog_is_ordered_and_self_consistent() {
+        let presets = known_token_presets();
+
+        // `tokens_gen.rs` emits `presets.sort_by(|a, b| a.id.cmp(&b.id))`, so a
+        // strictly ascending id sequence is a property of every generated
+        // catalog. Strict (not `<=`) also re-states the LazyLock's duplicate-id
+        // guard at the ordering level.
+        for pair in presets.windows(2) {
+            assert!(
+                pair[0].id < pair[1].id,
+                "known-tokens.toml is not strictly id-ascending: `{}` precedes `{}`",
+                pair[0].id,
+                pair[1].id
+            );
+        }
+
+        // The generator builds each preset's image ref from the same MTGJSON
+        // uuid it uses for `TokenPreset::id`, so a ref pointing at a different
+        // preset means the entry was assembled by something other than
+        // tokens-gen. Consistency is asserted only where a ref exists: a token
+        // with no Scryfall image is legal upstream data, and requiring one
+        // would re-introduce a weekly false-red.
+        for preset in presets {
+            let Some(image_ref) = &preset.token_image_ref else {
+                continue;
+            };
+            assert_eq!(
+                image_ref.preset_id, preset.id,
+                "preset `{}` carries an image ref for `{}`",
+                preset.id, image_ref.preset_id
+            );
+        }
     }
 
     /// Every `PredefinedArtifact { kind }` preset must carry the matching


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds the two structural properties of `tokens-gen` output that are checkable at test time — ids strictly ascending, and `token_image_ref.preset_id == id` where a ref exists — and corrects a doc comment on `known_token_presets()` that was wrong in both halves. Follow-up to #6274, where the review noted that the coverage snapshot's ratchet floors observe only three totals.

**This does not close that review's blocker, and does not claim to.** A deterministic provenance gate needs `tokens-gen` re-run against the ~560 MB gitignored `data/mtgjson/sets` input, which is absent at test time and would require a `.github/workflows/**` edit to wire into CI ([evidence in #6274](https://github.com/phase-rs/phase/pull/6274#issuecomment-5036034262)). These are the properties reachable without that input, landed on their own merits rather than as a substitute.

## Implementation method (required)

Method: not-applicable — test assertions plus a doc-comment correction. No parser, effect, resolver, targeting, or rules behavior is touched; the only non-test change is a `///` comment. Two independent read-only `/review-impl` passes were still run (the first returned CHANGES NEEDED; see below).

## CR references

None. These are catalog file-integrity properties, not game rules. `token_presets.rs` already carries CR 111.1 / 111.4 / 111.10 for catalog *semantics*; nothing in this diff implements a rule, and CLAUDE.md exempts serialization/plumbing from annotation.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy -p engine --all-targets -- -D warnings` — exit 0
- `cargo nextest run -p engine -E 'test(token_preset) + test(catalog_) + test(analyze_token_coverage) + test(token_coverage) + test(source_defined_pt) + test(token_rules_text) + test(known_token)'` — **31 tests run: 31 passed**
- `cargo nextest run -p engine -E 'test(catalog_) + test(predefined_artifact_subtypes) + test(token_ref)'` (at the amended head) — **19 tests run: 19 passed**

### Isolation revert-probes (each mutation moves exactly one axis)

Both assertions live in one test and run sequentially, so each was tripped in isolation to rule out upstream-conjunct dominance. The catalog was restored byte-identically after every probe (`sha256 9dc2222646ea230f46a09da0359f5aadf05c9e5349e1022fa54ea3148fe3c9b3`, `git status` clean).

| probe | mutation | measured side-effects | result |
|---|---|---|---|
| ordering | swapped two adjacent `[[token]]` blocks | ids ascending `False`; id↔preset_id mismatches **0** | **FAIL** — `known-tokens.toml is not strictly id-ascending: `001779ab…` precedes `00093ed9…`` |
| image-ref | retargeted **one** `preset_id` | ids ascending **`True`**; mismatches `1` | **FAIL** — ``preset `00093ed9…` carries an image ref for `f0093ed9…``` |
| baseline | none | — | PASS |

The image-ref probe is the anti-dominance check: ordering still passes under it, so the second assertion is not shadowed by the first.

### Non-vacuity, measured

- ordering loop executes **2857** comparisons; image-ref loop **2858/2858** (every committed preset carries a ref, so the `continue` branch is taken zero times — it is type-required by `Option<TokenImageRef>`, not dead-by-accident).
- `windows(2)` is a no-op on len ≤ 1 and the ref loop is a no-op if no entry carries a ref. Those edges are closed elsewhere: `catalog_loads_and_validates` asserts non-emptiness, and `fixed_source_related_token_matches_exact_body` (`token_presets.rs:656`) asserts concrete `preset_id`s.

### Why this cannot false-red on a weekly refresh

Both are per-entry properties with no pinned totals, derived from the generator rather than from today's catalog:

- dedupe by uuid — `tokens_gen.rs:97`; `id = token.uuid.clone()` — `:227`; sort — `:106` `presets.sort_by(|a, b| a.id.cmp(&b.id))`. Deduped + sorted ⟹ strictly ascending. Nothing re-orders in `build.rs:32-37` or the `LazyLock` (`token_presets.rs:172-187`).
- `image_ref.preset_id` (`:216`) and `id` (`:227`) are both `token.uuid.clone()` from the same token — the generator structurally cannot emit a mismatch.
- Consistency is asserted only where a ref exists: `SetIdentifiers.scryfall_id` is `Option<String>` (`database/mtgjson.rs:218`), so a token with no Scryfall image is legal upstream data. Requiring presence would assert an *MTGJSON data* property and re-introduce the #6237 false-red class that #6274 removed.

### Scope, stated because it is narrow

These catch **reordering** and **an image ref pointing at a different preset**. They do **not** catch a body-only rewrite (nothing here ties `body`/`fidelity`/`source_card_refs` to an identity) nor a **deleted** entry — removing from the middle keeps the sequence ascending. Deletion is the count floors' job, and they have zero slack: the catalog is 2858 `[[token]]` and `coverage.rs` asserts `total_tokens >= 2858`, so any single deletion reds.

## Gate A

Gate A PASS head=21284f7f51a71ef8a1d03ed91bd773cf6bfb9441 base=836ff312ae2073c99af28d286b0c4915faa8a458

## Anchored on

- crates/engine/src/game/token_presets.rs:629 — `predefined_artifact_subtypes_match_registry`: the existing per-preset invariant test in this module; iterates `known_token_presets()` and asserts a cross-field invariant with `preset.id` in the panic message. The new test mirrors its shape exactly.
- crates/engine/src/game/token_presets.rs:179 — the `LazyLock` duplicate-id guard: the existing catalog-integrity assertion loop over `&parsed.token`, and the source of the ``known-tokens.toml: …`` panic-message convention the ordering assert follows.

## Final review-impl

Final review-impl PASS head=21284f7f51a71ef8a1d03ed91bd773cf6bfb9441

The first pass (against predecessor `73217b7f5`) returned CHANGES NEEDED with two comment-text findings, both fixed in the amend and both worth recording:

1. The doc fix corrected the sort key but kept a false rationale — "for stable display order". Nothing displays in engine order: `DebugCreateActions.tsx:452-483` regroups by category and re-sorts by (power, toughness, name). Reworded to the real reason (minimal diff on regen) and to say explicitly that this is not a display order.
2. The test doc claimed the assertions catch a catalog "hand-edited, spliced, or partially rewritten while keeping its counts" — an overclaim, since a body-only rewrite and a middle deletion both pass. Replaced with the explicit scope paragraph above.
