### PR TITLE
ship/cr733 p2 scalar status

### DIFF
--- a/.agents/cr733/RUN6-REPORT.md
+++ b/.agents/cr733/RUN6-REPORT.md
@@ -1,0 +1,115 @@
+# CR733 resolved-command journal — Run 6 P2 tranche 2 report
+
+## Starting state
+
+Confirmed before edits: `/Users/matt/dev/forge.rs-cr733`, branch
+`cr733/resolved-commands`, `HEAD`
+`039983da1ec679a49fb6362c8ba3fb0a4f7d47b3`, and no tracked modifications.
+Only untracked `.agents/` material was permitted by the charter; none affected the starting
+worktree check.
+
+## Landed implementation
+
+- `770b993c2e` — `cr733(p2): apply resolved scalar and status commands`
+
+## P2 recipe coverage
+
+### Scalar resources
+
+1. `GameState::apply_resolved_player_edit` is the final semantic mutation primitive for
+   `Life { delta }`, `Energy { delta }`, `Counter { kind, delta }`, and
+   `Speed { old, new }`. It changes only the addressed resource axis; it never restores a
+   captured `Player` snapshot.
+2. `ResolvedPlayerEditCommand` carries the exact `PlayerId`, typed semantic edit, and
+   `RulesExecutionNodeRef` cause. Resource edits reject zero deltas, underflow, and overflow;
+   speed validates its old value before applying its exact transition.
+3. Ordinary life gain/loss/damage routes through the existing replacement pipeline, then the
+   final post-replacement delta reaches the applier. Energy gain/payment, player-counter gain
+   and removal (including rad/ticket), speed, and the debug resource actions also construct and
+   apply typed commands. Life bookkeeping remains part of the semantic delta rather than a
+   caller-side write.
+4. Each ordinary edit records `ResolvedRulesCommand::PlayerEdit` under the active execution node
+   (or a proposal node when no active node exists), using the shared P1/P2 ordinal stream.
+5. The factored paths preserve their existing replacement, event, and preflight structure;
+   only their final direct field writes were replaced with the applier call. This was reviewed
+   by source comparison, not by an executed test suite.
+6. The integration coverage drives a real Lightning Bolt cast through `GameRunner`, captures the
+   final `-3` life command, replays it from the pre-state, and compares life plus the per-turn
+   life-loss bookkeeping. It also exercises every scalar command shape for compositional writes.
+7. The hostile scalar test applies an exact energy removal twice and requires
+   `ResolvedPlayerEditReplayInvariantError::ResourceUnderflow` on the second application.
+
+### Tap/untap/exert/status
+
+1. `game::object_state::apply_resolved_object_edit` is the final transition primitive for the
+   typed `Tapped` and `Exerted` status axes.
+2. `ResolvedObjectStatusCommand` carries `ObjectIncarnationRef`, status axis, required old
+   boolean, new boolean, and cause. Its applier verifies both the exact incarnation and the
+   prior status before mutating.
+3. Tap/untap effects, replacement-choice completion, tap/untap costs, auto-tapping, the untap
+   step/Seedborn, manual land helpers, attacking, exerting, and debug tap actions now construct
+   and apply the status command through the shared authority.
+4. The authority records `ResolvedRulesCommand::ObjectStatus` under the active node after a
+   successful non-no-op transition. It keeps no-op requests out of the semantic stream.
+5. Existing event emission and replacement choice flow remain at their old callers; the applier
+   owns only the final exact status write.
+6. The real Dimir Signet activation replay applies the full journal from the pre-state and now
+   compares both exact mana state and the Signet source's tapped status.
+7. The hostile status test selects that source's recorded command, proves the second apply fails
+   with `StatusPreconditionMismatch`, then bumps the same object ID's incarnation and proves a
+   `StaleObject` failure.
+
+## Applier contracts and wire checks
+
+```rust
+GameState::apply_resolved_player_edit(
+    &mut self,
+    command: &ResolvedPlayerEditCommand,
+) -> Result<(), ResolvedPlayerEditReplayInvariantError>
+
+game::object_state::apply_resolved_object_edit(
+    state: &mut GameState,
+    command: &ResolvedObjectStatusCommand,
+) -> Result<(), ResolvedObjectStatusReplayInvariantError>
+```
+
+`ResolvedRulesJournal` validates both new payload families fail-closed on deserialize: a player
+edit must have a non-empty semantic operation and matching cause/node; an object-status command
+must have a true transition and matching cause/node. Unit coverage round-trips valid payloads and
+rejects zero scalar edits, no-op status commands, and an unrelated cause. The new status command
+uses `ObjectIncarnationRef` directly; it introduces no new sentinel/default identity field, so no
+new legacy-shape sentinel migration was needed.
+
+## Rules evidence
+
+Verified against `/Users/matt/dev/forge.rs/docs/MagicCompRules.txt` before annotations:
+
+- CR 107.14 and CR 122.1 — energy/player counters.
+- CR 119.2, CR 119.3, CR 119.4, and CR 119.5 — damage, gain/loss, paying life, and setting life.
+- CR 701.26a-b — tap and untap.
+- CR 701.43d — exert as an attack cost.
+- CR 702.179b-f — speed.
+
+## Verification and parity risk
+
+- `cargo fmt --all` and `git diff --check` passed before commit.
+- The commit's parser-combinator and router/grant architecture pre-commit gates passed.
+- Per the binding charter, no Cargo build, clippy, or test suite was run. Tilt status from another
+  checkout was not treated as evidence.
+- Confidence is moderate. The inspected ordinary paths retain their existing replacement and
+  event boundaries, and commands are semantic deltas rather than snapshots. The unrun integration
+  suite remains the material risk, particularly in broad cost/replacement/turn status funnels.
+
+## Remaining P2 families
+
+The next matrix boundary is **Counters**. Later P2 families remain zone changes; draw/mill/
+discard/exile/sacrifice/return; library order/reveal/shuffle; token/object creation; deletion/
+cleanup; modifier registries; stack; turn/combat/outcome; triggers/LKI; continuations; ledgers;
+information; and player leave. Do not begin P3 reconstruction.
+
+## Most important next-run fact
+
+P1 node placeholders and every P2 semantic entry share one contiguous
+`ResolvedCommandOrdinal` stream. New family work must append its typed command under the owning
+node and call the final authority applier; it must never replay by redispatching an effect,
+replacement pipeline, solver, RNG, or allocator.

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6368,11 +6368,20 @@ fn pay_additional_cost_with_source(
                 super::quantity::resolve_quantity(state, &amount, player, pending.object_id).max(0),
             )
             .unwrap_or(0);
-            let player_state = &mut state.players[player.0 as usize];
-            if player_state.energy < amount {
+            let energy = state.players[player.0 as usize].energy;
+            if energy < amount {
                 return Err(EngineError::ActionNotAllowed("Not enough energy".into()));
             }
-            player_state.energy -= amount;
+            if amount > 0 {
+                state
+                    .resolve_and_apply_player_edit(
+                        player,
+                        crate::types::resolved_commands::ResolvedPlayerEdit::Energy {
+                            delta: -(amount as i32),
+                        },
+                    )
+                    .expect("preflighted cast energy payment must apply");
+            }
             events.push(GameEvent::EnergyChanged {
                 player,
                 delta: -(amount as i32),
@@ -10120,14 +10129,18 @@ fn auto_tap_mana_sources_inner(
             // Basic-land-subtype fallback — no explicit ability, just tap + produce.
             let node = state.begin_activated_mana_journal_node(option.object_id);
             state.with_rules_execution_node(node, |state| {
-                if let Some(obj) = state.objects.get_mut(&option.object_id) {
-                    if !obj.tapped {
-                        obj.tapped = true;
-                        events.push(GameEvent::PermanentTapped {
-                            object_id: option.object_id,
-                            caused_by: None,
-                        });
-                    }
+                if crate::game::object_state::resolve_and_apply_object_edit(
+                    state,
+                    option.object_id,
+                    crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+                    true,
+                )
+                .expect("auto-tap source must remain a live exact object")
+                {
+                    events.push(GameEvent::PermanentTapped {
+                        object_id: option.object_id,
+                        caused_by: None,
+                    });
                 }
                 mana_payment::produce_mana(
                     state,

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -442,9 +442,20 @@ pub fn place_attacking_alongside(
     attack_target: AttackTarget,
     _events: &mut Vec<GameEvent>,
 ) {
-    if let Some(obj) = state.objects.get_mut(&object_id) {
-        obj.tapped = true;
-        obj.entered_battlefield_turn = Some(state.turn_number);
+    if state.objects.contains_key(&object_id) {
+        let turn_number = state.turn_number;
+        crate::game::object_state::resolve_and_apply_object_edit(
+            state,
+            object_id,
+            crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+            true,
+        )
+        .expect("an existing attacker must satisfy the resolved tap precondition");
+        let obj = state
+            .objects
+            .get_mut(&object_id)
+            .expect("the resolved attacker must remain present");
+        obj.entered_battlefield_turn = Some(turn_number);
         // CR 302.6: Ninjutsu/Sneak places a new permanent already attacking.
         // The attack declaration itself bypasses the normal summoning-
         // sickness check for attacking, but the flag remains true so {T}

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -741,8 +741,14 @@ fn pay_ability_cost_inner(
                     "Cannot pay untap cost: permanent is already untapped".to_string(),
                 ));
             }
-            let obj = state.objects.get_mut(&source_id).unwrap();
-            obj.tapped = false;
+            let untapped = crate::game::object_state::resolve_and_apply_object_edit(
+                state,
+                source_id,
+                crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+                false,
+            )
+            .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
+            debug_assert!(untapped, "preflighted untap cost must transition status");
             events.push(GameEvent::PermanentUntapped {
                 object_id: source_id,
             });
@@ -1298,11 +1304,20 @@ fn pay_ability_cost_inner(
                 resolve_cost_quantity(state, amount, player, source_id, scope).max(0),
             )
             .unwrap_or(0);
-            let player_state = &mut state.players[player.0 as usize];
-            if player_state.energy < amount {
+            let energy = state.players[player.0 as usize].energy;
+            if energy < amount {
                 return Ok(payment_failed("Not enough energy"));
             }
-            player_state.energy -= amount;
+            if amount > 0 {
+                state
+                    .resolve_and_apply_player_edit(
+                        player,
+                        crate::types::resolved_commands::ResolvedPlayerEdit::Energy {
+                            delta: -(amount as i32),
+                        },
+                    )
+                    .expect("preflighted energy payment must apply");
+            }
             events.push(GameEvent::EnergyChanged {
                 player,
                 delta: -(amount as i32),

--- a/crates/engine/src/game/effects/energy.rs
+++ b/crates/engine/src/game/effects/energy.rs
@@ -7,6 +7,7 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, PendingCounterAddition, PendingEffectResolved};
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
+use crate::types::resolved_commands::ResolvedPlayerEdit;
 
 pub(crate) fn add_energy_with_replacement(
     state: &mut GameState,
@@ -55,8 +56,14 @@ pub(crate) fn apply_energy_addition(
         return;
     }
 
-    let player = &mut state.players[player_id.0 as usize];
-    player.energy += amount;
+    state
+        .resolve_and_apply_player_edit(
+            player_id,
+            ResolvedPlayerEdit::Energy {
+                delta: amount as i32,
+            },
+        )
+        .expect("post-replacement energy gain must target a live player");
 
     // CR 122.1 + CR 107.14: Energy counters are counters placed on a player.
     events.push(GameEvent::EnergyChanged {

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -12,6 +12,7 @@ use crate::types::game_state::{
 };
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::ProposedEvent;
+use crate::types::resolved_commands::ResolvedPlayerEdit;
 
 /// Signals that a replacement effect requires player choice before the event can proceed.
 /// Callers receiving this must yield control (the engine will re-enter after the choice).
@@ -67,31 +68,7 @@ pub fn resolve_gain(
     // CR 614.1a: Route life gain through replacement pipeline.
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(event) => {
-            if let ProposedEvent::LifeGain {
-                player_id,
-                amount: gain_amount,
-                ..
-            } = event
-            {
-                let player = state
-                    .players
-                    .iter_mut()
-                    .find(|p| p.id == player_id)
-                    .ok_or(EffectError::PlayerNotFound)?;
-                player.life += gain_amount as i32;
-                // CR 119.9: Track life gained this turn for triggered ability matching.
-                player.life_gained_this_turn += gain_amount;
-                // CR 611.3a + CR 119: escalate layers only if a live continuous
-                // static reads the life family (life total / life-above-starting
-                // / per-turn life counters); otherwise this life change cannot
-                // flip any derived board.
-                crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
-
-                events.push(GameEvent::LifeChanged {
-                    player_id,
-                    amount: gain_amount as i32,
-                });
-            }
+            apply_life_gain_after_replacement(state, event, events);
         }
         ReplacementResult::Prevented => {
             // CR 614.1a + CR 614.6 — Issue #317: Cross-event-type
@@ -211,10 +188,14 @@ pub fn apply_life_gain_after_replacement(
         );
         return 0;
     };
-    if let Some(player) = state.players.iter_mut().find(|p| p.id == pid) {
-        player.life += gain_amount as i32;
-        player.life_gained_this_turn += gain_amount;
-    }
+    state
+        .resolve_and_apply_player_edit(
+            pid,
+            ResolvedPlayerEdit::Life {
+                delta: gain_amount as i32,
+            },
+        )
+        .expect("post-replacement life gain must target a live player");
     // CR 611.3a + CR 119: gate escalation on a live life-reading static.
     crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
     events.push(GameEvent::LifeChanged {
@@ -288,10 +269,14 @@ pub fn apply_life_loss_after_replacement(
         );
         return 0;
     };
-    if let Some(player) = state.players.iter_mut().find(|p| p.id == pid) {
-        player.life -= loss_amount as i32;
-        player.life_lost_this_turn += loss_amount;
-    }
+    state
+        .resolve_and_apply_player_edit(
+            pid,
+            ResolvedPlayerEdit::Life {
+                delta: -(loss_amount as i32),
+            },
+        )
+        .expect("post-replacement life loss must target a live player");
     // CR 611.3a + CR 119 + CR 120.3a: gate escalation on a live life-reading
     // static. Also the sink for non-infect player damage (deal_damage.rs).
     crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
@@ -481,27 +466,7 @@ pub fn resolve_lose(
 
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(event) => {
-            if let ProposedEvent::LifeLoss {
-                player_id,
-                amount: loss_amount,
-                ..
-            } = event
-            {
-                let player = state
-                    .players
-                    .iter_mut()
-                    .find(|p| p.id == player_id)
-                    .ok_or(EffectError::PlayerNotFound)?;
-                player.life -= loss_amount as i32;
-                player.life_lost_this_turn += loss_amount;
-                // CR 611.3a + CR 119: gate escalation on a live life-reading static.
-                crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
-
-                events.push(GameEvent::LifeChanged {
-                    player_id,
-                    amount: -(loss_amount as i32),
-                });
-            }
+            apply_life_loss_after_replacement(state, event, events);
         }
         ReplacementResult::Prevented => {
             // CR 614.1a + CR 614.6 — Issue #317: Drain substitute effect

--- a/crates/engine/src/game/effects/life.rs
+++ b/crates/engine/src/game/effects/life.rs
@@ -188,14 +188,18 @@ pub fn apply_life_gain_after_replacement(
         );
         return 0;
     };
-    state
-        .resolve_and_apply_player_edit(
-            pid,
-            ResolvedPlayerEdit::Life {
-                delta: gain_amount as i32,
-            },
-        )
-        .expect("post-replacement life gain must target a live player");
+    // CR 119.8: gaining 0 life doesn't count as gaining life — no state
+    // mutation and no journal command; the event below still fires as before.
+    if gain_amount != 0 {
+        state
+            .resolve_and_apply_player_edit(
+                pid,
+                ResolvedPlayerEdit::Life {
+                    delta: gain_amount as i32,
+                },
+            )
+            .expect("post-replacement life gain must target a live player");
+    }
     // CR 611.3a + CR 119: gate escalation on a live life-reading static.
     crate::game::layers::mark_layers_full_if_life_reading_static_live(state);
     events.push(GameEvent::LifeChanged {
@@ -269,14 +273,18 @@ pub fn apply_life_loss_after_replacement(
         );
         return 0;
     };
-    state
-        .resolve_and_apply_player_edit(
-            pid,
-            ResolvedPlayerEdit::Life {
-                delta: -(loss_amount as i32),
-            },
-        )
-        .expect("post-replacement life loss must target a live player");
+    // CR 119.8: losing 0 life doesn't count as losing life — no state
+    // mutation and no journal command; the event below still fires as before.
+    if loss_amount != 0 {
+        state
+            .resolve_and_apply_player_edit(
+                pid,
+                ResolvedPlayerEdit::Life {
+                    delta: -(loss_amount as i32),
+                },
+            )
+            .expect("post-replacement life loss must target a live player");
+    }
     // CR 611.3a + CR 119 + CR 120.3a: gate escalation on a live life-reading
     // static. Also the sink for non-infect player damage (deal_damage.rs).
     crate::game::layers::mark_layers_full_if_life_reading_static_live(state);

--- a/crates/engine/src/game/effects/player_counter.rs
+++ b/crates/engine/src/game/effects/player_counter.rs
@@ -6,6 +6,7 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, PendingCounterAddition, PendingEffectResolved};
 use crate::types::player::{PlayerCounterKind, PlayerId};
 use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
+use crate::types::resolved_commands::ResolvedPlayerEdit;
 
 pub fn add_player_counter_with_replacement(
     state: &mut GameState,
@@ -67,8 +68,15 @@ pub fn apply_player_counter_addition(
     if amount == 0 {
         return;
     }
-    let player = &mut state.players[player_id.0 as usize];
-    player.add_player_counters(&counter_kind, amount);
+    state
+        .resolve_and_apply_player_edit(
+            player_id,
+            ResolvedPlayerEdit::Counter {
+                kind: counter_kind,
+                delta: amount as i32,
+            },
+        )
+        .expect("post-replacement player counter gain must target a live player");
 
     // CR 122.1: Emit event for counter change.
     events.push(GameEvent::PlayerCounterChanged {
@@ -241,11 +249,23 @@ fn clear_all_player_counters(
     player_id: PlayerId,
     events: &mut Vec<GameEvent>,
 ) {
-    let player = &mut state.players[player_id.0 as usize];
-
-    if player.poison_counters > 0 {
-        let delta = -(player.poison_counters as i32);
-        player.poison_counters = 0;
+    let poison = state
+        .players
+        .iter()
+        .find(|player| player.id == player_id)
+        .expect("counter target must be a live player")
+        .poison_counters;
+    if poison > 0 {
+        let delta = -(poison as i32);
+        state
+            .resolve_and_apply_player_edit(
+                player_id,
+                ResolvedPlayerEdit::Counter {
+                    kind: PlayerCounterKind::Poison,
+                    delta,
+                },
+            )
+            .expect("live player counter removal must apply");
         events.push(GameEvent::PlayerCounterChanged {
             player: player_id,
             counter_kind: PlayerCounterKind::Poison,
@@ -255,12 +275,26 @@ fn clear_all_player_counters(
 
     // Drain the generic map — collect kinds first to release the borrow before
     // mutating/emitting events.
-    let drained: Vec<(PlayerCounterKind, u32)> = player
+    let drained: Vec<(PlayerCounterKind, u32)> = state
+        .players
+        .iter()
+        .find(|player| player.id == player_id)
+        .expect("counter target must be a live player")
         .player_counters
-        .drain()
+        .iter()
+        .map(|(kind, count)| (*kind, *count))
         .filter(|(_, count)| *count > 0)
         .collect();
     for (counter_kind, count) in drained {
+        state
+            .resolve_and_apply_player_edit(
+                player_id,
+                ResolvedPlayerEdit::Counter {
+                    kind: counter_kind,
+                    delta: -(count as i32),
+                },
+            )
+            .expect("live player counter removal must apply");
         events.push(GameEvent::PlayerCounterChanged {
             player: player_id,
             counter_kind,

--- a/crates/engine/src/game/effects/rad_counters.rs
+++ b/crates/engine/src/game/effects/rad_counters.rs
@@ -7,6 +7,7 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 use crate::types::player::PlayerCounterKind;
 use crate::types::proposed_event::ProposedEvent;
+use crate::types::resolved_commands::ResolvedPlayerEdit;
 use crate::types::zones::Zone;
 
 /// CR 728.1: Resolve the inherent rad counter triggered ability.
@@ -133,20 +134,29 @@ pub fn resolve(
         // CR 728.1: Remove one rad counter per nonland card milled.
         // This happens regardless of whether life loss was prevented or
         // deferred to a replacement choice.
-        let player = state
+        let current_rad = state
             .players
-            .iter_mut()
+            .iter()
             .find(|p| p.id == player_id)
-            .ok_or(EffectError::PlayerNotFound)?;
-        let current_rad = player.player_counter(&PlayerCounterKind::Rad);
+            .ok_or(EffectError::PlayerNotFound)?
+            .player_counter(&PlayerCounterKind::Rad);
         let to_remove = nonland_count.min(current_rad);
-        player.remove_player_counters(&PlayerCounterKind::Rad, to_remove);
-
-        events.push(GameEvent::PlayerCounterChanged {
-            player: player_id,
-            counter_kind: PlayerCounterKind::Rad,
-            delta: -(to_remove as i32),
-        });
+        if to_remove > 0 {
+            state
+                .resolve_and_apply_player_edit(
+                    player_id,
+                    ResolvedPlayerEdit::Counter {
+                        kind: PlayerCounterKind::Rad,
+                        delta: -(to_remove as i32),
+                    },
+                )
+                .expect("the captured rad-counter removal must satisfy its precondition");
+            events.push(GameEvent::PlayerCounterChanged {
+                player: player_id,
+                counter_kind: PlayerCounterKind::Rad,
+                delta: -(to_remove as i32),
+            });
+        }
     }
 
     events.push(GameEvent::EffectResolved {

--- a/crates/engine/src/game/effects/tap_untap.rs
+++ b/crates/engine/src/game/effects/tap_untap.rs
@@ -10,6 +10,7 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::{ObjectId, TrackedSetId};
 use crate::types::proposed_event::ProposedEvent;
+use crate::types::resolved_commands::ResolvedObjectStatus;
 use crate::types::zones::Zone;
 
 /// CR 603.7e + CR 608.2c: Resolve the objects a `Tap`/`Untap` effect acts on.
@@ -167,15 +168,19 @@ pub(crate) fn process_one_tap(
     match replacement::replace_event(state, proposed, events) {
         ReplacementResult::Execute(event) => {
             if let ProposedEvent::Tap { object_id, .. } = event {
-                let obj = state
-                    .objects
-                    .get_mut(&object_id)
-                    .ok_or(EffectError::ObjectNotFound(object_id))?;
-                obj.tapped = true;
-                events.push(GameEvent::PermanentTapped {
+                if crate::game::object_state::resolve_and_apply_object_edit(
+                    state,
                     object_id,
-                    caused_by: Some(source_id),
-                });
+                    ResolvedObjectStatus::Tapped,
+                    true,
+                )
+                .map_err(|_| EffectError::ObjectNotFound(object_id))?
+                {
+                    events.push(GameEvent::PermanentTapped {
+                        object_id,
+                        caused_by: Some(source_id),
+                    });
+                }
             }
             Ok(TapUntapOutcome::Complete)
         }
@@ -229,12 +234,16 @@ pub(crate) fn process_one_untap(
                         });
                     }
                 } else {
-                    let obj = state
-                        .objects
-                        .get_mut(&object_id)
-                        .ok_or(EffectError::ObjectNotFound(object_id))?;
-                    obj.tapped = false;
-                    events.push(GameEvent::PermanentUntapped { object_id });
+                    if crate::game::object_state::resolve_and_apply_object_edit(
+                        state,
+                        object_id,
+                        ResolvedObjectStatus::Tapped,
+                        false,
+                    )
+                    .map_err(|_| EffectError::ObjectNotFound(object_id))?
+                    {
+                        events.push(GameEvent::PermanentUntapped { object_id });
+                    }
                 }
             }
             Ok(TapUntapOutcome::Complete)

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -9253,8 +9253,14 @@ pub(super) fn handle_tap_land_for_mana(
         }
     } else {
         // Legacy fallback for subtype-only lands.
-        let obj = state.objects.get_mut(&object_id).unwrap();
-        obj.tapped = true;
+        let tapped = crate::game::object_state::resolve_and_apply_object_edit(
+            state,
+            object_id,
+            crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+            true,
+        )
+        .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
+        debug_assert!(tapped, "preflighted land tap must transition status");
         events.push(GameEvent::PermanentTapped {
             object_id,
             caused_by: None,
@@ -9354,11 +9360,14 @@ pub(super) fn handle_untap_land_for_mana(
     }
 
     // Untap the land
-    let obj = state
-        .objects
-        .get_mut(&object_id)
-        .ok_or_else(|| EngineError::InvalidAction("Object not found".to_string()))?;
-    obj.tapped = false;
+    let untapped = crate::game::object_state::resolve_and_apply_object_edit(
+        state,
+        object_id,
+        crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+        false,
+    )
+    .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
+    debug_assert!(untapped, "a tracked manually tapped land must be tapped");
     events.push(GameEvent::PermanentUntapped { object_id });
 
     // Remove from tracking

--- a/crates/engine/src/game/engine_combat.rs
+++ b/crates/engine/src/game/engine_combat.rs
@@ -218,7 +218,16 @@ pub(super) fn apply_attack_exert(
         return;
     }
     let controller = obj.controller;
-    state.exerted_this_turn.insert(attacker);
+    let exerted = crate::game::object_state::resolve_and_apply_object_edit(
+        state,
+        attacker,
+        crate::types::resolved_commands::ResolvedObjectStatus::Exerted,
+        true,
+    )
+    .expect("declared attacker must remain a live exact object");
+    if !exerted {
+        return;
+    }
     state.add_transient_continuous_effect(
         attacker,
         controller,

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -10,6 +10,7 @@ use crate::types::game_state::{ActionResult, GameState, WaitingFor};
 use crate::types::identifiers::ObjectId;
 use crate::types::player::{PlayerCounterKind, PlayerId};
 use crate::types::proposed_event::ProposedEvent;
+use crate::types::resolved_commands::ResolvedPlayerEdit;
 use crate::types::zones::Zone;
 
 use super::effects::attach::{attach_to, attach_to_player};
@@ -243,7 +244,14 @@ pub fn apply_debug_action(
         }
 
         DebugAction::SetTapped { object_id, tapped } => {
-            validate_object_mut(state, object_id)?.tapped = tapped;
+            // CR 701.26a-b: Debug actions use the same checked status authority.
+            crate::game::object_state::resolve_and_apply_object_edit(
+                state,
+                object_id,
+                crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+                tapped,
+            )
+            .map_err(|err| EngineError::InvalidAction(format!("{err:?}")))?;
         }
 
         DebugAction::SetPrepared {
@@ -366,9 +374,21 @@ pub fn apply_debug_action(
         }
 
         DebugAction::SetLife { player_id, life } => {
+            // CR 119.5: Setting life gains or loses the required semantic delta.
             validate_player(state, player_id)?;
-            if let Some(player) = state.players.iter_mut().find(|p| p.id == player_id) {
-                player.life = life;
+            let current_life = state
+                .players
+                .iter()
+                .find(|player| player.id == player_id)
+                .expect("the validated debug player must remain present")
+                .life;
+            if current_life != life {
+                let delta = life.checked_sub(current_life).ok_or_else(|| {
+                    EngineError::InvalidAction("Debug: life delta is not representable".to_string())
+                })?;
+                state
+                    .resolve_and_apply_player_edit(player_id, ResolvedPlayerEdit::Life { delta })
+                    .map_err(|err| EngineError::InvalidAction(format!("{err:?}")))?;
             }
         }
 
@@ -593,6 +613,8 @@ pub fn apply_debug_action(
     })
 }
 
+/// CR 122.1: Apply a final debug-selected player-counter delta through the
+/// same scalar authority as ordinary rules actions.
 fn apply_player_counter_delta(
     state: &mut GameState,
     player_id: PlayerId,
@@ -600,18 +622,33 @@ fn apply_player_counter_delta(
     delta: i32,
     events: &mut Vec<GameEvent>,
 ) {
-    let Some(player) = state.players.iter_mut().find(|p| p.id == player_id) else {
+    let Some(before) = state
+        .players
+        .iter()
+        .find(|player| player.id == player_id)
+        .map(|player| player.player_counter(&counter_kind))
+    else {
         return;
     };
-    let before = player.player_counter(&counter_kind);
-    if delta > 0 {
-        player.add_player_counters(&counter_kind, delta as u32);
-    } else if delta < 0 {
-        player.remove_player_counters(&counter_kind, delta.unsigned_abs());
-    }
-    let after = player.player_counter(&counter_kind);
-    let actual_delta = after as i32 - before as i32;
+    let after = if delta.is_positive() {
+        before
+            .checked_add(delta as u32)
+            .expect("debug counter addition must not overflow")
+    } else {
+        before.saturating_sub(delta.unsigned_abs())
+    };
+    let actual_delta = i32::try_from(i64::from(after) - i64::from(before))
+        .expect("a requested i32 counter delta must remain representable");
     if actual_delta != 0 {
+        state
+            .resolve_and_apply_player_edit(
+                player_id,
+                ResolvedPlayerEdit::Counter {
+                    kind: counter_kind,
+                    delta: actual_delta,
+                },
+            )
+            .expect("the computed debug counter delta must satisfy its resolved precondition");
         events.push(GameEvent::PlayerCounterChanged {
             player: player_id,
             counter_kind,
@@ -620,24 +657,40 @@ fn apply_player_counter_delta(
     }
 }
 
+/// CR 107.14 + CR 122.1: Apply a final debug-selected energy-counter delta
+/// through the same scalar authority as ordinary rules actions.
 fn apply_energy_delta(
     state: &mut GameState,
     player_id: PlayerId,
     delta: i32,
     events: &mut Vec<GameEvent>,
 ) {
-    let Some(player) = state.players.iter_mut().find(|p| p.id == player_id) else {
+    let Some(before) = state
+        .players
+        .iter()
+        .find(|player| player.id == player_id)
+        .map(|player| player.energy)
+    else {
         return;
     };
-    let before = player.energy;
-    if delta > 0 {
-        player.energy += delta as u32;
-    } else if delta < 0 {
-        player.energy = player.energy.saturating_sub(delta.unsigned_abs());
-    }
-    let after = player.energy;
-    let actual_delta = after as i32 - before as i32;
+    let after = if delta.is_positive() {
+        before
+            .checked_add(delta as u32)
+            .expect("debug energy addition must not overflow")
+    } else {
+        before.saturating_sub(delta.unsigned_abs())
+    };
+    let actual_delta = i32::try_from(i64::from(after) - i64::from(before))
+        .expect("a requested i32 energy delta must remain representable");
     if actual_delta != 0 {
+        state
+            .resolve_and_apply_player_edit(
+                player_id,
+                ResolvedPlayerEdit::Energy {
+                    delta: actual_delta,
+                },
+            )
+            .expect("the computed debug energy delta must satisfy its resolved precondition");
         events.push(GameEvent::EnergyChanged {
             player: player_id,
             delta: actual_delta,

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -423,8 +423,14 @@ pub(super) fn handle_replacement_choice(
                 }
                 // CR 701.26a: Tap accepted after replacement choice.
                 ProposedEvent::Tap { object_id, .. } => {
-                    if let Some(obj) = state.objects.get_mut(&object_id) {
-                        obj.tapped = true;
+                    if crate::game::object_state::resolve_and_apply_object_edit(
+                        state,
+                        object_id,
+                        crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+                        true,
+                    )
+                    .is_ok()
+                    {
                         events.push(GameEvent::PermanentTapped {
                             object_id,
                             caused_by: None,
@@ -433,8 +439,14 @@ pub(super) fn handle_replacement_choice(
                 }
                 // CR 701.26b: Untap accepted after replacement choice.
                 ProposedEvent::Untap { object_id, .. } => {
-                    if let Some(obj) = state.objects.get_mut(&object_id) {
-                        obj.tapped = false;
+                    if crate::game::object_state::resolve_and_apply_object_edit(
+                        state,
+                        object_id,
+                        crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+                        false,
+                    )
+                    .is_ok()
+                    {
                         events.push(GameEvent::PermanentUntapped { object_id });
                     }
                 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2398,14 +2398,28 @@ pub(super) fn handle_resolution_choice(
                 }
                 PayableResource::Energy => {
                     // CR 107.14: Remove N energy counters from the player.
-                    if let Some(p) = state.players.iter_mut().find(|p| p.id == player) {
-                        if p.energy < amount {
+                    if let Some(energy) = state
+                        .players
+                        .iter()
+                        .find(|candidate| candidate.id == player)
+                        .map(|candidate| candidate.energy)
+                    {
+                        if energy < amount {
                             return Err(EngineError::InvalidAction(format!(
                                 "Player {:?} has {} energy, cannot pay {}",
-                                player, p.energy, amount
+                                player, energy, amount
                             )));
                         }
-                        p.energy -= amount;
+                        if amount > 0 {
+                            state
+                                .resolve_and_apply_player_edit(
+                                    player,
+                                    crate::types::resolved_commands::ResolvedPlayerEdit::Energy {
+                                        delta: -(amount as i32),
+                                    },
+                                )
+                                .expect("preflighted resolution energy payment must apply");
+                        }
                         events.push(GameEvent::EnergyChanged {
                             player,
                             delta: -(amount as i32),

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -105,6 +105,7 @@ mod conspiracy_tests;
 mod merge_tests;
 pub mod morph;
 pub mod mulligan;
+pub mod object_state;
 pub(crate) mod off_zone_characteristics;
 pub mod pairing;
 pub mod perf_counters;

--- a/crates/engine/src/game/object_state.rs
+++ b/crates/engine/src/game/object_state.rs
@@ -1,0 +1,99 @@
+//! Final authority for exact object-status transitions.
+
+use crate::game::game_object::GameObject;
+use crate::types::game_state::GameState;
+use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
+use crate::types::resolved_commands::{
+    ResolvedObjectStatus, ResolvedObjectStatusCommand, ResolvedObjectStatusReplayInvariantError,
+};
+
+/// Constructs, applies, and journals one exact object-status transition.
+///
+/// Callers resolve replacements and all ordinary legality before this boundary.
+/// A no-op status request is intentionally not journaled.
+pub fn resolve_and_apply_object_edit(
+    state: &mut GameState,
+    object_id: ObjectId,
+    status: ResolvedObjectStatus,
+    new: bool,
+) -> Result<bool, ResolvedObjectStatusReplayInvariantError> {
+    let object = state.objects.get(&object_id).ok_or(
+        ResolvedObjectStatusReplayInvariantError::UnknownObject(object_id),
+    )?;
+    let reference = ObjectIncarnationRef::from_object(object);
+    let expected_old = status_value(state, object, status);
+    if expected_old == new {
+        return Ok(false);
+    }
+
+    let command = ResolvedObjectStatusCommand {
+        object: reference,
+        status,
+        expected_old,
+        new,
+        cause: state.current_or_begin_rules_execution_node(),
+    };
+    apply_resolved_object_edit(state, &command)?;
+    state
+        .resolved_rules_journal
+        .record_object_status(command)
+        .expect("resolved object status must have a live journal cause");
+    Ok(true)
+}
+
+/// Applies one exact object-status transition with no replacement, lookup, or
+/// inference beyond validating the captured object incarnation and old status.
+pub fn apply_resolved_object_edit(
+    state: &mut GameState,
+    command: &ResolvedObjectStatusCommand,
+) -> Result<(), ResolvedObjectStatusReplayInvariantError> {
+    let object = state.objects.get(&command.object.object_id).ok_or(
+        ResolvedObjectStatusReplayInvariantError::MissingObject(command.object),
+    )?;
+    let found_reference = ObjectIncarnationRef::from_object(object);
+    if found_reference != command.object {
+        return Err(ResolvedObjectStatusReplayInvariantError::StaleObject {
+            expected: command.object,
+            found: found_reference,
+        });
+    }
+    let found_status = status_value(state, object, command.status);
+    if found_status != command.expected_old {
+        return Err(
+            ResolvedObjectStatusReplayInvariantError::StatusPreconditionMismatch {
+                status: command.status,
+                expected: command.expected_old,
+                found: found_status,
+            },
+        );
+    }
+
+    match command.status {
+        // CR 701.26a-b: A status transition is valid only from the captured
+        // opposite tapped state; replay never silently re-taps or re-untaps.
+        ResolvedObjectStatus::Tapped => {
+            state
+                .objects
+                .get_mut(&command.object.object_id)
+                .expect("the validated object must remain present")
+                .tapped = command.new;
+        }
+        // CR 701.43d: The per-turn exert record belongs to this exact current
+        // object incarnation, never a same-id object that later re-entered.
+        ResolvedObjectStatus::Exerted => {
+            if command.new {
+                state.exerted_this_turn.insert(command.object.object_id);
+            } else {
+                state.exerted_this_turn.remove(&command.object.object_id);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn status_value(state: &GameState, object: &GameObject, status: ResolvedObjectStatus) -> bool {
+    match status {
+        ResolvedObjectStatus::Tapped => object.tapped,
+        ResolvedObjectStatus::Exerted => state.exerted_this_turn.contains(&object.id),
+    }
+}

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -833,13 +833,19 @@ pub(crate) fn tap_permanent_for_cost(
             "This permanent can't become tapped".to_string(),
         ));
     }
-    if let Some(obj) = state.objects.get_mut(&id) {
-        obj.tapped = true;
+    if crate::game::object_state::resolve_and_apply_object_edit(
+        state,
+        id,
+        crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+        true,
+    )
+    .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+    {
+        events.push(GameEvent::PermanentTapped {
+            object_id: id,
+            caused_by: None,
+        });
     }
-    events.push(GameEvent::PermanentTapped {
-        object_id: id,
-        caused_by: None,
-    });
     Ok(())
 }
 

--- a/crates/engine/src/game/speed.rs
+++ b/crates/engine/src/game/speed.rs
@@ -3,6 +3,7 @@ use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::player::PlayerId;
+use crate::types::resolved_commands::ResolvedPlayerEdit;
 use crate::types::statics::StaticMode;
 
 /// CR 702.179f: Effects that refer to speed treat "no speed" as 0.
@@ -32,14 +33,26 @@ pub fn set_speed(
     new_speed: Option<u8>,
     events: &mut Vec<GameEvent>,
 ) {
-    let Some(player_state) = state.players.iter_mut().find(|p| p.id == player) else {
+    let Some(old_speed) = state
+        .players
+        .iter()
+        .find(|candidate| candidate.id == player)
+        .map(|candidate| candidate.speed)
+    else {
         return;
     };
-    let old_speed = player_state.speed;
     if old_speed == new_speed {
         return;
     }
-    player_state.speed = new_speed;
+    state
+        .resolve_and_apply_player_edit(
+            player,
+            ResolvedPlayerEdit::Speed {
+                old: old_speed,
+                new: new_speed,
+            },
+        )
+        .expect("live player speed transition must apply");
     events.push(GameEvent::SpeedChanged {
         player,
         old_speed,

--- a/crates/engine/src/game/stickers.rs
+++ b/crates/engine/src/game/stickers.rs
@@ -17,6 +17,7 @@ use crate::types::keywords::Keyword;
 use crate::types::layers::{ActiveContinuousEffect, Layer};
 use crate::types::mana::ManaCost;
 use crate::types::player::{PlayerCounterKind, PlayerId};
+use crate::types::resolved_commands::ResolvedPlayerEdit;
 use crate::types::stickers::{AppliedSticker, StickerKind, StickerLocator};
 use crate::types::zones::Zone;
 
@@ -373,13 +374,24 @@ pub fn apply_selected_sticker(
     };
 
     if pay_ticket {
-        let Some(player_entry) = state.players.iter_mut().find(|p| p.id == player) else {
+        // CR 122.1: Ticket payment removes counters through the scalar authority.
+        let Some(player_entry) = state.players.iter().find(|p| p.id == player) else {
             return;
         };
         if player_entry.player_counter(&PlayerCounterKind::Ticket) < ticket_cost {
             return;
         }
-        player_entry.remove_player_counters(&PlayerCounterKind::Ticket, ticket_cost);
+        if ticket_cost > 0 {
+            state
+                .resolve_and_apply_player_edit(
+                    player,
+                    ResolvedPlayerEdit::Counter {
+                        kind: PlayerCounterKind::Ticket,
+                        delta: -(ticket_cost as i32),
+                    },
+                )
+                .expect("the checked ticket cost must satisfy its resolved precondition");
+        }
     }
 
     let timestamp = state.next_timestamp();

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -1369,8 +1369,14 @@ pub fn execute_untap_with_choices(
                                 count: 1,
                             });
                         }
-                    } else if let Some(obj) = state.objects.get_mut(&object_id) {
-                        obj.tapped = false;
+                    } else if crate::game::object_state::resolve_and_apply_object_edit(
+                        state,
+                        object_id,
+                        crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+                        false,
+                    )
+                    .expect("untap-step object must remain a live exact object")
+                    {
                         events.push(GameEvent::PermanentUntapped { object_id });
                     }
                 }
@@ -1693,8 +1699,14 @@ fn execute_seedborn_statics(state: &mut GameState, events: &mut Vec<GameEvent>, 
                                     count: 1,
                                 });
                             }
-                        } else if let Some(obj) = state.objects.get_mut(&object_id) {
-                            obj.tapped = false;
+                        } else if crate::game::object_state::resolve_and_apply_object_edit(
+                            state,
+                            object_id,
+                            crate::types::resolved_commands::ResolvedObjectStatus::Tapped,
+                            false,
+                        )
+                        .expect("Seedborn untap object must remain a live exact object")
+                        {
                             events.push(GameEvent::PermanentUntapped { object_id });
                         }
                     }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -50,7 +50,8 @@ use super::resolution::{
 };
 use super::resolved_commands::{
     ManaPaymentRecipient, ResolvedManaInsertCommand, ResolvedManaReplayInvariantError,
-    ResolvedManaSpendCommand, ResolvedRulesJournal, RulesExecutionNodeRef,
+    ResolvedManaSpendCommand, ResolvedPlayerEdit, ResolvedPlayerEditCommand,
+    ResolvedPlayerEditReplayInvariantError, ResolvedRulesJournal, RulesExecutionNodeRef,
 };
 use super::zones::EtbTapState;
 use super::zones::{ExileCostSourceZone, Zone};
@@ -72,6 +73,25 @@ fn default_game_number() -> u8 {
 
 fn is_zero_u32(value: &u32) -> bool {
     *value == 0
+}
+
+fn nonzero_delta_magnitude(delta: i32) -> Result<u32, ResolvedPlayerEditReplayInvariantError> {
+    (delta != 0)
+        .then_some(delta.unsigned_abs())
+        .ok_or(ResolvedPlayerEditReplayInvariantError::ZeroDelta)
+}
+
+fn apply_u32_delta(value: u32, delta: i32) -> Result<u32, ResolvedPlayerEditReplayInvariantError> {
+    let amount = nonzero_delta_magnitude(delta)?;
+    if delta.is_positive() {
+        value
+            .checked_add(amount)
+            .ok_or(ResolvedPlayerEditReplayInvariantError::ResourceOverflow)
+    } else {
+        value
+            .checked_sub(amount)
+            .ok_or(ResolvedPlayerEditReplayInvariantError::ResourceUnderflow)
+    }
 }
 
 pub(crate) fn is_zero_usize(value: &usize) -> bool {
@@ -15155,11 +15175,7 @@ impl GameState {
         if !self.players.iter().any(|candidate| candidate.id == player) {
             return None;
         }
-        let producer = self.active_rules_execution_node.unwrap_or_else(|| {
-            self.resolved_rules_journal
-                .begin_proposal()
-                .expect("resolved-rules journal proposal ordinal overflow")
-        });
+        let producer = self.current_or_begin_rules_execution_node();
         let command = ResolvedManaInsertCommand {
             player,
             unit: unit.clone(),
@@ -15171,6 +15187,97 @@ impl GameState {
             .record_mana_insert(command)
             .expect("stamped mana must have one unique journal producer");
         Some(unit)
+    }
+
+    /// Applies and journals one already-resolved player resource edit.
+    ///
+    /// Replacements and dynamic quantities must be settled before this boundary;
+    /// the command is the final composable semantic edit against the live prefix.
+    pub fn resolve_and_apply_player_edit(
+        &mut self,
+        player: PlayerId,
+        edit: ResolvedPlayerEdit,
+    ) -> Result<(), ResolvedPlayerEditReplayInvariantError> {
+        let command = ResolvedPlayerEditCommand {
+            player,
+            edit,
+            cause: self.current_or_begin_rules_execution_node(),
+        };
+        self.apply_resolved_player_edit(&command)?;
+        self.resolved_rules_journal
+            .record_player_edit(command)
+            .expect("resolved player edit must have a live journal cause");
+        Ok(())
+    }
+
+    /// Applies one final player-resource edit without replacements, quantity
+    /// evaluation, or an implicit player selection.
+    pub fn apply_resolved_player_edit(
+        &mut self,
+        command: &ResolvedPlayerEditCommand,
+    ) -> Result<(), ResolvedPlayerEditReplayInvariantError> {
+        let player = self
+            .players
+            .iter_mut()
+            .find(|candidate| candidate.id == command.player)
+            .ok_or(ResolvedPlayerEditReplayInvariantError::UnknownPlayer(
+                command.player,
+            ))?;
+
+        match &command.edit {
+            ResolvedPlayerEdit::Life { delta } => {
+                let amount = nonzero_delta_magnitude(*delta)?;
+                let life = player
+                    .life
+                    .checked_add(*delta)
+                    .ok_or(ResolvedPlayerEditReplayInvariantError::ResourceOverflow)?;
+                if *delta > 0 {
+                    let gained = player
+                        .life_gained_this_turn
+                        .checked_add(amount)
+                        .ok_or(ResolvedPlayerEditReplayInvariantError::ResourceOverflow)?;
+                    player.life = life;
+                    player.life_gained_this_turn = gained;
+                } else {
+                    let lost = player
+                        .life_lost_this_turn
+                        .checked_add(amount)
+                        .ok_or(ResolvedPlayerEditReplayInvariantError::ResourceOverflow)?;
+                    player.life = life;
+                    player.life_lost_this_turn = lost;
+                }
+            }
+            ResolvedPlayerEdit::Energy { delta } => {
+                player.energy = apply_u32_delta(player.energy, *delta)?;
+            }
+            ResolvedPlayerEdit::Counter { kind, delta } => {
+                let count = apply_u32_delta(player.player_counter(kind), *delta)?;
+                match kind {
+                    PlayerCounterKind::Poison => player.poison_counters = count,
+                    _ if count == 0 => {
+                        player.player_counters.remove(kind);
+                    }
+                    _ => {
+                        player.player_counters.insert(*kind, count);
+                    }
+                }
+            }
+            ResolvedPlayerEdit::Speed { old, new } => {
+                if player.speed != *old {
+                    return Err(
+                        ResolvedPlayerEditReplayInvariantError::SpeedPreconditionMismatch {
+                            expected: *old,
+                            found: player.speed,
+                        },
+                    );
+                }
+                if old == new {
+                    return Err(ResolvedPlayerEditReplayInvariantError::ZeroDelta);
+                }
+                player.speed = *new;
+            }
+        }
+        Ok(())
     }
 
     /// CR 106.4: Apply one exact, already-resolved mana insertion without
@@ -15271,6 +15378,14 @@ impl GameState {
             .ok_or(ResolvedManaReplayInvariantError::ManaPipIdOverflow(pip))?;
         self.next_pip_id = self.next_pip_id.max(next);
         Ok(())
+    }
+
+    pub(crate) fn current_or_begin_rules_execution_node(&mut self) -> RulesExecutionNodeRef {
+        self.active_rules_execution_node.unwrap_or_else(|| {
+            self.resolved_rules_journal
+                .begin_proposal()
+                .expect("resolved-rules journal proposal ordinal overflow")
+        })
     }
 
     /// CR 605.3b: Begin the distinct, immediate execution node for one

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -76,9 +76,11 @@ pub use resolution::{
 pub use resolved_commands::{
     ManaPaymentRecipient, ProducedManaUnit, ResolvedCommandJournalEntry, ResolvedCommandOrdinal,
     ResolvedManaInsertCommand, ResolvedManaReplayInvariantError, ResolvedManaSpendCommand,
-    ResolvedManaSpentUnit, ResolvedRulesCommand, ResolvedRulesJournal, ResolvedRulesJournalError,
-    RulesExecutionNodeKind, RulesExecutionNodeRef, SettlementNode, SettlementNodeOrdinal,
-    SpentManaUnit,
+    ResolvedManaSpentUnit, ResolvedObjectStatus, ResolvedObjectStatusCommand,
+    ResolvedObjectStatusReplayInvariantError, ResolvedPlayerEdit, ResolvedPlayerEditCommand,
+    ResolvedPlayerEditReplayInvariantError, ResolvedRulesCommand, ResolvedRulesJournal,
+    ResolvedRulesJournalError, RulesExecutionNodeKind, RulesExecutionNodeRef, SettlementNode,
+    SettlementNodeOrdinal, SpentManaUnit,
 };
 pub use statics::StaticMode;
 pub use stickers::{AppliedSticker, StickerKind, StickerLocator};

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use super::ability::TriggerDefinitionRef;
 use super::identifiers::ObjectIncarnationRef;
 use super::mana::{ManaPipId, ManaUnit};
-use super::player::PlayerId;
+use super::player::{PlayerCounterKind, PlayerId};
 
 /// Globally ordered identity of a resolved command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -69,6 +69,51 @@ pub struct ResolvedManaSpendCommand {
     pub units: Vec<ResolvedManaSpentUnit>,
 }
 
+/// One resolved scalar change to a player's rules-visible resources.
+///
+/// Each variant is a semantic edit rather than a whole-player replacement, so
+/// independently retained resource commands compose against the retained
+/// prefix. Life changes record their final post-replacement delta.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolvedPlayerEdit {
+    /// CR 119.2 + CR 119.3 + CR 119.4 + CR 119.5: A final gain/loss delta
+    /// applied after any replacement.
+    Life { delta: i32 },
+    /// CR 122.1 + CR 107.14: A final energy-counter delta.
+    Energy { delta: i32 },
+    /// CR 122.1: A final delta for one exact player counter kind.
+    Counter { kind: PlayerCounterKind, delta: i32 },
+    /// CR 702.179b: An exact speed transition, including no-speed.
+    Speed { old: Option<u8>, new: Option<u8> },
+}
+
+/// One exact player-resource mutation after replacement and quantity resolution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedPlayerEditCommand {
+    pub player: PlayerId,
+    pub edit: ResolvedPlayerEdit,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// The object-state status axis owned by a resolved command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolvedObjectStatus {
+    /// CR 701.26: The permanent's tapped state.
+    Tapped,
+    /// CR 701.43d: The exact object was exerted during this turn.
+    Exerted,
+}
+
+/// One exact object-status transition with an optimistic old-status precondition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedObjectStatusCommand {
+    pub object: ObjectIncarnationRef,
+    pub status: ResolvedObjectStatus,
+    pub expected_old: bool,
+    pub new: bool,
+    pub cause: RulesExecutionNodeRef,
+}
+
 /// Semantic command payload currently carried by a resolved-rules journal entry.
 ///
 /// Additional command families are intentionally added by their owning P2
@@ -77,6 +122,8 @@ pub struct ResolvedManaSpendCommand {
 pub enum ResolvedRulesCommand {
     ManaInsert(ResolvedManaInsertCommand),
     ManaSpend(ResolvedManaSpendCommand),
+    PlayerEdit(ResolvedPlayerEditCommand),
+    ObjectStatus(ResolvedObjectStatusCommand),
 }
 
 /// Typed failure while applying an already-resolved mana command to a replay state.
@@ -116,6 +163,87 @@ impl std::fmt::Display for ResolvedManaReplayInvariantError {
 }
 
 impl std::error::Error for ResolvedManaReplayInvariantError {}
+
+/// Typed failure while applying an already-resolved player-resource command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedPlayerEditReplayInvariantError {
+    UnknownPlayer(PlayerId),
+    ZeroDelta,
+    ResourceUnderflow,
+    ResourceOverflow,
+    SpeedPreconditionMismatch {
+        expected: Option<u8>,
+        found: Option<u8>,
+    },
+}
+
+impl std::fmt::Display for ResolvedPlayerEditReplayInvariantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownPlayer(player) => write!(f, "unknown player-command player {}", player.0),
+            Self::ZeroDelta => write!(f, "resolved player command has a zero delta"),
+            Self::ResourceUnderflow => {
+                write!(f, "resolved player command would underflow a resource")
+            }
+            Self::ResourceOverflow => {
+                write!(f, "resolved player command would overflow a resource")
+            }
+            Self::SpeedPreconditionMismatch { expected, found } => write!(
+                f,
+                "resolved speed command expected {expected:?}, found {found:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ResolvedPlayerEditReplayInvariantError {}
+
+/// Typed failure while applying an already-resolved object-status command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedObjectStatusReplayInvariantError {
+    UnknownObject(super::identifiers::ObjectId),
+    MissingObject(ObjectIncarnationRef),
+    StaleObject {
+        expected: ObjectIncarnationRef,
+        found: ObjectIncarnationRef,
+    },
+    StatusPreconditionMismatch {
+        status: ResolvedObjectStatus,
+        expected: bool,
+        found: bool,
+    },
+}
+
+impl std::fmt::Display for ResolvedObjectStatusReplayInvariantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownObject(object) => {
+                write!(
+                    f,
+                    "resolved object-status command cannot find object {}",
+                    object.0
+                )
+            }
+            Self::MissingObject(object) => {
+                write!(f, "resolved object-status command cannot find {object:?}")
+            }
+            Self::StaleObject { expected, found } => write!(
+                f,
+                "resolved object-status command expected {expected:?}, found {found:?}"
+            ),
+            Self::StatusPreconditionMismatch {
+                status,
+                expected,
+                found,
+            } => write!(
+                f,
+                "resolved {status:?} command expected status {expected}, found {found}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ResolvedObjectStatusReplayInvariantError {}
 
 /// Semantic category of a resolved rules-execution node.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -528,6 +656,22 @@ impl ResolvedRulesJournal {
         Ok(Some(command))
     }
 
+    /// Records one final scalar player-resource mutation under its causal node.
+    pub fn record_player_edit(
+        &mut self,
+        command: ResolvedPlayerEditCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(command.cause, ResolvedRulesCommand::PlayerEdit(command))
+    }
+
+    /// Records one exact object-status transition under its causal node.
+    pub fn record_object_status(
+        &mut self,
+        command: ResolvedObjectStatusCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(command.cause, ResolvedRulesCommand::ObjectStatus(command))
+    }
+
     fn begin_settlement(
         &mut self,
         identity_for: impl FnOnce(SettlementNodeOrdinal) -> RulesExecutionNodeRef,
@@ -723,6 +867,7 @@ impl ResolvedRulesJournal {
                         }
                     }
                 }
+                ResolvedRulesCommand::PlayerEdit(_) | ResolvedRulesCommand::ObjectStatus(_) => {}
             }
         }
         for node in &self.nodes {
@@ -892,6 +1037,21 @@ impl ResolvedRulesJournal {
                     ));
                 }
             }
+            ResolvedRulesCommand::PlayerEdit(command) => {
+                if entry.node != command.cause || player_edit_is_empty(&command.edit) {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "player command has an empty edit or unrelated cause".to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::ObjectStatus(command) => {
+                if entry.node != command.cause || command.expected_old == command.new {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "object-status command has a no-op transition or unrelated cause"
+                            .to_string(),
+                    ));
+                }
+            }
         }
         Ok(())
     }
@@ -926,6 +1086,15 @@ fn has_duplicate_values<T: Eq + std::hash::Hash>(values: &[T]) -> bool {
 
 fn exact_mana_unit_eq(left: &ManaUnit, right: &ManaUnit) -> bool {
     left.pip_id == right.pip_id && left == right
+}
+
+fn player_edit_is_empty(edit: &ResolvedPlayerEdit) -> bool {
+    match edit {
+        ResolvedPlayerEdit::Life { delta }
+        | ResolvedPlayerEdit::Energy { delta }
+        | ResolvedPlayerEdit::Counter { delta, .. } => *delta == 0,
+        ResolvedPlayerEdit::Speed { old, new } => old == new,
+    }
 }
 
 #[cfg(test)]
@@ -1064,7 +1233,7 @@ mod tests {
     }
 
     #[test]
-    fn semantic_mana_commands_roundtrip_and_reject_malformed_payloads() {
+    fn semantic_commands_roundtrip_and_reject_malformed_payloads() {
         let mut journal = ResolvedRulesJournal::default();
         let producer = journal.begin_proposal().unwrap();
         let produced = unit(1);
@@ -1120,6 +1289,69 @@ mod tests {
         duplicate_spend.next_command_ordinal = 5;
         assert!(serde_json::from_value::<ResolvedRulesJournal>(
             serde_json::to_value(duplicate_spend).unwrap()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn scalar_and_object_status_commands_roundtrip_and_reject_malformed_payloads() {
+        let mut journal = ResolvedRulesJournal::default();
+        let cause = journal.begin_proposal().unwrap();
+        journal
+            .record_player_edit(ResolvedPlayerEditCommand {
+                player: PlayerId(0),
+                edit: ResolvedPlayerEdit::Life { delta: -3 },
+                cause,
+            })
+            .unwrap();
+        journal
+            .record_object_status(ResolvedObjectStatusCommand {
+                object: ObjectIncarnationRef::of(ObjectId(9), 0),
+                status: ResolvedObjectStatus::Tapped,
+                expected_old: false,
+                new: true,
+                cause,
+            })
+            .unwrap();
+        assert_eq!(
+            serde_json::from_value::<ResolvedRulesJournal>(serde_json::to_value(&journal).unwrap())
+                .unwrap(),
+            journal
+        );
+
+        let mut empty_player_edit = journal.clone();
+        let Some(ResolvedRulesCommand::PlayerEdit(command)) =
+            empty_player_edit.entries[1].command.as_mut()
+        else {
+            panic!("entry 1 must be the player edit");
+        };
+        command.edit = ResolvedPlayerEdit::Energy { delta: 0 };
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(
+            serde_json::to_value(empty_player_edit).unwrap()
+        )
+        .is_err());
+
+        let mut no_op_status = journal.clone();
+        let Some(ResolvedRulesCommand::ObjectStatus(command)) =
+            no_op_status.entries[2].command.as_mut()
+        else {
+            panic!("entry 2 must be the object-status edit");
+        };
+        command.new = false;
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(
+            serde_json::to_value(no_op_status).unwrap()
+        )
+        .is_err());
+
+        let mut unrelated_cause = journal.clone();
+        let Some(ResolvedRulesCommand::PlayerEdit(command)) =
+            unrelated_cause.entries[1].command.as_mut()
+        else {
+            panic!("entry 1 must be the player edit");
+        };
+        command.cause = RulesExecutionNodeRef::Payment(SettlementNodeOrdinal(99));
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(
+            serde_json::to_value(unrelated_cause).unwrap()
         )
         .is_err());
     }

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -1,13 +1,18 @@
-//! P2 replay coverage for resolved mana insert and spend commands.
+//! P2 replay coverage for resolved mana, scalar, and object-status commands.
 
-use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::ManaColor;
 use engine::types::phase::Phase;
-use engine::types::resolved_commands::{ResolvedManaReplayInvariantError, ResolvedRulesCommand};
+use engine::types::player::PlayerCounterKind;
+use engine::types::resolved_commands::{
+    ResolvedManaReplayInvariantError, ResolvedObjectStatusReplayInvariantError, ResolvedPlayerEdit,
+    ResolvedPlayerEditCommand, ResolvedPlayerEditReplayInvariantError, ResolvedRulesCommand,
+    RulesExecutionNodeRef,
+};
 
 const DIMIR_SIGNET_ORACLE: &str = "{1}, {T}: Add {U}{B}.";
 
@@ -21,7 +26,7 @@ fn make_artifact(runner: &mut GameRunner, id: ObjectId) {
     object.base_toughness = None;
 }
 
-fn activated_signet_states() -> (GameState, GameState) {
+fn activated_signet_states() -> (GameState, GameState, ObjectId) {
     let mut scenario = GameScenario::new_n_player(2, 7);
     scenario.at_phase(Phase::PreCombatMain);
     scenario.add_basic_land(P0, ManaColor::White);
@@ -38,10 +43,10 @@ fn activated_signet_states() -> (GameState, GameState) {
             ability_index: 0,
         })
         .expect("the real Signet mana ability must activate");
-    (pre_state, runner.state().clone())
+    (pre_state, runner.state().clone(), signet)
 }
 
-fn semantic_mana_commands(state: &GameState) -> Vec<ResolvedRulesCommand> {
+fn semantic_commands(state: &GameState) -> Vec<ResolvedRulesCommand> {
     state
         .resolved_rules_journal
         .entries()
@@ -50,13 +55,19 @@ fn semantic_mana_commands(state: &GameState) -> Vec<ResolvedRulesCommand> {
         .collect()
 }
 
-fn apply_mana_command(state: &mut GameState, command: &ResolvedRulesCommand) {
+fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand) {
     match command {
         ResolvedRulesCommand::ManaInsert(command) => {
             state.apply_resolved_mana_insert(command).unwrap();
         }
         ResolvedRulesCommand::ManaSpend(command) => {
             state.apply_resolved_mana_spend(command).unwrap();
+        }
+        ResolvedRulesCommand::PlayerEdit(command) => {
+            state.apply_resolved_player_edit(command).unwrap();
+        }
+        ResolvedRulesCommand::ObjectStatus(command) => {
+            engine::game::object_state::apply_resolved_object_edit(state, command).unwrap();
         }
     }
 }
@@ -66,8 +77,8 @@ fn apply_mana_command(state: &mut GameState, command: &ResolvedRulesCommand) {
 /// commands in entry order must reproduce that pool and its pip high-water.
 #[test]
 fn real_mana_activation_replays_recorded_insert_and_spend_commands() {
-    let (pre_state, ordinary_state) = activated_signet_states();
-    let commands = semantic_mana_commands(&ordinary_state);
+    let (pre_state, ordinary_state, signet) = activated_signet_states();
+    let commands = semantic_commands(&ordinary_state);
 
     assert!(
         commands
@@ -85,7 +96,7 @@ fn real_mana_activation_replays_recorded_insert_and_spend_commands() {
     let mut replay = pre_state;
     replay.resolved_rules_journal = ordinary_state.resolved_rules_journal.clone();
     for command in &commands {
-        apply_mana_command(&mut replay, command);
+        apply_semantic_command(&mut replay, command);
     }
 
     for (replayed, ordinary) in replay.players.iter().zip(&ordinary_state.players) {
@@ -108,6 +119,10 @@ fn real_mana_activation_replays_recorded_insert_and_spend_commands() {
     }
     assert_eq!(replay.next_pip_id, ordinary_state.next_pip_id);
     assert_eq!(
+        replay.objects[&signet].tapped, ordinary_state.objects[&signet].tapped,
+        "replay preserves the activated source's exact tapped status"
+    );
+    assert_eq!(
         replay.resolved_rules_journal,
         ordinary_state.resolved_rules_journal
     );
@@ -118,15 +133,15 @@ fn real_mana_activation_replays_recorded_insert_and_spend_commands() {
 /// failure rather than a fresh payment-solver decision.
 #[test]
 fn exact_mana_spend_rejects_a_second_removal() {
-    let (pre_state, ordinary_state) = activated_signet_states();
-    let commands = semantic_mana_commands(&ordinary_state);
+    let (pre_state, ordinary_state, _) = activated_signet_states();
+    let commands = semantic_commands(&ordinary_state);
     let mut replay = pre_state;
     replay.resolved_rules_journal = ordinary_state.resolved_rules_journal.clone();
 
     let mut observed_spend = false;
     for command in &commands {
         match command {
-            ResolvedRulesCommand::ManaInsert(_) => apply_mana_command(&mut replay, command),
+            ResolvedRulesCommand::ManaInsert(_) => apply_semantic_command(&mut replay, command),
             ResolvedRulesCommand::ManaSpend(command) => {
                 replay.apply_resolved_mana_spend(command).unwrap();
                 assert!(matches!(
@@ -136,10 +151,172 @@ fn exact_mana_spend_rejects_a_second_removal() {
                 observed_spend = true;
                 break;
             }
+            ResolvedRulesCommand::PlayerEdit(_) | ResolvedRulesCommand::ObjectStatus(_) => {
+                apply_semantic_command(&mut replay, command);
+            }
         }
     }
     assert!(
         observed_spend,
         "the real activation must include a mana spend command"
+    );
+}
+
+fn damage_spell_states() -> (GameState, GameState) {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    let bolt = scenario.add_bolt_to_hand(P0);
+    let mut runner = scenario.build();
+    let pre_state = runner.state().clone();
+
+    let outcome = runner.cast(bolt).target_player(P1).resolve();
+    outcome.assert_life_delta(P1, -3);
+
+    (pre_state, runner.state().clone())
+}
+
+/// A real damage spell records the final post-replacement life delta. Replaying
+/// that semantic command changes only the retained prefix's player resources.
+#[test]
+fn real_damage_spell_replays_recorded_final_life_delta() {
+    let (pre_state, ordinary_state) = damage_spell_states();
+    let commands = semantic_commands(&ordinary_state);
+    let life_command = commands
+        .iter()
+        .find(|command| {
+            matches!(
+                command,
+                ResolvedRulesCommand::PlayerEdit(ResolvedPlayerEditCommand {
+                    player: P1,
+                    edit: ResolvedPlayerEdit::Life { delta: -3 },
+                    ..
+                })
+            )
+        })
+        .expect("Lightning Bolt must journal its final delivered life delta");
+
+    let mut replay = pre_state;
+    replay.resolved_rules_journal = ordinary_state.resolved_rules_journal.clone();
+    apply_semantic_command(&mut replay, life_command);
+
+    let replayed = replay
+        .players
+        .iter()
+        .find(|player| player.id == P1)
+        .unwrap();
+    let ordinary = ordinary_state
+        .players
+        .iter()
+        .find(|player| player.id == P1)
+        .unwrap();
+    assert_eq!(replayed.life, ordinary.life);
+    assert_eq!(
+        replayed.life_lost_this_turn, ordinary.life_lost_this_turn,
+        "the final delta carries life-loss bookkeeping without rerunning replacement"
+    );
+}
+
+/// Exact status commands are intentionally non-idempotent: replaying a recorded
+/// tap twice fails its old-status precondition, and a same-id new incarnation
+/// fails rather than accepting a stale reference.
+#[test]
+fn recorded_tap_rejects_double_apply_and_stale_incarnation() {
+    let (pre_state, ordinary_state, signet) = activated_signet_states();
+    let command = semantic_commands(&ordinary_state)
+        .into_iter()
+        .find_map(|command| match command {
+            ResolvedRulesCommand::ObjectStatus(command) if command.object.object_id == signet => {
+                Some(command)
+            }
+            _ => None,
+        })
+        .expect("the real Signet activation must journal its tap cost");
+
+    let mut replay = pre_state.clone();
+    engine::game::object_state::apply_resolved_object_edit(&mut replay, &command).unwrap();
+    assert!(matches!(
+        engine::game::object_state::apply_resolved_object_edit(&mut replay, &command),
+        Err(ResolvedObjectStatusReplayInvariantError::StatusPreconditionMismatch { .. })
+    ));
+
+    let mut stale = pre_state;
+    stale
+        .objects
+        .get_mut(&command.object.object_id)
+        .unwrap()
+        .bump_incarnation();
+    assert!(matches!(
+        engine::game::object_state::apply_resolved_object_edit(&mut stale, &command),
+        Err(ResolvedObjectStatusReplayInvariantError::StaleObject { .. })
+    ));
+}
+
+/// Scalar deltas compose until the resource's actual precondition rejects a
+/// duplicate removal; no player snapshot is restored over an independent edit.
+#[test]
+fn exact_scalar_resource_removal_rejects_a_second_underflowing_apply() {
+    let mut state = GameState::new_two_player(7);
+    state.players[0].energy = 1;
+    let command = ResolvedPlayerEditCommand {
+        player: P0,
+        edit: ResolvedPlayerEdit::Energy { delta: -1 },
+        cause: RulesExecutionNodeRef::Proposal(
+            engine::types::resolved_commands::ResolvedCommandOrdinal(0),
+        ),
+    };
+
+    state.apply_resolved_player_edit(&command).unwrap();
+    assert!(matches!(
+        state.apply_resolved_player_edit(&command),
+        Err(ResolvedPlayerEditReplayInvariantError::ResourceUnderflow)
+    ));
+}
+
+/// The scalar authority edits one resource axis at a time. It records semantic
+/// deltas/transitions instead of replacing a player snapshot, so unrelated
+/// retained resource edits remain intact.
+#[test]
+fn scalar_commands_compose_across_life_energy_counters_and_speed() {
+    let mut state = GameState::new_two_player(7);
+
+    state
+        .resolve_and_apply_player_edit(P0, ResolvedPlayerEdit::Life { delta: 2 })
+        .unwrap();
+    state
+        .resolve_and_apply_player_edit(P0, ResolvedPlayerEdit::Energy { delta: 3 })
+        .unwrap();
+    state
+        .resolve_and_apply_player_edit(
+            P0,
+            ResolvedPlayerEdit::Counter {
+                kind: PlayerCounterKind::Experience,
+                delta: 1,
+            },
+        )
+        .unwrap();
+    state
+        .resolve_and_apply_player_edit(
+            P0,
+            ResolvedPlayerEdit::Speed {
+                old: None,
+                new: Some(3),
+            },
+        )
+        .unwrap();
+
+    let player = state.players.iter().find(|player| player.id == P0).unwrap();
+    assert_eq!(player.life, 22);
+    assert_eq!(player.life_gained_this_turn, 2);
+    assert_eq!(player.energy, 3);
+    assert_eq!(
+        player.player_counter(&PlayerCounterKind::Experience),
+        1,
+        "the counter edit must not overwrite the preceding scalar edits"
+    );
+    assert_eq!(player.speed, Some(3));
+    assert_eq!(
+        semantic_commands(&state).len(),
+        4,
+        "each final scalar edit has one journal command"
     );
 }


### PR DESCRIPTION
- **cr733(p2): apply resolved scalar and status commands**
- **cr733(p2): record scalar and status tranche**
- **cr733(p2): skip the journal command for zero-amount life changes**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable replay support for player life, energy, counters, speed, and object tapped/exerted status changes.
  * Improved validation to reject stale, duplicate, no-op, or invalid state transitions.
  * Standardized gameplay actions such as paying costs, combat, tapping, untapping, and exerting to apply state changes consistently.

* **Bug Fixes**
  * Prevented incorrect events from being emitted when state changes fail or produce no actual transition.
  * Added safeguards against resource underflow and overflow during gameplay actions.

* **Tests**
  * Expanded replay coverage for scalar resource changes and object-status transitions, including stale-state and duplicate-application scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->