### PR TITLE
fix(desktop): keep preview navigation in app

### DIFF
--- a/client/src/components/chrome/BuildBadge.tsx
+++ b/client/src/components/chrome/BuildBadge.tsx
@@ -94,7 +94,7 @@ export function BuildBadge({ className = "", inline = false, compact = false }: 
   if (compact) {
     const tooltip = [
       `v${__APP_VERSION__} · ${__BUILD_HASH__}`,
-      shellVersion && `shell ${shellVersion}`,
+      shellVersion && t("buildBadge.desktopAppVersion", { version: shellVersion }),
       cardDataMeta &&
         t("buildBadge.cardDataTitle", {
           date: cardDataMeta.generated_at,
@@ -114,7 +114,6 @@ export function BuildBadge({ className = "", inline = false, compact = false }: 
           className="inline-flex items-center gap-1 font-mono text-[10.5px] leading-none text-slate-400 transition-colors hover:text-white"
         >
           <span>v{__APP_VERSION__}</span>
-          {shellVersion && <span>shell {shellVersion}</span>}
           <span className={`text-[11px] text-slate-500 ${isActive ? "animate-spin" : ""}`} aria-hidden>
             ↻
           </span>
@@ -157,7 +156,7 @@ export function BuildBadge({ className = "", inline = false, compact = false }: 
         {shellVersion && (
           <>
             <span className="text-slate-700">·</span>
-            <span>shell {shellVersion}</span>
+            <span>{t("buildBadge.desktopAppVersion", { version: shellVersion })}</span>
           </>
         )}
 

--- a/client/src/components/chrome/PreviewBadge.tsx
+++ b/client/src/components/chrome/PreviewBadge.tsx
@@ -39,8 +39,8 @@ export function PreviewBadge() {
       <div className="fixed right-3 top-[calc(env(safe-area-inset-top)+3.75rem)] z-30 flex max-w-[calc(100vw-1.5rem)] justify-end sm:right-4">
         <a
           href={__RELEASE_SITE_URL__}
-          target="_blank"
-          rel="noopener noreferrer"
+          target={isRemoteTauriShell ? undefined : "_blank"}
+          rel={isRemoteTauriShell ? undefined : "noopener noreferrer"}
           onClick={(e) => {
             e.preventDefault();
             rememberChannelPreference("release");
@@ -64,14 +64,17 @@ export function PreviewBadge() {
     );
   }
 
-  if (!__IS_RELEASE_BUILD__) return null;
+  // A remote desktop shell must always be able to switch back to preview,
+  // including when it is testing a locally-built release page without the
+  // production release flag stamped into the bundle.
+  if (!__IS_RELEASE_BUILD__ && !isRemoteTauriShell) return null;
 
   return (
     <div className="fixed right-3 top-[calc(env(safe-area-inset-top)+3.75rem)] z-30 flex max-w-[calc(100vw-1.5rem)] justify-end sm:right-4">
       <a
         href={__PREVIEW_SITE_URL__}
-        target="_blank"
-        rel="noopener noreferrer"
+        target={isRemoteTauriShell ? undefined : "_blank"}
+        rel={isRemoteTauriShell ? undefined : "noopener noreferrer"}
         // The remote Tauri shell keeps first-party navigation in the webview;
         // web builds retain the existing external-tab behavior.
         onClick={(e) => {

--- a/client/src/components/chrome/__tests__/PreviewBadge.test.tsx
+++ b/client/src/components/chrome/__tests__/PreviewBadge.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { isBundledTauriOriginMock, isTauriMock } = vi.hoisted(() => ({
+  isBundledTauriOriginMock: vi.fn(),
+  isTauriMock: vi.fn(),
+}));
+
+vi.mock("../../../services/platform", () => ({
+  isBundledTauriOrigin: isBundledTauriOriginMock,
+  isTauri: isTauriMock,
+}));
+
+vi.mock("../../../services/channelPreference", () => ({
+  rememberChannelPreference: vi.fn(),
+}));
+
+vi.mock("../../../services/openExternal", () => ({
+  openExternal: vi.fn(),
+}));
+
+import { PreviewBadge } from "../PreviewBadge";
+
+beforeEach(() => {
+  isTauriMock.mockReturnValue(true);
+  isBundledTauriOriginMock.mockReturnValue(false);
+});
+
+describe("PreviewBadge", () => {
+  it("keeps preview navigation in the remote Tauri webview", () => {
+    render(<PreviewBadge />);
+
+    const link = screen.getByRole("link", { name: /try preview/i });
+    expect(link).toHaveAttribute("href", "https://preview.phase-rs.dev");
+    expect(link).not.toHaveAttribute("target");
+  });
+});

--- a/client/src/components/menu/MenuActionTile.tsx
+++ b/client/src/components/menu/MenuActionTile.tsx
@@ -100,9 +100,9 @@ export function MenuActionTile({
           {renderIcon("h-4 w-4")}
         </span>
       </div>
-      <div className="relative flex min-h-[120px] flex-1 items-center justify-center overflow-hidden rounded-[6px] bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(0,0,0,0.32))] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.35)]">
+      <div className="relative flex min-h-[120px] flex-1 items-center justify-center overflow-hidden rounded-[6px] bg-[linear-gradient(180deg,rgba(255,255,255,0.05),rgba(0,0,0,0.32))] shadow-[inset_0_0_0_1px_rgba(0,0,0,0.35)] [@media(max-height:540px)]:min-h-[64px]">
         <span className={`relative -rotate-6 opacity-[0.14] transition-all duration-300 ${ghostHover}`}>
-          {renderIcon("h-28 w-28")}
+          {renderIcon("h-28 w-28 [@media(max-height:540px)]:h-16 [@media(max-height:540px)]:w-16")}
         </span>
         {/* Particle field renders in front of the icon so motes sparkle over it. */}
         {showMotif && <TileMotifLayer motif={motif!} color={`rgb(${t.rgb})`} />}

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -22,6 +22,7 @@
     "updatePending": "Aktualisierung nach dem Spiel ausstehend",
     "cards": "Karten {{age}} ({{commit}})",
     "cardDataTitle": "Kartendaten erzeugt am {{date}} aus {{commit}}",
+    "desktopAppVersion": "Desktop-App v{{version}}",
     "checkForUpdates": "Nach Updates suchen",
     "updaterDebugInfo": "Updater-Debug-Informationen",
     "updaterIssue": "Updater-Problem: {{error}}",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -22,6 +22,7 @@
     "updatePending": "update pending after game",
     "cards": "cards {{age}} ({{commit}})",
     "cardDataTitle": "Card data generated {{date}} from {{commit}}",
+    "desktopAppVersion": "Desktop app v{{version}}",
     "checkForUpdates": "Check for updates",
     "updaterDebugInfo": "Updater debug info",
     "updaterIssue": "Updater issue: {{error}}",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -22,6 +22,7 @@
     "updatePending": "actualización pendiente tras la partida",
     "cards": "cartas {{age}} ({{commit}})",
     "cardDataTitle": "Datos de cartas generados el {{date}} desde {{commit}}",
+    "desktopAppVersion": "Aplicación de escritorio v{{version}}",
     "checkForUpdates": "Buscar actualizaciones",
     "updaterDebugInfo": "Información de depuración del actualizador",
     "updaterIssue": "Problema del actualizador: {{error}}",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -22,6 +22,7 @@
     "updatePending": "mise à jour en attente après la partie",
     "cards": "cartes {{age}} ({{commit}})",
     "cardDataTitle": "Données de cartes générées le {{date}} à partir de {{commit}}",
+    "desktopAppVersion": "Application de bureau v{{version}}",
     "checkForUpdates": "Rechercher des mises à jour",
     "updaterDebugInfo": "Infos de débogage de la mise à jour",
     "updaterIssue": "Problème de mise à jour : {{error}}",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -22,6 +22,7 @@
     "updatePending": "aggiornamento in attesa al termine della partita",
     "cards": "carte {{age}} ({{commit}})",
     "cardDataTitle": "Dati carte generati il {{date}} da {{commit}}",
+    "desktopAppVersion": "App desktop v{{version}}",
     "checkForUpdates": "Controlla aggiornamenti",
     "updaterDebugInfo": "Info di debug dell'aggiornatore",
     "updaterIssue": "Problema dell'aggiornatore: {{error}}",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -22,6 +22,7 @@
     "updatePending": "aktualizacja oczekuje po zakończeniu gry",
     "cards": "karty {{age}} ({{commit}})",
     "cardDataTitle": "Dane kart wygenerowane {{date}} z {{commit}}",
+    "desktopAppVersion": "Aplikacja komputerowa v{{version}}",
     "checkForUpdates": "Sprawdź aktualizacje",
     "updaterDebugInfo": "Informacje debugowania aktualizatora",
     "updaterIssue": "Problem z aktualizatorem: {{error}}",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -22,6 +22,7 @@
     "updatePending": "atualização pendente após o jogo",
     "cards": "cartas {{age}} ({{commit}})",
     "cardDataTitle": "Dados das cartas gerados em {{date}} a partir de {{commit}}",
+    "desktopAppVersion": "Aplicativo para desktop v{{version}}",
     "checkForUpdates": "Verificar atualizações",
     "updaterDebugInfo": "Informações de depuração do atualizador",
     "updaterIssue": "Problema no atualizador: {{error}}",

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -54,6 +54,8 @@ export default defineConfig({
       process.env.DEFAULT_MULTIPLAYER_SERVER_URL || "wss://lobby.phase-rs.dev/ws",
     ),
     __GIT_REPO_URL__: JSON.stringify("https://github.com/phase-rs/phase"),
+    __PREVIEW_SITE_URL__: JSON.stringify("https://preview.phase-rs.dev"),
+    __RELEASE_SITE_URL__: JSON.stringify("https://phase-rs.dev"),
     __IS_RELEASE_BUILD__: JSON.stringify(false),
     // Empty ⇒ telemetry is build-disabled in tests (no network egress).
     __TELEMETRY_URL__: JSON.stringify(""),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview and release switching is now available in remote desktop app environments.
  * Preview and back links remain within the desktop app instead of opening a new browser tab.
  * Desktop app version labels are now localized across supported languages.
* **Bug Fixes**
  * Desktop app version information is consistently displayed in badges and compact layouts.
* **Style**
  * Updated menu tile visuals and responsive icon sizing for shorter screens.
* **Tests**
  * Added coverage for preview link behavior in the desktop app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->