### PR TITLE
fix(engine): scope delayed return correctly for Disorder in the Court

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -8339,8 +8339,25 @@ fn resolve_chain_body(
 
             let initial_waiting_for = state.waiting_for.clone();
             let mut iteration = 0usize;
-            let repeated_full_chain =
-                ability.repeat_for.is_some() && effective.sub_ability.is_some();
+            // CR 608.2c: A `repeat_for` count scopes only the instructions that
+            // are part of the repeated process. A member-/kind-driven loop ("For
+            // each non-Saga permanent, choose a counter on it. You may put an
+            // additional counter of that kind on that permanent." — Caves of
+            // Chaos Adventurer) applies its whole chain per member, even across a
+            // sentence boundary, because the trailing clause refers back to the
+            // current iteration's binding ("that kind", "that permanent"). So the
+            // full chain repeats regardless of the sub's link. A PLAIN NUMERIC
+            // repeat is different: a `ContinuationStep` sub is part of the process
+            // ("Exile any number of creatures, then return them. Then repeat this
+            // process X more times." — Another Round) and repeats, but a
+            // `SequentialSibling` sub is an INDEPENDENT following instruction
+            // printed as its own sentence ("…investigate X times. Return the
+            // exiled cards…" — Disorder in the Court) and runs exactly once AFTER
+            // the loop — it falls through to the generic sub tail below.
+            let repeated_full_chain = ability.repeat_for.is_some()
+                && effective.sub_ability.as_deref().is_some_and(|sub| {
+                    member_driven || kind_driven || sub.sub_link == SubAbilityLink::ContinuationStep
+                });
             while iteration < iterations {
                 // Snapshot per-iteration ability with parent-target rebinding when
                 // applicable. CR 109.5: the rebind is SINGLE-slot — every reachable

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -2094,7 +2094,7 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
         // CR 603.7: Wrap in CreateDelayedTrigger if temporal suffix was found.
         if let Some(ref delayed_cond) = clause_ir.delayed_condition {
             for current in &mut current_defs {
-                let inner = std::mem::replace(
+                let mut inner = std::mem::replace(
                     current,
                     AbilityDefinition::new(
                         kind,
@@ -2114,6 +2114,19 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
                 let lifted_optional_for = inner.optional_for;
                 let lifted_repeat_for = inner.repeat_for.clone();
                 let lifted_player_scope = inner.player_scope.clone();
+                // CR 608.2c: The `CreateDelayedTrigger` wrapper — not its payload —
+                // is the node that occupies this clause's slot in the parent's
+                // `sub_ability` chain, so it must carry the clause's `sub_link`
+                // (the boundary that separated it from the preceding clause). A
+                // separate sentence ("…investigate X times. Return the exiled
+                // cards…" — Disorder in the Court) stamps `SequentialSibling`, which
+                // keeps the delayed-return OUT of a preceding `repeat_for` process
+                // (it is created once after the loop, not once per iteration) and
+                // lets it resolve when an optional parent is declined. The inner
+                // payload's link is to the delayed trigger it fires from, not to the
+                // parent chain, so reset it to the default within-process step.
+                let lifted_sub_link = inner.sub_link;
+                inner.sub_link = SubAbilityLink::ContinuationStep;
                 *current = AbilityDefinition::new(
                     kind,
                     Effect::CreateDelayedTrigger {
@@ -2127,6 +2140,7 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
                 current.optional_for = lifted_optional_for;
                 current.repeat_for = lifted_repeat_for;
                 current.player_scope = lifted_player_scope;
+                current.sub_link = lifted_sub_link;
             }
         }
 

--- a/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__delayed_exile_return_next_end_step.snap
+++ b/crates/engine/src/parser/oracle_effect/snapshots/engine__parser__oracle_effect__snapshot_tests__delayed_exile_return_next_end_step.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/engine/src/parser/oracle_effect/mod.rs
+source: crates/engine/src/parser/oracle_effect/snapshot_tests.rs
 expression: def
 ---
 {
@@ -52,8 +52,7 @@ expression: def
         "condition": null,
         "optional_targeting": false,
         "optional": false,
-        "forward_result": false,
-        "sub_link": "SequentialSibling"
+        "forward_result": false
       },
       "uses_tracked_set": true
     },
@@ -65,7 +64,8 @@ expression: def
     "condition": null,
     "optional_targeting": false,
     "optional": false,
-    "forward_result": false
+    "forward_result": false,
+    "sub_link": "SequentialSibling"
   },
   "duration": null,
   "description": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
@@ -76,8 +76,7 @@ expression: "&ir"
                 "condition": null,
                 "optional_targeting": false,
                 "optional": false,
-                "forward_result": false,
-                "sub_link": "SequentialSibling"
+                "forward_result": false
               },
               "uses_tracked_set": true
             },
@@ -89,7 +88,8 @@ expression: "&ir"
             "condition": null,
             "optional_targeting": false,
             "optional": false,
-            "forward_result": false
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
           },
           "duration": null,
           "description": "{U}: Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step.",

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_lowered.snap
@@ -58,8 +58,7 @@ expression: "&lowered"
             "condition": null,
             "optional_targeting": false,
             "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+            "forward_result": false
           },
           "uses_tracked_set": true
         },
@@ -71,7 +70,8 @@ expression: "&lowered"
         "condition": null,
         "optional_targeting": false,
         "optional": false,
-        "forward_result": false
+        "forward_result": false,
+        "sub_link": "SequentialSibling"
       },
       "duration": null,
       "description": "{U}: Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step.",

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_ir.snap
@@ -134,8 +134,7 @@ expression: "&ir"
                     "condition": null,
                     "optional_targeting": false,
                     "optional": false,
-                    "forward_result": false,
-                    "sub_link": "SequentialSibling"
+                    "forward_result": false
                   },
                   "uses_tracked_set": false
                 },
@@ -147,7 +146,8 @@ expression: "&ir"
                 "condition": null,
                 "optional_targeting": false,
                 "optional": false,
-                "forward_result": false
+                "forward_result": false,
+                "sub_link": "SequentialSibling"
               },
               "duration": "UntilEndOfTurn",
               "description": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_lowered.snap
@@ -117,8 +117,7 @@ expression: "&lowered"
                 "condition": null,
                 "optional_targeting": false,
                 "optional": false,
-                "forward_result": false,
-                "sub_link": "SequentialSibling"
+                "forward_result": false
               },
               "uses_tracked_set": false
             },
@@ -130,7 +129,8 @@ expression: "&lowered"
             "condition": null,
             "optional_targeting": false,
             "optional": false,
-            "forward_result": false
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
           },
           "duration": "UntilEndOfTurn",
           "description": null,

--- a/crates/engine/tests/integration/disorder_in_the_court_5955.rs
+++ b/crates/engine/tests/integration/disorder_in_the_court_5955.rs
@@ -1,0 +1,152 @@
+//! Regression for issue #5955 — Disorder in the Court.
+//!
+//! "Exile X target creatures, then investigate X times. Return the exiled cards
+//! to the battlefield tapped under their owners' control at the beginning of the
+//! next end step."
+//!
+//! The return sentence is a separate printed instruction (CR 608.2c: "follow the
+//! instructions in the order written"), so it is a `SequentialSibling` of the
+//! `repeat_for: X` investigate clause — the delayed-return trigger is created
+//! exactly ONCE after the repeats, not once per investigation. Before the fix the
+//! `CreateDelayedTrigger` wrapper defaulted to `ContinuationStep`, scoping it into
+//! the investigate `repeat_for` loop and creating X copies of the return trigger.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DISORDER: &str = "Exile X target creatures, then investigate X times. Return the exiled cards to the battlefield tapped under their owners' control at the beginning of the next end step.";
+
+fn clue_count(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner
+        .state()
+        .objects
+        .values()
+        .filter(|o| o.name == "Clue")
+        .count()
+}
+
+/// X=2: exile two targeted creatures, investigate twice (two Clues), and create a
+/// SINGLE delayed return that puts the two exiled cards back onto the battlefield
+/// tapped at the next end step. The Clues are untouched by the return.
+#[test]
+fn disorder_in_the_court_returns_exiled_cards_once() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Disorder in the Court", true, DISORDER)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::X, ManaCostShard::White, ManaCostShard::Blue],
+            generic: 0,
+        })
+        .id();
+    let c1 = scenario.add_vanilla(P1, 2, 2);
+    let c2 = scenario.add_vanilla(P1, 3, 3);
+    let dummy = ObjectId(0);
+    // {X=2}{W}{U} → W, U, and two generic.
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::White, dummy, false, vec![]),
+            ManaUnit::new(ManaType::Blue, dummy, false, vec![]),
+            ManaUnit::new(ManaType::Colorless, dummy, false, vec![]),
+            ManaUnit::new(ManaType::Colorless, dummy, false, vec![]),
+        ],
+    );
+    let mut runner = scenario.build();
+
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast begins");
+
+    for _ in 0..20 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ChooseXValue { .. } => {
+                runner
+                    .act(GameAction::ChooseX { value: 2 })
+                    .expect("choose X=2");
+            }
+            WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(engine::types::ability::TargetRef::Object(c1)),
+                    })
+                    .or_else(|_| {
+                        runner.act(GameAction::ChooseTarget {
+                            target: Some(engine::types::ability::TargetRef::Object(c2)),
+                        })
+                    })
+                    .expect("target select");
+            }
+            WaitingFor::Priority { .. } => {
+                runner.act(GameAction::PassPriority).expect("pass");
+                if runner.state().stack.is_empty() {
+                    break;
+                }
+            }
+            other => panic!("unexpected waiting_for during cast: {other:?}"),
+        }
+    }
+
+    // On resolution: both creatures are exiled, X=2 Clues were created, and the
+    // return is scheduled exactly ONCE (regression: was created X=2 times).
+    assert_eq!(runner.state().objects[&c1].zone, Zone::Exile, "c1 exiled");
+    assert_eq!(runner.state().objects[&c2].zone, Zone::Exile, "c2 exiled");
+    assert_eq!(clue_count(&runner), 2, "investigate X=2 → two Clues");
+    assert_eq!(
+        runner.state().delayed_triggers.len(),
+        1,
+        "the SequentialSibling return is a single delayed trigger, not one per investigation",
+    );
+
+    // Advance until the delayed trigger fires and its return resolves.
+    let mut guard = 0;
+    while !runner.state().delayed_triggers.is_empty() || !runner.state().stack.is_empty() {
+        guard += 1;
+        assert!(guard <= 400, "did not reach/clear the end step return");
+        if runner.act(GameAction::PassPriority).is_err() {
+            break;
+        }
+    }
+
+    // The exiled cards return to the battlefield tapped under their owner's control.
+    assert_eq!(
+        runner.state().objects[&c1].zone,
+        Zone::Battlefield,
+        "c1 returned",
+    );
+    assert_eq!(
+        runner.state().objects[&c2].zone,
+        Zone::Battlefield,
+        "c2 returned",
+    );
+    assert!(runner.state().objects[&c1].tapped, "c1 returns tapped");
+    assert!(runner.state().objects[&c2].tapped, "c2 returns tapped");
+    assert_eq!(
+        runner.state().objects[&c1].controller,
+        P1,
+        "c1 owner control"
+    );
+    assert_eq!(
+        runner.state().objects[&c2].controller,
+        P1,
+        "c2 owner control"
+    );
+    // The Clues are NOT part of the returned tracked set — they stay put.
+    assert_eq!(clue_count(&runner), 2, "Clues untouched by the return");
+    assert_eq!(
+        runner.state().delayed_triggers.len(),
+        0,
+        "the single return trigger resolved and cleared",
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -118,6 +118,7 @@ mod devour_co_entry_regression;
 mod devour_intellect_treasure_rider;
 mod dig_rest_pile_stranding_on_etb_pause;
 mod diligent_farmhand_counts_as_named;
+mod disorder_in_the_court_5955;
 mod divine_visitation_token_substitution;
 mod doran_attack_block_pump;
 mod double_strike_first_strike_trigger_removes_attacker;


### PR DESCRIPTION
Closes #5955

## Summary

Discord report: **Disorder in the Court** ("Exile X target creatures, then investigate X times. Return the exiled cards to the battlefield tapped under their owners' control at the beginning of the next end step.") misbehaved on the delayed return.

The return sentence is a separate printed instruction, so per CR 608.2c it must resolve **once after** the investigate loop — not once per investigation. Two bugs conspired to scope it inside the `repeat_for: X` loop, creating X copies of the delayed return trigger.

Root cause:

1. **Parser** — when wrapping a clause into `CreateDelayedTrigger`, `condition`/`optional`/`repeat_for`/`player_scope` were lifted onto the wrapper, but **`sub_link` was not**. The clause's `SequentialSibling` link was stranded on the delayed trigger's inner payload while the wrapper (the actual node in the parent's `sub_ability` chain) silently defaulted to `ContinuationStep`.
2. **Engine** — `repeated_full_chain` only checked `repeat_for.is_some() && sub_ability.is_some()`, so it scoped that mislabeled return sub into the investigate loop and created the return trigger X times.

Fix:

- Lift `sub_link` onto the `CreateDelayedTrigger` wrapper and reset the inner payload to the default `ContinuationStep`.
- Gate `repeated_full_chain` so a `SequentialSibling` sub is excluded from a plain **numeric** `repeat_for`, while **member-/kind-driven** (`for each`) loops still repeat their full chain per iteration (their trailing clause refers back to the per-iteration binding, e.g. Caves of Chaos Adventurer's "that kind"/"that permanent").

Now at X=2: two creatures exile, two Clues are created, **exactly one** delayed return fires at the next end step, and both cards return tapped under their owner's control with the Clues untouched.

## Changes

- **`crates/engine/src/parser/oracle_effect/assembly.rs`** — lift `sub_link` onto the `CreateDelayedTrigger` wrapper; reset inner payload to `ContinuationStep`.
- **`crates/engine/src/game/effects/mod.rs`** — restrict `repeated_full_chain` to `ContinuationStep` subs on plain numeric repeats; keep member-/kind-driven loops repeating the full chain.
- **`crates/engine/tests/integration/disorder_in_the_court_5955.rs`** (+ `main.rs` mod) — regression: exile X, investigate X, single delayed return of exactly the exiled cards.
- **Snapshots** — `delayed_exile_return_next_end_step`, `aetherling_ir`/`aetherling_lowered`, `mishra_eminent_one_ir`/`mishra_eminent_one_lowered` now carry `sub_link` on the wrapper (also corrects Aetherling and Mishra, Eminent One).

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p engine --all-targets --features engine/proptest -- -D warnings`
- [x] `cargo test -p engine` (full suite: 21,132 pass)
- [x] `cargo test -p engine --test integration disorder_in_the_court_returns_exiled_cards_once`
- [x] `cargo test -p engine caves_chapter_repeat_choose_and_put_round_trip caves_chapter_two_counter_kinds_suspends_resumes_and_advances`
- [x] Regenerate card-data (`./scripts/gen-card-data.sh` or Tilt `card-data`) so Disorder's runtime body picks up the parser fix
