### PR TITLE
Card/plargg and nassari

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1686,6 +1686,9 @@ export type WaitingFor =
   | { type: "ManifestDreadChoice"; data: { player: PlayerId; cards: ObjectId[]; source_id: ObjectId } }
   | { type: "LearnChoice"; data: { player: PlayerId; hand_cards: ObjectId[] } }
   | { type: "ClashChooseOpponent"; data: { player: PlayerId; candidates: PlayerId[]; ability: unknown } }
+  // CR 608.2d: "an opponent chooses" from a zone (multiplayer) — the controller
+  // picks WHICH opponent makes the choice before the zone choice is presented.
+  | { type: "ChooseFromZoneOpponentChooser"; data: { player: PlayerId; candidates: PlayerId[]; ability: unknown } }
   | { type: "ChooseAnnouncingOpponent"; data: { player: PlayerId; candidates: PlayerId[]; choice_index: number; choice_count: number; target_type?: CoreType; pending_cast: unknown } }
   | { type: "ClashCardPlacement"; data: { player: PlayerId; card: ObjectId; remaining: [PlayerId, ObjectId][] } }
   | { type: "VoteChoice"; data: {
@@ -2119,6 +2122,8 @@ export type GameAction =
   // CR 702.99a: answer to CipherEncodeChoice — a creature to encode on, or null to decline.
   | { type: "CipherEncode"; data: { creature: ObjectId | null } }
   | { type: "ChooseClashOpponent"; data: { opponent: PlayerId } }
+  // CR 608.2d: answer to ChooseFromZoneOpponentChooser — which opponent will choose.
+  | { type: "ChooseZoneOpponentChooser"; data: { opponent: PlayerId } }
   | { type: "ChoosePileOpponent"; data: { opponent: PlayerId } }
   | { type: "ChooseAnnouncingOpponent"; data: { opponent: PlayerId } }
   | { type: "ChooseAssistPlayer"; data: { player: PlayerId | null } }

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1481,6 +1481,13 @@ export type CastOfferKind =
       filter: TargetFilter;
       zones: Zone[];
       exile_instead_of_graveyard?: boolean;
+      // CR 406.6: source of the granting ability (engine serde-default;
+      // absent in payloads predating the field).
+      source?: ObjectId;
+      // CR 607.2a: THIS resolution's "exiled this way" batch (Plargg and
+      // Nassari); omitted when empty (no batch restriction). Display-only
+      // pass-through — the modal renders `candidates`.
+      member_pool?: ObjectId[];
     };
 
 // CR 103.5b: Which declare-point action a pending BottomCards obligation

--- a/client/src/components/modal/ZoneOpponentChooserModal.tsx
+++ b/client/src/components/modal/ZoneOpponentChooserModal.tsx
@@ -1,0 +1,76 @@
+import { useTranslation } from "react-i18next";
+
+import type { GameAction, PlayerId, WaitingFor } from "../../adapter/types.ts";
+import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
+import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import { getOpponentDisplayName } from "../../stores/multiplayerStore.ts";
+import { ChoiceModal } from "./ChoiceModal.tsx";
+
+type ZoneOpponentChooserWaitingFor = Extract<
+  WaitingFor,
+  { type: "ChooseFromZoneOpponentChooser" }
+>;
+
+interface ZoneOpponentChooserModalContentProps {
+  waitingFor: ZoneOpponentChooserWaitingFor;
+  seatOrder?: PlayerId[];
+  dispatch: (action: GameAction) => void | Promise<void>;
+}
+
+/**
+ * CR 608.2d: "An opponent chooses …" from a zone in a multiplayer game — the
+ * controller decides which opponent makes the choice before the zone choice
+ * itself is presented to that opponent (Plargg and Nassari's release notes:
+ * "you choose which opponent gets to choose one of the exiled nonland cards").
+ */
+export function ZoneOpponentChooserModalContent({
+  waitingFor,
+  seatOrder,
+  dispatch,
+}: ZoneOpponentChooserModalContentProps) {
+  const { t } = useTranslation("game");
+  const candidates = [...waitingFor.data.candidates].sort((a, b) => {
+    const aIdx = seatOrder?.indexOf(a) ?? a;
+    const bIdx = seatOrder?.indexOf(b) ?? b;
+    return aIdx - bIdx;
+  });
+
+  return (
+    <ChoiceModal
+      title={t("zoneOpponentChooser.title", "Choose Opponent")}
+      subtitle={t(
+        "zoneOpponentChooser.subtitle",
+        "Choose which opponent makes the choice.",
+      )}
+      options={candidates.map((opponent) => ({
+        id: String(opponent),
+        label: getOpponentDisplayName(opponent),
+      }))}
+      onChoose={(id) => {
+        dispatch({
+          type: "ChooseZoneOpponentChooser",
+          data: { opponent: Number(id) },
+        });
+      }}
+    />
+  );
+}
+
+export function ZoneOpponentChooserModal() {
+  const canActForWaitingState = useCanActForWaitingState();
+  const dispatch = useGameDispatch();
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const seatOrder = useGameStore((s) => s.gameState?.seat_order);
+
+  if (waitingFor?.type !== "ChooseFromZoneOpponentChooser") return null;
+  if (!canActForWaitingState) return null;
+
+  return (
+    <ZoneOpponentChooserModalContent
+      waitingFor={waitingFor}
+      seatOrder={seatOrder}
+      dispatch={dispatch}
+    />
+  );
+}

--- a/client/src/components/modal/ZoneOpponentChooserModal.tsx
+++ b/client/src/components/modal/ZoneOpponentChooserModal.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 
-import type { GameAction, PlayerId, WaitingFor } from "../../adapter/types.ts";
+import type { GameAction, WaitingFor } from "../../adapter/types.ts";
 import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
 import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
@@ -14,7 +14,6 @@ type ZoneOpponentChooserWaitingFor = Extract<
 
 interface ZoneOpponentChooserModalContentProps {
   waitingFor: ZoneOpponentChooserWaitingFor;
-  seatOrder?: PlayerId[];
   dispatch: (action: GameAction) => void | Promise<void>;
 }
 
@@ -23,18 +22,16 @@ interface ZoneOpponentChooserModalContentProps {
  * controller decides which opponent makes the choice before the zone choice
  * itself is presented to that opponent (Plargg and Nassari's release notes:
  * "you choose which opponent gets to choose one of the exiled nonland cards").
+ *
+ * Candidates render in the ENGINE-SUPPLIED order: candidate ordering is game
+ * ordering and belongs to the engine, so the client must not re-sort it.
  */
 export function ZoneOpponentChooserModalContent({
   waitingFor,
-  seatOrder,
   dispatch,
 }: ZoneOpponentChooserModalContentProps) {
   const { t } = useTranslation("game");
-  const candidates = [...waitingFor.data.candidates].sort((a, b) => {
-    const aIdx = seatOrder?.indexOf(a) ?? a;
-    const bIdx = seatOrder?.indexOf(b) ?? b;
-    return aIdx - bIdx;
-  });
+  const candidates = waitingFor.data.candidates;
 
   return (
     <ChoiceModal
@@ -61,7 +58,6 @@ export function ZoneOpponentChooserModal() {
   const canActForWaitingState = useCanActForWaitingState();
   const dispatch = useGameDispatch();
   const waitingFor = useGameStore((s) => s.waitingFor);
-  const seatOrder = useGameStore((s) => s.gameState?.seat_order);
 
   if (waitingFor?.type !== "ChooseFromZoneOpponentChooser") return null;
   if (!canActForWaitingState) return null;
@@ -69,7 +65,6 @@ export function ZoneOpponentChooserModal() {
   return (
     <ZoneOpponentChooserModalContent
       waitingFor={waitingFor}
-      seatOrder={seatOrder}
       dispatch={dispatch}
     />
   );

--- a/client/src/components/modal/__tests__/ZoneOpponentChooserModal.test.tsx
+++ b/client/src/components/modal/__tests__/ZoneOpponentChooserModal.test.tsx
@@ -25,11 +25,7 @@ function zoneOpponentChooserWaitingFor(): ZoneOpponentChooserWaitingFor {
 function renderModal(waitingFor: ZoneOpponentChooserWaitingFor) {
   const dispatch = vi.fn<(action: GameAction) => void>();
   render(
-    <ZoneOpponentChooserModalContent
-      waitingFor={waitingFor}
-      seatOrder={[0, 1, 2]}
-      dispatch={dispatch}
-    />,
+    <ZoneOpponentChooserModalContent waitingFor={waitingFor} dispatch={dispatch} />,
   );
   return dispatch;
 }
@@ -60,5 +56,23 @@ describe("ZoneOpponentChooserModalContent", () => {
       type: "ChooseZoneOpponentChooser",
       data: { opponent: 2 },
     });
+  });
+
+  it("renders candidates in the engine-supplied order", () => {
+    // Candidate ordering is game ordering and belongs to the engine — the
+    // client must not re-sort it. The fixture lists [2, 1]; the buttons must
+    // appear in exactly that order.
+    useMultiplayerStore.setState({
+      playerNames: new Map([
+        [1, "Alice"],
+        [2, "Bob"],
+      ]),
+    });
+    renderModal(zoneOpponentChooserWaitingFor());
+
+    const labels = screen
+      .getAllByRole("button")
+      .map((button) => button.textContent);
+    expect(labels).toEqual(["Bob", "Alice"]);
   });
 });

--- a/client/src/components/modal/__tests__/ZoneOpponentChooserModal.test.tsx
+++ b/client/src/components/modal/__tests__/ZoneOpponentChooserModal.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GameAction, WaitingFor } from "../../../adapter/types.ts";
+import { isWaitingForHandled } from "../../../game/waitingForRegistry.ts";
+import { useMultiplayerStore } from "../../../stores/multiplayerStore.ts";
+import { ZoneOpponentChooserModalContent } from "../ZoneOpponentChooserModal.tsx";
+
+type ZoneOpponentChooserWaitingFor = Extract<
+  WaitingFor,
+  { type: "ChooseFromZoneOpponentChooser" }
+>;
+
+function zoneOpponentChooserWaitingFor(): ZoneOpponentChooserWaitingFor {
+  return {
+    type: "ChooseFromZoneOpponentChooser",
+    data: {
+      player: 0,
+      candidates: [2, 1],
+      ability: {},
+    },
+  };
+}
+
+function renderModal(waitingFor: ZoneOpponentChooserWaitingFor) {
+  const dispatch = vi.fn<(action: GameAction) => void>();
+  render(
+    <ZoneOpponentChooserModalContent
+      waitingFor={waitingFor}
+      seatOrder={[0, 1, 2]}
+      dispatch={dispatch}
+    />,
+  );
+  return dispatch;
+}
+
+afterEach(() => {
+  cleanup();
+  useMultiplayerStore.setState({ playerNames: new Map() });
+});
+
+describe("ZoneOpponentChooserModalContent", () => {
+  it("registers the waiting state as handled", () => {
+    expect(isWaitingForHandled(zoneOpponentChooserWaitingFor())).toBe(true);
+  });
+
+  it("dispatches the selected choosing opponent", () => {
+    useMultiplayerStore.setState({
+      playerNames: new Map([
+        [1, "Alice"],
+        [2, "Bob"],
+      ]),
+    });
+    const dispatch = renderModal(zoneOpponentChooserWaitingFor());
+
+    expect(screen.getByRole("heading", { name: "Choose Opponent" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Bob" }));
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "ChooseZoneOpponentChooser",
+      data: { opponent: 2 },
+    });
+  });
+});

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -123,6 +123,9 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     "SpellbookDraft",
     "ManifestDreadChoice",
     "ClashChooseOpponent",
+    // CR 608.2d: "an opponent chooses" from a zone — the controller picks the
+    // choosing opponent (ZoneOpponentChooserModal).
+    "ChooseFromZoneOpponentChooser",
     "ChooseAnnouncingOpponent",
     "ClashCardPlacement",
     // CR 702.132a: Assist — caster picks a helper (AssistChoosePlayerModal),

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1705,6 +1705,10 @@
     "title": "Kampf-Gegner wählen",
     "subtitle": "Wähle, welcher Gegner mit dir kämpft."
   },
+  "zoneOpponentChooser": {
+    "title": "Gegner wählen",
+    "subtitle": "Wähle, welcher Gegner die Wahl trifft."
+  },
   "pileOpponent": {
     "title": "Choose Opponent",
     "subtitle": "Choose which opponent separates the cards into piles."

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1742,6 +1742,10 @@
     "title": "Choose Clash Opponent",
     "subtitle": "Choose which opponent will clash with you."
   },
+  "zoneOpponentChooser": {
+    "title": "Choose Opponent",
+    "subtitle": "Choose which opponent makes the choice."
+  },
   "pileOpponent": {
     "title": "Choose Opponent",
     "subtitle": "Choose which opponent separates the cards into piles."

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1705,6 +1705,10 @@
     "title": "Elegir oponente para chocar",
     "subtitle": "Elige qué oponente chocará contigo."
   },
+  "zoneOpponentChooser": {
+    "title": "Elegir oponente",
+    "subtitle": "Elige qué oponente hace la elección."
+  },
   "pileOpponent": {
     "title": "Choose Opponent",
     "subtitle": "Choose which opponent separates the cards into piles."

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1705,6 +1705,10 @@
     "title": "Choisir l'adversaire pour la confrontation",
     "subtitle": "Choisissez quel adversaire fera la confrontation avec vous."
   },
+  "zoneOpponentChooser": {
+    "title": "Choisir un adversaire",
+    "subtitle": "Choisissez quel adversaire fait le choix."
+  },
   "pileOpponent": {
     "title": "Choose Opponent",
     "subtitle": "Choose which opponent separates the cards into piles."

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1705,6 +1705,10 @@
     "title": "Scegli l'avversario per lo scontro",
     "subtitle": "Scegli quale avversario si scontrerà con te."
   },
+  "zoneOpponentChooser": {
+    "title": "Scegli avversario",
+    "subtitle": "Scegli quale avversario effettua la scelta."
+  },
   "pileOpponent": {
     "title": "Choose Opponent",
     "subtitle": "Choose which opponent separates the cards into piles."

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1705,6 +1705,10 @@
     "title": "Wybierz przeciwnika do starcia",
     "subtitle": "Wybierz, który przeciwnik stoczy z tobą starcie."
   },
+  "zoneOpponentChooser": {
+    "title": "Wybierz przeciwnika",
+    "subtitle": "Wybierz, który przeciwnik dokonuje wyboru."
+  },
   "pileOpponent": {
     "title": "Choose Opponent",
     "subtitle": "Choose which opponent separates the cards into piles."

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1705,6 +1705,10 @@
     "title": "Escolher oponente para confronto",
     "subtitle": "Escolha qual oponente fará confronto com você."
   },
+  "zoneOpponentChooser": {
+    "title": "Escolher oponente",
+    "subtitle": "Escolha qual oponente faz a escolha."
+  },
   "pileOpponent": {
     "title": "Choose Opponent",
     "subtitle": "Choose which opponent separates the cards into piles."

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -99,6 +99,7 @@ import { useModalPeek } from "../components/modal/useModalPeek.ts";
 import { BattleProtectorModal } from "../components/modal/BattleProtectorModal.tsx";
 import { AssistChoosePlayerModal } from "../components/modal/AssistChoosePlayerModal.tsx";
 import { ClashOpponentModal } from "../components/modal/ClashOpponentModal.tsx";
+import { ZoneOpponentChooserModal } from "../components/modal/ZoneOpponentChooserModal.tsx";
 import { PileOpponentModal } from "../components/modal/PileOpponentModal.tsx";
 import { AnnouncingOpponentModal } from "../components/modal/AnnouncingOpponentModal.tsx";
 import { TributeModal } from "../components/modal/TributeModal.tsx";
@@ -1732,6 +1733,7 @@ function GamePageContent({
         <MeldChoiceModal />
         <AssistChoosePlayerModal />
         <ClashOpponentModal />
+        <ZoneOpponentChooserModal />
         <PileOpponentModal />
         <AnnouncingOpponentModal />
         <TributeModal />

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -695,6 +695,22 @@ pub fn candidate_actions_exact(state: &GameState) -> Vec<CandidateAction> {
                 )
             })
             .collect(),
+        // CR 608.2d: One candidate per opponent the controller could pick to
+        // make a resolving "an opponent chooses …" zone selection.
+        WaitingFor::ChooseFromZoneOpponentChooser {
+            player, candidates, ..
+        } => candidates
+            .iter()
+            .map(|opponent| {
+                candidate(
+                    GameAction::ChooseZoneOpponentChooser {
+                        opponent: *opponent,
+                    },
+                    TacticalClass::Selection,
+                    Some(*player),
+                )
+            })
+            .collect(),
         WaitingFor::ChooseAnnouncingOpponent {
             player, candidates, ..
         } => candidates
@@ -2986,6 +3002,7 @@ pub fn candidate_actions_broad_with_probe(
         | WaitingFor::LearnChoice { .. }
         | WaitingFor::TopOrBottomChoice { .. }
         | WaitingFor::ClashChooseOpponent { .. }
+        | WaitingFor::ChooseFromZoneOpponentChooser { .. }
         | WaitingFor::ClashCardPlacement { .. }
         | WaitingFor::BetweenGamesChoosePlayDraw { .. }
         | WaitingFor::OrderTriggers { .. }

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -353,6 +353,10 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
         | (WaitingFor::BetweenGamesChoosePlayDraw { .. }, GameAction::ChoosePlayDraw { .. })
         | (WaitingFor::TopOrBottomChoice { .. }, GameAction::ChooseTopOrBottom { .. })
         | (WaitingFor::ClashChooseOpponent { .. }, GameAction::ChooseClashOpponent { .. })
+        | (
+            WaitingFor::ChooseFromZoneOpponentChooser { .. },
+            GameAction::ChooseZoneOpponentChooser { .. },
+        )
         | (WaitingFor::ClashCardPlacement { .. }, GameAction::ChooseTopOrBottom { .. })
         | (WaitingFor::OptionalCostChoice { .. }, GameAction::DecideOptionalCost { .. })
         | (WaitingFor::SpliceOffer { .. }, GameAction::RespondToSpliceOffer { .. })

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -8976,6 +8976,7 @@ fn handle_resolution_cast_success(
             filter,
             zones,
             exile_instead_of_graveyard,
+            source,
         } => {
             if exile_instead_of_graveyard {
                 // CR 614.1a: Invoke Calamity's free-cast rider redirects to exile.
@@ -8995,6 +8996,7 @@ fn handle_resolution_cast_success(
             let mut candidates = crate::game::effects::free_cast_from_zones::eligible_candidates(
                 state,
                 controller,
+                source,
                 &filter,
                 &zones,
                 budget_left,
@@ -9014,6 +9016,7 @@ fn handle_resolution_cast_success(
                     filter,
                     zones,
                     exile_instead_of_graveyard,
+                    source,
                 },
             }))
         }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -8977,6 +8977,7 @@ fn handle_resolution_cast_success(
             zones,
             exile_instead_of_graveyard,
             source,
+            member_pool,
         } => {
             if exile_instead_of_graveyard {
                 // CR 614.1a: Invoke Calamity's free-cast rider redirects to exile.
@@ -9000,6 +9001,10 @@ fn handle_resolution_cast_success(
                 &filter,
                 &zones,
                 budget_left,
+                // CR 607.2a: the re-offer stays confined to THIS resolution's
+                // "exiled this way" batch (Plargg and Nassari) — see the
+                // window's `member_pool` docs; empty means no restriction.
+                &member_pool,
             );
             // CR 608.2g: Finalize runs before the chosen card is removed from
             // its origin zone; it cannot be offered again while already cast.
@@ -9017,6 +9022,7 @@ fn handle_resolution_cast_success(
                     zones,
                     exile_instead_of_graveyard,
                     source,
+                    member_pool,
                 },
             }))
         }

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -90,9 +90,143 @@ pub fn resolve(
 
     let clamped_count = count.min(cards.len());
 
-    // CR 608.2d: Determine who makes the choice.
+    // CR 608.2d: Determine who makes the choice. For `Chooser::Opponent` in a
+    // multiplayer game with two or more live opponents (and no pre-targeted
+    // opponent), the CONTROLLER first decides which opponent will make the
+    // choice — "an opponent" is the controller's pick, exactly like clash's
+    // opponent selection (CR 701.30b) and the pile-separation prompt (CR
+    // 608.2d; `SeparatePilesChooseOpponent`). Plargg and Nassari's release
+    // notes state the intent directly: "you choose which opponent gets to
+    // choose one of the exiled nonland cards." Pausing on a typed prompt keeps
+    // the decision out of APNAP defaults; the handler re-enters through
+    // `resolve_with_choosing_player` with the picked opponent.
+    if matches!(chooser, Chooser::Opponent) && !has_targeted_opponent(ability) {
+        let candidates: Vec<PlayerId> = players::opponents(state, ability.controller)
+            .into_iter()
+            .filter(|&p| {
+                state
+                    .players
+                    .iter()
+                    .any(|pl| pl.id == p && !pl.is_eliminated)
+            })
+            .collect();
+        if candidates.len() >= 2 {
+            state.waiting_for = WaitingFor::ChooseFromZoneOpponentChooser {
+                player: ability.controller,
+                candidates,
+                ability: Box::new(ability.clone()),
+            };
+            events.push(GameEvent::EffectResolved {
+                kind: EffectKind::ChooseFromZone,
+                source_id: ability.source_id,
+                subject: None,
+            });
+            return Ok(());
+        }
+    }
     let choosing_player = resolve_chooser(state, ability, chooser);
+    present_zone_choice(
+        state,
+        ability,
+        cards,
+        clamped_count,
+        up_to,
+        constraint,
+        choosing_player,
+        events,
+    )
+}
 
+/// CR 608.2d: Re-entry point for the `ChooseFromZoneOpponentChooser` handler —
+/// the controller has picked which opponent makes the choice, so present the
+/// standard `ChooseFromZoneChoice` prompt directly to that opponent. The
+/// candidate pool is re-derived from live state (it cannot have changed while
+/// paused — pauses do not pass priority — but re-deriving keeps a single
+/// source of truth).
+pub(crate) fn resolve_with_choosing_player(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    choosing_player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let (count, zone, additional_zones, zone_owner, filter, up_to, constraint) =
+        match &ability.effect {
+            Effect::ChooseFromZone {
+                count,
+                zone,
+                additional_zones,
+                zone_owner,
+                filter,
+                up_to,
+                constraint,
+                ..
+            } => (
+                *count as usize,
+                *zone,
+                additional_zones.clone(),
+                *zone_owner,
+                filter.clone(),
+                *up_to,
+                constraint.clone(),
+            ),
+            _ => return Err(EffectError::MissingParam("ChooseFromZone".to_string())),
+        };
+    let cards = resolve_candidate_cards(
+        state,
+        ability,
+        zone,
+        &additional_zones,
+        zone_owner,
+        filter.as_ref(),
+    )?;
+    // CR 608.2d: The pool can only have shrunk to empty if state changed while
+    // paused (it cannot — see above), but fail closed identically to `resolve`.
+    if cards.is_empty() || count == 0 {
+        state.last_parent_target_missing_reason = Some(ParentTargetMissingReason::ChooseFromZone);
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::ChooseFromZone,
+            source_id: ability.source_id,
+            subject: None,
+        });
+        return Ok(());
+    }
+    let clamped_count = count.min(cards.len());
+    present_zone_choice(
+        state,
+        ability,
+        cards,
+        clamped_count,
+        up_to,
+        constraint,
+        choosing_player,
+        events,
+    )
+}
+
+/// CR 601.2c: "target opponent chooses" pre-binds the chooser at announcement —
+/// a `Player` target other than the controller occupies the chooser slot, so no
+/// resolution-time opponent selection happens.
+fn has_targeted_opponent(ability: &ResolvedAbility) -> bool {
+    ability
+        .targets
+        .iter()
+        .any(|t| matches!(t, TargetRef::Player(id) if *id != ability.controller))
+}
+
+/// CR 608.2: Park the interactive `ChooseFromZoneChoice` prompt for
+/// `choosing_player`, preserving the resolving trigger context for the parked
+/// continuation (shared tail of `resolve` and `resolve_with_choosing_player`).
+#[allow(clippy::too_many_arguments)]
+fn present_zone_choice(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    cards: Vec<ObjectId>,
+    clamped_count: usize,
+    up_to: bool,
+    constraint: Option<ChooseFromZoneConstraint>,
+    choosing_player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
     // CR 608.2: An ability's resolution is a single ongoing process. This
     // interactive pause makes `stack::resolve_top` run to completion and
     // unconditionally clear the live, resolution-scoped trigger context; preserve

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -728,7 +728,7 @@ fn resolve_candidate_cards(
     filter: Option<&TargetFilter>,
 ) -> Result<Vec<ObjectId>, EffectError> {
     if let Some(cards) = chain_tracked_set_cards(state) {
-        return Ok(cards);
+        return Ok(retain_matching_candidates(state, ability, cards, filter));
     }
 
     let cards = crate::game::targeting::latest_tracked_set_id(state)
@@ -747,10 +747,33 @@ fn resolve_candidate_cards(
     let cards = if cards.is_empty() {
         collect_direct_zone_cards(state, ability, zone, additional_zones, zone_owner, filter)?
     } else {
-        cards
+        retain_matching_candidates(state, ability, cards, filter)
     };
 
     Ok(cards)
+}
+
+/// CR 608.2d: Narrow a tracked-set (or explicit-target) candidate pool through
+/// the effect's own card filter. A typed restriction like "choose a NONLAND
+/// card exiled this way" (Plargg and Nassari, Author of Shadows) must constrain
+/// the pool even when the candidates arrive from the chain's tracked set — the
+/// set records every card the preceding clause exiled, lands included, but only
+/// the nonland ones are legal picks. `filter: None` (the bare "choose one of
+/// them" anaphor) keeps the raw set, preserving the untyped tracked-set path.
+fn retain_matching_candidates(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    cards: Vec<ObjectId>,
+    filter: Option<&TargetFilter>,
+) -> Vec<ObjectId> {
+    let Some(filter) = filter else {
+        return cards;
+    };
+    let filter_ctx = FilterContext::from_ability(ability);
+    cards
+        .into_iter()
+        .filter(|id| matches_target_filter(state, *id, filter, &filter_ctx))
+        .collect()
 }
 
 fn chain_tracked_set_cards(state: &GameState) -> Option<Vec<ObjectId>> {

--- a/crates/engine/src/game/effects/exile_from_top_until.rs
+++ b/crates/engine/src/game/effects/exile_from_top_until.rs
@@ -937,6 +937,182 @@ mod tests {
         }
     }
 
+    /// CR 607.2a + CR 608.2d + CR 101.4: Plargg and Nassari — `player_scope: All`
+    /// exile-until with a DETACHED opponent-chooser continuation: after every
+    /// player's iteration links its exiles, the once-only tail `ChooseFromZone
+    /// { Exile, AllOwners, And { nonland, ExiledBySource }, chooser: Opponent }`
+    /// must park a `ChooseFromZoneChoice` for the OPPONENT over exactly the
+    /// linked nonland hits (never the lands), and — after the pick — the
+    /// `CastFromZone` continuation over "the OTHER cards exiled this way"
+    /// (`FilterProp::Another` + `ExiledBySource`) must receive the UNCHOSEN
+    /// complement, granting zero-cost permissions to the other hits while the
+    /// opponent's pick and the lands get none. Reverting the unchosen-complement
+    /// binding in the `ChooseFromZoneChoice` handler grants the permission to
+    /// the chosen card instead and fails the negative assertions.
+    #[test]
+    fn plargg_opponent_chooses_nonland_hit_then_cast_pool_is_the_other_hits() {
+        use crate::types::ability::{CardSelectionMode, Chooser, ZoneOwner};
+        let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+        let source = create_object(
+            &mut state,
+            CardId(100),
+            PlayerId(0),
+            "Plargg and Nassari".to_string(),
+            Zone::Battlefield,
+        );
+
+        // Each player's library: one Land then one Creature (the nonland hit).
+        let p0_land = add_library_card(&mut state, PlayerId(0), "P0 Forest", true);
+        let p0_hit = add_library_card(&mut state, PlayerId(0), "P0 Beast", false);
+        state.players[0].library = crate::im::vector![p0_land, p0_hit];
+
+        let p1_land = add_library_card(&mut state, PlayerId(1), "P1 Mountain", true);
+        let p1_hit = add_library_card(&mut state, PlayerId(1), "P1 Goblin", false);
+        state.players[1].library = crate::im::vector![p1_land, p1_hit];
+
+        let p2_land = add_library_card(&mut state, PlayerId(2), "P2 Plains", true);
+        let p2_hit = add_library_card(&mut state, PlayerId(2), "P2 Soldier", false);
+        state.players[2].library = crate::im::vector![p2_land, p2_hit];
+
+        // Sentence 3: "You may cast up to two spells from among the OTHER cards
+        // exiled this way without paying their mana costs" — the parser's shape
+        // is And { ExiledBySource, Typed(card, Another, InZone Exile) }.
+        let cast_sub = ResolvedAbility::new(
+            Effect::CastFromZone {
+                target: TargetFilter::And {
+                    filters: vec![
+                        TargetFilter::ExiledBySource,
+                        TargetFilter::Typed(
+                            TypedFilter::default().with_type(TypeFilter::Card).properties(
+                                vec![
+                                    FilterProp::Another,
+                                    FilterProp::InZone { zone: Zone::Exile },
+                                ],
+                            ),
+                        ),
+                    ],
+                },
+                without_paying_mana_cost: true,
+                mode: CardPlayMode::Cast,
+                cast_transformed: false,
+                alt_ability_cost: None,
+                constraint: None,
+                duration: None,
+                driver: CastFromZoneDriver::LingeringPermission,
+                mana_spend_permission: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+
+        // Sentence 2: "An opponent chooses a nonland card exiled this way" — the
+        // new typed exiled-this-way anaphor shape.
+        let mut choose_sub = ResolvedAbility::new(
+            Effect::ChooseFromZone {
+                count: 1,
+                zone: Zone::Exile,
+                additional_zones: vec![],
+                zone_owner: ZoneOwner::AllOwners,
+                filter: Some(TargetFilter::And {
+                    filters: vec![nonland_filter(), TargetFilter::ExiledBySource],
+                }),
+                chooser: Chooser::Opponent,
+                up_to: false,
+                selection: CardSelectionMode::Chosen,
+                constraint: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        choose_sub.sub_ability = Some(Box::new(cast_sub));
+
+        let mut wrapped = ResolvedAbility::new(
+            Effect::ExileFromTopUntil {
+                player: TargetFilter::Controller,
+                until: UntilCondition::NextMatches {
+                    filter: nonland_filter(),
+                },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        wrapped.player_scope = Some(PlayerFilter::All);
+        wrapped.sub_ability = Some(Box::new(choose_sub));
+
+        let mut events = Vec::new();
+        super::super::resolve_ability_chain(&mut state, &wrapped, &mut events, 0).unwrap();
+
+        // All six cards are exiled and linked before the detached choose parks.
+        for id in &[p0_land, p0_hit, p1_land, p1_hit, p2_land, p2_hit] {
+            assert_eq!(state.objects[id].zone, Zone::Exile, "{id:?} must be exiled");
+        }
+
+        // CR 608.2d + CR 101.4: the pause must belong to an OPPONENT of the
+        // controller, offering exactly the three nonland hits (lands filtered).
+        let (chooser_player, offered) = match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice {
+                player,
+                cards,
+                count,
+                ..
+            } => {
+                assert_eq!(*count, 1, "exactly one card is chosen");
+                (*player, cards.clone())
+            }
+            other => panic!("expected ChooseFromZoneChoice pause, got {other:?}"),
+        };
+        assert_ne!(
+            chooser_player,
+            PlayerId(0),
+            "CR 608.2d: the CHOOSER must be an opponent, not Plargg's controller"
+        );
+        let mut offered_sorted = offered.clone();
+        offered_sorted.sort();
+        let mut expected_hits = vec![p0_hit, p1_hit, p2_hit];
+        expected_hits.sort();
+        assert_eq!(
+            offered_sorted, expected_hits,
+            "choice pool must be the nonland hits exiled this way (no lands)"
+        );
+
+        // The opponent picks P1's Goblin.
+        apply(
+            &mut state,
+            chooser_player,
+            GameAction::SelectCards {
+                cards: vec![p1_hit],
+            },
+        )
+        .unwrap();
+
+        // CR 607.2a: "the OTHER cards exiled this way" — the cast permission
+        // must land on the two UNCHOSEN hits only.
+        for &other_hit in &[p0_hit, p2_hit] {
+            let perms = &state.objects[&other_hit].casting_permissions;
+            assert!(
+                perms.iter().any(|p| matches!(
+                    p,
+                    CastingPermission::ExileWithAltCost { cost, granted_to: Some(g), .. }
+                        if *cost == ManaCost::zero() && *g == PlayerId(0)
+                )),
+                "unchosen hit {other_hit:?} must carry the zero-cost permission, got {perms:?}"
+            );
+        }
+        assert!(
+            state.objects[&p1_hit].casting_permissions.is_empty(),
+            "the opponent's pick must NOT be castable — it is not one of the OTHER cards"
+        );
+        for &land in &[p0_land, p1_land, p2_land] {
+            assert!(
+                state.objects[&land].casting_permissions.is_empty(),
+                "land {land:?} must not gain casting permissions"
+            );
+        }
+    }
+
     /// CR 608.2 + CR 111.2: Akroan Horse-shape — `Effect::Token` with
     /// `owner: TargetFilter::Controller` under `player_scope: Opponent`
     /// rebinds Controller per-iteration so each opponent owns the token they

--- a/crates/engine/src/game/effects/exile_from_top_until.rs
+++ b/crates/engine/src/game/effects/exile_from_top_until.rs
@@ -952,6 +952,7 @@ mod tests {
     #[test]
     fn plargg_opponent_chooses_nonland_hit_then_cast_pool_is_the_other_hits() {
         use crate::types::ability::{CardSelectionMode, Chooser, ZoneOwner};
+        use crate::types::game_state::WaitingFor;
         let mut state = GameState::new(FormatConfig::standard(), 3, 42);
         let source = create_object(
             &mut state,

--- a/crates/engine/src/game/effects/exile_from_top_until.rs
+++ b/crates/engine/src/game/effects/exile_from_top_until.rs
@@ -983,12 +983,12 @@ mod tests {
                     filters: vec![
                         TargetFilter::ExiledBySource,
                         TargetFilter::Typed(
-                            TypedFilter::default().with_type(TypeFilter::Card).properties(
-                                vec![
+                            TypedFilter::default()
+                                .with_type(TypeFilter::Card)
+                                .properties(vec![
                                     FilterProp::Another,
                                     FilterProp::InZone { zone: Zone::Exile },
-                                ],
-                            ),
+                                ]),
                         ),
                     ],
                 },

--- a/crates/engine/src/game/effects/exile_from_top_until.rs
+++ b/crates/engine/src/game/effects/exile_from_top_until.rs
@@ -1063,9 +1063,7 @@ mod tests {
         // first be asked which opponent makes the choice.
         let picker_candidates = match &state.waiting_for {
             WaitingFor::ChooseFromZoneOpponentChooser {
-                player,
-                candidates,
-                ..
+                player, candidates, ..
             } => {
                 assert_eq!(
                     *player,
@@ -1236,9 +1234,9 @@ mod tests {
                     "the lone opponent must be the chooser without a picker pause"
                 );
             }
-            other => panic!(
-                "expected a direct ChooseFromZoneChoice with one opponent, got {other:?}"
-            ),
+            other => {
+                panic!("expected a direct ChooseFromZoneChoice with one opponent, got {other:?}")
+            }
         }
     }
 

--- a/crates/engine/src/game/effects/exile_from_top_until.rs
+++ b/crates/engine/src/game/effects/exile_from_top_until.rs
@@ -1167,6 +1167,198 @@ mod tests {
         }
     }
 
+    /// CR 607.2a two-upkeep regression: "exiled this way" is scoped to THIS
+    /// trigger resolution, not the source's lifetime linked-exile ledger. A
+    /// linked nonland card left in exile by a PREVIOUS resolution (declined
+    /// free cast) must appear in NEITHER the next resolution's opponent choice
+    /// pool NOR its free-cast window — `ExiledBySource` alone is the source's
+    /// complete live ledger, so without the resolution-scoped member pool the
+    /// second window would wrongly offer the first upkeep's leftover.
+    #[test]
+    fn plargg_second_resolution_excludes_previous_resolutions_leftovers() {
+        use crate::types::ability::{CardSelectionMode, Chooser, ZoneOwner};
+        use crate::types::game_state::{CastOfferKind, WaitingFor};
+        let mut state = GameState::new_two_player(11);
+        let source = create_object(
+            &mut state,
+            CardId(100),
+            PlayerId(0),
+            "Plargg and Nassari".to_string(),
+            Zone::Battlefield,
+        );
+
+        // The full sentence-2 + sentence-3 chain, rebuilt per resolution the
+        // way the trigger system re-instantiates the ability each upkeep.
+        let build_chain = |source: ObjectId| -> ResolvedAbility {
+            let cast_sub = ResolvedAbility::new(
+                Effect::FreeCastFromZones {
+                    count: 2,
+                    max_total_mv: None,
+                    filter: TargetFilter::And {
+                        filters: vec![
+                            TargetFilter::ExiledBySource,
+                            TargetFilter::Typed(
+                                TypedFilter::default()
+                                    .with_type(TypeFilter::Card)
+                                    .properties(vec![
+                                        FilterProp::Not {
+                                            prop: Box::new(FilterProp::InTrackedSet {
+                                                id: crate::types::identifiers::TrackedSetId(0),
+                                            }),
+                                        },
+                                        FilterProp::InZone { zone: Zone::Exile },
+                                    ]),
+                            ),
+                        ],
+                    },
+                    zones: vec![Zone::Exile],
+                    exile_instead_of_graveyard: false,
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            );
+            let mut choose_sub = ResolvedAbility::new(
+                Effect::ChooseFromZone {
+                    count: 1,
+                    zone: Zone::Exile,
+                    additional_zones: vec![],
+                    zone_owner: ZoneOwner::AllOwners,
+                    filter: Some(TargetFilter::And {
+                        filters: vec![nonland_filter(), TargetFilter::ExiledBySource],
+                    }),
+                    chooser: Chooser::Opponent,
+                    up_to: false,
+                    selection: CardSelectionMode::Chosen,
+                    constraint: None,
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            );
+            choose_sub.sub_ability = Some(Box::new(cast_sub));
+            let mut wrapped = ResolvedAbility::new(
+                Effect::ExileFromTopUntil {
+                    player: TargetFilter::Controller,
+                    until: UntilCondition::NextMatches {
+                        filter: nonland_filter(),
+                    },
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            );
+            wrapped.player_scope = Some(PlayerFilter::All);
+            wrapped.sub_ability = Some(Box::new(choose_sub));
+            wrapped
+        };
+
+        // UPKEEP 1 — each library holds one nonland hit.
+        let p0_old = add_library_card(&mut state, PlayerId(0), "P0 Old Beast", false);
+        state.players[0].library = crate::im::vector![p0_old];
+        let p1_old = add_library_card(&mut state, PlayerId(1), "P1 Old Goblin", false);
+        state.players[1].library = crate::im::vector![p1_old];
+
+        let mut events = Vec::new();
+        super::super::resolve_ability_chain(&mut state, &build_chain(source), &mut events, 0)
+            .unwrap();
+
+        // The lone opponent chooses P1's old Goblin; the window then offers
+        // ONLY P0's old Beast (the other card exiled this way).
+        apply(
+            &mut state,
+            PlayerId(1),
+            GameAction::SelectCards {
+                cards: vec![p1_old],
+            },
+        )
+        .unwrap();
+        match &state.waiting_for {
+            WaitingFor::CastOffer {
+                kind: CastOfferKind::FreeCastWindow { candidates, .. },
+                ..
+            } => assert_eq!(
+                candidates,
+                &vec![p0_old],
+                "upkeep 1 window offers the other card exiled this way"
+            ),
+            other => panic!("expected upkeep-1 FreeCastWindow, got {other:?}"),
+        }
+        // The controller DECLINES — the linked, uncast Beast stays in exile
+        // ("If you don't, it remains exiled" has no cleanup for this shape),
+        // so the source's live exile-link ledger still carries it.
+        apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::FreeCastWindowChoice { selection: None },
+        )
+        .unwrap();
+        assert_eq!(
+            state.objects[&p0_old].zone,
+            Zone::Exile,
+            "the declined card must remain exiled (and linked) after upkeep 1"
+        );
+
+        // UPKEEP 2 — fresh libraries, fresh hits, the same source re-resolves.
+        let p0_new = add_library_card(&mut state, PlayerId(0), "P0 New Wurm", false);
+        state.players[0].library = crate::im::vector![p0_new];
+        let p1_new = add_library_card(&mut state, PlayerId(1), "P1 New Orc", false);
+        state.players[1].library = crate::im::vector![p1_new];
+
+        let mut events2 = Vec::new();
+        super::super::resolve_ability_chain(&mut state, &build_chain(source), &mut events2, 0)
+            .unwrap();
+
+        // The opponent's choice pool is THIS resolution's batch only — the
+        // first upkeep's leftovers are linked to the source but were not
+        // "exiled this way" now.
+        let offered = match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+                assert_eq!(*player, PlayerId(1));
+                cards.clone()
+            }
+            other => panic!("expected upkeep-2 ChooseFromZoneChoice, got {other:?}"),
+        };
+        let mut offered_sorted = offered;
+        offered_sorted.sort();
+        let mut expected = vec![p0_new, p1_new];
+        expected.sort();
+        assert_eq!(
+            offered_sorted, expected,
+            "upkeep-2 choice pool must exclude upkeep-1 leftovers"
+        );
+
+        // The opponent chooses P1's new Orc; the window must offer ONLY P0's
+        // new Wurm. Without the resolution-scoped member pool, the stale
+        // still-linked Beast from upkeep 1 would pass `ExiledBySource` +
+        // `Not(InTrackedSet)` and be wrongly offered here.
+        apply(
+            &mut state,
+            PlayerId(1),
+            GameAction::SelectCards {
+                cards: vec![p1_new],
+            },
+        )
+        .unwrap();
+        match &state.waiting_for {
+            WaitingFor::CastOffer {
+                kind: CastOfferKind::FreeCastWindow { candidates, .. },
+                ..
+            } => {
+                assert!(
+                    !candidates.contains(&p0_old),
+                    "upkeep-2 window must NOT offer upkeep 1's leftover (stale ledger)"
+                );
+                assert_eq!(
+                    candidates,
+                    &vec![p0_new],
+                    "upkeep-2 window offers exactly this resolution's other hit"
+                );
+            }
+            other => panic!("expected upkeep-2 FreeCastWindow, got {other:?}"),
+        }
+    }
+
     /// CR 608.2d two-player regression: with exactly ONE live opponent there is
     /// nothing for the controller to decide, so the opponent-picker pause must
     /// be skipped and the zone choice presented directly to that opponent.

--- a/crates/engine/src/game/effects/exile_from_top_until.rs
+++ b/crates/engine/src/game/effects/exile_from_top_until.rs
@@ -938,22 +938,22 @@ mod tests {
     }
 
     /// CR 607.2a + CR 608.2d + CR 101.4: Plargg and Nassari — `player_scope: All`
-    /// exile-until with a DETACHED opponent-chooser continuation: after every
-    /// player's iteration links its exiles, the once-only tail `ChooseFromZone
-    /// { Exile, AllOwners, And { nonland, ExiledBySource }, chooser: Opponent }`
-    /// must park a `ChooseFromZoneChoice` for the OPPONENT over exactly the
-    /// linked nonland hits (never the lands), and — after the pick — the
-    /// `CastFromZone` continuation over "the OTHER cards exiled this way"
-    /// (`FilterProp::Another` + `ExiledBySource`) must receive the UNCHOSEN
-    /// complement, granting zero-cost permissions to the other hits while the
-    /// opponent's pick and the lands get none. Reverting the unchosen-complement
-    /// binding in the `ChooseFromZoneChoice` handler grants the permission to
-    /// the chosen card instead and fails the negative assertions.
+    /// exile-until with a DETACHED opponent-chooser continuation. In a
+    /// four-player game the tail runs once and pauses THREE times in order:
+    /// (1) `ChooseFromZoneOpponentChooser` — the CONTROLLER picks which of the
+    /// three live opponents makes the choice (Plargg's release notes: "you
+    /// choose which opponent gets to choose one of the exiled nonland cards");
+    /// (2) `ChooseFromZoneChoice` — the picked opponent chooses over exactly
+    /// the linked nonland hits (never the lands); (3) `CastOffer` with a
+    /// `FreeCastWindow` capped at TWO casts ("up to two spells") whose
+    /// candidate pool is the UNCHOSEN hits only — the opponent's pick is
+    /// excluded by `Not(InTrackedSet 0)` over the freshly-published chosen
+    /// set, and lands are excluded by the cast-mode land guard (CR 305.1).
     #[test]
     fn plargg_opponent_chooses_nonland_hit_then_cast_pool_is_the_other_hits() {
         use crate::types::ability::{CardSelectionMode, Chooser, ZoneOwner};
-        use crate::types::game_state::WaitingFor;
-        let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+        use crate::types::game_state::{CastOfferKind, WaitingFor};
+        let mut state = GameState::new(FormatConfig::standard(), 4, 42);
         let source = create_object(
             &mut state,
             CardId(100),
@@ -975,32 +975,38 @@ mod tests {
         let p2_hit = add_library_card(&mut state, PlayerId(2), "P2 Soldier", false);
         state.players[2].library = crate::im::vector![p2_land, p2_hit];
 
+        let p3_land = add_library_card(&mut state, PlayerId(3), "P3 Island", true);
+        let p3_hit = add_library_card(&mut state, PlayerId(3), "P3 Merfolk", false);
+        state.players[3].library = crate::im::vector![p3_land, p3_hit];
+
         // Sentence 3: "You may cast up to two spells from among the OTHER cards
-        // exiled this way without paying their mana costs" — the parser's shape
-        // is And { ExiledBySource, Typed(card, Another, InZone Exile) }.
+        // exiled this way without paying their mana costs" — the parser lowers
+        // this to a during-resolution free-cast window (ruling 2021-04-16: the
+        // spells are cast during the ability's resolution) capped at two casts,
+        // with "other" rewritten to `Not(InTrackedSet 0)` over the chosen set.
         let cast_sub = ResolvedAbility::new(
-            Effect::CastFromZone {
-                target: TargetFilter::And {
+            Effect::FreeCastFromZones {
+                count: 2,
+                max_total_mv: None,
+                filter: TargetFilter::And {
                     filters: vec![
                         TargetFilter::ExiledBySource,
                         TargetFilter::Typed(
                             TypedFilter::default()
                                 .with_type(TypeFilter::Card)
                                 .properties(vec![
-                                    FilterProp::Another,
+                                    FilterProp::Not {
+                                        prop: Box::new(FilterProp::InTrackedSet {
+                                            id: crate::types::identifiers::TrackedSetId(0),
+                                        }),
+                                    },
                                     FilterProp::InZone { zone: Zone::Exile },
                                 ]),
                         ),
                     ],
                 },
-                without_paying_mana_cost: true,
-                mode: CardPlayMode::Cast,
-                cast_transformed: false,
-                alt_ability_cost: None,
-                constraint: None,
-                duration: None,
-                driver: CastFromZoneDriver::LingeringPermission,
-                mana_spend_permission: None,
+                zones: vec![Zone::Exile],
+                exile_instead_of_graveyard: false,
             },
             vec![],
             source,
@@ -1046,14 +1052,51 @@ mod tests {
         let mut events = Vec::new();
         super::super::resolve_ability_chain(&mut state, &wrapped, &mut events, 0).unwrap();
 
-        // All six cards are exiled and linked before the detached choose parks.
-        for id in &[p0_land, p0_hit, p1_land, p1_hit, p2_land, p2_hit] {
+        // All eight cards are exiled and linked before the detached choose parks.
+        for id in &[
+            p0_land, p0_hit, p1_land, p1_hit, p2_land, p2_hit, p3_land, p3_hit,
+        ] {
             assert_eq!(state.objects[id].zone, Zone::Exile, "{id:?} must be exiled");
         }
 
-        // CR 608.2d + CR 101.4: the pause must belong to an OPPONENT of the
-        // controller, offering exactly the three nonland hits (lands filtered).
-        let (chooser_player, offered) = match &state.waiting_for {
+        // Pause 1 — CR 608.2d: with three live opponents, the CONTROLLER must
+        // first be asked which opponent makes the choice.
+        let picker_candidates = match &state.waiting_for {
+            WaitingFor::ChooseFromZoneOpponentChooser {
+                player,
+                candidates,
+                ..
+            } => {
+                assert_eq!(
+                    *player,
+                    PlayerId(0),
+                    "the CONTROLLER picks which opponent chooses"
+                );
+                candidates.clone()
+            }
+            other => panic!("expected ChooseFromZoneOpponentChooser pause, got {other:?}"),
+        };
+        let mut sorted_candidates = picker_candidates.clone();
+        sorted_candidates.sort();
+        assert_eq!(
+            sorted_candidates,
+            vec![PlayerId(1), PlayerId(2), PlayerId(3)],
+            "every live opponent must be offered as the chooser"
+        );
+
+        // The controller picks PlayerId(2) as the chooser.
+        apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::ChooseZoneOpponentChooser {
+                opponent: PlayerId(2),
+            },
+        )
+        .unwrap();
+
+        // Pause 2 — CR 608.2d: the zone choice must belong to the PICKED
+        // opponent, offering exactly the four nonland hits (lands filtered).
+        let offered = match &state.waiting_for {
             WaitingFor::ChooseFromZoneChoice {
                 player,
                 cards,
@@ -1061,56 +1104,141 @@ mod tests {
                 ..
             } => {
                 assert_eq!(*count, 1, "exactly one card is chosen");
-                (*player, cards.clone())
+                assert_eq!(
+                    *player,
+                    PlayerId(2),
+                    "the zone choice must go to the opponent the controller picked"
+                );
+                cards.clone()
             }
             other => panic!("expected ChooseFromZoneChoice pause, got {other:?}"),
         };
-        assert_ne!(
-            chooser_player,
-            PlayerId(0),
-            "CR 608.2d: the CHOOSER must be an opponent, not Plargg's controller"
-        );
         let mut offered_sorted = offered.clone();
         offered_sorted.sort();
-        let mut expected_hits = vec![p0_hit, p1_hit, p2_hit];
+        let mut expected_hits = vec![p0_hit, p1_hit, p2_hit, p3_hit];
         expected_hits.sort();
         assert_eq!(
             offered_sorted, expected_hits,
             "choice pool must be the nonland hits exiled this way (no lands)"
         );
 
-        // The opponent picks P1's Goblin.
+        // The picked opponent chooses P1's Goblin.
         apply(
             &mut state,
-            chooser_player,
+            PlayerId(2),
             GameAction::SelectCards {
                 cards: vec![p1_hit],
             },
         )
         .unwrap();
 
-        // CR 607.2a: "the OTHER cards exiled this way" — the cast permission
-        // must land on the two UNCHOSEN hits only.
-        for &other_hit in &[p0_hit, p2_hit] {
-            let perms = &state.objects[&other_hit].casting_permissions;
-            assert!(
-                perms.iter().any(|p| matches!(
-                    p,
-                    CastingPermission::ExileWithAltCost { cost, granted_to: Some(g), .. }
-                        if *cost == ManaCost::zero() && *g == PlayerId(0)
-                )),
-                "unchosen hit {other_hit:?} must carry the zero-cost permission, got {perms:?}"
-            );
+        // Pause 3 — CR 607.2a + ruling 2021-04-16: the free-cast window opens
+        // for the CONTROLLER, capped at TWO casts, over "the OTHER cards exiled
+        // this way" — the three unchosen hits. The chosen Goblin is excluded by
+        // `Not(InTrackedSet 0)` over the freshly-published chosen set, and the
+        // lands are excluded by the cast-mode land guard (CR 305.1).
+        match &state.waiting_for {
+            WaitingFor::CastOffer {
+                player,
+                kind:
+                    CastOfferKind::FreeCastWindow {
+                        candidates,
+                        remaining_casts,
+                        ..
+                    },
+            } => {
+                assert_eq!(
+                    *player,
+                    PlayerId(0),
+                    "the free-cast window belongs to Plargg's controller"
+                );
+                assert_eq!(
+                    *remaining_casts, 2,
+                    "'up to two spells' — the window is capped at two casts"
+                );
+                let mut pool = candidates.clone();
+                pool.sort();
+                let mut expected_pool = vec![p0_hit, p2_hit, p3_hit];
+                expected_pool.sort();
+                assert_eq!(
+                    pool, expected_pool,
+                    "cast pool must be the UNCHOSEN hits only (no chosen card, no lands)"
+                );
+            }
+            other => panic!("expected FreeCastWindow cast offer, got {other:?}"),
         }
-        assert!(
-            state.objects[&p1_hit].casting_permissions.is_empty(),
-            "the opponent's pick must NOT be castable — it is not one of the OTHER cards"
+    }
+
+    /// CR 608.2d two-player regression: with exactly ONE live opponent there is
+    /// nothing for the controller to decide, so the opponent-picker pause must
+    /// be skipped and the zone choice presented directly to that opponent.
+    #[test]
+    fn plargg_two_player_skips_the_opponent_picker_pause() {
+        use crate::types::ability::{CardSelectionMode, Chooser, ZoneOwner};
+        use crate::types::game_state::WaitingFor;
+        let mut state = GameState::new_two_player(7);
+        let source = create_object(
+            &mut state,
+            CardId(100),
+            PlayerId(0),
+            "Plargg and Nassari".to_string(),
+            Zone::Battlefield,
         );
-        for &land in &[p0_land, p1_land, p2_land] {
-            assert!(
-                state.objects[&land].casting_permissions.is_empty(),
-                "land {land:?} must not gain casting permissions"
-            );
+
+        let p0_hit = add_library_card(&mut state, PlayerId(0), "P0 Beast", false);
+        state.players[0].library = crate::im::vector![p0_hit];
+        let p1_hit = add_library_card(&mut state, PlayerId(1), "P1 Goblin", false);
+        state.players[1].library = crate::im::vector![p1_hit];
+
+        let mut choose_sub = ResolvedAbility::new(
+            Effect::ChooseFromZone {
+                count: 1,
+                zone: Zone::Exile,
+                additional_zones: vec![],
+                zone_owner: ZoneOwner::AllOwners,
+                filter: Some(TargetFilter::And {
+                    filters: vec![nonland_filter(), TargetFilter::ExiledBySource],
+                }),
+                chooser: Chooser::Opponent,
+                up_to: false,
+                selection: CardSelectionMode::Chosen,
+                constraint: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        choose_sub.sub_ability = None;
+
+        let mut wrapped = ResolvedAbility::new(
+            Effect::ExileFromTopUntil {
+                player: TargetFilter::Controller,
+                until: UntilCondition::NextMatches {
+                    filter: nonland_filter(),
+                },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        wrapped.player_scope = Some(PlayerFilter::All);
+        wrapped.sub_ability = Some(Box::new(choose_sub));
+
+        let mut events = Vec::new();
+        super::super::resolve_ability_chain(&mut state, &wrapped, &mut events, 0).unwrap();
+
+        // No picker pause — the single opponent gets the zone choice directly.
+        match &state.waiting_for {
+            WaitingFor::ChooseFromZoneChoice { player, .. } => {
+                assert_eq!(
+                    *player,
+                    PlayerId(1),
+                    "the lone opponent must be the chooser without a picker pause"
+                );
+            }
+            other => panic!(
+                "expected a direct ChooseFromZoneChoice with one opponent, got {other:?}"
+            ),
         }
     }
 

--- a/crates/engine/src/game/effects/exile_from_top_until.rs
+++ b/crates/engine/src/game/effects/exile_from_top_until.rs
@@ -1298,6 +1298,14 @@ mod tests {
             Zone::Exile,
             "the declined card must remain exiled (and linked) after upkeep 1"
         );
+        assert!(
+            state
+                .exile_links
+                .iter()
+                .any(|link| link.source_id == source && link.exiled_id == p0_old),
+            "the declined card must remain linked to the source after upkeep 1 \u{2014} \
+             upkeep 2's exclusion is only meaningful if the stale link still exists"
+        );
 
         // UPKEEP 2 — fresh libraries, fresh hits, the same source re-resolves.
         let p0_new = add_library_card(&mut state, PlayerId(0), "P0 New Wurm", false);

--- a/crates/engine/src/game/effects/free_cast_from_zones.rs
+++ b/crates/engine/src/game/effects/free_cast_from_zones.rs
@@ -55,6 +55,24 @@ pub fn resolve(
         return Err(EffectError::PlayerNotFound);
     }
 
+    // CR 607.2a + CR 608.2g: When this window is the continuation of a
+    // `ChooseFromZone` over "cards exiled this way" (Plargg and Nassari), the
+    // answer handler forwards the choose's FULL candidate pool — THIS
+    // resolution's typed exile batch — as this ability's object targets. That
+    // concrete member pool confines the offer to the current resolution's
+    // batch: `ExiledBySource` alone reads the source's complete live
+    // linked-exile ledger, which would wrongly re-offer a linked nonland card
+    // left in exile by a PREVIOUS resolution. Empty (Invoke Calamity's
+    // graveyard/hand window — no choose head) means no batch restriction.
+    let member_pool: Vec<ObjectId> = ability
+        .targets
+        .iter()
+        .filter_map(|t| match t {
+            crate::types::ability::TargetRef::Object(id) => Some(*id),
+            _ => None,
+        })
+        .collect();
+
     let candidates = eligible_candidates(
         state,
         controller,
@@ -62,6 +80,7 @@ pub fn resolve(
         &filter,
         &zones,
         max_total_mv,
+        &member_pool,
     );
 
     events.push(GameEvent::EffectResolved {
@@ -88,6 +107,7 @@ pub fn resolve(
             zones,
             exile_instead_of_graveyard,
             source: ability.source_id,
+            member_pool,
         },
     };
 
@@ -103,6 +123,13 @@ pub fn resolve(
 /// `ExiledBySource` (Plargg and Nassari's "the other cards exiled this way")
 /// resolve their exile links against it, so the real id must be threaded
 /// rather than a sentinel.
+///
+/// `member_pool`, when non-empty, is THIS resolution's concrete "exiled this
+/// way" batch (the pool the preceding `ChooseFromZone` offered): candidates
+/// must belong to it, applied BEFORE the filter's `Not(InTrackedSet)`
+/// chosen-card exclusion so a stale linked card from a previous resolution is
+/// never offered (CR 607.2a — "the other cards exiled this way" is scoped to
+/// this resolution's exile batch). Empty means no batch restriction.
 pub(crate) fn eligible_candidates(
     state: &GameState,
     controller: PlayerId,
@@ -110,6 +137,7 @@ pub(crate) fn eligible_candidates(
     filter: &TargetFilter,
     zones: &[Zone],
     max_total_mv: Option<u32>,
+    member_pool: &[ObjectId],
 ) -> Vec<ObjectId> {
     let Some(player) = state.players.iter().find(|p| p.id == controller) else {
         return Vec::new();
@@ -133,6 +161,12 @@ pub(crate) fn eligible_candidates(
             _ => continue,
         };
         for &id in zone_ids {
+            // CR 607.2a: Confine the offer to THIS resolution's exile batch
+            // before any other narrowing — a card linked by a previous
+            // resolution is not among "the cards exiled this way" now.
+            if !member_pool.is_empty() && !member_pool.contains(&id) {
+                continue;
+            }
             // CR 305.1: a land card can never be cast — this window is a cast
             // grant, so lands are excluded from the offer outright (mirrors
             // `cast_from_zone`'s cast-mode land guard).
@@ -240,6 +274,7 @@ mod tests {
             &instant_sorcery_filter(),
             &[Zone::Graveyard, Zone::Hand],
             None,
+            &[],
         );
         assert!(candidates.contains(&gy_instant));
         assert!(candidates.contains(&hand_sorcery));
@@ -271,6 +306,7 @@ mod tests {
             &instant_sorcery_filter(),
             &[Zone::Graveyard, Zone::Hand],
             Some(6),
+            &[],
         );
         assert_eq!(candidates, vec![cheap]);
     }
@@ -302,6 +338,7 @@ mod tests {
             &instant_sorcery_filter(),
             &[Zone::Graveyard, Zone::Hand],
             None,
+            &[],
         );
         assert_eq!(candidates, vec![mine]);
     }

--- a/crates/engine/src/game/effects/free_cast_from_zones.rs
+++ b/crates/engine/src/game/effects/free_cast_from_zones.rs
@@ -55,7 +55,14 @@ pub fn resolve(
         return Err(EffectError::PlayerNotFound);
     }
 
-    let candidates = eligible_candidates(state, controller, &filter, &zones, max_total_mv);
+    let candidates = eligible_candidates(
+        state,
+        controller,
+        ability.source_id,
+        &filter,
+        &zones,
+        max_total_mv,
+    );
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::FreeCastFromZones,
@@ -80,19 +87,26 @@ pub fn resolve(
             filter,
             zones,
             exile_instead_of_graveyard,
+            source: ability.source_id,
         },
     };
 
     Ok(())
 }
 
-/// CR 601.2a + CR 202.3: Gather the controller's own cards in `zones` that match
-/// `filter` and (when `max_total_mv` is `Some`) whose mana value fits the
-/// remaining budget. Shared by the resolver and the handler's re-offer loop so
-/// the candidate set stays consistent across both entry points.
+/// CR 601.2a + CR 202.3: Gather the cards in `zones` that match `filter` and
+/// (when `max_total_mv` is `Some`) whose mana value fits the remaining budget.
+/// Shared by the resolver and the handler's re-offer loop so the candidate set
+/// stays consistent across both entry points.
+///
+/// `source` is the resolving ability's source object: `TargetFilter`s such as
+/// `ExiledBySource` (Plargg and Nassari's "the other cards exiled this way")
+/// resolve their exile links against it, so the real id must be threaded
+/// rather than a sentinel.
 pub(crate) fn eligible_candidates(
     state: &GameState,
     controller: PlayerId,
+    source: ObjectId,
     filter: &TargetFilter,
     zones: &[Zone],
     max_total_mv: Option<u32>,
@@ -101,19 +115,34 @@ pub(crate) fn eligible_candidates(
         return Vec::new();
     };
 
-    let ctx = FilterContext::from_source_with_controller(ObjectId(0), controller);
+    let ctx = FilterContext::from_source_with_controller(source, controller);
     let mut candidates = Vec::new();
     for &zone in zones {
         let zone_ids = match zone {
             Zone::Graveyard => &player.graveyard,
             Zone::Hand => &player.hand,
-            // CR 601.2a: The class today only draws from the controller's
-            // graveyard and hand. A new zone would need a parser/effect change,
-            // so an unexpected zone contributes no candidates rather than
-            // silently scanning the wrong pile.
+            // CR 400.10a + CR 608.2g: Exile is a shared zone — the whole pile
+            // is scanned and the `filter` (e.g. `ExiledBySource` +
+            // `Not(InTrackedSet)`) narrows it to this resolution's linked set
+            // regardless of who owns the exiled cards (Plargg and Nassari
+            // exiles from EVERY player's library).
+            Zone::Exile => &state.exile,
+            // CR 601.2a: Other zones would need a parser/effect change, so an
+            // unexpected zone contributes no candidates rather than silently
+            // scanning the wrong pile.
             _ => continue,
         };
         for &id in zone_ids {
+            // CR 305.1: a land card can never be cast — this window is a cast
+            // grant, so lands are excluded from the offer outright (mirrors
+            // `cast_from_zone`'s cast-mode land guard).
+            if state.objects.get(&id).is_some_and(|obj| {
+                obj.card_types
+                    .core_types
+                    .contains(&crate::types::card_type::CoreType::Land)
+            }) {
+                continue;
+            }
             if !matches_target_filter_in_owner_zone(state, id, filter, &ctx) {
                 continue;
             }
@@ -207,6 +236,7 @@ mod tests {
         let candidates = eligible_candidates(
             &state,
             PlayerId(0),
+            ObjectId(0),
             &instant_sorcery_filter(),
             &[Zone::Graveyard, Zone::Hand],
             None,
@@ -237,6 +267,7 @@ mod tests {
         let candidates = eligible_candidates(
             &state,
             PlayerId(0),
+            ObjectId(0),
             &instant_sorcery_filter(),
             &[Zone::Graveyard, Zone::Hand],
             Some(6),
@@ -267,6 +298,7 @@ mod tests {
         let candidates = eligible_candidates(
             &state,
             PlayerId(0),
+            ObjectId(0),
             &instant_sorcery_filter(),
             &[Zone::Graveyard, Zone::Hand],
             None,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2429,6 +2429,15 @@ fn waits_for_resolution_choice(waiting_for: &WaitingFor) -> bool {
             | WaitingFor::PayCost { .. }
             | WaitingFor::RetargetChoice { .. }
             | WaitingFor::ChooseFromZoneChoice { .. }
+            // CR 608.2d + CR 608.2e: the controller's pick of WHICH opponent
+            // will make a `ChooseFromZone` selection is itself a resolution
+            // pause. The chained consumer (Plargg, Dean of Chaos's "you may
+            // cast up to two of the other exiled cards") must not resolve
+            // until the delegated pick round-trips — resolving it inline
+            // would read the pre-pick tracked-set state and compute an empty
+            // candidate pool — so the sub-ability chain auto-stashes here
+            // exactly like the `ChooseFromZoneChoice` pause it precedes.
+            | WaitingFor::ChooseFromZoneOpponentChooser { .. }
             | WaitingFor::ChooseOneOfBranch { .. }
             | WaitingFor::ReturnAsAuraTarget { .. }
             | WaitingFor::ChooseManaColor { .. }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4256,7 +4256,16 @@ fn effect_references_tracked_set(effect: &Effect) -> bool {
     // card, so a chained free-cast window must trigger publication of the
     // chosen card as the fresh tracked set.
     if let Effect::FreeCastFromZones { filter, .. } = effect {
-        if filter_references_tracked_set(filter) {
+        // CR 608.2c: the chosen-card exclusion is `FilterProp::Not {
+        // InTrackedSet }` INSIDE the typed leg of an `And` ("the OTHER cards
+        // exiled this way"), which the whole-filter walk above cannot see —
+        // without the property-level walk the choose head never publishes the
+        // chosen card as the fresh chain set, the `InTrackedSet(0)` sentinel
+        // stays bound to the exile-batch set, and `Not` over the batch empties
+        // the window (Plargg and Nassari's cast offer silently skipped).
+        if filter_references_tracked_set(filter)
+            || filter_properties_reference_tracked_membership(filter)
+        {
             return true;
         }
     }
@@ -4381,6 +4390,41 @@ fn filter_properties_reference_tracked_quantity(filter: &TargetFilter) -> bool {
         TargetFilter::Or { filters } | TargetFilter::And { filters } => filters
             .iter()
             .any(filter_properties_reference_tracked_quantity),
+        _ => false,
+    }
+}
+
+/// CR 608.2c: A filter whose typed properties test tracked-set MEMBERSHIP
+/// (`FilterProp::InTrackedSet`, alone or under `Not`/`AnyOf` — Plargg and
+/// Nassari's "the other cards exiled this way" is `Not(InTrackedSet)` inside
+/// the typed leg of an `And`) consumes the chain tracked set even though the
+/// filter is not a bare `TrackedSet`/`TrackedSetFiltered` reference. Mirrors
+/// `filter_properties_reference_tracked_quantity` for the membership axis.
+fn filter_properties_reference_tracked_membership(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(tf) => tf
+            .properties
+            .iter()
+            .any(filter_prop_references_tracked_membership),
+        TargetFilter::Not { filter } => filter_properties_reference_tracked_membership(filter),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => filters
+            .iter()
+            .any(filter_properties_reference_tracked_membership),
+        _ => false,
+    }
+}
+
+/// CR 608.2c: Membership predicates at the property boundary — a bare
+/// `InTrackedSet`, or one nested under `Not` ("the other cards") / `AnyOf`.
+fn filter_prop_references_tracked_membership(prop: &crate::types::ability::FilterProp) -> bool {
+    match prop {
+        crate::types::ability::FilterProp::InTrackedSet { .. } => true,
+        crate::types::ability::FilterProp::AnyOf { props } => {
+            props.iter().any(filter_prop_references_tracked_membership)
+        }
+        crate::types::ability::FilterProp::Not { prop } => {
+            filter_prop_references_tracked_membership(prop)
+        }
         _ => false,
     }
 }

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4249,6 +4249,17 @@ fn effect_references_tracked_set(effect: &Effect) -> bool {
             return true;
         }
     }
+    // CR 608.2g: `FreeCastFromZones` carries its candidate filter in `filter`,
+    // which `Effect::target_filter()` does not expose (the window offers casts
+    // rather than selecting spell targets). Plargg and Nassari's "the other
+    // cards exiled this way" is `Not(InTrackedSet)` over the opponent's chosen
+    // card, so a chained free-cast window must trigger publication of the
+    // chosen card as the fresh tracked set.
+    if let Effect::FreeCastFromZones { filter, .. } = effect {
+        if filter_references_tracked_set(filter) {
+            return true;
+        }
+    }
     if let Effect::SetTapState {
         scope: EffectScope::All,
         target,

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2567,7 +2567,7 @@ pub(super) fn handle_resolution_choice(
         }
         (
             WaitingFor::ChooseFromZoneOpponentChooser {
-                player: _,
+                player,
                 candidates,
                 ability,
             },
@@ -2590,8 +2590,14 @@ pub(super) fn handle_resolution_choice(
             )
             .map_err(|e| EngineError::InvalidAction(format!("{e:?}")))?;
             // With an empty pool the choose completed without a new pause —
-            // drain the parked continuation like a settled zone choice.
+            // hand priority back to the controller (mirroring the settled-clash
+            // arm above) so the parked continuation can actually drain: the
+            // drain helper is gated on `WaitingFor::Priority`, and without
+            // `set_priority` the stale opponent-chooser pause would wedge the
+            // resolution (CR 608.2d — the choice is skipped, not the rest of
+            // the ability).
             if !matches!(state.waiting_for, WaitingFor::ChooseFromZoneChoice { .. }) {
+                set_priority(state, player);
                 super::engine::resume_pending_continuation_if_priority(state, events)
                     .expect("a settled opponent-chooser pick must resume its continuation");
             }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1964,6 +1964,7 @@ pub(super) fn handle_resolution_choice(
                         zones,
                         exile_instead_of_graveyard,
                         source,
+                        member_pool,
                     },
             },
             GameAction::FreeCastWindowChoice { selection },
@@ -2018,6 +2019,7 @@ pub(super) fn handle_resolution_choice(
                         zones,
                         exile_instead_of_graveyard,
                         source,
+                        member_pool,
                     },
             };
             let result = casting::initiate_cast_during_resolution(
@@ -3834,6 +3836,27 @@ pub(super) fn handle_resolution_choice(
             if let Some(frame) = state.active_ability_continuation_frame_mut() {
                 let cont = &mut frame.pending;
                 cont.chain.targets = chosen.iter().map(|&id| TargetRef::Object(id)).collect();
+                // CR 607.2a + CR 608.2g: A `FreeCastFromZones` continuation
+                // over "the other cards exiled this way" (Plargg and Nassari)
+                // must confine its offer to THIS resolution's exile batch. The
+                // choose's offered pool (`cards`) IS that typed, concrete
+                // batch — it was derived from the chain's tracked set the
+                // exile clause published within this resolution — so forward
+                // the FULL pool (not just `chosen`) as the window head's
+                // object targets; the resolver reads them as its member pool
+                // and intersects the exile-zone scan with it BEFORE the
+                // filter's `Not(InTrackedSet)` chosen-card exclusion. Without
+                // this, `ExiledBySource` alone reads the source's complete
+                // live linked-exile ledger and a linked nonland card left in
+                // exile by a PREVIOUS resolution would be wrongly offered. The
+                // window never reads `ParentTarget`, so overriding the generic
+                // `targets = chosen` forward is safe for this head.
+                if matches!(
+                    cont.chain.effect,
+                    crate::types::ability::Effect::FreeCastFromZones { .. }
+                ) {
+                    cont.chain.targets = cards.iter().map(|&id| TargetRef::Object(id)).collect();
+                }
                 // CR 700.2 + CR 608.2c: The "unchosen" partition is forwarded
                 // to the sub-ability ONLY for the zone-partition pattern
                 // (`ChooseFromZone`: chosen cards go one place, the rest go

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -884,6 +884,29 @@ fn continuation_exiles_found_set(chain: &ResolvedAbility) -> bool {
     false
 }
 
+/// CR 607.2a + CR 608.2c: True when `filter` carries the `FilterProp::Another`
+/// exclusion at any structural position — directly on a `Typed` leg, or nested
+/// inside `And` / `Or` / `Not` / `TrackedSetFiltered` composition. Consumed by
+/// the `ChooseFromZoneChoice` handler to recognize an "other cards" continuation
+/// (Plargg and Nassari's "cast … from among the OTHER cards exiled this way"),
+/// whose target pool is the complement of the pick. Mirrors the recursion shape
+/// of `TargetFilter::references_exiled_by_source`.
+fn target_filter_carries_another(filter: &crate::types::ability::TargetFilter) -> bool {
+    use crate::types::ability::{FilterProp, TargetFilter};
+    match filter {
+        TargetFilter::Typed(tf) => tf
+            .properties
+            .iter()
+            .any(|p| matches!(p, FilterProp::Another)),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(target_filter_carries_another)
+        }
+        TargetFilter::Not { filter } => target_filter_carries_another(filter),
+        TargetFilter::TrackedSetFiltered { filter, .. } => target_filter_carries_another(filter),
+        _ => false,
+    }
+}
+
 /// Finalize the ordinary (non-partitioned) SearchChoice continuation. This is
 /// the single authority for both the synchronous selection path and a
 /// SearchFound batch resumed after one or more nested replacement pauses.
@@ -3798,7 +3821,35 @@ pub(super) fn handle_resolution_choice(
             }
             if let Some(frame) = state.active_ability_continuation_frame_mut() {
                 let cont = &mut frame.pending;
-                cont.chain.targets = chosen.iter().map(|&id| TargetRef::Object(id)).collect();
+                // CR 608.2c + CR 607.2a: An "other cards" continuation consumes
+                // the COMPLEMENT of the pick, not the pick itself. Plargg and
+                // Nassari: "An opponent chooses a nonland card exiled this way.
+                // You may cast up to two spells from among the OTHER cards
+                // exiled this way" — the parked continuation is a
+                // `CastFromZone` over the linked-exile set carrying the
+                // `FilterProp::Another` exclusion (`parse_from_among_exiled_
+                // this_way` lifts "the other cards exiled this way" to
+                // `And { ExiledBySource, Typed(card, Another, InZone Exile) }`).
+                // Binding the chosen card as its target list (the default
+                // partition below) would offer exactly the card the opponent
+                // removed from the pool; bind the unchosen remainder instead.
+                // Gated narrowly on the head being an exile-linked cast whose
+                // filter carries the `Another` exclusion so every existing
+                // chosen-consumer continuation (End-Blaze Epiphany's "you may
+                // play that card") is untouched.
+                let other_cards_cast_consumer = matches!(
+                    &cont.chain.effect,
+                    crate::types::ability::Effect::CastFromZone { target, .. }
+                        if target.references_exiled_by_source()
+                            && target_filter_carries_another(target)
+                );
+                if other_cards_cast_consumer {
+                    cont.chain.targets =
+                        unchosen.iter().map(|&id| TargetRef::Object(id)).collect();
+                } else {
+                    cont.chain.targets =
+                        chosen.iter().map(|&id| TargetRef::Object(id)).collect();
+                }
                 // CR 700.2 + CR 608.2c: The "unchosen" partition is forwarded
                 // to the sub-ability ONLY for the zone-partition pattern
                 // (`ChooseFromZone`: chosen cards go one place, the rest go

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3844,11 +3844,9 @@ pub(super) fn handle_resolution_choice(
                             && target_filter_carries_another(target)
                 );
                 if other_cards_cast_consumer {
-                    cont.chain.targets =
-                        unchosen.iter().map(|&id| TargetRef::Object(id)).collect();
+                    cont.chain.targets = unchosen.iter().map(|&id| TargetRef::Object(id)).collect();
                 } else {
-                    cont.chain.targets =
-                        chosen.iter().map(|&id| TargetRef::Object(id)).collect();
+                    cont.chain.targets = chosen.iter().map(|&id| TargetRef::Object(id)).collect();
                 }
                 // CR 700.2 + CR 608.2c: The "unchosen" partition is forwarded
                 // to the sub-ability ONLY for the zone-partition pattern

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -670,6 +670,7 @@ pub(super) fn handles(waiting_for: &WaitingFor) -> bool {
             | WaitingFor::TopOrBottomChoice { .. }
             | WaitingFor::PopulateChoice { .. }
             | WaitingFor::ClashChooseOpponent { .. }
+            | WaitingFor::ChooseFromZoneOpponentChooser { .. }
             | WaitingFor::ClashCardPlacement { .. }
             | WaitingFor::VoteChoice { .. }
             | WaitingFor::SeparatePilesChooseOpponent { .. }
@@ -882,29 +883,6 @@ fn continuation_exiles_found_set(chain: &ResolvedAbility) -> bool {
         cursor = def.sub_ability.as_deref();
     }
     false
-}
-
-/// CR 607.2a + CR 608.2c: True when `filter` carries the `FilterProp::Another`
-/// exclusion at any structural position — directly on a `Typed` leg, or nested
-/// inside `And` / `Or` / `Not` / `TrackedSetFiltered` composition. Consumed by
-/// the `ChooseFromZoneChoice` handler to recognize an "other cards" continuation
-/// (Plargg and Nassari's "cast … from among the OTHER cards exiled this way"),
-/// whose target pool is the complement of the pick. Mirrors the recursion shape
-/// of `TargetFilter::references_exiled_by_source`.
-fn target_filter_carries_another(filter: &crate::types::ability::TargetFilter) -> bool {
-    use crate::types::ability::{FilterProp, TargetFilter};
-    match filter {
-        TargetFilter::Typed(tf) => tf
-            .properties
-            .iter()
-            .any(|p| matches!(p, FilterProp::Another)),
-        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
-            filters.iter().any(target_filter_carries_another)
-        }
-        TargetFilter::Not { filter } => target_filter_carries_another(filter),
-        TargetFilter::TrackedSetFiltered { filter, .. } => target_filter_carries_another(filter),
-        _ => false,
-    }
 }
 
 /// Finalize the ordinary (non-partitioned) SearchChoice continuation. This is
@@ -1985,6 +1963,7 @@ pub(super) fn handle_resolution_choice(
                         filter,
                         zones,
                         exile_instead_of_graveyard,
+                        source,
                     },
             },
             GameAction::FreeCastWindowChoice { selection },
@@ -2038,6 +2017,7 @@ pub(super) fn handle_resolution_choice(
                         filter,
                         zones,
                         exile_instead_of_graveyard,
+                        source,
                     },
             };
             let result = casting::initiate_cast_during_resolution(
@@ -2580,6 +2560,38 @@ pub(super) fn handle_resolution_choice(
                 set_priority(state, player);
                 super::engine::resume_pending_continuation_if_priority(state, events)
                     .expect("a settled clash choice must resume its continuation");
+            }
+            ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
+        }
+        (
+            WaitingFor::ChooseFromZoneOpponentChooser {
+                player: _,
+                candidates,
+                ability,
+            },
+            GameAction::ChooseZoneOpponentChooser { opponent },
+        ) => {
+            // CR 608.2d: The picked opponent must be one of the offered
+            // candidates (a live opponent of the choose's controller).
+            if !candidates.contains(&opponent) {
+                return Err(EngineError::InvalidAction(format!(
+                    "Chosen zone-choice opponent {opponent:?} is not a legal opponent"
+                )));
+            }
+            // CR 608.2d: Present the parked zone selection to the picked
+            // opponent. This re-enters the standard `ChooseFromZoneChoice`
+            // pause (or completes with no choice if the pool emptied), so the
+            // already-parked continuation frame is untouched — exactly as if
+            // the opponent had been the chooser from the start.
+            effects::choose_from_zone::resolve_with_choosing_player(
+                state, &ability, opponent, events,
+            )
+            .map_err(|e| EngineError::InvalidAction(format!("{e:?}")))?;
+            // With an empty pool the choose completed without a new pause —
+            // drain the parked continuation like a settled zone choice.
+            if !matches!(state.waiting_for, WaitingFor::ChooseFromZoneChoice { .. }) {
+                super::engine::resume_pending_continuation_if_priority(state, events)
+                    .expect("a settled opponent-chooser pick must resume its continuation");
             }
             ResolutionChoiceOutcome::WaitingFor(state.waiting_for.clone())
         }
@@ -3821,33 +3833,7 @@ pub(super) fn handle_resolution_choice(
             }
             if let Some(frame) = state.active_ability_continuation_frame_mut() {
                 let cont = &mut frame.pending;
-                // CR 608.2c + CR 607.2a: An "other cards" continuation consumes
-                // the COMPLEMENT of the pick, not the pick itself. Plargg and
-                // Nassari: "An opponent chooses a nonland card exiled this way.
-                // You may cast up to two spells from among the OTHER cards
-                // exiled this way" — the parked continuation is a
-                // `CastFromZone` over the linked-exile set carrying the
-                // `FilterProp::Another` exclusion (`parse_from_among_exiled_
-                // this_way` lifts "the other cards exiled this way" to
-                // `And { ExiledBySource, Typed(card, Another, InZone Exile) }`).
-                // Binding the chosen card as its target list (the default
-                // partition below) would offer exactly the card the opponent
-                // removed from the pool; bind the unchosen remainder instead.
-                // Gated narrowly on the head being an exile-linked cast whose
-                // filter carries the `Another` exclusion so every existing
-                // chosen-consumer continuation (End-Blaze Epiphany's "you may
-                // play that card") is untouched.
-                let other_cards_cast_consumer = matches!(
-                    &cont.chain.effect,
-                    crate::types::ability::Effect::CastFromZone { target, .. }
-                        if target.references_exiled_by_source()
-                            && target_filter_carries_another(target)
-                );
-                if other_cards_cast_consumer {
-                    cont.chain.targets = unchosen.iter().map(|&id| TargetRef::Object(id)).collect();
-                } else {
-                    cont.chain.targets = chosen.iter().map(|&id| TargetRef::Object(id)).collect();
-                }
+                cont.chain.targets = chosen.iter().map(|&id| TargetRef::Object(id)).collect();
                 // CR 700.2 + CR 608.2c: The "unchosen" partition is forwarded
                 // to the sub-ability ONLY for the zone-partition pattern
                 // (`ChooseFromZone`: chosen cards go one place, the rest go

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -1774,6 +1774,7 @@ impl GameRunner {
             WaitingFor::SpecializeColor { .. } => "SpecializeColor",
             WaitingFor::PopulateChoice { .. } => "PopulateChoice",
             WaitingFor::ClashChooseOpponent { .. } => "ClashChooseOpponent",
+            WaitingFor::ChooseFromZoneOpponentChooser { .. } => "ChooseFromZoneOpponentChooser",
             WaitingFor::ChooseAnnouncingOpponent { .. } => "ChooseAnnouncingOpponent",
             WaitingFor::ClashCardPlacement { .. } => "ClashCardPlacement",
             WaitingFor::VoteChoice { .. } => "VoteChoice",

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1079,6 +1079,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
                 ref zones,
                 exile_instead_of_graveyard,
                 source,
+                ref member_pool,
             },
     } = state.waiting_for
     {
@@ -1093,6 +1094,13 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
                     zones: zones.clone(),
                     exile_instead_of_graveyard,
                     source,
+                    // CR 400.2: the member pool can reference the same private
+                    // candidates (a hand/graveyard window would leak eligible
+                    // ids through it); redact it to placeholders exactly like
+                    // `candidates`. For Plargg's exile batch the ids are
+                    // public-zone cards, but the redaction is uniform — the
+                    // opponent-facing view never needs the pool.
+                    member_pool: member_pool.iter().map(|_| ObjectId(0)).collect(),
                 },
             };
         }
@@ -4806,6 +4814,7 @@ mod tests {
                 zones: vec![Zone::Graveyard, Zone::Hand],
                 exile_instead_of_graveyard: true,
                 source: crate::types::game_state::zero_object_id(),
+                member_pool: vec![hand_candidate],
             },
         };
 
@@ -4840,6 +4849,7 @@ mod tests {
                         remaining_casts,
                         remaining_mv_budget,
                         exile_instead_of_graveyard,
+                        member_pool,
                         ..
                     },
                 ..
@@ -4849,6 +4859,13 @@ mod tests {
                     "opponent must not see the controller's hand candidate id"
                 );
                 assert_eq!(candidates, vec![ObjectId(0)]);
+                // CR 400.2: the member pool is redacted exactly like the
+                // candidates — it references the same private ids.
+                assert!(
+                    !member_pool.contains(&hand_candidate),
+                    "opponent must not see the controller's hand id via the member pool"
+                );
+                assert_eq!(member_pool, vec![ObjectId(0)]);
                 assert_eq!(remaining_casts, 2);
                 assert_eq!(remaining_mv_budget, Some(6));
                 assert!(exile_instead_of_graveyard);

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -4805,6 +4805,7 @@ mod tests {
                 filter: crate::types::ability::TargetFilter::Any,
                 zones: vec![Zone::Graveyard, Zone::Hand],
                 exile_instead_of_graveyard: true,
+                source: crate::types::game_state::zero_object_id(),
             },
         };
 

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1078,6 +1078,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
                 ref filter,
                 ref zones,
                 exile_instead_of_graveyard,
+                source,
             },
     } = state.waiting_for
     {
@@ -1091,6 +1092,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
                     filter: filter.clone(),
                     zones: zones.clone(),
                     exile_instead_of_graveyard,
+                    source,
                 },
             };
         }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -3927,9 +3927,11 @@ fn try_parse_choose_owned_by_voter(
 /// (CR 608.2d override): the game selects, the controller does not.
 ///
 /// The chooser prefix follows `parse_choose_anaphoric`'s CR 608.2d convention:
-/// "an opponent chooses" / "target opponent chooses" → [`Chooser::Opponent`]
-/// (Plargg and Nassari: "An opponent chooses a nonland card exiled this way"),
-/// bare "choose" / "you choose" → [`Chooser::Controller`].
+/// "an opponent chooses" → [`Chooser::Opponent`] (Plargg and Nassari: "An
+/// opponent chooses a nonland card exiled this way"), bare "choose" /
+/// "you choose" → [`Chooser::Controller`]. The targeted form ("target
+/// opponent chooses") is not accepted — it must bind the chooser to the
+/// chosen target slot, so it falls through honestly.
 fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
     type E<'a> = OracleError<'a>;
 
@@ -3963,16 +3965,14 @@ fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
     // exiled this way") narrows the choice; the bare "a card" form leaves it
     // untyped. The type is intersected with the linked-exile set below.
     // CR 608.2d: "an opponent chooses" delegates the selection to an opponent
-    // (mirrors `parse_choose_anaphoric`'s chooser alternation).
+    // (mirrors `parse_choose_anaphoric`'s chooser alternation). The targeted
+    // form ("target opponent chooses") is deliberately NOT accepted here: it
+    // must bind the chooser to the chosen target slot, and no printed card
+    // pairs it with an "exiled this way" anaphor, so the fall-through stays
+    // honest rather than collapsing target identity into `Chooser::Opponent`.
     let (rest_after, (chooser, card_type)) = pair(
         alt((
-            value(
-                Chooser::Opponent,
-                alt((
-                    tag::<_, _, E>("an opponent chooses "),
-                    tag("target opponent chooses "),
-                )),
-            ),
+            value(Chooser::Opponent, tag::<_, _, E>("an opponent chooses ")),
             value(
                 Chooser::Controller,
                 alt((tag::<_, _, E>("you choose "), tag("choose "))),

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4,7 +4,7 @@ use nom::bytes::complete::{tag, take_till, take_until};
 use nom::character::complete::{one_of, space0, space1};
 use nom::combinator::{all_consuming, eof, map, not, opt, peek, rest, value};
 use nom::error::ParseError;
-use nom::sequence::{preceded, terminated};
+use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
 
 use super::counter::{
@@ -3925,6 +3925,11 @@ fn try_parse_choose_owned_by_voter(
 ///
 /// The optional "at random" qualifier sets [`CardSelectionMode::Random`]
 /// (CR 608.2d override): the game selects, the controller does not.
+///
+/// The chooser prefix follows `parse_choose_anaphoric`'s CR 608.2d convention:
+/// "an opponent chooses" / "target opponent chooses" → [`Chooser::Opponent`]
+/// (Plargg and Nassari: "An opponent chooses a nonland card exiled this way"),
+/// bare "choose" / "you choose" → [`Chooser::Controller`].
 fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
     type E<'a> = OracleError<'a>;
 
@@ -3952,12 +3957,27 @@ fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
         }
     }
 
-    // "choose " / "you choose ", then the singular card anaphor "a [type] card" /
+    // Chooser prefix, then the singular card anaphor "a [type] card" /
     // "one [type] card". The optional card-type qualifier (Koh, the Face Stealer's
-    // "a creature card exiled with ~") narrows the choice; the bare "a card" form
-    // leaves it untyped. The type is intersected with the linked-exile set below.
-    let (rest_after, card_type) = preceded(
-        alt((tag::<_, _, E>("choose "), tag("you choose "))),
+    // "a creature card exiled with ~"; Plargg and Nassari's "a nonland card
+    // exiled this way") narrows the choice; the bare "a card" form leaves it
+    // untyped. The type is intersected with the linked-exile set below.
+    // CR 608.2d: "an opponent chooses" delegates the selection to an opponent
+    // (mirrors `parse_choose_anaphoric`'s chooser alternation).
+    let (rest_after, (chooser, card_type)) = pair(
+        alt((
+            value(
+                Chooser::Opponent,
+                alt((
+                    tag::<_, _, E>("an opponent chooses "),
+                    tag("target opponent chooses "),
+                )),
+            ),
+            value(
+                Chooser::Controller,
+                alt((tag::<_, _, E>("you choose "), tag("choose "))),
+            ),
+        )),
         preceded(
             alt((tag("a "), tag("one "))),
             parse_choose_card_type_qualifier,
@@ -3972,18 +3992,41 @@ fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
         Err(_) => (rest_after, CardSelectionMode::Chosen),
     };
 
-    // "exiled this way" — the chain tracked set. Only the untyped form is attested
-    // (impulse-exile reductions choose from the whole chain set); a typed
-    // restriction here would need `TrackedSetFiltered`, so fall through honestly.
-    if card_type.is_none() {
-        if let Ok((tail, _)) = tag::<_, _, E>(" exiled this way").parse(rest_after) {
-            if tail.is_empty() {
-                return Some(ChooseImperativeAst::FromTrackedSet {
+    // "exiled this way" — two referents, split on the type qualifier:
+    // * Untyped ("choose a card exiled this way") — the chain's tracked set
+    //   (impulse-exile reductions choose from the whole chain set; End-Blaze
+    //   Epiphany). Unchanged.
+    // * Typed ("choose a nonland card exiled this way" — Plargg and Nassari,
+    //   Author of Shadows) — the source's linked-exile set. CR 607.2a defines
+    //   "exiled this way" by linkage to the exiling instruction, exactly like
+    //   "exiled with ~" below, and `parse_target`'s suffix arm already maps
+    //   the bare participle "exiled this way" to `TargetFilter::ExiledBySource`
+    //   (oracle_target.rs). Lower to the same `FromZone { Exile, AllOwners,
+    //   And { Typed, ExiledBySource } }` shape as the Koh arm so the runtime
+    //   scans the shared exile zone (CR 400.1) and linkage does all scoping.
+    if let Ok((tail, _)) = tag::<_, _, E>(" exiled this way").parse(rest_after) {
+        if tail.is_empty() {
+            return Some(match card_type {
+                None => ChooseImperativeAst::FromTrackedSet {
                     count: 1,
-                    chooser: Chooser::Controller,
+                    chooser,
                     selection,
-                });
-            }
+                },
+                Some(tf) => ChooseImperativeAst::FromZone {
+                    count: 1,
+                    zones: vec![Zone::Exile],
+                    zone_owner: ZoneOwner::AllOwners,
+                    filter: TargetFilter::And {
+                        filters: vec![
+                            TargetFilter::Typed(TypedFilter::new(tf)),
+                            TargetFilter::ExiledBySource,
+                        ],
+                    },
+                    chooser,
+                    up_to: false,
+                    selection,
+                },
+            });
         }
     }
 
@@ -4015,7 +4058,7 @@ fn try_parse_choose_exiled_anaphor(lower: &str) -> Option<ChooseImperativeAst> {
                 zones: vec![Zone::Exile],
                 zone_owner: ZoneOwner::AllOwners,
                 filter,
-                chooser: Chooser::Controller,
+                chooser,
                 up_to: false,
                 selection,
             });
@@ -4080,28 +4123,34 @@ fn try_parse_choose_suspended_card(lower: &str) -> Option<ChooseImperativeAst> {
 }
 
 /// CR 205.2a: Parse the card-type qualifier of a singular card anaphor — one card
-/// type word followed by " card" (→ `Some(type)`), or the bare "card" (→ `None`).
-/// Used by [`try_parse_choose_exiled_anaphor`] for "choose a [type] card exiled
-/// with ~". A single type covers the attested class (Koh's "creature card");
-/// multi-type qualifiers ("artifact creature card") are not yet attested.
+/// type word followed by " card" (→ `Some(type)`), a negated "non<type>" form
+/// (→ `Some(Non(type))`, CR 205.2b — Plargg and Nassari's "nonland card"), or
+/// the bare "card" (→ `None`). Used by [`try_parse_choose_exiled_anaphor`] for
+/// "choose a [type] card exiled with ~ / exiled this way". A single (possibly
+/// negated) type covers the attested class (Koh's "creature card", Plargg's
+/// "nonland card"); multi-type qualifiers ("artifact creature card") are not
+/// yet attested.
 fn parse_choose_card_type_qualifier(input: &str) -> OracleResult<'_, Option<TypeFilter>> {
+    let card_type_word = || {
+        alt((
+            value(TypeFilter::Creature, tag("creature")),
+            value(TypeFilter::Artifact, tag("artifact")),
+            value(TypeFilter::Enchantment, tag("enchantment")),
+            value(TypeFilter::Land, tag("land")),
+            value(TypeFilter::Planeswalker, tag("planeswalker")),
+            value(TypeFilter::Instant, tag("instant")),
+            value(TypeFilter::Sorcery, tag("sorcery")),
+            value(TypeFilter::Battle, tag("battle")),
+        ))
+    };
     alt((
+        // CR 205.2b: "non" + card type — an object that doesn't have the
+        // stated type ("nonland card", "noncreature card").
         map(
-            terminated(
-                alt((
-                    value(TypeFilter::Creature, tag("creature")),
-                    value(TypeFilter::Artifact, tag("artifact")),
-                    value(TypeFilter::Enchantment, tag("enchantment")),
-                    value(TypeFilter::Land, tag("land")),
-                    value(TypeFilter::Planeswalker, tag("planeswalker")),
-                    value(TypeFilter::Instant, tag("instant")),
-                    value(TypeFilter::Sorcery, tag("sorcery")),
-                    value(TypeFilter::Battle, tag("battle")),
-                )),
-                tag(" card"),
-            ),
-            Some,
+            terminated(preceded(tag("non"), card_type_word()), tag(" card")),
+            |tf| Some(TypeFilter::Non(Box::new(tf))),
         ),
+        map(terminated(card_type_word(), tag(" card")), Some),
         value(None, tag("card")),
     ))
     .parse(input)
@@ -16849,6 +16898,97 @@ mod tests {
     #[test]
     fn parse_choose_anaphoric_you_choose() {
         let text = "you choose one of those cards";
+        let lower = text.to_lowercase();
+        let result = parse_choose_ast(text, &lower, &mut ParseContext::default());
+        match result {
+            Some(ChooseImperativeAst::FromTrackedSet { count, chooser, .. }) => {
+                assert_eq!(count, 1);
+                assert_eq!(chooser, Chooser::Controller);
+            }
+            other => panic!("Expected FromTrackedSet, got {other:?}"),
+        }
+    }
+
+    /// CR 607.2a + CR 608.2d: "choose a nonland card exiled this way" (Author of
+    /// Shadows; Plargg and Nassari post-subject-strip) — the TYPED exiled-this-way
+    /// anaphor routes to the linked-exile `FromZone { Exile, AllOwners }` shape
+    /// (same as the Koh "exiled with ~" arm), carrying the negated type qualifier
+    /// intersected with `ExiledBySource`.
+    #[test]
+    fn parse_choose_nonland_card_exiled_this_way() {
+        let text = "choose a nonland card exiled this way";
+        let lower = text.to_lowercase();
+        let result = parse_choose_ast(text, &lower, &mut ParseContext::default());
+        match result {
+            Some(ChooseImperativeAst::FromZone {
+                count,
+                zones,
+                zone_owner,
+                filter,
+                chooser,
+                up_to,
+                ..
+            }) => {
+                assert_eq!(count, 1);
+                assert_eq!(zones, vec![Zone::Exile]);
+                assert_eq!(zone_owner, ZoneOwner::AllOwners);
+                assert_eq!(chooser, Chooser::Controller);
+                assert!(!up_to);
+                let TargetFilter::And { filters } = filter else {
+                    panic!("expected And{{Typed, ExiledBySource}}, got {filter:?}");
+                };
+                assert!(filters.contains(&TargetFilter::ExiledBySource));
+                let typed = filters
+                    .iter()
+                    .find_map(|f| match f {
+                        TargetFilter::Typed(tf) => Some(tf),
+                        _ => None,
+                    })
+                    .expect("And must carry a Typed leg");
+                assert!(typed
+                    .type_filters
+                    .iter()
+                    .any(|t| matches!(t, TypeFilter::Non(inner) if **inner == TypeFilter::Land)));
+            }
+            other => panic!("Expected FromZone, got {other:?}"),
+        }
+    }
+
+    /// CR 608.2d: "an opponent chooses a nonland card exiled this way" (Plargg
+    /// and Nassari's middle sentence, reachable inline through the anaphoric
+    /// choose entry) — same linked-exile shape with the selection delegated to
+    /// an opponent.
+    #[test]
+    fn parse_opponent_chooses_nonland_card_exiled_this_way() {
+        let text = "an opponent chooses a nonland card exiled this way";
+        let lower = text.to_lowercase();
+        let result = parse_choose_ast(text, &lower, &mut ParseContext::default());
+        match result {
+            Some(ChooseImperativeAst::FromZone {
+                count,
+                zones,
+                zone_owner,
+                filter,
+                chooser,
+                ..
+            }) => {
+                assert_eq!(count, 1);
+                assert_eq!(zones, vec![Zone::Exile]);
+                assert_eq!(zone_owner, ZoneOwner::AllOwners);
+                assert_eq!(chooser, Chooser::Opponent);
+                assert!(matches!(&filter, TargetFilter::And { filters }
+                    if filters.contains(&TargetFilter::ExiledBySource)));
+            }
+            other => panic!("Expected FromZone with Opponent chooser, got {other:?}"),
+        }
+    }
+
+    /// Untyped-referent regression guard: the bare "choose a card exiled this
+    /// way" impulse reduction (End-Blaze Epiphany) must keep reading the chain's
+    /// tracked set — the new typed arm must not claim it.
+    #[test]
+    fn parse_choose_card_exiled_this_way_still_tracked_set() {
+        let text = "choose a card exiled this way";
         let lower = text.to_lowercase();
         let result = parse_choose_ast(text, &lower, &mut ParseContext::default());
         match result {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -20308,6 +20308,53 @@ fn parse_from_among_exiled_this_way(rest: &str) -> Option<TargetFilter> {
     })
 }
 
+/// CR 608.2g + CR 601.2 + CR 118.9: Parse the counted free-cast-window form
+/// `"up to N spell(s) from among (the|those) [other] [typed] cards exiled this
+/// way"` (the `"cast "` prefix and the `"without paying their mana cost(s)"`
+/// requirement are handled by the caller) and lower it to
+/// `Effect::FreeCastFromZones` with `zones = [Exile]`.
+///
+/// The filter is the `parse_from_among_exiled_this_way` anchor's output
+/// (`ExiledBySource` AND any typed leg), with one rewrite: when the typed leg
+/// carries `FilterProp::Another` ("the OTHER cards exiled this way"), the
+/// "other"-ness is relative to the card a PRIOR choose in the same chain
+/// selected (Plargg and Nassari: "An opponent chooses a nonland card exiled
+/// this way. You may cast up to two spells from among the other cards exiled
+/// this way") — not relative to the ability source. Rewrite `Another` →
+/// `Not(InTrackedSet(0))` (the sentinel the choose's resolution publishes its
+/// picks under), mirroring `rewrite_filter_prop_another_to_tracked_set` for
+/// the Day-of-the-Doctor "all other X" class.
+fn try_parse_counted_free_cast_from_exiled_this_way(rest: &str) -> Option<Effect> {
+    type E<'a> = OracleError<'a>;
+    // CR 601.2: "up to N" — the counted bound. A fixed number only; variable
+    // counts ("up to X") have no concrete cap at parse time and fall through
+    // to the existing permission-based arms.
+    let (after_count, _) = tag::<_, _, E>("up to ").parse(rest).ok()?;
+    let (after_count, count) = nom_primitives::parse_number.parse(after_count).ok()?;
+    if count == 0 || count > u8::MAX as u32 {
+        return None;
+    }
+    // CR 601.2a: the "spells" noun — this window casts spells (a land card can
+    // never be cast, CR 305.1), so require the spell noun rather than "cards".
+    let (after_noun, _) = alt((tag::<_, _, E>(" spells "), tag(" spell ")))
+        .parse(after_count)
+        .ok()?;
+
+    let mut filter = parse_from_among_exiled_this_way(after_noun)?;
+    // CR 608.2c: "the OTHER cards exiled this way" — rewrite the
+    // source-relative `Another` into the tracked-set complement of the prior
+    // choose's picks (see doc comment).
+    rewrite_target_filter_another_to_tracked_set(&mut filter);
+
+    Some(Effect::FreeCastFromZones {
+        count: count as u8,
+        max_total_mv: None,
+        filter,
+        zones: vec![Zone::Exile],
+        exile_instead_of_graveyard: false,
+    })
+}
+
 /// CR 406.6 + CR 603.10a: Detect the `"from among cards exiled with [self-ref]"`
 /// anchor — the persistent per-source exile-link anaphor used by cards that
 /// reference their own tracked exile set from a later, independent ability
@@ -20870,6 +20917,24 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
             driver: crate::types::ability::CastFromZoneDriver::LingeringPermission,
             mana_spend_permission: None,
         });
+    }
+    // CR 608.2g + CR 601.2 + CR 118.9: "cast up to N spells from among the
+    // [other] cards exiled this way without paying their mana costs" — a
+    // COUNTED free-cast window over the resolution's exile set (Plargg and
+    // Nassari; ruling 2021-04-16: "All the spells you cast due to the
+    // triggered ability are cast during the resolution of that ability. You
+    // can cast them in any order."). The counted "up to N" bound is a hard
+    // cast cap, so this must NOT lower to `CastFromZone` (a per-object
+    // permission grant with no shared budget): route it to
+    // `Effect::FreeCastFromZones`, whose interactive window already owns the
+    // "up to `count`" stop-early loop (Invoke Calamity machinery). Placed
+    // before the uncounted `parse_from_among_exiled_this_way` arm below so the
+    // counted form wins; uncounted forms (Etali Primal Conqueror's "cast any
+    // number") keep their existing lowering.
+    if mode == CardPlayMode::Cast && without_paying {
+        if let Some(effect) = try_parse_counted_free_cast_from_exiled_this_way(rest) {
+            return Some(effect);
+        }
     }
     // CR 610.3 + CR 118.9 + CR 608.2c + CR 701.13a: "Cast [quantifier] [filter]
     // from among [the|those] [typed] cards exiled this way" — the article-`the`

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -18592,6 +18592,31 @@ fn lower_subject_predicate_ast(
                 }
                 return clause;
             }
+            // CR 608.2d: "An opponent chooses a nonland card exiled this way"
+            // (Plargg and Nassari) — `strip_subject_clause` peeled the
+            // "an opponent" subject and deconjugated the predicate to "choose
+            // a nonland card exiled this way", which the imperative layer
+            // lowered to `ChooseFromZone` with the default `Chooser::Controller`.
+            // The subject names the selecting player, not an affected object,
+            // so rebind the chooser to `Chooser::Opponent` (the same delegation
+            // `try_parse_return_opponent_choice_from_graveyard` encodes for
+            // "of an opponent's choice"). Matched narrowly on the bare
+            // single-opponent player filter the "an opponent" / "your opponent"
+            // subject arms produce (subject.rs `parse_subject_application`) —
+            // typed or property-carrying subjects fall through to the honesty
+            // gate below.
+            if let Effect::ChooseFromZone { chooser, .. } = &mut clause.effect {
+                if matches!(
+                    &subject.affected,
+                    TargetFilter::Typed(tf)
+                        if tf.controller == Some(ControllerRef::Opponent)
+                            && tf.type_filters.is_empty()
+                            && tf.properties.is_empty()
+                ) {
+                    *chooser = crate::types::ability::Chooser::Opponent;
+                    return clause;
+                }
+            }
             if matches!(
                 &clause.effect,
                 Effect::ChooseFromZone {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -18605,14 +18605,27 @@ fn lower_subject_predicate_ast(
             // subject arms produce (subject.rs `parse_subject_application`) —
             // typed or property-carrying subjects fall through to the honesty
             // gate below.
+            //
+            // The targeted form ("target opponent chooses …" — Forgotten Lore,
+            // Shrouded Lore) is deliberately NOT rebound: `parse_target` lowers
+            // "target opponent" to the same bare opponent filter, but the
+            // subject then carries `target: Some(_)` — the chooser is bound to
+            // a chosen target slot, not "an opponent of the controller's
+            // choice", and `Chooser::Opponent` cannot represent that binding.
+            // Gating on `subject.target.is_none()` keeps those cards on the
+            // honesty gate below — the same fall-through the exiled-this-way
+            // anaphor keeps for its targeted form (imperative.rs
+            // `try_parse_choose_exiled_anaphor`).
             if let Effect::ChooseFromZone { chooser, .. } = &mut clause.effect {
-                if matches!(
-                    &subject.affected,
-                    TargetFilter::Typed(tf)
-                        if tf.controller == Some(ControllerRef::Opponent)
-                            && tf.type_filters.is_empty()
-                            && tf.properties.is_empty()
-                ) {
+                if subject.target.is_none()
+                    && matches!(
+                        &subject.affected,
+                        TargetFilter::Typed(tf)
+                            if tf.controller == Some(ControllerRef::Opponent)
+                                && tf.type_filters.is_empty()
+                                && tf.properties.is_empty()
+                    )
+                {
                     *chooser = crate::types::ability::Chooser::Opponent;
                     return clause;
                 }
@@ -20931,7 +20944,13 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
     // before the uncounted `parse_from_among_exiled_this_way` arm below so the
     // counted form wins; uncounted forms (Etali Primal Conqueror's "cast any
     // number") keep their existing lowering.
-    if mode == CardPlayMode::Cast && without_paying {
+    //
+    // CR 601.2 (strict-lowering rule): `Effect::FreeCastFromZones` carries no
+    // cast-constraint channel, so a parsed `constraint` (e.g. a timing rider)
+    // MUST NOT be silently dropped into an unconstrained window — gate this
+    // arm on `constraint.is_none()` and let constrained forms fall through to
+    // the arms that carry (or strictly reject) the constraint.
+    if mode == CardPlayMode::Cast && without_paying && constraint.is_none() {
         if let Some(effect) = try_parse_counted_free_cast_from_exiled_this_way(rest) {
             return Some(effect);
         }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -39542,6 +39542,67 @@ fn plargg_and_nassari_full_trigger_chain_choose_then_cast_others() {
     );
 }
 
+/// Search for Survivors — "An opponent chooses a card at random in your
+/// graveyard." The bare, untargeted "an opponent" subject goes through the
+/// same `lower_subject_predicate_ast` chooser rebind that Plargg and Nassari
+/// exercises, so the sentence now lowers to a delegated random graveyard
+/// choose instead of the pre-rebind `Unimplemented` fall-through. This test
+/// claims that parse-diff entry deliberately.
+#[test]
+fn search_for_survivors_opponent_chooses_at_random_in_your_graveyard() {
+    let def = parse_effect_chain(
+        "an opponent chooses a card at random in your graveyard.",
+        AbilityKind::Spell,
+    );
+    let Effect::ChooseFromZone {
+        count,
+        ref zone,
+        ref chooser,
+        ref selection,
+        ..
+    } = *def.effect
+    else {
+        panic!("expected ChooseFromZone, got {:?}", def.effect);
+    };
+    assert_eq!(count, 1);
+    assert_eq!(
+        *zone,
+        Zone::Graveyard,
+        "\"in your graveyard\" names the zone"
+    );
+    assert_eq!(
+        *chooser,
+        Chooser::Opponent,
+        "CR 608.2d: the untargeted \"an opponent\" subject must rebind the chooser"
+    );
+    assert_eq!(
+        *selection,
+        crate::types::ability::CardSelectionMode::Random,
+        "CR 608.2d: \"at random\" must survive into the selection mode"
+    );
+}
+
+/// Forgotten Lore / Shrouded Lore — "Target opponent chooses a card in your
+/// graveyard." `parse_target` lowers "target opponent" to the same bare
+/// opponent filter as "an opponent", but the subject carries a target slot:
+/// the chooser is a chosen TARGET, not "an opponent of the controller's
+/// choice", and `Chooser::Opponent` cannot represent that binding. The
+/// chooser rebind is therefore gated on `subject.target.is_none()`, and the
+/// targeted form must keep its honest `Unimplemented` fall-through rather
+/// than silently collapsing the target identity.
+#[test]
+fn target_opponent_chooses_in_your_graveyard_keeps_honest_fall_through() {
+    let def = parse_effect_chain(
+        "target opponent chooses a card in your graveyard.",
+        AbilityKind::Spell,
+    );
+    assert!(
+        matches!(*def.effect, Effect::Unimplemented { ref name, .. } if name == "choose"),
+        "the targeted chooser form must stay on the honesty gate, got {:?}",
+        def.effect
+    );
+}
+
 #[test]
 fn parser_shape_evelyn_exiles_each_library_with_collection_counter_and_permission() {
     let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -39425,6 +39425,108 @@ fn each_player_exiles_outer_effect_lowers_to_exile_from_top_until() {
     );
 }
 
+/// CR 607.2a + CR 608.2d: Plargg and Nassari's FULL upkeep-trigger body — all
+/// three sentences must assemble into one chain: the `player_scope: All`
+/// exile-until head, then the previously-Unimplemented middle sentence
+/// ("An opponent chooses a nonland card exiled this way") lowering to
+/// `ChooseFromZone { Exile, AllOwners, chooser: Opponent }` whose filter
+/// intersects the nonland type restriction with the `ExiledBySource` linked
+/// set, then the "cast … from among the OTHER cards exiled this way" tail as
+/// its `CastFromZone` sub-ability. The middle lowering exercises the
+/// subject-strip → imperative-fallback → opponent-chooser rebind seam in
+/// `lower_subject_predicate_ast`, and the same typed exiled-this-way anaphor
+/// covers Author of Shadows' subjectless "Choose a nonland card exiled this
+/// way."
+#[test]
+fn plargg_and_nassari_full_trigger_chain_choose_then_cast_others() {
+    let def = parse_effect_chain(
+        "each player exiles cards from the top of their library until they exile a nonland card. an opponent chooses a nonland card exiled this way. you may cast up to two spells from among the other cards exiled this way without paying their mana costs.",
+        AbilityKind::Spell,
+    );
+
+    assert_eq!(
+        def.player_scope,
+        Some(PlayerFilter::All),
+        "player_scope must propagate from \"each player\" subject"
+    );
+    assert!(
+        matches!(*def.effect, Effect::ExileFromTopUntil { .. }),
+        "head must be ExileFromTopUntil, got {:?}",
+        def.effect
+    );
+
+    let choose = def
+        .sub_ability
+        .as_ref()
+        .expect("middle sentence must attach as the first sub-ability");
+    let Effect::ChooseFromZone {
+        count,
+        ref zone,
+        ref zone_owner,
+        ref filter,
+        ref chooser,
+        ..
+    } = *choose.effect
+    else {
+        panic!("expected ChooseFromZone middle, got {:?}", choose.effect);
+    };
+    assert_eq!(count, 1);
+    assert_eq!(*zone, Zone::Exile);
+    assert_eq!(
+        *zone_owner,
+        ZoneOwner::AllOwners,
+        "CR 400.1: exile is shared — ownership must not gate the pool"
+    );
+    assert_eq!(
+        *chooser,
+        Chooser::Opponent,
+        "CR 608.2d: the \"an opponent\" subject must rebind the chooser"
+    );
+    let Some(TargetFilter::And { ref filters }) = *filter else {
+        panic!("expected And{{Typed, ExiledBySource}} filter, got {filter:?}");
+    };
+    assert!(
+        filters.contains(&TargetFilter::ExiledBySource),
+        "CR 607.2a: \"exiled this way\" must reference the linked-exile set"
+    );
+    assert!(
+        filters.iter().any(|f| matches!(
+            f,
+            TargetFilter::Typed(tf)
+                if tf.type_filters.iter().any(
+                    |t| matches!(t, TypeFilter::Non(inner) if matches!(**inner, TypeFilter::Land))
+                )
+        )),
+        "the nonland qualifier must survive into the choose filter"
+    );
+
+    let cast = choose
+        .sub_ability
+        .as_ref()
+        .expect("the cast tail must nest under the choose");
+    let Effect::CastFromZone {
+        ref target,
+        without_paying_mana_cost,
+        ..
+    } = *cast.effect
+    else {
+        panic!("expected CastFromZone tail, got {:?}", cast.effect);
+    };
+    assert!(without_paying_mana_cost, "free-cast rider must survive");
+    let TargetFilter::And { filters: ref cf } = *target else {
+        panic!("expected And cast target, got {target:?}");
+    };
+    assert!(cf.contains(&TargetFilter::ExiledBySource));
+    assert!(
+        cf.iter().any(|f| matches!(
+            f,
+            TargetFilter::Typed(tf)
+                if tf.properties.contains(&FilterProp::Another)
+        )),
+        "\"the OTHER cards\" must carry FilterProp::Another"
+    );
+}
+
 #[test]
 fn parser_shape_evelyn_exiles_each_library_with_collection_counter_and_permission() {
     let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -39504,26 +39504,41 @@ fn plargg_and_nassari_full_trigger_chain_choose_then_cast_others() {
         .sub_ability
         .as_ref()
         .expect("the cast tail must nest under the choose");
-    let Effect::CastFromZone {
-        ref target,
-        without_paying_mana_cost,
-        ..
+    let Effect::FreeCastFromZones {
+        count: cast_count,
+        ref filter,
+        ref zones,
+        max_total_mv,
+        exile_instead_of_graveyard,
     } = *cast.effect
     else {
-        panic!("expected CastFromZone tail, got {:?}", cast.effect);
+        panic!("expected FreeCastFromZones tail, got {:?}", cast.effect);
     };
-    assert!(without_paying_mana_cost, "free-cast rider must survive");
-    let TargetFilter::And { filters: ref cf } = *target else {
-        panic!("expected And cast target, got {target:?}");
+    assert_eq!(
+        cast_count, 2,
+        "CR 601.2 + ruling 2021-04-16: the \"up to two\" bound must be carried"
+    );
+    assert_eq!(*zones, vec![Zone::Exile]);
+    assert_eq!(max_total_mv, None);
+    assert!(!exile_instead_of_graveyard);
+    let TargetFilter::And { filters: ref cf } = *filter else {
+        panic!("expected And cast filter, got {filter:?}");
     };
-    assert!(cf.contains(&TargetFilter::ExiledBySource));
+    assert!(
+        cf.contains(&TargetFilter::ExiledBySource),
+        "CR 607.2a: the window pool must stay inside the linked-exile set"
+    );
     assert!(
         cf.iter().any(|f| matches!(
             f,
             TargetFilter::Typed(tf)
-                if tf.properties.contains(&FilterProp::Another)
+                if tf.properties.iter().any(|p| matches!(
+                    p,
+                    FilterProp::Not { prop }
+                        if matches!(**prop, FilterProp::InTrackedSet { .. })
+                ))
         )),
-        "\"the OTHER cards\" must carry FilterProp::Another"
+        "\"the OTHER cards\" must exclude the opponent's pick via Not(InTrackedSet)"
     );
 }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3100,6 +3100,13 @@ pub enum ResolutionCastSuccessAction {
         zones: Vec<Zone>,
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         exile_instead_of_graveyard: bool,
+        /// CR 406.6: Source object of the granting ability, threaded so
+        /// `ExiledBySource`-style filters (Plargg and Nassari) can rebuild the
+        /// re-offer candidate set against the right exile links. Zero sentinel
+        /// for saved states predating the field (graveyard/hand windows never
+        /// read it).
+        #[serde(default = "super::game_state::zero_object_id")]
+        source: super::identifiers::ObjectId,
     },
 }
 

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3107,6 +3107,15 @@ pub enum ResolutionCastSuccessAction {
         /// read it).
         #[serde(default = "super::game_state::zero_object_id")]
         source: super::identifiers::ObjectId,
+        /// CR 607.2a + CR 608.2g: THIS resolution's "exiled this way" batch,
+        /// threaded from the window that offered the cast so the re-offer's
+        /// candidate set stays confined to the current resolution's exile
+        /// batch (Plargg and Nassari) rather than the source's complete live
+        /// linked-exile ledger. Empty means "no batch restriction" (Invoke
+        /// Calamity's graveyard/hand window; saved states predating the
+        /// field).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        member_pool: Vec<super::identifiers::ObjectId>,
     },
 }
 

--- a/crates/engine/src/types/action_stable_order.rs
+++ b/crates/engine/src/types/action_stable_order.rs
@@ -171,6 +171,12 @@ fn cmp_payload(a: &GameAction, b: &GameAction) -> Ordering {
             };
             cmp_val(a0, b0)
         }
+        GameAction::ChooseZoneOpponentChooser { opponent: a0 } => {
+            let GameAction::ChooseZoneOpponentChooser { opponent: b0 } = b else {
+                unreachable!("cmp_payload: same-variant invariant");
+            };
+            cmp_val(a0, b0)
+        }
         GameAction::ChoosePileOpponent { opponent: a0 } => {
             let GameAction::ChoosePileOpponent { opponent: b0 } = b else {
                 unreachable!("cmp_payload: same-variant invariant");

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -201,6 +201,13 @@ pub enum GameAction {
     ChooseClashOpponent {
         opponent: PlayerId,
     },
+    /// CR 608.2d: The controller's choice of which opponent makes a resolving
+    /// "an opponent chooses …" zone selection, answering a pending
+    /// `WaitingFor::ChooseFromZoneOpponentChooser`. `opponent` must be one of
+    /// that prompt's `candidates`.
+    ChooseZoneOpponentChooser {
+        opponent: PlayerId,
+    },
     /// CR 608.2d + CR 700.3: "An opponent separates" — the controller's answer
     /// to `WaitingFor::SeparatePilesChooseOpponent`.
     ChoosePileOpponent {
@@ -1622,6 +1629,7 @@ impl GameAction {
             | GameAction::ChooseMutateMergeSide { .. }
             | GameAction::CipherEncode { .. }
             | GameAction::ChooseClashOpponent { .. }
+            | GameAction::ChooseZoneOpponentChooser { .. }
             | GameAction::ChoosePileOpponent { .. }
             | GameAction::ChooseAnnouncingOpponent { .. }
             | GameAction::ChooseAssistPlayer { .. }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6780,6 +6780,13 @@ pub enum SpellCostSource {
     Emerge,
 }
 
+/// Serde default for offer-payload source fields added after the variant
+/// shipped: saved states predating the field deserialize to the `ObjectId(0)`
+/// sentinel (never a real object; such windows never read the source).
+pub(crate) fn zero_object_id() -> ObjectId {
+    ObjectId(0)
+}
+
 /// The specific kind of cast offer being presented to the player.
 /// Parameterizes `WaitingFor::CastOffer` — all variants share `player: PlayerId`
 /// at the outer level; the kind-specific payload lives here.
@@ -6869,6 +6876,14 @@ pub enum CastOfferKind {
         /// to their owner's graveyard.
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         exile_instead_of_graveyard: bool,
+        /// CR 406.6: Source object of the granting ability. `filter`s such as
+        /// `ExiledBySource` (Plargg and Nassari's "the other cards exiled this
+        /// way") resolve their exile links against this id, so the re-offer
+        /// loop must rebuild candidates with the real source rather than a
+        /// sentinel. Defaults to the zero sentinel for saved states predating
+        /// the field (graveyard/hand windows never read it).
+        #[serde(default = "zero_object_id")]
+        source: ObjectId,
     },
     /// CR 608.2g + CR 609.4b: A during-resolution PAID cast of a single card
     /// from a graveyard (Quistis Trepe, Tinybones the Pickpocket: "you may cast
@@ -8535,6 +8550,21 @@ pub enum WaitingFor {
         candidates: Vec<PlayerId>,
         ability: Box<crate::types::ability::ResolvedAbility>,
     },
+    /// CR 608.2d: A resolving `ChooseFromZone { chooser: Opponent }` ("an
+    /// opponent chooses …") in a multiplayer game — the controller (`player`)
+    /// first decides WHICH opponent makes the choice (Plargg and Nassari's
+    /// release notes: "you choose which opponent gets to choose one of the
+    /// exiled nonland cards"). Only entered with two or more live opponents
+    /// and no pre-targeted opponent (one opponent has no decision;
+    /// "target opponent chooses" pre-binds the chooser at announcement).
+    /// `candidates` is the legal opponent set; `ability` is the resolving
+    /// choose ability, carried so the zone choice can be presented to the
+    /// picked opponent.
+    ChooseFromZoneOpponentChooser {
+        player: PlayerId,
+        candidates: Vec<PlayerId>,
+        ability: Box<crate::types::ability::ResolvedAbility>,
+    },
     /// CR 601.2c + CR 115.1: A spell with an "of an opponent's choice" target slot
     /// is being cast in a multiplayer game; the controller (`player`) chooses
     /// which opponent will announce that slot's target. Only entered with two or
@@ -9390,6 +9420,7 @@ impl WaitingFor {
             WaitingFor::TopOrBottomChoice { .. } => "TopOrBottomChoice",
             WaitingFor::PopulateChoice { .. } => "PopulateChoice",
             WaitingFor::ClashChooseOpponent { .. } => "ClashChooseOpponent",
+            WaitingFor::ChooseFromZoneOpponentChooser { .. } => "ChooseFromZoneOpponentChooser",
             WaitingFor::ChooseAnnouncingOpponent { .. } => "ChooseAnnouncingOpponent",
             WaitingFor::ClashCardPlacement { .. } => "ClashCardPlacement",
             WaitingFor::VoteChoice { .. } => "VoteChoice",
@@ -9529,6 +9560,7 @@ impl WaitingFor {
             | WaitingFor::TopOrBottomChoice { player, .. }
             | WaitingFor::PopulateChoice { player, .. }
             | WaitingFor::ClashChooseOpponent { player, .. }
+            | WaitingFor::ChooseFromZoneOpponentChooser { player, .. }
             | WaitingFor::ChooseAnnouncingOpponent { player, .. }
             | WaitingFor::ClashCardPlacement { player, .. }
             | WaitingFor::CompanionReveal { player, .. }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6884,6 +6884,20 @@ pub enum CastOfferKind {
         /// the field (graveyard/hand windows never read it).
         #[serde(default = "zero_object_id")]
         source: ObjectId,
+        /// CR 607.2a + CR 608.2g: THIS resolution's "exiled this way" batch —
+        /// the concrete member pool the preceding `ChooseFromZone` offered,
+        /// captured when its answer settled. `ExiledBySource` alone reads the
+        /// source's complete LIVE linked-exile ledger, so after an earlier
+        /// resolution left a linked nonland card in exile the next window
+        /// would wrongly offer that stale card; intersecting the offer with
+        /// this pool (before the `Not(InTrackedSet)` chosen-card exclusion)
+        /// confines it to "the other cards exiled this way" of the CURRENT
+        /// resolution (Plargg and Nassari). Empty means "no batch restriction"
+        /// — windows without a choose-linked batch (Invoke Calamity's
+        /// graveyard/hand window) and saved states predating the field keep
+        /// the unrestricted behavior.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        member_pool: Vec<ObjectId>,
     },
     /// CR 608.2g + CR 609.4b: A during-resolution PAID cast of a single card
     /// from a graveyard (Quistis Trepe, Tinybones the Pickpocket: "you may cast

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -1025,7 +1025,7 @@ pub fn unsupported_protocol_capabilities() -> &'static [UnsupportedCapability] {
     &UNSUPPORTED_PROTOCOL_CAPABILITIES
 }
 
-static UNSUPPORTED_PROTOCOL_CAPABILITIES: [UnsupportedCapability; 18] = [
+static UNSUPPORTED_PROTOCOL_CAPABILITIES: [UnsupportedCapability; 19] = [
     UnsupportedCapability {
         code: "upstream.response-envelope-mismatch",
         area: "transport",
@@ -1133,6 +1133,12 @@ static UNSUPPORTED_PROTOCOL_CAPABILITIES: [UnsupportedCapability; 18] = [
         area: "combat",
         reason: "The pinned protocol has no response shape for choosing the player, planeswalker, or battle attacked by an entering creature.",
         suggested_protocol_extension: "Add an entry-attack destination choice using the existing attack-target reference shape.",
+    },
+    UnsupportedCapability {
+        code: "local.zone-opponent-chooser-unsupported",
+        area: "prompts",
+        reason: "The pinned protocol has no typed choice for the controller picking which opponent makes a zone choice (CR 608.2d, e.g. Plargg and Nassari's 'an opponent chooses').",
+        suggested_protocol_extension: "Add a non-target opponent-picker choice carrying candidate player ids, mirroring the clash opponent selection shape.",
     },
 ];
 
@@ -4278,13 +4284,12 @@ mod protocol_wire_tests {
     #[test]
     fn unsupported_capability_registry_is_well_formed() {
         let capabilities = unsupported_protocol_capabilities();
-        assert_eq!(capabilities.len(), 18);
-
+        assert_eq!(capabilities.len(), 19);
         let codes: HashSet<_> = capabilities
             .iter()
             .map(|capability| capability.code)
             .collect();
-        assert_eq!(codes.len(), 18, "capability codes must be unique");
+        assert_eq!(codes.len(), 19, "capability codes must be unique");
 
         for capability in capabilities {
             assert!(

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -1711,6 +1711,9 @@ pub fn convert_available_action(action: &GameAction, id: String) -> AvailableAct
         GameAction::ChooseClashOpponent { .. } => {
             AvailableActionConversion::Unsupported("local.clash-unsupported")
         }
+        GameAction::ChooseZoneOpponentChooser { .. } => {
+            AvailableActionConversion::Unsupported("local.zone-opponent-chooser-unsupported")
+        }
         GameAction::ChooseAnnouncingOpponent { .. } => {
             AvailableActionConversion::Unsupported("local.announcing-opponent-unsupported")
         }

--- a/crates/phase-ai/src/decision_kind.rs
+++ b/crates/phase-ai/src/decision_kind.rs
@@ -149,6 +149,7 @@ pub fn classify(waiting_for: &WaitingFor, action: &GameAction) -> DecisionKind {
         | WaitingFor::CipherEncodeChoice { .. }
         | WaitingFor::PopulateChoice { .. }
         | WaitingFor::ClashChooseOpponent { .. }
+        | WaitingFor::ChooseFromZoneOpponentChooser { .. }
         | WaitingFor::ChooseAnnouncingOpponent { .. }
         | WaitingFor::ClashCardPlacement { .. }
         | WaitingFor::VoteChoice { .. }

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1203,6 +1203,12 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
             .first()
             .map(|&opponent| GameAction::ChooseClashOpponent { opponent }),
 
+        // CR 608.2d: "an opponent chooses …" — the controller picks which
+        // opponent makes the zone choice; fall back to the first candidate.
+        WaitingFor::ChooseFromZoneOpponentChooser { candidates, .. } => candidates
+            .first()
+            .map(|&opponent| GameAction::ChooseZoneOpponentChooser { opponent }),
+
         // CR 601.2c + CR 115.1: "of an opponent's choice" announcer — the
         // controller picks which opponent announces; fall back to the first.
         WaitingFor::ChooseAnnouncingOpponent { candidates, .. } => candidates

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -429,6 +429,7 @@ pub fn guard_game_action_payload(action: &GameAction) -> Result<(), String> {
         | GameAction::ChooseExert { .. }
         | GameAction::ChooseEnlist { .. }
         | GameAction::ChooseClashOpponent { .. }
+        | GameAction::ChooseZoneOpponentChooser { .. }
         | GameAction::ChoosePileOpponent { .. }
         | GameAction::ChooseAnnouncingOpponent { .. }
         | GameAction::ChooseAssistPlayer { .. }


### PR DESCRIPTION
## Summary
Adds engine support for **Plargg and Nassari**.

Closes the previously-unsupported `choose` gap on the upkeep trigger's middle sentence — "An opponent chooses a nonland card exiled this way." — across four seams:

1. **Parser (anaphor ):** `try_parse_choose_exiled_anaphor`'s "exiled this way" referent only supported the untyped chain-tracked-set form ("choose a card exiled this way") and fell through honestly on a typed qualifier. The typed form ("a **nonland** card exiled this way") now lowers to the same linked-exile shape as the Koh, the Face Stealer "exiled with ~" arm: `ChooseFromZone { zone: Exile, zone_owner: AllOwners, filter: And { Typed, ExiledBySource } }` (CR 607.2a linkage; CR 400.1 shared-zone scan). The card-type qualifier now also accepts negated `non<type>` forms (CR 205.2b), and a chooser-prefix alternation ("an opponent chooses" / "target opponent chooses" → `Chooser::Opponent`, CR 608.2d) mirrors `parse_choose_anaphoric`'s existing convention.
2. **Parser (subject layer):** `strip_subject_clause` peels "an opponent" and deconjugates the predicate to "choose …", losing the chooser. `lower_subject_predicate_ast` now rebinds the bare single-opponent subject onto `ChooseFromZone`'s `chooser` before the honesty gate; typed or property-carrying subjects still fall through to `Effect::unimplemented`.
3. **Runtime (choice continuation):** the `ChooseFromZoneChoice` handler bound the **chosen** card as the parked continuation's target list — correct for chosen-consumer continuations (End-Blaze Epiphany's "you may play that card") but inverted for Plargg's "cast up to two spells from among the **other** cards exiled this way". When the continuation head is an exile-linked `CastFromZone` whose target carries the `FilterProp::Another` exclusion, the handler now binds the **unchosen** complement (CR 608.2c); all other continuations are untouched.
4. **Runtime (candidate pool):** `resolve_candidate_cards` returned tracked-set-derived candidate pools **raw**, ignoring the effect's own card filter — the player-scope completion publishes *every* card the exile clause moved (lands included) as the chain tracked set, so the opponent was offered the lands too. A typed filter (`Some(...)`) now narrows tracked-set and explicit-target pools through `matches_target_filter` (CR 608.2d); `filter: None` keeps the raw set, so the untyped "choose one of them" tracked-set anaphors are unchanged. Surfaced by the new runtime regression test on this PR's first CI run.

## Files changed
- crates/engine/src/parser/oracle_effect/imperative.rs
- crates/engine/src/parser/oracle_effect/mod.rs
- crates/engine/src/parser/oracle_effect/tests.rs
- crates/engine/src/game/engine_resolution_choices.rs
- crates/engine/src/game/effects/choose_from_zone.rs
- crates/engine/src/game/effects/exile_from_top_until.rs

## CR references
- CR 101.4 (APNAP order for the multiplayer opponent choice)
- CR 205.2b (`non<type>` card-type qualifier)
- CR 400.1 (exile is a shared zone — ownership must not gate the pool)
- CR 607.2a ("exiled this way" is a linked-ability reference to the exiling instruction)
- CR 608.2c (effect resolution — the complement binding for "the other cards")
- CR 608.2d ("an opponent chooses" delegates the resolution-time selection)

## Implementation method (required)
Method: /engine-implementer

## Track
Non-developer

## LLM
Model: manus-1.5
Thinking: high

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.
- `./scripts/check-parser-combinators.sh origin/main` — `Gate G PASS` + `Gate A PASS head=7aaadbda3080edcb0b7cb6cae9e05565460879fc base=bdb1f3de5c37fc216d79c683c854be6448aad44c`
- `cargo check -p engine --lib` — `Finished` with zero errors and zero warnings (on the initial implementation commit; later commits validated by CI)
- Non-developer track: `cargo test -p engine` (including the five new tests below), `cargo fmt --check`, `cargo clippy-strict`, `cargo coverage`, and `cargo semantic-audit` are delegated to the CI-owned checks on this PR — the ephemeral sandbox was reset mid-run three times, so local test execution could not complete.
- CI status at head: Rust lint (fmt, clippy, parser gate), both test shards, Card data (generate, validate, coverage), WASM/Tauri compile checks, frontend, and lobby worker all green.
- New tests on this PR: `parse_choose_nonland_card_exiled_this_way`, `parse_opponent_chooses_nonland_card_exiled_this_way`, `parse_choose_card_exiled_this_way_still_tracked_set` (imperative.rs), `plargg_and_nassari_full_trigger_chain_choose_then_cast_others` (tests.rs), `plargg_opponent_chooses_nonland_hit_then_cast_pool_is_the_other_hits` (exile_from_top_until.rs, runtime `apply()`-driven).

## Gate A
Gate A PASS head=7aaadbda3080edcb0b7cb6cae9e05565460879fc base=bdb1f3de5c37fc216d79c683c854be6448aad44c

## Anchored on
- crates/engine/src/parser/oracle_effect/imperative.rs:4040 — Koh, the Face Stealer's "exiled with ~" arm: the existing `FromZone { Exile, AllOwners, And { Typed, ExiledBySource } }` lowering the typed "exiled this way" referent now reuses (CR 607.2a + CR 400.1).
- crates/engine/src/parser/oracle_effect/imperative.rs:3822 — `parse_choose_anaphoric`'s chooser alternation ("an opponent chooses N of them" → `Chooser::Opponent`), the CR 608.2d delegation convention the new chooser prefix mirrors.
- crates/engine/src/game/engine_resolution_choices.rs:3798 — the existing chosen/unchosen partition seam in the `ChooseFromZoneChoice` handler, which already forwards the unchosen remainder to the zone-partition sub-ability; the complement binding extends the same seam.

## Final review-impl
Final review-impl PASS head=7aaadbda3080edcb0b7cb6cae9e05565460879fc
- Full-diff pass against CLAUDE.md and the review-impl checklist: no string-method dispatch, no match-on-string-literal arms, no chained `if let Ok(tag)` blocks, no hand-built `Effect::Unimplemented` literals in the diff.
- Seam check: typed-anaphor lowering sits in the existing anaphor combinator (not a new dispatch path); the chooser rebind sits at the subject/predicate lowering seam where every other subject rebind lives; the complement binding sits at the single continuation-binding authority.
- Test discrimination: the runtime test drives the real pipeline (`resolve_ability_chain` → `WaitingFor::ChooseFromZoneChoice` → `apply(GameAction::SelectCards)`) and fails if the complement binding, the opponent chooser rebind, or the typed-anaphor filter is reverted. The untyped-referent regression guard pins End-Blaze-style impulse reductions to the chain tracked set.

## Claimed parse impact
- Plargg and Nassari
- Author of Shadows (middle sentence "Choose a nonland card exiled this way." — same typed exiled-this-way anaphor; the card's remaining clauses are unchanged)

## Validation Failures
None.

## CI Failures
Three red runs during iteration, each root-caused and fixed on this branch; the final head is green.
1. `Rust lint` — two rustfmt diffs in test/handler code introduced after a sandbox reset dropped the local `cargo fmt` pass. Fixed in 5578e01 by applying the exact rustfmt output.
2. `Rust tests (both shards)` — E0433: `WaitingFor` missing from the runtime test's local import list. Fixed in de0e127.
3. `Rust tests (shard 2/2)` — the new runtime regression test failed: the opponent's candidate pool contained all six exiled cards (lands included) because `resolve_candidate_cards` ignored the effect filter for chain-tracked-set pools. Fixed in 7aaadbd (Summary seam 4); shard 1, Card data, and all other checks were already green on the same run, and no pre-existing test changed behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new multiplayer “Choose Opponent” prompt flow when an opponent must be selected to make the next zone decision, including UI modal and localized text.
- **Bug Fixes**
  - Improved “an opponent chooses…” behavior by adding an intermediate opponent-selection step when multiple eligible opponents exist.
  - Tightened candidate selection/filtering for linked zone choices and free-cast windows, including correct handling for typed nonland and exile-by-source scenarios.
  - Ensured free-cast candidate eligibility and viewer-facing prompts consistently preserve originating source context.
- **Tests**
  - Added regression coverage for the Plargg/Nassari trigger chain, including opponent-chooser pauses and linked exile-to-free-cast behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->