### PR TITLE
fix(parser): bind Fraying Sanity where-X mill to ZoneChangeCountThisTurn

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -2388,6 +2388,16 @@ pub(super) fn parse_subject_application(
             is_optional: false,
         });
     }
+    // CR 303.4b + CR 702.5a + CR 701.17a (issue #5947): "enchanted player"
+    // names the Aura's attached player host — `AttachedTo`, not a Typed
+    // EnchantedBy filter (which is object-only). Used by curse bodies such as
+    // Fraying Sanity's "enchanted player mills X cards".
+    if all_consuming(tag::<_, _, OracleError<'_>>("enchanted player"))
+        .parse(lower.as_str())
+        .is_ok()
+    {
+        return subject_filter_application(TargetFilter::AttachedTo, false);
+    }
     // "those creatures" / "those lands" — anaphoric reference to previous
     // targets. Maps to ParentTarget so the restriction applies to the same
     // objects.

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -5728,7 +5728,11 @@ fn parse_object_put_into_graveyard_from_battlefield_this_turn(
 /// `TargetFilter::Any` into a fresh `Typed` filter carrying the same property
 /// set; returns other variants (`Player`, `SpecificObject`, …) unchanged
 /// because owner-tagging is meaningless on non-typed shapes.
-fn add_owned_with_props(
+///
+/// Shared with `oracle_nom::quantity` so the where-X / CDA reading of "cards
+/// put into [possessive] graveyard from anywhere this turn" (Fraying Sanity)
+/// builds the same owned+nontoken population the Ravenous Trap condition uses.
+pub(crate) fn add_owned_with_props(
     filter: TargetFilter,
     controller: ControllerRef,
     extras: &[FilterProp],

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1518,6 +1518,11 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
             parse_number_of_creatures_died_this_turn,
             parse_number_of_sacrificed_this_turn,
             parse_number_of_descended_this_turn,
+            // CR 404.1 + CR 111.7 + CR 303.4b: "cards put into [possessive]
+            // graveyard from anywhere this turn" (Fraying Sanity where-X) —
+            // must precede the generic controlled-type arm and share the nest
+            // with the other this-turn zone-change counts.
+            parse_number_of_cards_put_into_graveyard_from_anywhere_this_turn,
             parse_number_of_times_you_chose_a_mode,
         )),
         parse_tokens_created_this_turn_tail,
@@ -4618,6 +4623,61 @@ fn parse_number_of_descended_this_turn(input: &str) -> OracleResult<'_, Quantity
                     controller: ControllerRef::You,
                 },
             ])),
+        },
+    ))
+}
+
+/// CR 404.1 + CR 111.7 + CR 303.4b (issue #5947): "cards put into [possessive]
+/// graveyard from anywhere this turn" — the Fraying Sanity where-X class.
+///
+/// A card is put into *its owner's* graveyard (CR 404.1), so the possessive
+/// scopes by ownership (`FilterProp::Owned`), not control. "From anywhere"
+/// means `from: None` (any origin zone). Bare "cards" carries no type, so the
+/// filter starts as `Any` narrowed by Owned + NonToken — tokens cease to exist
+/// instead of being put into a graveyard (CR 111.7), matching Ravenous Trap's
+/// condition population (`oracle_nom::condition`).
+///
+/// Possessive axis (compose, don't enumerate):
+///   - `"your "` → `ControllerRef::You`
+///   - `"their "` / `"his or her "` / `"enchanted player's "` →
+///     `ControllerRef::EnchantedPlayer` (curse anaphor: "enchanted player mills
+///     X … cards put into their graveyard")
+fn parse_number_of_cards_put_into_graveyard_from_anywhere_this_turn(
+    input: &str,
+) -> OracleResult<'_, QuantityRef> {
+    // Optional leading type phrase ("creature cards" / bare "cards").
+    // Consume up to the fixed "put into … from anywhere this turn" tail so a
+    // typed prefix is optional without enumerating every type × possessive
+    // permutation.
+    let plural = "cards put into ";
+    let singular = "card put into ";
+    let (rest, type_text) = alt((
+        terminated(take_until(plural), tag(plural)),
+        terminated(take_until(singular), tag(singular)),
+    ))
+    .parse(input)?;
+    let (filter, leftover) = parse_type_phrase(type_text.trim());
+    if !leftover.trim().is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            leftover,
+            nom::error::ErrorKind::Fail,
+        )));
+    }
+    // Possessive owner of the graveyard.
+    let (rest, owner) = alt((
+        value(ControllerRef::You, tag("your ")),
+        value(ControllerRef::EnchantedPlayer, tag("their ")),
+        value(ControllerRef::EnchantedPlayer, tag("his or her ")),
+        value(ControllerRef::EnchantedPlayer, tag("enchanted player's ")),
+    ))
+    .parse(rest)?;
+    let (rest, _) = tag("graveyard from anywhere this turn").parse(rest)?;
+    Ok((
+        rest,
+        QuantityRef::ZoneChangeCountThisTurn {
+            from: None,
+            to: Some(Zone::Graveyard),
+            filter: super::condition::add_owned_with_props(filter, owner, &[FilterProp::NonToken]),
         },
     ))
 }
@@ -8831,6 +8891,53 @@ mod tests {
                 };
                 assert_eq!(tf.controller, None, "{phrase:?} must not scope controller");
             }
+        }
+    }
+
+    /// CR 404.1 + CR 111.7 + CR 303.4b (issue #5947): Fraying Sanity's where-X
+    /// phrase — "the number of cards put into their graveyard from anywhere
+    /// this turn" — must bind to `ZoneChangeCountThisTurn` scoped by
+    /// `Owned { EnchantedPlayer }` (curse anaphor) + `NonToken`, with
+    /// `from: None` ("from anywhere"). The "your" possessive is the controller-
+    /// owned sibling.
+    #[test]
+    fn parse_cards_put_into_graveyard_from_anywhere_this_turn() {
+        let cases = [
+            (
+                "cards put into their graveyard from anywhere this turn",
+                ControllerRef::EnchantedPlayer,
+            ),
+            (
+                "cards put into his or her graveyard from anywhere this turn",
+                ControllerRef::EnchantedPlayer,
+            ),
+            (
+                "cards put into enchanted player's graveyard from anywhere this turn",
+                ControllerRef::EnchantedPlayer,
+            ),
+            (
+                "cards put into your graveyard from anywhere this turn",
+                ControllerRef::You,
+            ),
+        ];
+        for (phrase, owner) in cases {
+            let (_, q) = parse_quantity_ref(&format!("the number of {phrase}"))
+                .unwrap_or_else(|_| panic!("number-of {phrase:?} should parse"));
+            let QuantityRef::ZoneChangeCountThisTurn { from, to, filter } = q else {
+                panic!("expected ZoneChangeCountThisTurn for {phrase:?}, got {q:?}");
+            };
+            assert_eq!(from, None, "{phrase:?}: from anywhere → from: None");
+            assert_eq!(to, Some(Zone::Graveyard));
+            assert_eq!(
+                filter,
+                TargetFilter::Typed(TypedFilter::default().properties(vec![
+                    FilterProp::Owned {
+                        controller: owner.clone(),
+                    },
+                    FilterProp::NonToken,
+                ])),
+                "{phrase:?}"
+            );
         }
     }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -15031,6 +15031,70 @@ fn phase_trigger_enchanted_players_first_upkeep() {
     ));
 }
 
+/// CR 701.17a + CR 404.1 + CR 303.4b + CR 111.7 (issue #5947): Fraying Sanity —
+/// "At the beginning of each end step, enchanted player mills X cards, where X
+/// is the number of cards put into their graveyard from anywhere this turn."
+/// Must lower to `Effect::Mill` (not `Unimplemented { where_x_binding }`) with:
+///   - `target: AttachedTo` (the enchanted player)
+///   - `count: ZoneChangeCountThisTurn { from: None, to: Graveyard,
+///      filter: Owned{EnchantedPlayer} + NonToken }`
+#[test]
+fn fraying_sanity_mills_zone_change_count_this_turn() {
+    use crate::types::ability::{
+        ControllerRef, FilterProp, QuantityExpr, QuantityRef, TypedFilter,
+    };
+    use crate::types::zones::Zone;
+
+    let def = parse_trigger_line(
+        "At the beginning of each end step, enchanted player mills X cards, where X is \
+         the number of cards put into their graveyard from anywhere this turn.",
+        "Fraying Sanity",
+    );
+    assert_eq!(def.mode, TriggerMode::Phase);
+    assert_eq!(def.phase, Some(Phase::End));
+    let execute = def.execute.as_ref().expect("execute");
+    // Duration must NOT steal the quantity's "this turn" suffix.
+    assert!(
+        execute.duration.is_none()
+            || !matches!(
+                execute.duration,
+                Some(crate::types::ability::Duration::UntilEndOfTurn)
+            ),
+        "where-X's 'this turn' must not become UntilEndOfTurn duration, got {:?}",
+        execute.duration
+    );
+    match execute.effect.as_ref() {
+        Effect::Mill {
+            count,
+            target,
+            destination,
+        } => {
+            assert_eq!(
+                *target,
+                TargetFilter::AttachedTo,
+                "mill target must be the enchanted player"
+            );
+            assert_eq!(*destination, Zone::Graveyard);
+            assert_eq!(
+                count,
+                &QuantityExpr::Ref {
+                    qty: QuantityRef::ZoneChangeCountThisTurn {
+                        from: None,
+                        to: Some(Zone::Graveyard),
+                        filter: TargetFilter::Typed(TypedFilter::default().properties(vec![
+                            FilterProp::Owned {
+                                controller: ControllerRef::EnchantedPlayer,
+                            },
+                            FilterProp::NonToken,
+                        ])),
+                    },
+                }
+            );
+        }
+        other => panic!("expected Mill with ZoneChangeCountThisTurn, got {other:?}"),
+    }
+}
+
 #[test]
 fn phase_trigger_each_opponents_upkeep() {
     let def = parse_trigger_line(

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -15055,11 +15055,7 @@ fn fraying_sanity_mills_zone_change_count_this_turn() {
     let execute = def.execute.as_ref().expect("execute");
     // Duration must NOT steal the quantity's "this turn" suffix.
     assert!(
-        execute.duration.is_none()
-            || !matches!(
-                execute.duration,
-                Some(crate::types::ability::Duration::UntilEndOfTurn)
-            ),
+        execute.duration.is_none(),
         "where-X's 'this turn' must not become UntilEndOfTurn duration, got {:?}",
         execute.duration
     );

--- a/crates/engine/tests/integration/curse_misc_triggers.rs
+++ b/crates/engine/tests/integration/curse_misc_triggers.rs
@@ -397,6 +397,14 @@ fn fraying_sanity_mills_cards_put_into_graveyard_this_turn() {
         .expect("P1")
         .library
         .len();
+    let p0_lib_before = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .expect("P0")
+        .library
+        .len();
     let gy_before = runner
         .state()
         .players
@@ -419,6 +427,14 @@ fn fraying_sanity_mills_cards_put_into_graveyard_this_turn() {
         .expect("P1")
         .library
         .len();
+    let p0_lib_after = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .expect("P0")
+        .library
+        .len();
     let gy_after = runner
         .state()
         .players
@@ -439,5 +455,9 @@ fn fraying_sanity_mills_cards_put_into_graveyard_this_turn() {
         gy_after,
         gy_before + milled,
         "milled cards must land in the enchanted player's graveyard"
+    );
+    assert_eq!(
+        p0_lib_after, p0_lib_before,
+        "only the enchanted player should be milled"
     );
 }

--- a/crates/engine/tests/integration/curse_misc_triggers.rs
+++ b/crates/engine/tests/integration/curse_misc_triggers.rs
@@ -338,12 +338,16 @@ fn curse_of_shaken_faith_fires_on_second_spell() {
     );
 }
 
-/// Fraying Sanity: trigger fires at end step, mills X cards where X = cards
-/// put into graveyard this turn. We seed the graveyard with some cards first.
+/// Fraying Sanity (issue #5947): at each end step, enchanted player mills X
+/// cards where X is the number of cards put into their graveyard from anywhere
+/// this turn. Seed N owned GY puts, advance to the end step, and assert the
+/// enchanted player mills exactly N.
 #[test]
-fn fraying_sanity_fires_at_end_step() {
+fn fraying_sanity_mills_cards_put_into_graveyard_this_turn() {
+    use engine::types::game_state::WaitingFor;
+
     let mut scenario = GameScenario::new();
-    scenario.at_phase(Phase::Untap);
+    scenario.at_phase(Phase::PreCombatMain);
 
     let curse_id = {
         let mut builder =
@@ -353,7 +357,13 @@ fn fraying_sanity_fires_at_end_step() {
         builder.id()
     };
 
-    // Library padding — P1 needs lots of cards to mill.
+    // Cards that will be counted as "put into [enchanted player's] graveyard
+    // this turn" — owned by P1 (CR 404.1).
+    let gy_seeds: Vec<_> = (0..3)
+        .map(|i| scenario.add_creature(P1, &format!("Seed {i}"), 1, 1).id())
+        .collect();
+
+    // Library padding — P1 needs cards to mill.
     for _ in 0..30 {
         scenario.add_card_to_library_top(P0, "Plains");
         scenario.add_card_to_library_top(P1, "Island");
@@ -362,20 +372,72 @@ fn fraying_sanity_fires_at_end_step() {
     let mut runner = scenario.build();
     runner.state_mut().active_player = P0;
     runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
 
     attach_to_player(runner.state_mut(), curse_id, P1);
     evaluate_layers(runner.state_mut());
     reindex_object_triggers(runner.state_mut(), curse_id);
 
-    // Verify the curse is properly set up.
-    let curse_obj = runner.state().objects.get(&curse_id);
-    assert!(
-        curse_obj.is_some(),
-        "Fraying Sanity must be on the battlefield"
+    // Put the seeds into P1's graveyard so they populate zone_changes_this_turn.
+    for &id in &gy_seeds {
+        let mut events = Vec::new();
+        move_to_zone(runner.state_mut(), id, Zone::Graveyard, &mut events);
+        process_triggers(runner.state_mut(), &events);
+        drain_order_triggers_with_identity(runner.state_mut());
+    }
+    // Clear any leftover stack from the dies moves — Fraying Sanity itself
+    // does not trigger on those zone changes (only at end step).
+    runner.advance_until_stack_empty();
+
+    let lib_before = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .expect("P1")
+        .library
+        .len();
+    let gy_before = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .expect("P1")
+        .graveyard
+        .len();
+
+    // Advance to the end step of the active turn; Fraying Sanity fires for
+    // "each end step" and mills the enchanted player.
+    runner.advance_to_end_step();
+    runner.advance_until_stack_empty();
+
+    let lib_after = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .expect("P1")
+        .library
+        .len();
+    let gy_after = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .expect("P1")
+        .graveyard
+        .len();
+
+    let milled = lib_before.saturating_sub(lib_after);
+    assert_eq!(
+        milled, 3,
+        "CR 701.17a + CR 404.1: enchanted player must mill X = cards put into \
+         their graveyard this turn (expected 3, milled {milled}; \
+         lib {lib_before}→{lib_after}, gy {gy_before}→{gy_after})"
     );
     assert_eq!(
-        curse_obj.unwrap().attached_to.and_then(|h| h.as_player()),
-        Some(P1),
-        "Fraying Sanity must be attached to P1"
+        gy_after,
+        gy_before + milled,
+        "milled cards must land in the enchanted player's graveyard"
     );
 }


### PR DESCRIPTION
Closes #5947

## Summary

Discord report: **Fraying Sanity** does not mill the enchanted player at each end step for X = cards put into their graveyard from anywhere this turn.

The Phase End trigger was present, but the execute effect collapsed to `Effect::Unimplemented { name: "where_x_binding", description: "where X is the number of cards put into their graveyard from anywhere this turn" }`. The mill imperative parsed (`Mill { count: Variable("X"), … }`), then `apply_where_x_effect_expression` failed to recognize the where-X phrase and replaced the entire Mill with that gap node. A secondary symptom: `" this turn"` was stolen as `Duration::UntilEndOfTurn` because the quantity clause did not own the suffix.

## Root cause

Two gaps, both parser-side (runtime already supports the needed building blocks):

1. **Where-X quantity** — `"the number of cards put into [possessive] graveyard from anywhere this turn"` was not wired into `parse_number_of_inner`. The engine already has `QuantityRef::ZoneChangeCountThisTurn { from, to, filter }` (Ravenous Trap's condition uses the same population). No new `QuantityRef` sibling.
2. **Enchanted-player subject** — `"enchanted player mills …"` did not map to `TargetFilter::AttachedTo` in `parse_subject_application` (only enchanted creature/permanent / equipped creature were handled). Without that, even a successful where-X bind would mill the wrong player.

## Changes

- **`crates/engine/src/parser/oracle_nom/quantity.rs`** — add `parse_number_of_cards_put_into_graveyard_from_anywhere_this_turn` into the this-turn zone-change nest of `parse_number_of_inner`. Possessive axis: `your` → `Owned{You}`; `their` / `his or her` / `enchanted player's` → `Owned{EnchantedPlayer}`. Emits `ZoneChangeCountThisTurn { from: None, to: Graveyard, filter: Owned + NonToken }` (CR 404.1 + CR 111.7 + CR 303.4b).
- **`crates/engine/src/parser/oracle_nom/condition.rs`** — expose `add_owned_with_props` as `pub(crate)` so the quantity arm shares the Ravenous Trap owned+nontoken population builder (single authority).
- **`crates/engine/src/parser/oracle_effect/subject.rs`** — `"enchanted player"` → `TargetFilter::AttachedTo` so mill injection stamps the Aura host (CR 303.4b + CR 701.17a).
- **Tests** — quantity unit test for the possessive axis; trigger parse test asserting `Mill { AttachedTo, ZoneChangeCountThisTurn{…EnchantedPlayer…} }` (not `where_x_binding`); integration test seeds 3 GY puts for the enchanted player, advances to end step, asserts mill of exactly 3.

## Test Plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test -p engine --lib -- parse_cards_put_into_graveyard fraying_sanity opponent_cards_put_into_their_graveyard card_put_into_your_graveyard_from_anywhere`
- [ ] `cargo test -p engine --test integration -- fraying_sanity`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for parsing the standalone subject phrase “enchanted player”.
  * Added support for Fraying Sanity-style text that counts non-token cards put into a graveyard from anywhere this turn, with correct “your/their” ownership handling.

* **Bug Fixes**
  * Fixed Fraying Sanity trigger behavior so the mill amount and affected destination reflect zone changes for the current turn, including correct target and count semantics.

* **Tests**
  * Added parser regression coverage for all possessive variants and updated integration coverage to use a deterministic end-step scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->