### PR TITLE
fix(client): reject failed worker initialization

### DIFF
--- a/client/src/adapter/__tests__/ai-card-subset.test.ts
+++ b/client/src/adapter/__tests__/ai-card-subset.test.ts
@@ -166,6 +166,41 @@ describe("WasmAdapter AI-pool subset lifecycle", () => {
     expect(action).toEqual({ type: "PassPriority" });
   });
 
+  it("disposes a partially initialized pool and never reuses it", async () => {
+    const { WasmAdapter } = await import("../wasm-adapter");
+
+    mockWorkerClient.buildAiCardSubset.mockResolvedValue(
+      JSON.stringify({ kind: "subset", json: "{}", count: 0 }),
+    );
+    mockWorkerClient.getAiAction.mockResolvedValue({ type: "PassPriority" });
+
+    const adapter = new WasmAdapter();
+    await adapter.initialize();
+    await adapter.warmCardDatabase();
+
+    const workersBeforePool = vi.mocked(EngineWorkerClient).mock.calls.length;
+    mockWorkerClient.initialize.mockRejectedValueOnce(
+      new Error("pool worker initialization timed out"),
+    );
+
+    const first = await adapter.getAiAction("VeryHard", 0, "Priority");
+    const workersAfterFailure = vi.mocked(EngineWorkerClient).mock.calls.length;
+    const failedPoolSize = workersAfterFailure - workersBeforePool;
+
+    expect(first).toEqual({ type: "PassPriority" });
+    expect(failedPoolSize).toBeGreaterThan(0);
+    expect(mockWorkerClient.dispose).toHaveBeenCalledTimes(failedPoolSize);
+    expect(mockWorkerClient.getAiScoredCandidates).not.toHaveBeenCalled();
+    expect(mockWorkerClient.getAiAction).toHaveBeenCalledTimes(1);
+
+    const second = await adapter.getAiAction("VeryHard", 0, "Priority");
+
+    expect(second).toEqual({ type: "PassPriority" });
+    expect(vi.mocked(EngineWorkerClient).mock.calls.length).toBe(workersAfterFailure);
+    expect(mockWorkerClient.getAiScoredCandidates).not.toHaveBeenCalled();
+    expect(mockWorkerClient.getAiAction).toHaveBeenCalledTimes(2);
+  });
+
   it("degrades to the single-worker path when the rebuild subset fails, then retries next decision", async () => {
     const { WasmAdapter } = await import("../wasm-adapter");
 

--- a/client/src/adapter/__tests__/ai-card-subset.test.ts
+++ b/client/src/adapter/__tests__/ai-card-subset.test.ts
@@ -94,6 +94,7 @@ describe("resolveAiPoolCardDbPlan / applyAiPoolCardDbPlan", () => {
 describe("WasmAdapter AI-pool subset lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockWorkerClient.initialize.mockResolvedValue(undefined);
     mockWorkerClient.getAiScoredCandidates.mockResolvedValue([
       [{ type: "PassPriority" }, 1.0],
     ]);
@@ -199,6 +200,82 @@ describe("WasmAdapter AI-pool subset lifecycle", () => {
     expect(vi.mocked(EngineWorkerClient).mock.calls.length).toBe(workersAfterFailure);
     expect(mockWorkerClient.getAiScoredCandidates).not.toHaveBeenCalled();
     expect(mockWorkerClient.getAiAction).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one pool initialization between concurrent decisions", async () => {
+    const { WasmAdapter } = await import("../wasm-adapter");
+
+    const adapter = new WasmAdapter();
+    await adapter.initialize();
+    const workersBeforePool = vi.mocked(EngineWorkerClient).mock.calls.length;
+
+    let finishPoolInitialization!: () => void;
+    const poolInitialization = new Promise<void>((resolve) => {
+      finishPoolInitialization = resolve;
+    });
+    mockWorkerClient.initialize.mockReturnValue(poolInitialization);
+
+    const first = adapter.getAiAction("VeryHard", 0, "Priority");
+    await vi.waitFor(() => {
+      expect(vi.mocked(EngineWorkerClient).mock.calls.length).toBeGreaterThan(
+        workersBeforePool,
+      );
+    });
+    const second = adapter.getAiAction("VeryHard", 0, "Priority");
+    finishPoolInitialization();
+    await Promise.all([first, second]);
+
+    const expectedPoolSize = Math.max(
+      2,
+      Math.min((navigator.hardwareConcurrency ?? 0) - 1, 4),
+    );
+    expect(
+      vi.mocked(EngineWorkerClient).mock.calls.length - workersBeforePool,
+    ).toBe(expectedPoolSize);
+  });
+
+  it("discards a pool candidate invalidated by a game reset", async () => {
+    const { WasmAdapter } = await import("../wasm-adapter");
+
+    mockWorkerClient.buildAiCardSubset.mockResolvedValue(
+      JSON.stringify({ kind: "subset", json: "{}", count: 0 }),
+    );
+    mockWorkerClient.getAiAction.mockResolvedValue({ type: "PassPriority" });
+
+    const adapter = new WasmAdapter();
+    await adapter.initialize();
+    await adapter.warmCardDatabase();
+    const workersBeforePool = vi.mocked(EngineWorkerClient).mock.calls.length;
+
+    let finishPoolInitialization!: () => void;
+    const poolInitialization = new Promise<void>((resolve) => {
+      finishPoolInitialization = resolve;
+    });
+    mockWorkerClient.initialize.mockReturnValue(poolInitialization);
+
+    const staleDecision = adapter.getAiAction("VeryHard", 0, "Priority");
+    await vi.waitFor(() => {
+      expect(vi.mocked(EngineWorkerClient).mock.calls.length).toBeGreaterThan(
+        workersBeforePool,
+      );
+    });
+    const workersAfterStaleCandidate = vi.mocked(EngineWorkerClient).mock.calls.length;
+    const poolSize = workersAfterStaleCandidate - workersBeforePool;
+
+    await adapter.resetGameState();
+    finishPoolInitialization();
+    await staleDecision;
+
+    expect(mockWorkerClient.dispose).toHaveBeenCalledTimes(poolSize);
+    expect(mockWorkerClient.getAiScoredCandidates).not.toHaveBeenCalled();
+
+    mockWorkerClient.initialize.mockResolvedValue(undefined);
+    await adapter.getAiAction("VeryHard", 0, "Priority");
+
+    expect(vi.mocked(EngineWorkerClient).mock.calls.length).toBe(
+      workersAfterStaleCandidate + poolSize,
+    );
+    expect(mockWorkerClient.getAiScoredCandidates).toHaveBeenCalled();
   });
 
   it("degrades to the single-worker path when the rebuild subset fails, then retries next decision", async () => {

--- a/client/src/adapter/__tests__/ai-card-subset.test.ts
+++ b/client/src/adapter/__tests__/ai-card-subset.test.ts
@@ -200,6 +200,14 @@ describe("WasmAdapter AI-pool subset lifecycle", () => {
     expect(vi.mocked(EngineWorkerClient).mock.calls.length).toBe(workersAfterFailure);
     expect(mockWorkerClient.getAiScoredCandidates).not.toHaveBeenCalled();
     expect(mockWorkerClient.getAiAction).toHaveBeenCalledTimes(2);
+
+    await adapter.resetGameState();
+    await adapter.getAiAction("VeryHard", 0, "Priority");
+
+    expect(vi.mocked(EngineWorkerClient).mock.calls.length).toBeGreaterThan(
+      workersAfterFailure,
+    );
+    expect(mockWorkerClient.getAiScoredCandidates).toHaveBeenCalled();
   });
 
   it("shares one pool initialization between concurrent decisions", async () => {
@@ -313,6 +321,98 @@ describe("WasmAdapter AI-pool subset lifecycle", () => {
     const calls = mockWorkerClient.loadCardDb.mock.calls;
     expect(calls[calls.length - 1][0] as string).toContain("Retry Card");
   });
+
+  it.each([
+    [
+      "bounded",
+      JSON.stringify({
+        kind: "subset",
+        json: '{"Stale Game Card":{}}',
+        count: 1,
+      }),
+    ],
+    ["unbounded", JSON.stringify({ kind: "full" })],
+  ])(
+    "ignores a stale %s preserved-pool reload after reset",
+    async (_staleKind, stalePlan) => {
+      const { WasmAdapter } = await import("../wasm-adapter");
+
+      let resolveStalePlan!: (plan: string) => void;
+      const stalePlanPromise = new Promise<string>((resolve) => {
+        resolveStalePlan = resolve;
+      });
+      let resolveCurrentPlan!: (plan: string) => void;
+      const currentPlanPromise = new Promise<string>((resolve) => {
+        resolveCurrentPlan = resolve;
+      });
+
+      mockWorkerClient.buildAiCardSubset
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            kind: "subset",
+            json: '{"Initial Game Card":{}}',
+            count: 1,
+          }),
+        )
+        .mockReturnValueOnce(stalePlanPromise)
+        .mockReturnValueOnce(currentPlanPromise);
+      mockWorkerClient.getAiAction.mockResolvedValue({ type: "PassPriority" });
+
+      const adapter = new WasmAdapter();
+      await adapter.initialize();
+      await adapter.warmCardDatabase();
+      await adapter.getAiAction("VeryHard", 0, "Priority");
+
+      await adapter.resetGameState();
+      const staleDecision = adapter.getAiAction("VeryHard", 0, "Priority");
+      await vi.waitFor(() => {
+        expect(mockWorkerClient.buildAiCardSubset).toHaveBeenCalledTimes(2);
+      });
+      const concurrentStaleDecision = adapter.getAiAction(
+        "VeryHard",
+        0,
+        "Priority",
+      );
+      await Promise.resolve();
+      expect(mockWorkerClient.buildAiCardSubset).toHaveBeenCalledTimes(2);
+
+      await adapter.resetGameState();
+      const currentDecision = adapter.getAiAction("VeryHard", 0, "Priority");
+      await vi.waitFor(() => {
+        expect(mockWorkerClient.buildAiCardSubset).toHaveBeenCalledTimes(3);
+      });
+
+      resolveStalePlan(stalePlan);
+      resolveCurrentPlan(
+        JSON.stringify({
+          kind: "subset",
+          json: '{"Current Game Card":{}}',
+          count: 1,
+        }),
+      );
+      await Promise.all([
+        staleDecision,
+        concurrentStaleDecision,
+        currentDecision,
+      ]);
+
+      const loadedSubsets = mockWorkerClient.loadCardDb.mock.calls.map(
+        ([text]) => text as string,
+      );
+      expect(loadedSubsets.some((text) => text.includes("Stale Game Card"))).toBe(
+        false,
+      );
+      expect(loadedSubsets[loadedSubsets.length - 1]).toContain("Current Game Card");
+
+      const scoredBeforeFollowUp = mockWorkerClient.getAiScoredCandidates.mock.calls.length;
+      await adapter.getAiAction("VeryHard", 0, "Priority");
+
+      expect(mockWorkerClient.buildAiCardSubset).toHaveBeenCalledTimes(3);
+      expect(mockWorkerClient.getAiScoredCandidates.mock.calls.length).toBeGreaterThan(
+        scoredBeforeFollowUp,
+      );
+    },
+  );
 
   it("drops the pool for an unbounded game (Momir) and restores it next game", async () => {
     const { WasmAdapter } = await import("../wasm-adapter");

--- a/client/src/adapter/__tests__/ai-worker-pool.test.ts
+++ b/client/src/adapter/__tests__/ai-worker-pool.test.ts
@@ -11,12 +11,16 @@ const mockWorkers = Array.from({ length: 2 }, () => ({
 }));
 
 let workerIndex = 0;
+let workerConstructorErrorAt: number | null = null;
 
 vi.mock("../engine-worker-client", () => ({
   EngineWorkerClient: vi.fn().mockImplementation(function () {
-    const worker = mockWorkers[workerIndex];
+    const currentWorkerIndex = workerIndex;
     workerIndex += 1;
-    return worker;
+    if (currentWorkerIndex === workerConstructorErrorAt) {
+      throw new Error("worker construction failed");
+    }
+    return mockWorkers[currentWorkerIndex];
   }),
 }));
 
@@ -24,6 +28,16 @@ describe("AiWorkerPool", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     workerIndex = 0;
+    workerConstructorErrorAt = null;
+  });
+
+  it("disposes earlier workers when a later worker fails to construct", () => {
+    workerConstructorErrorAt = 1;
+
+    expect(() => new AiWorkerPool(2)).toThrow("worker construction failed");
+
+    expect(mockWorkers[0].dispose).toHaveBeenCalledOnce();
+    expect(mockWorkers[1].dispose).not.toHaveBeenCalled();
   });
 
   it("merges worker scores without reintroducing missing actions", async () => {

--- a/client/src/adapter/__tests__/engine-worker-client.test.ts
+++ b/client/src/adapter/__tests__/engine-worker-client.test.ts
@@ -57,6 +57,19 @@ beforeEach(() => {
 });
 
 describe("EngineWorkerClient initialization", () => {
+  it("resolves normally when the worker initializes before the deadline", async () => {
+    vi.useFakeTimers();
+    const client = new EngineWorkerClient();
+    const promise = client.initialize();
+    const worker = currentWorker();
+    const reqId = worker.posted[0].id as number;
+
+    worker.replyResult(reqId, null);
+
+    await expect(promise).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(30_000);
+  });
+
   it("rejects when WASM initialization returns a typed worker error", async () => {
     const client = new EngineWorkerClient();
     const promise = client.initialize();
@@ -75,6 +88,19 @@ describe("EngineWorkerClient initialization", () => {
     currentWorker().emitError("Worker script failed to load");
 
     await expect(promise).rejects.toThrow("Worker script failed to load");
+  });
+
+  it("rejects when the worker never responds to initialization", async () => {
+    vi.useFakeTimers();
+    const client = new EngineWorkerClient();
+    const promise = client.initialize();
+    const rejection = expect(promise).rejects.toThrow(
+      "Engine worker init timed out after 30000ms",
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await rejection;
   });
 });
 

--- a/client/src/adapter/__tests__/engine-worker-client.test.ts
+++ b/client/src/adapter/__tests__/engine-worker-client.test.ts
@@ -35,6 +35,16 @@ class MockWorker {
   replyResult(id: number, data: unknown): void {
     this.onmessage?.({ data: { type: "result", id, data } } as MessageEvent);
   }
+
+  /** Simulate a typed failure reply for a previously-posted request id. */
+  replyError(id: number, message: string): void {
+    this.onmessage?.({ data: { type: "error", id, message } } as MessageEvent);
+  }
+
+  /** Simulate failure to load or execute the worker script itself. */
+  emitError(message: string): void {
+    this.onerror?.({ message } as ErrorEvent);
+  }
 }
 
 function currentWorker(): MockWorker {
@@ -44,6 +54,28 @@ function currentWorker(): MockWorker {
 
 beforeEach(() => {
   vi.stubGlobal("Worker", MockWorker);
+});
+
+describe("EngineWorkerClient initialization", () => {
+  it("rejects when WASM initialization returns a typed worker error", async () => {
+    const client = new EngineWorkerClient();
+    const promise = client.initialize();
+    const worker = currentWorker();
+    const reqId = worker.posted[0].id as number;
+
+    worker.replyError(reqId, "WASM initialization failed");
+
+    await expect(promise).rejects.toThrow("WASM initialization failed");
+  });
+
+  it("rejects when the worker script fails during initialization", async () => {
+    const client = new EngineWorkerClient();
+    const promise = client.initialize();
+
+    currentWorker().emitError("Worker script failed to load");
+
+    await expect(promise).rejects.toThrow("Worker script failed to load");
+  });
 });
 
 afterEach(() => {

--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -97,6 +97,29 @@ describe("WasmAdapter", () => {
       expect(ensureWasmInit).toHaveBeenCalledOnce();
       expect(adapter.getEngineClient()).toBeNull();
     });
+
+    it("does not reactivate after disposal while initialization is pending", async () => {
+      let finishInitialization!: () => void;
+      mockWorkerClient.initialize.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishInitialization = resolve;
+          }),
+      );
+
+      const staleInitialization = adapter.initialize();
+      adapter.dispose();
+      finishInitialization();
+      await staleInitialization;
+
+      await expect(adapter.ping()).rejects.toMatchObject({
+        code: AdapterErrorCode.NOT_INITIALIZED,
+      });
+
+      await adapter.initialize();
+      expect(vi.mocked(EngineWorkerClient)).toHaveBeenCalledTimes(2);
+      await expect(adapter.ping()).resolves.toBe("phase-rs engine ready");
+    });
   });
 
   describe("warmCardDatabase", () => {

--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -5,6 +5,13 @@ import type { EngineAdapter, SubmitResult } from "../types";
 import { AdapterError, AdapterErrorCode } from "../types";
 import { buildGameState } from "../../test/factories/gameStateFactory";
 
+const ensureWasmInit = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("../../services/cardData", () => ({
+  ensureWasmInit,
+  ensureCardDatabase: vi.fn().mockResolvedValue(100),
+}));
+
 // Mock EngineWorkerClient to avoid actual Worker creation in tests
 const mockWorkerClient = {
   initialize: vi.fn().mockResolvedValue(undefined),
@@ -77,6 +84,18 @@ describe("WasmAdapter", () => {
       await Promise.all([adapter.initialize(), adapter.initialize()]);
       expect(vi.mocked(EngineWorkerClient)).toHaveBeenCalledOnce();
       expect(mockWorkerClient.initialize).toHaveBeenCalledOnce();
+    });
+
+    it("disposes a worker that fails initialization and falls back to main-thread WASM", async () => {
+      mockWorkerClient.initialize.mockRejectedValueOnce(
+        new Error("WASM initialization failed"),
+      );
+
+      await expect(adapter.initialize()).resolves.toBeUndefined();
+
+      expect(mockWorkerClient.dispose).toHaveBeenCalledOnce();
+      expect(ensureWasmInit).toHaveBeenCalledOnce();
+      expect(adapter.getEngineClient()).toBeNull();
     });
   });
 

--- a/client/src/adapter/ai-worker-pool.ts
+++ b/client/src/adapter/ai-worker-pool.ts
@@ -23,8 +23,16 @@ export class AiWorkerPool {
   private scoringLock: Promise<void> = Promise.resolve();
 
   constructor(workerCount: number) {
-    for (let i = 0; i < workerCount; i++) {
-      this.workers.push(new EngineWorkerClient());
+    try {
+      for (let i = 0; i < workerCount; i++) {
+        this.workers.push(new EngineWorkerClient());
+      }
+    } catch (error) {
+      // Construction is transactional: if a later worker fails to spawn,
+      // dispose every worker that was already created before propagating the
+      // failure to the adapter's single-worker fallback path.
+      this.dispose();
+      throw error;
     }
   }
 

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -21,7 +21,6 @@ import { debugLog } from "../game/debugLog";
 import { notifyEngineSlow } from "../game/engineRecovery";
 
 type EngineResponse =
-  | { type: "ready" }
   | { type: "result"; id: number; data: unknown }
   | { type: "error"; id: number; message: string; bracketViolation?: true };
 
@@ -61,25 +60,15 @@ export class EngineWorkerClient {
       slowNotified?: boolean;
     }
   >();
-  private readyPromise: Promise<void>;
-  private readyResolve!: () => void;
-
   constructor() {
     this.worker = new Worker(
       new URL("./engine-worker.ts", import.meta.url),
       { type: "module" },
     );
 
-    this.readyPromise = new Promise<void>((resolve) => {
-      this.readyResolve = resolve;
-    });
-
     this.worker.onmessage = (e: MessageEvent<EngineResponse>) => {
       const msg = e.data;
       switch (msg.type) {
-        case "ready":
-          this.readyResolve();
-          break;
         case "result": {
           const entry = this.pending.get(msg.id);
           if (entry) {
@@ -151,8 +140,7 @@ export class EngineWorkerClient {
   }
 
   async initialize(): Promise<void> {
-    this.worker.postMessage({ type: "init" });
-    await this.readyPromise;
+    await this.request<null>({ type: "init" });
   }
 
   async loadCardDb(text: string): Promise<number> {

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -36,6 +36,15 @@ type EngineResponse =
 const ENGINE_REQUEST_TIMEOUT_MS = 60_000;
 
 /**
+ * Hard deadline for the initial WASM worker handshake. Unlike gameplay
+ * watchdogs, initialization has no useful late-response path: rejecting lets
+ * WasmAdapter dispose the stalled worker and activate its main-thread fallback.
+ */
+const ENGINE_INITIALIZATION_TIMEOUT_MS = 30_000;
+
+type RequestTimeoutBehavior = "notify" | "reject";
+
+/**
  * Watchdog timeout for AI search round-trips (getAiAction /
  * getAiScoredCandidates / selectActionFromScores). Deliberately much larger
  * than ENGINE_REQUEST_TIMEOUT_MS: AI search legitimately exceeds 60s on
@@ -110,21 +119,32 @@ export class EngineWorkerClient {
   /**
    * Post a typed message to the worker and resolve when it replies.
    *
-   * `timeoutMs` arms a watchdog: if the worker doesn't reply within the
-   * window, the pending entry stays alive and the UI is notified that the
-   * request is slow. This is applied ONLY to gameplay round-trips (see call
-   * sites below) — never to bulk/long setup calls (card-DB load, game init,
-   * batch resolve, restore), where a long runtime is expected. A late worker
-   * reply still resolves the original promise and clears the dispatch mutex.
+   * `timeoutMs` arms a watchdog. The default `notify` behavior keeps a slow
+   * gameplay request alive and informs the UI, allowing a late reply to resolve
+   * normally. The initialization-only `reject` behavior removes and rejects a
+   * stalled request so the adapter can fall back. Bulk setup calls (card-DB
+   * load, game init, batch resolve, restore) deliberately have no timeout.
    */
-  private request<T>(message: Record<string, unknown>, timeoutMs?: number): Promise<T> {
+  private request<T>(
+    message: Record<string, unknown>,
+    timeoutMs?: number,
+    timeoutBehavior: RequestTimeoutBehavior = "notify",
+  ): Promise<T> {
     const id = this.nextId++;
     return new Promise<T>((resolve, reject) => {
       const timer =
         timeoutMs !== undefined
           ? setTimeout(() => {
               const entry = this.pending.get(id);
-              if (entry && !entry.slowNotified) {
+              if (!entry) return;
+              if (timeoutBehavior === "reject") {
+                this.pending.delete(id);
+                entry.reject(
+                  new Error(
+                    `Engine worker ${String(message.type)} timed out after ${timeoutMs}ms`,
+                  ),
+                );
+              } else if (!entry.slowNotified) {
                 entry.slowNotified = true;
                 notifyEngineSlow(`${String(message.type)}-timeout`);
               }
@@ -140,7 +160,11 @@ export class EngineWorkerClient {
   }
 
   async initialize(): Promise<void> {
-    await this.request<null>({ type: "init" });
+    await this.request<null>(
+      { type: "init" },
+      ENGINE_INITIALIZATION_TIMEOUT_MS,
+      "reject",
+    );
   }
 
   async loadCardDb(text: string): Promise<number> {

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -48,7 +48,7 @@ import type { BracketDeckRequest } from "../types/bracketEstimate";
 // ── Message Protocol ─────────────────────────────────────────────────────
 
 type EngineRequest =
-  | { type: "init" }
+  | { type: "init"; id: number }
   | { type: "loadCardDb"; id: number; cardDataText: string }
   | {
       type: "initializeGame";
@@ -109,7 +109,6 @@ type EngineRequest =
   | { type: "clearReplayPlayback"; id: number };
 
 type EngineResponse =
-  | { type: "ready" }
   | { type: "result"; id: number; data: unknown }
   | { type: "error"; id: number; message: string; bracketViolation?: true };
 
@@ -146,7 +145,7 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
         } else {
           await init();
         }
-        respond({ type: "ready" });
+        result(msg.id, null);
         break;
       }
 
@@ -518,7 +517,6 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
       }
     }
   } catch (err) {
-    const id = "id" in msg ? (msg as { id: number }).id : -1;
-    error(id, err instanceof Error ? err.message : String(err));
+    error(msg.id, err instanceof Error ? err.message : String(err));
   }
 };

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -171,11 +171,13 @@ export class WasmAdapter implements EngineAdapter {
       try {
         this.engine = new EngineWorkerClient();
         await this.engine.initialize();
-      } catch {
-        // Worker creation failed — fall back to main-thread WASM
+      } catch (error) {
+        // Worker creation or initialization failed — fall back to main-thread WASM
         console.warn(
-          "Web Worker creation failed, falling back to main-thread WASM",
+          "Web Worker initialization failed, falling back to main-thread WASM",
+          error,
         );
+        this.engine?.dispose();
         this.engine = null;
         this.fallback = await createMainThreadFallback();
       }

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -480,6 +480,7 @@ export class WasmAdapter implements EngineAdapter {
     // path below (getAiAction), which runs the same fixed-budget beam search;
     // the pool only adds cross-seed rollout-variance averaging, not search depth.
     if (isMemoryConstrainedDevice()) return null;
+    let candidatePool: AiWorkerPool | null = null;
     try {
       // Resolve this game's card-data plan BEFORE paying to spawn workers:
       // an unbounded-universe game (e.g. Momir) never creates a pool at all.
@@ -493,13 +494,18 @@ export class WasmAdapter implements EngineAdapter {
       }
       const cores = navigator.hardwareConcurrency ?? 0;
       const count = Math.max(2, Math.min(cores - 1, 4));
-      this.aiPool = new AiWorkerPool(count);
-      await this.aiPool.initialize();
+      candidatePool = new AiWorkerPool(count);
+      await candidatePool.initialize();
       if (plan) {
-        await applyAiPoolCardDbPlan(plan, this.aiPool);
+        await applyAiPoolCardDbPlan(plan, candidatePool);
       }
-      return this.aiPool;
+      // Publish only a fully initialized, game-data-ready pool. A partially
+      // initialized pool must never become observable to later AI decisions.
+      this.aiPool = candidatePool;
+      return candidatePool;
     } catch {
+      candidatePool?.dispose();
+      this.aiPool = null;
       this.aiPoolFailed = true;
       return null;
     }

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -233,7 +233,7 @@ export class WasmAdapter implements EngineAdapter {
         // get the game-scoped subset (built on the main engine), not the full
         // corpus; an unbounded universe (e.g. Momir) disposes the pool instead.
         if (this.engine && this.aiPool && !this.aiPool.isCardDbLoaded) {
-          await this.loadAiPoolGameDb(this.engine, this.aiPool);
+          await this.ensureAiPool();
         }
       } catch (err) {
         console.warn("Failed to load card database:", err);
@@ -445,19 +445,37 @@ export class WasmAdapter implements EngineAdapter {
    * spawning workers (see `ensureAiPool`); this handles the cross-game case
    * where a pool from a bounded game meets an unbounded one. Returns the
    * surviving pool or null. */
-  private async loadAiPoolGameDb(
+  private async reloadAiPoolGameDb(
     engine: EngineWorkerClient,
     aiPool: AiWorkerPool,
+    generation: number,
   ): Promise<AiWorkerPool | null> {
-    const plan = await resolveAiPoolCardDbPlan(this.aiCardDataMode, engine);
-    if (plan.kind === "unbounded") {
-      aiPool.dispose();
-      this.aiPool = null;
-      this.aiPoolUnboundedGame = true;
+    try {
+      const plan = await resolveAiPoolCardDbPlan(this.aiCardDataMode, engine);
+      if (this.aiPoolGeneration !== generation || this.aiPool !== aiPool) {
+        return null;
+      }
+      if (plan.kind === "unbounded") {
+        aiPool.dispose();
+        this.aiPool = null;
+        this.aiPoolUnboundedGame = true;
+        return null;
+      }
+      await applyAiPoolCardDbPlan(plan, aiPool);
+      if (this.aiPoolGeneration !== generation || this.aiPool !== aiPool) {
+        aiPool.invalidateCardDb();
+        return null;
+      }
+      return aiPool;
+    } catch (err) {
+      if (this.aiPoolGeneration === generation && this.aiPool === aiPool) {
+        // Degrade to the single-worker path for this decision instead of
+        // crashing the AI flow. The pool stays invalid so a transient failure
+        // retries on the next decision.
+        console.warn("Failed to load game DB into AI pool:", err);
+      }
       return null;
     }
-    await applyAiPoolCardDbPlan(plan, aiPool);
-    return aiPool;
   }
 
   /** Lazy AI pool init — only created on first VeryHard request. */
@@ -466,11 +484,15 @@ export class WasmAdapter implements EngineAdapter {
     // this game — don't recreate it just to escalate and drop it again on
     // every AI decision.
     if (this.aiPoolUnboundedGame) return Promise.resolve(null);
+    if (this.aiPoolPromise) return this.aiPoolPromise;
     if (this.aiPool) {
       // The pool's subset is game-scoped: after `resetGameState` invalidated it,
       // rebuild this game's subset (the pool instance is preserved across games).
       if (this.cardDbLoaded && this.engine && !this.aiPool.isCardDbLoaded) {
-        return this.loadExistingAiPoolGameDb(this.engine, this.aiPool);
+        const generation = this.aiPoolGeneration;
+        return this.trackAiPoolWork(
+          this.reloadAiPoolGameDb(this.engine, this.aiPool, generation),
+        );
       }
       return Promise.resolve(this.aiPool);
     }
@@ -482,33 +504,20 @@ export class WasmAdapter implements EngineAdapter {
     // path below (getAiAction), which runs the same fixed-budget beam search;
     // the pool only adds cross-seed rollout-variance averaging, not search depth.
     if (isMemoryConstrainedDevice()) return Promise.resolve(null);
-    if (this.aiPoolPromise) return this.aiPoolPromise;
 
     const generation = this.aiPoolGeneration;
-    const pending = this.createAiPool(generation);
+    return this.trackAiPoolWork(this.createAiPool(generation));
+  }
+
+  private trackAiPoolWork(
+    pending: Promise<AiWorkerPool | null>,
+  ): Promise<AiWorkerPool | null> {
     this.aiPoolPromise = pending;
     const clearPending = () => {
       if (this.aiPoolPromise === pending) this.aiPoolPromise = null;
     };
     void pending.then(clearPending, clearPending);
     return pending;
-  }
-
-  private async loadExistingAiPoolGameDb(
-    engine: EngineWorkerClient,
-    aiPool: AiWorkerPool,
-  ): Promise<AiWorkerPool | null> {
-    try {
-      return await this.loadAiPoolGameDb(engine, aiPool);
-    } catch (err) {
-      // Degrade to the single-worker path for this decision instead of
-      // crashing the AI flow (`getAiAction` calls ensureAiPool outside its
-      // try block). `isCardDbLoaded` stays false, so a transient failure
-      // retries on the next decision. A dead engine worker surfaces
-      // properly downstream via the single-worker path's classifier.
-      console.warn("Failed to load game DB into AI pool:", err);
-      return null;
-    }
   }
 
   private async createAiPool(generation: number): Promise<AiWorkerPool | null> {
@@ -673,6 +682,7 @@ export class WasmAdapter implements EngineAdapter {
     // the newer one.
     this.aiPoolGeneration += 1;
     this.aiPoolPromise = null;
+    this.aiPoolFailed = false;
     if (this.aiCardDataMode !== "full") {
       this.aiPool?.invalidateCardDb();
     }

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -143,6 +143,8 @@ export class WasmAdapter implements EngineAdapter {
 
   // Multi-worker AI pool for VeryHard root parallelism (lazy-initialized)
   private aiPool: AiWorkerPool | null = null;
+  private aiPoolPromise: Promise<AiWorkerPool | null> | null = null;
+  private aiPoolGeneration = 0;
   private aiPoolFailed = false;
   /** This game's card universe is unbounded (e.g. Momir): the pool was
    *  disposed instead of loading the full corpus into every worker, and must
@@ -163,23 +165,33 @@ export class WasmAdapter implements EngineAdapter {
   // flag check and spawn a second EngineWorkerClient, orphaning the first
   // worker's ~90 MB instance. Concurrent callers share one promise.
   private initPromise: Promise<void> | null = null;
+  private lifecycleGeneration = 0;
 
   async initialize(): Promise<void> {
     if (this.initialized) return;
     if (this.initPromise) return this.initPromise;
+    const generation = this.lifecycleGeneration;
     const pending = (async () => {
+      let candidateEngine: EngineWorkerClient | null = null;
       try {
-        this.engine = new EngineWorkerClient();
-        await this.engine.initialize();
+        candidateEngine = new EngineWorkerClient();
+        await candidateEngine.initialize();
+        if (this.lifecycleGeneration !== generation) {
+          candidateEngine.dispose();
+          return;
+        }
+        this.engine = candidateEngine;
       } catch (error) {
+        candidateEngine?.dispose();
+        if (this.lifecycleGeneration !== generation) return;
         // Worker creation or initialization failed — fall back to main-thread WASM
         console.warn(
           "Web Worker initialization failed, falling back to main-thread WASM",
           error,
         );
-        this.engine?.dispose();
-        this.engine = null;
-        this.fallback = await createMainThreadFallback();
+        const candidateFallback = await createMainThreadFallback();
+        if (this.lifecycleGeneration !== generation) return;
+        this.fallback = candidateFallback;
       }
       this.initialized = true;
     })();
@@ -188,7 +200,7 @@ export class WasmAdapter implements EngineAdapter {
     // `pending` is returned so the current caller still sees the error; only
     // future callers get a fresh attempt — matching the pre-dedupe semantics.
     pending.catch(() => {
-      this.initPromise = null;
+      if (this.initPromise === pending) this.initPromise = null;
     });
     this.initPromise = pending;
     return pending;
@@ -449,37 +461,57 @@ export class WasmAdapter implements EngineAdapter {
   }
 
   /** Lazy AI pool init — only created on first VeryHard request. */
-  private async ensureAiPool(): Promise<AiWorkerPool | null> {
+  private ensureAiPool(): Promise<AiWorkerPool | null> {
     // Unbounded-universe game (e.g. Momir): the pool was already dropped for
     // this game — don't recreate it just to escalate and drop it again on
     // every AI decision.
-    if (this.aiPoolUnboundedGame) return null;
+    if (this.aiPoolUnboundedGame) return Promise.resolve(null);
     if (this.aiPool) {
       // The pool's subset is game-scoped: after `resetGameState` invalidated it,
       // rebuild this game's subset (the pool instance is preserved across games).
       if (this.cardDbLoaded && this.engine && !this.aiPool.isCardDbLoaded) {
-        try {
-          return await this.loadAiPoolGameDb(this.engine, this.aiPool);
-        } catch (err) {
-          // Degrade to the single-worker path for this decision instead of
-          // crashing the AI flow (`getAiAction` calls ensureAiPool outside its
-          // try block). `isCardDbLoaded` stays false, so a transient failure
-          // retries on the next decision. A dead engine worker surfaces
-          // properly downstream via the single-worker path's classifier.
-          console.warn("Failed to load game DB into AI pool:", err);
-          return null;
-        }
+        return this.loadExistingAiPoolGameDb(this.engine, this.aiPool);
       }
-      return this.aiPool;
+      return Promise.resolve(this.aiPool);
     }
-    if (this.aiPoolFailed) return null;
+    if (this.aiPoolFailed) return Promise.resolve(null);
     // Skip the AI worker pool on memory-constrained handhelds (iOS WebKit in
     // particular): the main engine instance plus 2–4 pooled instances each hold
     // a full ~48MB WASM module and exceed the per-tab memory ceiling, silently
     // OOM-reloading the tab. VeryHard then falls through to the single-worker
     // path below (getAiAction), which runs the same fixed-budget beam search;
     // the pool only adds cross-seed rollout-variance averaging, not search depth.
-    if (isMemoryConstrainedDevice()) return null;
+    if (isMemoryConstrainedDevice()) return Promise.resolve(null);
+    if (this.aiPoolPromise) return this.aiPoolPromise;
+
+    const generation = this.aiPoolGeneration;
+    const pending = this.createAiPool(generation);
+    this.aiPoolPromise = pending;
+    const clearPending = () => {
+      if (this.aiPoolPromise === pending) this.aiPoolPromise = null;
+    };
+    void pending.then(clearPending, clearPending);
+    return pending;
+  }
+
+  private async loadExistingAiPoolGameDb(
+    engine: EngineWorkerClient,
+    aiPool: AiWorkerPool,
+  ): Promise<AiWorkerPool | null> {
+    try {
+      return await this.loadAiPoolGameDb(engine, aiPool);
+    } catch (err) {
+      // Degrade to the single-worker path for this decision instead of
+      // crashing the AI flow (`getAiAction` calls ensureAiPool outside its
+      // try block). `isCardDbLoaded` stays false, so a transient failure
+      // retries on the next decision. A dead engine worker surfaces
+      // properly downstream via the single-worker path's classifier.
+      console.warn("Failed to load game DB into AI pool:", err);
+      return null;
+    }
+  }
+
+  private async createAiPool(generation: number): Promise<AiWorkerPool | null> {
     let candidatePool: AiWorkerPool | null = null;
     try {
       // Resolve this game's card-data plan BEFORE paying to spawn workers:
@@ -487,6 +519,7 @@ export class WasmAdapter implements EngineAdapter {
       let plan: AiPoolCardDbPlan | null = null;
       if (this.cardDbLoaded && this.engine) {
         plan = await resolveAiPoolCardDbPlan(this.aiCardDataMode, this.engine);
+        if (this.aiPoolGeneration !== generation) return null;
         if (plan.kind === "unbounded") {
           this.aiPoolUnboundedGame = true;
           return null;
@@ -499,14 +532,20 @@ export class WasmAdapter implements EngineAdapter {
       if (plan) {
         await applyAiPoolCardDbPlan(plan, candidatePool);
       }
+      if (this.aiPoolGeneration !== generation) {
+        candidatePool.dispose();
+        return null;
+      }
       // Publish only a fully initialized, game-data-ready pool. A partially
       // initialized pool must never become observable to later AI decisions.
       this.aiPool = candidatePool;
       return candidatePool;
     } catch {
       candidatePool?.dispose();
-      this.aiPool = null;
-      this.aiPoolFailed = true;
+      if (this.aiPoolGeneration === generation) {
+        this.aiPool = null;
+        this.aiPoolFailed = true;
+      }
       return null;
     }
   }
@@ -628,15 +667,19 @@ export class WasmAdapter implements EngineAdapter {
    * running a full search.
    */
   async resetGameState(): Promise<void> {
-    if (this.engine) {
-      await this.engine.resetGame();
-    }
+    // Invalidate unpublished pool candidates immediately. A later game may
+    // start creating its own pool while an earlier game's initialization is
+    // still unwinding; identity checks prevent the stale promise from clearing
+    // the newer one.
+    this.aiPoolGeneration += 1;
+    this.aiPoolPromise = null;
     if (this.aiCardDataMode !== "full") {
       this.aiPool?.invalidateCardDb();
     }
-    // A pool dropped for an unbounded-universe game may be recreated for the
-    // next (bounded) game.
     this.aiPoolUnboundedGame = false;
+    if (this.engine) {
+      await this.engine.resetGame();
+    }
   }
 
   async estimateBracket(deck: BracketDeckRequest): Promise<BracketEstimate | null> {
@@ -704,6 +747,8 @@ export class WasmAdapter implements EngineAdapter {
   }
 
   dispose(): void {
+    this.lifecycleGeneration += 1;
+    this.aiPoolGeneration += 1;
     // Clear the singleton reference so getSharedAdapter() creates a fresh
     // instance if called after dispose (e.g., error recovery code paths).
     if (sharedAdapter === this) sharedAdapter = null;
@@ -711,6 +756,7 @@ export class WasmAdapter implements EngineAdapter {
     this.engine = null;
     this.aiPool?.dispose();
     this.aiPool = null;
+    this.aiPoolPromise = null;
     this.aiPoolFailed = false;
     this.aiPoolUnboundedGame = false;
     this.fallback = null;


### PR DESCRIPTION
## What changed

- route worker initialization through the existing request/response protocol with a correlated request ID
- reject initialization when WASM setup or the worker script fails
- dispose failed workers before falling back to main-thread WASM
- cover typed init failures, worker load failures, and the fallback path with regression tests

## Why

Initialization previously waited on a one-way `ready` promise. If WASM initialization threw, the worker emitted an uncorrelated error and the promise never settled, leaving startup stuck on “Preparing Cards…” instead of activating the existing fallback.

## Scope

This is the cross-platform worker initialization extraction only. 

## Verification

- `cargo fmt --all`
- protocol version check
- TypeScript project build (`tsc -b --noEmit`)
- ESLint on all changed files
- targeted adapter tests: 30 passed
- full frontend unit suite: 2,206 passed, 4 skipped, 18 todo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Web Worker engine initialization with a dedicated timeout, request-correlated init replies, and clearer handling of typed worker failures.
  * Removed the standalone “ready” handshake for more reliable startup.
  * Hardened failure behavior: worker/init errors are logged, partially created resources are cleaned up, and the app falls back to main-thread operation.
  * Improved AI-pool lifecycle safety: prevents stale/overlapping pool work across resets and ensures transactional worker-pool construction.

* **Tests**
  * Expanded coverage for init success/failure modes, worker script load errors, timeouts, pool worker construction failures, concurrency deduping, and stale decision invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->