### PR TITLE
feat(shell): pre-trust app.phase-rs.dev in the remote-shell capability and bootstrap CSP

### DIFF
--- a/client/src-tauri/capabilities/default.json
+++ b/client/src-tauri/capabilities/default.json
@@ -11,7 +11,11 @@
     "local": false,
     "windows": ["main"],
     "remote": {
-      "urls": ["https://phase-rs.dev/*", "https://preview.phase-rs.dev/*"]
+      "urls": [
+        "https://phase-rs.dev/*",
+        "https://app.phase-rs.dev/*",
+        "https://preview.phase-rs.dev/*"
+      ]
     },
     "permissions": [
       "core:default",

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://phase-rs.dev https://preview.phase-rs.dev"
+      "csp": "default-src 'self'; connect-src 'self' https://phase-rs.dev https://app.phase-rs.dev https://preview.phase-rs.dev"
     }
   },
   "bundle": {


### PR DESCRIPTION
The app may move from phase-rs.dev to app.phase-rs.dev (with a landing
page taking over the apex). The remote-shell capability allowlist is
baked into installed shell binaries and gates Tauri IPC injection —
without this, a shell redirected to the new origin would render the app
with no updater, native engine, or legacy-storage import, and could
never self-repair. Pre-trusting the origin now makes shell-v1.0.0
binaries forward-compatible with the move at zero cost today.
