### PR TITLE
refactor(parser): route Frozen-in-Ice replacement through IR lowering (05b tranche 2)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3456,6 +3456,9 @@ impl<'a> DocEmitter<'a> {
         self.last_static = Some(lower_static_ir(&ir));
         self.emit_at(line, OracleNodeIr::Static(ir));
     }
+    fn replacement_ir_at(&mut self, line: usize, ir: ReplacementIr) {
+        self.emit_at(line, OracleNodeIr::Replacement(ir));
+    }
 
     /// Last-emitted node per category — the read-only peeks for
     /// `parsed_result_recently_granted_flashback` (the one mid-loop reader of
@@ -4856,7 +4859,10 @@ pub(crate) fn parse_oracle_ir(
             for __item in statics {
                 emitter.static_ir_at(item_line, StaticIr::from_definition(&static_line, __item));
             }
-            emitter.replacement_at(item_line, replacement);
+            emitter.replacement_ir_at(
+                item_line,
+                ReplacementIr::from_definition(&static_line, replacement),
+            );
             i += 1;
             continue;
         }

--- a/crates/engine/src/parser/oracle_ir/replacement.rs
+++ b/crates/engine/src/parser/oracle_ir/replacement.rs
@@ -26,3 +26,18 @@ pub(crate) struct ReplacementIr {
     /// by replacement sub-parsers internally.
     pub(crate) execute_ir: Option<EffectChainIr>,
 }
+
+impl ReplacementIr {
+    /// Wrap a recognizer-produced replacement in the common replacement lowering path.
+    ///
+    /// Some whole-line recognizers already construct the typed replacement definition
+    /// they need. They still emit this IR node so source-order document lowering
+    /// owns the final replacement post-processing.
+    pub(crate) fn from_definition(source_text: &str, definition: ReplacementDefinition) -> Self {
+        Self {
+            definition,
+            source_text: source_text.to_string(),
+            execute_ir: None,
+        }
+    }
+}


### PR DESCRIPTION
## Plan 05b — Tranche 2: Frozen-in-Ice replacement → IR lowering

Routes the single `try_split_and_cant_become_untapped` replacement producer (Frozen-in-Ice
class) from the legacy `DocEmitter::replacement_at` through the IR path, via a new
`ReplacementIr::from_definition(source_text, definition)` seam and `DocEmitter::replacement_ir_at`.

Behavioral no-op: pure routing, no new parsing logic. `replacement_ir_at` emits only —
unlike `static_at`, `replacement_at` never maintained a `last_*` peek. `execute_ir: None`
mirrors `StaticIr`'s `body_ir: None` (the untap-prevention replacement has no execute body).
The IR `Replacement` node is already a live lowered path (tranche 1's compound-static path
emits it), so this routes one more producer into a proven node type.

### Correctness evidence
- **Byte-identity**: full-pool `card-data.json` regen is sha256-identical to baseline (`b6c79b7a…`).
- **Snapshots**: zero churn — no IR snapshot test covers this path.
- **Gates**: clippy `-D warnings` clean; engine lib 17,479 passed / 0 failed; integration 3,702 / 0.

Scope guard: the two out-of-scope `replacement_at` sites (`drain_result_vectors`, ETB) are
untouched — they belong to later tranches. Second of the 05b tranches feeding the Plan-05
gate-1 zero-hit ratchet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of continuous grants or restrictions that prevent permanents from becoming untapped.
  * Ensured replacement effects are consistently represented and applied during rules processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->