### PR TITLE
fix(parser): gate DamageDone triggers on combat-status recipient

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -8430,6 +8430,77 @@ mod tests {
         ));
     }
 
+    /// CR 509.1g + CR 120.3: a parsed blocking-creature recipient is enforced
+    /// by the production damage matcher. This must reject player damage while
+    /// continuing to accept damage dealt to a creature currently blocking.
+    #[test]
+    fn parsed_blocking_creature_recipient_gates_damage_matcher() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Damage Source".to_string(),
+            Zone::Battlefield,
+        );
+        let blocker = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Blocking Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let attacker = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [source, blocker, attacker] {
+            state
+                .objects
+                .get_mut(&id)
+                .unwrap()
+                .card_types
+                .core_types
+                .push(CoreType::Creature);
+        }
+        state.combat = Some(crate::game::combat::CombatState {
+            blocker_to_attacker: HashMap::from([(blocker, vec![attacker])]),
+            ..Default::default()
+        });
+
+        let trigger = parse_trigger_line(
+            "Whenever a creature deals damage to a blocking creature, draw a card.",
+            "Blocking Recipient Test",
+        );
+        let context = test_trigger_source_context(&state, source);
+        let player_damage = GameEvent::DamageDealt {
+            source_id: source,
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 1,
+            is_combat: true,
+            excess: 0,
+        };
+        let blocker_damage = GameEvent::DamageDealt {
+            source_id: source,
+            target: TargetRef::Object(blocker),
+            amount: 1,
+            is_combat: true,
+            excess: 0,
+        };
+
+        assert!(
+            !match_damage_done(&player_damage, &trigger, &context, &state),
+            "a blocking-creature recipient must reject player damage"
+        );
+        assert!(
+            match_damage_done(&blocker_damage, &trigger, &context, &state),
+            "a blocking creature must satisfy the parsed recipient filter"
+        );
+    }
+
     #[test]
     fn damage_done_once_by_controller_matches_aggregated_combat_damage_event() {
         let mut state = setup();

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -8457,7 +8457,14 @@ mod tests {
             "Attacker".to_string(),
             Zone::Battlefield,
         );
-        for id in [source, blocker, attacker] {
+        let nonblocking_creature = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(1),
+            "Nonblocking Creature".to_string(),
+            Zone::Battlefield,
+        );
+        for id in [source, blocker, attacker, nonblocking_creature] {
             state
                 .objects
                 .get_mut(&id)
@@ -8490,6 +8497,13 @@ mod tests {
             is_combat: true,
             excess: 0,
         };
+        let nonblocking_creature_damage = GameEvent::DamageDealt {
+            source_id: source,
+            target: TargetRef::Object(nonblocking_creature),
+            amount: 1,
+            is_combat: true,
+            excess: 0,
+        };
 
         assert!(
             !match_damage_done(&player_damage, &trigger, &context, &state),
@@ -8498,6 +8512,10 @@ mod tests {
         assert!(
             match_damage_done(&blocker_damage, &trigger, &context, &state),
             "a blocking creature must satisfy the parsed recipient filter"
+        );
+        assert!(
+            !match_damage_done(&nonblocking_creature_damage, &trigger, &context, &state),
+            "a nonblocking creature must not satisfy the parsed recipient filter"
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3,7 +3,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{one_of, space1};
 use nom::combinator::{all_consuming, eof, map, opt, peek, recognize, rest, value};
-use nom::multi::{many1, separated_list1};
+use nom::multi::{many0, many1, separated_list1};
 use nom::sequence::{delimited, pair, preceded, terminated};
 use nom::Parser;
 
@@ -25,7 +25,7 @@ use super::oracle_nom::condition::parse_inner_condition;
 use super::oracle_nom::condition::{parse_source_counters_exist, parse_source_has_counters};
 use super::oracle_nom::error::{oracle_err, OracleResult};
 use super::oracle_nom::filter::{
-    parse_color_property, parse_enters_origin_zone, parse_with_property,
+    parse_color_property, parse_enters_origin_zone, parse_property_filter, parse_with_property,
 };
 use super::oracle_nom::primitives::{
     self as nom_primitives, scan_contains, scan_preceded, scan_split_at_phrase,
@@ -9229,7 +9229,16 @@ fn parse_object_recipient_filter(after_verb: &str) -> OracleResult<'_, TargetFil
     let (rest, ()) =
         value((), tag::<_, _, OracleError<'_>>("to ")).parse(after_verb.trim_start())?;
     let (rest, _) = alt((tag("a "), tag("an "))).parse(rest)?;
-    let (rest, filter) = parse_type_phrase_nom(rest)?;
+    // CR 509.1a + CR 509.1h: optional state/combat-status adjective prefix on the
+    // damage recipient — "a blocking creature" (Kusari-Gama), "an attacking
+    // creature", "a tapped creature". `parse_type_phrase_nom` only handles
+    // type/color/supertype words, so without this the whole recipient failed to
+    // parse and the trigger fell back to `valid_target = None` (fires on ANY
+    // recipient, including a player). Consume the leading `FilterProp`s and merge
+    // them into the typed recipient so the trigger gates on the damaged object's
+    // combat state. Mirrors the prefix loop in `oracle_target::parse_type_phrase`.
+    let (rest, prefix_props) = many0(terminated(parse_property_filter, space1)).parse(rest)?;
+    let (rest, mut filter) = parse_type_phrase_nom(rest)?;
     // Phrase-terminator guard: accept only end-of-string or a non-alphanumeric
     // terminator (comma, period, space-before-clause), and explicitly reject the
     // " or <player-word>" disjunction. Declines "creature or player",
@@ -9251,6 +9260,17 @@ fn parse_object_recipient_filter(after_verb: &str) -> OracleResult<'_, TargetFil
             rest,
             nom::error::ErrorKind::Eof,
         )));
+    }
+    // CR 509.1a: merge the consumed combat-status prefixes onto the typed
+    // recipient so the trigger matcher gates on them.
+    if !prefix_props.is_empty() {
+        if let TargetFilter::Typed(ref mut tf) = filter {
+            for prop in prefix_props {
+                if !tf.properties.contains(&prop) {
+                    tf.properties.push(prop);
+                }
+            }
+        }
     }
     Ok((rest, filter))
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9229,7 +9229,7 @@ fn parse_object_recipient_filter(after_verb: &str) -> OracleResult<'_, TargetFil
     let (rest, ()) =
         value((), tag::<_, _, OracleError<'_>>("to ")).parse(after_verb.trim_start())?;
     let (rest, _) = alt((tag("a "), tag("an "))).parse(rest)?;
-    // CR 509.1a + CR 509.1h: optional state/combat-status adjective prefix on the
+    // CR 509.1g + CR 120.3: optional state/combat-status adjective prefix on the
     // damage recipient — "a blocking creature" (Kusari-Gama), "an attacking
     // creature", "a tapped creature". `parse_type_phrase_nom` only handles
     // type/color/supertype words, so without this the whole recipient failed to
@@ -9261,7 +9261,7 @@ fn parse_object_recipient_filter(after_verb: &str) -> OracleResult<'_, TargetFil
             nom::error::ErrorKind::Eof,
         )));
     }
-    // CR 509.1a: merge the consumed combat-status prefixes onto the typed
+    // CR 509.1g: merge the consumed combat-status prefixes onto the typed
     // recipient so the trigger matcher gates on them.
     if !prefix_props.is_empty() {
         if let TargetFilter::Typed(ref mut tf) = filter {

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -216,7 +216,7 @@ fn glory_of_battle_trigger_gates_on_creature_recipient() {
 
 #[test]
 fn damage_done_recipient_gates_on_blocking_creature() {
-    // CR 509.1a + CR 120.3 (issue #5951): "Whenever equipped creature deals
+    // CR 509.1g + CR 120.3 (issue #5951): "Whenever equipped creature deals
     // damage to a blocking creature, ..." (Kusari-Gama) must set a typed
     // `valid_target` carrying `FilterProp::Blocking` so the trigger fires ONLY
     // when the damaged object is a blocker — not when the equipped creature

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -214,6 +214,34 @@ fn glory_of_battle_trigger_gates_on_creature_recipient() {
     }
 }
 
+#[test]
+fn damage_done_recipient_gates_on_blocking_creature() {
+    // CR 509.1a + CR 120.3 (issue #5951): "Whenever equipped creature deals
+    // damage to a blocking creature, ..." (Kusari-Gama) must set a typed
+    // `valid_target` carrying `FilterProp::Blocking` so the trigger fires ONLY
+    // when the damaged object is a blocker — not when the equipped creature
+    // deals combat damage to a player. A bare combat-status adjective on the
+    // recipient is the class fixed here, so exercise the building block
+    // ("a blocking creature") rather than the single card.
+    let def = parse_trigger_line(
+        "Whenever equipped creature deals damage to a blocking creature, \
+         this Equipment deals that much damage to each other creature defending player controls.",
+        "Kusari-Gama",
+    );
+    assert_eq!(def.mode, TriggerMode::DamageDone);
+    match &def.valid_target {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+            assert!(
+                tf.properties.contains(&FilterProp::Blocking),
+                "recipient must be gated on the blocking combat status, got {:?}",
+                tf.properties,
+            );
+        }
+        other => panic!("expected a blocking-creature valid_target, got {other:?}"),
+    }
+}
+
 fn blocking_source_beyond_first_expr() -> QuantityExpr {
     let count_minus_one = QuantityExpr::Offset {
         inner: Box::new(QuantityExpr::Ref {


### PR DESCRIPTION
Closes #5951

## Summary

Discord report: **Kusari-Gama** deals its equipment damage even when the equipped creature deals combat damage to a *player*. Its trigger is "Whenever equipped creature deals damage to **a blocking creature**, this Equipment deals that much damage to each other creature defending player controls." — the equipment's damage should fire *only* when the recipient is a blocking creature.

Root cause (matches the classifier's `supported_aspect_defect` verdict): the trigger AST had `valid_target: null`, so the matcher fired on **any** recipient, including a player. The DamageDone recipient parser (`parse_object_recipient_filter`) delegates the recipient phrase to the nom `parse_type_phrase`, which only handles type/color/supertype words — it does not consume a leading combat-status adjective, so `"a blocking creature"` failed to parse and the recipient filter was silently dropped.

Fix: in `parse_object_recipient_filter`, consume an optional leading run of state/combat-status adjectives (`FilterProp` via the shared `parse_property_filter` building block) before the type phrase and merge them onto the typed recipient. This gates the whole class of combat-state damage recipients (`"a blocking creature"`, `"an attacking creature"`, `"a tapped creature"`, …), mirroring the combat-status prefix loop already in `oracle_target::parse_type_phrase`. The runtime matcher (`match_damage_done`) already rejects a player recipient when `valid_target` is a type-bearing object filter (CR 120.3 + CR 102.2) and evaluates `FilterProp::Blocking` against the damaged object via `combat.blocker_to_attacker` (CR 509.1a), so no engine change is required once the AST is faithful.

## Changes

- **`crates/engine/src/parser/oracle_trigger.rs`** — `parse_object_recipient_filter` now consumes an optional leading combat-status/state adjective prefix (`many0(terminated(parse_property_filter, space1))`) and merges the resulting `FilterProp`s onto the typed recipient. Adds the `many0` and `parse_property_filter` imports.
- **`crates/engine/src/parser/oracle_trigger_tests.rs`** — building-block parser regression `damage_done_recipient_gates_on_blocking_creature`: `"deals damage to a blocking creature"` must yield a `DamageDone` trigger whose `valid_target` is a `Typed([Creature])` filter carrying `FilterProp::Blocking`.

## Test Plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy -p engine --lib -- -D warnings`
- [ ] `cargo test -p engine --lib` (full suite: 17,473 pass)
- [ ] `cargo test -p engine --lib -- damage_done_recipient_gates_on_blocking_creature`
- [ ] `cargo test -p engine --lib -- glory_of_battle_trigger_gates_on_creature_recipient` (sibling `"to a creature"` recipient, still green)

## Out of scope

The "each **other** creature" wording (the effect's `Another` exclusion is relative to the Equipment, not the blocking creature already dealt combat damage) is a separate, unreported effect-side nuance and is not addressed here — the reported symptom is the trigger firing on damage to a player, which this fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle trigger parsing to support optional combat-state/property qualifiers before the target recipient type, ensuring correct handling of blocking-related recipients.
  * Updated damage-done trigger matching so it only matches recipients constrained to the intended type/state (e.g., blocking creatures), preventing incorrect matches.

* **Tests**
  * Added coverage for damage-done triggers gated to blocking creatures, including assertions that player recipients are rejected while blocking-creature recipients are accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->