### PR TITLE
feat(ci): serve the engine wasm from R2 with a 25 MiB pages-deploy guard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -400,6 +400,30 @@ jobs:
           cache: pnpm
           cache-dependency-path: client/pnpm-lock.yaml
 
+      - name: Compute content-addressed engine WASM filename
+        id: engine-wasm-hash
+        run: |
+          ENGINE_WASM_SHA256=$(sha256sum client/src/wasm/engine_wasm_bg.wasm | awk '{print $1}')
+          ENGINE_WASM_HASH16=${ENGINE_WASM_SHA256:0:16}
+          echo "sha256=$ENGINE_WASM_SHA256" >> "$GITHUB_OUTPUT"
+          echo "hash=$ENGINE_WASM_HASH16" >> "$GITHUB_OUTPUT"
+          echo "filename=engine_wasm_bg-$ENGINE_WASM_HASH16.wasm" >> "$GITHUB_OUTPUT"
+
+      - name: Upload engine WASM to R2 (staging)
+        # Keep the binary raw: wasm-bindgen uses streaming instantiation, which
+        # requires R2 to serve the object as application/wasm. The immutable
+        # content-addressed URL is baked into the frontend build below.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ENGINE_WASM_FILENAME: ${{ steps.engine-wasm-hash.outputs.filename }}
+        run: |
+          npx wrangler r2 object put "phase-rs-data/staging/wasm/$ENGINE_WASM_FILENAME" \
+            --file client/src/wasm/engine_wasm_bg.wasm \
+            --remote \
+            --content-type application/wasm \
+            --cache-control "public, max-age=31536000, immutable"
+
       - name: Use preview icons
         run: |
           cp client/public/preview-icons/favicon.ico client/public/favicon.ico
@@ -418,6 +442,7 @@ jobs:
           # card-data it was built against (filename from the card-data job).
           DATA_BASE_URL: "https://data.phase-rs.dev/staging"
           CARD_DATA_URL: "https://data.phase-rs.dev/staging/${{ needs.card-data.outputs.card_data_filename }}"
+          ENGINE_WASM_URL: "https://data.phase-rs.dev/staging/wasm/${{ steps.engine-wasm-hash.outputs.filename }}"
           ENGINE_FINGERPRINT: ${{ needs.card-data.outputs.engine_fingerprint }}
           AUDIO_BASE_URL: "https://data.phase-rs.dev/audio"
           # Cloud-sync config. The anon/publishable key is client-safe (RLS is the
@@ -452,6 +477,19 @@ jobs:
           rm -f client/dist/card-data.json client/dist/card-data.json.br \
             client/dist/card-data-????????????????.json \
             client/dist/card-data-????????????????.json.br
+
+      - name: Guard Cloudflare Pages asset size limit
+        # Preview publishes to GitHub Pages today, but production Cloudflare
+        # Pages has a hard 25 MiB per-file ceiling. Keep the preview artifact
+        # within that ceiling so release cannot fail only at Pages deployment.
+        shell: bash
+        run: |
+          oversized=$(find client/dist -type f -size +25M -print -quit)
+          if [ -n "$oversized" ]; then
+            size=$(du -h "$oversized" | awk '{print $1}')
+            echo "::error::Cloudflare Pages 25 MiB file limit exceeded: $oversized ($size)"
+            exit 1
+          fi
 
       - name: SPA fallback for GitHub Pages
         run: cp client/dist/index.html client/dist/404.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,30 @@ jobs:
       - name: Build WASM
         run: ./scripts/build-wasm.sh release
 
+      - name: Compute content-addressed engine WASM filename
+        id: engine-wasm-hash
+        run: |
+          ENGINE_WASM_SHA256=$(sha256sum client/src/wasm/engine_wasm_bg.wasm | awk '{print $1}')
+          ENGINE_WASM_HASH16=${ENGINE_WASM_SHA256:0:16}
+          echo "sha256=$ENGINE_WASM_SHA256" >> "$GITHUB_OUTPUT"
+          echo "hash=$ENGINE_WASM_HASH16" >> "$GITHUB_OUTPUT"
+          echo "filename=engine_wasm_bg-$ENGINE_WASM_HASH16.wasm" >> "$GITHUB_OUTPUT"
+
+      - name: Upload engine WASM to R2
+        # The engine WASM is intentionally uncompressed: wasm-bindgen's
+        # cross-origin streaming initialization needs application/wasm, and the
+        # immutable content-addressed URL below is its cache key.
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          ENGINE_WASM_FILENAME: ${{ steps.engine-wasm-hash.outputs.filename }}
+        run: |
+          npx wrangler r2 object put "phase-rs-data/wasm/$ENGINE_WASM_FILENAME" \
+            --file client/src/wasm/engine_wasm_bg.wasm \
+            --remote \
+            --content-type application/wasm \
+            --cache-control "public, max-age=31536000, immutable"
+
       - name: Build frontend
         env:
           # Standardized data URL config — see vite.config.ts. DATA_BASE_URL is
@@ -262,6 +286,7 @@ jobs:
           # WASM bundle to its content-addressed card-data forever.
           DATA_BASE_URL: "https://data.phase-rs.dev"
           CARD_DATA_URL: "https://data.phase-rs.dev/${{ steps.card-data-hash.outputs.filename }}"
+          ENGINE_WASM_URL: "https://data.phase-rs.dev/wasm/${{ steps.engine-wasm-hash.outputs.filename }}"
           AUDIO_BASE_URL: "https://data.phase-rs.dev/audio"
           # Tagged production release: surfaces the "try the preview build" CTA
           # on the menu (see __IS_RELEASE_BUILD__ in vite.config.ts). The staging
@@ -324,6 +349,7 @@ jobs:
         env:
           CARD_DATA_FILENAME: ${{ steps.card-data-hash.outputs.filename }}
           DRAFT_POOLS_FILENAME: draft-pools-${{ steps.card-data-hash.outputs.draft_pools_hash16 }}.json
+          ENGINE_WASM_FILENAME: ${{ steps.engine-wasm-hash.outputs.filename }}
         run: |
           BASE="https://data.phase-rs.dev"
           fail=0
@@ -345,6 +371,7 @@ jobs:
           }
           check "$CARD_DATA_FILENAME"
           check "$DRAFT_POOLS_FILENAME"
+          check "wasm/$ENGINE_WASM_FILENAME"
           while IFS= read -r f; do check "$f"; done < <(jq -r '.[]' data-files.json)
           # Prove the brotli round-trip end-to-end on one small file: --compressed
           # requests + decodes br, jq confirms it decoded to valid JSON.
@@ -503,6 +530,16 @@ jobs:
 
       - name: Inject Cloudflare Pages _headers
         run: cp client/deploy/cloudflare-pages/_headers dist/_headers
+
+      - name: Guard Cloudflare Pages asset size limit
+        shell: bash
+        run: |
+          oversized=$(find dist -type f -size +25M -print -quit)
+          if [ -n "$oversized" ]; then
+            size=$(du -h "$oversized" | awk '{print $1}')
+            echo "::error::Cloudflare Pages 25 MiB file limit exceeded: $oversized ($size)"
+            exit 1
+          fi
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -141,7 +141,11 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
   try {
     switch (msg.type) {
       case "init": {
-        await init();
+        if (__ENGINE_WASM_URL__) {
+          await init({ module_or_path: __ENGINE_WASM_URL__ });
+        } else {
+          await init();
+        }
         respond({ type: "ready" });
         break;
       }

--- a/client/src/services/engineRuntime.ts
+++ b/client/src/services/engineRuntime.ts
@@ -27,7 +27,11 @@ export async function ensureWasmInit(): Promise<void> {
   if (!wasmInitPromise) {
     wasmInitPromise = (async () => {
       const engine = await loadEngineModule();
-      await engine.default();
+      if (__ENGINE_WASM_URL__) {
+        await engine.default({ module_or_path: __ENGINE_WASM_URL__ });
+      } else {
+        await engine.default();
+      }
     })();
   }
   return wasmInitPromise;

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -4,6 +4,7 @@
 declare const __APP_VERSION__: string;
 declare const __BUILD_HASH__: string;
 declare const __ENGINE_FINGERPRINT__: string | undefined;
+declare const __ENGINE_WASM_URL__: string | undefined;
 declare const __DEFAULT_MULTIPLAYER_SERVER_URL__: string;
 declare const __CARD_DATA_URL__: string;
 declare const __CARD_DATA_LOCALE_URL_TEMPLATE__: string;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -261,7 +261,12 @@ export default defineConfig(({ mode }) => ({
             },
           },
           {
-            urlPattern: /engine_wasm_bg-.*\.wasm$/,
+            // Workbox accepts cross-origin RegExpRoute matches only when they
+            // begin at index 0. The anchored R2 branch covers production and
+            // staging uploads; the existing unanchored branch preserves
+            // same-origin bundled-WASM behavior.
+            urlPattern:
+              /(?:^https:\/\/data\.phase-rs\.dev\/(?:staging\/)?wasm\/engine_wasm_bg-.*\.wasm$|engine_wasm_bg-.*\.wasm$)/,
             handler: "CacheFirst",
             options: {
               cacheName: "engine-wasm",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -30,6 +30,33 @@ function wasmEnvShim(): Plugin {
   };
 }
 
+// wasm-bindgen's web glue defaults to `new URL("engine_wasm_bg.wasm",
+// import.meta.url)`. Vite recognizes that static URL and emits the WASM asset
+// even when every caller supplies an R2 URL explicitly. For external builds,
+// replace only that generated fallback with the build-time URL so Rollup has no
+// local engine WASM asset to emit. Without ENGINE_WASM_URL this plugin leaves
+// the generated glue untouched, preserving local/self-hosted behavior.
+function externalEngineWasm(): Plugin {
+  const engineGlue = path.resolve(__dirname, "src/wasm/engine_wasm.js");
+  const bundledWasmUrl = "new URL('engine_wasm_bg.wasm', import.meta.url)";
+  return {
+    name: "external-engine-wasm",
+    apply: "build",
+    transform(code, id) {
+      if (!process.env.ENGINE_WASM_URL || id !== engineGlue) return;
+      if (!code.includes(bundledWasmUrl)) {
+        this.error(
+          "engine_wasm.js no longer contains the expected wasm-bindgen fallback URL",
+        );
+      }
+      return {
+        code: code.replace(bundledWasmUrl, "__ENGINE_WASM_URL__"),
+        map: null,
+      };
+    },
+  };
+}
+
 // mana-font ships a legacy @font-face (eot/woff/ttf/svg) for BOTH the "Mana"
 // glyph family AND an unused "MPlantin" text family. Imported verbatim, Vite
 // emits every referenced url() — ~3.4 MB of fonts (a 1.8 MB SVG among them,
@@ -112,6 +139,12 @@ function dataFileDefines(mode: string): Record<string, string> {
     __ENGINE_FINGERPRINT__: process.env.ENGINE_FINGERPRINT
       ? JSON.stringify(process.env.ENGINE_FINGERPRINT)
       : "undefined",
+    // Release/staging builds pin the engine binary to an immutable R2 object.
+    // Keep the local bundled WASM fallback when this is unset (dev, Tauri, and
+    // self-hosted builds).
+    __ENGINE_WASM_URL__: process.env.ENGINE_WASM_URL
+      ? JSON.stringify(process.env.ENGINE_WASM_URL)
+      : "undefined",
     __AUDIO_BASE_URL__: JSON.stringify(process.env.AUDIO_BASE_URL || ""),
     __GIT_REPO_URL__: JSON.stringify("https://github.com/phase-rs/phase"),
     __PREVIEW_SITE_URL__: JSON.stringify("https://preview.phase-rs.dev"),
@@ -169,6 +202,7 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     wasmEnvShim(),
+    externalEngineWasm(),
     trimManaFont(),
     react(),
     tailwindcss(),
@@ -341,7 +375,7 @@ export default defineConfig(({ mode }) => ({
   ],
   define: dataFileDefines(mode),
   worker: {
-    plugins: () => [wasmEnvShim()],
+    plugins: () => [wasmEnvShim(), externalEngineWasm()],
   },
   // Vite's host-check rejects requests with a Host header outside its
   // known list — required to allow the Caddy proxy at local.phase-rs.dev

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
     __CHANGELOG_META_URL__: JSON.stringify("/changelog-meta.json"),
     __APP_VERSION__: JSON.stringify("0.0.0-test"),
     __BUILD_HASH__: JSON.stringify("testhash"),
+    __ENGINE_WASM_URL__: "undefined",
     __DEFAULT_MULTIPLAYER_SERVER_URL__: JSON.stringify(
       process.env.DEFAULT_MULTIPLAYER_SERVER_URL || "wss://lobby.phase-rs.dev/ws",
     ),


### PR DESCRIPTION
Fixes the v0.32.0 production-deploy failure: `engine_wasm_bg.wasm` (25.1 MiB post-wasm-opt) exceeds Cloudflare Pages' hard 25 MiB per-file cap, and it only grows with coverage.

## What
- **Client**: new optional `__ENGINE_WASM_URL__` define. When set, the direct runtime and the engine worker pass `{ module_or_path: url }` to wasm-bindgen init, and a build-only vite transform rewrites the generated glue's bundled-URL fallback so Rollup never emits the wasm asset (fails loudly if a wasm-bindgen upgrade changes the expression). Env unset ⇒ byte-identical bundled behavior (proved via normalized asset-list diff vs an origin/main build: identical, 95 assets).
- **CI (deploy.yml + release.yml)**: sha256 the built wasm, upload content-addressed to R2 (`wasm/engine_wasm_bg-<sha16>.wasm`, `application/wasm`, immutable 1-year caching; staging under `staging/wasm/`), inject the URL into the frontend build. release.yml verifies the R2 object responds before the production deploy proceeds.
- **Guard**: both pages-deploy jobs fail before deploy if any dist file exceeds 25 MiB, naming the file.
- **SW**: the engine-wasm runtime-cache rule is anchored for the cross-origin R2 URL (Workbox rejects cross-origin regex matches that don't start at index 0); same-origin bundled branch retained.

`draft_wasm` measured 10.55 MiB — stays bundled (14+ MiB of headroom).

Adversarial review: CLEAN after one MED (the SW anchoring) was fixed and re-verified, including negative tests that no foreign host can match the rule. Known follow-up (pre-existing, untouched): the sibling card-data SW rule has the same cross-origin-index-0 latent flaw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved WASM asset delivery with content-addressed files, long-lived caching, and external hosting support.

- **Reliability**
  - Added safeguards to prevent deployments when individual assets exceed 25 MiB.
  - Added verification that required WASM assets are available before release completion.

- **Compatibility**
  - Updated runtime caching to support both bundled and externally hosted WASM files.
  - Preserved local fallback behavior when external WASM hosting is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->