### PR TITLE
fix(ci): parenthesize jq string concatenation in the preview-server manifest

### DIFF
--- a/.github/workflows/preview-server.yml
+++ b/.github/workflows/preview-server.yml
@@ -323,28 +323,28 @@ jobs:
                        commit: $commit,
                        binaries: {
                          "x86_64-unknown-linux-musl": {
-                           url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-unknown-linux-musl",
-                           sig_url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-unknown-linux-musl.minisig"
+                           url: ("https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-unknown-linux-musl"),
+                           sig_url: ("https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-unknown-linux-musl.minisig")
                          },
                          "aarch64-apple-darwin": {
-                           url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-aarch64-apple-darwin",
-                           sig_url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-aarch64-apple-darwin.minisig"
+                           url: ("https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-aarch64-apple-darwin"),
+                           sig_url: ("https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-aarch64-apple-darwin.minisig")
                          },
                          "x86_64-pc-windows-msvc": {
-                           url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-pc-windows-msvc.exe",
-                           sig_url: "https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-pc-windows-msvc.exe.minisig"
+                           url: ("https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-pc-windows-msvc.exe"),
+                           sig_url: ("https://data.phase-rs.dev/desktop/preview-server/" + $fingerprint + "/phase-server-x86_64-pc-windows-msvc.exe.minisig")
                          }
                        },
                        data: [
                          {
                            name: "card-data.json",
                            sha256: $card_data_sha256,
-                           url: "https://data.phase-rs.dev/staging/card-data-" + $card_data_hash16 + ".json"
+                           url: ("https://data.phase-rs.dev/staging/card-data-" + $card_data_hash16 + ".json")
                          },
                          {
                            name: "draft-pools.json",
                            sha256: $draft_pools_sha256,
-                           url: "https://data.phase-rs.dev/staging/draft-pools-" + $draft_pools_hash16 + ".json"
+                           url: ("https://data.phase-rs.dev/staging/draft-pools-" + $draft_pools_hash16 + ".json")
                          }
                        ]
                      }


### PR DESCRIPTION
jq's object-construction grammar does not accept infix + in values;
all eight url/sig_url concatenations compiled fine as standalone
expressions but fail inside {}, so the sign-and-publish step died with
8 compile errors on its first-ever reach (earlier runs failed at the
musl build). Validated by executing the extracted program for both the
first-publish and previous-fingerprint-retention paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the generated preview manifest’s download and signature URL formatting for platform binaries and metadata files.
  * Preserved existing URL destinations while ensuring they are interpreted consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->