### PR TITLE
fix(ci): gate nightly CI-wait on the nearest ci-relevant ancestor for paths-filtered tips

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -350,12 +350,38 @@ jobs:
           RELEASE_SHA=$(git rev-parse HEAD)
           deadline=$((SECONDS + 3600))
 
+          # ci.yml's push trigger is paths-filtered, so a tip commit that touches
+          # none of those paths (workflow chores, docs) never gets a push run and
+          # waiting on its SHA times out after an hour. The code state of such a
+          # commit is identical to its nearest ancestor that DID touch a filtered
+          # path, so that ancestor's run is the honest gate — walk first-parents
+          # to it and wait on that SHA instead. Keep this pattern list in sync
+          # with the push.paths filter in ci.yml.
+          touches_ci_paths() {
+            git diff-tree --no-commit-id --name-only -r "$1" | grep -qE \
+              '^(crates/|client/|lobby-worker/|scripts/|Cargo\.|\.cargo/|Dockerfile$|\.dockerignore$|docker/|\.github/actions/|\.github/workflows/(ci|deploy|release)\.yml$)'
+          }
+          WAIT_SHA=$RELEASE_SHA
+          if ! touches_ci_paths "$WAIT_SHA"; then
+            for _ in $(seq 1 50); do
+              WAIT_SHA=$(git rev-parse "$WAIT_SHA^")
+              if touches_ci_paths "$WAIT_SHA"; then
+                break
+              fi
+            done
+            if ! touches_ci_paths "$WAIT_SHA"; then
+              echo "::error::No CI-relevant ancestor found within 50 commits of $RELEASE_SHA"
+              exit 1
+            fi
+            echo "Release commit $RELEASE_SHA touches no ci.yml paths; gating on ancestor $WAIT_SHA instead"
+          fi
+
           while [ "$SECONDS" -lt "$deadline" ]; do
             RUNS=$(gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \
               -f branch=main \
               -f event=push \
               -f per_page=20)
-            MATCH=$(jq -r --arg sha "$RELEASE_SHA" '
+            MATCH=$(jq -r --arg sha "$WAIT_SHA" '
               [
                 .workflow_runs[]
                 | select(.head_sha == $sha)
@@ -376,7 +402,7 @@ jobs:
               if [ "$status" = "completed" ]; then
                 case "$conclusion" in
                   success)
-                    echo "CI succeeded for $RELEASE_SHA: $url"
+                    echo "CI succeeded for $WAIT_SHA: $url"
                     exit 0
                     ;;
                   cancelled|skipped|stale|neutral)
@@ -385,35 +411,35 @@ jobs:
                     # benign supersession apart from a genuine transient cancel by
                     # asking whether main has advanced *past* the release commit.
                     git fetch --force origin main
-                    if [ "$(git rev-parse origin/main)" != "$RELEASE_SHA" ] \
-                       && git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+                    if [ "$(git rev-parse origin/main)" != "$WAIT_SHA" ] \
+                       && git merge-base --is-ancestor "$WAIT_SHA" origin/main; then
                       # main advanced past the release commit, so its own CI was
                       # superseded. Its base was a merge_group-gated (green) main tip
                       # and its delta is version-files only, so a superseded run is
                       # not a real failure — proceed to tag the landed release commit.
-                      echo "CI for $RELEASE_SHA was superseded by a later push to main; release commit is a green ancestor, proceeding: $url"
+                      echo "CI for $WAIT_SHA was superseded by a later push to main; release commit is a green ancestor, proceeding: $url"
                       exit 0
                     fi
                     # Cancelled while still at main's tip: not a concurrency
                     # supersession, so treat as transient and keep polling.
-                    echo "CI for $RELEASE_SHA is completed/$conclusion while still at main's tip (transient); continuing to wait: $url"
+                    echo "CI for $WAIT_SHA is completed/$conclusion while still at main's tip (transient); continuing to wait: $url"
                     ;;
                   *)
-                    echo "::error::CI completed with $conclusion for $RELEASE_SHA: $url"
+                    echo "::error::CI completed with $conclusion for $WAIT_SHA: $url"
                     exit 1
                     ;;
                 esac
               else
-                echo "CI for $RELEASE_SHA is $status: $url"
+                echo "CI for $WAIT_SHA is $status: $url"
               fi
             else
-              echo "Waiting for CI run for $RELEASE_SHA..."
+              echo "Waiting for CI run for $WAIT_SHA..."
             fi
 
             sleep 30
           done
 
-          echo "::error::Timed out waiting for CI on $RELEASE_SHA"
+          echo "::error::Timed out waiting for CI on $WAIT_SHA"
           exit 1
 
       - name: Push release tag


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly release validation when continuous integration checks are skipped for unrelated changes.
  * Nightly releases now wait for the most recent relevant CI run, improving reliability and preventing unnecessary timeouts.
  * Updated status reporting to accurately identify the commit used for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->