### PR TITLE
ship/cr733 p2 mana appliers

### DIFF
--- a/.agents/cr733/RUN5-REPORT.md
+++ b/.agents/cr733/RUN5-REPORT.md
@@ -1,0 +1,92 @@
+# CR733 resolved-command journal — Run 5 P2 tranche 1 report
+
+## Starting state
+
+Confirmed before edits: `/Users/matt/dev/forge.rs-cr733`, branch
+`cr733/resolved-commands`, `HEAD` `d571b0c25cacd890a5ef22f223fb4c99551c5cfc`, and no
+tracked modifications. The prior run's exact-pip/producer/payment provenance was read and
+retained.
+
+## Landed commit
+
+- `5e24ac6900` — `cr733(p2): apply resolved mana commands`
+
+## P2 recipe coverage
+
+### Mana insert
+
+1. `GameState::add_mana_to_pool` remains the real-pool insertion authority. It stamps the
+   ordinary pip, constructs `ResolvedManaInsertCommand`, calls the exact applier, and records
+   the command/provenance.
+2. `ResolvedManaInsertCommand` contains the exact `ManaUnit`, recipient `PlayerId`, and
+   producer node. The enclosing `ResolvedCommandJournalEntry.ordinal` carries command order.
+3. `GameState::apply_resolved_mana_insert(&ResolvedManaInsertCommand) -> Result<(),
+   ResolvedManaReplayInvariantError>` accepts no allocator, replacement pipeline, RNG, or
+   dynamic query context. It rejects unknown players, unstamped/duplicate pips, re-inserts the
+   recorded unit, and advances only the recorded pip high-water.
+4. The journal records `ResolvedRulesCommand::ManaInsert` under its producer node using a new
+   contiguous command ordinal. P1's initial node slot remains an intentionally empty payload.
+5. Existing state-facing producers still call `add_mana_to_pool`; no producer was rerouted
+   around the final authority.
+6. The integration test snapshots a real Dimir Signet activation's pre-state, replays every
+   recorded semantic mana command in journal order, and compares pools, surviving exact pip IDs,
+   pip high-water, and the canonical journal.
+7. That same real activation composes the auto-tapped basic-land insert, its exact payment, and
+   the Signet's inserts in ordinal order.
+
+### Mana spend/remove
+
+1. `game::mana_payment::remove_exact_mana_units` is the final exact-unit primitive. It first
+   validates a scratch pool, then removes only the recorded units from the live pool with the
+   solver's existing `swap_remove` ordering; a malformed command cannot partially debit a pool.
+2. `ResolvedManaSpendCommand` contains payer, recipient, payment node, and consumption-ordered
+   `ResolvedManaSpentUnit` values, each preserving exact unit and producer identity.
+3. `select_mana_payment` now owns selection on an immutable pool. Every live P1 payment funnel
+   (cast, non-cast, nested auto-tap, mana-ability hybrid sub-cost, and Assist finalization) calls
+   `GameState::resolve_and_apply_mana_spend`, which journals and delegates to
+   `GameState::apply_resolved_mana_spend(&ResolvedManaSpendCommand) -> Result<(),
+   ResolvedManaReplayInvariantError>`. The applier has no solver or dynamic query input.
+4. A payment node gets its preserved P1 placeholder entry plus a semantic
+   `ResolvedRulesCommand::ManaSpend` entry under its own fresh ordinal.
+5. Selection continues to use the existing scratch solver and its original fallback/order rules;
+   final removal repeats its exact selected `swap_remove` sequence rather than assigning a
+   scratch pool into player state.
+6. The real-activation replay test covers the exact selected payment from its pre-state.
+7. The hostile replay test applies one recorded spend twice and asserts the second removal fails
+   with `ResolvedManaReplayInvariantError::MissingExactManaUnit`, not a substitute selection.
+
+## Journal and wire checks
+
+`ResolvedCommandJournalEntry` now carries an optional semantic command for P2 while accepting
+old P1 slots via serde default. Custom validation retains ordinal/node/provenance checks and now
+also rejects malformed command payloads: wrong producer/payment node, wrong payer/recipient,
+empty spends, unstamped/duplicate command pips, mismatched exact units, and duplicate semantic
+insert/spend payloads. Inline tests cover valid round-trip plus malformed and duplicated payload
+rejection. The viewer projection continues to replace the entire journal with its default, and
+the existing turn-boundary truncation remains unchanged.
+
+## Rules evidence
+
+Verified against `/Users/matt/dev/forge.rs/docs/MagicCompRules.txt` before editing:
+
+- CR 106.4 — mana enters a player's pool.
+- CR 118.3a — paying mana removes the indicated mana from that pool.
+- CR 605.3b and CR 605.4a — activated and triggered mana abilities resolve immediately where
+  the P1 node boundaries are touched.
+
+## Verification and risk
+
+- `cargo fmt --all` and `git diff --check` passed before the implementation commit.
+- The commit's parser-combinator and architecture pre-commit gates passed.
+- Per charter, no cargo build, clippy, or test suite was run. Tilt reported green only for the
+  main checkout, so it is not evidence for this worktree.
+- Parity confidence is moderate: the real mutation paths preserve the existing solver choice and
+  `swap_remove` ordering; state-layer dirtiness remains at its former call sites after a
+  successful applier call. The unrun full suite is the remaining verification risk.
+
+## Next P2 boundary
+
+The next tranche should take the next matrix family only; do not start retained-subset
+reconstruction. The most important fact to preserve is that P1 node placeholders and new P2
+semantic entries share one contiguous ordinal stream: append a typed command entry under its
+owning node, and use P2's exact payment command operands rather than ever re-solving mana.

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -14239,11 +14239,11 @@ pub(super) fn pay_mana_cost_from_pool_with_choices(
     let pins: Vec<crate::types::mana::ManaPipId> = state.active_payment_pins.clone();
     let player_data = state
         .players
-        .iter_mut()
+        .iter()
         .find(|p| p.id == player)
         .expect("player exists");
-    let (spent_units, life_payments) = mana_payment::pay_cost_with_demand_and_choices(
-        &mut player_data.mana_pool,
+    let (spent_units, life_payments) = mana_payment::select_mana_payment(
+        &player_data.mana_pool,
         cost,
         Some(&hand_demand),
         spell_ctx.as_ref(),
@@ -14254,7 +14254,11 @@ pub(super) fn pay_mana_cost_from_pool_with_choices(
     )
     .map_err(|_| EngineError::ActionNotAllowed("Mana payment failed".to_string()))?;
     let recipient = state.mana_payment_recipient(source_id, player);
-    state.record_mana_payment(player, recipient, &spent_units);
+    state
+        .resolve_and_apply_mana_spend(player, recipient, &spent_units)
+        .map_err(|_| {
+            EngineError::ActionNotAllowed("Mana pool changed before payment applied".to_string())
+        })?;
     if !spent_units.is_empty() && mana_payment::has_unspent_mana_continuous_effects(state) {
         state.layers_dirty.mark_full();
     }
@@ -14717,11 +14721,11 @@ fn pay_non_cast_mana_cost(
     state.restamp_pool_pip_ids(player);
     let player_data = state
         .players
-        .iter_mut()
+        .iter()
         .find(|p| p.id == player)
         .expect("player exists");
-    let (spent_units, life_payments) = mana_payment::pay_cost_with_demand_and_choices(
-        &mut player_data.mana_pool,
+    let (spent_units, life_payments) = mana_payment::select_mana_payment(
+        &player_data.mana_pool,
         cost,
         None,
         Some(&ctx),
@@ -14735,7 +14739,11 @@ fn pay_non_cast_mana_cost(
     let recipient = source_id
         .map(|source| state.mana_payment_recipient(source, player))
         .unwrap_or(ManaPaymentRecipient::Player(player));
-    state.record_mana_payment(player, recipient, &spent_units);
+    state
+        .resolve_and_apply_mana_spend(player, recipient, &spent_units)
+        .map_err(|_| {
+            EngineError::ActionNotAllowed("Mana pool changed before payment applied".to_string())
+        })?;
     if !spent_units.is_empty() && mana_payment::has_unspent_mana_continuous_effects(state) {
         state.layers_dirty.mark_full();
     }
@@ -14877,11 +14885,11 @@ fn auto_tap_and_pay_cost_excluding(
     let pins: Vec<crate::types::mana::ManaPipId> = state.active_payment_pins.clone();
     let player_data = state
         .players
-        .iter_mut()
+        .iter()
         .find(|p| p.id == player)
         .expect("player exists");
-    let (spent_units, life_payments) = mana_payment::pay_cost_with_demand_and_choices(
-        &mut player_data.mana_pool,
+    let (spent_units, life_payments) = mana_payment::select_mana_payment(
+        &player_data.mana_pool,
         cost,
         Some(&combined_demand),
         ctx,
@@ -14892,7 +14900,11 @@ fn auto_tap_and_pay_cost_excluding(
     )
     .map_err(|_| EngineError::ActionNotAllowed("Mana payment failed".to_string()))?;
     let recipient = state.mana_payment_recipient(source_id, player);
-    state.record_mana_payment(player, recipient, &spent_units);
+    state
+        .resolve_and_apply_mana_spend(player, recipient, &spent_units)
+        .map_err(|_| {
+            EngineError::ActionNotAllowed("Mana pool changed before payment applied".to_string())
+        })?;
     if !spent_units.is_empty() && mana_payment::has_unspent_mana_continuous_effects(state) {
         state.layers_dirty.mark_full();
     }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -10860,12 +10860,36 @@ pub(super) fn apply_committed_assist(
             "Assist mana payment is awaiting a replacement choice".to_string(),
         ));
     }
-    if let Some(p) = state.players.iter_mut().find(|p| p.id == helper) {
-        mana_payment::pay_from_pool(&mut p.mana_pool, &probe).map_err(|e| {
+    if state.players.iter().any(|p| p.id == helper) {
+        state.restamp_pool_pip_ids(helper);
+        let (spent, _) = mana_payment::select_mana_payment(
+            &state
+                .players
+                .iter()
+                .find(|p| p.id == helper)
+                .expect("assisting player exists")
+                .mana_pool,
+            &probe,
+            None,
+            None,
+            false,
+            None,
+            crate::types::mana::LifePaymentColors::EMPTY,
+            &[],
+        )
+        .map_err(|e| {
             EngineError::ActionNotAllowed(format!(
                 "Assisting player could not pay {generic} generic mana at finalization: {e:?}"
             ))
         })?;
+        let recipient = state.mana_payment_recipient(pending.object_id, helper);
+        state
+            .resolve_and_apply_mana_spend(helper, recipient, &spent)
+            .map_err(|_| {
+                EngineError::ActionNotAllowed(
+                    "Assisting player's mana pool changed before payment applied".to_string(),
+                )
+            })?;
         if mana_payment::has_unspent_mana_continuous_effects(state) {
             state.layers_dirty.mark_full();
         }

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -3210,27 +3210,27 @@ fn enumerate_plans_rec(
 /// covers the cost, `None` otherwise. Deterministic — uses the same
 /// auto-pay rules as `pay_cost` except hybrid shards defer to `plan`.
 fn try_pay_with_hybrid_plan(pool: &ManaPool, cost: &ManaCost, plan: &[ManaType]) -> Option<()> {
-    let mut sim = pool.clone();
+    let sim = pool.clone();
     // Simulation path — `None` context preserves the prior "can pool cover
     // this at all" semantics. Restriction-aware affordability is checked at
     // the real payment site via `pay_mana_sub_cost`; the simulated spent
     // units are discarded (provenance is recorded only at the real site).
-    debit_cost_with_plan(&mut sim, cost, plan, None)
+    select_cost_with_plan(&sim, cost, plan, None)
         .ok()
         .map(|_| ())
 }
 
-/// CR 107.4e + CR 601.2h: Debit `cost` from `pool` using `plan` for hybrid
+/// CR 107.4e + CR 601.2h: Select the exact units that pay `cost` using `plan` for hybrid
 /// shards. Non-hybrid shards (single, Phyrexian, snow, colorless-hybrid,
 /// hybrid-Phyrexian, two-generic-hybrid, X) are routed through the same
 /// auto-pay rules the casting flow uses via `mana_payment::pay_from_pool`, but
 /// with the hybrid shards already resolved, the plan is unambiguous.
 ///
 /// Implementation: build a scratch cost with hybrid shards rewritten to
-/// single-color shards per `plan`, then delegate to `pay_cost`. This keeps
+/// single-color shards per `plan`, then delegate to the shared selector. This keeps
 /// every shard-kind's payment rules in one place.
-fn debit_cost_with_plan(
-    pool: &mut ManaPool,
+fn select_cost_with_plan(
+    pool: &ManaPool,
     cost: &ManaCost,
     plan: &[ManaType],
     ctx: Option<&PaymentContext<'_>>,
@@ -3261,7 +3261,7 @@ fn debit_cost_with_plan(
     // ShardChoice and is paid implicitly during ability resolution; pass an
     // empty `LifePaymentColors` since K'rrik substitution does not apply to
     // mana abilities' own activation costs in any printed exemplar today.
-    mana_payment::pay_cost_with_demand_and_choices(
+    mana_payment::select_mana_payment(
         pool,
         &scratch_cost,
         None,
@@ -3350,14 +3350,19 @@ fn pay_mana_sub_cost(
         ability_tag: None,
     };
     state.restamp_pool_pip_ids(player);
-    let pool = &mut state.players[player.0 as usize].mana_pool;
     let spent = match hybrid_plan {
-        Some(plan) => debit_cost_with_plan(pool, cost, plan, Some(&ctx)).map_err(|_| {
+        Some(plan) => select_cost_with_plan(
+            &state.players[player.0 as usize].mana_pool,
+            cost,
+            plan,
+            Some(&ctx),
+        )
+        .map_err(|_| {
             EngineError::ActionNotAllowed("Mana pool cannot cover mana ability cost".to_string())
         })?,
         None => {
-            mana_payment::pay_cost_with_demand_and_choices(
-                pool,
+            mana_payment::select_mana_payment(
+                &state.players[player.0 as usize].mana_pool,
                 cost,
                 None,
                 Some(&ctx),
@@ -3376,11 +3381,15 @@ fn pay_mana_sub_cost(
             .0
         }
     };
+    let recipient = state.mana_payment_recipient(source_id, player);
+    state
+        .resolve_and_apply_mana_spend(player, recipient, &spent)
+        .map_err(|_| {
+            EngineError::ActionNotAllowed("Mana pool changed before payment applied".to_string())
+        })?;
     if !spent.is_empty() || hybrid_plan.is_some() {
         state.layers_dirty.mark_full();
     }
-    let recipient = state.mana_payment_recipient(source_id, player);
-    state.record_mana_payment(player, recipient, &spent);
     // CR 605.3b: The player's mana pool mutation is the public signal; no
     // dedicated event exists for ability mana payments. The pool-diff is
     // surfaced via the standard state-update machinery.

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -266,11 +266,11 @@ pub enum PaymentError {
 /// Typed failure while applying an already-selected exact pool removal.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub(crate) enum ExactManaRemovalError {
-    #[error("duplicate exact mana pip {0}")]
+    #[error("duplicate exact mana pip {0:?}")]
     DuplicatePip(ManaPipId),
-    #[error("missing exact mana pip {0}")]
+    #[error("missing exact mana pip {0:?}")]
     MissingPip(ManaPipId),
-    #[error("mismatched exact mana unit for pip {0}")]
+    #[error("mismatched exact mana unit for pip {0:?}")]
     MismatchedUnit(ManaPipId),
 }
 

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -263,6 +263,64 @@ pub enum PaymentError {
     InvalidCost,
 }
 
+/// Typed failure while applying an already-selected exact pool removal.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub(crate) enum ExactManaRemovalError {
+    #[error("duplicate exact mana pip {0}")]
+    DuplicatePip(ManaPipId),
+    #[error("missing exact mana pip {0}")]
+    MissingPip(ManaPipId),
+    #[error("mismatched exact mana unit for pip {0}")]
+    MismatchedUnit(ManaPipId),
+}
+
+/// CR 118.3a: Apply a payment solver's exact selected units in consumption
+/// order. This is deliberately separate from selection: it never chooses a
+/// substitute unit when a recorded pip is absent or differs.
+pub(crate) fn remove_exact_mana_units(
+    pool: &mut ManaPool,
+    units: &[ManaUnit],
+) -> Result<(), ExactManaRemovalError> {
+    let mut seen = std::collections::HashSet::new();
+    for unit in units {
+        if unit.pip_id.0 != 0 && !seen.insert(unit.pip_id) {
+            return Err(ExactManaRemovalError::DuplicatePip(unit.pip_id));
+        }
+    }
+    // Validate against a scratch pool first, so a malformed replay command
+    // cannot partially debit a real pool. The final pass then performs the
+    // same exact semantic removals on the live pool; it never replaces it.
+    let mut validation_pool = pool.clone();
+    remove_exact_mana_units_once(&mut validation_pool, units)?;
+    remove_exact_mana_units_once(pool, units)
+}
+
+fn remove_exact_mana_units_once(
+    pool: &mut ManaPool,
+    units: &[ManaUnit],
+) -> Result<(), ExactManaRemovalError> {
+    for unit in units {
+        let position = pool
+            .mana
+            .iter()
+            .position(|candidate| candidate.pip_id == unit.pip_id && *candidate == *unit);
+        match position {
+            Some(position) => {
+                pool.mana.swap_remove(position);
+            }
+            None if pool
+                .mana
+                .iter()
+                .any(|candidate| candidate.pip_id == unit.pip_id) =>
+            {
+                return Err(ExactManaRemovalError::MismatchedUnit(unit.pip_id));
+            }
+            None => return Err(ExactManaRemovalError::MissingPip(unit.pip_id)),
+        }
+    }
+    Ok(())
+}
+
 /// Result of a Phyrexian mana payment that used life instead of mana (CR 107.4f).
 ///
 /// CR 107.4f: A Phyrexian mana symbol represents a cost that can be paid either
@@ -1151,8 +1209,38 @@ pub fn pay_cost_with_demand_and_choices(
     // which makes the spend byte-identical to the pre-feature ordering.
     pins: &[ManaPipId],
 ) -> Result<(Vec<ManaUnit>, Vec<LifePayment>), PaymentError> {
+    let payment = select_mana_payment(
+        pool,
+        cost,
+        hand_demand,
+        spell,
+        any_color,
+        phyrexian_choices,
+        life_colors,
+        pins,
+    )?;
+    remove_exact_mana_units(pool, &payment.0).map_err(|_| PaymentError::InsufficientMana)?;
+    Ok(payment)
+}
+
+/// Resolve which exact units pay a mana cost without mutating the real pool.
+///
+/// The scratch solver remains the authority for all payment choices. Live
+/// `GameState` callers pass its result to the resolved-command applier, while
+/// detached preview pools may use [`pay_cost_with_demand_and_choices`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn select_mana_payment(
+    pool: &ManaPool,
+    cost: &ManaCost,
+    hand_demand: Option<&ColorDemand>,
+    spell: Option<&PaymentContext<'_>>,
+    any_color: bool,
+    phyrexian_choices: Option<&[ShardChoice]>,
+    life_colors: crate::types::mana::LifePaymentColors,
+    pins: &[ManaPipId],
+) -> Result<(Vec<ManaUnit>, Vec<LifePayment>), PaymentError> {
     // CR 601.2h: Partial payments are not allowed. Spend from scratch pools so a
-    // failed attempt never leaks a partial payment into the caller's mana pool.
+    // failed attempt never leaks a partial payment into the caller's real pool.
     let mut scratch = pool.clone();
     match pay_cost_with_demand_and_choices_once(
         &mut scratch,
@@ -1164,10 +1252,7 @@ pub fn pay_cost_with_demand_and_choices(
         life_colors,
         pins,
     ) {
-        Ok(payment) => {
-            *pool = scratch;
-            Ok(payment)
-        }
+        Ok(payment) => Ok(payment),
         Err(PaymentError::InsufficientMana) if hand_demand.is_some() => {
             let mut fallback = pool.clone();
             match pay_cost_with_demand_and_choices_once(
@@ -1180,10 +1265,7 @@ pub fn pay_cost_with_demand_and_choices(
                 life_colors,
                 pins,
             ) {
-                Ok(payment) => {
-                    *pool = fallback;
-                    Ok(payment)
-                }
+                Ok(payment) => Ok(payment),
                 Err(error) => Err(error),
             }
         }
@@ -2719,6 +2801,22 @@ mod tests {
             grants: vec![ManaSpellGrant::CantBeCountered],
             expiry: Some(ManaExpiry::EndOfTurn),
         }
+    }
+
+    #[test]
+    fn exact_removal_is_atomic_when_a_recorded_pip_is_missing() {
+        let present = rich_unit(ManaType::Blue, 1, 1);
+        let missing = rich_unit(ManaType::Green, 2, 2);
+        let mut pool = ManaPool {
+            mana: vec![present.clone()],
+        };
+        let before = fingerprint(&pool.mana);
+
+        assert_eq!(
+            remove_exact_mana_units(&mut pool, &[present, missing]),
+            Err(ExactManaRemovalError::MissingPip(ManaPipId(2)))
+        );
+        assert_eq!(fingerprint(&pool.mana), before);
     }
 
     fn make_two_or_more_color_source_unit(color: ManaType) -> ManaUnit {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -48,7 +48,10 @@ use super::resolution::{
     PendingCoinFlip, PendingMutateMerge, PendingProliferateActions, RepeatedOptionalPaymentFrame,
     ResolutionFrame, ResolutionStack, ResolutionStackError, ResolutionStateWire,
 };
-use super::resolved_commands::{ManaPaymentRecipient, ResolvedRulesJournal, RulesExecutionNodeRef};
+use super::resolved_commands::{
+    ManaPaymentRecipient, ResolvedManaInsertCommand, ResolvedManaReplayInvariantError,
+    ResolvedManaSpendCommand, ResolvedRulesJournal, RulesExecutionNodeRef,
+};
 use super::zones::EtbTapState;
 use super::zones::{ExileCostSourceZone, Zone};
 
@@ -10957,9 +10960,9 @@ pub struct GameState {
     /// games don't re-mint colliding ids.
     #[serde(default)]
     pub next_pip_id: u64,
-    /// P1 provenance-only journal for resolved rules work. It is serialized so
-    /// a restored game retains exact stamped mana provenance, but it does not
-    /// yet participate in command application.
+    /// Resolved-rules journal for exact mana provenance and P2 mana commands.
+    /// It is serialized so a restored game retains the command operands needed
+    /// by later retained-prefix replay.
     #[serde(default)]
     pub resolved_rules_journal: ResolvedRulesJournal,
     /// CR 118.3a: transient carrier for the caster's pin hints during a single
@@ -15142,27 +15145,132 @@ impl GameState {
         ManaPipId(id)
     }
 
-    /// CR 118.3a: Stamp a stable pip id on `unit` and add it to `player`'s mana
-    /// pool. This is the single authority for mana entering a *real* pool: every
+    /// CR 106.4 + CR 118.3a: Resolve and apply one real-pool mana insertion.
+    /// This is the single authority for mana entering a *real* pool: every
     /// production/refill/convoke/delve injection routes here so that each pooled
     /// unit has a unique id the player can pin to direct payment. Detached
     /// preview pools (with no `GameState`) keep calling `ManaPool::add` directly.
     pub fn add_mana_to_pool(&mut self, player: PlayerId, mut unit: ManaUnit) -> Option<ManaUnit> {
         unit.pip_id = self.next_pip_id();
-        if let Some(p) = self.players.iter_mut().find(|p| p.id == player) {
-            p.mana_pool.add(unit.clone());
-            let producer = self.active_rules_execution_node.unwrap_or_else(|| {
-                self.resolved_rules_journal
-                    .begin_proposal()
-                    .expect("resolved-rules journal proposal ordinal overflow")
-            });
-            self.resolved_rules_journal
-                .record_produced_mana(producer, unit.clone())
-                .expect("stamped mana must have one unique journal producer");
-            Some(unit)
-        } else {
-            None
+        if !self.players.iter().any(|candidate| candidate.id == player) {
+            return None;
         }
+        let producer = self.active_rules_execution_node.unwrap_or_else(|| {
+            self.resolved_rules_journal
+                .begin_proposal()
+                .expect("resolved-rules journal proposal ordinal overflow")
+        });
+        let command = ResolvedManaInsertCommand {
+            player,
+            unit: unit.clone(),
+            producer,
+        };
+        self.apply_resolved_mana_insert(&command)
+            .expect("fresh mana insertion must satisfy its replay preconditions");
+        self.resolved_rules_journal
+            .record_mana_insert(command)
+            .expect("stamped mana must have one unique journal producer");
+        Some(unit)
+    }
+
+    /// CR 106.4: Apply one exact, already-resolved mana insertion without
+    /// allocating a replacement pip or consulting mana-production state.
+    pub fn apply_resolved_mana_insert(
+        &mut self,
+        command: &ResolvedManaInsertCommand,
+    ) -> Result<(), ResolvedManaReplayInvariantError> {
+        if command.unit.pip_id.0 == 0 {
+            return Err(ResolvedManaReplayInvariantError::UnstampedManaPip);
+        }
+        let player = self
+            .players
+            .iter_mut()
+            .find(|candidate| candidate.id == command.player)
+            .ok_or(ResolvedManaReplayInvariantError::UnknownPlayer(
+                command.player,
+            ))?;
+        if player
+            .mana_pool
+            .mana
+            .iter()
+            .any(|unit| unit.pip_id == command.unit.pip_id)
+        {
+            return Err(ResolvedManaReplayInvariantError::DuplicateManaPip(
+                command.unit.pip_id,
+            ));
+        }
+        player.mana_pool.add(command.unit.clone());
+        self.advance_pip_high_water(command.unit.pip_id)
+    }
+
+    /// CR 118.3a: Construct, journal, and apply the solver-selected exact mana
+    /// payment. Solver choice happens before this boundary; this method never
+    /// re-solves or substitutes units.
+    pub(crate) fn resolve_and_apply_mana_spend(
+        &mut self,
+        payer: PlayerId,
+        recipient: ManaPaymentRecipient,
+        spent: &[ManaUnit],
+    ) -> Result<(), ResolvedManaReplayInvariantError> {
+        let Some(command) = self
+            .resolved_rules_journal
+            .record_mana_spend(payer, recipient, spent)
+            .expect("every paid mana pip must have one unique journal producer")
+        else {
+            return Ok(());
+        };
+        self.apply_resolved_mana_spend(&command)
+    }
+
+    /// CR 118.3a: Apply one exact, already-resolved mana payment. A missing or
+    /// mismatched pip is a typed replay-invariant failure, never an invitation
+    /// to choose substitute mana.
+    pub fn apply_resolved_mana_spend(
+        &mut self,
+        command: &ResolvedManaSpendCommand,
+    ) -> Result<(), ResolvedManaReplayInvariantError> {
+        let player = self
+            .players
+            .iter_mut()
+            .find(|candidate| candidate.id == command.payer)
+            .ok_or(ResolvedManaReplayInvariantError::UnknownPlayer(
+                command.payer,
+            ))?;
+        let units: Vec<ManaUnit> = command
+            .units
+            .iter()
+            .map(|spent| spent.unit.clone())
+            .collect();
+        for unit in &units {
+            if unit.pip_id.0 == 0 {
+                return Err(ResolvedManaReplayInvariantError::UnstampedManaPip);
+            }
+        }
+        crate::game::mana_payment::remove_exact_mana_units(&mut player.mana_pool, &units).map_err(
+            |error| match error {
+                crate::game::mana_payment::ExactManaRemovalError::DuplicatePip(pip) => {
+                    ResolvedManaReplayInvariantError::DuplicateSpentManaPip(pip)
+                }
+                crate::game::mana_payment::ExactManaRemovalError::MissingPip(pip) => {
+                    ResolvedManaReplayInvariantError::MissingExactManaUnit(pip)
+                }
+                crate::game::mana_payment::ExactManaRemovalError::MismatchedUnit(pip) => {
+                    ResolvedManaReplayInvariantError::MismatchedExactManaUnit(pip)
+                }
+            },
+        )
+    }
+
+    fn advance_pip_high_water(
+        &mut self,
+        pip: ManaPipId,
+    ) -> Result<(), ResolvedManaReplayInvariantError> {
+        let next = pip
+            .0
+            .checked_add(1)
+            .ok_or(ResolvedManaReplayInvariantError::ManaPipIdOverflow(pip))?;
+        self.next_pip_id = self.next_pip_id.max(next);
+        Ok(())
     }
 
     /// CR 605.3b: Begin the distinct, immediate execution node for one
@@ -15224,20 +15332,6 @@ impl GameState {
             Some(node) => self.with_rules_execution_node(node, operation),
             None => operation(self),
         }
-    }
-
-    /// CR 118.3a: Record the exact stamped pool units consumed for one mana
-    /// cost component. The payment solver remains authoritative for which
-    /// units leave the pool; this only captures its completed result.
-    pub(crate) fn record_mana_payment(
-        &mut self,
-        payer: PlayerId,
-        recipient: ManaPaymentRecipient,
-        spent: &[ManaUnit],
-    ) {
-        self.resolved_rules_journal
-            .record_spent_mana(payer, recipient, spent)
-            .expect("every paid mana pip must have one unique journal producer");
     }
 
     pub(crate) fn mana_payment_recipient(

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -75,8 +75,10 @@ pub use resolution::{
 };
 pub use resolved_commands::{
     ManaPaymentRecipient, ProducedManaUnit, ResolvedCommandJournalEntry, ResolvedCommandOrdinal,
-    ResolvedRulesJournal, ResolvedRulesJournalError, RulesExecutionNodeKind, RulesExecutionNodeRef,
-    SettlementNode, SettlementNodeOrdinal, SpentManaUnit,
+    ResolvedManaInsertCommand, ResolvedManaReplayInvariantError, ResolvedManaSpendCommand,
+    ResolvedManaSpentUnit, ResolvedRulesCommand, ResolvedRulesJournal, ResolvedRulesJournalError,
+    RulesExecutionNodeKind, RulesExecutionNodeRef, SettlementNode, SettlementNodeOrdinal,
+    SpentManaUnit,
 };
 pub use statics::StaticMode;
 pub use stickers::{AppliedSticker, StickerKind, StickerLocator};

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -1,7 +1,7 @@
 //! Append-only, identity-bearing records for resolved rules work.
 //!
-//! P1 records provenance only. Existing engine reducers remain the behavior
-//! authority until the later resolved-command application phase.
+//! P1 established provenance and ordering. P2 makes mana insert and exact
+//! spend commands executable through their owning authority appliers.
 
 use std::collections::HashSet;
 
@@ -38,6 +38,84 @@ pub enum ManaPaymentRecipient {
     Object(ObjectIncarnationRef),
     Player(PlayerId),
 }
+
+/// One exact mana-pool insertion after mana production has been resolved.
+///
+/// CR 106.4: resolved mana enters this player’s pool with this already-stamped
+/// pip identity; replay must neither choose a new recipient nor mint a new pip.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedManaInsertCommand {
+    pub player: PlayerId,
+    pub unit: ManaUnit,
+    pub producer: RulesExecutionNodeRef,
+}
+
+/// One exact mana unit selected by the payment solver, with its producer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedManaSpentUnit {
+    pub unit: ManaUnit,
+    pub producer: RulesExecutionNodeRef,
+}
+
+/// One exact mana-pool removal after the payment solver has selected its units.
+///
+/// CR 118.3a: this command removes precisely these units, in their recorded
+/// consumption order. It never asks a solver to choose replacement mana.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedManaSpendCommand {
+    pub payer: PlayerId,
+    pub recipient: ManaPaymentRecipient,
+    pub payment: RulesExecutionNodeRef,
+    pub units: Vec<ResolvedManaSpentUnit>,
+}
+
+/// Semantic command payload currently carried by a resolved-rules journal entry.
+///
+/// Additional command families are intentionally added by their owning P2
+/// authority rather than by a central replay dispatcher.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolvedRulesCommand {
+    ManaInsert(ResolvedManaInsertCommand),
+    ManaSpend(ResolvedManaSpendCommand),
+}
+
+/// Typed failure while applying an already-resolved mana command to a replay state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedManaReplayInvariantError {
+    UnknownPlayer(PlayerId),
+    UnstampedManaPip,
+    DuplicateManaPip(ManaPipId),
+    ManaPipIdOverflow(ManaPipId),
+    DuplicateSpentManaPip(ManaPipId),
+    MissingExactManaUnit(ManaPipId),
+    MismatchedExactManaUnit(ManaPipId),
+}
+
+impl std::fmt::Display for ResolvedManaReplayInvariantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownPlayer(player) => write!(f, "unknown mana-command player {}", player.0),
+            Self::UnstampedManaPip => write!(f, "resolved mana command has an unstamped pip"),
+            Self::DuplicateManaPip(pip) => {
+                write!(f, "resolved mana command would duplicate pip {}", pip.0)
+            }
+            Self::ManaPipIdOverflow(pip) => {
+                write!(f, "resolved mana command cannot advance past pip {}", pip.0)
+            }
+            Self::DuplicateSpentManaPip(pip) => {
+                write!(f, "resolved mana spend repeats pip {}", pip.0)
+            }
+            Self::MissingExactManaUnit(pip) => {
+                write!(f, "resolved mana spend cannot find pip {}", pip.0)
+            }
+            Self::MismatchedExactManaUnit(pip) => {
+                write!(f, "resolved mana spend found mismatched pip {}", pip.0)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResolvedManaReplayInvariantError {}
 
 /// Semantic category of a resolved rules-execution node.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -86,6 +164,10 @@ pub struct SettlementNode {
 pub struct ResolvedCommandJournalEntry {
     pub ordinal: ResolvedCommandOrdinal,
     pub node: RulesExecutionNodeRef,
+    /// P1 node slots intentionally have no semantic payload. P2 commands append
+    /// their own globally ordered entry while preserving those original slots.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub command: Option<ResolvedRulesCommand>,
 }
 
 /// Exact stamped mana created by one node.
@@ -273,6 +355,7 @@ impl ResolvedRulesJournal {
         self.entries.push(ResolvedCommandJournalEntry {
             ordinal: command,
             node: identity,
+            command: None,
         });
         self.nodes.push(SettlementNode {
             ordinal,
@@ -338,6 +421,16 @@ impl ResolvedRulesJournal {
         Ok(())
     }
 
+    /// Records and owns the exact command that inserted one mana unit.
+    pub fn record_mana_insert(
+        &mut self,
+        command: ResolvedManaInsertCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.ensure_command_capacity()?;
+        self.record_produced_mana(command.producer, command.unit.clone())?;
+        self.append_command(command.producer, ResolvedRulesCommand::ManaInsert(command))
+    }
+
     /// Records all exact units consumed by one cost component in solver order.
     pub fn record_spent_mana(
         &mut self,
@@ -395,6 +488,46 @@ impl ResolvedRulesJournal {
         Ok(Some(payment))
     }
 
+    /// Records and owns one exact solver-selected mana payment command.
+    pub fn record_mana_spend(
+        &mut self,
+        payer: PlayerId,
+        recipient: ManaPaymentRecipient,
+        spent: &[ManaUnit],
+    ) -> Result<Option<ResolvedManaSpendCommand>, ResolvedRulesJournalError> {
+        if spent.is_empty() {
+            return Ok(None);
+        }
+        self.ensure_command_capacity_for(2)?;
+        let Some(payment) = self.record_spent_mana(payer, recipient.clone(), spent)? else {
+            return Ok(None);
+        };
+        self.ensure_command_capacity()?;
+        let units = spent
+            .iter()
+            .map(|unit| {
+                let producer = self
+                    .spent_mana
+                    .iter()
+                    .find(|record| record.payment == payment && record.unit.pip_id == unit.pip_id)
+                    .expect("recorded spent mana must retain its producer")
+                    .producer;
+                ResolvedManaSpentUnit {
+                    unit: unit.clone(),
+                    producer,
+                }
+            })
+            .collect();
+        let command = ResolvedManaSpendCommand {
+            payer,
+            recipient,
+            payment,
+            units,
+        };
+        self.append_command(payment, ResolvedRulesCommand::ManaSpend(command.clone()))?;
+        Ok(Some(command))
+    }
+
     fn begin_settlement(
         &mut self,
         identity_for: impl FnOnce(SettlementNodeOrdinal) -> RulesExecutionNodeRef,
@@ -413,6 +546,7 @@ impl ResolvedRulesJournal {
         self.entries.push(ResolvedCommandJournalEntry {
             ordinal: command,
             node: identity,
+            command: None,
         });
         self.nodes.push(SettlementNode {
             ordinal,
@@ -428,8 +562,29 @@ impl ResolvedRulesJournal {
         Ok(identity)
     }
 
+    fn append_command(
+        &mut self,
+        node: RulesExecutionNodeRef,
+        command: ResolvedRulesCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.ensure_command_capacity()?;
+        let node_index = self.node_index(node)?;
+        let ordinal = self.allocate_command();
+        self.entries.push(ResolvedCommandJournalEntry {
+            ordinal,
+            node,
+            command: Some(command),
+        });
+        self.nodes[node_index].journal_ordinals.push(ordinal);
+        Ok(ordinal)
+    }
+
     fn ensure_command_capacity(&self) -> Result<(), ResolvedRulesJournalError> {
-        (self.next_command_ordinal != u64::MAX)
+        self.ensure_command_capacity_for(1)
+    }
+
+    fn ensure_command_capacity_for(&self, count: u64) -> Result<(), ResolvedRulesJournalError> {
+        (self.next_command_ordinal <= u64::MAX.saturating_sub(count))
             .then_some(())
             .ok_or(ResolvedRulesJournalError::CommandOrdinalOverflow)
     }
@@ -544,6 +699,32 @@ impl ResolvedRulesJournal {
                 ));
             }
         }
+        let mut inserted_command_pips = HashSet::new();
+        let mut spent_command_pips = HashSet::new();
+        for entry in &self.entries {
+            let Some(command) = &entry.command else {
+                continue;
+            };
+            self.validate_resolved_command(entry, command)?;
+            match command {
+                ResolvedRulesCommand::ManaInsert(command) => {
+                    if !inserted_command_pips.insert(command.unit.pip_id) {
+                        return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                            "duplicate mana-insert command pip".to_string(),
+                        ));
+                    }
+                }
+                ResolvedRulesCommand::ManaSpend(command) => {
+                    for spent in &command.units {
+                        if !spent_command_pips.insert(spent.unit.pip_id) {
+                            return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                                "duplicate mana-spend command pip".to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
         for node in &self.nodes {
             for ordinal in &node.journal_ordinals {
                 if !self
@@ -641,6 +822,79 @@ impl ResolvedRulesJournal {
         }
         Ok(())
     }
+
+    fn validate_resolved_command(
+        &self,
+        entry: &ResolvedCommandJournalEntry,
+        command: &ResolvedRulesCommand,
+    ) -> Result<(), ResolvedRulesJournalError> {
+        match command {
+            ResolvedRulesCommand::ManaInsert(command) => {
+                Self::require_stamped(command.unit.pip_id)?;
+                if entry.node != command.producer
+                    || !self.produced_mana.iter().any(|record| {
+                        record.producer == command.producer
+                            && exact_mana_unit_eq(&record.unit, &command.unit)
+                    })
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "mana-insert command disagrees with produced mana".to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::ManaSpend(command) => {
+                if command.units.is_empty() || entry.node != command.payment {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "mana-spend command has an empty or unrelated payment".to_string(),
+                    ));
+                }
+                let payment = self.node_index(command.payment).map_err(|_| {
+                    ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "mana-spend command references an unknown payment".to_string(),
+                    )
+                })?;
+                let RulesExecutionNodeKind::Payment { payer, recipient } =
+                    &self.nodes[payment].kind
+                else {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "mana-spend command references a non-payment node".to_string(),
+                    ));
+                };
+                if *payer != command.payer || *recipient != command.recipient {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "mana-spend command disagrees with payment metadata".to_string(),
+                    ));
+                }
+                let records: Vec<&SpentManaUnit> = self
+                    .spent_mana
+                    .iter()
+                    .filter(|record| record.payment == command.payment)
+                    .collect();
+                if records.len() != command.units.len()
+                    || records.iter().zip(&command.units).any(|(record, spent)| {
+                        record.producer != spent.producer
+                            || !exact_mana_unit_eq(&record.unit, &spent.unit)
+                            || record.recipient != command.recipient
+                    })
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "mana-spend command disagrees with spent mana".to_string(),
+                    ));
+                }
+                let mut pips = HashSet::new();
+                if command
+                    .units
+                    .iter()
+                    .any(|spent| spent.unit.pip_id.0 == 0 || !pips.insert(spent.unit.pip_id))
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "mana-spend command has duplicate or unstamped pips".to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 fn identity_matches_kind(identity: RulesExecutionNodeRef, kind: &RulesExecutionNodeKind) -> bool {
@@ -668,6 +922,10 @@ fn identity_matches_kind(identity: RulesExecutionNodeRef, kind: &RulesExecutionN
 fn has_duplicate_values<T: Eq + std::hash::Hash>(values: &[T]) -> bool {
     let mut seen = HashSet::new();
     values.iter().any(|value| !seen.insert(value))
+}
+
+fn exact_mana_unit_eq(left: &ManaUnit, right: &ManaUnit) -> bool {
+    left.pip_id == right.pip_id && left == right
 }
 
 #[cfg(test)]
@@ -803,5 +1061,66 @@ mod tests {
         let mut nonmonotonic = serialized;
         nonmonotonic["nodes"][1]["ordinal"] = serde_json::json!(0);
         assert!(serde_json::from_value::<ResolvedRulesJournal>(nonmonotonic).is_err());
+    }
+
+    #[test]
+    fn semantic_mana_commands_roundtrip_and_reject_malformed_payloads() {
+        let mut journal = ResolvedRulesJournal::default();
+        let producer = journal.begin_proposal().unwrap();
+        let produced = unit(1);
+        journal
+            .record_mana_insert(ResolvedManaInsertCommand {
+                player: PlayerId(0),
+                unit: produced.clone(),
+                producer,
+            })
+            .unwrap();
+        let spend = journal
+            .record_mana_spend(
+                PlayerId(0),
+                ManaPaymentRecipient::Player(PlayerId(0)),
+                std::slice::from_ref(&produced),
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(spend.units[0].unit, produced);
+        assert!(matches!(
+            journal.entries()[1].command.as_ref(),
+            Some(ResolvedRulesCommand::ManaInsert(_))
+        ));
+        assert!(matches!(
+            journal.entries()[3].command.as_ref(),
+            Some(ResolvedRulesCommand::ManaSpend(_))
+        ));
+        let serialized = serde_json::to_value(&journal).unwrap();
+        assert_eq!(
+            serde_json::from_value::<ResolvedRulesJournal>(serialized).unwrap(),
+            journal
+        );
+
+        let mut mismatched_insert = journal.clone();
+        let Some(ResolvedRulesCommand::ManaInsert(command)) =
+            mismatched_insert.entries[1].command.as_mut()
+        else {
+            panic!("entry 1 must be the insert command");
+        };
+        command.unit.pip_id = ManaPipId(99);
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(
+            serde_json::to_value(mismatched_insert).unwrap()
+        )
+        .is_err());
+
+        let mut duplicate_spend = journal.clone();
+        let mut duplicate_entry = duplicate_spend.entries[3].clone();
+        duplicate_entry.ordinal = ResolvedCommandOrdinal(4);
+        duplicate_spend.entries.push(duplicate_entry);
+        duplicate_spend.nodes[1]
+            .journal_ordinals
+            .push(ResolvedCommandOrdinal(4));
+        duplicate_spend.next_command_ordinal = 5;
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(
+            serde_json::to_value(duplicate_spend).unwrap()
+        )
+        .is_err());
     }
 }

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -1,0 +1,145 @@
+//! P2 replay coverage for resolved mana insert and spend commands.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::{ResolvedManaReplayInvariantError, ResolvedRulesCommand};
+
+const DIMIR_SIGNET_ORACLE: &str = "{1}, {T}: Add {U}{B}.";
+
+fn make_artifact(runner: &mut GameRunner, id: ObjectId) {
+    let object = runner.state_mut().objects.get_mut(&id).unwrap();
+    object.card_types.core_types = vec![CoreType::Artifact];
+    object.base_card_types = object.card_types.clone();
+    object.power = None;
+    object.toughness = None;
+    object.base_power = None;
+    object.base_toughness = None;
+}
+
+fn activated_signet_states() -> (GameState, GameState) {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::White);
+    let signet = scenario
+        .add_creature_from_oracle(P0, "Dimir Signet", 0, 0, DIMIR_SIGNET_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    make_artifact(&mut runner, signet);
+    let pre_state = runner.state().clone();
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: signet,
+            ability_index: 0,
+        })
+        .expect("the real Signet mana ability must activate");
+    (pre_state, runner.state().clone())
+}
+
+fn semantic_mana_commands(state: &GameState) -> Vec<ResolvedRulesCommand> {
+    state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .filter_map(|entry| entry.command.clone())
+        .collect()
+}
+
+fn apply_mana_command(state: &mut GameState, command: &ResolvedRulesCommand) {
+    match command {
+        ResolvedRulesCommand::ManaInsert(command) => {
+            state.apply_resolved_mana_insert(command).unwrap();
+        }
+        ResolvedRulesCommand::ManaSpend(command) => {
+            state.apply_resolved_mana_spend(command).unwrap();
+        }
+    }
+}
+
+/// The real activation inserts the auto-tapped land's exact pip, spends it for
+/// the Signet, then inserts the two produced pips. Reapplying the recorded
+/// commands in entry order must reproduce that pool and its pip high-water.
+#[test]
+fn real_mana_activation_replays_recorded_insert_and_spend_commands() {
+    let (pre_state, ordinary_state) = activated_signet_states();
+    let commands = semantic_mana_commands(&ordinary_state);
+
+    assert!(
+        commands
+            .iter()
+            .any(|command| matches!(command, ResolvedRulesCommand::ManaInsert(_))),
+        "the ordinary activation must journal exact insert commands"
+    );
+    assert!(
+        commands
+            .iter()
+            .any(|command| matches!(command, ResolvedRulesCommand::ManaSpend(_))),
+        "the ordinary activation must journal its exact solver-selected payment"
+    );
+
+    let mut replay = pre_state;
+    replay.resolved_rules_journal = ordinary_state.resolved_rules_journal.clone();
+    for command in &commands {
+        apply_mana_command(&mut replay, command);
+    }
+
+    for (replayed, ordinary) in replay.players.iter().zip(&ordinary_state.players) {
+        assert_eq!(replayed.mana_pool, ordinary.mana_pool);
+        assert_eq!(
+            replayed
+                .mana_pool
+                .mana
+                .iter()
+                .map(|unit| unit.pip_id)
+                .collect::<Vec<_>>(),
+            ordinary
+                .mana_pool
+                .mana
+                .iter()
+                .map(|unit| unit.pip_id)
+                .collect::<Vec<_>>(),
+            "replay preserves the exact surviving mana identities"
+        );
+    }
+    assert_eq!(replay.next_pip_id, ordinary_state.next_pip_id);
+    assert_eq!(
+        replay.resolved_rules_journal,
+        ordinary_state.resolved_rules_journal
+    );
+}
+
+/// A mana-spend command composes after its producer's insert command and is
+/// not idempotent: applying the same exact removal twice is a typed invariant
+/// failure rather than a fresh payment-solver decision.
+#[test]
+fn exact_mana_spend_rejects_a_second_removal() {
+    let (pre_state, ordinary_state) = activated_signet_states();
+    let commands = semantic_mana_commands(&ordinary_state);
+    let mut replay = pre_state;
+    replay.resolved_rules_journal = ordinary_state.resolved_rules_journal.clone();
+
+    let mut observed_spend = false;
+    for command in &commands {
+        match command {
+            ResolvedRulesCommand::ManaInsert(_) => apply_mana_command(&mut replay, command),
+            ResolvedRulesCommand::ManaSpend(command) => {
+                replay.apply_resolved_mana_spend(command).unwrap();
+                assert!(matches!(
+                    replay.apply_resolved_mana_spend(command),
+                    Err(ResolvedManaReplayInvariantError::MissingExactManaUnit(_))
+                ));
+                observed_spend = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        observed_spend,
+        "the real activation must include a mana spend command"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -90,6 +90,7 @@ mod counter_spell_zone_redirect;
 mod court_of_cunning_multi_target_mill;
 mod cr733_resolved_commands_p0;
 mod cr733_resolved_commands_p1;
+mod cr733_resolved_commands_p2;
 mod cr_annotations;
 mod craft_tithing_blade_transform;
 mod cross_line_instead_override_branch;


### PR DESCRIPTION
- **cr733(p2): apply resolved mana commands**
- **cr733(p2): record mana command run report**
- **cr733(p2): debug-format ManaPipId in ExactManaRemovalError messages**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic journaling for mana entering and leaving players’ mana pools.
  * Preserved exact mana identities and payment details during replay.
  * Added validation to detect invalid, duplicate, missing, or mismatched mana records.
  * Maintained compatibility with existing journal entries and replay behavior.

* **Bug Fixes**
  * Prevented partial mana removal when a payment cannot be applied exactly.
  * Improved handling when a mana pool changes before payment is finalized.

* **Tests**
  * Added coverage for replay consistency, exact mana removal, journal serialization, and invalid command rejection.

* **Documentation**
  * Added a report documenting verification results and replay guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->