### PR TITLE
refactor(parser): route single-clause statics through IR lowering (05b tranche 1)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4920,7 +4920,7 @@ pub(crate) fn parse_oracle_ir(
                     parse_flashback_trailing_self_spell_cost_reduction(reduction_part),
                 ) {
                     emitter.keyword_at(item_line, kw);
-                    emitter.static_at(item_line, def);
+                    emitter.static_ir_at(item_line, StaticIr::from_definition(reduction_part, def));
                     i += 1;
                     continue;
                 }
@@ -5809,7 +5809,7 @@ pub(crate) fn parse_oracle_ir(
                     parse_flashback_trailing_self_spell_cost_reduction(reduction_part),
                 ) {
                     emitter.keyword_at(item_line, kw);
-                    emitter.static_at(item_line, def);
+                    emitter.static_ir_at(item_line, StaticIr::from_definition(reduction_part, def));
                     i += 1;
                     continue;
                 }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5102,7 +5102,10 @@ pub(crate) fn parse_oracle_ir(
                 );
                 if !defs.is_empty() {
                     for __item in defs {
-                        emitter.static_at(item_line, __item);
+                        emitter.static_ir_at(
+                            item_line,
+                            StaticIr::from_definition(&static_line, __item),
+                        );
                     }
                     i += 1;
                     continue;
@@ -5962,7 +5965,7 @@ pub(crate) fn parse_oracle_ir(
         );
         if !defs.is_empty() {
             for __item in defs {
-                emitter.static_at(item_line, __item);
+                emitter.static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
             }
             i += 1;
             continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4883,7 +4883,10 @@ pub(crate) fn parse_oracle_ir(
                     let rider_gap =
                         TriggerDefinition::new(TriggerMode::Unknown("when you do".to_string()))
                             .description(line.to_string());
-                    emitter.static_at(item_line, static_def.description(line.to_string()));
+                    emitter.static_ir_at(
+                        item_line,
+                        StaticIr::from_definition(&line, static_def.description(line.to_string())),
+                    );
                     emitter.trigger_at(item_line, rider_gap);
                     i += 1;
                     continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5057,7 +5057,10 @@ pub(crate) fn parse_oracle_ir(
                                 None,
                                 None,
                             ) {
-                                emitter.static_at(item_line, __item);
+                                emitter.static_ir_at(
+                                    item_line,
+                                    StaticIr::from_definition(&clause_dot, __item),
+                                );
                             }
                         }
                     }
@@ -5078,7 +5081,10 @@ pub(crate) fn parse_oracle_ir(
                                 None,
                                 None,
                             ) {
-                                emitter.static_at(item_line, __item);
+                                emitter.static_ir_at(
+                                    item_line,
+                                    StaticIr::from_definition(&clause_dot, __item),
+                                );
                             }
                         }
                     }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1173,6 +1173,7 @@ fn item_trigger(item: &OracleItemIr) -> Option<&TriggerDefinition> {
 
 fn item_static(item: &OracleItemIr) -> Option<&StaticDefinition> {
     match &item.node {
+        OracleNodeIr::Static(ir) => Some(&ir.definition),
         OracleNodeIr::PreLoweredStatic(def) => Some(def),
         _ => None,
     }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5035,7 +5035,10 @@ pub(crate) fn parse_oracle_ir(
                             def.description = Some(line.to_string());
                         }
                         for __item in defs {
-                            emitter.static_at(item_line, __item);
+                            emitter.static_ir_at(
+                                item_line,
+                                StaticIr::from_definition(&effect_static, __item),
+                            );
                         }
                         i += 1;
                         continue;
@@ -5922,7 +5925,10 @@ pub(crate) fn parse_oracle_ir(
                         }
                     }
                     for __item in defs {
-                        emitter.static_at(item_line, __item);
+                        emitter.static_ir_at(
+                            item_line,
+                            StaticIr::from_definition(&effect_static, __item),
+                        );
                     }
                     i += 1;
                     continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -69,6 +69,7 @@ use super::oracle_ir::doc::{
 use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
+use super::oracle_ir::static_ir::StaticIr;
 pub use super::oracle_keyword::keyword_display_name;
 use super::oracle_keyword::{
     is_keyword_cost_line, is_kicker_family_line, parse_kicker_additional_cost_line,
@@ -1998,7 +1999,10 @@ fn push_graveyard_keyword_same_is_true_tail(
         statics.push(new_def);
     }
     for __item in statics {
-        emitter.static_at(item_line, __item);
+        emitter.static_ir_at(
+            item_line,
+            StaticIr::from_definition(modeled_sentence, __item),
+        );
     }
     if !unqualified.is_empty() {
         emitter.ability_at(
@@ -3440,6 +3444,10 @@ impl<'a> DocEmitter<'a> {
         self.last_static = Some(def.clone());
         self.emit_at(line, OracleNodeIr::PreLoweredStatic(def));
     }
+    fn static_ir_at(&mut self, line: usize, ir: StaticIr) {
+        self.last_static = Some(lower_static_ir(&ir));
+        self.emit_at(line, OracleNodeIr::Static(ir));
+    }
 
     /// Last-emitted node per category — the read-only peeks for
     /// `parsed_result_recently_granted_flashback` (the one mid-loop reader of
@@ -3914,7 +3922,7 @@ pub(crate) fn parse_oracle_ir(
                         },
                         None => StaticCondition::AdditionalCostPaid,
                     });
-                    emitter.static_at(item_line, def);
+                    emitter.static_ir_at(item_line, StaticIr::from_definition(reduction_text, def));
                 }
             }
             i += 1;
@@ -4049,7 +4057,10 @@ pub(crate) fn parse_oracle_ir(
                     if let Some(static_def) =
                         try_parse_graveyard_keyword_static_with_continuation(&combined_static_line)
                     {
-                        emitter.static_at(item_line, static_def);
+                        emitter.static_ir_at(
+                            item_line,
+                            StaticIr::from_definition(&combined_static_line, static_def),
+                        );
                         i += 2;
                         continue;
                     }
@@ -4080,7 +4091,8 @@ pub(crate) fn parse_oracle_ir(
                 );
             if is_self_color_cda {
                 for __item in defs {
-                    emitter.static_at(item_line, __item);
+                    emitter
+                        .static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
                 }
                 i += 1;
                 continue;
@@ -4101,7 +4113,8 @@ pub(crate) fn parse_oracle_ir(
             );
             if !defs.is_empty() {
                 for __item in defs {
-                    emitter.static_at(item_line, __item);
+                    emitter
+                        .static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
                 }
                 i += 1;
                 continue;
@@ -4163,7 +4176,10 @@ pub(crate) fn parse_oracle_ir(
                             None,
                             None,
                         ) {
-                            emitter.static_at(item_line, __item);
+                            emitter.static_ir_at(
+                                item_line,
+                                StaticIr::from_definition(&clause_dot, __item),
+                            );
                         }
                     }
                 }
@@ -4180,7 +4196,8 @@ pub(crate) fn parse_oracle_ir(
             );
             if !defs.is_empty() {
                 for __item in defs {
-                    emitter.static_at(item_line, __item);
+                    emitter
+                        .static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
                 }
                 i += 1;
                 continue;
@@ -4680,7 +4697,7 @@ pub(crate) fn parse_oracle_ir(
                     lines.get(i + 1).map(|l| l.to_lowercase())
                 })
             {
-                emitter.static_at(item_line, static_def);
+                emitter.static_ir_at(item_line, StaticIr::from_definition(&line, static_def));
                 i += if consumes_next_line { 2 } else { 1 };
                 continue;
             }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4712,7 +4712,7 @@ pub(crate) fn parse_oracle_ir(
         // Effect::PayCost.
         if is_spells_alternative_cost_pattern(&lower) {
             if let Some(static_def) = parse_spells_alternative_cost(&line) {
-                emitter.static_at(item_line, static_def);
+                emitter.static_ir_at(item_line, StaticIr::from_definition(&line, static_def));
                 i += 1;
                 continue;
             }
@@ -4725,7 +4725,7 @@ pub(crate) fn parse_oracle_ir(
             let defs = parse_cast_spells_alternative_cost_multi(&line);
             if !defs.is_empty() {
                 for __item in defs {
-                    emitter.static_at(item_line, __item);
+                    emitter.static_ir_at(item_line, StaticIr::from_definition(&line, __item));
                 }
                 i += 1;
                 continue;
@@ -4739,7 +4739,7 @@ pub(crate) fn parse_oracle_ir(
         // and would miss this verb form.
         if is_collect_evidence_alt_cost_pattern(&lower) {
             if let Some(static_def) = parse_collect_evidence_alt_cost(&line) {
-                emitter.static_at(item_line, static_def);
+                emitter.static_ir_at(item_line, StaticIr::from_definition(&line, static_def));
                 i += 1;
                 continue;
             }
@@ -4756,7 +4756,8 @@ pub(crate) fn parse_oracle_ir(
             );
             if !defs.is_empty() {
                 for __item in defs {
-                    emitter.static_at(item_line, __item);
+                    emitter
+                        .static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
                 }
                 i += 1;
                 continue;
@@ -4768,7 +4769,7 @@ pub(crate) fn parse_oracle_ir(
         // New Perspectives (cycling) / Heart of Kiran (crew) / Gavi class.
         if is_alternative_keyword_cost_pattern(&lower) {
             if let Some(static_def) = parse_alternative_keyword_cost(&line) {
-                emitter.static_at(item_line, static_def);
+                emitter.static_ir_at(item_line, StaticIr::from_definition(&line, static_def));
                 i += 1;
                 continue;
             }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4795,7 +4795,8 @@ pub(crate) fn parse_oracle_ir(
             );
             if !defs.is_empty() {
                 for __item in defs {
-                    emitter.static_at(item_line, __item);
+                    emitter
+                        .static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
                 }
                 consumed = true;
             }
@@ -4825,7 +4826,7 @@ pub(crate) fn parse_oracle_ir(
             parse_static_replacement_compound(&static_line, &static_line_lower, card_name)
         {
             for __item in statics {
-                emitter.static_at(item_line, __item);
+                emitter.static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
             }
             for replacement_ir in replacements {
                 emitter.emit_at(item_line, OracleNodeIr::Replacement(replacement_ir));
@@ -4846,7 +4847,7 @@ pub(crate) fn parse_oracle_ir(
         // silently drops it. Split so both layers see their conjunct.
         if let Some((statics, replacement)) = try_split_and_cant_become_untapped(&static_line) {
             for __item in statics {
-                emitter.static_at(item_line, __item);
+                emitter.static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
             }
             emitter.replacement_at(item_line, replacement);
             i += 1;

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
@@ -43,44 +43,48 @@ expression: "&ir"
         "fragment": "Equipped creature gets +4/+4 and has vigilance and lifelink."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": [
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "EquippedBy"
+                }
+              ]
+            },
+            "modifications": [
               {
-                "type": "EquippedBy"
+                "type": "AddPower",
+                "value": 4
+              },
+              {
+                "type": "AddToughness",
+                "value": 4
+              },
+              {
+                "type": "AddKeyword",
+                "keyword": "Vigilance"
+              },
+              {
+                "type": "AddKeyword",
+                "keyword": "Lifelink"
               }
-            ]
+            ],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Equipped creature gets +4/+4 and has vigilance and lifelink."
           },
-          "modifications": [
-            {
-              "type": "AddPower",
-              "value": 4
-            },
-            {
-              "type": "AddToughness",
-              "value": 4
-            },
-            {
-              "type": "AddKeyword",
-              "keyword": "Vigilance"
-            },
-            {
-              "type": "AddKeyword",
-              "keyword": "Lifelink"
-            }
-          ],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Equipped creature gets +4/+4 and has vigilance and lifelink."
+          "source_text": "Equipped creature gets +4/+4 and has vigilance and lifelink.",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
@@ -96,34 +96,38 @@ expression: "&ir"
         "fragment": "~ can block only creatures with flying."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": {
-            "BlockRestriction": {
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": null,
-                "properties": [
-                  {
-                    "type": "WithKeyword",
-                    "value": "Flying"
-                  }
-                ]
+        "Static": {
+          "definition": {
+            "mode": {
+              "BlockRestriction": {
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": null,
+                  "properties": [
+                    {
+                      "type": "WithKeyword",
+                      "value": "Flying"
+                    }
+                  ]
+                }
               }
-            }
+            },
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "~ can block only creatures with flying."
           },
-          "affected": {
-            "type": "SelfRef"
-          },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "~ can block only creatures with flying."
+          "source_text": "~ can block only creatures with flying.",
+          "body_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
@@ -59,18 +59,22 @@ expression: "&ir"
         "fragment": "~ can't block and can't be blocked."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "CantBlock",
-          "affected": {
-            "type": "SelfRef"
+        "Static": {
+          "definition": {
+            "mode": "CantBlock",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "~ can't block and can't be blocked."
           },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "~ can't block and can't be blocked."
+          "source_text": "~ can't block and can't be blocked.",
+          "body_ir": null
         }
       }
     },
@@ -92,18 +96,22 @@ expression: "&ir"
         "fragment": "~ can't block and can't be blocked."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "CantBeBlocked",
-          "affected": {
-            "type": "SelfRef"
+        "Static": {
+          "definition": {
+            "mode": "CantBeBlocked",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "~ can't block and can't be blocked."
           },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "~ can't block and can't be blocked."
+          "source_text": "~ can't block and can't be blocked.",
+          "body_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conformer_shuriken_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conformer_shuriken_ir.snap
@@ -22,102 +22,106 @@ expression: "&ir"
         "fragment": "Equipped creature has \"Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.\""
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": [
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "EquippedBy"
+                }
+              ]
+            },
+            "modifications": [
               {
-                "type": "EquippedBy"
-              }
-            ]
-          },
-          "modifications": [
-            {
-              "type": "GrantTrigger",
-              "trigger": {
-                "mode": "Attacks",
-                "execute": {
-                  "kind": "Spell",
-                  "effect": {
-                    "type": "SetTapState",
-                    "target": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "DefendingPlayer",
-                      "properties": []
-                    },
-                    "scope": {
-                      "type": "Single"
-                    },
-                    "state": {
-                      "type": "Tap"
-                    }
-                  },
-                  "cost": null,
-                  "sub_ability": {
+                "type": "GrantTrigger",
+                "trigger": {
+                  "mode": "Attacks",
+                  "execute": {
                     "kind": "Spell",
                     "effect": {
-                      "type": "Unimplemented",
-                      "name": "put",
-                      "description": "counters equal to the difference"
+                      "type": "SetTapState",
+                      "target": {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Creature"
+                        ],
+                        "controller": "DefendingPlayer",
+                        "properties": []
+                      },
+                      "scope": {
+                        "type": "Single"
+                      },
+                      "state": {
+                        "type": "Tap"
+                      }
                     },
                     "cost": null,
-                    "sub_ability": null,
+                    "sub_ability": {
+                      "kind": "Spell",
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "put",
+                        "description": "counters equal to the difference"
+                      },
+                      "cost": null,
+                      "sub_ability": null,
+                      "duration": null,
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": {
+                        "type": "TargetHasKeywordInstead",
+                        "keyword": {
+                          "Unknown": "greater power than ~"
+                        }
+                      },
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false
+                    },
                     "duration": null,
                     "description": null,
                     "target_prompt": null,
-                    "condition": {
-                      "type": "TargetHasKeywordInstead",
-                      "keyword": {
-                        "Unknown": "greater power than ~"
-                      }
-                    },
+                    "condition": null,
                     "optional_targeting": false,
                     "optional": false,
                     "forward_result": false
                   },
-                  "duration": null,
-                  "description": null,
-                  "target_prompt": null,
-                  "condition": null,
-                  "optional_targeting": false,
+                  "valid_card": {
+                    "type": "SelfRef"
+                  },
+                  "origin": null,
+                  "destination": null,
+                  "trigger_zones": [
+                    "Battlefield"
+                  ],
+                  "phase": null,
                   "optional": false,
-                  "forward_result": false
-                },
-                "valid_card": {
-                  "type": "SelfRef"
-                },
-                "origin": null,
-                "destination": null,
-                "trigger_zones": [
-                  "Battlefield"
-                ],
-                "phase": null,
-                "optional": false,
-                "damage_kind": "Any",
-                "secondary": false,
-                "valid_target": null,
-                "valid_source": null,
-                "description": "Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.",
-                "constraint": null,
-                "condition": null,
-                "batched": false
+                  "damage_kind": "Any",
+                  "secondary": false,
+                  "valid_target": null,
+                  "valid_source": null,
+                  "description": "Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.",
+                  "constraint": null,
+                  "condition": null,
+                  "batched": false
+                }
               }
-            }
-          ],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Equipped creature has \"Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.\""
+            ],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Equipped creature has \"Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.\""
+          },
+          "source_text": "Equipped creature has \"Whenever ~ attacks, tap target creature defending player controls. If that creature has greater power than ~, put a number of +1/+1 counters on ~ equal to the difference.\"",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_ir.snap
@@ -22,57 +22,61 @@ expression: "&ir"
         "fragment": "~'s power and toughness are each equal to the greatest mana value among artifacts you control."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "SelfRef"
-          },
-          "modifications": [
-            {
-              "type": "SetDynamicPower",
-              "value": {
-                "type": "Ref",
-                "qty": {
-                  "type": "Aggregate",
-                  "function": "Max",
-                  "property": "ManaValue",
-                  "filter": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Artifact"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  }
-                }
-              }
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
             },
-            {
-              "type": "SetDynamicToughness",
-              "value": {
-                "type": "Ref",
-                "qty": {
-                  "type": "Aggregate",
-                  "function": "Max",
-                  "property": "ManaValue",
-                  "filter": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Artifact"
-                    ],
-                    "controller": "You",
-                    "properties": []
+            "modifications": [
+              {
+                "type": "SetDynamicPower",
+                "value": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "Aggregate",
+                    "function": "Max",
+                    "property": "ManaValue",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Artifact"
+                      ],
+                      "controller": "You",
+                      "properties": []
+                    }
+                  }
+                }
+              },
+              {
+                "type": "SetDynamicToughness",
+                "value": {
+                  "type": "Ref",
+                  "qty": {
+                    "type": "Aggregate",
+                    "function": "Max",
+                    "property": "ManaValue",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Artifact"
+                      ],
+                      "controller": "You",
+                      "properties": []
+                    }
                   }
                 }
               }
-            }
-          ],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": true,
-          "description": "~'s power and toughness are each equal to the greatest mana value among artifacts you control."
+            ],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": true,
+            "description": "~'s power and toughness are each equal to the greatest mana value among artifacts you control."
+          },
+          "source_text": "~'s power and toughness are each equal to the greatest mana value among artifacts you control.",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leyline_of_anticipation_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leyline_of_anticipation_ir.snap
@@ -66,29 +66,33 @@ expression: "&ir"
         "fragment": "You may cast spells as though they had flash."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": {
-            "CastWithKeyword": {
-              "keyword": "Flash"
-            }
-          },
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Card"
+        "Static": {
+          "definition": {
+            "mode": {
+              "CastWithKeyword": {
+                "keyword": "Flash"
+              }
+            },
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Card"
+              ],
+              "controller": "You",
+              "properties": []
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [
+              "Battlefield"
             ],
-            "controller": "You",
-            "properties": []
+            "characteristic_defining": false,
+            "description": "You may cast spells as though they had flash."
           },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [
-            "Battlefield"
-          ],
-          "characteristic_defining": false,
-          "description": "You may cast spells as though they had flash."
+          "source_text": "You may cast spells as though they had flash.",
+          "body_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lovestruck_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lovestruck_beast_ir.snap
@@ -22,56 +22,60 @@ expression: "&ir"
         "fragment": "~ can't attack unless you control a 1/1 creature."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "CantAttack",
-          "affected": {
-            "type": "SelfRef"
-          },
-          "modifications": [],
-          "condition": {
-            "type": "Not",
+        "Static": {
+          "definition": {
+            "mode": "CantAttack",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [],
             "condition": {
-              "type": "IsPresent",
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": "You",
-                "properties": [
-                  {
-                    "type": "PtComparison",
-                    "stat": "Power",
-                    "scope": "Current",
-                    "comparator": "EQ",
-                    "value": {
-                      "type": "Fixed",
-                      "value": 1
+              "type": "Not",
+              "condition": {
+                "type": "IsPresent",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "PtComparison",
+                      "stat": "Power",
+                      "scope": "Current",
+                      "comparator": "EQ",
+                      "value": {
+                        "type": "Fixed",
+                        "value": 1
+                      }
+                    },
+                    {
+                      "type": "PtComparison",
+                      "stat": "Toughness",
+                      "scope": "Current",
+                      "comparator": "EQ",
+                      "value": {
+                        "type": "Fixed",
+                        "value": 1
+                      }
+                    },
+                    {
+                      "type": "InZone",
+                      "zone": "Battlefield"
                     }
-                  },
-                  {
-                    "type": "PtComparison",
-                    "stat": "Toughness",
-                    "scope": "Current",
-                    "comparator": "EQ",
-                    "value": {
-                      "type": "Fixed",
-                      "value": 1
-                    }
-                  },
-                  {
-                    "type": "InZone",
-                    "zone": "Battlefield"
-                  }
-                ]
+                  ]
+                }
               }
-            }
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "~ can't attack unless you control a 1/1 creature."
           },
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "~ can't attack unless you control a 1/1 creature."
+          "source_text": "~ can't attack unless you control a 1/1 creature.",
+          "body_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
@@ -59,40 +59,44 @@ expression: "&ir"
         "fragment": "~ can't be blocked by creatures with power 2 or less."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": {
-            "CantBeBlockedBy": {
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": null,
-                "properties": [
-                  {
-                    "type": "PtComparison",
-                    "stat": "Power",
-                    "scope": "Current",
-                    "comparator": "LE",
-                    "value": {
-                      "type": "Fixed",
-                      "value": 2
+        "Static": {
+          "definition": {
+            "mode": {
+              "CantBeBlockedBy": {
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": null,
+                  "properties": [
+                    {
+                      "type": "PtComparison",
+                      "stat": "Power",
+                      "scope": "Current",
+                      "comparator": "LE",
+                      "value": {
+                        "type": "Fixed",
+                        "value": 2
+                      }
                     }
-                  }
-                ]
+                  ]
+                }
               }
-            }
+            },
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "~ can't be blocked by creatures with power 2 or less."
           },
-          "affected": {
-            "type": "SelfRef"
-          },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "~ can't be blocked by creatures with power 2 or less."
+          "source_text": "~ can't be blocked by creatures with power 2 or less.",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__savage_summoning_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__savage_summoning_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 152
 expression: "&ir"
 ---
 {
@@ -23,18 +22,22 @@ expression: "&ir"
         "fragment": "This spell can't be countered."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "CantBeCountered",
-          "affected": {
-            "type": "SelfRef"
+        "Static": {
+          "definition": {
+            "mode": "CantBeCountered",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "This spell can't be countered."
           },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "This spell can't be countered."
+          "source_text": "This spell can't be countered.",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__short_sword_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__short_sword_ir.snap
@@ -22,36 +22,40 @@ expression: "&ir"
         "fragment": "Equipped creature gets +1/+1."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": [
-              {
-                "type": "EquippedBy"
-              }
-            ]
-          },
-          "modifications": [
-            {
-              "type": "AddPower",
-              "value": 1
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "EquippedBy"
+                }
+              ]
             },
-            {
-              "type": "AddToughness",
-              "value": 1
-            }
-          ],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Equipped creature gets +1/+1."
+            "modifications": [
+              {
+                "type": "AddPower",
+                "value": 1
+              },
+              {
+                "type": "AddToughness",
+                "value": 1
+              }
+            ],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Equipped creature gets +1/+1."
+          },
+          "source_text": "Equipped creature gets +1/+1.",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tarmogoyf_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tarmogoyf_ir.snap
@@ -22,31 +22,16 @@ expression: "&ir"
         "fragment": "~'s power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "SelfRef"
-          },
-          "modifications": [
-            {
-              "type": "SetDynamicPower",
-              "value": {
-                "type": "Ref",
-                "qty": {
-                  "type": "DistinctCardTypes",
-                  "source": {
-                    "type": "Zone",
-                    "zone": "Graveyard",
-                    "scope": "All"
-                  }
-                }
-              }
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
             },
-            {
-              "type": "SetDynamicToughness",
-              "value": {
-                "type": "Offset",
-                "inner": {
+            "modifications": [
+              {
+                "type": "SetDynamicPower",
+                "value": {
                   "type": "Ref",
                   "qty": {
                     "type": "DistinctCardTypes",
@@ -56,17 +41,36 @@ expression: "&ir"
                       "scope": "All"
                     }
                   }
-                },
-                "offset": 1
+                }
+              },
+              {
+                "type": "SetDynamicToughness",
+                "value": {
+                  "type": "Offset",
+                  "inner": {
+                    "type": "Ref",
+                    "qty": {
+                      "type": "DistinctCardTypes",
+                      "source": {
+                        "type": "Zone",
+                        "zone": "Graveyard",
+                        "scope": "All"
+                      }
+                    }
+                  },
+                  "offset": 1
+                }
               }
-            }
-          ],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": true,
-          "description": "~'s power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1."
+            ],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": true,
+            "description": "~'s power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1."
+          },
+          "source_text": "~'s power is equal to the number of card types among cards in all graveyards and its toughness is equal to that number plus 1.",
+          "body_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
@@ -59,42 +59,46 @@ expression: "&ir"
         "fragment": "Noncreature spells cost {1} more to cast."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": {
-            "ModifyCost": {
-              "mode": "Raise",
-              "amount": {
-                "type": "Cost",
-                "shards": [],
-                "generic": 1
-              },
-              "spell_filter": {
-                "type": "Typed",
-                "type_filters": [
-                  {
-                    "Non": "Creature"
-                  }
-                ],
-                "controller": null,
-                "properties": []
+        "Static": {
+          "definition": {
+            "mode": {
+              "ModifyCost": {
+                "mode": "Raise",
+                "amount": {
+                  "type": "Cost",
+                  "shards": [],
+                  "generic": 1
+                },
+                "spell_filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    {
+                      "Non": "Creature"
+                    }
+                  ],
+                  "controller": null,
+                  "properties": []
+                }
               }
-            }
+            },
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Card"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Noncreature spells cost {1} more to cast."
           },
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Card"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Noncreature spells cost {1} more to cast."
+          "source_text": "Noncreature spells cost {1} more to cast.",
+          "body_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thunderous_velocipede_ir.snap
@@ -22,72 +22,76 @@ expression: "&ir"
         "fragment": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": {
-            "EntersWithAdditionalCounters": {
-              "counter_type": "P1P1",
-              "count": 1
-            }
-          },
-          "affected": {
-            "type": "And",
-            "filters": [
-              {
-                "type": "Typed",
-                "type_filters": [],
-                "controller": null,
-                "properties": [
-                  {
-                    "type": "Cmc",
-                    "comparator": "LE",
-                    "value": {
-                      "type": "Fixed",
-                      "value": 4
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "Or",
-                "filters": [
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Artifact",
-                      {
-                        "Subtype": "Vehicle"
-                      }
-                    ],
-                    "controller": "You",
-                    "properties": [
-                      {
-                        "type": "Another"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": [
-                      {
-                        "type": "Another"
-                      }
-                    ]
-                  }
-                ]
+        "Static": {
+          "definition": {
+            "mode": {
+              "EntersWithAdditionalCounters": {
+                "counter_type": "P1P1",
+                "count": 1
               }
-            ]
+            },
+            "affected": {
+              "type": "And",
+              "filters": [
+                {
+                  "type": "Typed",
+                  "type_filters": [],
+                  "controller": null,
+                  "properties": [
+                    {
+                      "type": "Cmc",
+                      "comparator": "LE",
+                      "value": {
+                        "type": "Fixed",
+                        "value": 4
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "Or",
+                  "filters": [
+                    {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Artifact",
+                        {
+                          "Subtype": "Vehicle"
+                        }
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "Another"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "Another"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
           },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+          "source_text": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.",
+          "body_ir": null
         }
       }
     },
@@ -109,72 +113,76 @@ expression: "&ir"
         "fragment": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": {
-            "EntersWithAdditionalCounters": {
-              "counter_type": "P1P1",
-              "count": 3
-            }
-          },
-          "affected": {
-            "type": "And",
-            "filters": [
-              {
-                "type": "Typed",
-                "type_filters": [],
-                "controller": null,
-                "properties": [
-                  {
-                    "type": "Cmc",
-                    "comparator": "GT",
-                    "value": {
-                      "type": "Fixed",
-                      "value": 4
-                    }
-                  }
-                ]
-              },
-              {
-                "type": "Or",
-                "filters": [
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Artifact",
-                      {
-                        "Subtype": "Vehicle"
-                      }
-                    ],
-                    "controller": "You",
-                    "properties": [
-                      {
-                        "type": "Another"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": [
-                      {
-                        "type": "Another"
-                      }
-                    ]
-                  }
-                ]
+        "Static": {
+          "definition": {
+            "mode": {
+              "EntersWithAdditionalCounters": {
+                "counter_type": "P1P1",
+                "count": 3
               }
-            ]
+            },
+            "affected": {
+              "type": "And",
+              "filters": [
+                {
+                  "type": "Typed",
+                  "type_filters": [],
+                  "controller": null,
+                  "properties": [
+                    {
+                      "type": "Cmc",
+                      "comparator": "GT",
+                      "value": {
+                        "type": "Fixed",
+                        "value": 4
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "Or",
+                  "filters": [
+                    {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Artifact",
+                        {
+                          "Subtype": "Vehicle"
+                        }
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "Another"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "Another"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
           },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it."
+          "source_text": "Each other Vehicle and creature you control enters with an additional +1/+1 counter on it if its mana value is 4 or less. Otherwise, it enters with three additional +1/+1 counters on it.",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
@@ -59,29 +59,33 @@ expression: "&ir"
         "fragment": "As long as ~ is paired with another creature, each of those creatures gets +4/+4."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "SourceOrPaired"
-          },
-          "modifications": [
-            {
-              "type": "AddPower",
-              "value": 4
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SourceOrPaired"
             },
-            {
-              "type": "AddToughness",
-              "value": 4
-            }
-          ],
-          "condition": {
-            "type": "SourceIsPaired"
+            "modifications": [
+              {
+                "type": "AddPower",
+                "value": 4
+              },
+              {
+                "type": "AddToughness",
+                "value": 4
+              }
+            ],
+            "condition": {
+              "type": "SourceIsPaired"
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "As long as ~ is paired with another creature, each of those creatures gets +4/+4."
           },
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "As long as ~ is paired with another creature, each of those creatures gets +4/+4."
+          "source_text": "As long as ~ is paired with another creature, each of those creatures gets +4/+4.",
+          "body_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/static_ir.rs
+++ b/crates/engine/src/parser/oracle_ir/static_ir.rs
@@ -26,3 +26,18 @@ pub(crate) struct StaticIr {
     /// `parse_effect_chain_ir` which is already called by internal sub-parsers.
     pub(crate) body_ir: Option<EffectChainIr>,
 }
+
+impl StaticIr {
+    /// Wrap a recognizer-produced static in the common static lowering path.
+    ///
+    /// Some whole-line recognizers already construct the typed static definition
+    /// they need. They still emit this IR node so source-order document lowering
+    /// owns the final static post-processing.
+    pub(crate) fn from_definition(source_text: &str, definition: StaticDefinition) -> Self {
+        Self {
+            definition,
+            source_text: source_text.to_string(),
+            body_ir: None,
+        }
+    }
+}

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -11306,6 +11306,52 @@ fn triarch_stalker_choose_opponent_persists_for_last_chosen_player_static() {
 }
 
 #[test]
+fn granted_static_reader_persists_last_chosen_player() {
+    // CR 607.2d + CR 613.1 + CR 608.2c: the document relation scan must see a
+    // granted static that is emitted through `OracleNodeIr::Static`, otherwise
+    // the preceding opponent choice would be incorrectly resolution-scoped.
+    use crate::parser::oracle::parse_oracle_text;
+    use crate::types::ability::ChoiceType;
+
+    let parsed = parse_oracle_text(
+        "Targeting Relay — At the beginning of combat on your turn, choose an opponent.\nCreatures attacking the last chosen player have \"{T}: Add {C}.\"",
+        "Triarch Stalker",
+        &[],
+        &["Artifact".to_string(), "Creature".to_string()],
+        &["Necron".to_string()],
+    );
+
+    assert!(
+        parsed.statics.iter().any(|s| matches!(
+            &s.affected,
+            Some(TargetFilter::Typed(tf)) if tf.properties.contains(&FilterProp::Attacking {
+                defender: Some(ControllerRef::SourceChosenPlayer),
+            })
+        )),
+        "granted static must scope attackers by SourceChosenPlayer, got {:?}",
+        parsed.statics
+    );
+
+    let choose = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("expected a triggered choose ability");
+    assert!(
+        matches!(
+            &*choose.effect,
+            Effect::Choose {
+                choice_type: ChoiceType::Opponent { .. },
+                persist: true,
+                ..
+            }
+        ),
+        "a granted static reader must persist the opponent choice, got {:?}",
+        choose.effect
+    );
+}
+
+#[test]
 fn choose_opponent_without_source_chosen_reference_does_not_persist() {
     // Targeted-pass regression: a "choose an opponent" trigger whose choice is
     // consumed WITHIN the same resolution (Ruhan — the forced attack reads the


### PR DESCRIPTION
## Plan 05b — Tranche 1: single-clause static → IR lowering

Routes all 25 single-clause static recognizers in `parser/oracle.rs` from the legacy
`DocEmitter::static_at` producer through the IR path via the new
`StaticIr::from_definition(source_text, definition)` seam and `DocEmitter::static_ir_at`
(which preserves the mid-loop `last_static` peek by lowering the IR).

This is a **behavioral no-op**: pure routing, no new parsing logic. Each `from_definition`
carries the genuine source slice its definition was parsed from (`&line`/`&static_line`/
`&effect_static`/`&clause_dot`/`reduction_part`).

### Correctness evidence
- **Byte-identity**: full-pool `card-data.json` regenerated at the tip is sha256-identical to
  baseline (`b6c79b7a…`). `source_text`/`body_ir` are carried but corpus-inert — the lowered
  `StaticDefinition` reaching the engine is unchanged.
- **IR snapshots (14)**: `PreLoweredStatic` → `Static{definition, source_text, body_ir}` wrapper +
  re-indent only; every `definition` field verified identical (values + order).
- **Gates**: clippy `-D warnings` clean; engine lib 17,479 passed / 0 failed; integration 3,702
  passed / 0 failed.

Footprint is parser-only (`oracle.rs`, `static_ir.rs`, `oracle_static/tests.rs`, 14 snapshots) —
no `crates/engine/src/game/` changes. First of the 05b tranches feeding the Plan-05 gate-1
zero-hit ratchet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of static abilities during parsing and emission.
  * Fixed granted static effects so choices such as “the last chosen player” persist correctly when resolving related abilities.

* **Tests**
  * Added regression coverage for persisted opponent choices in granted static abilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->