### PR TITLE
fix(engine): spelled-out goad requirements must not goad (CR 701.15a)

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -1029,6 +1029,7 @@ impl LegalityPoisonGates {
                     | StaticMode::MustAttack
                     | StaticMode::MustAttackPlayer { .. }
                     | StaticMode::Goaded
+                    | StaticMode::MustAttackAwayFromSource
                     | StaticMode::CanAttackWithDefender
                     | StaticMode::MaxAttackersEachCombat { .. }
                     | StaticMode::CombatAlone { .. }

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -2075,6 +2075,7 @@ fn static_mode_references_growing_class(mode: &crate::types::statics::StaticMode
         | StaticMode::MustBeBlocked { .. }
         | StaticMode::MustBeBlockedByAll { .. }
         | StaticMode::Goaded
+        | StaticMode::MustAttackAwayFromSource
         | StaticMode::CombatAlone { .. }
         | StaticMode::CantCrew
         | StaticMode::CantPhaseIn

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -4236,7 +4236,7 @@ pub(crate) fn players_to_attack_away_from_gated(
 ) -> HashSet<PlayerId> {
     let mut players = goading_players_for_creature_gated(state, creature_id, has_goad_static);
     if let Some(obj) = state.objects.get(&creature_id) {
-        // CR 611.2c: the avoided player is the anchor snapshotted at graft time.
+        // CR 109.5: the avoided player is the anchor snapshotted at graft time.
         // `unwrap_or(obj.controller)` is a defensive default with NO producer
         // today — the parser is the sole producer of this mode and always routes
         // through the transient graft, which stamps the anchor (layers.rs). It is

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -2730,12 +2730,16 @@ fn creature_must_attack_with_attackable_players_gated(
             StaticMode::MustAttack,
             &static_target_ctx(obj_id),
         );
-    // CR 701.15b: Goaded creatures must attack each combat if able.
-    let is_goaded = !goading_players_for_creature_gated(state, obj_id, gates.has_goad).is_empty();
+    // CR 508.1d + CR 701.15b (first clause): a creature under an "attacks a
+    // player other than X if able" requirement — whether from the goad
+    // designation or from the spelled-out `MustAttackAwayFromSource` grant —
+    // also attacks each combat if able.
+    let must_attack_away =
+        !players_to_attack_away_from_gated(state, obj_id, gates.has_goad).is_empty();
     let has_attackable_must_attack_player = must_attack_players_for_creature(state, obj)
         .iter()
         .any(|player| attackable_players.contains(player));
-    if !has_must_attack && !is_goaded && !has_attackable_must_attack_player {
+    if !has_must_attack && !must_attack_away && !has_attackable_must_attack_player {
         return false;
     }
     // Exemptions: tapped, defender (no override), summoning sick.
@@ -3043,10 +3047,16 @@ enum AttackRequirement {
         player: PlayerId,
     },
     /// CR 701.15b (second clause) + CR 701.15c: `creature` attacks a player other
-    /// than `goader` if able. Obeyed iff `creature` attacks a player ≠ `goader`.
-    Goad {
+    /// than `avoided` if able. Obeyed iff `creature` attacks a player ≠
+    /// `avoided`. Two source classes produce it — the goad DESIGNATION
+    /// (`goaded_by` / `StaticMode::Goaded`, CR 701.15a/b) and the spelled-out
+    /// requirement without any designation (`StaticMode::MustAttackAwayFromSource`
+    /// — Kardur, Doomscourge; Maximum Carnage chapter I) — so the variant is
+    /// named for the requirement, not for goad. Each distinct avoided player is
+    /// an additional requirement (CR 701.15c).
+    AttackAwayFrom {
         creature: ObjectId,
-        goader: PlayerId,
+        avoided: PlayerId,
     },
 }
 
@@ -3348,14 +3358,16 @@ impl AttackDeclarationConstraints {
                     StaticMode::MustAttack,
                     &static_target_ctx(cid),
                 );
-            // CR 701.15b: goaders (distinct players).
-            let goaders = goading_players_for_creature_gated(state, cid, gates.has_goad);
-            // CR 701.15b (first clause): a goaded creature ALSO "attacks each
-            // combat if able" — emit the generic requirement independently so it
-            // is scored even when the second (attack-a-non-goader) clause is
-            // unsatisfiable. This is executor-confirmation #1 implemented by
-            // construction rather than relying on the shared predicate.
-            if has_generic_must || !goaders.is_empty() {
+            // CR 508.1d + CR 701.15b: the distinct players this creature must
+            // attack away from (goad designations + spelled-out grants).
+            let avoided = players_to_attack_away_from_gated(state, cid, gates.has_goad);
+            // CR 701.15b (first clause): a creature under the away-from
+            // requirement ALSO "attacks each combat if able" — emit the generic
+            // requirement independently so it is scored even when the second
+            // (attack-a-different-player) clause is unsatisfiable. This is
+            // executor-confirmation #1 implemented by construction rather than
+            // relying on the shared predicate.
+            if has_generic_must || !avoided.is_empty() {
                 requirements.push(AttackRequirement::MustAttackGeneric { creature: cid });
             }
             for player in must_attack_players_for_creature(state, obj) {
@@ -3366,12 +3378,12 @@ impl AttackDeclarationConstraints {
                     });
                 }
             }
-            let mut goader_list: Vec<PlayerId> = goaders.into_iter().collect();
-            goader_list.sort_unstable_by_key(|p| p.0);
-            for goader in goader_list {
-                requirements.push(AttackRequirement::Goad {
+            let mut avoided_list: Vec<PlayerId> = avoided.into_iter().collect();
+            avoided_list.sort_unstable_by_key(|p| p.0);
+            for avoided_player in avoided_list {
+                requirements.push(AttackRequirement::AttackAwayFrom {
                     creature: cid,
-                    goader,
+                    avoided: avoided_player,
                 });
             }
             // CR 506.5: CombatAlone classification.
@@ -3478,9 +3490,9 @@ fn requirement_obeyed(req: &AttackRequirement, attacks: &[(ObjectId, AttackTarge
         AttackRequirement::MustAttackPlayer { creature, player } => attacks
             .iter()
             .any(|(c, t)| c == creature && matches!(t, AttackTarget::Player(p) if p == player)),
-        AttackRequirement::Goad { creature, goader } => attacks
+        AttackRequirement::AttackAwayFrom { creature, avoided } => attacks
             .iter()
-            .any(|(c, t)| c == creature && matches!(t, AttackTarget::Player(p) if p != goader)),
+            .any(|(c, t)| c == creature && matches!(t, AttackTarget::Player(p) if p != avoided)),
     }
 }
 
@@ -4177,6 +4189,79 @@ pub(crate) fn goading_players_for_creature_gated(
         players.extend(goad_static_hits_for_creature(state, creature_id).map(|(p, _)| p));
     }
 
+    players
+}
+
+/// CR 508.1d + CR 701.15b: the players `creature_id` must attack AWAY from —
+/// the single authority for the "attacks a player other than X if able"
+/// requirement. Three contributors, all producing the same requirement:
+///  1. `obj.goaded_by` — the goad designation (CR 701.15a/b);
+///  2. `StaticMode::Goaded` statics — a continuous designation (CR 701.15b);
+///  3. `StaticMode::MustAttackAwayFromSource` — the requirement WITHOUT any
+///     designation (CR 701.15a: only a spell/ability that *goads* makes a
+///     creature goaded; Kardur, Doomscourge / Maximum Carnage chapter I).
+///
+/// (1) and (2) are designations that IMPLY the requirement; (3) is the
+/// requirement alone. `goading_players_for_creature_gated` remains the
+/// DESIGNATION-only query and must NOT absorb (3) — `FilterProp::Goaded`
+/// (filter.rs) reads the designation, and these two cards must not match it.
+///
+/// Union semantics are legality-neutral (CR 508.1d): two contributors naming the
+/// same player collapse to one requirement, which adds +1 to BOTH
+/// `score_declaration` and `max_no_payment`, leaving `score == max` unchanged.
+/// Distinct players still yield independent requirements (CR 701.15c).
+///
+/// No `CombatStaticGates` field: this is a PER-OBJECT scan of
+/// `active_static_definitions`, exactly like
+/// `must_attack_player_directives_for_creature` — not a battlefield sweep.
+///
+/// Source attribution for the frontend badge is deliberately NOT extended here
+/// (see `must_attack_sources_gated`): this mode does not carry `source_object`,
+/// so the badge renders bare, which the client already handles.
+///
+/// The scan below deliberately ignores `sd.affected`, mirroring the adjacent
+/// `must_attack_player_directives_for_creature` sibling. This is NOT the #6296
+/// (`has_local_must_attack`) case where a remote-scoped carrier forced ITSELF to
+/// attack: that bug needs a PRINTED remote-scoped def, which only generic
+/// `MustAttack` has (Fumiko the Lowblood). `MustAttackAwayFromSource` is
+/// grafted-only — the parser (`must_attack_away_static_definition`) is the sole
+/// producer, `StaticMode`'s `FromStr` is test-only, and the graft always stamps
+/// `affected: TargetFilter::SelfRef` on the recipient (`layers.rs`), so a carrier
+/// never receives its own remote-scoped def. Add an `sd.affected` check here the
+/// moment a printed (non-grafted) producer of this mode appears.
+pub(crate) fn players_to_attack_away_from_gated(
+    state: &GameState,
+    creature_id: ObjectId,
+    has_goad_static: bool,
+) -> HashSet<PlayerId> {
+    let mut players = goading_players_for_creature_gated(state, creature_id, has_goad_static);
+    if let Some(obj) = state.objects.get(&creature_id) {
+        // CR 611.2c: the avoided player is the anchor snapshotted at graft time.
+        // `unwrap_or(obj.controller)` is a defensive default with NO producer
+        // today — the parser is the sole producer of this mode and always routes
+        // through the transient graft, which stamps the anchor (layers.rs). It is
+        // the correct reading for a hypothetical printed static ("…other than
+        // you" on a permanent means that permanent's controller).
+        players.extend(
+            super::functioning_abilities::active_static_definitions(state, obj)
+                .filter(|sd| sd.mode == StaticMode::MustAttackAwayFromSource)
+                .map(|sd| {
+                    // Tripwire for the deferral documented above: both shapes
+                    // below mean "the carrier itself" (`None` skips the filter
+                    // check in `static_ability_match_applies`; the graft stamps
+                    // `SelfRef`). Anything else is a remote-scoped def, which
+                    // this scan would wrongly apply to its own carrier.
+                    debug_assert!(
+                        matches!(sd.affected, Some(TargetFilter::SelfRef) | None),
+                        "MustAttackAwayFromSource is grafted-only (layers.rs stamps \
+                         SelfRef); a printed remote-scoped producer needs an \
+                         `sd.affected` check here, got {:?}",
+                        sd.affected
+                    );
+                    sd.source_controller.unwrap_or(obj.controller)
+                }),
+        );
+    }
     players
 }
 
@@ -5655,7 +5740,7 @@ mod tests {
     /// two-player state carries no tax statics, so free_targets == legal_targets.
     #[test]
     fn best_free_declaration_matches_brute_force_oracle() {
-        use AttackRequirement::{Goad, MustAttackGeneric, MustAttackPlayer};
+        use AttackRequirement::{AttackAwayFrom, MustAttackGeneric, MustAttackPlayer};
         let state = GameState::new_two_player(42);
         let p = |n: u8| AttackTarget::Player(PlayerId(n));
         let pid = PlayerId;
@@ -5766,9 +5851,9 @@ mod tests {
                         MustAttackGeneric {
                             creature: ObjectId(10),
                         },
-                        Goad {
+                        AttackAwayFrom {
                             creature: ObjectId(10),
-                            goader: pid(1),
+                            avoided: pid(1),
                         },
                     ],
                     None,
@@ -5796,9 +5881,9 @@ mod tests {
                         MustAttackGeneric {
                             creature: ObjectId(12),
                         },
-                        Goad {
+                        AttackAwayFrom {
                             creature: ObjectId(10),
-                            goader: pid(1),
+                            avoided: pid(1),
                         },
                     ],
                     Some(2),

--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -229,6 +229,60 @@ fn register_transient_effect(
         }
     }
 
+    // CR 611.2c + CR 613.11 + CR 508.1d: A duration-bound combat REQUIREMENT
+    // ("until your next turn, creatures your opponents control attack each
+    // combat if able and attack a player other than you if able") modifies no
+    // characteristics and changes no controller, so per CR 611.2c it modifies
+    // the rules of the game and "can affect objects that weren't affected when
+    // that continuous effect began". Official rulings agree: Kardur
+    // (2021-02-05) "including any that enter the battlefield after the ability
+    // resolves"; Maximum Carnage (2025-09-19) "regardless of whether or not they
+    // were on the battlefield at the time the ability resolved". Keep the
+    // affected filter INTACT on one TCE so the layer pass re-evaluates WHICH
+    // OBJECTS it matches against the live board every derivation, instead of
+    // letting the broadcast branch below freeze it to a resolution-time
+    // `SpecificObject` set. Mirrors the `MayLookAtFaceDown` / `ReduceAbilityCost`
+    // branches above; unlike those, this one IS grafted onto objects, so it
+    // stays out of the layer skip list.
+    //
+    // Only the OBJECT SET is re-derived. The filter's "your opponents" PLAYER
+    // reference must NOT be — CR 109.5: for a triggered ability, "you" is the
+    // controller of the object when the ability triggered; CR 611.2c makes only
+    // "the set of objects" dynamic. `layers.rs` reads that player from this
+    // TCE's snapshotted `controller` rather than from the source object's
+    // current controller, so a Kardur that changes controller mid-window does
+    // not flip the bound population onto its new controller's opponents.
+    //
+    // The inherited-target guard is a shape check, not a card check: no printed
+    // card reaches it today (both members carry a broadcast `Typed` filter), but
+    // `subject::static_affected_for_application` returns `TargetFilter::ParentTarget`
+    // whenever the subject is a chosen target, and a `ParentTarget` TCE is
+    // exactly what the broadcast arm below refuses. Falling through lets the
+    // chosen-targets arms bind the single named object — correct for a targeted
+    // grant, where CR 611.2c's dynamic-population concern does not arise.
+    if modifications.iter().any(|m| {
+        matches!(
+            m,
+            ContinuousModification::AddStaticMode {
+                mode: crate::types::statics::StaticMode::MustAttackAwayFromSource,
+            }
+        )
+    }) {
+        if let Some(affected) = static_def.affected.clone() {
+            if !generic_effect_affected_uses_inherited_targets(&affected) {
+                state.add_transient_continuous_effect(
+                    ability.source_id,
+                    ability.controller,
+                    duration.clone(),
+                    affected,
+                    modifications,
+                    static_def.condition.clone(),
+                );
+                return;
+            }
+        }
+    }
+
     // CR 608.2c (issue #323 class): SelfRef is the printed-name anaphor and
     // always refers to the source object regardless of `ability.targets`.
     // Short-circuit BEFORE the chosen-targets branch so chained Effect

--- a/crates/engine/src/game/effects/goad.rs
+++ b/crates/engine/src/game/effects/goad.rs
@@ -231,14 +231,24 @@ mod tests {
 
     /// CR 701.15a + CR 701.15b: Maximum Carnage chapter I — "each creature
     /// attacks each combat if able and attacks a player other than you if able"
-    /// is the printed goad definition. The parser must lower it to
-    /// `Effect::GoadAll` over all creatures; resolving that effect marks every
-    /// creature (both the controller's and the opponents') as goaded by the
-    /// resolving controller. Reverting `try_parse_goad_equivalent` makes the
-    /// chapter line lower to `Effect::Unimplemented` — there is no GoadAll to
-    /// resolve and no creature gets goaded, so this test fails.
+    /// prints the goad *requirement pair*, not the goad keyword action. Official
+    /// ruling (2025-09-19): "that ability doesn't cause any creatures to become
+    /// goaded. Effects that refer to 'goaded creatures' won't apply."
+    ///
+    /// So the parser must lower the line to `Effect::GenericEffect` carrying ONE
+    /// `StaticDefinition` with both `AddStaticMode` mods, and resolving it must
+    /// leave every creature's `goaded_by` empty while registering a transient
+    /// continuous effect whose affected filter is still the INTACT broadcast
+    /// `Typed` filter (CR 611.2c — the affected set stays dynamic).
+    ///
+    /// This is the inversion of the previous `…goads_every_creature…` test:
+    /// restoring the `Effect::GoadAll` lowering in `subject.rs` fails the shape
+    /// assertion, and restoring the goad resolver path fails `goaded_by`.
     #[test]
-    fn maximum_carnage_goads_every_creature_via_real_parser() {
+    fn maximum_carnage_chapter_one_creates_requirements_without_goading() {
+        use crate::types::ability::ContinuousModification;
+        use crate::types::statics::StaticMode;
+
         let parsed = crate::parser::parse_oracle_text(
             "Until your next turn, each creature attacks each combat if able and attacks a player other than you if able.",
             "Maximum Carnage",
@@ -246,12 +256,41 @@ mod tests {
             &["Sorcery".to_string()],
             &[],
         );
-        let goad_effect = parsed
+        let (requirement_effect, ability_duration) = parsed
             .abilities
             .iter()
-            .map(|def| def.effect.as_ref().clone())
-            .find(|effect| matches!(effect, Effect::GoadAll { .. }))
-            .expect("Maximum Carnage chapter I must parse to Effect::GoadAll");
+            .find_map(|def| match def.effect.as_ref() {
+                effect @ Effect::GenericEffect { .. } => {
+                    Some((effect.clone(), def.duration.clone()))
+                }
+                _ => None,
+            })
+            .expect("Maximum Carnage chapter I must parse to Effect::GenericEffect");
+
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = &requirement_effect
+        else {
+            unreachable!("matched above")
+        };
+        assert_eq!(
+            static_abilities.len(),
+            1,
+            "both requirements must ride ONE StaticDefinition so the affected \
+             filter stays intact for both (CR 611.2c), got {static_abilities:?}"
+        );
+        assert_eq!(
+            static_abilities[0].modifications,
+            vec![
+                ContinuousModification::AddStaticMode {
+                    mode: StaticMode::MustAttack,
+                },
+                ContinuousModification::AddStaticMode {
+                    mode: StaticMode::MustAttackAwayFromSource,
+                },
+            ],
+            "CR 701.15b attaches exactly two combat requirements"
+        );
 
         let mut state = GameState::new_two_player(42);
         let my_creature = create_object(
@@ -278,15 +317,38 @@ mod tests {
                 .push(CoreType::Creature);
         }
 
-        let ability = ResolvedAbility::new(goad_effect, vec![], ObjectId(100), PlayerId(0));
-        resolve(&mut state, &ability, &mut Vec::new()).unwrap();
+        let mut ability =
+            ResolvedAbility::new(requirement_effect, vec![], ObjectId(100), PlayerId(0));
+        ability.duration = ability_duration;
+        crate::game::effects::effect::resolve(&mut state, &ability, &mut Vec::new()).unwrap();
 
-        // CR 701.15b: even the controller's own creature is goaded by the
-        // controller — it must then attack a player other than the controller.
-        assert!(state.objects[&my_creature].goaded_by.contains(&PlayerId(0)));
-        assert!(state.objects[&opp_creature]
-            .goaded_by
-            .contains(&PlayerId(0)));
+        // CR 701.15a + the 2025-09-19 ruling: NO designation on either creature.
+        for id in [my_creature, opp_creature] {
+            assert!(
+                state.objects[&id].goaded_by.is_empty(),
+                "chapter I must not goad anything, got {:?}",
+                state.objects[&id].goaded_by
+            );
+        }
+
+        // CR 611.2c: the requirement rides one TCE whose affected filter is still
+        // the broadcast `Typed` filter, so creatures entering later are bound too.
+        let tce = state
+            .transient_continuous_effects
+            .iter()
+            .find(|e| {
+                e.modifications
+                    .contains(&ContinuousModification::AddStaticMode {
+                        mode: StaticMode::MustAttackAwayFromSource,
+                    })
+            })
+            .expect("the requirement must register a transient continuous effect");
+        assert!(
+            matches!(tce.affected, TargetFilter::Typed(_)),
+            "CR 611.2c: the affected filter must stay INTACT (not frozen to a \
+             resolution-time SpecificObject set), got {:?}",
+            tce.affected
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -5266,17 +5266,22 @@ fn static_mode_uses_chosen_color(mode: &crate::types::statics::StaticMode) -> bo
     }
 }
 
-/// CR 611.2c + CR 109.5: True when a granted `MustBeBlockedByAll` /
-/// `MustBeBlocked` static carries a controller-relative blocker filter
-/// (`ControllerRef::You`/`Opponent`/… — "your opponents", "you control").
-/// When such a static is grafted onto a TARGET permanent by a one-shot effect
-/// (You Look Upon the Tarrasque), CR 109.5 would otherwise evaluate the filter
-/// relative to the target's controller. This gate is the condition under which
-/// the installing player must be snapshotted as the anchor (mirrors
-/// `static_mode_uses_chosen_color`).
-fn static_mode_uses_controller_relative_blocker_filter(
-    mode: &crate::types::statics::StaticMode,
-) -> bool {
+/// CR 611.2c + CR 109.5: True when a granted static mode resolves a player
+/// reference ("you"/"your opponents") that must be the INSTALLING player rather
+/// than the carrier's controller, so the graft has to snapshot
+/// `effect.controller` as the definition's anchor.
+///
+/// Two member classes today:
+/// - `MustBeBlockedByAll` / `MustBeBlocked` carrying a controller-relative
+///   blocker filter (`ControllerRef::You`/`Opponent`/… — "your opponents", "you
+///   control"). Grafted onto a TARGET permanent by a one-shot effect (You Look
+///   Upon the Tarrasque), CR 109.5 would otherwise evaluate the filter relative
+///   to the target's controller.
+/// - `MustAttackAwayFromSource`, whose avoided player is the granting effect's
+///   controller (CR 701.15b).
+///
+/// Mirrors `static_mode_uses_chosen_color`.
+fn static_mode_needs_source_controller_anchor(mode: &crate::types::statics::StaticMode) -> bool {
     use crate::types::statics::StaticMode;
     match mode {
         StaticMode::MustBeBlockedByAll {
@@ -5285,6 +5290,12 @@ fn static_mode_uses_controller_relative_blocker_filter(
         | StaticMode::MustBeBlocked { by: Some(filter) } => {
             target_filter_controller_is_relative(filter)
         }
+        // CR 611.2c + CR 701.15b: the avoided player is the INSTALLING player,
+        // not the carrier's controller — the requirement is grafted onto an
+        // opponent's creature (Kardur, Doomscourge) or the controller's own
+        // (Maximum Carnage chapter I), so re-deriving it from the carrier would
+        // avoid the wrong player.
+        StaticMode::MustAttackAwayFromSource => true,
         _ => false,
     }
 }
@@ -5767,7 +5778,34 @@ fn apply_continuous_effect_filtered(
         retained
     } else {
         let scan_ids = effect_candidate_ids(state, &effect.affected_filter, zone_cache);
-        let ctx = FilterContext::from_source(state, effect.source_id);
+        // CR 109.5 + CR 611.2c: a continuous effect created by a RESOLVED spell
+        // or ability reads "you"/"your" as that spell or ability's controller,
+        // not as whoever controls the source object at the moment of some later
+        // layer pass. CR 109.5 fixes this for EVERY resolution-created case:
+        // "The words 'you' and 'your' on an object refer to the object's
+        // controller" (so, for a spell, the spell's controller); "For an
+        // activated ability, this is the player who activated the ability";
+        // "For a triggered ability, this is the controller of the object when
+        // the ability triggered". `effect.controller` is that player in all
+        // three cases. CR 611.2c makes only "the set of objects" dynamic for a
+        // rules-modifying continuous effect; the PLAYER reference stays fixed,
+        // so a controller-relative `affected` filter ("creatures your opponents
+        // control") must be evaluated against the snapshot the TCE already
+        // carries. A PRINTED static keeps the live reading (CR 109.5: "For a
+        // static ability, this is the current controller of the object it's
+        // on"), which is exactly what `transient_id` discriminates: `Some(..)`
+        // for resolution-created transients (`gather_transient_continuous_effects`),
+        // `None` for printed static-definition entries.
+        //
+        // Second half of the CR 611.2c migration that keeps the
+        // `MustAttackAwayFromSource` affected filter intact
+        // (`effects/effect.rs`) — see the T13 regression
+        // (`affected_population_does_not_follow_a_stolen_source`).
+        let ctx = if effect.transient_id.is_some() {
+            FilterContext::from_source_with_controller(effect.source_id, effect.controller)
+        } else {
+            FilterContext::from_source(state, effect.source_id)
+        };
         newly_affected_ids = scan_ids
             .iter()
             // Incremental fast path: re-apply only to the freshly-entered objects.
@@ -6623,15 +6661,17 @@ fn apply_continuous_effect_filtered(
                 let resolved_mode = resolve_static_mode_chosen_color(mode, chosen_color);
                 let mut def =
                     StaticDefinition::new(resolved_mode.clone()).affected(TargetFilter::SelfRef);
-                // CR 611.2c + CR 109.5: A controller-relative blocker filter
-                // ("your opponents") grafted onto a TARGET permanent would
-                // otherwise resolve "you" as the target's controller. Snapshot
-                // the installing player (`effect.controller`, the single
-                // authority) so combat re-derives the filter context from the
-                // spell controller — the continuous effect's anchor is locked at
-                // materialization. `None` anchor (permanent-static lures) still
-                // resolves from the carrier.
-                if static_mode_uses_controller_relative_blocker_filter(&resolved_mode) {
+                // CR 611.2c + CR 109.5: A player reference carried by the granted
+                // mode — a controller-relative blocker filter ("your opponents")
+                // or `MustAttackAwayFromSource`'s avoided player (CR 701.15b) —
+                // grafted onto a TARGET permanent would otherwise resolve "you"
+                // as the target's controller. Snapshot the installing player
+                // (`effect.controller`, the single authority) so combat
+                // re-derives the reference from the spell controller — the
+                // continuous effect's anchor is locked at materialization.
+                // `None` anchor (permanent-static lures) still resolves from the
+                // carrier.
+                if static_mode_needs_source_controller_anchor(&resolved_mode) {
                     def = def.source_controller(effect.controller);
                 }
                 // CR 611.2c: stamp the directing object so combat / future

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -5290,7 +5290,7 @@ fn static_mode_needs_source_controller_anchor(mode: &crate::types::statics::Stat
         | StaticMode::MustBeBlocked { by: Some(filter) } => {
             target_filter_controller_is_relative(filter)
         }
-        // CR 611.2c + CR 701.15b: the avoided player is the INSTALLING player,
+        // CR 109.5 + CR 701.15b: the avoided player is the INSTALLING player,
         // not the carrier's controller — the requirement is grafted onto an
         // opponent's creature (Kardur, Doomscourge) or the controller's own
         // (Maximum Carnage chapter I), so re-deriving it from the carrier would

--- a/crates/engine/src/game/static_abilities.rs
+++ b/crates/engine/src/game/static_abilities.rs
@@ -193,6 +193,14 @@ pub fn build_static_registry() -> HashMap<StaticMode, StaticAbilityHandler> {
     // CR 701.15b: Goaded — this creature must attack and avoid the goading
     // player if able. Runtime enforcement lives in combat.rs.
     registry.insert(StaticMode::Goaded, handle_rule_mod);
+    // CR 508.1d + CR 701.15b: MustAttackAwayFromSource — the goad requirement
+    // pair without the designation (Kardur, Doomscourge; Maximum Carnage I).
+    // Nullary, so it is registry-keyable (unlike the data-carrying
+    // `MustAttackPlayer`). Runtime enforcement lives in combat.rs. The registry
+    // key is ALSO what keeps `coverage::unimplemented_mechanics` quiet for every
+    // creature this grafts onto — it is load-bearing for the client, not
+    // decoration.
+    registry.insert(StaticMode::MustAttackAwayFromSource, handle_rule_mod);
     // CR 506.5 + CR 508.1c + CR 509.1b: CombatAlone — parameterized "alone"
     // restriction. Runtime enforcement lives in combat.rs.
     registry.insert(

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -12560,18 +12560,20 @@ pub(super) fn try_parse_attack_if_able(lower: &str) -> Option<ImperativeFamilyAs
     None
 }
 
-/// CR 701.15a + CR 701.15b: Recognize the verbatim goad *definition* —
+/// CR 508.1d + CR 701.15b: Recognize the printed goad *requirement pair* —
 /// "attack[s] each combat if able and attack[s] a player other than you if able".
-/// This compound is precisely what goad does (CR 701.15a: must attack each combat
-/// if able; CR 701.15b: must attack a player other than the goading player),
-/// printed in full on cards that grant the effect without the "goad" keyword
-/// (Maximum Carnage chapter I). Mapping it to the goad mechanic is the correct
-/// class reuse: the goading player is the resolving controller ("you"), so the
-/// subject's own creatures are forced onto opponents, and `goaded_by` cleanup at
-/// the goading player's next turn matches the card's "Until your next turn"
-/// duration (CR 701.15a). Returns the bare marker; `subject.rs` binds the affected
-/// set to `Effect::GoadAll`.
-pub(super) fn try_parse_goad_equivalent(lower: &str) -> bool {
+/// CR 701.15b attaches exactly these two combat requirements to a goaded
+/// creature; two cards print them in full without the "goad" keyword (Kardur,
+/// Doomscourge; Maximum Carnage chapter I).
+///
+/// This compound does NOT lower to the goad mechanic. CR 701.15a: only a spell
+/// or ability that *goads* a creature makes it goaded, and the official Maximum
+/// Carnage ruling (2025-09-19) is explicit — "Although the effects of the first
+/// chapter ability are the same as the goad keyword action, that ability doesn't
+/// cause any creatures to become goaded. Effects that refer to 'goaded
+/// creatures' won't apply." Returns the bare marker; `subject.rs` binds the
+/// affected set to a `MustAttack` + `MustAttackAwayFromSource` static grant.
+pub(super) fn try_parse_attack_away_requirement(lower: &str) -> bool {
     let trimmed = lower.trim_end_matches('.').trim();
     let parsed: Result<(&str, ()), nom::Err<OracleError<'_>>> = (
         alt((tag("attacks"), tag("attack"))),
@@ -12654,6 +12656,40 @@ pub(super) fn must_attack_static_definition() -> StaticDefinition {
     StaticDefinition::new(StaticMode::MustAttack).modifications(vec![
         ContinuousModification::AddStaticMode {
             mode: StaticMode::MustAttack,
+        },
+    ])
+}
+
+/// CR 508.1d + CR 701.15b: Build the transient `StaticDefinition` for the printed
+/// goad-requirement compound ("… attacks each combat if able and attacks a player
+/// other than you if able"). CR 701.15b attaches TWO requirements to a goaded
+/// creature; a card that prints them in full creates the same two requirements
+/// and NO goaded designation (CR 701.15a — only a spell or ability that *goads*
+/// makes a creature goaded; official Maximum Carnage ruling 2025-09-19).
+///
+/// Both requirements ride ONE definition so `register_transient_effect` sees them
+/// in a single `modifications` vec and keeps the affected filter intact for both
+/// (CR 611.2c — the set stays dynamic). `mode` carries the away-from requirement
+/// so the coverage/registry surface classifies the def by its distinguishing
+/// mode; `mode` is otherwise inert for transient grants
+/// (`snapshot_transient_modifications` reads only `modifications`), which is why
+/// both modes are also listed explicitly.
+pub(super) fn must_attack_away_static_definition() -> StaticDefinition {
+    use crate::types::statics::StaticMode;
+    // DELIBERATE GAP (plan §5.9): keying `mode` on the away-from requirement also
+    // excludes this def from `is_mass_coerce_static` (oracle_effect/mod.rs), which
+    // publishes the chain tracked set only for `MustAttack`/`MustAttackPlayer`. A
+    // future card printing this compound followed by a "those creatures" anaphor
+    // (CR 608.2c) would therefore not publish the set, unlike the plain-`MustAttack`
+    // sibling above. Unreachable today and not a regression: neither card-data key
+    // carrying this compound has a following anaphor, and the `Effect::GoadAll` path
+    // this replaces never published the set either.
+    StaticDefinition::new(StaticMode::MustAttackAwayFromSource).modifications(vec![
+        ContinuousModification::AddStaticMode {
+            mode: StaticMode::MustAttack,
+        },
+        ContinuousModification::AddStaticMode {
+            mode: StaticMode::MustAttackAwayFromSource,
         },
     ])
 }

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -1671,23 +1671,28 @@ fn try_parse_subject_restriction_clause(
                 unless_pay: None,
             });
         }
-        // CR 701.15a + CR 701.15b: "[subject] attacks each combat if able and
-        // attacks a player other than you if able" is the printed goad definition
-        // (Maximum Carnage chapter I). Map it to `Effect::GoadAll` over the subject
-        // population so the goad mechanic (goaded_by mark, "attack a player other
-        // than the goading player", goading-player next-turn cleanup) handles it.
-        // Tried before the plain attack recognizer since the goad compound is the
-        // strict superset and must win. The subject is a population ("each
-        // creature"), so the GoadAll target is `application.affected`.
-        if imperative::try_parse_goad_equivalent(&predicate) {
+        // CR 508.1d + CR 701.15b + CR 611.2c: "[subject] attacks each combat if
+        // able and attacks a player other than you if able" is the goad
+        // *requirement pair* printed in full (Kardur, Doomscourge; Maximum
+        // Carnage chapter I). CR 701.15a: only a spell or ability that *goads*
+        // makes a creature goaded, so this lowers to combat requirements and NOT
+        // to the goad mechanic — official Maximum Carnage ruling (2025-09-19):
+        // "that ability doesn't cause any creatures to become goaded. Effects
+        // that refer to 'goaded creatures' won't apply."
+        // Tried before the plain attack recognizer since the compound is the
+        // strict superset. `duration: None` — the stated duration ("Until your
+        // next turn,") arrives on `ability.duration` and wins in
+        // `effects/effect.rs::resolve`.
+        if imperative::try_parse_attack_away_requirement(&predicate) {
             let application = parse_subject_application(subject, ctx)?;
-            let goad_target = application
-                .target
-                .clone()
-                .unwrap_or_else(|| application.affected.clone());
+            let affected = static_affected_for_application(&application);
             return Some(ParsedEffectClause {
-                effect: Effect::GoadAll {
-                    target: goad_target,
+                effect: Effect::GenericEffect {
+                    static_abilities: vec![
+                        imperative::must_attack_away_static_definition().affected(affected)
+                    ],
+                    duration: None,
+                    target: application.target,
                 },
                 distribute: None,
                 multi_target: application.multi_target,

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1709,8 +1709,8 @@ pub enum StaticMode {
     /// Doomscourge and Maximum Carnage chapter I are the two printed members.
     ///
     /// The avoided player is `StaticDefinition::source_controller`, snapshotted
-    /// at graft time (CR 611.2c locks a resolution-created effect's anchor at
-    /// materialization). Nullary and registry-registered (mirrors [`Goaded`]);
+    /// at graft time: CR 109.5 fixes "you" in a resolving ability to that
+    /// ability's controller. Nullary and registry-registered (mirrors [`Goaded`]);
     /// runtime enforcement lives in `combat.rs`.
     MustAttackAwayFromSource,
     /// CR 506.5 + CR 508.1c + CR 509.1b: Parameterized "alone" combat

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1695,6 +1695,24 @@ pub enum StaticMode {
     /// The source controller is the goading player for the "attack another
     /// player if able" requirement.
     Goaded,
+    /// CR 508.1d + CR 701.15b: This creature attacks each combat if able AND
+    /// attacks a player other than the *granting effect's* controller if able —
+    /// the two combat requirements CR 701.15b attaches to goad, WITHOUT the
+    /// goaded designation.
+    ///
+    /// CR 701.15a: only a spell or ability that *goads* a creature makes it
+    /// goaded, so a card that prints the requirements in full creates no
+    /// designation. Official Maximum Carnage ruling (2025-09-19): "Although the
+    /// effects of the first chapter ability are the same as the goad keyword
+    /// action, that ability doesn't cause any creatures to become goaded.
+    /// Effects that refer to 'goaded creatures' won't apply." Kardur,
+    /// Doomscourge and Maximum Carnage chapter I are the two printed members.
+    ///
+    /// The avoided player is `StaticDefinition::source_controller`, snapshotted
+    /// at graft time (CR 611.2c locks a resolution-created effect's anchor at
+    /// materialization). Nullary and registry-registered (mirrors [`Goaded`]);
+    /// runtime enforcement lives in `combat.rs`.
+    MustAttackAwayFromSource,
     /// CR 506.5 + CR 508.1c + CR 509.1b: Parameterized "alone" combat
     /// restriction.  `action` selects whether it applies to attacking or
     /// blocking; `requirement` selects the polarity:
@@ -2086,6 +2104,7 @@ pub enum StaticModeKind {
     MustBeBlocked,
     MustBeBlockedByAll,
     Goaded,
+    MustAttackAwayFromSource,
     CombatAlone,
     CantCrew,
     CantPhaseIn,
@@ -2228,6 +2247,7 @@ impl StaticMode {
             StaticMode::MustBeBlocked { .. } => StaticModeKind::MustBeBlocked,
             StaticMode::MustBeBlockedByAll { .. } => StaticModeKind::MustBeBlockedByAll,
             StaticMode::Goaded => StaticModeKind::Goaded,
+            StaticMode::MustAttackAwayFromSource => StaticModeKind::MustAttackAwayFromSource,
             StaticMode::CombatAlone { .. } => StaticModeKind::CombatAlone,
             StaticMode::CantCrew => StaticModeKind::CantCrew,
             StaticMode::CantPhaseIn => StaticModeKind::CantPhaseIn,
@@ -2581,6 +2601,7 @@ impl StaticMode {
             | StaticMode::MustBeBlocked { .. }
             | StaticMode::MustBeBlockedByAll { .. }
             | StaticMode::Goaded
+            | StaticMode::MustAttackAwayFromSource
             | StaticMode::CombatAlone { .. }
             | StaticMode::CantCrew
             | StaticMode::CantPhaseIn
@@ -2949,6 +2970,7 @@ impl fmt::Display for StaticMode {
                 write!(f, "MustBeBlockedByAll:By({filter:?})")
             }
             StaticMode::Goaded => write!(f, "Goaded"),
+            StaticMode::MustAttackAwayFromSource => write!(f, "MustAttackAwayFromSource"),
             StaticMode::CombatAlone {
                 action,
                 requirement,
@@ -3429,6 +3451,7 @@ impl FromStr for StaticMode {
             "CantPhaseIn" => StaticMode::CantPhaseIn,
             "MustBeBlockedByAll" => StaticMode::MustBeBlockedByAll { blockers: None },
             "Goaded" => StaticMode::Goaded,
+            "MustAttackAwayFromSource" => StaticMode::MustAttackAwayFromSource,
             "CombatAlone(Attack,NeedsCompanion)" => StaticMode::CombatAlone {
                 action: CombatAloneAction::Attack,
                 requirement: CombatAloneRequirement::NeedsCompanion,
@@ -4117,6 +4140,10 @@ mod tests {
                 action: CombatAloneAction::Attack,
                 requirement: CombatAloneRequirement::MustBeSole,
             },
+            // CR 508.1d + CR 701.15b: nullary requirement leaf — `Display` and
+            // `FromStr` must stay symmetric (Kardur, Doomscourge; Maximum
+            // Carnage chapter I).
+            StaticMode::MustAttackAwayFromSource,
             StaticMode::CantCrew,
             StaticMode::MayLookAtTopOfLibrary,
             // CR 702.170a grant + CR 702.170f permission — nullary plot-from-
@@ -4278,6 +4305,7 @@ mod tests {
             StaticMode::CantBeBlocked,
             StaticMode::Flying,
             StaticMode::MustBeBlocked { by: None },
+            StaticMode::MustAttackAwayFromSource,
             StaticMode::GrantsExtraVote,
             // CR 118.9: data-carrying ManaCost — serde must preserve {0} and {WUBRG}.
             StaticMode::CastWithAlternativeCost {

--- a/crates/engine/tests/integration/bbfu7_attacks_if_able_not_goad.rs
+++ b/crates/engine/tests/integration/bbfu7_attacks_if_able_not_goad.rs
@@ -672,6 +672,11 @@ fn cant_attack_restriction_beats_the_spelled_out_requirement() {
     // Reach: BOTH creatures carry the requirement, so the legality difference
     // below is the Pacifism restriction and not a missing grant.
     assert!(
+        bound_by_requirement(runner.state(), pacified),
+        "reach: the pacified creature must still carry the requirement after \
+         Pacifism is applied"
+    );
+    assert!(
         bound_by_requirement(runner.state(), free),
         "reach: the unrestricted creature must carry the requirement"
     );

--- a/crates/engine/tests/integration/bbfu7_attacks_if_able_not_goad.rs
+++ b/crates/engine/tests/integration/bbfu7_attacks_if_able_not_goad.rs
@@ -1,0 +1,949 @@
+//! BB-FU7 — a spelled-out "attacks each combat if able and attacks a player
+//! other than you if able" effect is NOT the goad keyword action.
+//!
+//! Two cards print the goad *effect* without the goad *keyword*:
+//!   - Kardur, Doomscourge: "When Kardur enters, until your next turn, creatures
+//!     your opponents control attack each combat if able and attack a player
+//!     other than you if able."
+//!   - Maximum Carnage chapter I: "Until your next turn, each creature attacks
+//!     each combat if able and attacks a player other than you if able."
+//!
+//! (Both verbatim from MTGJSON `AtomicCards.json`.)
+//!
+//! CR 701.15a: only a spell or ability that *goads* a creature makes it goaded.
+//! CR 701.15b: "Goaded is a designation a permanent can have" — the designation,
+//! not the pair of requirements, is what "goaded creature" effects read.
+//! Official Maximum Carnage ruling (2025-09-19, Scryfall/MTGJSON): "Although the
+//! effects of the first chapter ability are the same as the goad keyword action,
+//! that ability doesn't cause any creatures to become goaded. Effects that refer
+//! to 'goaded creatures' won't apply."
+//!
+//! The engine reads that designation from `GameObject::goaded_by`
+//! (`game/filter.rs`: `FilterProp::Goaded => !obj.goaded_by.is_empty()`), which
+//! is exactly what these tests assert on.
+//!
+//! Second divergence, same rulings: the effect is a *continuous* effect with a
+//! dynamic affected set. Kardur ruling (2021-02-05): "Kardur's first ability
+//! affects all creatures your opponents control, including any that enter the
+//! battlefield after the ability resolves." Maximum Carnage ruling (2025-09-19):
+//! "affects all creatures until your next turn, regardless of whether or not they
+//! were on the battlefield at the time the ability resolved." A one-shot goad mark
+//! only touches the creatures present at resolution.
+
+use std::sync::Arc;
+
+use engine::game::combat::{
+    attacker_constraints_for_active_player, get_valid_attacker_ids, CombatRequirement,
+};
+use engine::game::derived::derive_display_state;
+use engine::game::functioning_abilities::active_static_definitions;
+use engine::game::layers::evaluate_layers;
+use engine::game::public_state::mark_public_state_all_dirty;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::turns::{execute_cleanup, execute_untap};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{ContinuousModification, Effect, StaticDefinition, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::statics::StaticMode;
+
+use super::rules::AttackTarget;
+
+const P2: PlayerId = PlayerId(2);
+const P3: PlayerId = PlayerId(3);
+
+/// Kardur's ETB effect sentence, verbatim minus the "When Kardur enters," trigger
+/// prefix so it can be cast as a sorcery (the effect text is what is under test).
+const KARDUR_EFFECT: &str = "Until your next turn, creatures your opponents control attack each combat if able and attack a player other than you if able.";
+
+/// Kardur, Doomscourge's full Oracle text (MTGJSON verbatim).
+const KARDUR_ORACLE: &str = "When Kardur enters, until your next turn, creatures your opponents control attack each combat if able and attack a player other than you if able.\nWhenever an attacking creature dies, each opponent loses 1 life and you gain 1 life.";
+
+/// Maximum Carnage chapter I (MTGJSON verbatim).
+const MAXIMUM_CARNAGE_CHAPTER_I: &str =
+    "Until your next turn, each creature attacks each combat if able and attacks a player other than you if able.";
+
+/// Maximum Carnage's FULL verbatim MTGJSON Oracle text — including the Saga
+/// reminder line and the `I —`/`II —`/`III —` chapter prefixes. The bare chapter
+/// body parses down a DIFFERENT path (measured: `Effect::Unimplemented`
+/// `{static_structure}` under `["Enchantment"]/["Saga"]`), so it is not a reach
+/// guard; only the full text exercises the Saga chapter lowering.
+const MAXIMUM_CARNAGE_ORACLE: &str = "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI — Until your next turn, each creature attacks each combat if able and attacks a player other than you if able.\nII — Add {R}{R}{R}.\nIII — This Saga deals 5 damage to each opponent.";
+
+/// Disrupt Decorum's FULL verbatim MTGJSON Oracle text, reminder parenthetical
+/// INCLUDED — that parenthetical is a word-for-word instance of the compound
+/// this change's recognizer matches, so a truncated fixture cannot guard the
+/// interaction. Reminder text is stripped in `parser/oracle.rs`
+/// (`strip_reminder_text` inside `prepare_spell_resolution_line`), so today's
+/// risk is low (measured: the full text yields abilities:1, triggers:0,
+/// statics:0) — which is exactly why the verbatim string is free and strictly
+/// stronger.
+const DISRUPT_DECORUM_ORACLE: &str = "Goad all creatures you don't control. (Until your next turn, those creatures attack each combat if able and attack a player other than you if able.)";
+
+/// CR 508.1d + CR 701.15b: true when the spelled-out requirement is grafted onto
+/// `id` as a functioning static. This is the reach guard every "no designation"
+/// / "no longer bound" assertion in this file is paired with — an empty
+/// `goaded_by` is satisfied vacuously by a parse that produced nothing.
+fn bound_by_requirement(state: &GameState, id: ObjectId) -> bool {
+    state.objects.get(&id).is_some_and(|obj| {
+        active_static_definitions(state, obj)
+            .any(|sd| sd.mode == StaticMode::MustAttackAwayFromSource)
+    })
+}
+
+/// P0 casts the spelled-out requirement in their precombat main; P1 has one
+/// creature on board. Returns the post-resolution runner and P1's creature.
+fn cast_requirement_spell(text: &str) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Spelled-Out Requirement", false, text)
+        .id();
+    let opp_creature = scenario.add_creature(P1, "Ornery Ox", 2, 2).id();
+    let mut runner = scenario.build();
+    runner.cast(spell).resolve();
+    (runner, opp_creature)
+}
+
+/// Put the game in P1's declare-attackers step with `attacker` as the only
+/// possible attacker and all three players as possible defenders.
+fn arm_declare_attackers(runner: &mut GameRunner, attacker: ObjectId) {
+    arm_declare_attackers_against(runner, &[attacker], &[P0, P2]);
+}
+
+/// Generalized form of [`arm_declare_attackers`]: P1 declares attackers with
+/// `attackers` as the only eligible creatures and `defenders` as the only
+/// attackable players (CR 508.1b).
+fn arm_declare_attackers_against(
+    runner: &mut GameRunner,
+    attackers: &[ObjectId],
+    defenders: &[PlayerId],
+) {
+    let state = runner.state_mut();
+    state.active_player = P1;
+    state.priority_player = P1;
+    state.phase = Phase::DeclareAttackers;
+    state.turn_number = 2;
+    state.waiting_for = WaitingFor::DeclareAttackers {
+        player: P1,
+        valid_attacker_ids: attackers.to_vec(),
+        valid_attack_targets: defenders
+            .iter()
+            .copied()
+            .map(AttackTarget::Player)
+            .collect(),
+        valid_attack_targets_by_attacker: None,
+        attacker_constraints: Default::default(),
+    };
+}
+
+/// Install a functioning intrinsic `CantAttackOrBlock` static (the Pacifism
+/// restriction, CR 508.1c), mirroring `goaded_creature_under_pacifism_visible`.
+fn pacify(runner: &mut GameRunner, creature: ObjectId) {
+    let def = StaticDefinition::new(StaticMode::CantAttackOrBlock)
+        .affected(TargetFilter::SelfRef)
+        .modifications(vec![ContinuousModification::AddStaticMode {
+            mode: StaticMode::CantAttackOrBlock,
+        }]);
+    let obj = runner.state_mut().objects.get_mut(&creature).unwrap();
+    obj.static_definitions = vec![def.clone()].into();
+    obj.base_static_definitions = Arc::new(vec![def]);
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+}
+
+/// FLIP LEG — CR 701.15a/b + the Maximum Carnage ruling: the affected creature
+/// must NOT carry the goaded designation. Today the parser lowers the sentence to
+/// `Effect::GoadAll`, whose resolver stamps `goaded_by`, so this fails.
+#[test]
+fn spelled_out_requirement_does_not_goad_the_creature() {
+    let (runner, opp_creature) = cast_requirement_spell(KARDUR_EFFECT);
+    // Reach guard: the requirement actually landed, so the empty `goaded_by`
+    // below cannot pass because the sentence failed to parse or resolve.
+    assert!(
+        bound_by_requirement(runner.state(), opp_creature),
+        "reach: the opponent's creature must carry the spelled-out requirement"
+    );
+    let goaded_by = &runner.state().objects[&opp_creature].goaded_by;
+    assert!(
+        goaded_by.is_empty(),
+        "CR 701.15a/b + official Maximum Carnage ruling: a spelled-out \
+         'attacks ... if able and attacks a player other than you if able' effect \
+         creates combat requirements but NO goaded designation; \
+         `goaded_by` must stay empty, got {goaded_by:?}"
+    );
+}
+
+/// FLIP LEG — same for the "each creature" (Maximum Carnage) population, which
+/// includes the effect controller's own creatures.
+#[test]
+fn maximum_carnage_chapter_one_does_not_goad_any_creature() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Maximum Carnage", false, MAXIMUM_CARNAGE_CHAPTER_I)
+        .id();
+    let own = scenario.add_creature(P0, "Bear", 2, 2).id();
+    let opp = scenario.add_creature(P1, "Wolf", 2, 2).id();
+    let mut runner = scenario.build();
+    runner.cast(spell).resolve();
+
+    for (id, label) in [
+        (own, "controller's own creature"),
+        (opp, "opponent's creature"),
+    ] {
+        // Reach guard: "each creature" binds BOTH populations, so an empty
+        // `goaded_by` below is a real negative and not a parse failure.
+        assert!(
+            bound_by_requirement(runner.state(), id),
+            "reach: {label} must carry the spelled-out requirement"
+        );
+        let goaded_by = &runner.state().objects[&id].goaded_by;
+        assert!(
+            goaded_by.is_empty(),
+            "Maximum Carnage ruling (2025-09-19): chapter I 'doesn't cause any \
+             creatures to become goaded' — {label} must have an empty \
+             `goaded_by`, got {goaded_by:?}"
+        );
+    }
+}
+
+/// FLIP LEG — Kardur ruling (2021-02-05) / Maximum Carnage ruling (2025-09-19):
+/// the effect binds creatures that enter AFTER it resolves. A one-shot goad mark
+/// cannot, so this fails today.
+#[test]
+fn requirement_binds_a_creature_that_enters_after_resolution() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Spelled-Out Requirement", false, KARDUR_EFFECT)
+        .id();
+    // No opponent creature exists at resolution: the late entrant below is the
+    // ONLY creature the requirement could bind, so the assertion cannot be
+    // satisfied by some other creature's requirement (measured: with a
+    // pre-existing goaded creature on board this test passed vacuously).
+    let mut runner = scenario.build();
+    runner.cast(spell).resolve();
+
+    // The late entrant: enters the battlefield AFTER the effect resolved (still
+    // during P0's turn 1), so on P1's turn 2 it is not summoning-sick (CR 302.6)
+    // and is able to attack.
+    let late = {
+        let state = runner.state_mut();
+        let card_id = engine::types::identifiers::CardId(state.next_object_id);
+        let id = engine::game::zones::create_object(
+            state,
+            card_id,
+            P1,
+            "Late Bloomer".to_string(),
+            engine::types::Zone::Battlefield,
+        );
+        let ts = state.next_timestamp();
+        let entered_turn = state.turn_number;
+        let obj = state.objects.get_mut(&id).unwrap();
+        obj.card_types
+            .core_types
+            .push(engine::types::CoreType::Creature);
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = Some(2);
+        obj.toughness = Some(2);
+        obj.base_power = Some(2);
+        obj.base_toughness = Some(2);
+        obj.entered_battlefield_turn = Some(entered_turn);
+        obj.summoning_sick = false;
+        obj.timestamp = ts;
+        // `zones::create_object` is raw test scaffolding and does NOT mark the
+        // layer system dirty (the real ETB pipeline does). Mark the incremental
+        // "entered" state exactly as a real entrant would, so the CR 611.2c
+        // dynamic-set machinery — `active_effects_force_incremental_escalation`
+        // → `entered_object_perturbs_affected_filter` → the intact TCE filter —
+        // actually runs for this object.
+        state.layers_dirty.mark_entered(id);
+        id
+    };
+
+    // `arm_declare_attackers` writes `waiting_for` directly, bypassing the phase
+    // machinery that normally flushes layers, so run the layer pass explicitly
+    // (same `refresh` staging as `goaded_creature_under_pacifism_visible`).
+    evaluate_layers(runner.state_mut());
+    // Reach guard: the requirement really did graft onto the LATE entrant via
+    // the intact filter — the `is_err()` below is not some unrelated illegality.
+    assert!(
+        bound_by_requirement(runner.state(), late),
+        "CR 611.2c: the intact affected filter must bind a creature that entered \
+         after the effect resolved"
+    );
+
+    arm_declare_attackers(&mut runner, late);
+    let res = runner.act(GameAction::DeclareAttackers {
+        attacks: vec![],
+        bands: vec![],
+    });
+    assert!(
+        res.is_err(),
+        "CR 508.1d + Kardur ruling: the requirement applies to creatures that \
+         enter after the effect resolves, so declaring no attackers with an able \
+         creature must be illegal"
+    );
+}
+
+/// GUARD LEG (passes today, must keep passing) — the two combat requirements are
+/// actually enforced: an able creature must attack (CR 508.1d), and it must
+/// attack a player other than the effect's controller.
+#[test]
+fn spelled_out_requirement_forces_attack_away_from_the_controller() {
+    // Declaring no attackers is illegal.
+    let (mut runner, ox) = cast_requirement_spell(KARDUR_EFFECT);
+    arm_declare_attackers(&mut runner, ox);
+    let none = runner.act(GameAction::DeclareAttackers {
+        attacks: vec![],
+        bands: vec![],
+    });
+    assert!(
+        none.is_err(),
+        "CR 508.1d: an able creature under an 'attacks each combat if able' \
+         requirement must attack"
+    );
+
+    // Attacking the effect's controller (P0) disobeys the "a player other than
+    // you" requirement while P2 is an available legal defender.
+    let (mut runner, ox) = cast_requirement_spell(KARDUR_EFFECT);
+    arm_declare_attackers(&mut runner, ox);
+    let at_controller = runner.act(GameAction::DeclareAttackers {
+        attacks: vec![(ox, AttackTarget::Player(P0))],
+        bands: vec![],
+    });
+    assert!(
+        at_controller.is_err(),
+        "the 'attacks a player other than you if able' requirement must forbid \
+         attacking the effect's controller when another player is attackable"
+    );
+
+    // Attacking the third player obeys both requirements.
+    let (mut runner, ox) = cast_requirement_spell(KARDUR_EFFECT);
+    arm_declare_attackers(&mut runner, ox);
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(ox, AttackTarget::Player(P2))],
+            bands: vec![],
+        })
+        .expect("attacking a player other than the effect's controller obeys both requirements");
+    assert!(
+        runner.state().combat.is_some(),
+        "the legal declaration must commit combat"
+    );
+}
+
+/// PARSE LEG (SHAPE) — neither real card's FULL Oracle text may lower to the
+/// goad mechanic, and each must produce exactly one requirement grant.
+///
+/// The negative alone would pass vacuously on a card that failed to parse (the
+/// prior revision of this test walked the bare chapter body, which measures to
+/// `Effect::Unimplemented{static_structure}` — `has_goad` is false there both
+/// before and after the fix). Assertions 1 and 3 close that hole: the parse must
+/// yield triggers, and exactly one walked effect must be the positive shape.
+#[test]
+fn neither_card_lowers_to_goad() {
+    fn has_goad(effect: &Effect) -> bool {
+        matches!(effect, Effect::GoadAll { .. } | Effect::Goad { .. })
+    }
+
+    /// CR 701.15b attaches exactly two combat requirements; both must ride ONE
+    /// `StaticDefinition` so `register_transient_effect` keeps the affected
+    /// filter intact for both (CR 611.2c).
+    fn is_requirement_grant(effect: &Effect) -> bool {
+        let Effect::GenericEffect {
+            static_abilities, ..
+        } = effect
+        else {
+            return false;
+        };
+        static_abilities.len() == 1
+            && static_abilities[0].modifications
+                == vec![
+                    ContinuousModification::AddStaticMode {
+                        mode: StaticMode::MustAttack,
+                    },
+                    ContinuousModification::AddStaticMode {
+                        mode: StaticMode::MustAttackAwayFromSource,
+                    },
+                ]
+    }
+
+    /// Every effect the card's parse produces: standalone abilities, trigger
+    /// executes, and their `sub_ability` chains.
+    fn walk(parsed: &engine::parser::oracle::ParsedAbilities) -> Vec<Effect> {
+        fn push_chain(def: &engine::types::ability::AbilityDefinition, out: &mut Vec<Effect>) {
+            out.push(def.effect.as_ref().clone());
+            if let Some(sub) = def.sub_ability.as_deref() {
+                push_chain(sub, out);
+            }
+        }
+        let mut out = Vec::new();
+        for ability in &parsed.abilities {
+            push_chain(ability, &mut out);
+        }
+        for trigger in &parsed.triggers {
+            if let Some(execute) = &trigger.execute {
+                push_chain(execute, &mut out);
+            }
+        }
+        out
+    }
+
+    for (label, oracle, core_types, subtypes) in [
+        (
+            "Kardur, Doomscourge",
+            KARDUR_ORACLE,
+            &["Creature"][..],
+            &["Demon"][..],
+        ),
+        (
+            "Maximum Carnage",
+            MAXIMUM_CARNAGE_ORACLE,
+            &["Enchantment"][..],
+            &["Saga"][..],
+        ),
+    ] {
+        let parsed = parse_oracle_text(
+            oracle,
+            label,
+            &[],
+            &core_types.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            &subtypes.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        );
+
+        // 1. Non-empty collection: a parse that produced nothing must not pass.
+        assert!(
+            !parsed.triggers.is_empty(),
+            "{label}: the full Oracle text must produce triggers (Kardur ETB / \
+             Maximum Carnage Saga chapters), got none"
+        );
+
+        let effects = walk(&parsed);
+
+        // 2. Negative — CR 701.15a + the 2025-09-19 ruling.
+        for effect in &effects {
+            assert!(
+                !has_goad(effect),
+                "{label} must not lower to the goad mechanic, got {effect:?}"
+            );
+        }
+
+        // 3. Positive reach — subsumes "not Effect::Unimplemented" and makes (2)
+        //    impossible to satisfy vacuously.
+        let grants = effects.iter().filter(|e| is_requirement_grant(e)).count();
+        assert_eq!(
+            grants, 1,
+            "{label} must produce exactly one MustAttack + \
+             MustAttackAwayFromSource grant, got {grants} in {effects:?}"
+        );
+    }
+}
+
+/// T6 — MULTI-AUTHORITY (CR 701.15c analogue): two different players each resolve
+/// the effect over P1's creature, so it carries two grafted definitions with
+/// distinct `source_controller` anchors and must avoid BOTH.
+///
+/// REVERT PROBE: collapse the `layers.rs` graft dedup from full-definition
+/// equality (`sd == &def`) to mode-only ⇒ only one anchor survives ⇒ one of
+/// P0/P2 becomes a legal defender ⇒ one of the two `is_err()` legs fails.
+#[test]
+fn two_controllers_each_add_their_own_avoided_player() {
+    let mut scenario = GameScenario::new_n_player(4, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let p0_spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Spelled-Out Requirement", false, KARDUR_EFFECT)
+        .id();
+    let p2_spell = scenario
+        .add_spell_to_hand_from_oracle(P2, "Spelled-Out Requirement", false, KARDUR_EFFECT)
+        .id();
+    let ox = scenario.add_creature(P1, "Ornery Ox", 2, 2).id();
+    let mut runner = scenario.build();
+
+    runner.cast(p0_spell).resolve();
+    {
+        // Hand the turn to P2 so it can cast the same sorcery-speed effect.
+        let state = runner.state_mut();
+        state.active_player = P2;
+        state.priority_player = P2;
+        state.phase = Phase::PreCombatMain;
+        state.waiting_for = WaitingFor::Priority { player: P2 };
+    }
+    runner.cast(p2_spell).resolve();
+
+    // Reach: BOTH anchors are present on the one creature (CR 701.15c — each
+    // distinct avoided player is an additional requirement).
+    let anchors: Vec<PlayerId> = {
+        let state = runner.state();
+        let obj = &state.objects[&ox];
+        let mut a: Vec<PlayerId> = active_static_definitions(state, obj)
+            .filter(|sd| sd.mode == StaticMode::MustAttackAwayFromSource)
+            .filter_map(|sd| sd.source_controller)
+            .collect();
+        a.sort_unstable_by_key(|p| p.0);
+        a
+    };
+    assert_eq!(
+        anchors,
+        vec![P0, P2],
+        "CR 701.15c: two installing players must leave two distinct anchors"
+    );
+
+    for avoided in [P0, P2] {
+        // A rejected declaration is validated before combat is committed, so the
+        // state is re-armable for the next leg.
+        arm_declare_attackers_against(&mut runner, &[ox], &[P0, P2, P3]);
+        let res = runner.act(GameAction::DeclareAttackers {
+            attacks: vec![(ox, AttackTarget::Player(avoided))],
+            bands: vec![],
+        });
+        assert!(
+            res.is_err(),
+            "CR 508.1d: attacking {avoided:?} disobeys that player's own \
+             away-from requirement while P3 is attackable"
+        );
+    }
+
+    arm_declare_attackers_against(&mut runner, &[ox], &[P0, P2, P3]);
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(ox, AttackTarget::Player(P3))],
+            bands: vec![],
+        })
+        .expect("attacking the one player neither installer named obeys both requirements");
+    assert!(
+        runner.state().combat.is_some(),
+        "the legal declaration must commit combat"
+    );
+}
+
+/// T7 — NEGATIVE SIBLING: the goad KEYWORD path is untouched. Disrupt Decorum
+/// still stamps the designation, and its reminder parenthetical (a word-for-word
+/// instance of the compound this change recognizes) must not graft a competing
+/// `MustAttackAwayFromSource` static.
+///
+/// REVERT PROBE (leg 1): route `Effect::GoadAll` through the new static instead
+/// of `goad.rs` ⇒ `goaded_by` stays empty ⇒ leg 1 fails. Leg 1 also proves the
+/// spell resolved, so leg 2's `is_none()` is reached rather than vacuous.
+///
+/// Leg 2 is a regression TRIPWIRE, not a discriminator: measured twice (executor
+/// and reviewer), deleting the `strip_reminder_text` call from `parser/oracle.rs`
+/// leaves this test green (suite still 12/12), so no known single edit flips it.
+/// Its non-vacuity comes only from the pairing with leg 1 above.
+#[test]
+fn keyword_goad_still_sets_the_designation() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Disrupt Decorum", false, DISRUPT_DECORUM_ORACLE)
+        .id();
+    let opp = scenario.add_creature(P1, "Ornery Ox", 2, 2).id();
+    let mut runner = scenario.build();
+    runner.cast(spell).resolve();
+
+    // Leg 1 (positive) — CR 701.15a/b: the keyword still designates.
+    assert!(
+        runner.state().objects[&opp].goaded_by.contains(&P0),
+        "the goad KEYWORD must still stamp the designation, got {:?}",
+        runner.state().objects[&opp].goaded_by
+    );
+
+    // Leg 2 (negative, reached because leg 1 proved resolution) — the reminder
+    // text must not produce a second, non-designating grant.
+    assert!(
+        !bound_by_requirement(runner.state(), opp),
+        "the reminder parenthetical must not graft a competing \
+         MustAttackAwayFromSource static alongside the keyword"
+    );
+}
+
+/// T8 — DURATION: the grant is bound to `UntilNextTurnOf { Controller }`, so it
+/// survives the intervening player's turn and dies at the controller's next
+/// untap step (CR 502). Note the expiry mechanism MOVED with this change: goad
+/// expired via `goaded_by.remove(active_player)`; this expires via
+/// `prune_until_next_turn_effects` on the transient continuous effect.
+///
+/// REVERT PROBE (measured): force `dur = Duration::UntilEndOfTurn`
+/// unconditionally in `game/effects/effect.rs::resolve` ⇒ P0's cleanup prunes the
+/// grant ⇒ leg A flips to fail. Leg A is therefore the discriminator for the
+/// duration carry-through the GoadAll → GenericEffect migration had to preserve.
+/// NOT a probe (measured): dropping only the `ability.duration` term of that same
+/// expression (leaving `duration.clone().unwrap_or(UntilEndOfTurn)`) leaves all 12
+/// tests passing — `ability.duration` is not the sole carrier at that seam.
+#[test]
+fn requirement_expires_at_the_controllers_next_untap() {
+    let (mut runner, ox) = cast_requirement_spell(KARDUR_EFFECT);
+    assert!(
+        bound_by_requirement(runner.state(), ox),
+        "reach: the requirement must be grafted before the turn advances"
+    );
+
+    // CR 514.2: P0's cleanup step — this is where an `UntilEndOfTurn` grant dies.
+    let mut events = Vec::new();
+    execute_cleanup(runner.state_mut(), &mut events);
+
+    // P1's untap step: only P1-controlled `UntilNextTurnOf` effects are pruned.
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.turn_number = 2;
+    }
+    let mut events = Vec::new();
+    execute_untap(runner.state_mut(), &mut events);
+    // MANDATORY: the derived per-object graft only reflects a prune after the
+    // next layer pass, and `arm_declare_attackers` writes `waiting_for` directly
+    // (bypassing the phase machinery that would flush). Without this the leg-A
+    // assertion below reads STALE derived statics and passes for any duration.
+    evaluate_layers(runner.state_mut());
+
+    // LEG A (positive, the duration discriminator) — still bound during the
+    // intervening turn. An `UntilEndOfTurn` grant died at P0's cleanup above.
+    assert!(
+        bound_by_requirement(runner.state(), ox),
+        "CR 514.2: an `UntilNextTurnOf {{ Controller }}` grant survives P0's \
+         cleanup and P1's untap — it must still be grafted here"
+    );
+    arm_declare_attackers(&mut runner, ox);
+    assert!(
+        runner
+            .act(GameAction::DeclareAttackers {
+                attacks: vec![],
+                bands: vec![],
+            })
+            .is_err(),
+        "CR 508.1d: the requirement lasts until the CONTROLLER's next turn, so \
+         it is still enforced during the intervening turn"
+    );
+
+    // CR 502 (Untap Step): at the start of P0's next turn
+    // `prune_until_next_turn_effects` drops the transient effect. (CR 514.2 is the
+    // CLEANUP-step prune above, which this duration deliberately survives.)
+    {
+        let state = runner.state_mut();
+        state.active_player = P0;
+        state.turn_number = 3;
+    }
+    let mut events = Vec::new();
+    execute_untap(runner.state_mut(), &mut events);
+    // The prune removes the TCE and marks layers dirty; the per-object derived
+    // `static_definitions` only lose the graft on the next layer pass.
+    evaluate_layers(runner.state_mut());
+
+    // LEG B (negative, reached because leg A proved the grant existed).
+    assert!(
+        !bound_by_requirement(runner.state(), ox),
+        "CR 502: the grant must be gone at the controller's next untap step"
+    );
+    arm_declare_attackers(&mut runner, ox);
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![],
+            bands: vec![],
+        })
+        .expect("with the requirement expired, declining to attack is legal again");
+}
+
+/// T9 — RESTRICTION beats REQUIREMENT (CR 508.1c over CR 508.1d): a creature
+/// that can't attack is not force-attacked, while its unrestricted sibling under
+/// the same effect still is.
+///
+/// REVERT PROBE: remove the `MustAttackAwayFromSource` contribution from
+/// `players_to_attack_away_from_gated` ⇒ the AWAY-FROM leg below flips to `Ok`.
+/// (Measured: the plain "declaring no attackers is illegal" leg does NOT flip
+/// under that probe — the same `StaticDefinition` also grafts `MustAttack`,
+/// which carries it independently. The away-from leg is the discriminator.)
+#[test]
+fn cant_attack_restriction_beats_the_spelled_out_requirement() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Spelled-Out Requirement", false, KARDUR_EFFECT)
+        .id();
+    let pacified = scenario.add_creature(P1, "Pacified Ox", 2, 2).id();
+    let free = scenario.add_creature(P1, "Ornery Ox", 2, 2).id();
+    let mut runner = scenario.build();
+    runner.cast(spell).resolve();
+
+    pacify(&mut runner, pacified);
+    // Reach: BOTH creatures carry the requirement, so the legality difference
+    // below is the Pacifism restriction and not a missing grant.
+    assert!(
+        bound_by_requirement(runner.state(), free),
+        "reach: the unrestricted creature must carry the requirement"
+    );
+
+    // POSITIVE — the unrestricted creature is still forced.
+    arm_declare_attackers_against(&mut runner, &[pacified, free], &[P0, P2]);
+    assert!(
+        runner
+            .act(GameAction::DeclareAttackers {
+                attacks: vec![],
+                bands: vec![],
+            })
+            .is_err(),
+        "CR 508.1d: the unrestricted creature under the requirement must attack"
+    );
+
+    // AWAY-FROM leg (CR 701.15b second clause, the discriminator for the
+    // requirement AUTHORITY): the unrestricted creature may not attack the
+    // effect's controller while P2 is attackable. Pairs with the negative below.
+    arm_declare_attackers_against(&mut runner, &[pacified, free], &[P0, P2]);
+    assert!(
+        runner
+            .act(GameAction::DeclareAttackers {
+                attacks: vec![(free, AttackTarget::Player(P0))],
+                bands: vec![],
+            })
+            .is_err(),
+        "CR 508.1d + CR 701.15b: the away-from requirement must forbid attacking \
+         the effect's controller while another player is attackable"
+    );
+
+    // NEGATIVE — the pacified creature is NOT force-attacked (CR 508.1c).
+    arm_declare_attackers_against(&mut runner, &[pacified, free], &[P0, P2]);
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(free, AttackTarget::Player(P2))],
+            bands: vec![],
+        })
+        .expect("CR 508.1c: a creature that can't attack is not forced to");
+}
+
+/// T10 — WIRE: a creature bound by the requirement must not render
+/// `Static: MustAttackAwayFromSource` as an unimplemented mechanic. The graft
+/// reach assertion is mandatory: an unbound creature has an empty vec vacuously.
+///
+/// REVERT PROBE: delete
+/// `registry.insert(StaticMode::MustAttackAwayFromSource, handle_rule_mod)` ⇒
+/// `coverage::unimplemented_mechanics` reports the mode ⇒ this fails.
+#[test]
+fn bound_creature_reports_no_unimplemented_mechanics() {
+    let (mut runner, ox) = cast_requirement_spell(KARDUR_EFFECT);
+
+    // Reach: the graft happened, so the per-object registry scan in
+    // `coverage::unimplemented_mechanics` actually visits this mode.
+    assert!(
+        bound_by_requirement(runner.state(), ox),
+        "reach: the creature must carry the grafted requirement"
+    );
+
+    mark_public_state_all_dirty(runner.state_mut());
+    derive_display_state(runner.state_mut());
+
+    assert!(
+        runner.state().objects[&ox]
+            .unimplemented_mechanics
+            .is_empty(),
+        "a bound creature must not surface the requirement as an unimplemented \
+         mechanic, got {:?}",
+        runner.state().objects[&ox].unimplemented_mechanics
+    );
+}
+
+/// T12 — "no such players" (Maximum Carnage ruling 2025-09-19: "if such a
+/// creature can't attack players other than you, it must attack you"). With the
+/// effect's controller the ONLY attackable defender, the away-from requirement
+/// is unobeyable, so CR 508.1d's maximum is 1 (the generic requirement) and the
+/// creature must still attack.
+///
+/// REVERT PROBE: delete the unconditional `MustAttackGeneric` push in
+/// `AttackDeclarationConstraints::build` ⇒ `max_no_payment == 0` ⇒ declaring no
+/// attackers becomes legal ⇒ leg 1 fails. (Gating the away-from push on
+/// `attackable_players`, like the `MustAttackPlayer` push, would NOT flip leg 1 —
+/// `MustAttackGeneric` still carries it — which is why that is not the probe.)
+#[test]
+fn only_avoided_player_attackable_still_forces_the_attack() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Spelled-Out Requirement", false, KARDUR_EFFECT)
+        .id();
+    let ox = scenario.add_creature(P1, "Ornery Ox", 2, 2).id();
+    let mut runner = scenario.build();
+    runner.cast(spell).resolve();
+    assert!(
+        bound_by_requirement(runner.state(), ox),
+        "reach: the creature must carry the requirement"
+    );
+
+    // Leg 1 — declining is illegal even though the only defender is the player
+    // the creature is supposed to avoid.
+    arm_declare_attackers_against(&mut runner, &[ox], &[P0]);
+    assert!(
+        runner
+            .act(GameAction::DeclareAttackers {
+                attacks: vec![],
+                bands: vec![],
+            })
+            .is_err(),
+        "CR 508.1d: the generic 'attacks each combat if able' requirement is \
+         still obeyable, so declaring no attackers is illegal"
+    );
+
+    // Leg 2 — attacking the avoided player is legal and commits combat.
+    arm_declare_attackers_against(&mut runner, &[ox], &[P0]);
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(ox, AttackTarget::Player(P0))],
+            bands: vec![],
+        })
+        .expect("with no other attackable player the creature must attack the avoided player");
+    assert!(
+        runner.state().combat.is_some(),
+        "the forced declaration must commit combat"
+    );
+}
+
+/// T14 — the `MustAttack` HALF of the grant actually reaches combat.
+///
+/// Every legality leg elsewhere in this file is satisfied by the away-from term
+/// alone (`creature_must_attack_with_attackable_players_gated` ORs `has_must_attack`
+/// with `must_attack_away`), and `bound_by_requirement` only probes
+/// `MustAttackAwayFromSource` — so the suite would stay green if the grafted
+/// `AddStaticMode { MustAttack }` stopped being seen. That is a live risk: #6296
+/// rewrote exactly that computation (`has_local_must_attack` →
+/// `check_static_ability(MustAttack, static_target_ctx(id))`).
+///
+/// `CombatRequirement::MustAttack::sources` is the term-specific observable.
+/// `must_attack_sources_gated` unions three contributors: gated
+/// `check_static_ability_sources(MustAttack)`, `StaticMode::Goaded` carriers, and
+/// attackable `MustAttackPlayer` carriers. This fixture has neither of the latter
+/// two (asserted below), and `MustAttackAwayFromSource` deliberately contributes
+/// NO source (see `players_to_attack_away_from_gated`), so a non-empty `sources`
+/// can only come from the `MustAttack` graft — via the same gate + check pair the
+/// enforcement path uses.
+///
+/// REVERT PROBE (measured): delete the `AddStaticMode { mode: MustAttack }`
+/// element from `must_attack_away_static_definition`
+/// (`parser/oracle_effect/imperative.rs`) ⇒ `sources` is empty ⇒ the final
+/// assertion here fails, **along with** the parse-shape assertion in
+/// `neither_card_lowers_to_goad`, whose `is_requirement_grant` helper pins the
+/// same two-element `modifications` vec. The other 11 tests in this file stay
+/// green. Measured: `11 passed; 2 failed`.
+#[test]
+fn grafted_must_attack_half_reaches_the_combat_authority() {
+    let (mut runner, ox) = cast_requirement_spell(KARDUR_EFFECT);
+    assert!(
+        bound_by_requirement(runner.state(), ox),
+        "reach: the creature must carry the grafted requirement"
+    );
+
+    arm_declare_attackers(&mut runner, ox);
+    let valid = get_valid_attacker_ids(runner.state());
+    assert!(
+        valid.contains(&ox),
+        "reach: the bound creature must be an eligible attacker, got {valid:?}"
+    );
+
+    let constraints = attacker_constraints_for_active_player(runner.state(), &valid);
+    let Some(CombatRequirement::MustAttack { players, sources }) = constraints.get(&ox) else {
+        panic!(
+            "expected a MustAttack requirement for the bound creature, got {:?}",
+            constraints.get(&ox)
+        );
+    };
+    // Exclude the other two `sources` contributors, each by the thing that
+    // actually feeds it.
+    //
+    // (a) `MustAttackPlayer`: `players` and the carrier list are built from the
+    //     same filtered directive iterator, so empty players ⟺ no carriers.
+    assert!(
+        players.is_empty(),
+        "no MustAttackPlayer directive exists in this fixture, got {players:?}"
+    );
+    // (b) `StaticMode::Goaded`: fed by `goad_static_hits_for_creature`, which
+    //     supplies the CARRIER's id — so it could only yield `ox` if `ox` itself
+    //     carried a functioning `Goaded` static. `goaded_by` does NOT guard this
+    //     (a `Goaded` static never writes `goaded_by`); the static sweep does.
+    assert!(
+        !active_static_definitions(runner.state(), &runner.state().objects[&ox])
+            .any(|sd| sd.mode == StaticMode::Goaded),
+        "no functioning `StaticMode::Goaded` static is carried by the creature, so \
+         `goad_static_hits_for_creature` cannot contribute its id to `sources`"
+    );
+    // Not a `sources` guard — this is the CR 701.15a property the whole file
+    // exists to pin: the requirement without the designation.
+    assert!(
+        runner.state().objects[&ox].goaded_by.is_empty(),
+        "CR 701.15a: the spelled-out requirement must not set the goad designation"
+    );
+    assert_eq!(
+        sources,
+        &vec![ox],
+        "CR 508.1d: the grafted `AddStaticMode {{ MustAttack }}` must reach \
+         `check_static_ability(MustAttack)` — its `affected: SelfRef` graft makes \
+         the creature its own carrier. Empty here means combat no longer sees the \
+         MustAttack half of the grant"
+    );
+}
+
+/// T13 — CR 109.5 + CR 611.2c: the affected population's "your opponents"
+/// reference is the RESOLVING controller, snapshotted; only the *set of objects*
+/// is dynamic. Kardur is cast as a real creature spell so the source is a
+/// battlefield permanent whose controller can change mid-window (Control Magic
+/// class) — the sorcery-typed fixture used by every other test in this file puts
+/// the source in a graveyard where this is unobservable.
+///
+/// REVERT PROBE: restore the bare
+/// `FilterContext::from_source(state, effect.source_id)` at the
+/// `apply_continuous_effect_filtered` scan in `layers.rs` ⇒ the population is
+/// re-derived from the THIEF's perspective ⇒ P1's creature falls out (positive
+/// leg fails) and P0's own creature is pulled in (negative leg fails).
+#[test]
+fn affected_population_does_not_follow_a_stolen_source() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let kardur = scenario
+        .add_creature_to_hand_from_oracle(P0, "Kardur, Doomscourge", 3, 3, KARDUR_ORACLE)
+        .id();
+    let own = scenario.add_creature(P0, "Bear", 2, 2).id();
+    let p1_wolf = scenario.add_creature(P1, "Wolf", 2, 2).id();
+    let p2_ox = scenario.add_creature(P2, "Ornery Ox", 2, 2).id();
+    let mut runner = scenario.build();
+    runner.cast(kardur).resolve();
+
+    // Reach — the ETB trigger resolved and bound P0's opponents' creatures only.
+    assert!(
+        bound_by_requirement(runner.state(), p1_wolf)
+            && bound_by_requirement(runner.state(), p2_ox),
+        "reach: Kardur's ETB must bind both opponents' creatures"
+    );
+    assert!(
+        !bound_by_requirement(runner.state(), own),
+        "reach: Kardur must not bind its own controller's creature"
+    );
+
+    // An opponent steals Kardur mid-window. `evaluate_layers` resets `controller`
+    // from `base_controller` on every pass, so both fields must be set.
+    {
+        let obj = runner.state_mut().objects.get_mut(&kardur).unwrap();
+        obj.base_controller = Some(P1);
+        obj.controller = P1;
+    }
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+
+    // POSITIVE — the population is still P0's opponents (CR 109.5: for a
+    // triggered ability, "you" is the controller when the ability triggered).
+    assert!(
+        bound_by_requirement(runner.state(), p1_wolf),
+        "CR 109.5: the bound population must not follow the stolen source — \
+         P1's creature must stay bound"
+    );
+    assert!(
+        bound_by_requirement(runner.state(), p2_ox),
+        "CR 109.5: P2's creature must stay bound"
+    );
+
+    // NEGATIVE (the discriminator), paired with the positives above.
+    assert!(
+        !bound_by_requirement(runner.state(), own),
+        "CR 109.5 + CR 611.2c: only the SET OF OBJECTS is dynamic — the effect \
+         controller's own creature must never become bound because the source \
+         changed hands"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -39,6 +39,7 @@ mod baleful_mastery_regression;
 mod banding_combat;
 mod batched_trigger_subject_count;
 mod battle_of_wits;
+mod bbfu7_attacks_if_able_not_goad;
 mod belbe_thornbow_life_loss;
 mod betor_lifelink_counters_repro;
 mod birgi;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The parser lowered two cards that spell out the goad *effect* without the goad keyword — Kardur, Doomscourge and Maximum Carnage chapter I — to `Effect::GoadAll`, which stamped the goad **designation** and marked only the creatures present at resolution. Both are wrong: per CR 701.15a only a spell or ability that *goads* makes a creature goaded, and per CR 611.2c the affected set of a rules-modifying continuous effect stays dynamic. This lowers the compound to `Effect::GenericEffect` carrying one `StaticDefinition` with `StaticMode::MustAttack` + a new nullary `StaticMode::MustAttackAwayFromSource`, so the requirement is created without the designation and the affected set stays live.

Both cards' official rulings say exactly this:

- **Maximum Carnage** (2025-09-19): *"Although the effects of the first chapter ability are the same as the goad keyword action, that ability doesn't cause any creatures to become goaded. Effects that refer to 'goaded creatures' won't apply."*
- **Maximum Carnage** (2025-09-19): *"affects all creatures until your next turn, regardless of whether or not they were on the battlefield at the time the ability resolved."*
- **Kardur, Doomscourge** (2021-02-05): *"affects all creatures your opponents control, including any that enter the battlefield after the ability resolves."*

Cards that read the designation (Serene Sleuth, Hot Pursuit, Baeloth Barrityl, The Rani, The Kami Knight's "can't be goaded") therefore stop matching these two — which is the rules-correct outcome. Real goad cards (Agitator Ant, Disrupt Decorum, Marisi, Day of the Moon, …) use the keyword and keep lowering to `Goad`/`GoadAll`; a regression test pins that.

## Implementation method (required)

Method: /engine-implementer

## CR references

- **CR 701.15a** — only a spell/ability that *goads* makes a creature goaded (the load-bearing rule: these two cards create the requirement without the designation).
- **CR 701.15b** — "Goaded is a designation a permanent can have"; the two clauses of the goad requirement.
- **CR 701.15c** — each distinct avoided player is an additional requirement.
- **CR 611.2c** — a resolution-created continuous effect that modifies no characteristics modifies the rules of the game ⇒ dynamic affected set.
- **CR 508.1d** — the attack-requirement maximisation solver.
- **CR 109.5** — "you" is the controller of the object; for a triggered ability, the controller when it triggered (the player reference is snapshotted, the object set is not).

Every CR number in the diff was grep-verified against `docs/MagicCompRules.txt` before being written, and re-verified by two independent review agents.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

| Command | Result |
|---|---|
| `cargo fmt --all` | clean, zero diff |
| `scripts/check-parser-combinators.sh 23824afe7` | Gate A PASS + Gate G PASS |
| `cargo clippy --workspace --all-targets --features engine/proptest -- -D warnings` | exit 0, zero warnings |
| `cargo test -p engine --test integration bbfu7` | 13 passed / 0 failed |
| `cargo test -p engine --lib` | 17489 passed / 0 failed / 6 ignored |
| `cargo test-all` | 23463 run, 23455 passed, 8 failed — all 8 pre-existing, see below |
| `cargo coverage` | `supported_cards` 31502 → 31504 (+2) |
| card-data blast radius (regen at base vs head) | exactly **2** keys changed, 0 added, 0 removed |
| `FORGE_TEST_FULL_DB=1 cargo test -p engine --lib ordering_parity_sweep` | sweep line **byte-identical** to base (`unexplained=18` both sides) |

**The 8 `cargo test-all` failures are pre-existing on `main`, proven from git objects without a build.** They are all in `crates/mtgish-import`, a crate this PR does not touch (`git diff --stat 23824afe7...HEAD -- crates/mtgish-import` is empty). For `every_list_field_is_in_ordering_manifest` specifically: at `23824afe7` itself, `ORDERING_MANIFEST` in `crates/mtgish-import/src/diff/ordering.rs` contains **zero** entries for `mode_pawprints`, `spellbook` or `extra_core_types`, while those `Vec` fields **do** exist in `crates/engine/src/types/ability.rs` at the same commit — so the test fails on `23824afe7` by construction. This PR adds no `Vec<...>` struct field at all (the single `Vec<` line it adds is a function-local `let`).

`--all-features` additionally surfaces 16 compile errors under the `forge` feature; all six files involved are byte-identical to `23824afe7` (`git diff --quiet 23824afe7 HEAD -- <f>` for each), and `forge` is not in the repo's gate alias (`clippy-strict = "clippy --all-targets -- -D warnings"`).

### Non-vacuity evidence (measured revert-probes, not asserted)

The acceptance suite began life as a **probe gate**: before any design work, it was run at the pre-fix tip and measured **1 passed / 4 failed**, so every behavioural leg was proven to flip. One leg (`requirement_binds_a_creature_that_enters_after_resolution`) initially passed *vacuously* because a pre-existing goaded creature's own requirement already made the empty declaration illegal; removing that creature flipped it to FAIL. Measured, not assumed.

A late independent review found that **no runtime test discriminated the `MustAttack` half** of the grant — every "declining to attack is illegal" leg was also satisfied by the away-from term alone, so a silent regression in the `MustAttack` path (which #6296 had just rewritten) would have gone undetected. `grafted_must_attack_half_reaches_the_combat_authority` closes that hole, with a measured revert-probe: deleting **only** the `AddStaticMode { mode: StaticMode::MustAttack }` element from `must_attack_away_static_definition()` makes it fail (`left: []`, `right: [ObjectId(2)]`) along with the parse-shape assertion in `neither_card_lowers_to_goad`, which pins the same two-element `modifications` vec; the other 11 tests stay green. Measured: `11 passed; 2 failed`. Restoring the element returns 13/13; `imperative.rs` md5 verified identical before and after. Two independent agents ran this probe separately and got the same counts.

## Gate A

Gate A PASS head=2a91e56ee582f6bceed49ddbe35f5e0ded7601f6 base=23824afe75218442ce199f411169ed5462421585

## Anchored on

- `crates/engine/src/game/combat.rs:2631` — `must_attack_player_directives_for_creature`, the existing per-object `active_static_definitions` scan that the new `players_to_attack_away_from_gated` authority mirrors exactly (same seam, same unfiltered-scan shape, deliberately left unchanged by #6296).
- `crates/engine/src/game/layers.rs` — the existing `ContinuousModification::AddStaticMode` arm that grafts `StaticDefinition::new(mode).affected(TargetFilter::SelfRef)` onto recipients; the new mode rides this path rather than introducing one.

## Final review-impl

Final review-impl PASS head=2a91e56ee582f6bceed49ddbe35f5e0ded7601f6

## Claimed parse impact

- Kardur, Doomscourge
- Maximum Carnage

Both were **unsupported before this change** (one swallowed clause each) and become supported: `supported_cards` 31502 → 31504. Card-data blast radius is exactly these two keys.

## Disclosed follow-ups (not fixed here)

1. `crates/phase-ai/src/policies/effect_classify.rs` classifies the new mode via `_ => Contextual` where `MustAttack` is `Harmful`. Aura-scoped and unreachable today; fixing it would require `cargo ai-gate` plus a paired-seed baseline refresh, which is disproportionate for an unreachable path.
2. `players_to_attack_away_from_gated` and its sibling `must_attack_player_directives_for_creature` both scan `active_static_definitions` without an `sd.affected` check. Safe today for both (grafted-only producers, always `affected: SelfRef`), and documented in-code with the condition under which it must change — but it is a latent class-wide trap that belongs in one follow-up covering *both* siblings, not a one-sided fix here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for “must attack a player other than you” via a dedicated combat restriction mode.
  * Updated oracle parsing so BB-FU7-style “away-from” text becomes combat requirements rather than goading behavior.
* **Bug Fixes**
  * Corrected attacker-legality and requirement derivation for away-from restrictions, including proper controller anchoring and dynamic affected-object evaluation.
* **Tests**
  * Added a new integration test covering parsing, eligibility, timing/expiration, edge cases, and verifying goad cards still set goad designations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->