### PR TITLE
fix(engine): read entered-this-turn quantities from the entry ledger (BB-FU10)

### DIFF
--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -2183,9 +2183,42 @@ fn scan_quantity_ref(x: &QuantityRef, mode: ScanMode) -> Axes {
             acc
         }
         QuantityRef::BattlefieldEntriesThisTurn { player, filter } => {
+            // CR 732.2a: axis-2 self-assertion. This tally is a board-derived
+            // AGGREGATE — `record_battlefield_entry` (game/restrictions.rs) APPENDS
+            // to `battlefield_entries_this_turn` on every battlefield entry, so a
+            // sibling resolution, or a loop cycle that grows the board, changes its
+            // value.
+            //
+            // The engine ALREADY classifies this journal as loop-pumped:
+            // `project_out_resources` clears it at analysis/resource.rs:2977 under
+            // "CR 400 (zones) / CR 603.6a (ETB) / CR 701.21 (sacrifice) / CR 111
+            // (tokens): append-only event journals a loop pumps". A `sibling: false`
+            // here contradicted that, and in the unsafe direction: it let the
+            // CR 732.2a firewall certify a loop as bounded while a live observer read
+            // the growing class. Per the module header above (ADD-1) over-veto is the
+            // ONLY permitted error direction (#4603-preserving).
+            //
+            // Per the ⛔ INVARIANT on the `TargetFilter::Typed` arm of
+            // `scan_target_filter`, a board-AGGREGATE caller MUST self-assert
+            // `sibling: true` and must NOT delegate its board-read signal to the
+            // `Typed` arm, whose `LoopFirewall` relaxation otherwise erases the
+            // signal at the two `ability_definition_reads_sibling_mutable_for_loop`
+            // scans inside `fire_time_conditions_read_growing_class` —
+            // analysis/resource.rs:1699 (trigger `execute` bodies) and :1722
+            // (battlefield ability bodies) — neither of which has a `projected` twin
+            // in `fire_time_conditions_read_projected_resource`.
+            //
+            // The CR 603.3b APNAP ordering gate (game/triggers.rs, the
+            // `c2_order_independent` term) is the OTHER consumer of this arm and is
+            // provably UNAFFECTED: it scans in `ScanMode::Conservative`, where the
+            // `Typed`/`Or[Typed]` filter every producer emits already forces
+            // `sibling: true` — measured.
+            //
+            // The `filter` census intent stays `SnapshotOrEvent`: it is matched
+            // against a `BattlefieldEntryRecord`, never a live board.
             let mut acc = Axes {
                 event: false,
-                sibling: false,
+                sibling: true,
                 projected: true,
             };
             acc = acc.or(scan_player_scope(player));
@@ -7774,6 +7807,159 @@ mod tests {
         let mut b = fixed_drain();
         b.target_constraints = vec![TargetSelectionConstraint::DifferentTargetPlayers];
         assert!(!ability_uses_event_context(&b));
+    }
+
+    // ---- BB-FU10 Step 0c: the CR 608.2i ledger read is an axis-2 board read ----
+
+    /// Build an `AbilityDefinition` whose effect magnitude is `qty`.
+    fn ability_def_with_amount(qty: QuantityRef) -> crate::types::ability::AbilityDefinition {
+        use crate::types::ability::{AbilityDefinition, AbilityKind};
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::GainLife {
+                amount: QuantityExpr::Ref { qty },
+                player: TargetFilter::Controller,
+            },
+        )
+    }
+
+    fn creature_filter() -> TargetFilter {
+        TargetFilter::Typed(TypedFilter {
+            type_filters: vec![crate::types::ability::TypeFilter::Creature],
+            controller: None,
+            properties: vec![],
+        })
+    }
+
+    /// T15 (BB-FU10 Step 0c). `battlefield_entries_this_turn` is APPENDED to by
+    /// every battlefield entry (`record_battlefield_entry`), so a read of it is a
+    /// board-derived AGGREGATE and must self-assert `sibling: true` — CR 732.2a:
+    /// the object-growth firewall may only ever OVER-veto, never certify a loop as
+    /// bounded while a live observer reads the growing class.
+    ///
+    /// VACUITY TRAP, named explicitly: assertion (1) is `ScanMode::Conservative`,
+    /// where the `TargetFilter::Typed` arm already forces `sibling: true`. It
+    /// passes with AND without Step 0c and is therefore NOT the discriminator.
+    /// Assertion (2) — `ScanMode::LoopFirewall`, the mode the two production
+    /// callers in `analysis::resource::fire_time_conditions_read_growing_class`
+    /// use — is the one Step 0c actually moves.
+    ///
+    /// REVERT-PROBE: set the arm's `sibling` back to `false` → (2) and (3) FAIL
+    /// while (1) still passes.
+    #[test]
+    fn bbfu10_ledger_ref_is_sibling_mutable_in_both_scan_modes() {
+        let ledger = ability_def_with_amount(QuantityRef::BattlefieldEntriesThisTurn {
+            player: PlayerScope::Controller,
+            filter: creature_filter(),
+        });
+        let live = ability_def_with_amount(QuantityRef::EnteredThisTurn {
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![crate::types::ability::TypeFilter::Creature],
+                controller: Some(crate::types::ability::ControllerRef::You),
+                properties: vec![],
+            }),
+        });
+
+        // (1) Conservative — vacuity trap, true either way.
+        assert!(
+            ability_definition_reads_sibling_mutable(&ledger),
+            "(1) Conservative axis-2 (CR 603.3b consumer) — passes with or without Step 0c",
+        );
+        // (2) THE DISCRIMINATOR — LoopFirewall, the CR 732.2a firewall's mode.
+        assert!(
+            ability_definition_reads_sibling_mutable_for_loop(&ledger),
+            "(2) CR 732.2a: the ledger read must stay axis-2 under LoopFirewall — \
+             this is the exact predicate analysis/resource.rs calls at the two \
+             `..._for_loop` scan sites",
+        );
+        // (3) parity guard — the look-back and live siblings must agree on both axes.
+        assert_eq!(
+            (
+                ability_definition_reads_sibling_mutable(&ledger),
+                ability_definition_reads_sibling_mutable_for_loop(&ledger),
+            ),
+            (
+                ability_definition_reads_sibling_mutable(&live),
+                ability_definition_reads_sibling_mutable_for_loop(&live),
+            ),
+            "(3) parity: `BattlefieldEntriesThisTurn` and `EnteredThisTurn` are the \
+             same board-aggregate class on the sibling axis",
+        );
+        // (4) the projected axis is untouched by Step 0c.
+        assert!(
+            resolved_ability_axes(
+                &ability_with_amount(QuantityRef::BattlefieldEntriesThisTurn {
+                    player: PlayerScope::Controller,
+                    filter: creature_filter(),
+                }),
+                ScanMode::LoopFirewall,
+            )
+            .projected,
+            "(4) `projected` was already true and stays true",
+        );
+    }
+
+    /// T17 (BB-FU10 Step 0c, T16's non-vacuity instrument). Proves the SHIPPED
+    /// Park Heights Pegasus face is what
+    /// `analysis::resource::fire_time_conditions_read_growing_class` block (1)
+    /// visits, and that the flip lands on the trigger `execute` scan rather than
+    /// on the Conservative trigger-`condition` path that already forces
+    /// `sibling: true` (the Gargoyle Flock trap: `true → true`, non-discriminating).
+    ///
+    /// REVERT-PROBE: set the ledger arm's `sibling` back to `false` → (2) FAILS.
+    /// Measured: PRE-0c `false`, POST-0c `true`, with `condition.is_none()` in both.
+    #[test]
+    fn bbfu10_shipped_ledger_observer_flips_for_loop_axis() {
+        let db = crate::test_support::shared_card_db();
+        let face = db
+            .face_index
+            .get("park heights pegasus")
+            .expect("Park Heights Pegasus is in tests/fixtures/integration_cards.json");
+
+        // (1) the flip CANNOT be landing on the Conservative `condition` path.
+        assert_eq!(face.triggers.len(), 1, "(1) exactly one trigger definition");
+        assert!(
+            face.triggers[0].condition.is_none(),
+            "(1) no intervening-if condition, so `trigger_condition_reads_sibling_mutable` \
+             (Conservative, always true for a Typed filter) is NOT what fires here",
+        );
+        let execute = face.triggers[0]
+            .execute
+            .as_deref()
+            .expect("(1) the trigger must carry an execute body");
+
+        // (3) reach-guard — the body really contains the ledger read.
+        let rendered = serde_json::to_string(execute).expect("AbilityDefinition serializes");
+        assert!(
+            rendered.contains("BattlefieldEntriesThisTurn"),
+            "(3) reach-guard: the scanned body must carry the CR 608.2i ledger read, \
+             not some other board aggregate",
+        );
+
+        // (2) THE DISCRIMINATOR — literally the callee at the block-(1) scan site.
+        assert!(
+            ability_definition_reads_sibling_mutable_for_loop(execute),
+            "(2) CR 732.2a: a shipped ledger observer must veto an object-growth \
+             certificate — reads `false` without Step 0c",
+        );
+
+        // (4) negative sibling — a plain draw trigger body does NOT veto.
+        let plain = crate::parser::parse_oracle_text(
+            "Whenever this creature deals combat damage to a player, draw a card.",
+            "Bbfu10 Plain Draw Trigger",
+            &[],
+            &["Creature".to_string()],
+            &[],
+        );
+        let plain_execute = plain
+            .triggers
+            .first()
+            .and_then(|t| t.execute.as_deref())
+            .expect("(4) the plain trigger must parse an execute body");
+        assert!(
+            !ability_definition_reads_sibling_mutable_for_loop(plain_execute),
+            "(4) negative sibling: a fixed draw reads no board aggregate",
+        );
     }
 
     // ---- Axis 2: sibling-mutable board read (Rubblebelt / Orcish class) ----

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -3887,6 +3887,12 @@ fn quantity_ref_target_slot_spec(qty: &QuantityRef) -> Option<TargetFilter> {
         | QuantityRef::CountersOnObjects { filter, .. }
         | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::EnteredThisTurn { filter }
+        // CR 608.2i: the look-back sibling of `EnteredThisTurn` carries the same
+        // kind of population filter, so it must reach the same recursion instead
+        // of dropping into the `_ => None` fallback. Direct precedent in this
+        // group: `SacrificedThisTurn` / `TokensCreatedThisTurn`, both
+        // `PlayerScope`-carrying history refs.
+        | QuantityRef::BattlefieldEntriesThisTurn { filter, .. }
         | QuantityRef::SacrificedThisTurn { filter, .. }
         | QuantityRef::ZoneChangeCountThisTurn { filter, .. }
         | QuantityRef::ZoneChangeAggregateThisTurn { filter, .. }
@@ -11339,6 +11345,57 @@ mod tests {
         assert!(quantity_expr_references_target_creature(&mana_spent));
 
         assert!(!filter_references_target_creature_quantity(&fixed_filter()));
+    }
+
+    /// T14a (BB-FU10 Step 3a). `QuantityRef::BattlefieldEntriesThisTurn` is the
+    /// CR 608.2i look-back sibling of `EnteredThisTurn` and carries the same kind
+    /// of population filter, so it must reach the count-over-filter recursion
+    /// instead of the `_ => None` fallback.
+    ///
+    /// DISCRIMINATING BY CONSTRUCTION: the nested count must itself be
+    /// target-referencing. `filter_prop_target_slot_filter` routes
+    /// `FilterProp::Counters { count, .. }` to `quantity_expr_target_slot_filter`,
+    /// which returns `Some` only for a target-bearing ref — a `Fixed(1)` nested
+    /// count would be `None` both before AND after the fix (red in both
+    /// directions, i.e. broken rather than discriminating).
+    ///
+    /// REVERT-PROBE: remove the one-line or-group addition → `None`, FAIL.
+    #[test]
+    fn bbfu10_ledger_variant_surfaces_target_slot_filter() {
+        use crate::types::ability::FilterProp;
+        use crate::types::counter::{CounterMatch, CounterType};
+
+        let props = vec![FilterProp::Counters {
+            counters: CounterMatch::OfType(CounterType::Plus1Plus1),
+            comparator: Comparator::GE,
+            count: QuantityExpr::Ref {
+                qty: QuantityRef::Power {
+                    scope: ObjectScope::Target,
+                },
+            },
+        }];
+        let filter = TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Creature],
+            controller: None,
+            properties: props,
+        });
+
+        let ledger = QuantityRef::BattlefieldEntriesThisTurn {
+            player: PlayerScope::Controller,
+            filter: filter.clone(),
+        };
+        let live = QuantityRef::EnteredThisTurn { filter };
+
+        assert_eq!(
+            quantity_ref_target_slot_spec(&ledger),
+            Some(TargetFilter::Typed(TypedFilter::creature())),
+            "CR 608.2i: the ledger variant must surface the nested target slot",
+        );
+        assert_eq!(
+            quantity_ref_target_slot_spec(&ledger),
+            quantity_ref_target_slot_spec(&live),
+            "parity guard: the look-back and live siblings must agree",
+        );
     }
 
     /// CR 115.1 + CR 208.1 + CR 202.3 + CR 701.9 + CR 120.9: the count-derived

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -7516,7 +7516,27 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::BendTypesThisTurn => ("BendTypesThisTurn", Handled),
         QuantityRef::LifeGainedThisTurn { .. } => ("LifeGainedThisTurn", Handled),
         QuantityRef::CardsDrawnThisTurn { .. } => ("CardsDrawnThisTurn", Handled),
-        QuantityRef::BattlefieldEntriesThisTurn { .. } => ("BattlefieldEntriesThisTurn", Handled),
+        // CR 608.2h: `Handled` only when the entry-record matcher can actually evaluate the
+        // filter. `battlefield_entry_matches_filter` fails closed on props the entry snapshot
+        // never captured (game/restrictions.rs:517), so such a card would resolve a silent
+        // constant 0 while claiming support.
+        //
+        // REACHABILITY (measured, MTGJSON sweep): this arm is reached from
+        // `StaticDefinition.condition` (`:7050-7053`), ability conditions, `repeat_for`, and
+        // effect positions — 21 cards, 15 of them purely static-condition (e.g. Armory Mice,
+        // Saddled Rimestag, Mechan Shieldmate). It is NOT reached from a trigger
+        // intervening-if: `:7040-7042` emits only the structural tag and never descends, so
+        // Tunnel Tipster's `FilterProp::FaceDown` ledger read stays invisible here (see the
+        // §10.11 ledger item). No corpus card currently trips this arm (`unhandled=0`); it is a
+        // guard against the next printing, not a live reclassification.
+        QuantityRef::BattlefieldEntriesThisTurn { filter, .. } => (
+            "BattlefieldEntriesThisTurn",
+            if crate::game::restrictions::ledger_filter_is_evaluable(filter) {
+                Handled
+            } else {
+                Unhandled
+            },
+        ),
         QuantityRef::LandsPlayedThisTurn { .. } => ("LandsPlayedThisTurn", Handled),
         QuantityRef::ZoneChangeCountThisTurn { .. } => ("ZoneChangeCountThisTurn", Handled),
         QuantityRef::ZoneChangeAggregateThisTurn { .. } => ("ZoneChangeAggregateThisTurn", Handled),
@@ -12263,6 +12283,69 @@ mod tests {
             support,
             FeatureSupport::Handled,
             "TargetZoneCardCount is resolved by game::quantity and should not block coverage",
+        );
+    }
+
+    /// T22 (Step 7c). `battlefield_entry_matches_filter` fails closed on the
+    /// `FilterProp`s the entry snapshot never captured, so a ledger read over one
+    /// of them resolves a silent constant 0. The classifier must stop calling that
+    /// `Handled`. Case (a) is Tunnel Tipster's real live *filter shape* (its
+    /// intervening-if carries `FilterProp::FaceDown`, so its trigger can never fire);
+    /// note the classifier never reaches Tunnel Tipster's trigger intervening-if
+    /// (see `:7519`), so this test drives `quantity_ref_feature` directly.
+    ///
+    /// REVERT-PROBE: restore the unconditional `Handled` arm → (a) and (d) FAIL;
+    /// (b)/(c) pass in both builds and are the vacuity controls.
+    #[test]
+    fn ledger_ref_feature_is_unhandled_when_filter_is_unevaluable() {
+        let ledger = |properties: Vec<FilterProp>| QuantityRef::BattlefieldEntriesThisTurn {
+            player: PlayerScope::Controller,
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                controller: None,
+                properties,
+            }),
+        };
+
+        // (a) Tunnel Tipster's shape — unanswerable from the entry record.
+        assert_eq!(
+            quantity_ref_feature(&ledger(vec![FilterProp::FaceDown])),
+            ("BattlefieldEntriesThisTurn", FeatureSupport::Unhandled),
+            "(a) FaceDown is not answerable from a BattlefieldEntryRecord"
+        );
+        // (b)/(c) vacuity controls — the feature stays Handled for evaluable filters.
+        assert_eq!(
+            quantity_ref_feature(&ledger(vec![])),
+            ("BattlefieldEntriesThisTurn", FeatureSupport::Handled),
+            "(b) a bare filter is trivially evaluable"
+        );
+        assert_eq!(
+            quantity_ref_feature(&ledger(vec![FilterProp::HasColor {
+                color: ManaColor::Green
+            }])),
+            ("BattlefieldEntriesThisTurn", FeatureSupport::Handled),
+            "(c) HasColor is one of the four props the matcher answers"
+        );
+        // (d) composite recursion — one unanswerable leaf poisons the whole read.
+        let QuantityRef::BattlefieldEntriesThisTurn { filter: bare, .. } = ledger(vec![]) else {
+            unreachable!()
+        };
+        let QuantityRef::BattlefieldEntriesThisTurn {
+            filter: face_down, ..
+        } = ledger(vec![FilterProp::FaceDown])
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            quantity_ref_feature(&QuantityRef::BattlefieldEntriesThisTurn {
+                player: PlayerScope::Controller,
+                filter: TargetFilter::Or {
+                    filters: vec![bare, face_down]
+                },
+            }),
+            ("BattlefieldEntriesThisTurn", FeatureSupport::Unhandled),
+            "(d) CR 608.2i: an Or disjunct the matcher drops is a silent partial count of a \
+             look-back read"
         );
     }
 

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -641,7 +641,11 @@ pub(crate) fn candidate_player_scalar_with_state(
                     .filter(|record| {
                         record.controller == candidate.id
                             && crate::game::restrictions::battlefield_entry_matches_filter(
-                                record, filter, controller, None,
+                                record,
+                                filter,
+                                controller,
+                                &state.all_creature_types,
+                                None,
                             )
                     })
                     .count(),

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -2716,7 +2716,7 @@ fn zone_change_filter_inner(
 /// Changeling. This helper is the canonical fallback for non-battlefield
 /// zones — library, hand, graveyard, exile, stack, plus zone-change snapshots
 /// and spell-cast records — where the layer system does not run.
-fn subtype_matches_with_changeling(
+pub(crate) fn subtype_matches_with_changeling(
     subtype: &str,
     subtypes: &[String],
     keywords: &[Keyword],
@@ -2737,7 +2737,7 @@ fn subtype_matches_with_changeling(
     false
 }
 
-fn subtype_matches_host_supertype(subtype: &str, supertypes: &[Supertype]) -> bool {
+pub(crate) fn subtype_matches_host_supertype(subtype: &str, supertypes: &[Supertype]) -> bool {
     subtype.eq_ignore_ascii_case("host") && supertypes.contains(&Supertype::Host)
 }
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -851,10 +851,15 @@ pub(crate) fn static_condition_uses_unspent_mana(condition: &StaticCondition) ->
 
 /// CR 611.3a + CR 613.7d: Leaf classification for `quantity_expr_uses_object_count`.
 /// EXHAUSTIVE and wildcard-free — adding a `QuantityRef` variant forces a
-/// decision here. `true` for any reference that reads battlefield object
-/// population; `false` for single-object, player-level, history-record, and
-/// payment/choice references whose value is unaffected by another object
-/// entering or leaving the battlefield.
+/// decision here. `true` for any reference whose value another object's
+/// battlefield entry or departure can change; `false` for single-object,
+/// player-level, payment/choice, and history-record references whose value is
+/// unaffected by another object entering or leaving the battlefield.
+///
+/// "Population" here means the counted set, not necessarily a LIVE board census:
+/// a per-turn journal that every battlefield entry appends to (CR 608.2i
+/// look-back tallies) is population-sensitive in the sense this classifier means,
+/// even though it is a history record rather than a board scan.
 fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
     match qty {
         // Read battlefield object population directly.
@@ -870,6 +875,17 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::DistinctColorsAmongPermanents { .. }
         | QuantityRef::DistinctCounterKindsAmong { .. }
         | QuantityRef::EnteredThisTurn { .. }
+        // CR 611.3a + CR 608.2i: a continuous effect from a static ability is
+        // never "locked in", and this operand is the CR 608.2i look-back tally
+        // over `battlefield_entries_this_turn` — a per-turn journal that
+        // `record_battlefield_entry` (restrictions.rs) APPENDS to on every
+        // battlefield entry, including one produced by a sibling resolution. So
+        // an object entering DOES change this value even though it is a history
+        // journal rather than a live board census. Layer 7c magnitudes built on
+        // it (Kinbinding) must force the incremental-flush escalation scan in
+        // `active_effects_force_incremental_escalation` or a plain token entry
+        // leaves PRE-EXISTING recipients stale.
+        | QuantityRef::BattlefieldEntriesThisTurn { .. }
         | QuantityRef::CommanderManaValue { .. } => true,
         // Distinct card types reads battlefield population ONLY when its source
         // is the object-filter variant; zone / linked-exile sources do not.
@@ -934,7 +950,6 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::BendTypesThisTurn
         | QuantityRef::LifeGainedThisTurn { .. }
         | QuantityRef::CardsDrawnThisTurn { .. }
-        | QuantityRef::BattlefieldEntriesThisTurn { .. }
         | QuantityRef::LandsPlayedThisTurn { .. }
         | QuantityRef::TurnsTaken
         | QuantityRef::ZoneChangeCountThisTurn { .. }
@@ -1035,7 +1050,22 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::ControlledByEachPlayer { filter, .. }
         | QuantityRef::DistinctColorsAmongPermanents { filter }
         | QuantityRef::DistinctCounterKindsAmong { filter }
-        | QuantityRef::EnteredThisTurn { filter } => {
+        | QuantityRef::EnteredThisTurn { filter }
+        // CR 611.3a + CR 608.2i: narrowed to "would THIS object's entry join the
+        // counted population?" via the same live-filter probe the
+        // `EnteredThisTurn` sibling uses. MONOTONICITY, not equivalence, is the
+        // guarantee: the arm this replaces was a constant `false`, and every
+        // consumer is a should-we-recompute gate where `true` schedules more work
+        // and never less, so pointwise `false <= false || matches_target_filter(..)`
+        // makes this strictly less stale than before for ANY filter. It is NOT a
+        // superset of the ledger matcher (`battlefield_entry_matches_filter`):
+        // that one reads the ENTRY-TIME record snapshot, so a
+        // `FilterProp::WithKeyword` whose keyword a Layer-6 effect later removes,
+        // or a controller-bearing filter under a non-`Controller` `player` scope,
+        // can still under-trigger. Neither is reachable from any producer today
+        // (all emit a bare `Typed`/`Or[Typed]`); the upgrade is a plain `=> true`
+        // if one becomes reachable.
+        | QuantityRef::BattlefieldEntriesThisTurn { filter, .. } => {
             matches_target_filter(state, entered.id, filter, ctx)
         }
         QuantityRef::DistinctCardTypes { source } => match source {
@@ -1131,7 +1161,6 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::BendTypesThisTurn
         | QuantityRef::LifeGainedThisTurn { .. }
         | QuantityRef::CardsDrawnThisTurn { .. }
-        | QuantityRef::BattlefieldEntriesThisTurn { .. }
         | QuantityRef::LandsPlayedThisTurn { .. }
         | QuantityRef::TurnsTaken
         | QuantityRef::ZoneChangeCountThisTurn { .. }
@@ -3275,7 +3304,9 @@ fn resolve_ref(
                 u32_to_i32_saturating(p.cards_drawn_this_turn)
             })
         }
-        // CR 403.3 + CR 608.2h: Battlefield entries this turn for the scoped player.
+        // CR 403.3 + CR 608.2h + CR 608.2i: Battlefield entries this turn for the
+        // scoped player. CR 608.2i is the look-back exception that makes a
+        // departed permanent still count.
         QuantityRef::BattlefieldEntriesThisTurn { player, ref filter } => {
             resolve_per_player_scalar(
                 state,
@@ -3295,6 +3326,7 @@ fn resolve_ref(
                                         record,
                                         filter,
                                         controller,
+                                        &state.all_creature_types,
                                         Some(filter_ctx.source_id),
                                     )
                             })

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -417,7 +417,11 @@ fn entry_controller_matches(
     }
 }
 
-fn entry_type_filter_matches(record: &BattlefieldEntryRecord, type_filter: &TypeFilter) -> bool {
+fn entry_type_filter_matches(
+    record: &BattlefieldEntryRecord,
+    type_filter: &TypeFilter,
+    all_creature_types: &[String],
+) -> bool {
     match type_filter {
         TypeFilter::Creature => record.core_types.contains(&CoreType::Creature),
         TypeFilter::Land => record.core_types.contains(&CoreType::Land),
@@ -437,17 +441,32 @@ fn entry_type_filter_matches(record: &BattlefieldEntryRecord, type_filter: &Type
             )
         }),
         TypeFilter::Card | TypeFilter::Any => true,
-        TypeFilter::Non(inner) => !entry_type_filter_matches(record, inner),
-        TypeFilter::Subtype(subtype) => record
-            .subtypes
-            .iter()
-            .any(|record_subtype| record_subtype.eq_ignore_ascii_case(subtype)),
+        TypeFilter::Non(inner) => !entry_type_filter_matches(record, inner, all_creature_types),
+        // CR 702.73a + CR 205.3m: a Changeling entrant is every creature type. The entry
+        // snapshot is taken pre-layer (`record_zone_change`, `:616`), so `record.subtypes`
+        // is NOT layer-expanded — but `record.keywords` carries Changeling, which is all the
+        // single authority needs. Mirrors `zone_change_record_matches_type_filter`
+        // (`game/filter.rs:2871-2878`), the same helper over the sibling snapshot type.
+        TypeFilter::Subtype(subtype) => {
+            crate::game::filter::subtype_matches_with_changeling(
+                subtype,
+                &record.subtypes,
+                &record.keywords,
+                all_creature_types,
+            ) || crate::game::filter::subtype_matches_host_supertype(subtype, &record.supertypes)
+        }
         TypeFilter::AnyOf(filters) => filters
             .iter()
-            .any(|inner| entry_type_filter_matches(record, inner)),
+            .any(|inner| entry_type_filter_matches(record, inner, all_creature_types)),
         // CR 308.1: Kindred type check.
         TypeFilter::Kindred => record.core_types.contains(&CoreType::Kindred),
-        _ => false,
+        // CR 403.3: permanents exist only on the battlefield, so a battlefield-entry
+        // record is never an instant or a sorcery. `false` is the correct verdict here,
+        // not a fail-closed one, and `Non(Instant)` correctly inverts to `true`.
+        // Exhaustive on purpose: a new `TypeFilter` variant must fail to compile rather
+        // than silently join this arm while `ledger_filter_is_evaluable` (`:570-572`)
+        // keeps reporting type filters evaluable.
+        TypeFilter::Instant | TypeFilter::Sorcery => false,
     }
 }
 
@@ -459,6 +478,9 @@ pub(crate) fn battlefield_entry_matches_filter(
     record: &BattlefieldEntryRecord,
     filter: &TargetFilter,
     player: PlayerId,
+    // CR 702.73a: runtime creature-type catalog, for Changeling subtype expansion
+    // against the pre-layer entry snapshot.
+    all_creature_types: &[String],
     // CR 109.1: the ability source for the "another" exclusion. `None` on the
     // player-attribute count paths that carry no ability source — there
     // `FilterProp::Another` excludes nothing it could match (stays `false`),
@@ -473,11 +495,9 @@ pub(crate) fn battlefield_entry_matches_filter(
                     return false;
                 }
             }
-            if !typed
-                .type_filters
-                .iter()
-                .all(|type_filter| entry_type_filter_matches(record, type_filter))
-            {
+            if !typed.type_filters.iter().all(|type_filter| {
+                entry_type_filter_matches(record, type_filter, all_creature_types)
+            }) {
                 return false;
             }
             typed.properties.iter().all(|prop| match prop {
@@ -497,6 +517,85 @@ pub(crate) fn battlefield_entry_matches_filter(
                 _ => false,
             })
         }
+        // CR 608.2i: the entry ledger is a look-back-in-time read, so a permanent that has
+        // since left still counts. The connective recursion below is engine plumbing, not a
+        // rules construct — only the MONOTONE connectives are supported. `any`/`all` are monotone
+        // in the leaf verdict, so an unsupported leaf's fail-closed `false` can
+        // only make the result more `false` — never a false positive.
+        //
+        // KNOWN COST of that monotonicity: under `Or`, an unsupported leaf turns
+        // what is today a LOUD constant 0 into a SILENT PARTIAL COUNT — the
+        // supported leaves still match and the dropped leaf is invisible.
+        // Measured: `Or[Typed(Mount), Typed(Vehicle+Tapped)]` reads 0 today and
+        // would read 1 post-change with one leaf silently dropped. Accepted here
+        // because 0/5 migrating cards carry an unsupported `FilterProp` in a leaf
+        // (`Another` IS supported), so there is no live undercount; a future card
+        // that does needs the tri-state refactor below, not another connective.
+        //
+        // `TargetFilter::Not` is ANTI-monotone: it would invert an unsupported
+        // leaf's fail-closed `false` into a false POSITIVE, so it stays in the
+        // fail-closed arm until this matcher becomes tri-state (`Option<bool>`
+        // with the callers failing closed on `None`). No printed card in the
+        // class uses a top-level `Not` (measured: 0/34).
+        TargetFilter::Or { filters } => filters.iter().any(|inner| {
+            battlefield_entry_matches_filter(record, inner, player, all_creature_types, source_id)
+        }),
+        TargetFilter::And { filters } => filters.iter().all(|inner| {
+            battlefield_entry_matches_filter(record, inner, player, all_creature_types, source_id)
+        }),
+        _ => false,
+    }
+}
+
+/// CR 403.3 + CR 608.2h: can [`battlefield_entry_matches_filter`] actually answer this filter
+/// against a `BattlefieldEntryRecord`?
+///
+/// The record is an entry-time snapshot carrying only `object_id / name / core_types / subtypes /
+/// supertypes / colors / keywords / controller` (`types/game_state.rs:1586-1606`). Every other
+/// characteristic a `FilterProp` can name is live-object state the snapshot never captured, so the
+/// matcher fails closed at `:517` and the whole tally reads a silent constant 0. Measured: 98
+/// `FilterProp` variants exist (`types/ability.rs:3609-4251`); the matcher answers 4.
+///
+/// This is an ALLOW-LIST, deliberately not an exhaustive `match`. A `FilterProp` added later is
+/// absent from the list and therefore defaults to "not evaluable" — the conservative side, which
+/// yields an honest `Effect::Unimplemented` at the parser guard and an honest `Unhandled` in the
+/// coverage classifier. A deny-list would need exhaustiveness; a positive allow-list does not.
+/// The list must name exactly the props the matcher answers at `:504-516`; the binder is
+/// `ledger_guard_agrees_with_matcher` (test, below).
+///
+/// Upgrade path, ascending cost: `HasSupertype` and `Named` are answerable from `record.supertypes`
+/// / `record.name` TODAY — one matcher arm plus one line here. `FaceDown` (Tunnel Tipster),
+/// `Token`/`NonToken` and `Tapped` need a new snapshot field on `BattlefieldEntryRecord`.
+///
+/// `TypedFilter::type_filters` is intentionally NOT screened: `entry_type_filter_matches` is
+/// exhaustive; `Instant`/`Sorcery` answer `false` per CR 403.3, whose negation is correctly
+/// `true` for every permanent.
+pub(crate) fn ledger_filter_is_evaluable(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Any => true,
+        TargetFilter::Typed(typed) => {
+            // CR 109.5: `entry_controller_matches` (`:408-418`) answers only these two.
+            typed
+                .controller
+                .as_ref()
+                .is_none_or(|c| matches!(c, ControllerRef::You | ControllerRef::Opponent))
+                && typed.properties.iter().all(|prop| {
+                    matches!(
+                        prop,
+                        FilterProp::HasColor { .. }
+                            | FilterProp::InZone { .. }
+                            | FilterProp::WithKeyword { .. }
+                            | FilterProp::Another
+                    )
+                })
+        }
+        // CR 608.2i: mirrors the matcher's monotone connectives (`:540-545`); every leaf must be
+        // answerable, otherwise the composite silently drops one.
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().all(ledger_filter_is_evaluable)
+        }
+        // Everything else is the matcher's `_ => false` at `:546`, including the anti-monotone
+        // `TargetFilter::Not`.
         _ => false,
     }
 }
@@ -1484,7 +1583,13 @@ pub(crate) fn evaluate_condition(
                 .battlefield_entries_this_turn
                 .iter()
                 .filter(|record| {
-                    battlefield_entry_matches_filter(record, filter, player, Some(source_id))
+                    battlefield_entry_matches_filter(
+                        record,
+                        filter,
+                        player,
+                        &state.all_creature_types,
+                        Some(source_id),
+                    )
                 })
                 .count() as u32
                 >= *count
@@ -2440,6 +2545,242 @@ mod tests {
         state.battlefield_entries_this_turn.clear();
         enter_creature(&mut state, 4, opponent, &[Keyword::Flying]);
         assert!(!evaluate_condition(&state, player, source_id, &condition));
+    }
+
+    /// T24 (Step 8). CR 702.73a: a Changeling entrant is every creature type, so an
+    /// entry-ledger `TypeFilter::Subtype` read must route through the single authority
+    /// `subtype_matches_with_changeling` (`game/filter.rs:2719`) rather than a bare
+    /// `eq_ignore_ascii_case` over the pre-layer snapshot. Mirrors the sibling
+    /// `zone_change_record_matches_type_filter` (`game/filter.rs:2871-2878`). Drives the
+    /// production `evaluate_condition` → `battlefield_entry_matches_filter` seam.
+    ///
+    /// REVERT-PROBE: restoring the bare `eq_ignore_ascii_case` Subtype arm flips (a)
+    /// `true→false`. Cases (b)/(c)/(d)/(g) pass in BOTH builds and are the vacuity
+    /// controls — (a) and (b) differ ONLY in the subtype string, so the type/controller/
+    /// prop conjuncts are held constant and no discriminator is dominated by an upstream
+    /// conjunct. (e) flips if the host disjunct is dropped; (f) flips if `Another` is
+    /// bypassed, and its paired reach-guard proves the Changeling leg really matched.
+    #[test]
+    fn changeling_entry_ledger_matches_expanded_subtype() {
+        use crate::types::ability::TypedFilter;
+        use crate::types::card_type::Supertype;
+
+        let mut state = crate::types::game_state::GameState::new_two_player(42);
+        let player = PlayerId(0);
+        let opponent = PlayerId(1);
+        // CR 205.3m: the runtime creature-type namespace Changeling expands into.
+        // "Equipment" is an artifact type and is deliberately absent.
+        state.all_creature_types = vec![
+            "Goblin".to_string(),
+            "Human".to_string(),
+            "Shapeshifter".to_string(),
+        ];
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            player,
+            "Bbfu10 Ledger Reader".to_string(),
+            Zone::Battlefield,
+        );
+
+        let enter_creature = |state: &mut crate::types::game_state::GameState,
+                              card: u64,
+                              controller: PlayerId,
+                              subtypes: &[&str],
+                              supertypes: &[Supertype],
+                              keywords: &[Keyword]| {
+            let id = create_object(
+                state,
+                CardId(card),
+                controller,
+                "Bbfu10 Entrant".to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes = subtypes.iter().map(|s| (*s).to_string()).collect();
+            obj.card_types.supertypes = supertypes.to_vec();
+            obj.keywords = keywords.to_vec();
+            record_battlefield_entry(state, id);
+            id
+        };
+
+        let condition = |subtype: &str, ctrl: ControllerRef, properties: Vec<FilterProp>| {
+            ParsedCondition::BattlefieldEntriesThisTurn {
+                filter: TargetFilter::Typed(
+                    TypedFilter::creature()
+                        .subtype(subtype.to_string())
+                        .controller(ctrl)
+                        .properties(properties),
+                ),
+                count: 1,
+            }
+        };
+
+        // Changeling entrant, printed subtype Shapeshifter only.
+        enter_creature(
+            &mut state,
+            2,
+            player,
+            &["Shapeshifter"],
+            &[],
+            &[Keyword::Changeling],
+        );
+
+        // (a) THE CLAIM — CR 702.73a expands the entry snapshot to every creature type.
+        assert!(
+            evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Goblin", ControllerRef::You, vec![])
+            ),
+            "(a) a Changeling entrant is a Goblin for the entry ledger (CR 702.73a)"
+        );
+        // (b) VACUITY CONTROL — differs from (a) only in the subtype string.
+        assert!(
+            evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Shapeshifter", ControllerRef::You, vec![])
+            ),
+            "(b) the printed subtype must still match in both builds"
+        );
+        // (c) CR 205.3m gate — Changeling confers creature types only.
+        assert!(
+            !evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Equipment", ControllerRef::You, vec![])
+            ),
+            "(c) Equipment is not in the creature-type catalog (CR 205.3m)"
+        );
+
+        // (d) negative sibling — no Changeling keyword, no expansion.
+        state.battlefield_entries_this_turn.clear();
+        enter_creature(&mut state, 3, player, &["Human"], &[], &[]);
+        assert!(
+            !evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Goblin", ControllerRef::You, vec![])
+            ),
+            "(d) a non-Changeling Human entrant is not a Goblin"
+        );
+
+        // (e) pins the `subtype_matches_host_supertype` disjunct: "Host" is a supertype,
+        // absent from both the record subtypes and the creature-type catalog.
+        state.battlefield_entries_this_turn.clear();
+        enter_creature(&mut state, 4, player, &[], &[Supertype::Host], &[]);
+        assert!(
+            evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Host", ControllerRef::You, vec![])
+            ),
+            "(e) Supertype::Host answers the `Host` subtype filter"
+        );
+
+        // (f) multi-authority: the new Subtype arm must compose with `FilterProp::Another`
+        // (CR 109.1), not short-circuit it. The Changeling entrant IS the source.
+        state.battlefield_entries_this_turn.clear();
+        {
+            let obj = state.objects.get_mut(&source_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.card_types.subtypes = vec!["Shapeshifter".to_string()];
+            obj.keywords = vec![Keyword::Changeling];
+        }
+        record_battlefield_entry(&mut state, source_id);
+        enter_creature(&mut state, 5, player, &["Human"], &[], &[]);
+        // Reach-guard: without `Another`, the Changeling source DOES satisfy the Goblin leg,
+        // so the negative below is the `Another` exclusion firing, not a dead fixture.
+        assert!(
+            evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Goblin", ControllerRef::You, vec![])
+            ),
+            "(f-guard) the Changeling source itself matches Goblin when `Another` is absent"
+        );
+        assert!(
+            !evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Goblin", ControllerRef::You, vec![FilterProp::Another])
+            ),
+            "(f) `Another` excludes the source, and the Human entrant is not a Goblin"
+        );
+
+        // (g) multi-authority: the controller gate (CR 109.5) still applies.
+        state.battlefield_entries_this_turn.clear();
+        enter_creature(
+            &mut state,
+            6,
+            opponent,
+            &["Shapeshifter"],
+            &[],
+            &[Keyword::Changeling],
+        );
+        // Reach-guard: the same record DOES match under `Opponent`.
+        assert!(
+            evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Goblin", ControllerRef::Opponent, vec![])
+            ),
+            "(g-guard) the opponent's Changeling entrant matches under ControllerRef::Opponent"
+        );
+        assert!(
+            !evaluate_condition(
+                &state,
+                player,
+                source_id,
+                &condition("Goblin", ControllerRef::You, vec![])
+            ),
+            "(g) `ControllerRef::You` rejects an opponent-controlled entrant"
+        );
+    }
+
+    /// T25 (Step 8c). CR 403.3: permanents exist only on the battlefield, so a
+    /// battlefield-entry record is never an instant or a sorcery — `false` is the
+    /// CORRECT verdict there, not a fail-closed one, and `Non(Instant)` correctly
+    /// inverts to `true`. `entry_type_filter_matches` is now exhaustive, so the
+    /// compiler is the drift gate; this pins the semantics that justify the arm and
+    /// the doc claim at `ledger_filter_is_evaluable`.
+    ///
+    /// REVERT-PROBE: changing the arm to `true` flips both assertions.
+    #[test]
+    fn entry_type_filter_answers_instant_false_per_cr_403_3() {
+        let record = BattlefieldEntryRecord {
+            object_id: ObjectId(10),
+            name: "Bbfu10 Permanent".to_string(),
+            core_types: vec![CoreType::Creature],
+            subtypes: vec![],
+            supertypes: vec![],
+            colors: vec![],
+            keywords: vec![],
+            controller: PlayerId(0),
+        };
+
+        assert!(
+            !entry_type_filter_matches(&record, &TypeFilter::Instant, &[]),
+            "CR 403.3: a battlefield-entry record is never an instant"
+        );
+        assert!(
+            entry_type_filter_matches(
+                &record,
+                &TypeFilter::Non(Box::new(TypeFilter::Instant)),
+                &[]
+            ),
+            "CR 403.3: `Non(Instant)` is correctly true for every permanent"
+        );
     }
 
     /// MSH Wave 2 (Fixer, Techno Terror): the elided "[type] entered under your
@@ -4537,5 +4878,118 @@ mod tests {
             Phase::DeclareBlockers,
             Phase::CombatDamage,
         );
+    }
+
+    /// T23 — the ANTI-DRIFT BINDER for [`ledger_filter_is_evaluable`]'s allow-list.
+    /// It replaces a 98-arm exhaustive `match`: the two functions are driven AS A
+    /// PAIR against one record that positively satisfies every allowed prop, so a
+    /// prop in the allow-list that the matcher does not actually answer fails here.
+    ///
+    /// REVERT-PROBES, both measured:
+    /// - add `FilterProp::NonToken` to the allow-list → the paired matcher drive
+    ///   returns `false` while the guard says `true` → FAIL.
+    /// - delete an allowed prop from the list → its paired row FAILS on the guard side.
+    #[test]
+    fn ledger_guard_agrees_with_matcher() {
+        let player = PlayerId(0);
+        let source_id = ObjectId(99);
+        // Positively satisfies all four answerable props: green, on the
+        // battlefield, flying, and not the ability source. Also legendary and
+        // nontoken/untapped-in-fact, none of which the SNAPSHOT can express.
+        let record = BattlefieldEntryRecord {
+            object_id: ObjectId(10),
+            name: "Bbfu10 Binder Entrant".to_string(),
+            core_types: vec![CoreType::Creature],
+            subtypes: vec![],
+            supertypes: vec![Supertype::Legendary],
+            colors: vec![ManaColor::Green],
+            keywords: vec![Keyword::Flying],
+            controller: player,
+        };
+        let typed = |properties: Vec<FilterProp>, controller: Option<ControllerRef>| {
+            TargetFilter::Typed(crate::types::ability::TypedFilter {
+                type_filters: vec![TypeFilter::Creature],
+                controller,
+                properties,
+            })
+        };
+
+        // ALLOWED — the guard says yes AND the matcher really answers yes.
+        for prop in [
+            FilterProp::HasColor {
+                color: ManaColor::Green,
+            },
+            FilterProp::InZone {
+                zone: Zone::Battlefield,
+            },
+            FilterProp::WithKeyword {
+                value: Keyword::Flying,
+            },
+            FilterProp::Another,
+        ] {
+            let filter = typed(vec![prop.clone()], None);
+            assert!(
+                ledger_filter_is_evaluable(&filter),
+                "{prop:?} is answered by the matcher, so the allow-list must name it"
+            );
+            assert!(
+                battlefield_entry_matches_filter(&record, &filter, player, &[], Some(source_id)),
+                "{prop:?} must MATCH this record — otherwise the allow-list claims an \
+                 evaluability the matcher does not have"
+            );
+        }
+
+        // NOT ALLOWED — unanswerable from the entry snapshot, so the guard must
+        // refuse. (The record IS legendary and nontoken, so the matcher's `false`
+        // for those is the fail-closed arm, not a genuine mismatch.)
+        for prop in [
+            FilterProp::NonToken,
+            FilterProp::Token,
+            FilterProp::Tapped,
+            FilterProp::FaceDown,
+            FilterProp::HasSupertype {
+                value: Supertype::Legendary,
+            },
+        ] {
+            assert!(
+                !ledger_filter_is_evaluable(&typed(vec![prop.clone()], None)),
+                "{prop:?} is not answerable from a BattlefieldEntryRecord"
+            );
+        }
+
+        // Structure: monotone connectives recurse; every leaf must be answerable.
+        let bare = typed(vec![], None);
+        let green = typed(
+            vec![FilterProp::HasColor {
+                color: ManaColor::Green,
+            }],
+            None,
+        );
+        let nontoken = typed(vec![FilterProp::NonToken], None);
+        let tapped = typed(vec![FilterProp::Tapped], None);
+        assert!(ledger_filter_is_evaluable(&TargetFilter::Any));
+        assert!(ledger_filter_is_evaluable(&TargetFilter::Or {
+            filters: vec![bare.clone(), green]
+        }));
+        assert!(!ledger_filter_is_evaluable(&TargetFilter::Or {
+            filters: vec![bare.clone(), nontoken]
+        }));
+        assert!(!ledger_filter_is_evaluable(&TargetFilter::And {
+            filters: vec![bare.clone(), tapped]
+        }));
+        // CR 608.2i: `Not` is anti-monotone and stays fail-closed at the matcher.
+        assert!(!ledger_filter_is_evaluable(&TargetFilter::Not {
+            filter: Box::new(bare)
+        }));
+
+        // Controller: `entry_controller_matches` answers exactly You / Opponent.
+        assert!(ledger_filter_is_evaluable(&typed(
+            vec![],
+            Some(ControllerRef::You)
+        )));
+        assert!(ledger_filter_is_evaluable(&typed(
+            vec![],
+            Some(ControllerRef::Opponent)
+        )));
     }
 }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1330,7 +1330,14 @@ fn quantity_ref_uses_filter_prop(qty: &QuantityRef, pred: &impl Fn(&FilterProp) 
         | QuantityRef::ControlledByEachPlayer { filter, .. }
         | QuantityRef::DistinctColorsAmongPermanents { filter }
         | QuantityRef::DistinctCounterKindsAmong { filter }
-        | QuantityRef::EnteredThisTurn { filter } => target_filter_uses_filter_prop(filter, pred),
+        | QuantityRef::EnteredThisTurn { filter }
+        // CR 608.2i: the look-back sibling carries a `TargetFilter` too, and this
+        // predicate's question ("does any `TargetFilter` reachable from this
+        // quantity use `pred`?") is variant-agnostic — so it must recurse rather
+        // than fall to `_ => false`.
+        | QuantityRef::BattlefieldEntriesThisTurn { filter, .. } => {
+            target_filter_uses_filter_prop(filter, pred)
+        }
         QuantityRef::DistinctCardTypes {
             source: crate::types::ability::CardTypeSetSource::Objects { filter },
         }

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -7652,8 +7652,10 @@ fn parse_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
         return parse_entered_this_turn_subject(rest, had_enter_suffix, 1, PlayerScope::Controller);
     }
 
-    // CR 403.3 + CR 608.2h: self-inclusive disjunct "~ or another/a <type>
-    // entered the battlefield under your control this turn" (Master's
+    // CR 403.3 + CR 608.2h + CR 608.2i: self-inclusive disjunct "~ or another/a
+    // <type> entered the battlefield under your control this turn". CR 608.2i is
+    // the look-back exception that makes a departed permanent still count.
+    // (Master's
     // Manufactory: "this artifact or another artifact entered ..."). The
     // source's own entry counts, so the disjunct reduces to a bare `<type>`
     // filter carrying NO `FilterProp::Another` — a `~`-only entry (the source
@@ -7702,8 +7704,9 @@ fn parse_entered_this_turn(input: &str) -> OracleResult<'_, StaticCondition> {
     parse_entered_this_turn_subject(input, entered_suffix, 1, PlayerScope::Controller)
 }
 
-/// CR 403.3 + CR 608.2h: Parse "N or more [type] <suffix>" into a GE threshold
-/// on the this-turn battlefield-entry count. Shared by the bare past-tense
+/// CR 403.3 + CR 608.2h + CR 608.2i: Parse "N or more [type] <suffix>" into a GE
+/// threshold on the this-turn battlefield-entry count. CR 608.2i is the look-back
+/// exception that makes a departed permanent still count. Shared by the bare past-tense
 /// surface ("N or more creatures entered the battlefield under your control
 /// this turn") and the "you had"-auxiliary present-tense surface ("you had N
 /// or more creatures enter the battlefield under your control this turn", e.g.
@@ -7767,8 +7770,10 @@ fn parse_entered_this_turn_subject<'a>(
     ))
 }
 
-/// CR 102.2 + CR 102.3 + CR 608.2h: "an opponent had [N or more] <type> enter the
-/// battlefield under their control this turn" — the opponent-scoped mirror of
+/// CR 102.2 + CR 102.3 + CR 608.2h + CR 608.2i: "an opponent had [N or more]
+/// <type> enter the battlefield under their control this turn" — CR 608.2i is the
+/// look-back exception that makes a departed permanent still count. The
+/// opponent-scoped mirror of
 /// `parse_entered_this_turn`'s "you had …" auxiliary surface (the Zendikar trap
 /// cycle: Baloth Cage Trap, Lavaball Trap, Permafrost Trap, Whiplash Trap).
 ///

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -3869,13 +3869,39 @@ fn parse_source_self_ref(input: &str) -> OracleResult<'_, ()> {
     )))
 }
 
-/// CR 400.7: Parse "[type] that entered (the battlefield) this turn" into
-/// the shared entered-this-turn battlefield count. The "under your control"
-/// surface form stamps `ControllerRef::You` onto the typed filter; phrases
-/// that already include "you control" keep the controller supplied by
-/// `parse_type_phrase`.
+/// CR 608.2h / CR 608.2i: which grammatical constituent the controller qualifier
+/// of an "…that entered … this turn" relative clause attaches to. This is the
+/// single discriminator between the class's two readings, and WotC's own rulings
+/// track it:
+///
+/// - Hobgoblin Bandit Lord — "Goblins that entered the battlefield UNDER YOUR
+///   CONTROL this turn": "It doesn't matter if those Goblins are still on the
+///   battlefield as it resolves." The qualifier describes the past entry EVENT,
+///   so nothing in the phrase requires the object to exist now → CR 608.2i
+///   look-back tally over the `battlefield_entries_this_turn` ledger.
+/// - Tromell, Seymour's Butler — "nontoken creatures YOU CONTROL that entered
+///   this turn": "look at the nontoken creatures you control and count each one
+///   that entered this turn." The qualifier is a present-tense predicate on the
+///   subject noun, and by CR 109.2 an unqualified permanent noun names a
+///   battlefield permanent → CR 608.2h live population read.
+///
+/// The distinguishing token is NOT the substring "the battlefield": the
+/// `" the battlefield this turn"` surface carries it while binding any
+/// controller to the noun ("creatures you control that entered the battlefield
+/// this turn"), and must stay live.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EnteredControlBinding {
+    /// "…entered [the battlefield] under <whose> control this turn".
+    EntryEvent(PlayerScope),
+    /// "…[<noun> you control] that entered [the battlefield] this turn".
+    SubjectNoun,
+}
+
+/// CR 608.2h + CR 608.2i: Parse "[type] that entered (the battlefield) [under
+/// <whose> control] this turn" into whichever of the two readings the grammar
+/// selects — see [`EnteredControlBinding`].
 fn parse_entered_this_turn_ref(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, (type_text, inject_you)) = parse_entered_this_turn_clause(input)?;
+    let (rest, (type_text, binding)) = parse_entered_this_turn_clause(input)?;
     let (filter, remainder) = parse_type_phrase(type_text.trim());
     if matches!(filter, TargetFilter::Any) || !remainder.trim().is_empty() {
         return Err(nom::Err::Error(nom::error::Error::new(
@@ -3883,28 +3909,76 @@ fn parse_entered_this_turn_ref(input: &str) -> OracleResult<'_, QuantityRef> {
             nom::error::ErrorKind::Fail,
         )));
     }
-    let filter = if inject_you {
-        inject_controller(filter, ControllerRef::You)
-    } else {
-        filter
+    let qty = match binding {
+        // CR 608.2i: the controller belongs to the past entry event, so this is a
+        // look-back tally over `battlefield_entries_this_turn`. The scope carries
+        // "under whose control" (the runtime keys on `record.controller`) and the
+        // filter stays bare — mirroring `parse_or_more_entered_count`
+        // (oracle_nom/condition.rs), the condition-side sibling BB-FU1 migrated,
+        // which likewise omits the controller injection.
+        //
+        // CR 608.2i: the look-back tally is only honest if the entry-record matcher can evaluate
+        // the filter. `battlefield_entry_matches_filter` fails closed on the 94 `FilterProp`s the
+        // entry snapshot cannot answer (game/restrictions.rs:517), which would resolve to a silent
+        // constant 0 while `coverage.rs` reported the card supported. Refusing here is measurably
+        // better on this path: a failed quantity clause becomes `Effect::Unimplemented`, so the
+        // gap is visible to `cargo parser-gaps` instead of shipping a wrong number.
+        //
+        // NOT mirrored at the three condition-side emitters (oracle_nom/condition.rs:7688/:7738/
+        // :7767): an unparseable intervening-if is SILENTLY DROPPED (`condition: null` -> the
+        // trigger fires unconditionally) and an unparseable "Activate only if" clause drops the
+        // whole restriction (`activation_restrictions: []` -> always activatable). There, refusing
+        // would turn a conservative never-fires into an over-permit. Those sites are covered by the
+        // `coverage.rs` classifier instead.
+        EnteredControlBinding::EntryEvent(player) => {
+            if !crate::game::restrictions::ledger_filter_is_evaluable(&filter) {
+                return Err(nom::Err::Error(nom::error::Error::new(
+                    input,
+                    nom::error::ErrorKind::Fail,
+                )));
+            }
+            QuantityRef::BattlefieldEntriesThisTurn { player, filter }
+        }
+        // CR 608.2h: any controller came from the subject noun and is
+        // present-tense, so this names the current battlefield population
+        // (CR 109.2) narrowed by a historical predicate — Tromell's reading.
+        EnteredControlBinding::SubjectNoun => QuantityRef::EnteredThisTurn { filter },
     };
-    Ok((rest, QuantityRef::EnteredThisTurn { filter }))
+    Ok((rest, qty))
 }
 
-fn parse_entered_this_turn_clause(input: &str) -> OracleResult<'_, (&str, bool)> {
-    map(
-        pair(
-            take_until(" that entered"),
-            preceded(
-                tag(" that entered"),
-                alt((
-                    value(true, tag(" the battlefield under your control this turn")),
-                    value(false, tag(" the battlefield this turn")),
-                    value(false, tag(" this turn")),
-                )),
-            ),
+fn parse_entered_this_turn_clause(input: &str) -> OracleResult<'_, (&str, EnteredControlBinding)> {
+    pair(
+        take_until(" that entered"),
+        preceded(
+            pair(tag(" that entered"), opt(tag(" the battlefield"))),
+            alt((
+                map(
+                    parse_entry_event_controller,
+                    EnteredControlBinding::EntryEvent,
+                ),
+                value(EnteredControlBinding::SubjectNoun, tag(" this turn")),
+            )),
         ),
-        |(type_text, inject_you)| (type_text, inject_you),
+    )
+    .parse(input)
+}
+
+/// CR 109.5: the "under <whose> control" qualifier bound to the entry event.
+/// Only the controller reading is templated on any printed card today (measured:
+/// 0/34 corpus cards print the opponent or any-player surface in a quantity
+/// context), so those readings intentionally fall through to an honest
+/// `Effect::Unimplemented` rather than to a guessed parse.
+// ponytail: adding the opponent reading is one `value(PlayerScope::Opponent { aggregate: Max },
+// tag(" under an opponent's control"))` arm here PLUS normalizing any filter-borne controller off
+// the filter — measured, `"creatures you control that entered … under your control this turn"`
+// keeps `controller: You` on the ledger filter, and game/quantity.rs:3324/:3328 scopes records by
+// `scoped_player.id` while passing the ABILITY controller to the matcher, so a surviving `You`
+// contradicts a non-`Controller` scope and reads a constant 0.
+fn parse_entry_event_controller(input: &str) -> OracleResult<'_, PlayerScope> {
+    terminated(
+        value(PlayerScope::Controller, tag(" under your control")),
+        tag(" this turn"),
     )
     .parse(input)
 }
@@ -3929,28 +4003,6 @@ fn parse_tokens_created_this_turn_tail(input: &str) -> OracleResult<'_, Quantity
             filter,
         },
     ))
-}
-
-fn inject_controller(filter: TargetFilter, controller: ControllerRef) -> TargetFilter {
-    match filter {
-        TargetFilter::Typed(tf) => TargetFilter::Typed(tf.controller(controller)),
-        TargetFilter::Or { filters } => TargetFilter::Or {
-            filters: filters
-                .into_iter()
-                .map(|filter| inject_controller(filter, controller.clone()))
-                .collect(),
-        },
-        TargetFilter::And { filters } => TargetFilter::And {
-            filters: filters
-                .into_iter()
-                .map(|filter| inject_controller(filter, controller.clone()))
-                .collect(),
-        },
-        TargetFilter::Not { filter } => TargetFilter::Not {
-            filter: Box::new(inject_controller(*filter, controller)),
-        },
-        other => other,
-    }
 }
 
 /// CR 601.2h + CR 202.2: Parse a self-scoped mana-spent-to-cast reference in
@@ -8389,6 +8441,8 @@ mod tests {
         assert_eq!(rest, "");
     }
 
+    /// CR 608.2h: destructure the LIVE-population reading
+    /// (`QuantityRef::EnteredThisTurn`), whose controller lives on the filter.
     fn assert_entered_this_turn_typed(
         q: QuantityRef,
     ) -> (Vec<TypeFilter>, Option<ControllerRef>, Vec<FilterProp>) {
@@ -8405,6 +8459,31 @@ mod tests {
         }
     }
 
+    /// CR 608.2i: destructure the LOOK-BACK reading
+    /// (`QuantityRef::BattlefieldEntriesThisTurn`), whose "under whose control"
+    /// lives on the `PlayerScope` and whose filter is therefore BARE.
+    fn assert_ledger_entries_this_turn_typed(
+        q: QuantityRef,
+    ) -> (
+        PlayerScope,
+        Vec<TypeFilter>,
+        Option<ControllerRef>,
+        Vec<FilterProp>,
+    ) {
+        match q {
+            QuantityRef::BattlefieldEntriesThisTurn {
+                player,
+                filter:
+                    TargetFilter::Typed(TypedFilter {
+                        type_filters,
+                        controller,
+                        properties,
+                    }),
+            } => (player, type_filters, controller, properties),
+            other => panic!("expected typed BattlefieldEntriesThisTurn ref, got {other:?}"),
+        }
+    }
+
     #[test]
     fn parse_for_each_entered_this_turn_under_your_control() {
         let (rest, q) = parse_for_each_clause_ref(
@@ -8412,9 +8491,13 @@ mod tests {
         )
         .unwrap();
         assert_eq!(rest, "");
-        let (type_filters, controller, properties) = assert_entered_this_turn_typed(q);
+        let (player, type_filters, controller, properties) =
+            assert_ledger_entries_this_turn_typed(q);
+        assert_eq!(player, PlayerScope::Controller);
         assert_eq!(type_filters, vec![TypeFilter::Land]);
-        assert_eq!(controller, Some(ControllerRef::You));
+        // CR 608.2i: the tally keys on `record.controller` via the scope, so the
+        // filter must NOT carry a controller of its own.
+        assert_eq!(controller, None);
         assert!(properties.is_empty());
     }
 
@@ -8425,15 +8508,22 @@ mod tests {
         )
         .unwrap();
         assert_eq!(rest, "");
-        let (type_filters, controller, properties) = assert_entered_this_turn_typed(q);
+        let (player, type_filters, controller, properties) =
+            assert_ledger_entries_this_turn_typed(q);
+        assert_eq!(player, PlayerScope::Controller);
         assert_eq!(
             type_filters,
             vec![TypeFilter::Subtype("Zombie".to_string())]
         );
-        assert_eq!(controller, Some(ControllerRef::You));
+        assert_eq!(controller, None);
         assert!(properties.iter().any(|prop| prop == &FilterProp::Another));
     }
 
+    /// IN-CRATE BOUNDARY LOCK (BB-FU10): Tromell, Seymour's Butler binds the
+    /// controller to the SUBJECT NOUN ("nontoken creatures you control that
+    /// entered this turn"), which is CR 608.2h live-population, NOT the CR 608.2i
+    /// look-back ledger. If this ever asserts `BattlefieldEntriesThisTurn` the
+    /// discriminator has been widened to the wrong constituent.
     #[test]
     fn parse_number_of_controlled_entered_this_turn() {
         let (rest, q) = parse_quantity_ref(

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -22608,3 +22608,45 @@ fn standalone_spell_emblem_grant_parses_to_create_emblem() {
         "emblem carries both outcome-lock statics, got {create:#?}"
     );
 }
+
+/// T14b (BB-FU10 Step 3b). `quantity_ref_uses_filter_prop` asks a
+/// variant-agnostic question — "does any `TargetFilter` reachable from this
+/// quantity use `pred`?" — so the CR 608.2i look-back sibling must recurse into
+/// its filter instead of falling to `_ => false`.
+///
+/// REVERT-PROBE: remove the one-line or-group addition → the first assertion
+/// reads `false`, FAIL. The prop-free twin is the negative control that keeps the
+/// first assertion from passing on a "returns true for everything" bug.
+#[test]
+fn bbfu10_ledger_variant_reaches_filter_prop_scan() {
+    use crate::types::ability::{
+        FilterProp, PlayerScope, QuantityRef, TargetFilter, TypeFilter, TypedFilter,
+    };
+
+    let pred = |p: &FilterProp| matches!(p, FilterProp::IsChosenCreatureType);
+    let with_prop = QuantityRef::BattlefieldEntriesThisTurn {
+        player: PlayerScope::Controller,
+        filter: TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Creature],
+            controller: None,
+            properties: vec![FilterProp::IsChosenCreatureType],
+        }),
+    };
+    let without_prop = QuantityRef::BattlefieldEntriesThisTurn {
+        player: PlayerScope::Controller,
+        filter: TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Creature],
+            controller: None,
+            properties: vec![],
+        }),
+    };
+
+    assert!(
+        super::quantity_ref_uses_filter_prop(&with_prop, &pred),
+        "CR 608.2i: the ledger variant's filter must be scanned for filter props",
+    );
+    assert!(
+        !super::quantity_ref_uses_filter_prop(&without_prop, &pred),
+        "negative control: a prop-free ledger filter must still read false",
+    );
+}

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5785,9 +5785,11 @@ pub enum QuantityRef {
     /// "you've drawn two or more cards this turn" and "an opponent has drawn
     /// four or more cards this turn" reuse the existing per-player aggregate axis.
     CardsDrawnThisTurn { player: PlayerScope },
-    /// CR 403.3 + CR 608.2h: Count of battlefield entries this turn by the scoped
-    /// player matching `filter`, using `battlefield_entries_this_turn` snapshots
-    /// (lands that entered and later left still count). Smuggler's Share class:
+    /// CR 403.3 + CR 608.2h + CR 608.2i: Count of battlefield entries this turn by
+    /// the scoped player matching `filter`, using `battlefield_entries_this_turn`
+    /// snapshots. CR 608.2i is the look-back exception that makes a departed
+    /// permanent still count (lands that entered and later left still count).
+    /// Smuggler's Share class:
     /// "for each opponent who had two or more lands enter the battlefield under
     /// their control this turn."
     BattlefieldEntriesThisTurn {

--- a/crates/engine/tests/integration/bbfu10_entered_this_turn_snapshot.rs
+++ b/crates/engine/tests/integration/bbfu10_entered_this_turn_snapshot.rs
@@ -1,0 +1,1154 @@
+//! BB-FU10 PROBE — `parse_entered_this_turn_ref` emits the live-board
+//! `QuantityRef::EnteredThisTurn`, which under-counts a permanent that entered
+//! the battlefield this turn and has since LEFT.
+//!
+//! CR 608.2i (look-back): "Some effects look back in time ... they don't need to
+//! be currently in the zone they were in at the time of that previous game state
+//! or action ... as long as they did so at the specified time."
+//!
+//! Scryfall ruling, Hobgoblin Bandit Lord (card 09e9dc36-f2d8-4384-98cb-e44c00b02433):
+//! "Hobgoblin Bandit Lord's activated ability only counts the number of Goblins
+//! that entered the battlefield this turn. It doesn't matter if those Goblins are
+//! still on the battlefield as it resolves."
+//!
+//! Contrast Tromell, Seymour's Butler ("the number of nontoken creatures you
+//! control that entered this turn"), whose ruling says to "look at the nontoken
+//! creatures you control and count each one that entered this turn" — a LIVE set
+//! (CR 608.2h). That form must NOT migrate.
+
+use engine::game::quantity::resolve_quantity;
+use engine::game::restrictions::{check_activation_restrictions, record_battlefield_entry};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, ActivationRestriction, Comparator, ControllerRef, Effect, FilterProp,
+    ParsedCondition, PlayerScope, QuantityExpr, QuantityRef, TargetFilter, TypeFilter, TypedFilter,
+};
+use engine::types::card_type::Supertype;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const HOBGOBLIN: &str = "Other Goblins you control get +1/+1.\n{R}, {T}: This creature deals \
+damage equal to the number of Goblins that entered the battlefield under your control this turn \
+to any target.";
+
+// --- BB-FU10 verbatim Oracle text (MTGJSON `data/mtgjson/AtomicCards.json`) ---
+
+const CLOUDSPIRE: &str = "When this creature enters, scry 2.\n{T}: Create X 1/1 colorless Pilot \
+creature tokens, where X is the number of Mounts and/or Vehicles that entered the battlefield \
+under your control this turn. The tokens have \"This token saddles Mounts and crews Vehicles as \
+though its power were 2 greater.\"";
+
+const GERALF: &str = "Whenever you cast a spell during your turn other than your first spell that \
+turn, create a 2/2 blue and black Zombie Rogue creature token.\nWhenever a Zombie you control \
+enters, put a +1/+1 counter on it for each other Zombie that entered the battlefield under your \
+control this turn.";
+
+const KINBINDING: &str = "Creatures you control get +X/+X, where X is the number of creatures \
+that entered the battlefield under your control this turn.\nAt the beginning of combat on your \
+turn, create a 1/1 green and white Kithkin creature token.";
+
+const BIOENGINEERED_FUTURE: &str = "When this enchantment enters, create a Lander token. (It's an \
+artifact with \"{2}, {T}, Sacrifice this token: Search your library for a basic land card, put it \
+onto the battlefield tapped, then shuffle.\")\nEach creature you control enters with an \
+additional +1/+1 counter on it for each land that entered the battlefield under your control this \
+turn.";
+
+const TROMELL: &str = "Each other nontoken creature you control enters with an additional +1/+1 \
+counter on it.\n{1}, {T}: Proliferate X times, where X is the number of nontoken creatures you \
+control that entered this turn. (To proliferate, choose any number of permanents and/or players, \
+then give each another counter of each kind already there.)";
+
+const OCELOT_PRIDE: &str =
+    "First strike, lifelink\nAscend (If you control ten or more permanents, \
+you get the city's blessing for the rest of the game.)\nAt the beginning of your end step, if you \
+gained life this turn, create a 1/1 white Cat creature token. Then if you have the city's \
+blessing, for each token you control that entered this turn, create a token that's a copy of it.";
+
+const OAKHOLLOW_VILLAGE: &str = "{T}: Add {C}.\n{T}: Add {G}. Spend this mana only to cast a \
+creature spell.\n{G}, {T}: Put a +1/+1 counter on each Frog, Rabbit, Raccoon, or Squirrel you \
+control that entered the battlefield this turn.";
+
+const NOVIJEN: &str =
+    "{T}: Add {C}.\n{G}{U}, {T}: Put a +1/+1 counter on each creature that entered this turn.";
+
+const LILYPAD_VILLAGE: &str = "{T}: Add {C}.\n{T}: Add {U}. Spend this mana only to cast a \
+creature spell.\n{U}, {T}: Surveil 2. Activate only if a Bird, Frog, Otter, or Rat entered the \
+battlefield under your control this turn.";
+
+/// Synthetic T12 fixture: the CONTROLLER-ON-THE-SUBJECT-NOUN reading that still
+/// carries the substring "the battlefield". The discriminator is the attachment
+/// site, not that substring, so this must stay on the live variant.
+const NOUN_CONTROLLER_SYNTHETIC: &str = "{T}: This creature deals damage equal to the number of \
+creatures you control that entered the battlefield this turn to any target.";
+
+/// Synthetic T13 fixture: the opponent entry-event surface no printed card uses.
+const OPPONENT_SURFACE_SYNTHETIC: &str = "{T}: This creature deals damage equal to the number of \
+creatures that entered the battlefield under an opponent's control this turn to any target.";
+
+/// Synthetic T13 positive reach-guard: the SAME card shape with "under your
+/// control", which must parse to the ledger variant. Without this the T13
+/// `Unimplemented` assertion would pass for any parse failure whatsoever.
+const OWN_SURFACE_SYNTHETIC: &str = "{T}: This creature deals damage equal to the number of \
+creatures that entered the battlefield under your control this turn to any target.";
+
+/// Synthetic T20 fixture: the same shape whose subject noun carries a
+/// `FilterProp` the entry-record matcher cannot answer (`NonToken`).
+const NONEVALUABLE_PROP_SYNTHETIC: &str = "{T}: This creature deals damage equal to the number of \
+nontoken creatures that entered the battlefield under your control this turn to any target.";
+
+/// Synthetic T20 prop-discrimination reach-guard: same shape, a prop the matcher
+/// DOES answer (`HasColor`). Proves the guard screens *which* prop rather than
+/// rejecting every propertied filter.
+const EVALUABLE_PROP_SYNTHETIC: &str = "{T}: This creature deals damage equal to the number of \
+green creatures that entered the battlefield under your control this turn to any target.";
+
+/// Walk an ability chain and return the first `DealDamage` amount.
+fn find_damage_amount(def: &AbilityDefinition) -> Option<QuantityExpr> {
+    let mut cur = Some(def);
+    while let Some(d) = cur {
+        if let Effect::DealDamage { amount, .. } = &*d.effect {
+            return Some(amount.clone());
+        }
+        cur = d.sub_ability.as_deref();
+    }
+    None
+}
+
+fn hobgoblin_damage_amount() -> QuantityExpr {
+    let parsed = parse_oracle_text(
+        HOBGOBLIN,
+        "Hobgoblin Bandit Lord",
+        &[],
+        &["Creature".to_string()],
+        &["Goblin".to_string()],
+    );
+    parsed
+        .abilities
+        .iter()
+        .find_map(find_damage_amount)
+        .expect("Hobgoblin Bandit Lord must parse a DealDamage activated ability")
+}
+
+#[test]
+fn bbfu10_probe_departed_goblin_still_counts() {
+    let amount = hobgoblin_damage_amount();
+    eprintln!("PROBE parsed amount = {amount:?}");
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let lord = scenario
+        .add_creature_from_oracle(P0, "Hobgoblin Bandit Lord", 3, 3, HOBGOBLIN)
+        .id();
+    let goblin = scenario
+        .add_creature(P0, "Departed Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    let mut runner = scenario.build();
+    let turn = runner.state().turn_number;
+
+    // Production entry snapshot taken while the Goblin is still on the battlefield.
+    record_battlefield_entry(runner.state_mut(), goblin);
+    {
+        let obj = runner.state_mut().objects.get_mut(&goblin).unwrap();
+        obj.entered_battlefield_turn = Some(turn);
+        obj.zone = Zone::Graveyard;
+    }
+
+    let n = resolve_quantity(runner.state(), &amount, P0, lord);
+    eprintln!("PROBE departed-goblin count = {n}");
+    assert_eq!(
+        n, 1,
+        "CR 608.2i + Scryfall ruling: a Goblin that entered under your control this turn and has \
+         since left the battlefield must STILL count"
+    );
+}
+
+#[test]
+fn bbfu10_probe_present_goblin_counts_control() {
+    // Positive control: the same setup without the departure must count 1 under
+    // both the pre-fix live-board read and the post-fix ledger read. If this
+    // fails, the probe scaffolding itself is broken, not the engine.
+    let amount = hobgoblin_damage_amount();
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let lord = scenario
+        .add_creature_from_oracle(P0, "Hobgoblin Bandit Lord", 3, 3, HOBGOBLIN)
+        .id();
+    let goblin = scenario
+        .add_creature(P0, "Fresh Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    let mut runner = scenario.build();
+    let turn = runner.state().turn_number;
+    record_battlefield_entry(runner.state_mut(), goblin);
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&goblin)
+        .unwrap()
+        .entered_battlefield_turn = Some(turn);
+
+    let n = resolve_quantity(runner.state(), &amount, P0, lord);
+    eprintln!("PROBE present-goblin count = {n}");
+    assert_eq!(n, 1, "a Goblin that entered this turn and stayed counts");
+}
+
+// ===========================================================================
+// BB-FU10 shared helpers
+// ===========================================================================
+
+fn parse_card(
+    oracle: &str,
+    name: &str,
+    types: &[&str],
+    subtypes: &[&str],
+) -> engine::parser::oracle::ParsedAbilities {
+    let types: Vec<String> = types.iter().map(|s| s.to_string()).collect();
+    let subtypes: Vec<String> = subtypes.iter().map(|s| s.to_string()).collect();
+    parse_oracle_text(oracle, name, &[], &types, &subtypes)
+}
+
+/// The single ledger shape this migration produces: `PlayerScope::Controller`
+/// carries "under whose control", so the filter is BARE (CR 608.2i — the runtime
+/// keys on `record.controller`, not on a filter controller).
+fn ledger_typed(type_filters: Vec<TypeFilter>, properties: Vec<FilterProp>) -> QuantityExpr {
+    QuantityExpr::Ref {
+        qty: QuantityRef::BattlefieldEntriesThisTurn {
+            player: PlayerScope::Controller,
+            filter: TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: None,
+                properties,
+            }),
+        },
+    }
+}
+
+/// Stamp `id` into the production battlefield-entry ledger for the current turn,
+/// exactly as `record_zone_change` does in a real game.
+fn record_entry_now(runner: &mut GameRunner, id: ObjectId) {
+    let turn = runner.state().turn_number;
+    record_battlefield_entry(runner.state_mut(), id);
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&id)
+        .unwrap()
+        .entered_battlefield_turn = Some(turn);
+}
+
+/// Move an already-recorded permanent off the battlefield. CR 608.2i: its ledger
+/// record must survive.
+fn depart_to_graveyard(runner: &mut GameRunner, id: ObjectId) {
+    let st = runner.state_mut();
+    st.battlefield.retain(|&b| b != id);
+    st.objects.get_mut(&id).unwrap().zone = Zone::Graveyard;
+}
+
+// ===========================================================================
+// T1 — the entry-event surface emits the CR 608.2i ledger variant
+// ===========================================================================
+
+/// T1. Hobgoblin Bandit Lord's "…Goblins that entered the battlefield UNDER YOUR
+/// CONTROL this turn" binds its controller to the past entry EVENT (CR 608.2i),
+/// so it must lower to `BattlefieldEntriesThisTurn` with a BARE filter.
+///
+/// REVERT-PROBE: restoring the `EnteredThisTurn` + `inject_controller` arm makes
+/// the amount `EnteredThisTurn{Typed{[Subtype("Goblin")], controller: Some(You)}}`
+/// and this `assert_eq!` panics.
+#[test]
+fn bbfu10_hobgoblin_count_form_migrated_to_ledger() {
+    let amount = hobgoblin_damage_amount();
+    assert_eq!(
+        amount,
+        ledger_typed(vec![TypeFilter::Subtype("Goblin".to_string())], vec![]),
+        "CR 608.2i: entry-event binding lowers to the look-back ledger with the \
+         controller on the PlayerScope, never injected into the filter"
+    );
+}
+
+// ===========================================================================
+// T4 — the tally is scoped by `PlayerScope::Controller`, not a filter controller
+// ===========================================================================
+
+/// T4 (hostile, multi-authority). Two candidate controllers are on the board and
+/// BOTH have a Goblin entry on the ledger; only the ability controller's may
+/// count (CR 608.2i tallies `record.controller`).
+///
+/// NON-VACUITY: assertion (b) is an in-test positive reach-guard on the SAME
+/// state — recording one own Goblin flips 0 → 1, so (a)'s zero cannot be an
+/// "everything reads zero" scaffolding failure.
+///
+/// REVERT-PROBE: change Step 1's `PlayerScope::Controller` to
+/// `AllPlayers { aggregate: Sum }` → (a) becomes 1 and FAILS.
+#[test]
+fn bbfu10_opponent_goblin_does_not_count() {
+    let amount = hobgoblin_damage_amount();
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let lord = scenario
+        .add_creature_from_oracle(P0, "Hobgoblin Bandit Lord", 3, 3, HOBGOBLIN)
+        .id();
+    let opp_goblin = scenario
+        .add_creature(P1, "Opponent Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    let own_goblin = scenario
+        .add_creature(P0, "Own Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    let mut runner = scenario.build();
+
+    record_entry_now(&mut runner, opp_goblin);
+    assert_eq!(
+        resolve_quantity(runner.state(), &amount, P0, lord),
+        0,
+        "(a) an OPPONENT's Goblin entry must not count under PlayerScope::Controller"
+    );
+
+    record_entry_now(&mut runner, own_goblin);
+    assert_eq!(
+        resolve_quantity(runner.state(), &amount, P0, lord),
+        1,
+        "(b) positive reach-guard on the same state: the controller's own Goblin \
+         entry DOES count, so (a) is a scope result and not a dead fixture"
+    );
+}
+
+// ===========================================================================
+// T5 — composite (`Or`) filters match the ledger record
+// ===========================================================================
+
+/// T5 (hostile, composite filter). Cloudspire Coordinator's ledger filter is a
+/// `TargetFilter::Or`, which `battlefield_entry_matches_filter` failed closed on
+/// before Step 2 (measured: constant 0 on records that make `Typed(Mount)` = 1).
+///
+/// REVERT-PROBE: delete Step 2's `TargetFilter::Or` arm → the count drops to 0.
+#[test]
+fn bbfu10_cloudspire_or_filter_counts_mount_and_vehicle() {
+    let parsed = parse_card(
+        CLOUDSPIRE,
+        "Cloudspire Coordinator",
+        &["Creature"],
+        &["Human", "Pilot"],
+    );
+    let count = parsed
+        .abilities
+        .iter()
+        .find_map(|a| match &*a.effect {
+            Effect::Token { count, .. } => Some(count.clone()),
+            _ => None,
+        })
+        .expect("Cloudspire must parse a Token-creating activated ability");
+
+    // Reach-guard: the exact composite shape this test exists to exercise.
+    let QuantityExpr::Ref {
+        qty:
+            QuantityRef::BattlefieldEntriesThisTurn {
+                player: PlayerScope::Controller,
+                filter: TargetFilter::Or { ref filters },
+            },
+    } = count
+    else {
+        panic!("reach-guard: expected a ledger ref over TargetFilter::Or, got {count:?}");
+    };
+    assert_eq!(filters.len(), 2, "Or[Typed(Mount), Typed(Vehicle)]");
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let coordinator = scenario
+        .add_creature_from_oracle(P0, "Cloudspire Coordinator", 2, 2, CLOUDSPIRE)
+        .id();
+    let mount = scenario
+        .add_creature(P0, "Departed Mount", 2, 2)
+        .with_subtypes(vec!["Mount"])
+        .id();
+    let vehicle = scenario
+        .add_creature(P0, "Live Vehicle", 3, 3)
+        .with_subtypes(vec!["Vehicle"])
+        .id();
+    let mut runner = scenario.build();
+
+    record_entry_now(&mut runner, mount);
+    record_entry_now(&mut runner, vehicle);
+    depart_to_graveyard(&mut runner, mount);
+
+    assert_eq!(
+        resolve_quantity(runner.state(), &count, P0, coordinator),
+        2,
+        "CR 608.2i: BOTH disjuncts must match the entry ledger — the departed \
+         Mount still counts and the live Vehicle counts too"
+    );
+}
+
+// ===========================================================================
+// T6 — `FilterProp::Another` still excludes the ability source
+// ===========================================================================
+
+/// T6 (hostile, two candidate authorities). Geralf's "each OTHER Zombie" must
+/// exclude the ability source's own ledger record. Both the source and another
+/// Zombie are recorded, so a dropped `source_id` would read 2.
+///
+/// REVERT-PROBE: pass `None` for `source_id` on the ledger resolution path
+/// (`game/quantity.rs`, the `BattlefieldEntriesThisTurn` arm) → `Another` can
+/// exclude nothing, the count becomes 2, FAIL.
+#[test]
+fn bbfu10_geralf_another_excludes_source() {
+    let parsed = parse_card(
+        GERALF,
+        "Geralf, the Fleshwright",
+        &["Creature"],
+        &["Human", "Warlock"],
+    );
+    let count = parsed
+        .triggers
+        .iter()
+        .filter_map(|t| t.execute.as_deref())
+        .find_map(|d| match &*d.effect {
+            Effect::PutCounter { count, .. } => Some(count.clone()),
+            _ => None,
+        })
+        .expect("Geralf must parse a PutCounter trigger");
+    assert_eq!(
+        count,
+        ledger_typed(
+            vec![TypeFilter::Subtype("Zombie".to_string())],
+            vec![FilterProp::Another]
+        ),
+        "reach-guard: the migrated shape carries FilterProp::Another on a bare filter"
+    );
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // The source is itself a Zombie, so `Another` is load-bearing rather than
+    // trivially satisfied.
+    let geralf = scenario
+        .add_creature_from_oracle(P0, "Geralf, the Fleshwright", 3, 3, GERALF)
+        .with_subtypes(vec!["Zombie"])
+        .id();
+    let other = scenario
+        .add_creature(P0, "Other Zombie", 2, 2)
+        .with_subtypes(vec!["Zombie"])
+        .id();
+    let mut runner = scenario.build();
+
+    record_entry_now(&mut runner, geralf);
+    record_entry_now(&mut runner, other);
+    depart_to_graveyard(&mut runner, other);
+
+    assert_eq!(
+        runner.state().battlefield_entries_this_turn.len(),
+        2,
+        "reach-guard: BOTH Zombie entries are on the ledger, so a count of 1 is \
+         the `Another` exclusion and not a missing record"
+    );
+    assert_eq!(
+        resolve_quantity(runner.state(), &count, P0, geralf),
+        1,
+        "CR 109.1: the source's own entry is excluded; the departed OTHER Zombie \
+         still counts (CR 608.2i)"
+    );
+}
+
+// ===========================================================================
+// T7 — a token entry re-derives PRE-EXISTING recipients, controller-scoped only
+// ===========================================================================
+
+/// T7 (Step 0a/0b). Kinbinding's Layer 7c magnitude is the ledger tally. When its
+/// OWN begin-combat trigger creates a Kithkin token, the incremental-flush
+/// escalation scan must fire, or every PRE-EXISTING creature keeps the stale
+/// magnitude (CR 611.3a: a continuous effect from a static ability is never
+/// locked in).
+///
+/// The fixture pair is **(1) + (4)**: (1) is the multiplayer-scope discriminator
+/// and (4) is what makes it load-bearing — an OPPONENT entry really is on the
+/// ledger, so a wrong `PlayerScope` would fold it into the anthem magnitude.
+/// Assertion (2) is an affected-set guard, NOT a scope probe: Kinbinding's
+/// `affected` is `Typed{[Creature], controller: You}`, so P1's creature is never
+/// anthem-affected and cannot flip under a scope mutation.
+///
+/// REVERT-PROBES, both measured:
+/// - Step 0a/0b → P0 bystander reads 2/2 and `layers_incremental == 1` /
+///   `layers_escalated == 0`; (1) and (5) FAIL.
+/// - Step 1's `PlayerScope::Controller` → `AllPlayers { aggregate: Sum }` → the
+///   tally becomes 2 (Kithkin + P1's entry) and the bystander reads 4/4; (1) FAILS.
+#[test]
+fn bbfu10_kinbinding_token_entry_updates_existing_creatures() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "Kinbinding", 0, 0, KINBINDING)
+        .as_enchantment();
+    let bystander = scenario.add_creature(P0, "P0 Bystander", 2, 2).id();
+    let opponent_creature = scenario.add_creature(P1, "P1 Entrant", 3, 3).id();
+    let mut runner = scenario.build();
+
+    // `GameScenario` does not push a `BattlefieldEntryRecord`, so the opponent's
+    // entry must be stamped through the production authority by hand.
+    record_entry_now(&mut runner, opponent_creature);
+
+    engine::game::perf_counters::reset();
+    runner.advance_to_combat();
+    runner.advance_until_stack_empty();
+    let perf = engine::game::perf_counters::snapshot();
+
+    // (3) reach-guard — the trigger really fired and a token really entered.
+    let kithkin: Vec<ObjectId> = runner
+        .state()
+        .battlefield
+        .iter()
+        .copied()
+        .filter(|id| runner.state().objects[id].name == "Kithkin")
+        .collect();
+    assert_eq!(
+        kithkin.len(),
+        1,
+        "(3) reach-guard: one Kithkin token entered"
+    );
+
+    // (4) reach-guard — the OPPONENT's entry IS on the ledger. This is what makes
+    // (1) a real multiplayer-scope discriminator.
+    assert_eq!(
+        runner.state().battlefield_entries_this_turn.len(),
+        2,
+        "(4) reach-guard: the ledger holds P1's stamped entry AND the Kithkin's"
+    );
+
+    // (1) THE DISCRIMINATOR — a PRE-EXISTING recipient sees the new magnitude,
+    // and it is the CONTROLLER-scoped tally (1), not the all-players tally (2).
+    let by = &runner.state().objects[&bystander];
+    assert_eq!(
+        (by.power, by.toughness),
+        (Some(3), Some(3)),
+        "(1) CR 611.3a: the pre-existing bystander must be 2/2 + X where X = 1 \
+         (only P0's Kithkin entry counts)"
+    );
+
+    // (2) affected-set guard — the anthem is `controller: You`, so P1 is untouched.
+    let opp = &runner.state().objects[&opponent_creature];
+    assert_eq!(
+        (opp.power, opp.toughness),
+        (Some(3), Some(3)),
+        "(2) affected-set guard: Kinbinding's anthem must not spray across controllers"
+    );
+
+    // (5) path guard — the entry took the ESCALATED flush, not the incremental one.
+    assert_eq!(
+        (perf.layers_escalated, perf.layers_incremental),
+        (1, 0),
+        "(5) the token entry must force `active_effects_force_incremental_escalation`"
+    );
+}
+
+// ===========================================================================
+// T8 — the enters-with-counters replacement path reads the ledger
+// ===========================================================================
+
+/// T8. Bioengineered Future resolves its magnitude on demand inside a
+/// `ReplacementDefinition`, a path that never goes through the layer system.
+/// (a) is the positive reach-guard (land still on the battlefield); (b) is the
+/// CR 608.2i claim (the same land departed).
+///
+/// REVERT-PROBE: revert Step 1 → (b) enters 2/2 with no counters, FAIL.
+/// (Measured pre-fix: (a) 3/3 with `Plus1Plus1 = 1`, (b) 2/2 with none.)
+#[test]
+fn bbfu10_bioengineered_future_departed_land_counts() {
+    for depart in [false, true] {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario
+            .add_creature_from_oracle(P0, "Bioengineered Future", 0, 0, BIOENGINEERED_FUTURE)
+            .as_enchantment();
+        let land = scenario.add_land_from_oracle(P0, "Recorded Land", "").id();
+        let creature = scenario
+            .add_creature_to_hand(P0, "Entering Creature", 2, 2)
+            .id();
+        let mut runner = scenario.build();
+
+        record_entry_now(&mut runner, land);
+        if depart {
+            depart_to_graveyard(&mut runner, land);
+        }
+
+        runner.cast(creature).free_cast().resolve();
+
+        let obj = &runner.state().objects[&creature];
+        assert_eq!(
+            obj.zone,
+            Zone::Battlefield,
+            "reach-guard (depart={depart}): the creature must actually resolve onto \
+             the battlefield"
+        );
+        assert_eq!(
+            obj.counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or(0),
+            1,
+            "CR 608.2i (depart={depart}): the land that entered this turn counts \
+             whether or not it is still on the battlefield"
+        );
+        assert_eq!(
+            (obj.power, obj.toughness),
+            (Some(3), Some(3)),
+            "(depart={depart}) the +1/+1 counter must be reflected in P/T"
+        );
+    }
+}
+
+// ===========================================================================
+// T9 — BOUNDARY LOCK: Tromell's subject-noun form does NOT migrate
+// ===========================================================================
+
+/// T9. "nontoken creatures YOU CONTROL that entered this turn" binds the
+/// controller to the SUBJECT NOUN, which by CR 109.2 names a battlefield
+/// permanent — a CR 608.2h live read, not a CR 608.2i look-back.
+///
+/// REVERT-PROBE: route the `SubjectNoun` arm to the ledger → (a) panics and (b)'s
+/// first assertion reads 1 instead of 0.
+#[test]
+fn bbfu10_tromell_live_form_not_over_migrated() {
+    let parsed = parse_card(
+        TROMELL,
+        "Tromell, Seymour's Butler",
+        &["Creature"],
+        &["Elf", "Advisor"],
+    );
+    let repeat = parsed
+        .abilities
+        .iter()
+        .find_map(|a| a.repeat_for.clone())
+        .expect("Tromell must parse a `Proliferate X times` repeat quantity");
+
+    // (a) shape lock — the LIVE variant with the controller ON THE FILTER.
+    assert_eq!(
+        repeat,
+        QuantityExpr::Ref {
+            qty: QuantityRef::EnteredThisTurn {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Creature],
+                    controller: Some(ControllerRef::You),
+                    properties: vec![FilterProp::NonToken],
+                }),
+            },
+        },
+        "(a) CR 608.2h: subject-noun binding stays on the live-board variant"
+    );
+
+    // (b) runtime, with an in-test positive reach-guard.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let tromell = scenario
+        .add_creature_from_oracle(P0, "Tromell, Seymour's Butler", 2, 3, TROMELL)
+        .id();
+    let departed_own = scenario.add_creature(P0, "Departed Own", 1, 1).id();
+    let live_opponent = scenario.add_creature(P1, "Live Opponent", 1, 1).id();
+    let live_own = scenario.add_creature(P0, "Live Own", 1, 1).id();
+    let mut runner = scenario.build();
+
+    record_entry_now(&mut runner, departed_own);
+    record_entry_now(&mut runner, live_opponent);
+    depart_to_graveyard(&mut runner, departed_own);
+
+    assert_eq!(
+        resolve_quantity(runner.state(), &repeat, P0, tromell),
+        0,
+        "(b) a departed own creature and a LIVE opponent creature both entered \
+         this turn, and the live-board reading counts neither"
+    );
+
+    record_entry_now(&mut runner, live_own);
+    assert_eq!(
+        resolve_quantity(runner.state(), &repeat, P0, tromell),
+        1,
+        "(b) positive reach-guard on the same state: a live own nontoken creature \
+         stamped as entered-this-turn DOES count"
+    );
+}
+
+// ===========================================================================
+// T10 / T11 — SET-PATH and AFFECTED-SET locks (Step 4 does nothing)
+// ===========================================================================
+
+/// T10. The for-each-copy set path lowers "token you control that entered this
+/// turn" to `FilterProp::EnteredThisTurn` inside a `source_filter`, an entirely
+/// different enum surface from `QuantityRef`. It must be untouched.
+///
+/// REVERT-PROBE: add a ledger arm to
+/// `parse_for_each_object_filter_clause_with_context` that swallows the clause,
+/// or migrate the `SubjectNoun` arm → the filter disappears and this FAILS.
+#[test]
+fn bbfu10_ocelot_pride_for_each_copy_set_stays_live() {
+    let parsed = parse_card(OCELOT_PRIDE, "Ocelot Pride", &["Creature"], &["Cat"]);
+    let mut found = false;
+    for trigger in &parsed.triggers {
+        let mut cur = trigger.execute.as_deref();
+        while let Some(def) = cur {
+            if let Effect::CopyTokenOf { source_filter, .. } = &*def.effect {
+                let Some(TargetFilter::Typed(tf)) = source_filter else {
+                    panic!("expected a Typed source_filter, got {source_filter:?}");
+                };
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+                assert!(tf.properties.contains(&FilterProp::Token));
+                assert!(tf.properties.contains(&FilterProp::EnteredThisTurn));
+                found = true;
+            }
+            cur = def.sub_ability.as_deref();
+        }
+    }
+    assert!(
+        found,
+        "reach-guard: Ocelot Pride must still parse a CopyTokenOf with an \
+         EnteredThisTurn source_filter — a `None` here is the swallowed state"
+    );
+}
+
+/// T11. Oakhollow Village and Novijen route "entered the battlefield this turn"
+/// through the TARGET path (`PutCounterAll` + `FilterProp::EnteredThisTurn`), not
+/// through `QuantityRef` at all. This is the non-interference lock for Step 4.
+///
+/// REVERT-PROBE: any change routing the target path through the ledger → FAIL.
+#[test]
+fn bbfu10_oakhollow_novijen_affected_set_unchanged() {
+    let oak = parse_card(OAKHOLLOW_VILLAGE, "Oakhollow Village", &["Land"], &[]);
+    let oak_target = oak
+        .abilities
+        .iter()
+        .find_map(|a| match &*a.effect {
+            Effect::PutCounterAll { target, .. } => Some(target.clone()),
+            _ => None,
+        })
+        .expect("Oakhollow must parse a PutCounterAll");
+    let TargetFilter::Or { filters } = &oak_target else {
+        panic!("Oakhollow's affected set is Or[4x Typed], got {oak_target:?}");
+    };
+    assert_eq!(filters.len(), 4, "Frog / Rabbit / Raccoon / Squirrel");
+    for f in filters {
+        let TargetFilter::Typed(tf) = f else {
+            panic!("expected Typed disjunct, got {f:?}");
+        };
+        assert_eq!(tf.controller, Some(ControllerRef::You));
+        assert!(tf.properties.contains(&FilterProp::EnteredThisTurn));
+    }
+
+    let nov = parse_card(NOVIJEN, "Novijen, Heart of Progress", &["Land"], &[]);
+    let nov_target = nov
+        .abilities
+        .iter()
+        .find_map(|a| match &*a.effect {
+            Effect::PutCounterAll { target, .. } => Some(target.clone()),
+            _ => None,
+        })
+        .expect("Novijen must parse a PutCounterAll");
+    assert_eq!(
+        nov_target,
+        TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::Creature],
+            controller: None,
+            properties: vec![FilterProp::EnteredThisTurn],
+        }),
+        "Novijen's bare affected set stays a live FilterProp, not a ledger ref"
+    );
+}
+
+// ===========================================================================
+// T12 — DISCRIMINATOR LOCK: the predicate is controller attachment
+// ===========================================================================
+
+/// T12. "creatures YOU CONTROL that entered THE BATTLEFIELD this turn" carries
+/// the substring "the battlefield" while binding the controller to the noun. A
+/// substring-based discriminator would over-migrate it; the attachment-site
+/// discriminator must not.
+///
+/// REVERT-PROBE: implement "`the battlefield` present ⇒ migrate" → this becomes
+/// `BattlefieldEntriesThisTurn` and FAILS.
+#[test]
+fn bbfu10_the_battlefield_arm_with_noun_controller_stays_live() {
+    let parsed = parse_card(
+        NOUN_CONTROLLER_SYNTHETIC,
+        "Bbfu10 Discriminator Probe",
+        &["Creature"],
+        &["Elemental"],
+    );
+    let amount = parsed
+        .abilities
+        .iter()
+        .find_map(find_damage_amount)
+        .expect("the synthetic must parse a DealDamage activated ability");
+    assert_eq!(
+        amount,
+        QuantityExpr::Ref {
+            qty: QuantityRef::EnteredThisTurn {
+                filter: TargetFilter::Typed(TypedFilter {
+                    type_filters: vec![TypeFilter::Creature],
+                    controller: Some(ControllerRef::You),
+                    properties: vec![],
+                }),
+            },
+        },
+        "CR 608.2h: the controller came from the SUBJECT NOUN, so this stays live \
+         even though the clause says \"the battlefield\""
+    );
+}
+
+// ===========================================================================
+// T13 — FUTURE-ADDITION LOCK: the opponent surface stays honestly unsupported
+// ===========================================================================
+
+/// T13. No printed card templates "…under an opponent's control this turn" in a
+/// quantity context (measured: 0/34 corpus cards), so the parser must fall to an
+/// honest `Effect::Unimplemented` rather than guess a scope.
+///
+/// The `OWN_SURFACE_SYNTHETIC` half is the positive reach-guard: without it the
+/// `Unimplemented` assertion would pass for ANY parse failure on that card shape.
+///
+/// This is a LOCK, not a revert-probe: adding a guessed opponent arm with no
+/// printed card behind it makes it FAIL.
+#[test]
+fn bbfu10_opponent_entry_surface_stays_unimplemented() {
+    let opponent = parse_card(
+        OPPONENT_SURFACE_SYNTHETIC,
+        "Bbfu10 Opponent Probe",
+        &["Creature"],
+        &["Elemental"],
+    );
+    assert!(
+        opponent
+            .abilities
+            .iter()
+            .any(|a| matches!(&*a.effect, Effect::Unimplemented { .. })),
+        "the opponent entry-event surface must stay honestly unimplemented, got {:?}",
+        opponent
+            .abilities
+            .iter()
+            .map(|a| &a.effect)
+            .collect::<Vec<_>>()
+    );
+
+    let own = parse_card(
+        OWN_SURFACE_SYNTHETIC,
+        "Bbfu10 Own Probe",
+        &["Creature"],
+        &["Elemental"],
+    );
+    let amount = own.abilities.iter().find_map(find_damage_amount).expect(
+        "positive reach-guard: the SAME card shape with \"under your \
+                 control\" must parse",
+    );
+    assert_eq!(
+        amount,
+        ledger_typed(vec![TypeFilter::Creature], vec![]),
+        "positive reach-guard: the sibling surface reaches the ledger variant, so \
+         the Unimplemented above is about the OPPONENT scope specifically"
+    );
+}
+
+// ===========================================================================
+// T18 / T19 — Step 2 on a SHIPPED `Or` ledger card (Lilypad Village)
+// ===========================================================================
+
+/// Parse Lilypad Village and return `(ability_index, RequiresCondition list)`.
+///
+/// The index is found by SCANNING for the `RequiresCondition`, never hardcoded:
+/// Lilypad Village's gated ability is `abilities[2]` (`[0]`/`[1]` are the two
+/// mana abilities), so the BB-FU1 precedent helper's hardcoded `abilities[0]`
+/// would silently gate on `{T}: Add {C}` and pass vacuously.
+fn lilypad_gated_ability() -> (usize, Vec<ActivationRestriction>) {
+    let parsed = parse_card(LILYPAD_VILLAGE, "Lilypad Village", &["Land"], &[]);
+    let hits: Vec<(usize, Vec<ActivationRestriction>)> = parsed
+        .abilities
+        .iter()
+        .enumerate()
+        .filter_map(|(i, a)| {
+            let req: Vec<ActivationRestriction> = a
+                .activation_restrictions
+                .iter()
+                .filter(|r| matches!(r, ActivationRestriction::RequiresCondition { .. }))
+                .cloned()
+                .collect();
+            (!req.is_empty()).then_some((i, req))
+        })
+        .collect();
+    assert_eq!(
+        hits.len(),
+        1,
+        "reach-guard: exactly ONE Lilypad Village ability carries a \
+         RequiresCondition (found indices {:?})",
+        hits.iter().map(|(i, _)| *i).collect::<Vec<_>>()
+    );
+    hits.into_iter().next().unwrap()
+}
+
+/// Assert the isolated condition's `lhs` really is the composite ledger read, and
+/// return nothing. Pins `Some(condition)` — a `condition: None` is permissively
+/// TRUE at the production gate, so without this a reverted parse would look legal.
+fn assert_lilypad_condition_shape(req: &[ActivationRestriction]) {
+    let condition = req
+        .iter()
+        .find_map(|r| match r {
+            ActivationRestriction::RequiresCondition {
+                condition: Some(c), ..
+            } => Some(c),
+            _ => None,
+        })
+        .expect("condition: None is the reverted/permissive state, not a pass");
+    let ParsedCondition::QuantityComparison {
+        lhs,
+        comparator,
+        rhs,
+    } = condition
+    else {
+        panic!("expected a QuantityComparison, got {condition:?}");
+    };
+    assert_eq!(*comparator, Comparator::GE);
+    assert_eq!(*rhs, QuantityExpr::Fixed { value: 1 });
+    let QuantityExpr::Ref {
+        qty:
+            QuantityRef::BattlefieldEntriesThisTurn {
+                player: PlayerScope::Controller,
+                filter: TargetFilter::Or { filters },
+            },
+    } = lhs
+    else {
+        panic!("expected a ledger ref over TargetFilter::Or, got {lhs:?}");
+    };
+    assert_eq!(filters.len(), 4, "Bird / Frog / Otter / Rat");
+}
+
+/// T18 (M-1 deliverable). Lilypad Village is a SHIPPED card carrying the ledger
+/// variant with a `TargetFilter::Or` filter, which `battlefield_entry_matches_filter`
+/// failed closed on ⇒ a constant 0. Step 2 makes it count for real. This asserts
+/// on the QUANTITY only; T19 covers the activation layer.
+///
+/// REVERT-PROBE: delete Step 2's `TargetFilter::Or` arm → (b) reads 0, FAIL.
+#[test]
+fn bbfu10_shipped_or_ledger_card_counts_after_composite_fix() {
+    let (_idx, req) = lilypad_gated_ability();
+    assert_lilypad_condition_shape(&req); // (a) reach-guard
+    let ActivationRestriction::RequiresCondition {
+        condition: Some(ParsedCondition::QuantityComparison { lhs, .. }),
+        ..
+    } = &req[0]
+    else {
+        unreachable!("shape asserted above")
+    };
+
+    // (b) one MATCHING entry (a Frog) ⇒ the ledger reads at least 1.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let village = scenario
+        .add_land_from_oracle(P0, "Lilypad Village", LILYPAD_VILLAGE)
+        .id();
+    let frog = scenario
+        .add_creature(P0, "Qualifying Frog", 1, 1)
+        .with_subtypes(vec!["Frog"])
+        .id();
+    let human = scenario
+        .add_creature(P0, "Non-Qualifying Human", 1, 1)
+        .with_subtypes(vec!["Human"])
+        .id();
+    let mut runner = scenario.build();
+
+    record_entry_now(&mut runner, human);
+    // (c) negative sibling FIRST, on the same board: a non-matching entry alone
+    // must read 0, so (b) cannot pass on a mere "any record present" bug.
+    assert_eq!(
+        resolve_quantity(runner.state(), lhs, P0, village),
+        0,
+        "(c) a Human entry matches none of Bird/Frog/Otter/Rat"
+    );
+
+    record_entry_now(&mut runner, frog);
+    assert_eq!(
+        resolve_quantity(runner.state(), lhs, P0, village),
+        1,
+        "(b) CR 608.2i: the Frog disjunct must match the entry record — this reads \
+         a fail-closed 0 without Step 2's `TargetFilter::Or` arm"
+    );
+}
+
+/// T19 (F7 deliverable). The `Or` fail-closed 0 vs `GE 1` makes Lilypad Village's
+/// `{U}, {T}: Surveil 2.` **un-activatable, always** on the shipped card. Step 2
+/// is therefore a user-visible UNLOCK, and the repo's non-vacuous-test rule does
+/// not let the PR claim an unlock it never drives.
+///
+/// Depends on Step 2 ONLY (not on Step 1): Lilypad Village already carries the
+/// ledger variant on the shipped tip.
+///
+/// REVERT-PROBE: delete Step 2's `TargetFilter::Or` arm → the tally is 0,
+/// `0 >= 1` is false, and (3) becomes ILLEGAL: FAIL. That flip IS the unlock.
+/// (4) is ILLEGAL in BOTH builds and is the anti-vacuity control.
+#[test]
+fn bbfu10_lilypad_village_activation_unlocked_by_composite_fix() {
+    let (idx, req) = lilypad_gated_ability(); // (1) index reach-guard
+    assert_eq!(
+        idx, 2,
+        "(1) the gated ability is abilities[2]; [0]/[1] are the mana abilities"
+    );
+    assert_lilypad_condition_shape(&req); // (2) condition shape reach-guard
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let village = scenario
+        .add_land_from_oracle(P0, "Lilypad Village", LILYPAD_VILLAGE)
+        .id();
+    let human = scenario
+        .add_creature(P0, "Non-Qualifying Human", 1, 1)
+        .with_subtypes(vec!["Human"])
+        .id();
+    let frog = scenario
+        .add_creature(P0, "Qualifying Frog", 1, 1)
+        .with_subtypes(vec!["Frog"])
+        .id();
+    let mut runner = scenario.build();
+
+    // (4) NEGATIVE CONTROL — a non-matching entry leaves the ability illegal, so a
+    // fixture that silently failed to push a record cannot fake (3).
+    record_entry_now(&mut runner, human);
+    assert!(
+        check_activation_restrictions(runner.state(), P0, village, idx, &req).is_err(),
+        "(4) with only a Human entry the condition is false ⇒ still ILLEGAL"
+    );
+
+    // (3) THE UNLOCK — one qualifying entry flips the production gate to LEGAL.
+    record_entry_now(&mut runner, frog);
+    assert!(
+        check_activation_restrictions(runner.state(), P0, village, idx, &req).is_ok(),
+        "(3) CR 608.2i: with a Frog entry recorded the RequiresCondition is \
+         satisfied and `{{U}}, {{T}}: Surveil 2.` becomes activatable — this is \
+         ILLEGAL without Step 2's `TargetFilter::Or` arm"
+    );
+}
+
+// ===========================================================================
+// T20 / T21 — Step 7: the entry-record matcher's fail-closed `FilterProp` hole
+// ===========================================================================
+
+/// T20 (Step 7b). `battlefield_entry_matches_filter` answers only 4 of the 98
+/// `FilterProp` variants and fails closed on the rest, so a ledger tally over an
+/// unanswerable prop resolves to a silent constant 0. On the QUANTITY path a
+/// refused clause becomes an honest `Effect::Unimplemented`, so the guard refuses
+/// rather than mis-lowering.
+///
+/// (Deliberately NOT mirrored at the condition-side emitters, where an
+/// unparseable clause is silently dropped and would over-permit instead.)
+///
+/// REVERT-PROBE: delete the `if !ledger_filter_is_evaluable(..)` block in
+/// `parse_entered_this_turn_ref` → (a) lowers to
+/// `DealDamage{amount: Ref(BattlefieldEntriesThisTurn{…[NonToken]})}` and FAILS.
+/// (b) and (c) pass in both builds and are the vacuity controls.
+#[test]
+fn bbfu10_nonevaluable_entry_filter_stays_unimplemented() {
+    // (a) THE DISCRIMINATOR — `NonToken` is not answerable from the entry record.
+    let refused = parse_card(
+        NONEVALUABLE_PROP_SYNTHETIC,
+        "Bbfu10 Nonevaluable Prop Probe",
+        &["Creature"],
+        &["Elemental"],
+    );
+    let serialized = serde_json::to_string(&refused.abilities).expect("abilities serialize");
+    assert!(
+        !serialized.contains("BattlefieldEntriesThisTurn"),
+        "(a) a filter the entry-record matcher cannot evaluate must NOT reach the \
+         ledger variant (would resolve a silent constant 0), got {serialized}"
+    );
+    assert!(
+        refused
+            .abilities
+            .iter()
+            .any(|a| matches!(&*a.effect, Effect::Unimplemented { .. })),
+        "(a) the refused clause must surface as an honest Effect::Unimplemented, got {:?}",
+        refused
+            .abilities
+            .iter()
+            .map(|a| &a.effect)
+            .collect::<Vec<_>>()
+    );
+
+    // (b) PROP-DISCRIMINATION reach-guard — `HasColor` IS answerable
+    // (game/restrictions.rs:504), so the same shape must still lower.
+    let evaluable = parse_card(
+        EVALUABLE_PROP_SYNTHETIC,
+        "Bbfu10 Evaluable Prop Probe",
+        &["Creature"],
+        &["Elemental"],
+    );
+    assert_eq!(
+        evaluable
+            .abilities
+            .iter()
+            .find_map(find_damage_amount)
+            .expect("(b) the green-creature surface must still parse a DealDamage"),
+        ledger_typed(
+            vec![TypeFilter::Creature],
+            vec![FilterProp::HasColor {
+                color: ManaColor::Green
+            }]
+        ),
+        "(b) the guard screens WHICH prop, not whether any prop is present"
+    );
+
+    // (c) BARE reach-guard — an empty property list is trivially evaluable.
+    let bare = parse_card(
+        OWN_SURFACE_SYNTHETIC,
+        "Bbfu10 Bare Reach Guard",
+        &["Creature"],
+        &["Elemental"],
+    );
+    assert_eq!(
+        bare.abilities
+            .iter()
+            .find_map(find_damage_amount)
+            .expect("(c) the bare surface must parse a DealDamage"),
+        ledger_typed(vec![TypeFilter::Creature], vec![]),
+        "(c) the unpropertied ledger read is untouched by the guard"
+    );
+}
+
+/// T21. The MOTIVATING MEASUREMENT for Step 7, not a discriminator: it asserts
+/// existing runtime behaviour. A single own nontoken legendary tapped creature is
+/// stamped into the production ledger; every `FilterProp` outside the matcher's
+/// four reads a constant 0 even though the live object genuinely satisfies it.
+///
+/// It flips only when `battlefield_entry_matches_filter` gains those props, at
+/// which point `ledger_guard_agrees_with_matcher` (game/restrictions.rs) must be
+/// updated in the same commit.
+#[test]
+fn bbfu10_nonevaluable_ledger_prop_reads_constant_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Bbfu10 Ledger Source", 1, 1).id();
+    let entrant = scenario
+        .add_creature(P0, "Legendary Tapped Entrant", 2, 2)
+        .as_legendary()
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().objects.get_mut(&entrant).unwrap().tapped = true;
+    record_entry_now(&mut runner, entrant);
+
+    let read = |properties: Vec<FilterProp>| {
+        resolve_quantity(
+            runner.state(),
+            &ledger_typed(vec![TypeFilter::Creature], properties),
+            P0,
+            source,
+        )
+    };
+
+    // Positive reach-guard: the fixture really pushed a record.
+    assert_eq!(read(vec![]), 1, "the bare ledger read sees the entry");
+    // The live object IS nontoken, legendary and tapped — the SNAPSHOT is not.
+    assert_eq!(read(vec![FilterProp::NonToken]), 0, "NonToken fails closed");
+    assert_eq!(
+        read(vec![FilterProp::HasSupertype {
+            value: Supertype::Legendary
+        }]),
+        0,
+        "HasSupertype fails closed even though the record snapshots supertypes"
+    );
+    assert_eq!(read(vec![FilterProp::Tapped]), 0, "Tapped fails closed");
+}

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -4056,3 +4056,142 @@ fn predicted_winner_concede_mid_apnap_does_not_drive() {
         ref other => panic!("the liveness guard hands priority back (manual play), got {other:?}"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// BB-FU10 T16 — a battlefield-entry-LEDGER observer VETOES the object-growth
+// offer. This is the ruling's disclosed, sound post-Step-0c behaviour, asserted
+// as such so nobody "fixes" the test by deleting it.
+// ---------------------------------------------------------------------------
+
+/// Park Heights Pegasus, verbatim (Scryfall / MTGJSON `AtomicCards.json`). Its
+/// trigger `execute` body carries the CR 608.2i
+/// `QuantityRef::BattlefieldEntriesThisTurn` read, which
+/// `fire_time_conditions_read_growing_class` block (1) scans at the
+/// `ability_definition_reads_sibling_mutable_for_loop` call site.
+const PARK_HEIGHTS_PEGASUS_ORACLE: &str = "Flying, trample\nWhenever this creature deals combat damage to a player, draw a card if you had two or more creatures enter the battlefield under your control this turn.";
+
+/// ANTI-VACUITY CONTROL: the same board shape with a trigger that reads NOTHING
+/// board-mutable. Granted in BOTH builds, which is what proves the veto below
+/// comes from the ledger clause and not from the bystander's mere presence.
+const PLAIN_DRAW_TRIGGER_ORACLE: &str =
+    "Flying, trample\nWhenever this creature deals combat damage to a player, draw a card.";
+
+/// The passing 51st Sprout Swarm / Witherbloom object-growth row plus exactly ONE
+/// extra P0 battlefield permanent carrying `bystander_oracle`. Returns the final
+/// `WaitingFor` plus the bystander's id, so the caller can reach-guard its zone.
+fn object_growth_with_bystander(bystander_oracle: &str) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(
+        P0,
+        "Witherbloom, the Balancer",
+        5,
+        5,
+        WITHERBLOOM_AFFINITY_ORACLE,
+    );
+    let bystander = scenario
+        .add_creature_from_oracle(P0, "BBFU10 Bystander", 2, 2, bystander_oracle)
+        .id();
+    let mut fodder = Vec::new();
+    for _ in 0..4 {
+        fodder.push(scenario.add_creature(P0, "Saproling", 1, 1).id());
+    }
+    let sprout = {
+        let mut b =
+            scenario.add_spell_to_hand_from_oracle(P0, "Sprout Swarm", true, SPROUT_SWARM_ORACLE);
+        b.with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        });
+        b.id()
+    };
+    let mut runner = scenario.build();
+    {
+        let st = runner.state_mut();
+        st.loop_detection = LoopDetectionMode::Interactive;
+        for &id in &fodder {
+            st.objects.get_mut(&id).unwrap().color = vec![ManaColor::Green];
+        }
+    }
+    // The cast pipeline settles the loop verdict into `state().waiting_for`, which
+    // is what the caller reads (the borrowed `CastOutcome` is dropped here).
+    runner
+        .cast(sprout)
+        .accept_optional()
+        .convoke_with(&[fodder[0]])
+        .commit()
+        .resolve();
+    (runner, bystander)
+}
+
+/// T16 (BB-FU10 RULING deliverable). With Step 0c applied, a shipped
+/// battlefield-entry-ledger observer anywhere on a functioning battlefield
+/// SUPPRESSES a CR 732.2a object-growth offer that fires without it.
+///
+/// This asserts the SUPPRESSION as the sound behaviour. Per the plan's §0.5
+/// ruling, the engine already classifies `battlefield_entries_this_turn` as a
+/// journal a loop pumps (`project_out_resources` clears it), so `sibling: false`
+/// let the firewall hand out a false ∞ certificate while a live observer read the
+/// growing class — the one error direction `ability_scan`'s ADD-1 contract
+/// forbids.
+///
+/// **`BB-FU10-N` is the narrowing follow-up that will flip assertion (1) back to
+/// an offer** (gate the veto on whether the observer's filter can actually match
+/// the growing class, mirroring `etb_observer_provably_excludes_class`). Do NOT
+/// "fix" this test by deleting it — update it when `BB-FU10-N` lands.
+///
+/// REVERT-PROBE: set the `BattlefieldEntriesThisTurn` arm's `sibling` back to
+/// `false` in `game/ability_scan.rs` → (1) FAILS (the offer returns). Measured
+/// both directions; the (2) control is granted in BOTH builds.
+#[test]
+fn object_growth_ledger_observer_bystander_suppresses_offer() {
+    use engine::types::zones::Zone;
+
+    // (2) ANTI-VACUITY CONTROL first: an otherwise byte-identical board whose
+    // bystander reads nothing board-mutable still gets the offer.
+    let (control_runner, control_bystander) =
+        object_growth_with_bystander(PLAIN_DRAW_TRIGGER_ORACLE);
+    match &control_runner.state().waiting_for {
+        WaitingFor::LoopShortcut { certificate, .. } => assert!(
+            certificate.unbounded.contains(&ResourceAxis::TokensCreated),
+            "(2) control: the detected loop's unbounded axis must be TokensCreated, got {:?}",
+            certificate.unbounded
+        ),
+        other => panic!(
+            "(2) anti-vacuity control: a plain draw-trigger bystander must NOT suppress \
+             the offer, got {other:?}"
+        ),
+    }
+    assert_eq!(
+        control_runner.state().objects[&control_bystander].zone,
+        Zone::Battlefield,
+        "(3) control reach-guard: the bystander is a functioning battlefield permanent"
+    );
+
+    // The subject: the SAME board with Park Heights Pegasus instead.
+    let (runner, bystander) = object_growth_with_bystander(PARK_HEIGHTS_PEGASUS_ORACLE);
+
+    // (3) reach-guard — block (1) hard-skips non-battlefield zones, so the observer
+    // must actually be on the battlefield, and must carry exactly one trigger.
+    let obj = &runner.state().objects[&bystander];
+    assert_eq!(
+        obj.zone,
+        Zone::Battlefield,
+        "(3) reach-guard: the ledger observer must be a functioning battlefield permanent"
+    );
+    assert_eq!(
+        obj.trigger_definitions.len(),
+        1,
+        "(3) reach-guard: exactly one trigger definition carries the ledger read"
+    );
+
+    // (1) THE VETO — the disclosed, sound post-0c behaviour.
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::LoopShortcut { .. }),
+        "(1) CR 732.2a: a live observer reading the battlefield-entry ledger must \
+         VETO the object-growth certificate; got {:?}. If BB-FU10-N (the narrowing \
+         follow-up) has landed, this assertion is expected to flip back to an OFFER \
+         — update it, do not delete the test.",
+        runner.state().waiting_for
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -39,6 +39,7 @@ mod baleful_mastery_regression;
 mod banding_combat;
 mod batched_trigger_subject_count;
 mod battle_of_wits;
+mod bbfu10_entered_this_turn_snapshot;
 mod bbfu7_attacks_if_able_not_goad;
 mod belbe_thornbow_life_loss;
 mod betor_lifelink_counters_repro;


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`parse_entered_this_turn_ref` emitted the live-board `QuantityRef::EnteredThisTurn` for Oracle text whose "entered the battlefield under your control this turn" clause is an **entry event**, so a permanent that entered this turn and has since left stopped counting — contradicting CR 608.2i (look-back). This migrates only the entry-event surface to the ledger-backed `QuantityRef::BattlefieldEntriesThisTurn { player, filter }`, leaves the subject-noun surface (Tromell, CR 608.2h live set) alone, and repairs three defects the migration exposed in the entry-record matcher.

## Implementation method (required)

Method: /engine-implementer

## CR references

`CR 608.2i` (look-back — the migration's basis), `CR 608.2h` (once-determined live set — why Tromell must NOT migrate), `CR 702.73a` (Changeling CDA), `CR 205.3m` (creature-type namespace), `CR 403.3` (permanents exist only on the battlefield), `CR 109.1`, `CR 109.2`, `CR 109.5`, `CR 111`, `CR 400`, `CR 102.2`, `CR 102.3`, `CR 205.4b`, `CR 308.1`, `CR 603.3b`, `CR 603.6a`, `CR 611.3a`, `CR 701.21`, `CR 732.2a`.

Every number was grep-verified against `docs/MagicCompRules.txt` before being written; the whole-diff gate reports zero unverified. The pre-existing `// CR 608.2b: Disjunction` miscitation at `filter.rs:2833` was deliberately **not** propagated (neither 608.2b nor 608.2i is a disjunction rule).

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all --check` — exit 0
- `cargo clippy --all-targets -- -D warnings` — exit 0, zero diagnostics
- `cargo nextest run -p engine` — **21258 passed / 0 failed / 8 skipped**
- `cargo nextest run -p engine -E 'test(combo_infinite_pile) | test(kilo_live_offer_from_real_dump) | test(sprout_inalla_realistic_offer) | test(loop_shortcut)'` — **96/96 passed**
- `./scripts/check-parser-combinators.sh` — exit 0 (Gate G + Gate A PASS)
- `cargo combo-verify` — **13 confirmed / 4 gated / 37 deferred / 0 failed (of 54)**; all **54 rows row-for-row identical** to base
- BASE-vs-POST `data/card-data.json` — 35477 cards both sides, 0 added, 0 removed, **5 changed** (see Claimed parse impact)
- BASE-vs-POST `data/coverage-data.json` — `supported_cards` **31504 both sides**, supported-flip multiset diff **0 / 0**
- `FORGE_TEST_FULL_DB=1 … ordering_parity_sweep` — `unexplained=18` on **both base and head**, all metrics and all **18 rows byte-identical** (delta zero). Pre-existing Urza-block failure, opt-in gate, not default CI.

Base and head card-data were generated from **md5-identical MTGJSON inputs** (`AtomicCards.json` `0dd2d256…`, verified after both runs), so every delta above is code-caused, not input drift.

## Gate A

Gate A PASS head=96d5a3b0b434052651e4a95a77941839bcd7fb18 base=836ff312ae2073c99af28d286b0c4915faa8a458

## Anchored on

- `crates/engine/src/game/filter.rs:2840` — `zone_change_record_matches_type_filter`: the existing snapshot-record type-filter matcher that already threads `all_creature_types` live against a snapshotted record. Step 8 mirrors it exactly.
- `crates/engine/src/parser/oracle_nom/condition.rs:7725` — `parse_or_more_entered_count`: BB-FU1's already-shipped condition-side emitter of the same ledger variant, i.e. the sibling surface this PR's quantity-side migration matches.

## Final review-impl

Final review-impl PASS head=96d5a3b0b434052651e4a95a77941839bcd7fb18

## Claimed parse impact

- Hobgoblin Bandit Lord
- Geralf, the Fleshwright
- Cloudspire Coordinator
- Kinbinding
- Bioengineered Future

Three further cards change behavior with **no AST change**, so they cannot appear in a card-data diff — measured and confirmed absent from it:

- Cleaving Reaper
- Lilypad Village
- Nimble Trapfinder

They benefit from the `TargetFilter::Or` repair in the entry-record matcher; two of them gain a previously-impossible activation. The unlock is driven, not asserted: `bbfu10_lilypad_village_activation_unlocked_by_composite_fix` drives `check_activation_restrictions` and measures ILLEGAL → LEGAL.

## Disclosures

**1. A CR 732.2a firewall reclassification suppresses three shipping combo offers.**
`ability_scan.rs` classified `BattlefieldEntriesThisTurn` as `sibling: false`, while `analysis/resource.rs` already clears `battlefield_entries_this_turn` as *"append-only event journals a loop pumps"*. Those two statements contradict each other, and the combination lets the engine hand out a **false ∞ certificate** today. This PR flips the axis to `sibling: true`, which is what the module's own ⛔ INVARIANT requires.

Measured cost: three battlefield permanents — **Park Heights Pegasus**, **Smuggler's Share**, and **The Prydwen, Steel Flagship** (one card; the comma is part of its name) — stop receiving a CR 732.2a loop-shortcut offer they receive today. This is a deliberate, disclosed trade, not an oversight; restoring them under a narrower predicate is tracked as follow-up **BB-FU10-N**. `loop_shortcut.rs` carries a driven regression test that asserts the suppression and names BB-FU10-N as the item that will flip it back.

DB-wide census (measured at the pre-rebase base `e48c7d6e1`; the suppression itself is pinned at the current head by a committed driven test): 35454 faces, `sib_true` 16939 → 16945; the six added faces are exactly the predicted set and the removed set is **empty**. Step 1 in isolation measures 16937 — it *relaxes* Geralf and Hobgoblin Bandit Lord, which is precisely the false-certificate relaxation Step 0c closes.

**2. Not fixed, and deliberately so.** The entry-record snapshot is taken pre-layer, so only Changeling is repairable from it (the keyword travels; granted subtypes do not). 192 MTGJSON cards grant types via continuous effects and remain invisible to any snapshot-only matcher. `ParsedCondition::YouHadAngelOrBerserkerEnterThisTurn` still compares subtypes with a bare `eq_ignore_ascii_case`, so **Cleaving Reaper**'s Changeling axis stays wrong — that arm never routes through the matcher, so this PR's chokepoint cannot reach it. Our Cleaving Reaper claim above is about the ledger-count axis only.

**3. Coverage classification is filter-aware now, but only where the classifier looks.** `extract_card_features` walks static-ability conditions and effect positions (21 corpus cards reach the ledger arm, all `Handled`) but treats a trigger intervening-if as opaque, so it cannot see 20 measured trigger-side cards. **Tunnel Tipster** — `face-down creature entered … this turn` — is therefore still silently `supported=true` with a constant-false condition. That is a **pre-existing** BB-FU1-era defect, disclosed here, not introduced and not fixed.

**4. Instrument blindness, stated plainly.** The combo corpus contains none of the three suppressed cards, so `combo-verify`'s row-for-row identity is **expected** and is *not* evidence that no offer was suppressed. The suppression was measured directly by DB census and by a driven fixture instead.

## Re-verified after rebase

Rebased onto `upstream/main` = `8fe91f145` (29 commits). **Every gate above was re-measured at the rebased head against a freshly generated base**, and every result is identical to the pre-rebase measurement — including the blast radius holding at exactly the same 5 cards, which was the drift most worth checking given the upstream tip (`fix(parser): stamp Permanent on duration-less additive type grants`) touches this PR's seam. A dedicated review pass confirmed no semantic interaction: this PR's `condition.rs` diff is comment-only, and `entry_type_filter_matches` reads the pre-layer entry snapshot, which never observed the grant under either duration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of “entered the battlefield this turn” effects, including controller-specific and combined type conditions.
  * Departed permanents that entered this turn are now counted correctly where applicable.
  * Improved support for subtype checks, including Changeling interactions.

* **Bug Fixes**
  * Fixed ledger-based conditions that could previously return incorrect counts or remain inactive.
  * Prevented unsupported conditions from producing misleading results.
  * Improved loop detection when battlefield-entry effects depend on changing board state.

* **Documentation**
  * Clarified rules references and behavior for battlefield-entry look-back effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->