### PR TITLE
fix(ci): restore wasm shadow-stack rustflags and scope server builds to phase-server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -323,6 +323,12 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
           cache-shared-key: rust-wasm
+          # An env RUSTFLAGS (this action's default is "-D warnings") overrides
+          # ALL .cargo/config.toml rustflags, silently dropping the
+          # [target.wasm32-unknown-unknown] 16 MiB shadow-stack link-arg that
+          # build-wasm.sh's assert_wasm_stack guard requires. Keep config.toml
+          # authoritative.
+          rustflags: ""
 
       - uses: taiki-e/install-action@v2
         with:
@@ -505,7 +511,11 @@ jobs:
         # No chmod here: upload-artifact strips the executable bit anyway;
         # push-server-image re-applies it (and the Dockerfile chmods in-image).
         run: |
-          cargo build --profile server-release --bin phase-server --target x86_64-unknown-linux-musl
+          # -p scopes feature unification to phase-server's own graph: an
+          # unscoped workspace build unifies feed-scraper's native-tls reqwest
+          # features into phase-server, dragging openssl-sys into the musl
+          # cross-compile (which has no OpenSSL and fails).
+          cargo build -p phase-server --profile server-release --bin phase-server --target x86_64-unknown-linux-musl
           cp target/x86_64-unknown-linux-musl/server-release/phase-server ./phase-server
 
       - name: Upload server binary artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,11 @@ jobs:
         with:
           target: wasm32-unknown-unknown
           cache-shared-key: rust-wasm
+          # Keep .cargo/config.toml's [target.wasm32-unknown-unknown] 16 MiB
+          # shadow-stack rustflags authoritative: an env RUSTFLAGS (this
+          # action's default "-D warnings") would override them and trip
+          # build-wasm.sh's assert_wasm_stack guard.
+          rustflags: ""
 
       - uses: taiki-e/install-action@v2
         with:
@@ -413,7 +418,10 @@ jobs:
         # No chmod here: upload-artifact strips the executable bit anyway; both
         # consumers (image build, slim-asset packaging) re-apply it.
         run: |
-          cargo build --profile server-release --bin phase-server --target x86_64-unknown-linux-musl
+          # -p scopes feature unification to phase-server's own graph — an
+          # unscoped workspace build unifies feed-scraper's native-tls reqwest
+          # features in, dragging openssl-sys into the musl cross-compile.
+          cargo build -p phase-server --profile server-release --bin phase-server --target x86_64-unknown-linux-musl
           cp target/x86_64-unknown-linux-musl/server-release/phase-server ./phase-server
 
       - name: Upload server binary artifact
@@ -534,6 +542,10 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
           cache-shared-key: rust-wasm
+          # Same as the wasm job: broker-wasm needs the config.toml
+          # [target.wasm32-unknown-unknown] shadow-stack rustflags, which an
+          # env RUSTFLAGS would override.
+          rustflags: ""
 
       - uses: taiki-e/install-action@v2
         if: steps.lobby-worker.outputs.exists == 'true'
@@ -614,7 +626,8 @@ jobs:
         # Linux musl is compiled once in build-server-binary and reused below;
         # only the non-musl targets compile here.
         if: matrix.triple != 'x86_64-unknown-linux-musl'
-        run: cargo build --profile server-release --bin phase-server --target ${{ matrix.triple }}
+        # -p scopes feature unification (see the Linux leg's note).
+        run: cargo build -p phase-server --profile server-release --bin phase-server --target ${{ matrix.triple }}
 
       - name: Download prebuilt linux binary
         # Reuse the single musl build from build-server-binary, placed at the

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ WORKDIR /app
 
 COPY . .
 
-RUN cargo build --profile server-release --bin phase-server \
+# -p scopes feature unification to phase-server's own graph: unscoped, the
+# workspace unifies feed-scraper's native-tls reqwest features in, dynamically
+# linking OpenSSL — which the slim runtime image does not ship.
+RUN cargo build -p phase-server --profile server-release --bin phase-server \
     && cp target/server-release/phase-server /phase-server
 
 # Prebuilt path: expects ./phase-server (a static musl binary) in the build

--- a/Tiltfile
+++ b/Tiltfile
@@ -109,7 +109,7 @@ SERVER_SRC = ENGINE_SRC + AI_SRC + [
 ]
 
 local_resource('server',
-    cmd = 'cargo build --bin phase-server',
+    cmd = 'cargo build -p phase-server --bin phase-server',
     serve_cmd = './target/debug/phase-server',
     serve_env = {'PHASE_DATA_DIR': 'data'},
     deps = SERVER_SRC,


### PR DESCRIPTION
Two distinct causes broke the first executed deploy since #6238/#6282:

1. setup-rust-toolchain exports RUSTFLAGS='-D warnings' by default, and an
   env RUSTFLAGS overrides ALL .cargo/config.toml rustflags — silently
   dropping the [target.wasm32-unknown-unknown] 16 MiB shadow-stack
   link-arg #6238 added, tripping build-wasm.sh's assert_wasm_stack guard.
   Pass rustflags: '' on every wasm-building job (deploy build-wasm,
   release wasm + broker-wasm) so config.toml stays authoritative.

2. #6282 gave phase-server a rustls-only reqwest, but the CI builds run
   'cargo build --bin phase-server' unscoped from the workspace root, so
   feature unification folds feed-scraper's native-tls reqwest features
   in, dragging openssl-sys into the musl cross-compile (no OpenSSL →
   build failure) and dynamic OpenSSL into the Docker image (runtime has
   no libssl). Scope every server build with -p phase-server: deploy,
   release (linux + matrix legs), Dockerfile compile stage, Tiltfile.

Verified: cargo tree -p phase-server -i openssl-sys --target
x86_64-unknown-linux-musl finds no path post-fix (present unscoped);
rustflags input semantics confirmed against the action's action.yml.
