### PR TITLE
fix(ci): scope preview-server build to phase-server to avoid openssl-sys feature unification

### DIFF
--- a/.github/workflows/preview-server.yml
+++ b/.github/workflows/preview-server.yml
@@ -138,7 +138,10 @@ jobs:
           rustup target add x86_64-unknown-linux-musl
 
       - name: Build phase-server
-        run: cargo build --profile server-release --bin phase-server --target ${{ matrix.triple }}
+        # -p scopes feature unification to phase-server's own dependency set;
+        # an unscoped workspace build unifies feed-scraper's default-features
+        # reqwest (native-tls -> openssl-sys) into the musl target and fails.
+        run: cargo build -p phase-server --profile server-release --bin phase-server --target ${{ matrix.triple }}
 
       - name: Prepare preview server binary (Unix)
         if: matrix.os != 'windows'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the preview server build process to target the phase-server package directly.
  * Preserved the existing build profile, binary selection, and target platform settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->