### PR TITLE
fix(tauri): Set WEBKIT_DMABUF_RENDERER_FORCE_SHM=1 to avoid nvidia graphics bug at no performance cost

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -97,9 +97,6 @@ local_resource('tauri',
     cmd = 'cargo build -p phase-server && mkdir -p client/src-tauri/binaries && cp target/debug/phase-server ' + SIDECAR_DEST,
     serve_cmd = 'pnpm tauri:dev',
     serve_dir = 'client',
-    # Keep the dmabuf renderer (disabling it tanks in-game perf) but force
-    # shared-memory buffers, dodging the GPU-path glitches.
-    serve_env = {'WEBKIT_DMABUF_RENDERER_FORCE_SHM': '1'},
     deps = ENGINE_SRC + AI_SRC + WASM_SRC + TAURI_SRC + ['crates/server-core/src/', 'crates/phase-server/src/'],
     ignore = TMP_IGNORE,
     auto_init = 'tauri' in enabled,

--- a/Tiltfile
+++ b/Tiltfile
@@ -97,6 +97,9 @@ local_resource('tauri',
     cmd = 'cargo build -p phase-server && mkdir -p client/src-tauri/binaries && cp target/debug/phase-server ' + SIDECAR_DEST,
     serve_cmd = 'pnpm tauri:dev',
     serve_dir = 'client',
+    # Keep the dmabuf renderer (disabling it tanks in-game perf) but force
+    # shared-memory buffers, dodging the GPU-path glitches.
+    serve_env = {'WEBKIT_DMABUF_RENDERER_FORCE_SHM': '1'},
     deps = ENGINE_SRC + AI_SRC + WASM_SRC + TAURI_SRC + ['crates/server-core/src/', 'crates/phase-server/src/'],
     ignore = TMP_IGNORE,
     auto_init = 'tauri' in enabled,

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -4,6 +4,17 @@ mod migration;
 mod native_engine;
 
 pub fn run() {
+    // WebKitGTK's dmabuf renderer renders blank frames when the GPU import
+    // path misbehaves (NVIDIA drivers); forcing shared-memory buffers avoids
+    // that while keeping the dmabuf renderer (and thus acceleration), unlike
+    // WEBKIT_DISABLE_DMABUF_RENDERER which tanks in-game performance. Must be
+    // set before the first webview is created. A value already present in the
+    // environment wins so users can override.
+    #[cfg(target_os = "linux")]
+    if std::env::var_os("WEBKIT_DMABUF_RENDERER_FORCE_SHM").is_none() {
+        std::env::set_var("WEBKIT_DMABUF_RENDERER_FORCE_SHM", "1");
+    }
+
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_single_instance::init(|app, _, _| {
             if let Some(window) = app.get_webview_window("main") {


### PR DESCRIPTION
`WEBKIT_DMABUF_RENDERER_FORCE_SHM=1` on linux machines to avoid blank-screen, but keep acceleration, with nvidia graphics drivers. Without this tauri renders a blank screen, and the game is near unplayable without GPU acceleration, so `WEBKIT_DISABLE_DMABUF_RENDERER=1` is not the correct solution.

This PR adds a line to the Tiltfile to ensure this environment variable is set.