### PR TITLE
fix(ci): stamp the shell version into src-tauri's Cargo.lock alongside the manifest

### DIFF
--- a/.github/workflows/shell-release.yml
+++ b/.github/workflows/shell-release.yml
@@ -95,6 +95,18 @@ jobs:
           if replacements != 1:
               raise SystemExit("expected exactly one phase-tauri package version")
           cargo_path.write_text(cargo)
+
+          # Cargo.lock records phase-tauri's own version; without this the
+          # stamped manifest fails `cargo check --locked`.
+          lock_path = Path("client/src-tauri/Cargo.lock")
+          lock = lock_path.read_text()
+          lock, replacements = re.subn(
+              r'(\[\[package\]\]\nname = "phase-tauri"\nversion = ")[^"]+(")',
+              rf'\g<1>{version}\g<2>', lock, count=1,
+          )
+          if replacements != 1:
+              raise SystemExit("expected exactly one phase-tauri lockfile entry")
+          lock_path.write_text(lock)
           PY
 
       - name: Assert shell version stamping
@@ -102,6 +114,7 @@ jobs:
           set -euo pipefail
           test "$(jq -r '.version' client/src-tauri/tauri.conf.json)" = "$SHELL_VERSION"
           test "$(sed -nE 's/^version = "([^"]+)"/\1/p' client/src-tauri/Cargo.toml | head -1)" = "$SHELL_VERSION"
+          test "$(awk '/^name = "phase-tauri"$/ { getline; sub(/^version = "/, ""); sub(/"$/, ""); print }' client/src-tauri/Cargo.lock)" = "$SHELL_VERSION"
 
       - name: Validate Tauri JSON configs
         run: |
@@ -191,6 +204,19 @@ jobs:
             throw new Error("expected phase-tauri package version to be stamped");
           }
           fs.writeFileSync(cargoPath, stamped);
+
+          // Cargo.lock records phase-tauri's own version; keep it in sync so
+          // the build never resolves against a stale locked version.
+          const lockPath = "client/src-tauri/Cargo.lock";
+          const lock = fs.readFileSync(lockPath, "utf8");
+          const stampedLock = lock.replace(
+            /(\[\[package\]\]\nname = "phase-tauri"\nversion = ")[^"]+(")/,
+            `$1${version}$2`,
+          );
+          if (stampedLock === lock) {
+            throw new Error("expected phase-tauri lockfile entry to be stamped");
+          }
+          fs.writeFileSync(lockPath, stampedLock);
           NODE
 
       - name: Assert shell version stamping
@@ -199,6 +225,7 @@ jobs:
           set -euo pipefail
           test "$(node -p "require('./client/src-tauri/tauri.conf.json').version")" = "$SHELL_VERSION"
           test "$(sed -nE 's/^version = "([^"]+)"/\1/p' client/src-tauri/Cargo.toml | head -1)" = "$SHELL_VERSION"
+          test "$(awk '/^name = "phase-tauri"$/ { getline; sub(/^version = "/, ""); sub(/"$/, ""); print }' client/src-tauri/Cargo.lock)" = "$SHELL_VERSION"
 
       - name: Install system dependencies (Linux)
         if: matrix.os == 'linux'

--- a/.github/workflows/shell-release.yml
+++ b/.github/workflows/shell-release.yml
@@ -199,24 +199,21 @@ jobs:
 
           const cargoPath = "client/src-tauri/Cargo.toml";
           const cargo = fs.readFileSync(cargoPath, "utf8");
-          const stamped = cargo.replace(/^version = "[^"]+"$/m, `version = "${version}"`);
-          if (stamped === cargo) {
-            throw new Error("expected phase-tauri package version to be stamped");
+          const cargoPattern = /^version = "[^"]+"$/m;
+          if (!cargoPattern.test(cargo)) {
+            throw new Error("expected a phase-tauri package version to stamp");
           }
-          fs.writeFileSync(cargoPath, stamped);
+          fs.writeFileSync(cargoPath, cargo.replace(cargoPattern, `version = "${version}"`));
 
           // Cargo.lock records phase-tauri's own version; keep it in sync so
           // the build never resolves against a stale locked version.
           const lockPath = "client/src-tauri/Cargo.lock";
           const lock = fs.readFileSync(lockPath, "utf8");
-          const stampedLock = lock.replace(
-            /(\[\[package\]\]\nname = "phase-tauri"\nversion = ")[^"]+(")/,
-            `$1${version}$2`,
-          );
-          if (stampedLock === lock) {
-            throw new Error("expected phase-tauri lockfile entry to be stamped");
+          const lockPattern = /(\[\[package\]\]\nname = "phase-tauri"\nversion = ")[^"]+(")/;
+          if (!lockPattern.test(lock)) {
+            throw new Error("expected a phase-tauri lockfile entry to stamp");
           }
-          fs.writeFileSync(lockPath, stampedLock);
+          fs.writeFileSync(lockPath, lock.replace(lockPattern, `$1${version}$2`));
           NODE
 
       - name: Assert shell version stamping


### PR DESCRIPTION
Shell Preflight rewrites phase-tauri's version to the shell tag version
and then runs cargo check --locked, but the standalone Cargo.lock still
records the engine-release version, so the check refuses to resolve
(first shell-v1.0.0 run, job 29883756568). Stamp the lockfile's
phase-tauri entry in both stamping steps and assert it, keeping --locked
as a real guard against genuine dependency drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow’s version stamping to also synchronize the desktop app’s `phase-tauri` entry in the package lockfile.
  * Extended preflight and build checks to verify the lockfile’s `phase-tauri` version matches the stamped release version across Linux, macOS, and Windows before publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->