### PR TITLE
fix: order autotap funding sources before filters

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -9818,7 +9818,7 @@ fn auto_tap_mana_sources_inner(
                 .objects
                 .get(&option.object_id)
                 .and_then(|obj| obj.abilities.get(ability_index))
-                .is_some_and(|ability| mana_sub_cost_of(&ability.cost).is_none())
+                .is_some_and(|ability| mana_abilities::mana_sub_cost_of(&ability.cost).is_none())
         });
         if option.atomic_combination.is_none()
             && option.mana_type == ManaType::Colorless
@@ -9971,6 +9971,22 @@ fn auto_tap_mana_sources_inner(
     }
 
     // Phase 3: activate each selected mana source.
+    //
+    // CR 601.2g permits mana-ability activation; CR 605.3b resolves it
+    // immediately; CR 605.3c prevents reactivation. Those rules do not prescribe
+    // this ordering. Engine scheduling policy: selected sources without a mana
+    // sub-cost resolve first, stably, so their mana is available to pay a later cost.
+    // This preserves the plan and `used_sources` reservation; it changes only order.
+    to_tap.sort_by_key(|option| {
+        option.ability_index.is_some_and(|ability_index| {
+            state
+                .objects
+                .get(&option.object_id)
+                .and_then(|object| object.abilities.get(ability_index))
+                .is_some_and(|ability| mana_abilities::mana_sub_cost_of(&ability.cost).is_some())
+        })
+    });
+
     // Sources with an explicit ability delegate to resolve_mana_ability (the single
     // authority for cost payment — handles tap, sacrifice, and future cost types).
     // The basic-land-subtype fallback (ability_index: None) uses inline tap + produce.
@@ -10016,7 +10032,7 @@ fn auto_tap_mana_sources_inner(
                 // before resolving, so without this the sub-cost could grab a source
                 // the outer cost still needs. Unioning `used_sources` supersedes the
                 // prior `excluded.insert(option.object_id)`.
-                let sub_cost = mana_sub_cost_of(&ability_def.cost);
+                let sub_cost = mana_abilities::mana_sub_cost_of(&ability_def.cost);
                 let excluded_buf;
                 // CR 107.4b + CR 118.10: The outer cost's colored shards are
                 // reserved; computed once (only when a mana sub-cost is present, so
@@ -10185,17 +10201,6 @@ pub(crate) fn production_override_for_option(
         | crate::types::ability::ManaProduction::ChoiceAmongCombinations { .. }
         | crate::types::ability::ManaProduction::DistinctColorsAmongPermanents { .. }
         | crate::types::ability::ManaProduction::TriggerEventManaType => None,
-    }
-}
-
-fn mana_sub_cost_of(cost: &Option<AbilityCost>) -> Option<&ManaCost> {
-    match cost {
-        Some(AbilityCost::Mana { cost }) => Some(cost),
-        Some(AbilityCost::Composite { costs }) => costs.iter().find_map(|sub| match sub {
-            AbilityCost::Mana { cost } => Some(cost),
-            _ => None,
-        }),
-        _ => None,
     }
 }
 

--- a/crates/engine/tests/integration/costed_mana_ability_autotap_order.rs
+++ b/crates/engine/tests/integration/costed_mana_ability_autotap_order.rs
@@ -1,0 +1,152 @@
+//! Auto-tap must make an already-selected free mana source available before
+//! resolving a selected mana ability that has a mana sub-cost.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType};
+use engine::types::phase::Phase;
+
+const PLUNGE_INTO_DARKNESS_ORACLE: &str = "Choose one —\n• Sacrifice any number of creatures. You gain 3 life for each creature sacrificed this way.\n• Pay any amount of life, then look at that many cards from the top of your library. Put one of those cards into your hand and exile the rest.\nEntwine {B} (Choose both if you pay the entwine cost.)";
+const TWILIGHT_MIRE_ORACLE: &str = "{T}: Add {C}.\n{B/G}, {T}: Add {B}{B}, {B}{G}, or {G}{G}.";
+const DARKWATER_CATACOMBS_ORACLE: &str = "{1}, {T}: Add {U}{B}.";
+
+fn begin_plunge_cast(runner: &mut GameRunner, plunge: ObjectId) {
+    let card_id = runner.state().objects[&plunge].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: plunge,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("Plunge announcement must reach its mode choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ModeChoice { .. }
+    ));
+}
+
+/// CR 601.2g + CR 605.3b + CR 605.3c: the Swamp's selected mana ability resolves before
+/// Twilight Mire's selected `{B/G}`-costed ability, making the Swamp's {B}
+/// available for that activation and allowing the single selected mode to cast.
+#[test]
+fn plunge_into_darkness_one_mode_autotaps_swamp_before_twilight_mire() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let swamp = scenario.add_basic_land(P0, ManaColor::Black);
+    let twilight_mire = scenario
+        .add_land_from_oracle(P0, "Twilight Mire", TWILIGHT_MIRE_ORACLE)
+        .id();
+    let plunge = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Plunge into Darkness",
+            true,
+            PLUNGE_INTO_DARKNESS_ORACLE,
+        )
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 1,
+        })
+        .id();
+    let mut runner = scenario.build();
+
+    begin_plunge_cast(&mut runner, plunge);
+    let selected = runner
+        .act(GameAction::SelectModes { indices: vec![0] })
+        .expect("one-mode Plunge must cast with Swamp and Twilight Mire");
+
+    let mana_added: Vec<(ObjectId, ManaType)> = selected
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::ManaAdded {
+                source_id,
+                mana_type,
+                ..
+            } => Some((*source_id, *mana_type)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        mana_added,
+        vec![
+            (swamp, ManaType::Black),
+            (twilight_mire, ManaType::Black),
+            (twilight_mire, ManaType::Black),
+        ],
+        "the free Swamp must resolve before Twilight Mire's mana sub-cost"
+    );
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert!(!runner.state().stack.is_empty());
+    assert!(runner.state().objects[&swamp].tapped);
+    assert!(runner.state().objects[&twilight_mire].tapped);
+}
+
+/// CR 601.2g + CR 605.3b + CR 605.3c: the same scheduling class also covers an Island
+/// funding Darkwater Catacombs' selected `{1}`-costed mana ability for a
+/// `{1}{B}` spell.
+#[test]
+fn darkwater_catacombs_and_island_autotap_for_one_black() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let island = scenario.add_basic_land(P0, ManaColor::Blue);
+    let darkwater = scenario
+        .add_land_from_oracle(P0, "Darkwater Catacombs", DARKWATER_CATACOMBS_ORACLE)
+        .id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Autotap Order Witness", false, "Draw a card.")
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black],
+            generic: 1,
+        })
+        .id();
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+
+    let cast = runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("Darkwater Catacombs plus Island must cast {1}{B}");
+
+    let mana_added: Vec<(ObjectId, ManaType)> = cast
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::ManaAdded {
+                source_id,
+                mana_type,
+                ..
+            } => Some((*source_id, *mana_type)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        mana_added,
+        vec![
+            (island, ManaType::Blue),
+            (darkwater, ManaType::Blue),
+            (darkwater, ManaType::Black),
+        ],
+        "the Island must resolve before Darkwater Catacombs' mana sub-cost"
+    );
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert!(!runner.state().stack.is_empty());
+    assert!(runner.state().objects[&island].tapped);
+    assert!(runner.state().objects[&darkwater].tapped);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -898,6 +898,7 @@ mod constellation_enters_with_choice;
 mod construct_cosmic_cube_second_draw_token;
 mod corrupted_resolve_counter_poisoned;
 mod costed_mana_abilities_no_recursion;
+mod costed_mana_ability_autotap_order;
 mod costed_mana_ability_demand_aware_autotap;
 mod craft_material_references;
 mod craterhoof_behemoth_dynamic_pump_2875;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic mana selection so sources without additional mana costs are activated first.
  * Ensured mana is generated in the correct order when combining regular and costed mana abilities.

* **Tests**
  * Added coverage for automatic payment involving costed mana abilities.
  * Verified correct mana generation order and resulting game state across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->