### PR TITLE
fix: preserve colors_spent_to_cast for CR 603.4 Adamant ETBs (#5943)

### DIFF
--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1039,10 +1039,12 @@ pub struct GameObject {
     /// CR 601.2h: Per-color breakdown of mana spent to cast this object.
     /// Populated during casting finalization; consumed by trigger / ability
     /// conditions like Adamant (CR 207.2c) and by Converge-style quantity
-    /// refs. Like `mana_spent_to_cast_amount`, this is a historical cast fact
-    /// that persists through CR 603.4 intervening-if resolution re-checks —
-    /// `clear_post_collection_transients` clears only the transient
-    /// `mana_spent_to_cast` boolean, not this tally.
+    /// refs. Persists through CR 603.4 intervening-if resolution re-checks on
+    /// the **same** battlefield object (`clear_post_collection_transients`
+    /// clears only the transient `mana_spent_to_cast` boolean, not this tally).
+    /// Cleared by `reset_for_battlefield_exit` (CR 400.7) so a permanent that
+    /// leaves and re-enters without being cast again does not inherit a stale
+    /// color tally from its previous visit.
     #[serde(default, skip_serializing_if = "ColoredManaCount::is_empty")]
     pub colors_spent_to_cast: ColoredManaCount,
 
@@ -2322,6 +2324,13 @@ impl GameObject {
         // is a new object on any re-entry — clear the stale cast provenance.
         self.cast_from_zone = None;
         self.cast_controller = None;
+        // CR 601.2h + CR 400.7: The per-color cast tally is a historical fact
+        // for the object that actually resolved onto the battlefield from a
+        // cast, kept alive through CR 603.4 intervening-if re-checks on that
+        // same visit. Once the permanent leaves, any re-entry is a new object
+        // with no memory of how it was previously cast — clear alongside the
+        // other cast-entry provenance above (Emptiness / Adamant class).
+        self.colors_spent_to_cast = ColoredManaCount::default();
         // CR 611.2f: the cast-time keyword snapshot is bound to the same casting
         // event as `cast_from_zone`; clear it on the same zone-change boundary.
         self.cast_spell_keywords.clear();
@@ -2641,6 +2650,34 @@ mod tests {
     };
     use crate::types::counter::parse_counter_type;
     use crate::types::triggers::TriggerMode;
+
+    #[test]
+    fn reset_for_battlefield_exit_clears_colors_spent_to_cast() {
+        use crate::types::mana::ManaColor;
+
+        let mut obj = GameObject::new(
+            ObjectId(1),
+            CardId(1),
+            PlayerId(0),
+            "Emptiness".to_string(),
+            Zone::Battlefield,
+        );
+        obj.colors_spent_to_cast.add(ManaColor::White, 2);
+        obj.cast_from_zone = Some(Zone::Hand);
+
+        obj.reset_for_battlefield_exit();
+
+        assert_eq!(
+            obj.colors_spent_to_cast.get(ManaColor::White),
+            0,
+            "CR 400.7: a permanent that leaves the battlefield must not carry \
+             a stale cast-color tally into a later zone"
+        );
+        assert_eq!(
+            obj.cast_from_zone, None,
+            "cast provenance fields clear on the same exit boundary"
+        );
+    }
 
     #[test]
     fn game_object_has_all_rules_relevant_fields() {

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1042,9 +1042,9 @@ pub struct GameObject {
     /// refs. Persists through CR 603.4 intervening-if resolution re-checks on
     /// the **same** battlefield object (`clear_post_collection_transients`
     /// clears only the transient `mana_spent_to_cast` boolean, not this tally).
-    /// Cleared by `reset_for_battlefield_exit` (CR 400.7) so a permanent that
-    /// leaves and re-enters without being cast again does not inherit a stale
-    /// color tally from its previous visit.
+    /// Cleared by `reset_for_battlefield_exit` and when a spell leaves the stack
+    /// for any zone other than the battlefield (CR 400.7; CR 400.7d preserves
+    /// the tally only for the permanent the spell becomes).
     #[serde(default, skip_serializing_if = "ColoredManaCount::is_empty")]
     pub colors_spent_to_cast: ColoredManaCount,
 
@@ -2287,6 +2287,16 @@ impl GameObject {
         self.assigns_no_combat_damage = false;
     }
 
+    /// CR 400.7 + CR 601.2h: Clear cast-payment tallies bound to a spell on the
+    /// stack or to a permanent's current battlefield visit. Preserved through
+    /// CR 603.4 intervening-if re-checks on that same visit; cleared when the
+    /// spell leaves the stack for any zone other than the battlefield (CR
+    /// 400.7d applies only to the permanent the spell becomes) and when a
+    /// permanent leaves the battlefield.
+    pub fn clear_cast_payment_provenance(&mut self) {
+        self.colors_spent_to_cast = ColoredManaCount::default();
+    }
+
     /// CR 400.7: Clear battlefield-only designations when a permanent leaves the battlefield.
     /// Separate from entry reset because some state (counters, transform) is already handled
     /// by `apply_zone_exit_cleanup` in zones.rs.
@@ -2324,13 +2334,7 @@ impl GameObject {
         // is a new object on any re-entry — clear the stale cast provenance.
         self.cast_from_zone = None;
         self.cast_controller = None;
-        // CR 601.2h + CR 400.7: The per-color cast tally is a historical fact
-        // for the object that actually resolved onto the battlefield from a
-        // cast, kept alive through CR 603.4 intervening-if re-checks on that
-        // same visit. Once the permanent leaves, any re-entry is a new object
-        // with no memory of how it was previously cast — clear alongside the
-        // other cast-entry provenance above (Emptiness / Adamant class).
-        self.colors_spent_to_cast = ColoredManaCount::default();
+        self.clear_cast_payment_provenance();
         // CR 611.2f: the cast-time keyword snapshot is bound to the same casting
         // event as `cast_from_zone`; clear it on the same zone-change boundary.
         self.cast_spell_keywords.clear();

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1037,9 +1037,12 @@ pub struct GameObject {
     pub mana_spent_to_cast: bool,
 
     /// CR 601.2h: Per-color breakdown of mana spent to cast this object.
-    /// Populated during casting finalization; consumed by trigger conditions
-    /// like Adamant (CR 207.2c). Cleared in lockstep with `mana_spent_to_cast`
-    /// (see `triggers::clear_transient_cast_state`).
+    /// Populated during casting finalization; consumed by trigger / ability
+    /// conditions like Adamant (CR 207.2c) and by Converge-style quantity
+    /// refs. Like `mana_spent_to_cast_amount`, this is a historical cast fact
+    /// that persists through CR 603.4 intervening-if resolution re-checks —
+    /// `clear_post_collection_transients` clears only the transient
+    /// `mana_spent_to_cast` boolean, not this tally.
     #[serde(default, skip_serializing_if = "ColoredManaCount::is_empty")]
     pub colors_spent_to_cast: ColoredManaCount,
 
@@ -1051,7 +1054,7 @@ pub struct GameObject {
     /// for spell-resolution effects that read their own cost (Molten Note,
     /// "deals damage equal to the amount of mana spent to cast this spell").
     ///
-    /// Unlike `mana_spent_to_cast` / `colors_spent_to_cast`, this field is NOT
+    /// Unlike the transient `mana_spent_to_cast` boolean, this field is NOT
     /// cleared after trigger collection — it is a historical fact about the
     /// object that remains valid through spell resolution and beyond. Set once
     /// at cast finalization; initialized to 0 by `GameObject::new`.

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4629,10 +4629,13 @@ fn dispatch_collected_triggers(state: &mut GameState, pending: Vec<PendingTrigge
 /// spell is still on the stack — Cascade (CR 702.85a: "functions only while
 /// the spell with cascade is on the stack"), Storm, and dynamically-granted
 /// Casualty. Clearing it for stack objects here made every such cast-triggered
-/// ability silently do nothing at resolution. It is still cleared for
-/// objects in other zones (a fizzled spell that has left the stack, an object
-/// that bounced) since their cast provenance is no longer meaningful, and is
-/// cleared on battlefield exit by `reset_for_battlefield_exit`.
+/// ability silently do nothing at resolution. Cast-payment tallies
+/// (`colors_spent_to_cast`) are cleared when a spell leaves the stack for
+/// any zone other than the battlefield (`zones.rs`) and when a permanent
+/// leaves the battlefield (`reset_for_battlefield_exit`). `cast_from_zone` is
+/// still cleared for objects in other zones (a fizzled spell that has left
+/// the stack, an object that bounced) since their cast provenance is no longer
+/// meaningful for future zone changes.
 fn clear_post_collection_transients(state: &mut GameState) {
     for obj in state.objects.iter_mut().map(|(_, v)| v) {
         if !matches!(obj.zone, Zone::Battlefield | Zone::Stack) {
@@ -19587,6 +19590,23 @@ pub mod tests {
         assert!(
             check_trigger_condition(&state, &cond, PlayerId(0), Some(src), None),
             "ManaColorSpent must remain true after post-collection transient clear"
+        );
+    }
+
+    #[test]
+    fn colors_spent_to_cast_clears_when_spell_leaves_stack_for_graveyard() {
+        use crate::game::zones::move_to_zone;
+
+        let (mut state, src) = setup_with_colored_cast(ManaColor::White, 2);
+        state.objects.get_mut(&src).unwrap().zone = Zone::Stack;
+        let mut events = Vec::new();
+        move_to_zone(&mut state, src, Zone::Graveyard, &mut events);
+        assert_eq!(
+            state.objects[&src]
+                .colors_spent_to_cast
+                .get(ManaColor::White),
+            0,
+            "CR 400.7: a spell countered to the graveyard must not retain cast colors"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -4600,13 +4600,22 @@ fn dispatch_collected_triggers(state: &mut GameState, pending: Vec<PendingTrigge
     let _ = drain_deferred_triggers_after_trigger_construction(state, &mut events_out);
 }
 
-/// Clear transient cast-tally booleans/color breakdown on all objects after
-/// trigger collection. `mana_spent_to_cast_amount` is intentionally NOT
-/// cleared: it is a historical fact about the object (how much mana was
-/// spent to cast it) used by spell resolution effects like "deals damage
-/// equal to the amount of mana spent to cast this spell" (Molten Note) and
-/// by CR 603.4 intervening-if resolution re-checks (Hungry Graffalon /
-/// Topiary Lecturer Increment).
+/// Clear transient cast-tally booleans on all objects after trigger
+/// collection. `mana_spent_to_cast_amount` and `colors_spent_to_cast` are
+/// intentionally NOT cleared: they are historical facts about the object
+/// (how much mana / which colors were spent to cast it) used by spell
+/// resolution effects like "deals damage equal to the amount of mana spent
+/// to cast this spell" (Molten Note), Converge / Adamant-style riders
+/// (CR 207.2c), and by CR 603.4 intervening-if resolution re-checks
+/// (Hungry Graffalon / Topiary Lecturer Increment; Emptiness /
+/// `ManaColorSpent` ETBs).
+///
+/// CR 603.4: ETB intervening-if re-checks run while the permanent is still
+/// on the battlefield, so `TriggerSourceContext::source_read` prefers
+/// `ExactLive` and reads the live object's color tally. Clearing
+/// `colors_spent_to_cast` here after collection made every Adamant-style
+/// ETB (including Evoke-paid Emptiness) silently do nothing at resolution
+/// even though the condition passed at collection time.
 ///
 /// CR 603.4: `cast_from_zone` is likewise preserved for permanents on the
 /// battlefield — a `WasCast` / "if you cast it" ETB intervening-if is
@@ -4630,7 +4639,6 @@ fn clear_post_collection_transients(state: &mut GameState) {
             obj.cast_from_zone = None;
         }
         obj.mana_spent_to_cast = false;
-        obj.colors_spent_to_cast = crate::types::mana::ColoredManaCount::default();
     }
 }
 
@@ -8844,7 +8852,10 @@ fn evaluate_trigger_condition_with_source(
                 == Some((*permission, state.turn_number))
         }
         // CR 207.2c: Adamant — at least N mana of a specific color was spent to cast.
-        // Reads the per-color tally recorded in casting::pay_mana_cost.
+        // CR 601.2h + CR 207.2c: Adamant / "if {C}{C} was spent to cast it" —
+        // read the durable per-color tally (`colors_spent_to_cast`), which
+        // survives `clear_post_collection_transients` so CR 603.4 resolution
+        // re-checks still see the payment recorded at cast finalization.
         TriggerCondition::ManaColorSpent { color, minimum } => {
             source_context.is_some_and(|source| {
                 source.source_read(state).colors_spent_to_cast().get(*color) >= *minimum
@@ -19544,6 +19555,39 @@ pub mod tests {
             Some(src),
             None,
         ));
+    }
+
+    /// CR 207.2c + CR 601.2h + CR 603.4: `ManaColorSpent` must still see the
+    /// per-color payment after `clear_post_collection_transients`. ExactLive
+    /// ETB sources read the live object; wiping `colors_spent_to_cast` there
+    /// made Adamant-style ETBs (Emptiness, issue #5943) pass collection then
+    /// silently fail at resolution.
+    #[test]
+    fn adamant_intervening_if_survives_post_collection_transient_clear() {
+        let (mut state, src) = setup_with_colored_cast(ManaColor::White, 2);
+        state.objects.get_mut(&src).unwrap().mana_spent_to_cast = true;
+        let cond = TriggerCondition::ManaColorSpent {
+            color: ManaColor::White,
+            minimum: 2,
+        };
+
+        clear_post_collection_transients(&mut state);
+
+        assert!(
+            !state.objects[&src].mana_spent_to_cast,
+            "transient mana_spent_to_cast boolean must still clear"
+        );
+        assert_eq!(
+            state.objects[&src]
+                .colors_spent_to_cast
+                .get(ManaColor::White),
+            2,
+            "colors_spent_to_cast is a durable cast fact for CR 603.4 re-checks"
+        );
+        assert!(
+            check_trigger_condition(&state, &cond, PlayerId(0), Some(src), None),
+            "ManaColorSpent must remain true after post-collection transient clear"
+        );
     }
 
     // === CR 603.6a + CR 110.5b: "When ~ enters untapped/tapped" ETB gating ===

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -345,6 +345,14 @@ pub(crate) fn apply_zone_exit_cleanup(
                         | crate::types::ability::CastingPermission::PlayFromExile { .. }
                 )
             });
+            // CR 400.7 + CR 601.2h: A spell that leaves the stack without
+            // resolving onto the battlefield (countered, fizzled, bounced to
+            // hand) must not carry its cast-color tally into a later zone — only
+            // Stack → Battlefield preserves it for the permanent the spell
+            // becomes (CR 400.7d).
+            if to != Zone::Battlefield {
+                obj_mut.clear_cast_payment_provenance();
+            }
         }
 
         if from == Zone::Battlefield {

--- a/crates/engine/tests/integration/issue_5943_emptiness_evoke_color_spent.rs
+++ b/crates/engine/tests/integration/issue_5943_emptiness_evoke_color_spent.rs
@@ -1,0 +1,102 @@
+//! Issue #5943 — Evoking Emptiness doesn't fire its color-spent ETB.
+//!
+//! Emptiness Oracle:
+//!   When this creature enters, if {W}{W} was spent to cast it, return target
+//!   creature card with mana value 3 or less from your graveyard to the
+//!   battlefield.
+//!   When this creature enters, if {B}{B} was spent to cast it, put three -1/-1
+//!   counters on up to one target creature.
+//!   Evoke {W/B}{W/B}
+//!
+//! Classifier: supported_aspect_defect. The AST already carries
+//! `TriggerCondition::ManaColorSpent { minimum: 2 }` on both ETBs; the defect
+//! was runtime — `clear_post_collection_transients` wiped `colors_spent_to_cast`
+//! after collection, so CR 603.4 ExactLive re-checks failed at resolution
+//! (Adamant / color-spent class, not Evoke-specific).
+//!
+//! https://github.com/phase-rs/phase/issues/5943
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::AlternativeCastDecision;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const EMPTINESS_ORACLE: &str = "When this creature enters, if {W}{W} was spent to cast it, \
+return target creature card with mana value 3 or less from your graveyard to the battlefield.\n\
+When this creature enters, if {B}{B} was spent to cast it, put three -1/-1 counters on up to one \
+target creature.\n\
+Evoke {W/B}{W/B}";
+
+fn add_mana(state: &mut engine::types::game_state::GameState, color: ManaType, n: u32) {
+    for _ in 0..n {
+        state.players[0]
+            .mana_pool
+            .add(ManaUnit::new(color, ObjectId(0), false, vec![]));
+    }
+}
+
+fn emptiness_in_hand(scenario: &mut GameScenario) -> ObjectId {
+    scenario
+        .add_creature_to_hand(P0, "Emptiness", 3, 3)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::WhiteBlack, ManaCostShard::WhiteBlack],
+            generic: 4,
+        })
+        .from_oracle_text_with_keywords(&["Evoke"], EMPTINESS_ORACLE)
+        .id()
+}
+
+/// CR 702.74a + CR 207.2c + CR 601.2h + CR 603.4: Evoking Emptiness for {W}{W}
+/// must fire the white-spent ETB (return MV≤3 creature from GY) and then the
+/// evoke sacrifice — the color tally must survive post-collection clearing.
+#[test]
+fn emptiness_evoke_ww_returns_graveyard_creature_then_sacrifices() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let emptiness = emptiness_in_hand(&mut scenario);
+    let gy_creature = scenario
+        .add_creature_to_graveyard(P0, "Recoverable Bear", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+
+    let mut runner = scenario.build();
+    // Enough for printed and evoke so the AlternativeCastChoice surfaces;
+    // choosing Evoke spends only {W/B}{W/B} as white.
+    add_mana(runner.state_mut(), ManaType::White, 6);
+
+    let outcome = runner
+        .cast(emptiness)
+        .alternative_cast(AlternativeCastDecision::Alternative)
+        .target_objects(&[gy_creature])
+        .resolve();
+
+    outcome.assert_zone(&[gy_creature], Zone::Battlefield);
+    outcome.assert_zone(&[emptiness], Zone::Graveyard);
+}
+
+/// CR 702.74a + CR 207.2c + CR 601.2h + CR 603.4: Evoking for {B}{B} must fire
+/// the black-spent ETB (three -1/-1 counters) before the evoke sacrifice.
+#[test]
+fn emptiness_evoke_bb_puts_minus_counters_then_sacrifices() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let emptiness = emptiness_in_hand(&mut scenario);
+    let victim = scenario.add_creature(P1, "Victim Bear", 4, 4).id();
+
+    let mut runner = scenario.build();
+    add_mana(runner.state_mut(), ManaType::Black, 6);
+
+    let outcome = runner
+        .cast(emptiness)
+        .alternative_cast(AlternativeCastDecision::Alternative)
+        .target_objects(&[victim])
+        .resolve();
+
+    outcome.assert_counters(victim, CounterType::Minus1Minus1, 3);
+    outcome.assert_zone(&[emptiness], Zone::Graveyard);
+}

--- a/crates/engine/tests/integration/issue_5943_emptiness_evoke_color_spent.rs
+++ b/crates/engine/tests/integration/issue_5943_emptiness_evoke_color_spent.rs
@@ -130,6 +130,7 @@ fn emptiness_blinked_reentry_does_not_reuse_cast_color_tally() {
 
     let outcome = runner
         .cast(emptiness)
+        .alternative_cast(AlternativeCastDecision::Normal)
         .target_objects(&[first_return])
         .resolve();
 
@@ -140,7 +141,7 @@ fn emptiness_blinked_reentry_does_not_reuse_cast_color_tally() {
             .colors_spent_to_cast
             .get(engine::types::mana::ManaColor::White)
             >= 2,
-        "precondition: the original cast must record {W}{W} before the blink"
+        "precondition: the original cast must record two white mana before the blink"
     );
 
     let mut events = Vec::new();

--- a/crates/engine/tests/integration/issue_5943_emptiness_evoke_color_spent.rs
+++ b/crates/engine/tests/integration/issue_5943_emptiness_evoke_color_spent.rs
@@ -10,20 +10,20 @@
 //!
 //! Classifier: supported_aspect_defect. The AST already carries
 //! `TriggerCondition::ManaColorSpent { minimum: 2 }` on both ETBs; the defect
-//! was runtime — `clear_post_collection_transients` wiped `colors_spent_to_cast`
-//! after collection, so CR 603.4 ExactLive re-checks failed at resolution
-//! (Adamant / color-spent class, not Evoke-specific). The tally must also
-//! clear on battlefield exit (CR 400.7) so a blinked permanent does not
-//! inherit its previous cast colors on re-entry.
+//! was runtime lifecycle of `colors_spent_to_cast`:
+//!
+//!   * Too short: `clear_post_collection_transients` wiped the tally before CR
+//!     603.4 resolution re-checks on the original ETB.
+//!   * Too long: the tally survived battlefield exit or stack→graveyard without
+//!     becoming the permanent, so blink/reanimate paths inherited stale colors.
 //!
 //! https://github.com/phase-rs/phase/issues/5943
 
 use engine::game::scenario::{GameScenario, P0, P1};
-use engine::game::triggers::process_triggers;
-use engine::types::actions::AlternativeCastDecision;
+use engine::types::actions::{AlternativeCastDecision, GameAction};
 use engine::types::counter::CounterType;
 use engine::types::identifiers::ObjectId;
-use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
@@ -33,9 +33,21 @@ When this creature enters, if {B}{B} was spent to cast it, put three -1/-1 count
 target creature.\n\
 Evoke {W/B}{W/B}";
 
-fn add_mana(state: &mut engine::types::game_state::GameState, color: ManaType, n: u32) {
+const BLINK: &str =
+    "Exile target creature you control. Return it to the battlefield under its owner's control.";
+
+const COUNTERSPELL: &str = "Counter target spell.";
+
+const REANIMATE: &str = "Return target creature card from your graveyard to the battlefield.";
+
+fn add_mana(
+    state: &mut engine::types::game_state::GameState,
+    player: engine::types::player::PlayerId,
+    color: ManaType,
+    n: u32,
+) {
     for _ in 0..n {
-        state.players[0]
+        state.players[player.0 as usize]
             .mana_pool
             .add(ManaUnit::new(color, ObjectId(0), false, vec![]));
     }
@@ -67,9 +79,7 @@ fn emptiness_evoke_ww_returns_graveyard_creature_then_sacrifices() {
         .id();
 
     let mut runner = scenario.build();
-    // Enough for printed and evoke so the AlternativeCastChoice surfaces;
-    // choosing Evoke spends only {W/B}{W/B} as white.
-    add_mana(runner.state_mut(), ManaType::White, 6);
+    add_mana(runner.state_mut(), P0, ManaType::White, 6);
 
     let outcome = runner
         .cast(emptiness)
@@ -92,7 +102,7 @@ fn emptiness_evoke_bb_puts_minus_counters_then_sacrifices() {
     let victim = scenario.add_creature(P1, "Victim Bear", 4, 4).id();
 
     let mut runner = scenario.build();
-    add_mana(runner.state_mut(), ManaType::Black, 6);
+    add_mana(runner.state_mut(), P0, ManaType::Black, 6);
 
     let outcome = runner
         .cast(emptiness)
@@ -104,10 +114,8 @@ fn emptiness_evoke_bb_puts_minus_counters_then_sacrifices() {
     outcome.assert_zone(&[emptiness], Zone::Graveyard);
 }
 
-/// CR 400.7 + CR 603.4: A permanent cast with {W}{W} must satisfy
-/// `ManaColorSpent` on its **original** ETB, but after leaving and re-entering
-/// without a new cast the stale color tally must not survive — the white-spent
-/// branch must not fire again.
+/// CR 400.7 + CR 603.4: Blink through the production cast/zone-change pipeline
+/// must not let a hard-cast Emptiness reuse its prior {W}{W} tally on re-entry.
 #[test]
 fn emptiness_blinked_reentry_does_not_reuse_cast_color_tally() {
     let mut scenario = GameScenario::new();
@@ -122,11 +130,14 @@ fn emptiness_blinked_reentry_does_not_reuse_cast_color_tally() {
         .add_creature_to_graveyard(P0, "Blink Bait", 1, 1)
         .with_mana_cost(ManaCost::generic(1))
         .id();
+    let blink = scenario
+        .add_spell_to_hand_from_oracle(P0, "Cloudshift Test", true, BLINK)
+        .with_mana_cost(ManaCost::zero())
+        .id();
 
     let mut runner = scenario.build();
-    // Hard-cast for {W}{W}{4} (not Evoke) so Emptiness remains on the battlefield.
-    add_mana(runner.state_mut(), ManaType::White, 2);
-    add_mana(runner.state_mut(), ManaType::Colorless, 4);
+    add_mana(runner.state_mut(), P0, ManaType::White, 2);
+    add_mana(runner.state_mut(), P0, ManaType::Colorless, 4);
 
     let outcome = runner
         .cast(emptiness)
@@ -139,29 +150,12 @@ fn emptiness_blinked_reentry_does_not_reuse_cast_color_tally() {
     assert!(
         runner.state().objects[&emptiness]
             .colors_spent_to_cast
-            .get(engine::types::mana::ManaColor::White)
+            .get(ManaColor::White)
             >= 2,
         "precondition: the original cast must record two white mana before the blink"
     );
 
-    let mut events = Vec::new();
-    engine::game::zones::move_to_zone(runner.state_mut(), emptiness, Zone::Exile, &mut events);
-    assert_eq!(
-        runner.state().objects[&emptiness]
-            .colors_spent_to_cast
-            .get(engine::types::mana::ManaColor::White),
-        0,
-        "colors_spent_to_cast must clear on battlefield exit"
-    );
-
-    engine::game::zones::move_to_zone(
-        runner.state_mut(),
-        emptiness,
-        Zone::Battlefield,
-        &mut events,
-    );
-    process_triggers(runner.state_mut(), &events);
-    runner.advance_until_stack_empty();
+    runner.cast(blink).target_objects(&[emptiness]).resolve();
 
     assert_eq!(
         runner.state().objects[&blink_bait].zone,
@@ -172,5 +166,87 @@ fn emptiness_blinked_reentry_does_not_reuse_cast_color_tally() {
         runner.state().objects[&emptiness].zone,
         Zone::Battlefield,
         "Emptiness must remain on the battlefield after the blink"
+    );
+}
+
+/// CR 400.7: A {W}{W} Emptiness countered to the graveyard must drop its cast
+/// colors; a later Reanimate must not satisfy `ManaColorSpent` on entry.
+#[test]
+fn emptiness_countered_then_reanimated_does_not_reuse_cast_color_tally() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let emptiness = emptiness_in_hand(&mut scenario);
+    let reanimate_bait = scenario
+        .add_creature_to_graveyard(P0, "Reanimate Bait", 1, 1)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+
+    let counterspell = scenario
+        .add_spell_to_hand_from_oracle(P1, "Counterspell", true, COUNTERSPELL)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 0,
+            shards: vec![ManaCostShard::Blue, ManaCostShard::Blue],
+        })
+        .id();
+    scenario.add_basic_land(P1, ManaColor::Blue);
+    scenario.add_basic_land(P1, ManaColor::Blue);
+
+    let reanimate = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reanimate", false, REANIMATE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    add_mana(runner.state_mut(), P0, ManaType::White, 2);
+    add_mana(runner.state_mut(), P0, ManaType::Colorless, 4);
+
+    runner
+        .cast(emptiness)
+        .alternative_cast(AlternativeCastDecision::Normal)
+        .commit();
+
+    assert_eq!(
+        runner.state().objects[&emptiness].zone,
+        Zone::Stack,
+        "Emptiness must be on the stack before Counterspell"
+    );
+
+    // CR 117.7: P0 passes so P1 may cast Counterspell in response.
+    runner.act(GameAction::PassPriority).expect("P0 pass");
+
+    add_mana(runner.state_mut(), P1, ManaType::Blue, 2);
+    runner
+        .cast(counterspell)
+        .target_objects(&[emptiness])
+        .resolve();
+
+    assert_eq!(
+        runner.state().objects[&emptiness].zone,
+        Zone::Graveyard,
+        "Counterspell must move Emptiness to the graveyard"
+    );
+    assert_eq!(
+        runner.state().objects[&emptiness]
+            .colors_spent_to_cast
+            .get(ManaColor::White),
+        0,
+        "cast colors must clear when the spell leaves the stack without resolving"
+    );
+
+    runner
+        .cast(reanimate)
+        .target_objects(&[emptiness])
+        .resolve();
+
+    assert_eq!(
+        runner.state().objects[&emptiness].zone,
+        Zone::Battlefield,
+        "Reanimate must return Emptiness to the battlefield"
+    );
+    assert_eq!(
+        runner.state().objects[&reanimate_bait].zone,
+        Zone::Graveyard,
+        "without cast colors, the white-spent ETB must not return reanimate bait"
     );
 }

--- a/crates/engine/tests/integration/issue_5943_emptiness_evoke_color_spent.rs
+++ b/crates/engine/tests/integration/issue_5943_emptiness_evoke_color_spent.rs
@@ -12,11 +12,14 @@
 //! `TriggerCondition::ManaColorSpent { minimum: 2 }` on both ETBs; the defect
 //! was runtime — `clear_post_collection_transients` wiped `colors_spent_to_cast`
 //! after collection, so CR 603.4 ExactLive re-checks failed at resolution
-//! (Adamant / color-spent class, not Evoke-specific).
+//! (Adamant / color-spent class, not Evoke-specific). The tally must also
+//! clear on battlefield exit (CR 400.7) so a blinked permanent does not
+//! inherit its previous cast colors on re-entry.
 //!
 //! https://github.com/phase-rs/phase/issues/5943
 
 use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::triggers::process_triggers;
 use engine::types::actions::AlternativeCastDecision;
 use engine::types::counter::CounterType;
 use engine::types::identifiers::ObjectId;
@@ -99,4 +102,74 @@ fn emptiness_evoke_bb_puts_minus_counters_then_sacrifices() {
 
     outcome.assert_counters(victim, CounterType::Minus1Minus1, 3);
     outcome.assert_zone(&[emptiness], Zone::Graveyard);
+}
+
+/// CR 400.7 + CR 603.4: A permanent cast with {W}{W} must satisfy
+/// `ManaColorSpent` on its **original** ETB, but after leaving and re-entering
+/// without a new cast the stale color tally must not survive — the white-spent
+/// branch must not fire again.
+#[test]
+fn emptiness_blinked_reentry_does_not_reuse_cast_color_tally() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let emptiness = emptiness_in_hand(&mut scenario);
+    let first_return = scenario
+        .add_creature_to_graveyard(P0, "First Return", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    let blink_bait = scenario
+        .add_creature_to_graveyard(P0, "Blink Bait", 1, 1)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+
+    let mut runner = scenario.build();
+    // Hard-cast for {W}{W}{4} (not Evoke) so Emptiness remains on the battlefield.
+    add_mana(runner.state_mut(), ManaType::White, 2);
+    add_mana(runner.state_mut(), ManaType::Colorless, 4);
+
+    let outcome = runner
+        .cast(emptiness)
+        .target_objects(&[first_return])
+        .resolve();
+
+    outcome.assert_zone(&[first_return], Zone::Battlefield);
+    outcome.assert_zone(&[emptiness], Zone::Battlefield);
+    assert!(
+        runner.state().objects[&emptiness]
+            .colors_spent_to_cast
+            .get(engine::types::mana::ManaColor::White)
+            >= 2,
+        "precondition: the original cast must record {W}{W} before the blink"
+    );
+
+    let mut events = Vec::new();
+    engine::game::zones::move_to_zone(runner.state_mut(), emptiness, Zone::Exile, &mut events);
+    assert_eq!(
+        runner.state().objects[&emptiness]
+            .colors_spent_to_cast
+            .get(engine::types::mana::ManaColor::White),
+        0,
+        "colors_spent_to_cast must clear on battlefield exit"
+    );
+
+    engine::game::zones::move_to_zone(
+        runner.state_mut(),
+        emptiness,
+        Zone::Battlefield,
+        &mut events,
+    );
+    process_triggers(runner.state_mut(), &events);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&blink_bait].zone,
+        Zone::Graveyard,
+        "after blink, the white-spent ETB must not fire — blink bait stays in the graveyard"
+    );
+    assert_eq!(
+        runner.state().objects[&emptiness].zone,
+        Zone::Battlefield,
+        "Emptiness must remain on the battlefield after the blink"
+    );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -546,6 +546,7 @@ mod issue_5820_susan_foreman;
 mod issue_5821_psychic_paper_attach_choice;
 mod issue_583_vivi_ornitier_mana_source;
 mod issue_5910_kitchen_finks_persist;
+mod issue_5943_emptiness_evoke_color_spent;
 mod issue_5945_kellan_the_kid;
 mod issue_5946_pest_infestation_bogwater_softlock;
 mod issue_5963_scavengers_talent_food_sacrifice;


### PR DESCRIPTION
Closes #5943

## Summary

Discord report: **Emptiness** evoked with `{W}{W}` or `{B}{B}` (via hybrid Evoke `{W/B}{W/B}`) does not fire the matching color-spent ETB.

The parser AST was already faithful — two `ChangesZone` ETBs gated by `TriggerCondition::ManaColorSpent { minimum: 2 }` plus the synthetic Evoke sac. The defect was runtime: after trigger *collection* succeeded (colors still present), `clear_post_collection_transients` zeroed `colors_spent_to_cast` on every object. CR 603.4 re-checks the intervening-if at *resolution* via `ExactLive` (permanent still on the battlefield), so Adamant-style ETBs silently did nothing.

## Root cause

`mana_spent_to_cast_amount` was already treated as a durable cast fact (Hungry Graffalon / Topiary Lecturer), but `colors_spent_to_cast` was still cleared with the transient `mana_spent_to_cast` boolean. That asymmetric cleanup breaks every `ManaColorSpent` intervening-if that re-checks while the source is ExactLive — Evoke Emptiness is the reported instance of the Adamant / “if {C} was spent to cast it” class.

## Changes

- **`crates/engine/src/game/triggers.rs`** — stop clearing `colors_spent_to_cast` in `clear_post_collection_transients`; document CR 603.4 / ExactLive rationale; unit test that `ManaColorSpent` survives the clear.
- **`crates/engine/src/game/game_object.rs`** — align field docs: color tally is durable like `mana_spent_to_cast_amount`.
- **Integration** — evoke Emptiness paying WW (GY return + sac) and BB (three −1/−1 + sac).

## Test Plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo test -p engine --lib -- adamant_intervening_if_survives_post_collection_transient_clear`
- [ ] `cargo test -p engine --test integration -- emptiness_evoke`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved durable per-color “colors spent to cast” during post-trigger and intervening-if checks, while clearing transient cast markers (e.g., “mana spent to cast”).
  * Ensured cast-payment provenance is cleared when permanents leave the battlefield and when spells leave the stack to non-battlefield zones, preventing stale re-entry behavior.
  * Fixed *Emptiness* evoke/spent ETBs for both white and black mana paths across resolve, counter, blink, and reanimate scenarios.
* **Tests**
  * Added regression integration coverage for *Emptiness* evoke “color-spent,” including blink and counter/re-entry cases.
  * Added a unit test for battlefield-exit clearing of per-color tallies.
* **Documentation**
  * Clarified “colors spent to cast” vs transient cast tracking semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->