### PR TITLE
fix(ci): pass --repo to the tag-recovery release dispatch

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -457,4 +457,6 @@ jobs:
           # so a CI fix landed on main could never reach a stuck tag. `-f tag=` still pins
           # the SOURCE that gets built to the tag's SHA (see release.yml resolve-release-ref),
           # so this changes the CI config only, never the released code.
-          gh workflow run release.yml --ref main -f tag="$TAG"
+          # --repo is required: this job has no checkout, so gh cannot infer the
+          # repository from a local git directory and dies with "not a git repository".
+          gh workflow run release.yml --repo "$GITHUB_REPOSITORY" --ref main -f tag="$TAG"


### PR DESCRIPTION
The Dispatch Existing Tag Recovery job runs gh workflow run without a
checkout, so gh tried to infer the repository from a local git directory
and failed with 'not a git repository' — the mode-D residual: every
recovery dispatch for a stranded tag silently died (first hit: v0.32.0
after today's wasm-guard release failure).
