### PR TITLE
fix(engine): delayed ParentTarget snapshot must not bind the trigger source when zero targets were chosen (Depthshaker Titan)

### DIFF
--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -245,6 +245,23 @@ fn parent_target_snapshot(state: &GameState, ability: &ResolvedAbility) -> Vec<T
         return ability.targets.clone();
     }
 
+    // CR 601.2c + CR 608.2c (issue #5901): When the resolving root chain
+    // DECLARED a chooseable target slot — a `multi_target` bound ("any number
+    // of target noncreature artifacts", Depthshaker Titan) or an optional
+    // "up to one target" slot — reaching this point means the player legally
+    // chose ZERO targets: the two tiers above are empty precisely because the
+    // chosen set is empty. The ParentTarget anaphor ("them"/"it") refers to
+    // that empty chosen set, so the delayed trigger has no subject. Falling
+    // through to the triggering-source fallback instead bound the trigger's
+    // own event source — the Titan sacrificed ITSELF at the next end step.
+    // The fallback below remains for slotless parents (a dies/LTB trigger's
+    // "exile it at end of turn", where "it" genuinely names the event source).
+    if chain_declares_chooseable_target_slots(crate::game::targeting::resolving_root_ability(
+        state, ability,
+    )) {
+        return Vec::new();
+    }
+
     crate::game::targeting::resolve_event_context_target(
         state,
         &TargetFilter::TriggeringSource,
@@ -252,6 +269,25 @@ fn parent_target_snapshot(state: &GameState, ability: &ResolvedAbility) -> Vec<T
     )
     .map(|target| vec![target])
     .unwrap_or_default()
+}
+
+/// True when any link of the chain declares a target slot whose selection may
+/// legally be empty: a `multi_target` bound (CR 115.1d "any number of target
+/// ...") or `optional_targeting` (CR 115.1d "up to one target ..."). Used by
+/// [`parent_target_snapshot`] to distinguish "slots were declared but zero
+/// were chosen" (referent = empty set) from "no slots exist at all" (referent
+/// = the creation event's source object).
+fn chain_declares_chooseable_target_slots(ability: &ResolvedAbility) -> bool {
+    ability.multi_target.is_some()
+        || ability.optional_targeting
+        || ability
+            .sub_ability
+            .as_deref()
+            .is_some_and(chain_declares_chooseable_target_slots)
+        || ability
+            .else_ability
+            .as_deref()
+            .is_some_and(chain_declares_chooseable_target_slots)
 }
 
 fn triggering_source_destination_zone(state: &GameState) -> Option<Zone> {

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -245,15 +245,16 @@ fn parent_target_snapshot(state: &GameState, ability: &ResolvedAbility) -> Vec<T
         return ability.targets.clone();
     }
 
-    // CR 601.2c + CR 608.2c (issue #5901): When the resolving root chain
-    // DECLARED a chooseable target slot — a `multi_target` bound ("any number
-    // of target noncreature artifacts", Depthshaker Titan) or an optional
-    // "up to one target" slot — reaching this point means the player legally
-    // chose ZERO targets: the two tiers above are empty precisely because the
-    // chosen set is empty. The ParentTarget anaphor ("them"/"it") refers to
-    // that empty chosen set, so the delayed trigger has no subject. Falling
-    // through to the triggering-source fallback instead bound the trigger's
-    // own event source — the Titan sacrificed ITSELF at the next end step.
+    // CR 603.3d + CR 115.6 + CR 608.2c (issue #5901): When the resolving root
+    // chain DECLARED a chooseable target slot — a `multi_target` bound ("any
+    // number of target noncreature artifacts", Depthshaker Titan) or an
+    // optional "up to one target" slot — reaching this point means the player
+    // legally chose ZERO targets: triggered-ability targets are chosen while
+    // putting the ability on the stack, and such an ability may allow zero
+    // targets. The ParentTarget anaphor ("them"/"it") refers to that empty
+    // chosen set, so the delayed trigger has no subject. Falling through to the
+    // triggering-source fallback instead bound the trigger's own event source
+    // — the Titan sacrificed ITSELF at the next end step.
     // The fallback below remains for slotless parents (a dies/LTB trigger's
     // "exile it at end of turn", where "it" genuinely names the event source).
     if chain_declares_chooseable_target_slots(crate::game::targeting::resolving_root_ability(
@@ -272,9 +273,10 @@ fn parent_target_snapshot(state: &GameState, ability: &ResolvedAbility) -> Vec<T
 }
 
 /// True when any link of the chain declares a target slot whose selection may
-/// legally be empty: a `multi_target` bound (CR 115.1d "any number of target
-/// ...") or `optional_targeting` (CR 115.1d "up to one target ..."). Used by
-/// [`parent_target_snapshot`] to distinguish "slots were declared but zero
+/// legally be empty: a `multi_target` bound ("any number of target ...") or
+/// `optional_targeting` ("up to one target ..."). CR 115.6 permits zero
+/// targets; CR 603.3d governs the target choice for triggered abilities. Used
+/// by [`parent_target_snapshot`] to distinguish "slots were declared but zero
 /// were chosen" (referent = empty set) from "no slots exist at all" (referent
 /// = the creation event's source object).
 fn chain_declares_chooseable_target_slots(ability: &ResolvedAbility) -> bool {

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -850,7 +850,20 @@ pub(crate) fn parent_chain_targets_from_root(
     state: &GameState,
     ability: &ResolvedAbility,
 ) -> Vec<TargetRef> {
-    let root = state
+    super::ability_utils::flatten_targets_in_chain(resolving_root_ability(state, ability))
+}
+
+/// CR 608.2c: The root `ResolvedAbility` of the currently-resolving stack
+/// entry that `ability` belongs to (falling back to `ability` itself when no
+/// matching entry is found — e.g. hand-built test abilities resolved outside
+/// the stack). Single authority for the root-entry lookup shared by
+/// [`parent_chain_targets_from_root`] and the delayed-trigger creation
+/// snapshot (`effects::delayed_trigger`).
+pub(crate) fn resolving_root_ability<'a>(
+    state: &'a GameState,
+    ability: &'a ResolvedAbility,
+) -> &'a ResolvedAbility {
+    state
         .resolving_stack_entry
         .as_ref()
         .filter(|entry| entry.id == ability.source_id || entry.source_id == ability.source_id)
@@ -861,8 +874,7 @@ pub(crate) fn parent_chain_targets_from_root(
                 .find(|entry| entry.id == ability.source_id || entry.source_id == ability.source_id)
         })
         .and_then(|entry| entry.ability())
-        .unwrap_or(ability);
-    super::ability_utils::flatten_targets_in_chain(root)
+        .unwrap_or(ability)
 }
 
 /// CR 608.2c: Resolve a single earlier target slot by its declared `index` from

--- a/crates/engine/tests/integration/issue_5901_depthshaker_titan.rs
+++ b/crates/engine/tests/integration/issue_5901_depthshaker_titan.rs
@@ -5,7 +5,8 @@
 //! Reported symptom: the Titan sacrificed ITSELF at the next end step.
 //!
 //! Root cause: the ETB trigger's "any number of target ..." slot may legally
-//! be filled with ZERO targets (CR 115.1d). The delayed trigger's inner
+//! be filled with ZERO targets (CR 115.6; target choice for this triggered
+//! ability follows CR 603.3d). The delayed trigger's inner
 //! `Sacrifice { target: ParentTarget }` snapshots its subject at creation time
 //! via `parent_target_snapshot` (`game/effects/delayed_trigger.rs`), whose
 //! referent ladder was: root-chain chosen targets → the node's own propagated
@@ -34,6 +35,7 @@ const DEPTHSHAKER_TITAN: &str = "When this creature enters, any number of target
 /// any `EffectZoneChoice`, so tests can assert none was offered.
 fn settle_to_end_step(runner: &mut super::rules::GameRunner) -> Vec<Vec<ObjectId>> {
     let mut pools = Vec::new();
+    let mut settled = false;
     for _ in 0..120 {
         let at_end = runner.state().phase == Phase::End;
         let stack_len = runner.state().stack.len();
@@ -47,6 +49,7 @@ fn settle_to_end_step(runner: &mut super::rules::GameRunner) -> Vec<Vec<ObjectId
             }
             WaitingFor::Priority { .. } => {
                 if at_end && stack_len == 0 {
+                    settled = true;
                     // End step reached and settled (whether or not the delayed
                     // trigger fired) — stop so the asserts see final zones.
                     break;
@@ -67,6 +70,10 @@ fn settle_to_end_step(runner: &mut super::rules::GameRunner) -> Vec<Vec<ObjectId
             other => panic!("unexpected WaitingFor while settling end step: {other:?}"),
         }
     }
+    assert!(
+        settled,
+        "did not reach a settled end step within 120 actions"
+    );
     pools
 }
 

--- a/crates/engine/tests/integration/issue_5901_depthshaker_titan.rs
+++ b/crates/engine/tests/integration/issue_5901_depthshaker_titan.rs
@@ -1,0 +1,179 @@
+//! Regression tests for issue #5901 — Depthshaker Titan: "When this creature
+//! enters, any number of target noncreature artifacts you control become 3/3
+//! artifact creatures. Sacrifice them at the beginning of the next end step."
+//!
+//! Reported symptom: the Titan sacrificed ITSELF at the next end step.
+//!
+//! Root cause: the ETB trigger's "any number of target ..." slot may legally
+//! be filled with ZERO targets (CR 115.1d). The delayed trigger's inner
+//! `Sacrifice { target: ParentTarget }` snapshots its subject at creation time
+//! via `parent_target_snapshot` (`game/effects/delayed_trigger.rs`), whose
+//! referent ladder was: root-chain chosen targets → the node's own propagated
+//! targets → the creation event's source object (`TriggeringSource`). With
+//! zero chosen targets the first two tiers are empty, so the ladder fell
+//! through to the event-context tier and bound the ETB event's source — the
+//! Titan itself — as "them", sacrificing it at the next end step (CR 603.7c:
+//! the anaphor's referent is the empty chosen set, not the trigger's own
+//! source). Fixed by returning the empty set from the snapshot when the
+//! resolving root chain DECLARED a chooseable target slot (`multi_target` /
+//! `optional_targeting`): reaching the fallback with such a declaration means
+//! the player chose zero targets. The event-source fallback is preserved for
+//! slotless parents (a dies/LTB trigger's "exile it at the beginning of the
+//! next end step", where "it" genuinely names the event source).
+
+use super::rules::{GameScenario, Phase, WaitingFor, P0};
+use engine::types::actions::GameAction;
+use engine::types::identifiers::ObjectId;
+use engine::types::zones::Zone;
+
+const DEPTHSHAKER_TITAN: &str = "When this creature enters, any number of target noncreature artifacts you control become 3/3 artifact creatures. Sacrifice them at the beginning of the next end step.\nEach artifact creature you control has melee, trample, and haste. (Whenever a creature with melee attacks, it gets +1/+1 until end of turn for each opponent you attacked this combat.)";
+
+/// Drive the game to the first end step with a settled stack, answering the
+/// prompts that surface on the way (combat declarations, any sacrifice
+/// selection raised by the delayed trigger). Returns the card pools offered by
+/// any `EffectZoneChoice`, so tests can assert none was offered.
+fn settle_to_end_step(runner: &mut super::rules::GameRunner) -> Vec<Vec<ObjectId>> {
+    let mut pools = Vec::new();
+    for _ in 0..120 {
+        let at_end = runner.state().phase == Phase::End;
+        let stack_len = runner.state().stack.len();
+        match runner.state().waiting_for.clone() {
+            WaitingFor::EffectZoneChoice { cards, count, .. } => {
+                pools.push(cards.clone());
+                let pick: Vec<_> = cards.into_iter().take(count.max(1)).collect();
+                runner
+                    .act(GameAction::SelectCards { cards: pick })
+                    .expect("submit zone-choice selection");
+            }
+            WaitingFor::Priority { .. } => {
+                if at_end && stack_len == 0 {
+                    // End step reached and settled (whether or not the delayed
+                    // trigger fired) — stop so the asserts see final zones.
+                    break;
+                }
+                runner.act(GameAction::PassPriority).expect("pass priority");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::DeclareAttackers { .. } => {
+                runner
+                    .act(GameAction::DeclareAttackers {
+                        attacks: vec![],
+                        bands: vec![],
+                    })
+                    .expect("declare no attackers");
+            }
+            other => panic!("unexpected WaitingFor while settling end step: {other:?}"),
+        }
+    }
+    pools
+}
+
+/// Baseline (already-correct path, guards against over-fixing): two chosen
+/// artifacts are animated and BOTH are sacrificed at the next end step; the
+/// Titan itself and an unchosen artifact survive.
+#[test]
+fn depthshaker_titan_sacrifices_only_chosen_artifacts() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let titan = scenario
+        .add_creature_to_hand(P0, "Depthshaker Titan", 8, 8)
+        .from_oracle_text(DEPTHSHAKER_TITAN)
+        .id();
+    let chosen_a = scenario
+        .add_creature(P0, "Chosen Mox A", 0, 0)
+        .as_artifact()
+        .id();
+    let chosen_b = scenario
+        .add_creature(P0, "Chosen Mox B", 0, 0)
+        .as_artifact()
+        .id();
+    let unchosen = scenario
+        .add_creature(P0, "Unchosen Monument", 0, 0)
+        .as_artifact()
+        .id();
+
+    let mut runner = scenario.build();
+    runner
+        .cast(titan)
+        .free_cast()
+        .target_objects(&[chosen_a, chosen_b])
+        .resolve();
+
+    // The ETB animation must be live before the end step.
+    for id in [chosen_a, chosen_b] {
+        let obj = &runner.state().objects[&id];
+        assert!(
+            obj.card_types
+                .core_types
+                .contains(&engine::types::card_type::CoreType::Creature),
+            "chosen artifact must be animated to a creature before end step"
+        );
+    }
+
+    settle_to_end_step(&mut runner);
+
+    let state = runner.state();
+    assert_eq!(
+        state.objects.get(&titan).map(|o| o.zone),
+        Some(Zone::Battlefield),
+        "the Titan itself must NOT be sacrificed by its own delayed trigger"
+    );
+    assert_eq!(
+        state.objects.get(&chosen_a).map(|o| o.zone),
+        Some(Zone::Graveyard),
+        "first chosen artifact must be sacrificed at the next end step"
+    );
+    assert_eq!(
+        state.objects.get(&chosen_b).map(|o| o.zone),
+        Some(Zone::Graveyard),
+        "second chosen artifact must be sacrificed at the next end step"
+    );
+    assert_eq!(
+        state.objects.get(&unchosen).map(|o| o.zone),
+        Some(Zone::Battlefield),
+        "an unchosen artifact must survive the delayed trigger"
+    );
+}
+
+/// The reported bug: "any number of target ... artifacts" legally includes
+/// ZERO targets. With no chosen artifacts the delayed sacrifice has no
+/// subject — it must NOT fall back to sacrificing the Titan itself.
+///
+/// Pre-fix this failed with the Titan in the graveyard at the end step
+/// (`parent_target_snapshot`'s event-context tier bound the ETB event source).
+#[test]
+fn depthshaker_titan_zero_targets_does_not_sacrifice_itself() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let titan = scenario
+        .add_creature_to_hand(P0, "Depthshaker Titan", 8, 8)
+        .from_oracle_text(DEPTHSHAKER_TITAN)
+        .id();
+    let bystander = scenario
+        .add_creature(P0, "Bystander Monument", 0, 0)
+        .as_artifact()
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(titan).free_cast().resolve();
+
+    let pools = settle_to_end_step(&mut runner);
+
+    let state = runner.state();
+    assert_eq!(
+        state.objects.get(&titan).map(|o| o.zone),
+        Some(Zone::Battlefield),
+        "with zero chosen artifacts the Titan must NOT sacrifice itself"
+    );
+    assert_eq!(
+        state.objects.get(&bystander).map(|o| o.zone),
+        Some(Zone::Battlefield),
+        "an untargeted artifact must not be sacrificed either"
+    );
+    assert!(
+        pools.is_empty(),
+        "no sacrifice choice should be offered when nothing was animated; got {pools:?}"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -549,6 +549,7 @@ mod issue_581_mystic_remora_cumulative_upkeep;
 mod issue_5820_susan_foreman;
 mod issue_5821_psychic_paper_attach_choice;
 mod issue_583_vivi_ornitier_mana_source;
+mod issue_5901_depthshaker_titan;
 mod issue_5910_kitchen_finks_persist;
 mod issue_5945_kellan_the_kid;
 mod issue_5946_pest_infestation_bogwater_softlock;


### PR DESCRIPTION
Tier: Standard
Model: claude-fable-5
Thinking: high

Closes #5901

## What was broken

Depthshaker Titan — "When this creature enters, **any number of target** noncreature artifacts you control become 3/3 artifact creatures. **Sacrifice them** at the beginning of the next end step." — sacrificed **itself** at the next end step when the controller chose **zero** targets for the ETB trigger (a legal choice for an "any number of target …" slot, CR 115.1d).

## Root cause

The delayed trigger's inner `Sacrifice { target: ParentTarget }` snapshots its subject at creation time via `parent_target_snapshot` (`crates/engine/src/game/effects/delayed_trigger.rs`). The referent ladder was:

1. root-chain chosen targets (`parent_chain_targets_from_root`),
2. the node's own propagated `targets`,
3. the creation event's source object (`TriggeringSource`).

With zero chosen targets, tiers 1–2 are empty **because the chosen set is empty**, but the ladder couldn't tell that apart from "the parent has no target slots at all" — so it fell through to tier 3 and bound the ETB event's source, i.e. the Titan itself, as "them". At the next end step the delayed trigger dutifully sacrificed the Titan.

## Fix

`parent_target_snapshot` now returns the empty set instead of consulting the event-context fallback when the resolving root chain **declared a chooseable target slot** (`multi_target` — "any number of target …" — or `optional_targeting` — "up to one target …"). Reaching the fallback with such a declaration means the player legally chose zero targets, and the `ParentTarget` anaphor's referent is that empty chosen set (CR 608.2c), not the trigger's own source (CR 603.7c).

The event-source fallback is preserved unchanged for slotless parents, where it is load-bearing (a dies/LTB trigger's "exile **it** at the beginning of the next end step" — "it" genuinely names the event source).

Supporting refactor: the root-entry lookup previously inlined in `parent_chain_targets_from_root` (`game/targeting.rs`) is extracted into `resolving_root_ability` so the new predicate reads the same root the target flattening already uses — one authority, no duplicated stack walk.

## Tests

`crates/engine/tests/integration/issue_5901_depthshaker_titan.rs`, driving the real cast → ETB trigger targeting → delayed-trigger pipeline end to end:

- `depthshaker_titan_zero_targets_does_not_sacrifice_itself` — the reported bug. **Fails pre-fix** (Titan in graveyard at the end step, verified via stash) and passes post-fix; also asserts no sacrifice choice prompt surfaces and a bystander artifact is untouched.
- `depthshaker_titan_sacrifices_only_chosen_artifacts` — over-fix guard for the already-correct path: two chosen artifacts are animated and both ARE sacrificed at the next end step, while the Titan and an unchosen artifact survive. Passes pre- and post-fix.

## Verification

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- full engine lib suite: green
- full integration suite: green


## Gate A

`bash scripts/check-parser-combinators.sh` → **Gate A PASS head=6b9e1295074bdaa02fb906477eccd338b9347202 base=21fc5f3b476021ea78e38b712cbffe0ae417a5d9** (Gate G PASS as well — no parser files are touched by this diff). `scripts/check-engine-authorities.sh` → Gate B PASS (37 classified hits), Gate D PASS (28 classified hits), draw-replacement producers PASS.

## Anchored on

- `crates/engine/src/game/effects/delayed_trigger.rs` — `parent_target_snapshot`'s own tier documentation (the CR 608.2c phase#4767 note): the existing ladder already distinguishes "root chain exposes no concrete slot because the target was runtime-injected" (Animate Dead) from the declared-slot case; this fix adds the missing third distinction — "slots declared, zero chosen" — at the same seam.
- `crates/engine/src/game/targeting.rs` — `parent_chain_targets_from_root`, the single root-entry lookup authority; the new `resolving_root_ability` is extracted from it (not duplicated) so the predicate reads the same root the target flattening reads.
- `crates/engine/src/game/targeting.rs` — `resolved_targets`' documented `None`/`ParentTarget` → source fallback (Rancor / Spirit Loop): the reason the event-source tier must be *preserved* for slotless parents rather than removed outright.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected delayed effects with zero selected targets so they no longer incorrectly affect the effect’s source.
  * Improved target resolution across nested abilities and optional or multi-target effects.
  * Fixed Depthshaker Titan interactions so only selected artifacts are sacrificed, while zero-target resolutions leave all permanents intact.

* **Tests**
  * Added regression coverage for selected-target and zero-target Depthshaker Titan scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->