### PR TITLE
style(tests): move CR733 fixture loader import

### DIFF
--- a/crates/engine/tests/integration/cr733_resolved_commands_p0.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p0.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
+use std::io::Read;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -8,7 +9,6 @@ use serde_json::Value;
 // Fixtures are gzipped to keep the repo small; regenerating via
 // scripts/cr733_mutation_census.py requires re-gzipping (`gzip -9 -n`).
 fn gunzip(gz: &[u8]) -> String {
-    use std::io::Read;
     let mut json = String::new();
     flate2::read::GzDecoder::new(gz)
         .read_to_string(&mut json)


### PR DESCRIPTION
## Summary

Moves the `Read` trait import for the CR733 gzip fixture loader to the module import block.

## Verification

- `cargo fmt --all`
- Pre-commit parser combinator gates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified an internal test fixture’s import organization without changing functionality or user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->