### PR TITLE
feat(client): native-engine settings toggle and engine-mode telemetry

### DIFF
--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -44,6 +44,7 @@ import { ConfirmDialog } from "../ui/ConfirmDialog.tsx";
 import { ModalPanelShell } from "../ui/ModalPanelShell";
 import { MenuSelect } from "../ui/MenuSelect";
 import { downloadBackup, importBackupFromFile, type ImportMode } from "../../services/backup.ts";
+import { isTauri } from "../../services/platform.ts";
 import { useCloudSyncStore } from "../../stores/cloudSyncStore.ts";
 import { DiscordIcon, GoogleIcon } from "../ui/ProviderIcons";
 
@@ -191,6 +192,8 @@ export function PreferencesModal({
   const setSfxVolume = usePreferencesStore((s) => s.setSfxVolume);
   const setMusicVolume = usePreferencesStore((s) => s.setMusicVolume);
   const setAnimationSpeedMultiplier = usePreferencesStore((s) => s.setAnimationSpeedMultiplier);
+  const nativeEngineEnabled = usePreferencesStore((s) => s.nativeEngineEnabled);
+  const setNativeEngineEnabled = usePreferencesStore((s) => s.setNativeEngineEnabled);
   const showKeywordStrip = usePreferencesStore((s) => s.showKeywordStrip) ?? true;
   const setShowKeywordStrip = usePreferencesStore((s) => s.setShowKeywordStrip);
   const battlefieldPeekOnHover = usePreferencesStore((s) => s.battlefieldPeekOnHover) ?? true;
@@ -433,6 +436,23 @@ export function PreferencesModal({
                       <span className="text-sm text-slate-200">{t("gameplay.manualManaPayment")}</span>
                     </label>
                   </SettingGroup>
+
+                  {isTauri() && (
+                    <label className="mt-1 flex min-h-11 items-start gap-2">
+                      <input
+                        type="checkbox"
+                        checked={nativeEngineEnabled}
+                        onChange={(e) => setNativeEngineEnabled(e.target.checked)}
+                        className="mt-1 accent-cyan-500"
+                      />
+                      <span className="text-sm text-slate-200">
+                        {t("gameplay.nativeEngine")}
+                        <span className="mt-0.5 block text-xs text-slate-400">
+                          {t("gameplay.nativeEngineDescription")}
+                        </span>
+                      </span>
+                    </label>
+                  )}
 
                   <div
                     ref={boardBackgroundRef}

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -28,6 +28,8 @@
     "logDefault": "Protokoll-Standard",
     "spellPayment": "Zauberspruch-Bezahlung",
     "manualManaPayment": "Manuelle Manabezahlung für Zaubersprüche",
+    "nativeEngine": "Native Engine für KI-Spiele",
+    "nativeEngineDescription": "Verwende die heruntergeladene native Engine für lokale KI-Spiele. Fällt automatisch auf die integrierte Engine zurück, wenn sie nicht verfügbar ist.",
     "boardBackground": "Spielfeldhintergrund",
     "boardBackgroundGroups": {
       "automatic": "Automatisch",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -28,6 +28,8 @@
     "logDefault": "Log Default",
     "spellPayment": "Spell Payment",
     "manualManaPayment": "Manual mana payment for spells",
+    "nativeEngine": "Native engine for AI games",
+    "nativeEngineDescription": "Use the downloaded native engine for local AI games. Falls back to the built-in engine automatically when unavailable.",
     "boardBackground": "Board Background",
     "boardBackgroundGroups": {
       "automatic": "Automatic",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -28,6 +28,8 @@
     "logDefault": "Registro predeterminado",
     "spellPayment": "Pago de hechizos",
     "manualManaPayment": "Pago manual de maná para hechizos",
+    "nativeEngine": "Motor nativo para partidas contra IA",
+    "nativeEngineDescription": "Usa el motor nativo descargado para partidas locales contra IA. Vuelve automáticamente al motor integrado cuando no está disponible.",
     "boardBackground": "Fondo del tablero",
     "boardBackgroundGroups": {
       "automatic": "Automático",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -28,6 +28,8 @@
     "logDefault": "Journal par défaut",
     "spellPayment": "Paiement des sorts",
     "manualManaPayment": "Paiement manuel du mana pour les sorts",
+    "nativeEngine": "Moteur natif pour les parties contre l’IA",
+    "nativeEngineDescription": "Utilisez le moteur natif téléchargé pour les parties locales contre l’IA. Utilise automatiquement le moteur intégré lorsqu’il n’est pas disponible.",
     "boardBackground": "Arrière-plan du plateau",
     "boardBackgroundGroups": {
       "automatic": "Automatique",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -28,6 +28,8 @@
     "logDefault": "Registro predefinito",
     "spellPayment": "Pagamento magie",
     "manualManaPayment": "Pagamento manuale del mana per le magie",
+    "nativeEngine": "Motore nativo per le partite contro l'IA",
+    "nativeEngineDescription": "Usa il motore nativo scaricato per le partite locali contro l'IA. Passa automaticamente al motore integrato quando non è disponibile.",
     "boardBackground": "Sfondo del campo",
     "boardBackgroundGroups": {
       "automatic": "Automatico",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -28,6 +28,8 @@
     "logDefault": "Domyślny dziennik",
     "spellPayment": "Płatność za czary",
     "manualManaPayment": "Ręczna płatność many za czary",
+    "nativeEngine": "Natywny silnik dla gier z AI",
+    "nativeEngineDescription": "Używaj pobranego natywnego silnika do lokalnych gier z AI. Gdy jest niedostępny, automatycznie przełącza się na wbudowany silnik.",
     "boardBackground": "Tło pola bitwy",
     "boardBackgroundGroups": {
       "automatic": "Automatyczne",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -28,6 +28,8 @@
     "logDefault": "Registro Padrão",
     "spellPayment": "Pagamento de Mágicas",
     "manualManaPayment": "Pagamento manual de mana para mágicas",
+    "nativeEngine": "Motor nativo para partidas contra IA",
+    "nativeEngineDescription": "Use o motor nativo baixado para partidas locais contra IA. Volta automaticamente ao motor integrado quando não está disponível.",
     "boardBackground": "Plano de Fundo do Tabuleiro",
     "boardBackgroundGroups": {
       "automatic": "Automático",

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -1529,6 +1529,7 @@ export function GameProvider({
             }
           });
 
+          setEngineMode("native");
           await initGame(
             gameId,
             nativeAdapter,
@@ -1543,7 +1544,6 @@ export function GameProvider({
           }
 
           setGameMode("native-ai");
-          setEngineMode("native");
           controller = createGameLoopController({ mode: "online" });
           controller.start();
           audioManager.setContext("battlefield");

--- a/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
+++ b/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
@@ -309,6 +309,13 @@ describe("GameProvider native AI routing", () => {
     await waitFor(() => {
       expect(gameStoreState.setEngineMode).toHaveBeenCalledWith("native");
     });
+    const nativeEngineModeCall = gameStoreState.setEngineMode.mock.calls.findIndex(
+      ([mode]) => mode === "native",
+    );
+    expect(nativeEngineModeCall).toBeGreaterThanOrEqual(0);
+    expect(gameStoreState.setEngineMode.mock.invocationCallOrder[nativeEngineModeCall]).toBeLessThan(
+      gameStoreState.initGame.mock.invocationCallOrder[0],
+    );
     expect(clearActiveGame).toHaveBeenCalledOnce();
     expect(saveActiveGame).not.toHaveBeenCalled();
     expect(multiplayerGetState).not.toHaveBeenCalled();

--- a/client/src/services/__tests__/telemetryEvents.test.ts
+++ b/client/src/services/__tests__/telemetryEvents.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useGameStore } from "../../stores/gameStore";
+import { buildFormatConfig, buildGameState } from "../../test/factories/gameStateFactory";
+
+const { flushNow, installTelemetryLifecycle, trackEvent } = vi.hoisted(() => ({
+  flushNow: vi.fn(),
+  installTelemetryLifecycle: vi.fn(),
+  trackEvent: vi.fn(),
+}));
+
+vi.mock("../telemetry", () => ({
+  flushNow,
+  installTelemetryLifecycle,
+  trackEvent,
+}));
+
+import { installTelemetry } from "../telemetryEvents";
+
+describe("telemetry game event tracking", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+    vi.clearAllMocks();
+    installTelemetry();
+    trackEvent.mockClear();
+  });
+
+  it("reports the store's engine mode and fallback reason when a game ends", () => {
+    useGameStore.setState({
+      gameId: "engine-mode-telemetry",
+      gameMode: "ai",
+      engineMode: "wasm",
+      nativeEngineFallbackReason: "native_engine_unavailable",
+      aiSeatIds: [1],
+      gameState: buildGameState({
+        format_config: buildFormatConfig({ format: "Commander" }),
+        turn_number: 12,
+      }),
+    });
+    useGameStore.setState({ waitingFor: { type: "GameOver", data: { winner: 0 } } });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "game_start",
+      expect.objectContaining({
+        engine_mode: "wasm",
+        native_fallback_reason: "native_engine_unavailable",
+      }),
+    );
+    expect(trackEvent).toHaveBeenCalledWith(
+      "game_end",
+      expect.objectContaining({
+        engine_mode: "wasm",
+        native_fallback_reason: "native_engine_unavailable",
+      }),
+    );
+  });
+});

--- a/client/src/services/__tests__/telemetryEvents.test.ts
+++ b/client/src/services/__tests__/telemetryEvents.test.ts
@@ -25,13 +25,37 @@ describe("telemetry game event tracking", () => {
     trackEvent.mockClear();
   });
 
-  it("reports the store's engine mode and fallback reason when a game ends", () => {
+  it("reports native mode when it is committed before the first game snapshot", () => {
     useGameStore.setState({
       gameId: "engine-mode-telemetry",
+      gameMode: "ai",
+      engineMode: "native",
+      aiSeatIds: [1],
+    });
+    useGameStore.setState({
+      gameState: buildGameState({
+        format_config: buildFormatConfig({ format: "Commander" }),
+        turn_number: 12,
+      }),
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      "game_start",
+      expect.objectContaining({
+        engine_mode: "native",
+      }),
+    );
+  });
+
+  it("reports the store's engine mode and fallback reason when a game ends", () => {
+    useGameStore.setState({
+      gameId: "engine-mode-telemetry-fallback",
       gameMode: "ai",
       engineMode: "wasm",
       nativeEngineFallbackReason: "native_engine_unavailable",
       aiSeatIds: [1],
+    });
+    useGameStore.setState({
       gameState: buildGameState({
         format_config: buildFormatConfig({ format: "Commander" }),
         turn_number: 12,

--- a/client/src/services/telemetryEvents.ts
+++ b/client/src/services/telemetryEvents.ts
@@ -104,8 +104,9 @@ function installStuckDecisionTracking(): void {
  * Emit `game_end` once per game when the state's `waiting_for` first becomes
  * `GameOver`. Deduped by `gameId` (multiplayer emits one per participating
  * client — counts are per-client sessions, not per game). `spectate` mode is
- * skipped entirely. Every payload value is an engine-provided field forwarded
- * verbatim; `winner_kind` uses the client-owned `aiSeatIds` binding.
+ * skipped entirely. Engine-provided payload values are forwarded verbatim;
+ * `winner_kind`, `engine_mode`, and `native_fallback_reason` use client-owned
+ * store bindings.
  */
 function installGameEndTracking(): void {
   let lastEmittedGameId: string | null = null;
@@ -114,7 +115,14 @@ function installGameEndTracking(): void {
     (s) => s.waitingFor,
     (waitingFor) => {
       if (!waitingFor || waitingFor.type !== "GameOver") return;
-      const { gameId, gameMode, gameState, aiSeatIds } = useGameStore.getState();
+      const {
+        gameId,
+        gameMode,
+        gameState,
+        aiSeatIds,
+        engineMode,
+        nativeEngineFallbackReason,
+      } = useGameStore.getState();
       if (gameMode === "spectate") return;
       if (gameId === null || gameId === lastEmittedGameId) return;
       lastEmittedGameId = gameId;
@@ -138,6 +146,8 @@ function installGameEndTracking(): void {
         game_mode: gameMode,
         unimplemented_oracle_ids: (gameState?.unimplemented_oracle_ids ?? []).slice(0, 20),
         pending_trigger_abandons: (gameState?.pending_trigger_abandons ?? []).slice(0, 20),
+        engine_mode: engineMode,
+        native_fallback_reason: nativeEngineFallbackReason,
       });
       // Flush promptly so a game_end isn't stranded if the user leaves the
       // results screen before the batch timer fires.
@@ -165,7 +175,13 @@ function installGameStartTracking(): void {
     (s) => s.gameState,
     (gameState) => {
       if (!gameState) return;
-      const { gameId, gameMode, aiSeatIds } = useGameStore.getState();
+      const {
+        gameId,
+        gameMode,
+        aiSeatIds,
+        engineMode,
+        nativeEngineFallbackReason,
+      } = useGameStore.getState();
       if (gameMode === "spectate") return;
       if (gameId === null || gameId === lastEmittedGameId) return;
       lastEmittedGameId = gameId;
@@ -175,6 +191,8 @@ function installGameStartTracking(): void {
         format: gameState.format_config?.format,
         player_count: gameState.players.length,
         ai_count: aiSeatIds.length,
+        engine_mode: engineMode,
+        native_fallback_reason: nativeEngineFallbackReason,
       });
     },
   );

--- a/lobby-worker/src/telemetry.ts
+++ b/lobby-worker/src/telemetry.ts
@@ -60,6 +60,11 @@ export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] 
       "game_mode",
       "unimplemented_oracle_ids",
       "pending_trigger_abandons",
+      // `engine_mode` and `native_fallback_reason` appended 2026-07: selected
+      // local AI engine and native-engine fallback code; "" from clients
+      // predating the fields.
+      "engine_mode",
+      "native_fallback_reason",
     ],
     doubles: ["turn_count"],
   },
@@ -70,7 +75,13 @@ export const EVENT_SCHEMAS: Record<string, { blobs: string[]; doubles: string[] 
   session_start: { blobs: ["route"], doubles: [] },
   // `format` appended 2026-07: the engine `GameFormat` variant name (e.g.
   // "Commander", "HistoricBrawl"); "" from clients predating the field.
-  game_start: { blobs: ["game_mode", "format"], doubles: ["player_count", "ai_count"] },
+  // `engine_mode` and `native_fallback_reason` appended 2026-07: selected
+  // local AI engine and native-engine fallback code; "" from clients
+  // predating the fields.
+  game_start: {
+    blobs: ["game_mode", "format", "engine_mode", "native_fallback_reason"],
+    doubles: ["player_count", "ai_count"],
+  },
   route_view: { blobs: ["route"], doubles: [] },
 };
 

--- a/lobby-worker/test/telemetry.test.mjs
+++ b/lobby-worker/test/telemetry.test.mjs
@@ -60,7 +60,7 @@ test("sanitizeTelemetryBatch accepts the Tier 2 report/usage events with their c
   assert.deepEqual(report.doubles, [5, 2, 3]);
   assert.deepEqual(session.blobs, ["/game"]);
   assert.deepEqual(session.doubles, []);
-  assert.deepEqual(gameStart.blobs, ["ai", "HistoricBrawl"]);
+  assert.deepEqual(gameStart.blobs, ["ai", "HistoricBrawl", "", ""]);
   assert.deepEqual(gameStart.doubles, [2, 1]);
   assert.deepEqual(route.blobs, ["/deck-builder"]);
   assert.deepEqual(route.doubles, []);
@@ -200,8 +200,8 @@ test("booleans and numbers coerce; missing/other values default", () => {
     batch([{ event: "game_end", result: "draw", winner_kind: null, game_mode: "ai", turn_count: 7, unimplemented_oracle_ids: ["x", 5, "y"] }]),
   );
   // winner_kind null → ""; array keeps only strings, comma-joined;
-  // pending_trigger_abandons absent → "".
-  assert.deepEqual(drawn.blobs, ["draw", "", "ai", "x,y", ""]);
+  // pending_trigger_abandons and engine-mode fields absent → "".
+  assert.deepEqual(drawn.blobs, ["draw", "", "ai", "x,y", "", "", ""]);
   assert.deepEqual(drawn.doubles, [7]);
 });
 
@@ -222,4 +222,49 @@ test("the game_end pending_trigger_abandons list survives the join at the client
     batch([{ event: "game_end", result: "draw", winner_kind: null, game_mode: "ai", turn_count: 1, pending_trigger_abandons: ["a", 5, "b"] }]),
   );
   assert.equal(mixed.blobs[4], "a,b");
+});
+
+test("game event engine-mode fields occupy appended columns for current and older clients", () => {
+  const [gameEnd, gameStart, olderGameEnd, olderGameStart] = sanitizeTelemetryBatch(
+    batch([
+      {
+        event: "game_end",
+        result: "winner",
+        winner_kind: "human",
+        game_mode: "ai",
+        turn_count: 12,
+        engine_mode: "wasm",
+        native_fallback_reason: "native_engine_unavailable",
+      },
+      {
+        event: "game_start",
+        game_mode: "ai",
+        format: "Commander",
+        player_count: 2,
+        ai_count: 1,
+        engine_mode: "wasm",
+        native_fallback_reason: "native_engine_unavailable",
+      },
+      { event: "game_end", result: "draw", game_mode: "ai", turn_count: 8 },
+      { event: "game_start", game_mode: "ai", format: "Standard", player_count: 2, ai_count: 1 },
+    ]),
+  );
+
+  assert.deepEqual(toDataPoint(gameEnd).blobs.slice(4), [
+    "winner",
+    "human",
+    "ai",
+    "",
+    "",
+    "wasm",
+    "native_engine_unavailable",
+  ]);
+  assert.deepEqual(toDataPoint(gameStart).blobs.slice(4), [
+    "ai",
+    "Commander",
+    "wasm",
+    "native_engine_unavailable",
+  ]);
+  assert.deepEqual(toDataPoint(olderGameEnd).blobs.slice(4), ["draw", "", "ai", "", "", "", ""]);
+  assert.deepEqual(toDataPoint(olderGameStart).blobs.slice(4), ["ai", "Standard", "", ""]);
 });


### PR DESCRIPTION
Workstream F.3 + F.5 of the thin-shell native-compute plan (follow-up to #6305).

## F.3 — Settings toggle
- New checkbox in the Gameplay section of PreferencesModal bound to the existing `nativeEngineEnabled` preference (persistence v27, default on), mirroring the telemetry-checkbox pattern.
- Rendered only inside the desktop shell (`isTauri()`); web builds never show it.
- i18n keys added to all 7 locales (parity gate green, 67/67).

## F.5 — Telemetry attribution
- `game_start` and `game_end` now carry `engine_mode` and `native_fallback_reason` from the game store.
- Ingest side: both fields appended (positionally, at the end) to the `EVENT_SCHEMAS` blobs for the two events in lobby-worker, following the `format` append precedent; older clients sanitize to `""`.
- Fix folded in from review: `setEngineMode("native")` is now set **before** `initGame` commits the first snapshot — previously a successful native game emitted `game_start` with `engine_mode` unset, indistinguishable from pre-field clients. Order-sensitive tests added on both the provider (call-order assertion, fails on revert) and the telemetry subscription (separate ordered store writes mirroring production).

Verification: client type-check/vitest/eslint 0; lobby-worker tests 14/14; adversarial review CLEAN after one MED fix (red/green revert evidence recorded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Native Engine option for local AI games in the gameplay settings when running the desktop app.
  * Automatically falls back to the built-in engine if the native engine is unavailable.
* **Localization**
  * Added translated Native Engine labels and descriptions across supported languages.
* **Bug Fixes**
  * Improved engine selection timing for native AI games.
  * Enhanced game event tracking to record the selected engine and fallback details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->