### PR TITLE
fix(engine): cast self-library peek spells during resolution (Kiora class)

### DIFF
--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -1,7 +1,8 @@
 use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
 use crate::types::ability::{
-    AbilityCost, CastingPermission, Duration, Effect, EffectError, EffectKind, QuantityExpr,
-    ResolvedAbility, SpellStackToGraveyardReplacement, TargetFilter, TargetRef,
+    AbilityCost, CastPermissionConstraint, CastingPermission, Duration, Effect, EffectError,
+    EffectKind, QuantityExpr, ResolvedAbility, SpellStackToGraveyardReplacement, TargetFilter,
+    TargetRef,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{BatchCompletion, CastingVariant, GameState, WaitingFor};
@@ -24,6 +25,26 @@ fn extract_controller_ref(filter: &TargetFilter) -> Option<&crate::types::abilit
         }
         _ => None,
     }
+}
+
+/// CR 701.20e + CR 400.2: A private self-library peek keeps its looked-at
+/// cards in the controller-owned library while publishing their identities only
+/// through the resolving effect's `last_revealed_ids` window.
+pub(crate) fn looked_at_controller_library_cards(
+    state: &GameState,
+    controller: crate::types::player::PlayerId,
+) -> Vec<ObjectId> {
+    state
+        .last_revealed_ids
+        .iter()
+        .copied()
+        .filter(|id| {
+            state
+                .objects
+                .get(id)
+                .is_some_and(|object| object.zone == Zone::Library && object.owner == controller)
+        })
+        .collect()
 }
 
 /// CR 400.1/400.2 + CR 109.4: Eligible hand-pick pool for a private-zone
@@ -58,9 +79,20 @@ fn compute_hand_pick_eligible(
     let Some(player) = state.players.iter().find(|p| p.id == hand_owner) else {
         return Vec::new();
     };
-    let cards_iter = match source_zone {
-        Zone::Hand => player.hand.iter(),
-        _ => unreachable!("private CastFromZone selection is currently hand-only"),
+    let cards: Vec<ObjectId> = match source_zone {
+        Zone::Hand => player.hand.iter().copied().collect(),
+        Zone::Library => looked_at_controller_library_cards(state, ability.controller),
+        _ => unreachable!("private CastFromZone selection supports only hand and library"),
+    };
+    let remapped_library_filter = (source_zone == Zone::Library)
+        .then(|| crate::game::filter::remap_exiled_by_source_for_looked_cards(target_filter));
+    let target_filter = remapped_library_filter.as_ref().unwrap_or(target_filter);
+    let constraint = match &ability.effect {
+        Effect::CastFromZone {
+            constraint: Some(constraint),
+            ..
+        } => Some(constraint.clone()),
+        _ => effective_cast_from_zone_constraint(ability),
     };
     // CR 601.2 vs CR 305.1: a land is never *cast* — it is played. A "cast a
     // permanent spell from your hand" pick (Kellan, the Kid) carries a broad
@@ -74,8 +106,8 @@ fn compute_hand_pick_eligible(
             ..
         }
     );
-    cards_iter
-        .copied()
+    cards
+        .into_iter()
         .filter(|id| {
             if cast_mode_excludes_lands
                 && state.objects.get(id).is_some_and(|obj| {
@@ -87,6 +119,14 @@ fn compute_hand_pick_eligible(
                 return false;
             }
             crate::game::filter::matches_target_filter(state, *id, target_filter, &ctx)
+                && state.objects.get(id).is_some_and(|object| {
+                    crate::game::casting::cast_permission_constraint_allows_cast(
+                        state,
+                        object,
+                        &constraint,
+                        None,
+                    )
+                })
         })
         .collect()
 }
@@ -170,9 +210,24 @@ fn open_private_zone_cast_selection(
     source_zone: Zone,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let eligible = compute_hand_pick_eligible(state, ability, target_filter, source_zone);
+    let mut stash = ability.clone();
+    // CR 202.3 + CR 608.2h: Freeze before filtering so the private prompt's
+    // eligibility test and its later cast consume the same concrete ceiling.
+    snapshot_cast_from_zone_constraint_into_effect(state, ability, &mut stash);
+    stash.targets.clear();
+    let eligible = compute_hand_pick_eligible(state, &stash, target_filter, source_zone);
 
     if eligible.is_empty() {
+        if source_zone == Zone::Library {
+            let looked_at = looked_at_controller_library_cards(state, ability.controller);
+            let _ = crate::game::effects::cascade::shuffle_to_bottom(
+                state,
+                &looked_at,
+                ability.source_id,
+                None,
+                events,
+            );
+        }
         events.push(GameEvent::EffectResolved {
             kind: EffectKind::CastFromZone,
             source_id: ability.source_id,
@@ -181,8 +236,6 @@ fn open_private_zone_cast_selection(
         return Ok(());
     }
 
-    let mut stash = ability.clone();
-    stash.targets.clear();
     // CR 202.3 + CR 608.2h: The "equal or lesser mana value" gate (Kellan, the
     // Kid) references the triggering spell's mana value via a dynamic
     // `QuantityExpr` whose referent (the trigger-event source) is only in scope
@@ -191,7 +244,6 @@ fn open_private_zone_cast_selection(
     // cleared and the reference would read 0 and reject every cast. Freeze the
     // gate to a `Fixed` on the stashed ability now, while the trigger context is
     // live, so the resume's finalize-time re-evaluation is correct.
-    snapshot_cast_from_zone_constraint_into_effect(state, ability, &mut stash);
     crate::game::effects::append_to_pending_continuation(state, Some(Box::new(stash)));
     state.waiting_for = WaitingFor::EffectZoneChoice {
         player: ability.controller,
@@ -291,6 +343,7 @@ pub fn resolve(
     // Bring to Light, Urza) must NOT be re-filtered through that remap, which
     // would drop every target not in `last_revealed_ids`. The remap therefore
     // only applies on the empty-target fallback below.
+    let mut used_last_revealed_library_fallback = false;
     if target_ids.is_empty() && target_filter.references_exiled_by_source() {
         let linked = crate::game::players::linked_exile_cards_for_source(state, ability.source_id);
         let current_linked_ids: Vec<_> = state
@@ -330,9 +383,45 @@ pub fn resolve(
         // 0 }` publishes them via `last_revealed_ids`, not exile links, but the
         // parser still binds the cast step to `ExiledBySource`.
         if target_ids.is_empty() && !state.last_revealed_ids.is_empty() {
+            used_last_revealed_library_fallback = true;
             target_ids =
                 crate::game::filter::last_revealed_library_ids_matching(state, target_filter, &ctx);
         }
+    }
+
+    // The usual no-target fallback above observes the raw chain shape. Optional
+    // look-cast frames may instead arrive with the same looked-at cards already
+    // injected as resolved targets; both forms carry exactly the private-library
+    // candidate set and must use the same one-shot choice.
+    let library_candidates_from_last_revealed = used_last_revealed_library_fallback
+        || (target_filter.references_exiled_by_source()
+            && !state.last_revealed_ids.is_empty()
+            && !target_ids.is_empty()
+            && target_ids.iter().all(|id| {
+                state.last_revealed_ids.contains(id)
+                    && state
+                        .objects
+                        .get(id)
+                        .is_some_and(|object| object.zone == Zone::Library)
+            }));
+
+    // CR 608.2g: a self-library peek's "may cast one from among them" choice
+    // is made during the resolving ability, from the exact private look window.
+    // The library route snapshots the constraint while trigger context is live,
+    // then uses the typed one-shot resolution-cast cleanup rather than granting
+    // an exile permission.
+    if driver.is_during_resolution()
+        && without_paying
+        && alt_ability_cost.is_none()
+        && library_candidates_from_last_revealed
+    {
+        return open_private_zone_cast_selection(
+            state,
+            ability,
+            target_filter,
+            Zone::Library,
+            events,
+        );
     }
 
     // CR 310.11b + CR 608.2c: "exile it, then you may cast it transformed" —
@@ -661,23 +750,39 @@ fn snapshot_cast_from_zone_constraint_into_effect(
         } => Some(c.clone()),
         _ => effective_cast_from_zone_constraint(ability),
     };
-    let Some(crate::types::ability::CastPermissionConstraint::ManaValue { comparator, value }) =
-        effective
-    else {
+    let frozen = freeze_cast_permission_constraint(state, ability, effective.clone());
+    if frozen == effective {
         return;
+    }
+    if let Effect::CastFromZone { constraint, .. } = &mut stash.effect {
+        *constraint = frozen;
+    }
+}
+
+// CR 608.2h: information a resolving effect requires is determined once, when
+// the effect is applied. A cast-permission MV constraint whose value is a
+// dynamic Ref (for example Variable("X") or a board aggregate) must be resolved
+// to a concrete value at application time and stored as Fixed — never re-read
+// when the permission is exercised.
+fn freeze_cast_permission_constraint(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    constraint: Option<CastPermissionConstraint>,
+) -> Option<CastPermissionConstraint> {
+    let (comparator, value) = match constraint {
+        Some(CastPermissionConstraint::ManaValue { comparator, value }) => (comparator, value),
+        other => return other,
     };
     if matches!(value, QuantityExpr::Fixed { .. }) {
-        return;
+        return Some(CastPermissionConstraint::ManaValue { comparator, value });
     }
     let resolved = crate::game::quantity::resolve_quantity_with_targets(state, &value, ability);
-    if let Effect::CastFromZone { constraint, .. } = &mut stash.effect {
-        *constraint = Some(crate::types::ability::CastPermissionConstraint::ManaValue {
-            comparator,
-            value: QuantityExpr::Fixed {
-                value: resolved.max(0),
-            },
-        });
-    }
+    Some(CastPermissionConstraint::ManaValue {
+        comparator,
+        value: QuantityExpr::Fixed {
+            value: resolved.max(0),
+        },
+    })
 }
 
 fn effective_cast_from_zone_constraint(
@@ -806,12 +911,29 @@ fn cast_single_target_during_resolution(
         subject: None,
     });
     // CR 702.62a's "if you don't, it remains exiled" disposition is `RemainExiled`
-    // (only reached if a future free-cast adds an MV gate; these carry none).
-    // There are no dig misses for a targeted single-card free-cast.
+    // for targeted single-card free casts. A library-peek pick instead bottoms
+    // its declined hit with all unchosen looked-at cards (CR 401.4).
+    let exiled_misses = if state
+        .objects
+        .get(&card)
+        .is_some_and(|object| object.zone == Zone::Library)
+    {
+        looked_at_controller_library_cards(state, ability.controller)
+            .into_iter()
+            .filter(|id| *id != card)
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let reject_action = if exiled_misses.is_empty() {
+        crate::types::ability::ResolutionMvRejectAction::RemainExiled
+    } else {
+        crate::types::ability::ResolutionMvRejectAction::BottomWithMisses
+    };
     let cleanup = crate::types::ability::ResolutionCastCleanup {
         source_id: ability.source_id,
-        exiled_misses: Vec::new(),
-        reject_action: crate::types::ability::ResolutionMvRejectAction::RemainExiled,
+        exiled_misses,
+        reject_action,
         success_action: crate::types::ability::ResolutionCastSuccessAction::BottomMisses,
     };
     let graveyard_replacement = cast_from_zone_graveyard_destination(ability);
@@ -1037,6 +1159,7 @@ fn record_lingering_permissions(
         ),
         _ => return Err(EffectError::MissingParam("CastFromZone".to_string())),
     };
+    let constraint = freeze_cast_permission_constraint(state, ability, constraint);
     let graveyard_replacement = cast_from_zone_graveyard_destination(ability);
     // CR 614.1c + CR 122.1: "the creature cast this way enters with a [counter]
     // counter on it" — recorded on the granted permission so the cast

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -4456,6 +4456,26 @@ pub(super) fn handle_resolution_choice(
                     // No decline fallback: the taken continuation is discarded —
                     // the subless decline consumes it without granting a
                     // permission (below).
+                    if zone == Zone::Library {
+                        // CR 401.4: declining the one-shot self-library peek
+                        // cast bottoms every looked-at card in a random order.
+                        // `library_position: None` is guaranteed by the sole
+                        // `open_private_zone_cast_selection` producer.
+                        let looked_at = effects::cast_from_zone::looked_at_controller_library_cards(
+                            state,
+                            ability.controller,
+                        );
+                        if matches!(
+                            effects::cascade::shuffle_to_bottom(
+                                state, &looked_at, source_id, None, events,
+                            ),
+                            crate::game::zone_pipeline::BatchMoveResult::NeedsChoice
+                        ) {
+                            return Ok(ResolutionChoiceOutcome::WaitingFor(
+                                state.waiting_for.clone(),
+                            ));
+                        }
+                    }
                 }
                 // CR 609.1 / CR 601.2a: Declining an optional Electrodominance-
                 // style hand cast consumes the stashed CastFromZone continuation

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -316,6 +316,21 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
     } else {
         HashSet::new()
     };
+    let effect_zone_library_visible: HashSet<ObjectId> = if let WaitingFor::EffectZoneChoice {
+        player,
+        zone: Zone::Library,
+        ref cards,
+        ..
+    } = filtered.waiting_for
+    {
+        if can_view_private_for_player(player) {
+            cards.iter().copied().collect()
+        } else {
+            HashSet::new()
+        }
+    } else {
+        HashSet::new()
+    };
     let drawn_choice_hand_cards: HashSet<ObjectId> =
         if let WaitingFor::DrawnThisTurnTopdeckChoice { ref cards, .. } = filtered.waiting_for {
             cards.iter().copied().collect()
@@ -389,6 +404,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
             || dig_visible.contains(&obj_id)
             || private_look_visible.contains(&obj_id)
             || search_visible.contains(&obj_id)
+            || effect_zone_library_visible.contains(&obj_id)
             // Heist (and any ChooseFromZoneChoice over a hidden zone) — see
             // `choose_from_zone_hidden_visible` above.
             || choose_from_zone_hidden_visible.contains(&obj_id)
@@ -1204,7 +1220,10 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         enters_modified_if: _,
     } = state.waiting_for
     {
-        if !can_view_private_for_player(player) && zone == Zone::Hand {
+        // `open_private_zone_cast_selection` is the sole Library producer and
+        // always writes `library_position: None`, so this pattern redacts every
+        // private library cast-choice payload for non-prompt viewers.
+        if !can_view_private_for_player(player) && matches!(zone, Zone::Hand | Zone::Library) {
             filtered.waiting_for = WaitingFor::EffectZoneChoice {
                 player,
                 cards: cards.iter().map(|_| ObjectId(0)).collect(),

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -2328,22 +2328,13 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
         }
     }
 
-    // CR 701.20a + CR 608.2c: A bare private "look at the top N cards" instruction
+    // CR 701.20e + CR 608.2c: A bare private "look at the top N cards" instruction
     // is only a look; it does not move a chosen card to hand. Continuations that
     // actually choose cards from among them patch destination/keep_count before this
     // pass. Anything still in the raw private-Dig shape is a pure peek: skip
     // DigChoice and only populate last_revealed_ids for downstream conditions.
     for def in &mut defs {
-        if let Effect::Dig {
-            reveal: false,
-            keep_count: None,
-            keep_count_expr: None,
-            filter: TargetFilter::Any,
-            destination: None,
-            rest_destination: None,
-            ..
-        } = &*def.effect
-        {
+        if super::effect_is_bare_private_peek(&def.effect) {
             if let Effect::Dig { keep_count, .. } = &mut *def.effect {
                 *keep_count = Some(0);
             }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -96,21 +96,22 @@ use crate::parser::oracle_effect::subject::parse_subject_application;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AggregateFunction,
-    BounceSelection, CardPlayMode, CastPermissionConstraint, CastingPermission, ChoiceType,
-    ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard, ConjureSource,
-    ContinuousModification, ControlWindow, ControllerRef, CopyChooseScope, CopyRetargetPermission,
-    CopyScale, DamageModification, DamageSource, DelayedTriggerCondition, DelayedTriggerLifetime,
-    DoubleTarget, Duration, Effect, EffectOutcomeSignal, EffectScope, FilterProp, GameRestriction,
-    GuessSubject, IntensityScope, IterationKindBinding, KeeperConstraint, LibraryPosition,
-    ManaProduction, ManaSpendPermission, MultiTargetSpec, NumberDistinctness, ObjectProperty,
-    ObjectScope, OriginConstraint, PlayPermissionInvalidation, PlayerFilter, PlayerRelation,
-    PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue, QuantityExpr,
-    QuantityRef, ReplacementCondition, ReplacementDefinition, RestrictionExpiry,
-    RestrictionPlayerScope, RevealUntilDisposition, RoundingMode, SharedQuality,
-    SharedQualityRelation, SkipScope, SpellStackToGraveyardReplacement, StaticCondition,
-    StaticDefinition, StepSkipTarget, SubAbilityLink, TapStateChange, TargetFilter,
-    TargetSelectionMode, ThisWayCause, TrackedAnaphorSource, TriggerCondition, TriggerDefinition,
-    TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition, ZoneOwner,
+    BounceSelection, CardPlayMode, CastFromZoneDriver, CastPermissionConstraint, CastingPermission,
+    ChoiceType, ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard,
+    ConjureSource, ContinuousModification, ControlWindow, ControllerRef, CopyChooseScope,
+    CopyRetargetPermission, CopyScale, DamageModification, DamageSource, DelayedTriggerCondition,
+    DelayedTriggerLifetime, DoubleTarget, Duration, Effect, EffectOutcomeSignal, EffectScope,
+    FilterProp, GameRestriction, GuessSubject, IntensityScope, IterationKindBinding,
+    KeeperConstraint, LibraryPosition, ManaProduction, ManaSpendPermission, MultiTargetSpec,
+    NumberDistinctness, ObjectProperty, ObjectScope, OriginConstraint, PlayPermissionInvalidation,
+    PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount, PreventionScope,
+    ProhibitedActivity, PtValue, QuantityExpr, QuantityRef, ReplacementCondition,
+    ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RevealUntilDisposition,
+    RoundingMode, SharedQuality, SharedQualityRelation, SkipScope,
+    SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, StepSkipTarget,
+    SubAbilityLink, TapStateChange, TargetFilter, TargetSelectionMode, ThisWayCause,
+    TrackedAnaphorSource, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
+    UnlessPayModifier, UntilCondition, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -20908,6 +20909,20 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
                 });
             }
         }
+        // CR 608.2g: a self-library peek ("look at the top N of your library,
+        // you may cast one from among them without paying its mana cost") is a
+        // genuine during-resolution cast of ONE, not an exile-and-grant. Route
+        // it to the one-shot DuringResolution driver; every other bare "from
+        // among them" anaphor keeps the LingeringPermission exile path.
+        let driver = if mode == CardPlayMode::Cast
+            && without_paying
+            && ctx.chain_prior_self_library_peek
+            && !ctx.chain_has_prior_exile_producer
+        {
+            CastFromZoneDriver::DuringResolution
+        } else {
+            CastFromZoneDriver::LingeringPermission
+        };
         return Some(Effect::CastFromZone {
             target: TargetFilter::ExiledBySource,
             without_paying_mana_cost: without_paying,
@@ -20916,7 +20931,7 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
             alt_ability_cost: None,
             constraint,
             duration: None,
-            driver: crate::types::ability::CastFromZoneDriver::LingeringPermission,
+            driver,
             mana_spend_permission: None,
         });
     }
@@ -21242,7 +21257,35 @@ fn parse_cast_permission_constraint(lower: &str) -> Option<CastPermissionConstra
     // "with mana value <comparator> <quantity>" pre-value prefix used by Cosmic
     // Cube. They cannot share a comparator combinator (suffix vs. prefix), so
     // dispatch over two sub-combinators.
-    parse_beseech_mv_constraint(lower).or_else(|| parse_with_mana_value_constraint(lower))
+    parse_beseech_mv_constraint(lower)
+        .or_else(|| parse_with_mana_value_constraint(lower))
+        .or_else(|| parse_dig_peek_suffix_mv_constraint(lower))
+}
+
+/// Dig-peek-family constraint: `... from among them ... with mana value N or less`.
+/// CR 202.3: mana value is the comparison subject. CR 601.2e: the suffix gates
+/// cast legality. The `from among them` guard excludes unrelated mana-value
+/// suffixes, including total-mana-value caps.
+fn parse_dig_peek_suffix_mv_constraint(lower: &str) -> Option<CastPermissionConstraint> {
+    type E<'a> = OracleError<'a>;
+    if !nom_primitives::scan_contains(lower, "from among them") {
+        return None;
+    }
+    let (after_anchor, _) = many_till(anychar, tag::<_, _, E>("with mana value "))
+        .parse(lower)
+        .ok()?;
+    let (after_value, quantity) = nom_quantity::parse_quantity_expr_number(after_anchor).ok()?;
+    let after_value = after_value.trim_start();
+    let (_, comparator) = alt((
+        value(Comparator::LE, tag::<_, _, E>("or less")),
+        value(Comparator::GE, tag("or greater")),
+    ))
+    .parse(after_value)
+    .ok()?;
+    Some(CastPermissionConstraint::ManaValue {
+        comparator,
+        value: quantity,
+    })
 }
 
 /// Beseech-family constraint: `... if that spell's mana value is N or less`.
@@ -23030,6 +23073,41 @@ fn clause_ir_is_exile_producer(clause: &ClauseIr) -> bool {
     chain_clause_is_exile_producer(&clause.parsed.effect)
         || continuation_is_exile_producer(clause.disposition.followup())
         || continuation_is_exile_producer(clause.disposition.intrinsic())
+}
+
+/// CR 701.20e + CR 608.2c: the RAW "look at the top N cards" shape a private
+/// peek carries BEFORE the assembly pure-peek lowering stamps `keep_count =
+/// Some(0)`. Single authority shared by the assembly lowering match and the
+/// `ClauseIr` seed predicate so the two sites cannot drift on which `Dig` shape
+/// counts as a bare peek.
+pub(super) fn effect_is_bare_private_peek(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::Dig {
+            reveal: false,
+            keep_count: None,
+            keep_count_expr: None,
+            filter: TargetFilter::Any,
+            destination: None,
+            rest_destination: None,
+            ..
+        }
+    )
+}
+
+/// A "look at the top N cards of your library" peek: a RAW `Dig` that reveals
+/// nothing, keeps nothing, moves nothing, and reads the controller's own
+/// library. CR 701.20e — looking leaves the cards in the library.
+fn clause_ir_is_self_library_peek(clause: &ClauseIr) -> bool {
+    effect_is_bare_private_peek(&clause.parsed.effect)
+        && matches!(
+            &clause.parsed.effect,
+            Effect::Dig {
+                player: TargetFilter::Controller,
+                source,
+                ..
+            } if source.is_library()
+        )
 }
 
 /// CR 400.1/400.2 + CR 608.2c: If this clause is an `Effect::RevealHand`
@@ -28275,6 +28353,10 @@ pub(crate) fn parse_effect_chain_ir(
                 .clauses()
                 .iter()
                 .any(clause_ir_is_exile_producer),
+            chain_prior_self_library_peek: builder
+                .clauses()
+                .iter()
+                .any(clause_ir_is_self_library_peek),
             // CR 400.1/400.2 + CR 608.2c: most-recent earlier same-chain
             // `RevealHand` target, so a later "cast a spell from among those
             // cards" anaphor (Silent-Blade Oni) binds to that player's hand

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -261,6 +261,13 @@ pub(crate) struct ParseContext {
     /// `ParentTarget` — it must inherit the population FILTER itself. `None` when
     /// no such producer exists in this chain, or during standalone clause parsing.
     pub chain_prior_mass_population: Option<TargetFilter>,
+    /// True when the SAME chain's most recent producer was a self-library peek
+    /// (look at the top N cards of YOUR library without exiling/moving them).
+    /// The bare "from among them" cast anaphor that follows must route to the
+    /// one-shot during-resolution cast (CR 608.2g), not the exile-and-grant
+    /// lingering path. Mirrors `chain_has_prior_exile_producer`.
+    // CR 608.2g + CR 701.20e
+    pub chain_prior_self_library_peek: bool,
 }
 
 impl ParseContext {

--- a/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
+++ b/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
@@ -1,0 +1,745 @@
+//! Regression coverage for self-library "look ... cast from among them" chains.
+//!
+//! These tests exercise production Oracle parsing and the resolution-time cast
+//! path. They distinguish that one-shot private-library flow from the durable
+//! exile permission used by ordinary impulse-draw chains.
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::visibility::filter_state_for_viewer;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, CastFromZoneDriver, CastPermissionConstraint, Comparator, Effect,
+    ObjectScope, QuantityExpr, QuantityRef, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const KIORA: &str = "Vigilance, ward {3}\nWhenever you cast a Kraken, Leviathan, Octopus, or Serpent spell from your hand, look at the top X cards of your library, where X is that spell's mana value. You may cast a spell with mana value less than X from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.";
+const AETHERWORKS_MARVEL: &str = "Whenever a permanent you control is put into a graveyard, you get {E} (an energy counter).\n{T}, Pay six {E}: Look at the top six cards of your library. You may cast a spell from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.";
+const COSMIC_CUBE: &str = "Ward {2}\nWhenever you attack, look at the top six cards of your library. You may cast a spell from among them with mana value less than or equal to the greatest power among attacking creatures you control without paying its mana cost. Put the rest on the bottom of your library in a random order.";
+const BOBBLEHEAD: &str = "{T}: Add one mana of any color.\n{3}, {T}: Look at the top X cards of your library, where X is the number of Bobbleheads you control. You may cast a spell with mana value 3 or less from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.\n{3}, {T}: Create a colorless snow artifact token named Icy Manalith with \"{T}: Add one mana of any color.\"";
+const SVELLA: &str = "{6}{R}{G}, {T}: Look at the top four cards of your library. You may cast a spell from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.";
+const VELOMACHUS: &str = "Flying, vigilance, haste\nWhenever Velomachus Lorehold attacks, look at the top seven cards of your library. You may cast an instant or sorcery spell with mana value less than or equal to Velomachus Lorehold's power from among them without paying its mana cost. Put the rest on the bottom of your library in a random order.";
+const APEX: &str = "Exile the top seven cards of your library. Until end of turn, you may cast spells from among them.\nIf this spell was cast from your hand, add ten mana of any one color.";
+const TALENT: &str = "Target opponent reveals the top seven cards of their library. You may cast an instant or sorcery spell from among them without paying its mana cost. Then that player puts the rest into their graveyard.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, you may cast up to two instant and/or sorcery spells from among the revealed cards instead of one.";
+const JACE: &str = "Flying\nWhen Jace's Mindseeker enters, target opponent mills five cards. You may cast an instant or sorcery spell from among them without paying its mana cost.";
+const SILENT_BLADE: &str = "Ninjutsu {4}{U}{B} ({4}{U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever this creature deals combat damage to a player, look at that player's hand. You may cast a spell from among those cards without paying its mana cost.";
+const EPIC_EXPERIMENT: &str = "Exile the top X cards of your library. You may cast instant and sorcery spells with mana value X or less from among them without paying their mana costs. Then put all cards exiled this way that weren't cast into your graveyard.";
+const COLLECTED_CONJURING: &str = "Exile the top six cards of your library. You may cast up to two sorcery spells with mana value 3 or less from among them without paying their mana costs. Put the exiled cards not cast this way on the bottom of your library in a random order.";
+const HAZORET: &str = "Shuffle your library, then exile the top four cards. You may cast any number of spells with mana value 5 or less from among them without paying their mana costs. Lands you control don't untap during your next untap step.";
+const PRIMEVAL_SPAWN: &str = "Vigilance, trample, lifelink\nWhen Primeval Spawn leaves the battlefield, exile the top ten cards of your library. You may cast any number of spells with total mana value 10 or less from among them without paying their mana costs.";
+const CAPSTONE: &str = "Exile cards from the top of your library until you exile cards with total mana value 4 or greater. You may cast any number of spells from among them without paying their mana costs.";
+const FOUNDING: &str = "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI — You may cast an instant or sorcery spell with mana value 1 or 2 from your hand without paying its mana cost.\nII — Target player mills four cards.\nIII — Exile target instant or sorcery card from your graveyard. Copy it. You may cast the copy.";
+
+fn parse(oracle: &str, name: &str, types: &[&str]) -> engine::parser::oracle::ParsedAbilities {
+    parse_oracle_text(
+        oracle,
+        name,
+        &[],
+        &types.iter().map(|ty| ty.to_string()).collect::<Vec<_>>(),
+        &[],
+    )
+}
+
+fn cast_from_zone_in(definition: &AbilityDefinition) -> Option<&Effect> {
+    if matches!(definition.effect.as_ref(), Effect::CastFromZone { .. }) {
+        return Some(definition.effect.as_ref());
+    }
+    definition
+        .sub_ability
+        .as_deref()
+        .and_then(cast_from_zone_in)
+}
+
+fn parsed_cast_from_zone(parsed: &engine::parser::oracle::ParsedAbilities) -> &Effect {
+    parsed
+        .abilities
+        .iter()
+        .find_map(cast_from_zone_in)
+        .or_else(|| {
+            parsed
+                .triggers
+                .iter()
+                .filter_map(|trigger| trigger.execute.as_deref())
+                .find_map(cast_from_zone_in)
+        })
+        .expect("exact Oracle text must parse a real CastFromZone effect")
+}
+
+fn has_self_library_peek(definition: &AbilityDefinition) -> bool {
+    matches!(
+        definition.effect.as_ref(),
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            destination: None,
+            keep_count: Some(0),
+            reveal: false,
+            source,
+            ..
+        } if source.is_library()
+    ) || definition
+        .sub_ability
+        .as_deref()
+        .is_some_and(has_self_library_peek)
+}
+
+#[test]
+fn self_library_peek_casts_route_during_resolution() {
+    for (name, oracle, types) in [
+        ("Kiora, Sovereign of the Deep", KIORA, &["Creature"][..]),
+        ("Aetherworks Marvel", AETHERWORKS_MARVEL, &["Artifact"][..]),
+        ("Construct a Cosmic Cube", COSMIC_CUBE, &["Artifact"][..]),
+        ("Perception Bobblehead", BOBBLEHEAD, &["Artifact"][..]),
+        ("Svella, Ice Shaper", SVELLA, &["Creature"][..]),
+        ("Velomachus Lorehold", VELOMACHUS, &["Creature"][..]),
+    ] {
+        let parsed = parse(oracle, name, types);
+        assert!(
+            parsed.abilities.iter().any(has_self_library_peek)
+                || parsed
+                    .triggers
+                    .iter()
+                    .filter_map(|trigger| trigger.execute.as_deref())
+                    .any(has_self_library_peek),
+            "{name} must first parse its self-library Dig producer"
+        );
+        assert!(
+            matches!(
+                parsed_cast_from_zone(&parsed),
+                Effect::CastFromZone {
+                    driver: CastFromZoneDriver::DuringResolution,
+                    ..
+                }
+            ),
+            "{name} must use the one-shot DuringResolution driver"
+        );
+    }
+}
+
+#[test]
+fn self_library_peek_constraints_are_retained() {
+    let kiora = parse(KIORA, "Kiora, Sovereign of the Deep", &["Creature"]);
+    assert!(matches!(
+        parsed_cast_from_zone(&kiora),
+        Effect::CastFromZone {
+            constraint: Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::LT,
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectManaValue {
+                        scope: ObjectScope::EventSource,
+                    },
+                },
+            }),
+            ..
+        }
+    ));
+
+    let bobblehead = parse(BOBBLEHEAD, "Perception Bobblehead", &["Artifact"]);
+    assert!(matches!(
+        parsed_cast_from_zone(&bobblehead),
+        Effect::CastFromZone {
+            constraint: Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::LE,
+                value: QuantityExpr::Fixed { value: 3 },
+            }),
+            ..
+        }
+    ));
+
+    for (name, oracle, types, expected_constraint) in [
+        (
+            "Aetherworks Marvel",
+            AETHERWORKS_MARVEL,
+            &["Artifact"][..],
+            false,
+        ),
+        ("Svella, Ice Shaper", SVELLA, &["Creature"][..], false),
+        (
+            "Construct a Cosmic Cube",
+            COSMIC_CUBE,
+            &["Artifact"][..],
+            true,
+        ),
+        ("Velomachus Lorehold", VELOMACHUS, &["Creature"][..], true),
+    ] {
+        let parsed = parse(oracle, name, types);
+        let Effect::CastFromZone { constraint, .. } = parsed_cast_from_zone(&parsed) else {
+            unreachable!("helper returns CastFromZone")
+        };
+        assert_eq!(
+            constraint.is_some(),
+            expected_constraint,
+            "{name} constraint shape"
+        );
+    }
+}
+
+#[test]
+fn non_library_peek_anaphors_stay_lingering_permissions() {
+    for (name, oracle, types) in [
+        ("Apex of Power", APEX, &["Sorcery"][..]),
+        ("Talent of the Telepath", TALENT, &["Sorcery"][..]),
+        ("Jace's Mindseeker", JACE, &["Creature"][..]),
+        ("Silent-Blade Oni", SILENT_BLADE, &["Creature"][..]),
+    ] {
+        let parsed = parse(oracle, name, types);
+        assert!(matches!(
+            parsed_cast_from_zone(&parsed),
+            Effect::CastFromZone {
+                driver: CastFromZoneDriver::LingeringPermission,
+                ..
+            }
+        ));
+    }
+}
+
+#[test]
+fn dig_peek_suffix_constraints_and_negative_siblings() {
+    for (name, oracle, expected) in [
+        ("Collected Conjuring", COLLECTED_CONJURING, 3),
+        ("Hazoret's Undying Fury", HAZORET, 5),
+    ] {
+        let parsed = parse(oracle, name, &["Sorcery"]);
+        assert!(matches!(
+            parsed_cast_from_zone(&parsed),
+            Effect::CastFromZone {
+                constraint: Some(CastPermissionConstraint::ManaValue {
+                    comparator: Comparator::LE,
+                    value: QuantityExpr::Fixed { value },
+                }),
+                ..
+            } if *value == expected
+        ));
+    }
+
+    let epic = parse(EPIC_EXPERIMENT, "Epic Experiment", &["Sorcery"]);
+    assert!(matches!(
+        parsed_cast_from_zone(&epic),
+        Effect::CastFromZone {
+            driver: CastFromZoneDriver::LingeringPermission,
+            constraint: Some(CastPermissionConstraint::ManaValue {
+                comparator: Comparator::LE,
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { name },
+                },
+            }),
+            ..
+        } if name == "X"
+    ));
+
+    for (name, oracle) in [
+        ("Primeval Spawn", PRIMEVAL_SPAWN),
+        ("Improvisation Capstone", CAPSTONE),
+        ("Founding the Third Path", FOUNDING),
+    ] {
+        let parsed = parse(oracle, name, &["Sorcery"]);
+        let Effect::CastFromZone { constraint, .. } = parsed_cast_from_zone(&parsed) else {
+            unreachable!("helper returns CastFromZone")
+        };
+        assert!(
+            constraint.is_none(),
+            "{name} must not gain this suffix constraint"
+        );
+    }
+}
+
+fn reach_kiora_library_choice() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Kiora, Sovereign of the Deep", 4, 5)
+        .from_oracle_text_with_keywords(&["vigilance", "ward {3}"], KIORA);
+    let legal = scenario
+        .add_spell_to_library_top(P0, "Kiora Legal Spell", false)
+        .with_mana_cost(ManaCost::generic(1))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let rest = scenario
+        .add_spell_to_library_top(P0, "Kiora Illegal Spell", false)
+        .with_mana_cost(ManaCost::generic(2))
+        .from_oracle_text("You gain 2 life.")
+        .id();
+    let kraken = scenario
+        .add_creature_to_hand(P0, "Triggering Kraken", 2, 2)
+        .with_subtypes(vec!["Kraken"])
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..2)
+            .map(|_| ManaUnit::new(ManaType::Colorless, kraken, false, vec![]))
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    runner.cast(kraken).commit();
+    runner.resolve_top();
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting Kiora's optional cast must succeed");
+    (runner, legal, rest)
+}
+
+#[test]
+fn kiora_accept_casts_during_resolution_and_bottoms_the_rest() {
+    let (mut runner, legal, rest) = reach_kiora_library_choice();
+    let WaitingFor::EffectZoneChoice { cards, zone, .. } = runner.state().waiting_for.clone()
+    else {
+        panic!("Kiora must park the private library choice")
+    };
+    assert_eq!(zone, Zone::Library);
+    assert_eq!(cards, vec![legal], "MV equal to X is not legal for Kiora");
+    runner
+        .act(GameAction::SelectCards { cards: vec![legal] })
+        .expect("choosing Kiora's legal spell must succeed");
+    assert_eq!(runner.state().objects[&legal].zone, Zone::Stack);
+    assert_eq!(runner.state().objects[&rest].zone, Zone::Library);
+    assert!(
+        runner.state().objects[&rest].casting_permissions.is_empty(),
+        "the unchosen library card must not receive a cast permission"
+    );
+}
+
+#[test]
+fn kiora_decline_bottoms_every_looked_at_card_without_a_permission() {
+    let (mut runner, legal, rest) = reach_kiora_library_choice();
+    let WaitingFor::EffectZoneChoice { cards, zone, .. } = runner.state().waiting_for.clone()
+    else {
+        panic!("Kiora decline must reach the private library choice")
+    };
+    assert_eq!(zone, Zone::Library);
+    assert_eq!(cards, vec![legal]);
+
+    runner
+        .act(GameAction::SelectCards { cards: vec![] })
+        .expect("declining Kiora's cast must succeed");
+
+    assert_eq!(runner.state().objects[&legal].zone, Zone::Library);
+    assert_eq!(runner.state().objects[&rest].zone, Zone::Library);
+    assert!(
+        runner.state().objects[&legal]
+            .casting_permissions
+            .is_empty()
+            && runner.state().objects[&rest].casting_permissions.is_empty(),
+        "declining the one-shot cast must leave no standing permission"
+    );
+}
+
+#[test]
+fn kiora_zero_eligible_cards_bottom_without_parking_a_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Kiora, Sovereign of the Deep", 4, 5)
+        .from_oracle_text_with_keywords(&["vigilance", "ward {3}"], KIORA);
+    let equal_to_x = scenario
+        .add_spell_to_library_top(P0, "Kiora Equal Spell", false)
+        .with_mana_cost(ManaCost::generic(1))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let kraken = scenario
+        .add_creature_to_hand(P0, "One-Mana Triggering Kraken", 1, 1)
+        .with_subtypes(vec!["Kraken"])
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(ManaType::Colorless, kraken, false, vec![])],
+    );
+
+    let mut runner = scenario.build();
+    runner.cast(kraken).commit();
+    runner.resolve_top();
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting Kiora's optional cast must succeed");
+
+    assert_eq!(
+        runner.state().last_revealed_ids,
+        vec![equal_to_x],
+        "Kiora's look must run before the empty eligible pool auto-bottoms"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::EffectZoneChoice { .. }
+        ),
+        "no legal MV < X spell must not open an empty choice"
+    );
+    assert_eq!(runner.state().objects[&equal_to_x].zone, Zone::Library);
+    assert!(
+        runner.state().objects[&equal_to_x]
+            .casting_permissions
+            .is_empty(),
+        "an ineligible looked-at card must not receive a permission"
+    );
+}
+
+fn reach_kiora_multi_candidate_choice() -> (GameRunner, ObjectId, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Kiora, Sovereign of the Deep", 4, 5)
+        .from_oracle_text_with_keywords(&["vigilance", "ward {3}"], KIORA);
+    let legal_one = scenario
+        .add_spell_to_library_top(P0, "Kiora Legal One", false)
+        .with_mana_cost(ManaCost::generic(1))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let legal_two = scenario
+        .add_spell_to_library_top(P0, "Kiora Legal Two", false)
+        .with_mana_cost(ManaCost::generic(1))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let equal_to_x = scenario
+        .add_spell_to_library_top(P0, "Kiora Equal Spell", false)
+        .with_mana_cost(ManaCost::generic(3))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let kraken = scenario
+        .add_creature_to_hand(P0, "Triggering Kraken", 3, 3)
+        .with_subtypes(vec!["Kraken"])
+        .with_mana_cost(ManaCost::generic(3))
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..3)
+            .map(|_| ManaUnit::new(ManaType::Colorless, kraken, false, vec![]))
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    runner.cast(kraken).commit();
+    runner.resolve_top();
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting Kiora's optional cast must succeed");
+    (runner, legal_one, legal_two, equal_to_x)
+}
+
+#[test]
+fn kiora_multi_candidate_choice_casts_exactly_one_and_bottoms_the_rest() {
+    let (mut runner, legal_one, legal_two, equal_to_x) = reach_kiora_multi_candidate_choice();
+    let library_before = runner.state().players[P0.0 as usize].library.len();
+    let WaitingFor::EffectZoneChoice { cards, zone, .. } = runner.state().waiting_for.clone()
+    else {
+        panic!("multiple eligible Kiora cards must reach the private choice")
+    };
+    assert_eq!(zone, Zone::Library);
+    assert_eq!(cards.len(), 2);
+    assert!(cards.contains(&legal_one) && cards.contains(&legal_two));
+    assert!(!cards.contains(&equal_to_x));
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![legal_one],
+        })
+        .expect("choosing one of Kiora's eligible spells must succeed");
+
+    assert_eq!(runner.state().objects[&legal_one].zone, Zone::Stack);
+    assert_eq!(runner.state().objects[&legal_two].zone, Zone::Library);
+    assert_eq!(runner.state().objects[&equal_to_x].zone, Zone::Library);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].library.len(),
+        library_before - 1,
+        "exactly the selected spell leaves the looked-at library set"
+    );
+}
+
+#[test]
+fn kiora_bottom_order_is_deterministic_under_a_fixed_seed() {
+    let run_once = || {
+        let mut scenario = GameScenario::new_with_format(FormatConfig::standard(), 2, 42);
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario
+            .add_creature(P0, "Kiora, Sovereign of the Deep", 4, 5)
+            .from_oracle_text_with_keywords(&["vigilance", "ward {3}"], KIORA);
+        for name in ["Kiora First", "Kiora Second", "Kiora Third"] {
+            scenario
+                .add_spell_to_library_top(P0, name, false)
+                .with_mana_cost(ManaCost::generic(1))
+                .from_oracle_text("You gain 1 life.");
+        }
+        let kraken = scenario
+            .add_creature_to_hand(P0, "Three-Mana Triggering Kraken", 3, 3)
+            .with_subtypes(vec!["Kraken"])
+            .with_mana_cost(ManaCost::generic(3))
+            .id();
+        scenario.with_mana_pool(
+            P0,
+            (0..3)
+                .map(|_| ManaUnit::new(ManaType::Colorless, kraken, false, vec![]))
+                .collect(),
+        );
+
+        let mut runner = scenario.build();
+        runner.cast(kraken).commit();
+        runner.resolve_top();
+        runner
+            .act(GameAction::DecideOptionalEffect { accept: true })
+            .expect("accepting Kiora's optional cast must succeed");
+        let WaitingFor::EffectZoneChoice { cards, zone, .. } = runner.state().waiting_for.clone()
+        else {
+            panic!("three looked-at Kiora cards must reach the private choice")
+        };
+        assert_eq!(zone, Zone::Library);
+        assert_eq!(cards.len(), 3);
+        runner
+            .act(GameAction::SelectCards { cards: vec![] })
+            .expect("declining Kiora's cast must bottom the looked-at cards");
+        runner.state().players[P0.0 as usize].library.clone()
+    };
+
+    assert_eq!(
+        run_once(),
+        run_once(),
+        "the same seeded Kiora setup must randomize its bottom order deterministically"
+    );
+}
+
+#[test]
+fn svella_activated_peek_casts_one_spell_and_bottoms_the_rest() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let svella = scenario
+        .add_creature(P0, "Svella, Ice Shaper", 2, 4)
+        .from_oracle_text(SVELLA)
+        .id();
+    let chosen = scenario
+        .add_spell_to_library_top(P0, "Svella Chosen Spell", false)
+        .with_mana_cost(ManaCost::generic(1))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let rest = scenario
+        .add_spell_to_library_top(P0, "Svella Rest Spell", false)
+        .with_mana_cost(ManaCost::generic(4))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..6)
+            .map(|_| ManaUnit::new(ManaType::Colorless, svella, false, vec![]))
+            .chain([
+                ManaUnit::new(ManaType::Red, svella, false, vec![]),
+                ManaUnit::new(ManaType::Green, svella, false, vec![]),
+            ])
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    let outcome = runner.activate(svella, 0).accept_optional().resolve();
+    let WaitingFor::EffectZoneChoice { cards, zone, .. } = outcome.final_waiting_for() else {
+        panic!("Svella's activated ability must reach the library cast choice")
+    };
+    assert_eq!(*zone, Zone::Library);
+    assert!(cards.contains(&chosen) && cards.contains(&rest));
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![chosen],
+        })
+        .expect("choosing Svella's free spell must succeed");
+    assert_eq!(runner.state().objects[&chosen].zone, Zone::Stack);
+    assert_eq!(runner.state().objects[&rest].zone, Zone::Library);
+}
+
+#[test]
+fn perception_bobblehead_excludes_mana_value_four() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let bobblehead = scenario
+        .add_creature(P0, "Perception Bobblehead", 1, 1)
+        .as_artifact()
+        .with_subtypes(vec!["Bobblehead"])
+        .from_oracle_text(BOBBLEHEAD)
+        .id();
+    scenario
+        .add_creature(P0, "Perception Bobblehead", 1, 1)
+        .as_artifact()
+        .with_subtypes(vec!["Bobblehead"]);
+    let mana_value_three = scenario
+        .add_spell_to_library_top(P0, "Bobblehead MV3", false)
+        .with_mana_cost(ManaCost::generic(3))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let mana_value_four = scenario
+        .add_spell_to_library_top(P0, "Bobblehead MV4", false)
+        .with_mana_cost(ManaCost::generic(4))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..3)
+            .map(|_| ManaUnit::new(ManaType::Colorless, bobblehead, false, vec![]))
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    let look_ability_index = runner.state().objects[&bobblehead]
+        .abilities
+        .iter()
+        .position(|definition| matches!(definition.effect.as_ref(), Effect::Dig { .. }))
+        .expect("the verbatim Bobblehead Oracle text must produce its look ability");
+    let outcome = runner
+        .activate(bobblehead, look_ability_index)
+        .accept_optional()
+        .resolve();
+    let WaitingFor::EffectZoneChoice { cards, zone, .. } = outcome.final_waiting_for() else {
+        panic!("Bobblehead's look must reach a library cast choice")
+    };
+    assert_eq!(*zone, Zone::Library);
+    assert!(cards.contains(&mana_value_three));
+    assert!(
+        !cards.contains(&mana_value_four),
+        "Bobblehead's fixed mana-value cap must exclude MV 4"
+    );
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![mana_value_three],
+        })
+        .expect("choosing the MV 3 Bobblehead spell must succeed");
+    assert_eq!(runner.state().objects[&mana_value_three].zone, Zone::Stack);
+    assert_eq!(runner.state().objects[&mana_value_four].zone, Zone::Library);
+}
+
+#[test]
+fn velomachus_power_constraint_is_frozen_before_the_library_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::DeclareAttackers);
+    let velomachus = scenario
+        .add_creature(P0, "Velomachus Lorehold", 5, 5)
+        .from_oracle_text_with_keywords(&["flying", "vigilance", "haste"], VELOMACHUS)
+        .id();
+    let mana_value_five = scenario
+        .add_spell_to_library_top(P0, "Velomachus MV5", false)
+        .with_mana_cost(ManaCost::generic(5))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let mana_value_six = scenario
+        .add_spell_to_library_top(P0, "Velomachus MV6", false)
+        .with_mana_cost(ManaCost::generic(6))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    for index in 0..5 {
+        scenario
+            .add_spell_to_library_top(P0, &format!("Velomachus Filler {index}"), false)
+            .with_mana_cost(ManaCost::generic(6))
+            .from_oracle_text("You gain 1 life.");
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().waiting_for = WaitingFor::DeclareAttackers {
+        player: P0,
+        valid_attacker_ids: vec![velomachus],
+        valid_attack_targets: vec![AttackTarget::Player(P1)],
+        valid_attack_targets_by_attacker: None,
+        attacker_constraints: Default::default(),
+    };
+    runner
+        .declare_attackers(&[(velomachus, AttackTarget::Player(P1))])
+        .expect("Velomachus must be able to attack");
+    runner.resolve_top();
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting Velomachus's optional cast must succeed");
+
+    let WaitingFor::EffectZoneChoice { cards, zone, .. } = runner.state().waiting_for.clone()
+    else {
+        panic!("Velomachus's attack trigger must reach the library cast choice")
+    };
+    assert_eq!(zone, Zone::Library);
+    assert!(cards.contains(&mana_value_five));
+    assert!(
+        !cards.contains(&mana_value_six),
+        "Velomachus at power 5 must exclude a mana-value 6 spell"
+    );
+}
+
+#[test]
+fn epic_experiment_freezes_x_for_the_lingering_cast_permission() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let epic = scenario
+        .add_spell_to_hand_from_oracle(P0, "Epic Experiment", false, EPIC_EXPERIMENT)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::X],
+            generic: 0,
+        })
+        .id();
+    let mana_value_two = scenario
+        .add_spell_to_library_top(P0, "Epic MV2", false)
+        .with_mana_cost(ManaCost::generic(2))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    let mana_value_three = scenario
+        .add_spell_to_library_top(P0, "Epic MV3", false)
+        .with_mana_cost(ManaCost::generic(3))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..2)
+            .map(|_| ManaUnit::new(ManaType::Colorless, epic, false, vec![]))
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    let outcome = runner
+        .cast(epic)
+        .x(2)
+        .accept_optional()
+        .effect_zone(&[mana_value_two])
+        .resolve();
+
+    assert!(
+        !matches!(
+            outcome.final_waiting_for(),
+            WaitingFor::EffectZoneChoice { .. }
+        ),
+        "Epic's selected MV 2 spell must be accepted rather than leaving the cast choice parked"
+    );
+    assert_eq!(
+        runner.state().objects[&mana_value_two].zone,
+        Zone::Graveyard
+    );
+    assert_eq!(
+        runner.state().objects[&mana_value_three].zone,
+        Zone::Graveyard
+    );
+}
+
+#[test]
+fn kiora_library_choice_is_private_across_serde_round_trip() {
+    let (runner, legal, rest) = reach_kiora_library_choice();
+    let controller = filter_state_for_viewer(runner.state(), P0);
+    let opponent = filter_state_for_viewer(runner.state(), P1);
+    let WaitingFor::EffectZoneChoice { cards, .. } = &controller.waiting_for else {
+        panic!("controller must retain Kiora's library choice")
+    };
+    assert_eq!(cards, &vec![legal]);
+    assert_eq!(controller.objects[&legal].name, "Kiora Legal Spell");
+    let WaitingFor::EffectZoneChoice { cards, .. } = &opponent.waiting_for else {
+        panic!("opponent still sees a redacted choice envelope")
+    };
+    assert!(cards.iter().all(|id| *id == ObjectId(0)));
+    assert_eq!(opponent.objects[&legal].name, "Hidden Card");
+    assert_eq!(opponent.objects[&rest].name, "Hidden Card");
+
+    let restored: engine::types::game_state::GameState = serde_json::from_str(
+        &serde_json::to_string(runner.state()).expect("parked state serializes"),
+    )
+    .expect("parked state deserializes");
+    let restored_opponent = filter_state_for_viewer(&restored, P1);
+    let WaitingFor::EffectZoneChoice { cards, .. } = &restored_opponent.waiting_for else {
+        panic!("restored opponent view must retain redaction")
+    };
+    assert!(cards.iter().all(|id| *id == ObjectId(0)));
+    assert_eq!(restored_opponent.objects[&legal].name, "Hidden Card");
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -600,6 +600,7 @@ mod kaya_spirits_justice_per_opponent_exile;
 mod kaysa_green_anthem;
 mod kibo_uktabi_prince_defending_player_sacrifice;
 mod kilo_live_offer_from_real_dump;
+mod kiora_self_library_peek_cast;
 mod knighthood_first_strike_grant;
 mod knollspine_dragon_target_damage_draw;
 mod kodama_anti_recursion_intervening_if;


### PR DESCRIPTION
Self-library peek-and-cast cards (Kiora Sovereign of the Deep, Aetherworks
Marvel, Construct a Cosmic Cube, Perception Bobblehead, Svella Ice Shaper,
Velomachus Lorehold) previously routed "cast ... from among them" through the
LingeringPermission driver: the looked-at cards were exiled, the free cast was
never offered, and the rest were never bottomed.

- Parser: seed chain_prior_self_library_peek from the raw bare-private-peek
  Dig shape via a single shared effect_is_bare_private_peek predicate (also
  used by the assembly pure-peek lowering, so the two sites cannot drift);
  flip the "from among them" fall-through to CastFromZoneDriver::
  DuringResolution when the chain has a self-library peek and no exile
  producer (CR 608.2g).
- Parser: parse the "with mana value N or less/greater" dig-peek suffix into
  a typed cast-permission constraint (fixes Perception Bobblehead's dropped
  MV<=3 cap; Founding the Third Path stays constraint-free).
- Resolver: park an EffectZoneChoice on the Library for eligible candidates,
  freeze dynamic constraint refs (X, power) to Fixed at binding time
  (CR 608.2h), cast the chosen spell during resolution, and bottom the rest
  in a random order on accept, decline, and zero-eligible paths (CR 401.4).
- Resolver: gate the pre-injected-target library route on
  references_exiled_by_source() so Planetarium of Wan Shi Tong's
  ParentTarget flow keeps its direct free cast.
- Visibility: the prompt player sees the looked-at Library cards; opponents
  get redacted placeholders across serde round-trips (CR 701.20e, CR 400.2).

Fixes the Discord bug report (thread 1529132485668245575).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for privately looking at cards from your library and casting eligible cards from among them.
  * Added accurate filtering for cast permissions and mana-value restrictions.
  * Library choices now remain private to the appropriate player.
  * When no eligible card is available, looked-at cards are properly returned to the bottom of the library.

* **Bug Fixes**
  * Fixed handling of one-shot casts, lingering permissions, and library-peek cleanup.
  * Corrected parsing for “from among them” effects and related mana-value constraints.

* **Tests**
  * Added comprehensive coverage for parsing, privacy, eligibility, constraint freezing, and library ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->