### PR TITLE
Add mobile hand hold, scrub, and drag previews

### DIFF
--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import {
+  AnimatePresence,
+  motion,
+  useAnimationControls,
+  useReducedMotion,
+} from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 import type { AbilityBlockKind, ChosenAttribute, GameObject, Keyword, ManaCost, Zone } from "../../adapter/types.ts";
@@ -13,7 +18,7 @@ import { tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import type { CardRuling } from "../../services/engineRuntime.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
-import { useUiStore } from "../../stores/uiStore.ts";
+import { useUiStore, type MobileHandGesture } from "../../stores/uiStore.ts";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
 import { RichLabel } from "../mana/RichLabel.tsx";
 import { CardArtFallback } from "./CardArtFallback.tsx";
@@ -65,6 +70,10 @@ export interface CardHoverInfo {
 
 interface CardPreviewProps {
   cardName: string | null;
+  /** In-game object whose details and art metadata belong to this preview.
+   *  Explicitly carrying the identity keeps an exiting animation pinned to its
+   *  original object while a rapid hover/scrub starts the next preview. */
+  objectId?: number | null;
   backFaceName?: string | null;
   faceIndex?: number;
   position?: { x: number; y: number };
@@ -102,6 +111,7 @@ interface HandPreviewOrigin {
 
 export function CardPreview({
   cardName,
+  objectId,
   backFaceName,
   faceIndex,
   position,
@@ -112,6 +122,17 @@ export function CardPreview({
   mobileLayout = "modal",
   handSourceObjectId,
 }: CardPreviewProps) {
+  const mobileHandGesture = useUiStore((s) => s.mobileHandGesture);
+  const shouldReduceMotion = useReducedMotion();
+  const animationSpeedMultiplier = usePreferencesStore((s) => s.animationSpeedMultiplier);
+  const isHeldCardDrag =
+    mobileHandGesture?.phase === "drag"
+    && mobileHandGesture.objectId === handSourceObjectId;
+  const [dragHandoffComplete, setDragHandoffComplete] = useState(false);
+  const heldSourceOrigin =
+    mobileHandGesture != null && mobileHandGesture.objectId === handSourceObjectId
+      ? mobileHandGesture.sourceOrigin
+      : null;
   const [measuredHandOrigin, setMeasuredHandOrigin] = useState<{
     objectId: number;
     origin: HandPreviewOrigin | null;
@@ -120,6 +141,17 @@ export function CardPreview({
   useLayoutEffect(() => {
     if (!cardName || handSourceObjectId == null || typeof document === "undefined") {
       setMeasuredHandOrigin(null);
+      return;
+    }
+
+    // The source card leaves the fan as soon as the hold becomes active. Keep
+    // using the geometry captured immediately before that collapse so the
+    // preview still grows from the card the player's finger actually lifted.
+    if (heldSourceOrigin) {
+      setMeasuredHandOrigin({
+        objectId: handSourceObjectId,
+        origin: { objectId: handSourceObjectId, ...heldSourceOrigin },
+      });
       return;
     }
 
@@ -150,7 +182,34 @@ export function CardPreview({
         width: source.offsetWidth || rect.width,
       },
     });
-  }, [cardName, handSourceObjectId]);
+  }, [cardName, handSourceObjectId, heldSourceOrigin]);
+
+  useEffect(() => {
+    if (!isHeldCardDrag) {
+      setDragHandoffComplete(false);
+      return undefined;
+    }
+
+    if (animationSpeedMultiplier <= 0) {
+      setDragHandoffComplete(true);
+      return undefined;
+    }
+
+    const durationMs = (shouldReduceMotion ? 60 : 120) * animationSpeedMultiplier;
+    const timeoutId = window.setTimeout(() => {
+      setDragHandoffComplete(true);
+    }, durationMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [animationSpeedMultiplier, isHeldCardDrag, shouldReduceMotion]);
+
+  // Keep the large inspection card alive just long enough to crossfade into
+  // the lifted card. The hand-sized drag visual already tracks the live finger
+  // position, so translating this second copy during the handoff would make
+  // the same card appear in two moving places at once.
+  if (isHeldCardDrag && (dragHandoffComplete || animationSpeedMultiplier <= 0)) {
+    return null;
+  }
 
   const handMeasurementReady =
     handSourceObjectId == null || measuredHandOrigin?.objectId === handSourceObjectId;
@@ -158,13 +217,21 @@ export function CardPreview({
     measuredHandOrigin && measuredHandOrigin.objectId === handSourceObjectId
       ? measuredHandOrigin.origin
       : null;
+  // A hand browse is one continuous preview session. Keeping this key stable
+  // across adjacent cards prevents AnimatePresence from leaving a trail of
+  // full-size previews that shrink onto previously scrubbed hand slots. The
+  // initial appearance and final dismissal still mount/unmount normally.
+  const previewKey = handSourceObjectId != null
+    ? "hand-preview"
+    : `${objectId ?? cardName}:${faceIndex ?? 0}:${scryfallId ?? ""}`;
 
   return (
     <AnimatePresence>
       {cardName && handMeasurementReady ? (
         <CardPreviewInner
-          key={`${cardName}:${faceIndex ?? 0}:${scryfallId ?? ""}`}
+          key={previewKey}
           cardName={cardName}
+          objectId={objectId}
           backFaceName={backFaceName ?? null}
           faceIndex={faceIndex}
           position={position}
@@ -174,6 +241,7 @@ export function CardPreview({
           onDismiss={onDismiss}
           mobileLayout={mobileLayout}
           handOrigin={handOrigin}
+          mobileHandGesture={mobileHandGesture}
         />
       ) : null}
     </AnimatePresence>
@@ -182,6 +250,7 @@ export function CardPreview({
 
 function CardPreviewInner({
   cardName,
+  objectId,
   backFaceName: backFaceNameProp,
   faceIndex,
   position,
@@ -191,8 +260,10 @@ function CardPreviewInner({
   onDismiss,
   mobileLayout,
   handOrigin,
+  mobileHandGesture,
 }: {
   cardName: string;
+  objectId?: number | null;
   backFaceName: string | null;
   faceIndex?: number;
   position?: { x: number; y: number };
@@ -202,13 +273,15 @@ function CardPreviewInner({
   onDismiss?: () => void;
   mobileLayout?: "modal" | "compact";
   handOrigin: HandPreviewOrigin | null;
+  mobileHandGesture: MobileHandGesture | null;
 }) {
   const { t } = useTranslation("game");
   const inspectedObjectId = useUiStore((s) => s.inspectedObjectId);
+  const previewObjectId = objectId === undefined ? inspectedObjectId : objectId;
   const dismissPreview = useUiStore((s) => s.dismissPreview);
   const showDebugId = useUiStore((s) => s.debugPanelOpen || s.debugInteractionMode);
   const obj = useGameStore((s) =>
-    inspectedObjectId != null ? s.gameState?.objects[inspectedObjectId] ?? null : null,
+    previewObjectId != null ? s.gameState?.objects[previewObjectId] ?? null : null,
   );
   // `card_report` context needs a live, participating game: `obj == null` (deck
   // builder) has no zone and a possibly-stale `gameMode`, `gameId == null` means
@@ -456,24 +529,6 @@ function CardPreviewInner({
         }
       : undefined;
 
-  // Generic mobile inspections use the blocking modal. A held hand card is the
-  // exception: it uses the same bottom-anchored Arena animation as desktop so
-  // the player can keep their finger down and scrub the stable fan beneath it.
-  if (isMobile && !handPreview) {
-    return (
-      <MobilePreviewOverlay
-        cardName={cardName}
-        backFaceName={backFaceName}
-        faceIndex={defaultFaceIndex}
-        obj={obj}
-        onDismiss={onDismiss ?? dismissPreview}
-        sourcePrinting={sourcePrinting}
-        layout={mobileLayout ?? "modal"}
-        report={reportContext}
-      />
-    );
-  }
-
   const handPreviewLeft = handPreview
     ? Math.min(
         Math.max(margin, handOrigin.centerX - previewWidth / 2),
@@ -518,11 +573,126 @@ function CardPreviewInner({
 
   const animatePreview = animationSpeedMultiplier > 0;
   const movePreview = animatePreview && !shouldReduceMotion;
+  const previewControls = useAnimationControls();
+  const previousHandSourceRef = useRef<number | null>(null);
   const transformOrigin = handPreview
     ? "50% 100%"
     : position && position.x <= viewportWidth / 2
       ? "0% 50%"
       : "100% 50%";
+  const activeMobileHandGesture =
+    handPreview
+      && mobileHandGesture?.phase === "preview"
+      && mobileHandGesture.objectId === previewObjectId
+      ? mobileHandGesture
+      : null;
+  const activeMobileHandDrag =
+    handPreview
+      && mobileHandGesture?.phase === "drag"
+      && mobileHandGesture.objectId === previewObjectId
+      ? mobileHandGesture
+      : null;
+  const activeMobileHandDragObjectId = activeMobileHandDrag?.objectId ?? null;
+  const mobileHandPreviewState = activeMobileHandGesture?.castReady
+    ? "cast-ready"
+    : activeMobileHandGesture?.playable
+      ? "playable"
+      : undefined;
+  const mobileHandHighlightClass = activeMobileHandGesture?.castReady
+    ? "ring-2 ring-amber-300 shadow-[0_0_22px_6px_rgba(251,191,36,0.72)]"
+    : activeMobileHandGesture?.playable
+      ? "ring-2 ring-cyan-400 shadow-[0_0_16px_4px_rgba(34,211,238,0.6)]"
+      : "";
+  const wobbleHeldPreview =
+    activeMobileHandGesture != null
+    && animatePreview
+    && !shouldReduceMotion;
+
+  useLayoutEffect(() => {
+    if (activeMobileHandDragObjectId != null) {
+      const duration = (
+        shouldReduceMotion ? 0.06 : 0.12
+      ) * animationSpeedMultiplier;
+      void previewControls.start({
+        opacity: 0,
+        rotate: 0,
+        scale: 1,
+        x: 0,
+        y: 0,
+        transition: {
+          duration,
+          ease: "easeOut",
+        },
+      });
+      return;
+    }
+
+    const duration = (
+      shouldReduceMotion ? 0.12 : handPreview ? 0.24 : 0.2
+    ) * animationSpeedMultiplier;
+    const handSourceChanged =
+      handPreview
+      && handOrigin.objectId !== previousHandSourceRef.current;
+
+    if (handSourceChanged && previousHandSourceRef.current != null && movePreview) {
+      // A scrubbed card becomes the preview itself: reset the one persistent
+      // layer to the new source card's exact fan geometry, then grow it into
+      // the bottom-pinned inspection size. Starting another scrub cancels this
+      // motion and restarts from the next source, so no exit clones accumulate.
+      previewControls.set({
+        left: handPreviewLeft,
+        opacity: 1,
+        rotate: handOrigin.rotation,
+        scale: handPreviewScale,
+        x: handPreviewX,
+        y: handPreviewY,
+      });
+    }
+
+    previousHandSourceRef.current = handPreview ? handOrigin.objectId : null;
+    void previewControls.start({
+      left: handPreview ? handPreviewLeft : undefined,
+      opacity: 1,
+      rotate: 0,
+      scale: 1,
+      x: 0,
+      y: 0,
+      transition: {
+        duration,
+        ease: [0.22, 1, 0.36, 1],
+      },
+    });
+  }, [
+    activeMobileHandDragObjectId,
+    animationSpeedMultiplier,
+    handOrigin,
+    handPreview,
+    handPreviewLeft,
+    handPreviewScale,
+    handPreviewX,
+    handPreviewY,
+    movePreview,
+    previewControls,
+    shouldReduceMotion,
+  ]);
+
+  // Generic mobile inspections use the blocking modal. A held hand card is the
+  // exception: it uses the same bottom-anchored Arena animation as desktop so
+  // the player can keep their finger down and scrub the stable fan beneath it.
+  if (isMobile && !handPreview) {
+    return (
+      <MobilePreviewOverlay
+        cardName={cardName}
+        backFaceName={backFaceName}
+        faceIndex={defaultFaceIndex}
+        obj={obj}
+        onDismiss={onDismiss ?? dismissPreview}
+        sourcePrinting={sourcePrinting}
+        layout={mobileLayout ?? "modal"}
+        report={reportContext}
+      />
+    );
+  }
 
   return (
     <motion.div
@@ -542,19 +712,7 @@ function CardPreviewInner({
             : { opacity: 0, scale: movePreview ? 0.975 : 1, y: movePreview ? 6 : 0 }
           : false
       }
-      animate={{
-        opacity: 1,
-        rotate: 0,
-        scale: 1,
-        x: 0,
-        y: 0,
-        transition: {
-          duration: (
-            shouldReduceMotion ? 0.12 : handPreview ? 0.24 : 0.2
-          ) * animationSpeedMultiplier,
-          ease: [0.22, 1, 0.36, 1],
-        },
-      }}
+      animate={previewControls}
       exit={{
         opacity: animatePreview && (!handPreview || !movePreview) ? 0 : 1,
         rotate: handPreview && movePreview ? handOrigin.rotation : 0,
@@ -574,39 +732,56 @@ function CardPreviewInner({
       }}
       data-card-preview
     >
-      {altHeld && (frontParseDetails || engineFrontFace) ? (
-        <ParsedAbilitiesPanel
-          name={showOtherFace ? (engineBackFace?.name ?? backFaceName ?? "") : (obj?.name ?? engineFrontFace?.name ?? frontFaceName)}
-          cardTypes={showOtherFace ? engineBackFace?.card_type : (obj?.card_types ?? engineFrontFace?.card_type)}
-          keywords={showOtherFace ? undefined : obj?.keywords}
-          localizedTypeLine={showOtherFace ? engineBackFace?.localized_type_line : engineFrontFace?.localized_type_line}
-          parseDetails={showOtherFace && backParseDetails ? backParseDetails : frontParseDetails}
-          maxHeight={viewportHeight - margin * 2}
-          report={reportContext}
-        />
-      ) : (
-        <CardImagePreview
-          cardName={displayName}
-          classLevel={classLevel}
-          showInfoPanel={showInfoPanel}
-          showFooter={showCardPreviewFooter}
-          compactDesktop={handPreview}
-          obj={obj}
-          showOtherFace={showOtherFace}
-          otherFaceCost={obj?.back_face?.mana_cost ?? null}
-          isLoading={activeLoading}
-          src={activeSrc}
-          isRotated={activeRotated}
-          flip180={flip180}
-          backFaceHint={isFlip
-            ? (flip180 ? null : t("preview.holdCtrlFlip"))
-            : backFaceName != null && !showOtherFace
-              ? (isTransformed ? t("preview.holdCtrlFront") : t("preview.holdCtrlBack"))
-              : null}
-          altAvailable={Boolean(frontParseDetails || engineFrontFace)}
-          debugObjectId={showDebugId && inspectedObjectId != null ? inspectedObjectId : null}
-        />
-      )}
+      <motion.div
+        className={`rounded-[4%] transition-[box-shadow] motion-safe:duration-100 ${mobileHandHighlightClass}`}
+        style={{ transformOrigin: "50% 85%" }}
+        animate={wobbleHeldPreview ? { rotate: [0, -0.55, 0.55, 0] } : { rotate: 0 }}
+        transition={
+          wobbleHeldPreview
+            ? {
+                duration: 1.2 * animationSpeedMultiplier,
+                ease: "easeInOut",
+                repeat: Infinity,
+              }
+            : { duration: 0.08 * animationSpeedMultiplier }
+        }
+        data-mobile-hand-preview-state={mobileHandPreviewState}
+        data-mobile-hand-preview-wobble={wobbleHeldPreview || undefined}
+      >
+        {altHeld && (frontParseDetails || engineFrontFace) ? (
+          <ParsedAbilitiesPanel
+            name={showOtherFace ? (engineBackFace?.name ?? backFaceName ?? "") : (obj?.name ?? engineFrontFace?.name ?? frontFaceName)}
+            cardTypes={showOtherFace ? engineBackFace?.card_type : (obj?.card_types ?? engineFrontFace?.card_type)}
+            keywords={showOtherFace ? undefined : obj?.keywords}
+            localizedTypeLine={showOtherFace ? engineBackFace?.localized_type_line : engineFrontFace?.localized_type_line}
+            parseDetails={showOtherFace && backParseDetails ? backParseDetails : frontParseDetails}
+            maxHeight={viewportHeight - margin * 2}
+            report={reportContext}
+          />
+        ) : (
+          <CardImagePreview
+            cardName={displayName}
+            classLevel={classLevel}
+            showInfoPanel={showInfoPanel}
+            showFooter={showCardPreviewFooter}
+            compactDesktop={handPreview}
+            obj={obj}
+            showOtherFace={showOtherFace}
+            otherFaceCost={obj?.back_face?.mana_cost ?? null}
+            isLoading={activeLoading}
+            src={activeSrc}
+            isRotated={activeRotated}
+            flip180={flip180}
+            backFaceHint={isFlip
+              ? (flip180 ? null : t("preview.holdCtrlFlip"))
+              : backFaceName != null && !showOtherFace
+                ? (isTransformed ? t("preview.holdCtrlFront") : t("preview.holdCtrlBack"))
+                : null}
+            altAvailable={Boolean(frontParseDetails || engineFrontFace)}
+            debugObjectId={showDebugId && previewObjectId != null ? previewObjectId : null}
+          />
+        )}
+      </motion.div>
     </motion.div>
   );
 }
@@ -927,7 +1102,12 @@ function CardImagePreview({
           />
         )}
         {displayCost && (
-          <ManaCostPips cost={displayCost} isReduced={displayCostReduced} size="lg" className="absolute right-[7.00%] top-[5.25%] z-10" />
+          <ManaCostPips
+            cost={displayCost}
+            isReduced={displayCostReduced}
+            size="lg"
+            className="absolute right-[7.00%] top-[5.25%] z-10"
+          />
         )}
         {classLevel != null && (
           <div className="absolute bottom-3 left-3 z-10">

--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -128,9 +128,12 @@ export function CardPreview({
     );
     // The same hand object can also render inside an overlay (most notably the
     // mulligan screen) while the board's resting PlayerHand remains mounted
-    // underneath. Require the resting source to be hovered so overlays retain
-    // their normal preview instead of inheriting the hand-origin animation.
-    if (!source || !source.matches(":hover")) {
+    // underneath. Require either desktop hover or the explicit mobile scrub
+    // marker so overlays retain their normal preview instead of inheriting the
+    // hand-origin animation.
+    const isActiveHandSource =
+      source?.matches(":hover") || source?.dataset.handTouchActive === "true";
+    if (!source || !isActiveHandSource) {
       setMeasuredHandOrigin({ objectId: handSourceObjectId, origin: null });
       return;
     }
@@ -453,7 +456,10 @@ function CardPreviewInner({
         }
       : undefined;
 
-  if (isMobile) {
+  // Generic mobile inspections use the blocking modal. A held hand card is the
+  // exception: it uses the same bottom-anchored Arena animation as desktop so
+  // the player can keep their finger down and scrub the stable fan beneath it.
+  if (isMobile && !handPreview) {
     return (
       <MobilePreviewOverlay
         cardName={cardName}

--- a/client/src/components/card/GameCardPreview.tsx
+++ b/client/src/components/card/GameCardPreview.tsx
@@ -57,6 +57,7 @@ export function GameCardPreview() {
   return (
     <CardPreview
       cardName={previewSuppressed ? null : inspectedCardName}
+      objectId={inspectedObj?.id ?? null}
       backFaceName={previewSuppressed ? null : inspectedOtherFaceName}
       dockSide={cardPreviewMode === "side"}
       handSourceObjectId={inspectedObj?.zone === "Hand" ? inspectedObj.id : null}

--- a/client/src/components/card/__tests__/CardPreview.test.tsx
+++ b/client/src/components/card/__tests__/CardPreview.test.tsx
@@ -115,6 +115,43 @@ describe("CardPreview chosen attributes", () => {
     source.remove();
   });
 
+  it("uses the bottom-anchored hand animation for an active mobile scrub", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: 500 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, writable: true, value: 440 });
+    const source = document.createElement("div");
+    source.dataset.handCard = "";
+    source.dataset.handTouchActive = "true";
+    source.dataset.handRotation = "5";
+    source.dataset.objectId = "101";
+    Object.defineProperty(source, "offsetWidth", { configurable: true, value: 90 });
+    source.matches = vi.fn(() => false);
+    source.getBoundingClientRect = () => ({
+      bottom: 432,
+      height: 126,
+      left: 180,
+      right: 270,
+      top: 306,
+      width: 90,
+      x: 180,
+      y: 306,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(source);
+
+    const { container } = render(
+      <CardPreview cardName="Pithing Needle" handSourceObjectId={101} />,
+    );
+
+    const preview = container.querySelector<HTMLElement>("[data-card-preview]");
+    expect(preview).not.toBeNull();
+    expect(preview?.style.bottom).toBe("0px");
+    expect(preview).toHaveClass("pointer-events-none");
+    expect(screen.getByAltText("Pithing Needle")).toHaveClass(
+      "w-[clamp(190px,18vw,300px)]",
+    );
+    source.remove();
+  });
+
   it("uses the normal preview when the matching board hand card is not hovered", () => {
     const source = document.createElement("div");
     source.dataset.handCard = "";

--- a/client/src/components/card/__tests__/CardPreview.test.tsx
+++ b/client/src/components/card/__tests__/CardPreview.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { GameObject } from "../../../adapter/types.ts";
@@ -11,8 +11,8 @@ import { buildGameState } from "../../../test/factories/gameStateFactory.ts";
 import { CardPreview } from "../CardPreview.tsx";
 
 vi.mock("../../../hooks/useCardImage.ts", () => ({
-  useCardImage: vi.fn(() => ({
-    src: "card.png",
+  useCardImage: vi.fn((cardName: string, options?: { oracleId?: string }) => ({
+    src: `${options?.oracleId ?? cardName}.png`,
     isLoading: false,
     isRotated: false,
     isFlip: false,
@@ -82,6 +82,8 @@ describe("CardPreview chosen attributes", () => {
   });
 
   it("anchors a hand preview to the viewport bottom and grows from its source card", () => {
+    const object = battlefieldObject({ zone: "Hand" });
+    useGameStore.setState({ gameState: gameStateWithObject(object), spellCosts: {} });
     const source = document.createElement("div");
     source.dataset.handCard = "";
     source.dataset.handRotation = "-4";
@@ -102,7 +104,7 @@ describe("CardPreview chosen attributes", () => {
     document.body.appendChild(source);
 
     const { container } = render(
-      <CardPreview cardName="Pithing Needle" handSourceObjectId={101} />,
+      <CardPreview cardName="Pithing Needle" objectId={101} handSourceObjectId={101} />,
     );
 
     const preview = container.querySelector<HTMLElement>("[data-card-preview]");
@@ -152,7 +154,93 @@ describe("CardPreview chosen attributes", () => {
     source.remove();
   });
 
+  it("hands off a stationary blue preview before despawning for direct card drag", async () => {
+    const object = battlefieldObject({ zone: "Hand" });
+    useGameStore.setState({ gameState: gameStateWithObject(object), spellCosts: {} });
+    const source = document.createElement("div");
+    source.dataset.handCard = "";
+    source.dataset.handTouchActive = "true";
+    source.dataset.objectId = String(object.id);
+    Object.defineProperty(source, "offsetWidth", { configurable: true, value: 120 });
+    source.matches = vi.fn(() => false);
+    source.getBoundingClientRect = () => ({
+      bottom: 748,
+      height: 168,
+      left: 220,
+      right: 340,
+      top: 580,
+      width: 120,
+      x: 220,
+      y: 580,
+      toJSON: () => ({}),
+    });
+    document.body.appendChild(source);
+    useUiStore.setState({
+      mobileHandGesture: {
+        objectId: object.id,
+        phase: "preview",
+        sourceOrigin: {
+          bottom: 748,
+          centerX: 280,
+          height: 168,
+          rotation: 0,
+          top: 580,
+          width: 120,
+        },
+        offsetX: 12,
+        offsetY: -30,
+        playable: true,
+        castReady: false,
+      },
+    });
+
+    const { container } = render(
+      <CardPreview
+        cardName={object.name}
+        objectId={object.id}
+        handSourceObjectId={object.id}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-mobile-hand-preview-state="playable"]'),
+    ).toHaveClass("ring-cyan-400");
+    expect(
+      container.querySelector('[data-mobile-hand-preview-wobble="true"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      useUiStore.getState().setMobileHandGesture({
+        objectId: object.id,
+        phase: "drag",
+        sourceOrigin: {
+          bottom: 748,
+          centerX: 280,
+          height: 168,
+          rotation: 0,
+          top: 580,
+          width: 120,
+        },
+        offsetX: 16,
+        offsetY: -90,
+        playable: true,
+        castReady: true,
+      });
+    });
+
+    expect(container.querySelector("[data-card-preview]")).not.toBeNull();
+    expect(
+      container.querySelector("[data-mobile-hand-preview-wobble]"),
+    ).toBeNull();
+    await waitFor(() => {
+      expect(container.querySelector("[data-card-preview]")).toBeNull();
+    });
+    source.remove();
+  });
+
   it("uses the normal preview when the matching board hand card is not hovered", () => {
+    const object = battlefieldObject({ zone: "Hand" });
+    useGameStore.setState({ gameState: gameStateWithObject(object), spellCosts: {} });
     const source = document.createElement("div");
     source.dataset.handCard = "";
     source.dataset.objectId = "101";
@@ -160,7 +248,11 @@ describe("CardPreview chosen attributes", () => {
     document.body.appendChild(source);
 
     const { container } = render(
-      <CardPreview cardName="Pithing Needle" handSourceObjectId={101} />,
+      <CardPreview
+        cardName="Pithing Needle"
+        objectId={object.id}
+        handSourceObjectId={101}
+      />,
     );
 
     const preview = container.querySelector<HTMLElement>("[data-card-preview]");
@@ -170,6 +262,87 @@ describe("CardPreview chosen attributes", () => {
       "w-[clamp(190px,18vw,300px)]",
     );
     source.remove();
+  });
+
+  it("reuses one preview layer during rapid hand scrubbing", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 500,
+    });
+    const first = battlefieldObject({
+      id: 101,
+      zone: "Hand",
+      name: "First Card",
+      printed_ref: { oracle_id: "oracle-first", face_name: "First Card" },
+    });
+    const second = battlefieldObject({
+      id: 102,
+      zone: "Hand",
+      name: "Second Card",
+      printed_ref: { oracle_id: "oracle-second", face_name: "Second Card" },
+    });
+    useGameStore.setState({
+      gameState: buildGameState({
+        objects: buildObjectMap(first, second),
+        next_object_id: 103,
+      }),
+      spellCosts: {},
+    });
+
+    const firstSource = document.createElement("div");
+    firstSource.dataset.handCard = "";
+    firstSource.dataset.handTouchActive = "true";
+    firstSource.dataset.objectId = String(first.id);
+    firstSource.getBoundingClientRect = () => ({
+      bottom: 748,
+      height: 168,
+      left: 220,
+      right: 340,
+      top: 580,
+      width: 120,
+      x: 220,
+      y: 580,
+      toJSON: () => ({}),
+    });
+    const secondSource = firstSource.cloneNode() as HTMLElement;
+    secondSource.dataset.objectId = String(second.id);
+    secondSource.getBoundingClientRect = () => ({
+      ...firstSource.getBoundingClientRect(),
+      left: 320,
+      right: 440,
+      x: 320,
+    });
+    document.body.append(firstSource, secondSource);
+
+    useUiStore.setState({ inspectedObjectId: first.id });
+    const { rerender } = render(
+      <CardPreview
+        cardName={first.name}
+        objectId={first.id}
+        handSourceObjectId={first.id}
+      />,
+    );
+
+    firstSource.removeAttribute("data-hand-touch-active");
+    secondSource.dataset.handTouchActive = "true";
+    useUiStore.setState({ inspectedObjectId: second.id });
+    rerender(
+      <CardPreview
+        cardName={second.name}
+        objectId={second.id}
+        handSourceObjectId={second.id}
+      />,
+    );
+
+    expect(screen.getByAltText("Second Card")).toHaveAttribute(
+      "src",
+      "oracle-second.png",
+    );
+    expect(document.querySelectorAll("[data-card-preview]")).toHaveLength(1);
+    await waitFor(() => {
+      expect(screen.queryByAltText("First Card")).toBeNull();
+    });
   });
 
   it("hides the informational footer without hiding the card art", () => {

--- a/client/src/components/card/__tests__/GameCardPreview.test.tsx
+++ b/client/src/components/card/__tests__/GameCardPreview.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { GameObject } from "../../../adapter/types.ts";
@@ -64,6 +64,7 @@ afterEach(() => {
     inspectedObjectId: null,
     inspectedFaceIndex: 0,
     isDragging: false,
+    mobileHandGesture: null,
     shiftHeld: false,
     altHeld: false,
   });
@@ -141,6 +142,63 @@ describe("GameCardPreview", () => {
       expect(preview).toHaveStyle({ bottom: "0px" });
       expect(within(preview!).getByAltText("Hovered Card")).toBeInTheDocument();
     });
+  });
+
+  it("keeps the held card in the stable fan until direct dragging begins", () => {
+    const card = gameObjectFactory
+      .withId(203)
+      .inHand()
+      .named("Held Card")
+      .build();
+    const gameState = gameStateFactory
+      .withPlayers({ id: 0, hand: [card.id] }, 1)
+      .withObjects(card)
+      .build();
+    useGameStore.setState({ gameState, spellCosts: {} });
+
+    const { container } = render(<PlayerHand />);
+    const source = container.querySelector<HTMLElement>(
+      `[data-hand-card][data-object-id="${card.id}"]`,
+    );
+    expect(source).not.toBeNull();
+
+    const sourceOrigin = {
+      bottom: 700,
+      centerX: 450,
+      height: 140,
+      rotation: 0,
+      top: 560,
+      width: 100,
+    };
+    act(() => {
+      useUiStore.getState().setMobileHandGesture({
+        objectId: card.id,
+        phase: "preview",
+        sourceOrigin,
+        offsetX: 0,
+        offsetY: 0,
+        playable: true,
+        castReady: false,
+      });
+    });
+
+    expect(source).not.toHaveAttribute("data-hand-held-source");
+    expect(source).not.toHaveClass("w-0", "opacity-0");
+
+    act(() => {
+      useUiStore.getState().setMobileHandGesture({
+        objectId: card.id,
+        phase: "drag",
+        sourceOrigin,
+        offsetX: 0,
+        offsetY: -24,
+        playable: true,
+        castReady: false,
+      });
+    });
+
+    expect(source).toHaveAttribute("data-hand-held-source", "true");
+    expect(source).toHaveClass("w-0", "opacity-0");
   });
 
   it("renders no preview while a card is being dragged", () => {

--- a/client/src/components/hand/MobileHeldHandCard.tsx
+++ b/client/src/components/hand/MobileHeldHandCard.tsx
@@ -1,0 +1,141 @@
+import { useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
+import {
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useSpring,
+  useTransform,
+  useVelocity,
+} from "framer-motion";
+
+import type { GameObject } from "../../adapter/types.ts";
+import { useGameStore } from "../../stores/gameStore.ts";
+import { usePreferencesStore } from "../../stores/preferencesStore.ts";
+import type { MobileHandGesture } from "../../stores/uiStore.ts";
+import { spellCostDisplay } from "../../viewmodel/costLabel.ts";
+import { CardImage } from "../card/CardImage.tsx";
+import { ManaCostPips } from "../mana/ManaCostPips.tsx";
+
+interface MobileHeldHandCardProps {
+  gesture: MobileHandGesture | null;
+  object: GameObject | null;
+}
+
+/**
+ * Hand-sized drag visual for the mobile hold gesture.
+ *
+ * Portaled to the document so the hand container's `perspective` cannot turn a
+ * fixed-position child into a container-relative element. The real HandCard
+ * remains keyed in the fan but collapsed until the gesture ends.
+ */
+export function MobileHeldHandCard({ gesture, object }: MobileHeldHandCardProps) {
+  const effectiveCost = useGameStore((s) =>
+    object ? s.spellCosts[String(object.id)] : undefined,
+  );
+  const shouldReduceMotion = useReducedMotion();
+  const animationSpeedMultiplier = usePreferencesStore((s) => s.animationSpeedMultiplier);
+  const dragOffsetX = useMotionValue(gesture?.offsetX ?? 0);
+  const dragOffsetY = useMotionValue(gesture?.offsetY ?? 0);
+  const dragVelocityX = useVelocity(dragOffsetX);
+  const dragVelocityY = useVelocity(dragOffsetY);
+  const rotateTarget = useTransform(
+    dragVelocityX,
+    [-900, 0, 900],
+    [-5.5, 0, 5.5],
+    { clamp: true },
+  );
+  const rotateXTarget = useTransform(
+    dragVelocityY,
+    [-900, 0, 900],
+    [3.5, 0, -3.5],
+    { clamp: true },
+  );
+  const rotate = useSpring(rotateTarget, {
+    damping: 18,
+    mass: 0.45,
+    stiffness: 260,
+  });
+  const rotateX = useSpring(rotateXTarget, {
+    damping: 20,
+    mass: 0.45,
+    stiffness: 280,
+  });
+  const dynamicMotionEnabled =
+    animationSpeedMultiplier > 0 && !shouldReduceMotion;
+
+  useLayoutEffect(() => {
+    if (gesture?.phase !== "drag") return;
+    // Position remains a direct mapping from the live pointer. These motion
+    // values feed only the visual tilt, so the spring can never add input lag.
+    dragOffsetX.set(gesture.offsetX);
+    dragOffsetY.set(gesture.offsetY);
+  }, [dragOffsetX, dragOffsetY, gesture?.offsetX, gesture?.offsetY, gesture?.phase]);
+
+  if (
+    typeof document === "undefined"
+    || gesture?.phase !== "drag"
+    || object == null
+    || gesture.objectId !== object.id
+  ) {
+    return null;
+  }
+
+  const { displayCost, isReduced } = spellCostDisplay(effectiveCost, object.mana_cost);
+  const { sourceOrigin } = gesture;
+  const highlightClass = gesture.castReady
+    ? "ring-2 ring-amber-300 shadow-[0_0_22px_6px_rgba(251,191,36,0.72)]"
+    : gesture.playable
+      ? "ring-2 ring-cyan-400 shadow-[0_0_16px_4px_rgba(34,211,238,0.6)]"
+      : "";
+
+  return createPortal(
+    <motion.div
+      className={`pointer-events-none fixed z-[180] overflow-visible rounded-lg drop-shadow-[0_16px_22px_rgba(0,0,0,0.58)] ${highlightClass}`}
+      style={{
+        height: sourceOrigin.height,
+        left: sourceOrigin.centerX - sourceOrigin.width / 2 + gesture.offsetX,
+        top: sourceOrigin.top + gesture.offsetY,
+        rotate: dynamicMotionEnabled ? rotate : 0,
+        rotateX: dynamicMotionEnabled ? rotateX : 0,
+        transformOrigin: "50% 100%",
+        transformPerspective: 700,
+        width: sourceOrigin.width,
+      }}
+      initial={
+        animationSpeedMultiplier > 0
+          ? {
+              opacity: 0,
+              scale: 1,
+            }
+          : false
+      }
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{
+        duration: (shouldReduceMotion ? 0.06 : 0.12) * animationSpeedMultiplier,
+        ease: [0.22, 1, 0.36, 1],
+      }}
+      data-mobile-held-card
+      data-mobile-held-card-motion={dynamicMotionEnabled ? "velocity" : undefined}
+      data-mobile-held-card-state={gesture.castReady ? "cast-ready" : gesture.playable ? "playable" : "held"}
+    >
+      <CardImage
+        cardName={object.name}
+        size="normal"
+        oracleId={object.printed_ref?.oracle_id}
+        faceName={object.printed_ref?.face_name}
+        unimplementedMechanics={object.unimplemented_mechanics}
+        className="!h-full !w-full"
+      />
+      <div className="pointer-events-none absolute inset-0 @container">
+        <ManaCostPips
+          cost={displayCost}
+          isReduced={isReduced}
+          size="fluid"
+          className="absolute right-[4%] top-[2%]"
+        />
+      </div>
+    </motion.div>,
+    document.body,
+  );
+}

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -18,9 +18,13 @@ import { previewAutomaticManaPayment } from "../../game/manaPaymentPreview.ts";
 import type { GameObject, ManaCost, ObjectId } from "../../adapter/types.ts";
 import {
   collectObjectActions,
+  resolveDirectPlayOrCastAction,
   resolveSingleActionDispatch,
 } from "../../viewmodel/cardActionChoice.ts";
-import { DRAG_PLAY_THRESHOLD } from "../../hooks/useDragToCast.ts";
+import {
+  DRAG_PLAY_THRESHOLD,
+  HAND_DRAG_PLAY_THRESHOLD,
+} from "../../hooks/useDragToCast.ts";
 import {
   computeHandInsertionSlot,
   computeHandInsertionMarker,
@@ -42,6 +46,7 @@ import {
   playerHandFanSizingStyle,
 } from "./handFanPresentation.ts";
 import { useHandScrubPreview } from "./useHandScrubPreview.ts";
+import { MobileHeldHandCard } from "./MobileHeldHandCard.tsx";
 
 // Stable empty lookup so an undefined `objects` (pre-game) never busts the
 // organizer's filter memo with a fresh `{}` each render.
@@ -77,17 +82,13 @@ export function PlayerHand() {
   // otherwise rebuild the drag-end callback on every update.
   const hand = player?.hand;
   const objects = useGameStore((s) => s.gameState?.objects);
+  const mobileHandGesture = useUiStore((s) => s.mobileHandGesture);
   // Use dispatchAction (animation pipeline) instead of store dispatch
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
   const setMobileHandOpen = useUiStore((s) => s.setMobileHandOpen);
   const isMobile = useIsMobile();
   const isCompactHeight = useIsCompactHeight();
-  const {
-    handlers: handScrubHandlers,
-    consumeClick: consumeHandScrubClick,
-  } = useHandScrubPreview(handContainerRef, isMobile);
-
   const [expanded, setExpanded] = useState(false);
   const [selectedCardId, setSelectedCardId] = useState<number | null>(null);
   const [draggingCardId, setDraggingCardId] = useState<number | null>(null);
@@ -175,6 +176,28 @@ export function PlayerHand() {
     },
     [hasPriority, objects, legalActionsByObject, inspectObject, setPendingAbilityChoice],
   );
+
+  const isMobileHandCardPlayable = useCallback(
+    (objectId: number) => hasPriority && playableObjectIds.has(objectId),
+    [hasPriority, playableObjectIds],
+  );
+  const canReleaseMobileHandCardToCast = useCallback(
+    (objectId: number) =>
+      hasPriority
+      && resolveDirectPlayOrCastAction(
+        legalActionsByObject,
+        objects?.[objectId],
+      ) != null,
+    [hasPriority, legalActionsByObject, objects],
+  );
+  const {
+    handlers: handScrubHandlers,
+    consumeClick: consumeHandScrubClick,
+  } = useHandScrubPreview(handContainerRef, isMobile, {
+    isPlayable: isMobileHandCardPlayable,
+    canReleaseToCast: canReleaseMobileHandCardToCast,
+    onReleaseToCast: playCard,
+  });
 
   const previewManaPayment = useCallback((objectId: number) => {
     const requestId = ++manaPaymentPreviewRequestId.current;
@@ -319,7 +342,7 @@ export function PlayerHand() {
         !organizeActive &&
         marker != null &&
         insideHand &&
-        info.offset.y >= DRAG_PLAY_THRESHOLD &&
+        info.offset.y >= HAND_DRAG_PLAY_THRESHOLD &&
         slot !== fromIdx;
       arrowOpacity.set(show ? 1 : 0);
 
@@ -338,12 +361,9 @@ export function PlayerHand() {
     [isMobile, pendingObjectId, organizeActive, arrowXRaw, arrowYRaw, arrowRotateRaw, arrowOpacity, insertionSlotMV, draggingIndexMV, cardHeightMV, exileCards.length, graveyardCards.length, companionCount],
   );
 
-  // Drag-to-play applies the same gesture rule as `useDragToCast` (the
-  // Commander-zone single-cast path): release above DRAG_PLAY_THRESHOLD
-  // while holding priority and outside the source zone. A React hook cannot
-  // be called once per hand card, so we inline the rule here but share the
-  // threshold constant with `useDragToCast` — there is exactly one
-  // definition of "how far up counts as a play."
+  // Hand drag-to-play deliberately requires more vertical commitment than
+  // the generic Commander/companion gesture. This preserves a broad lateral
+  // reorder band before a release can count as casting the card.
   const handleDragEnd = useCallback(
     (objectId: number, _event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
       arrowOpacity.set(0);
@@ -398,7 +418,7 @@ export function PlayerHand() {
 
       // Play branch (unchanged from the existing implementation).
       if (!hasPriority) return false;
-      if (info.offset.y >= DRAG_PLAY_THRESHOLD) return false;
+      if (info.offset.y >= HAND_DRAG_PLAY_THRESHOLD) return false;
       playCard(objectId);
       return true;
     },
@@ -518,7 +538,8 @@ export function PlayerHand() {
   const fan = handFanGeometry(totalFanCards, "--hand-card-w", verticalMetrics.arcScale);
 
   return (
-    <div
+    <>
+      <div
       ref={handContainerRef}
       className={`relative flex items-end justify-center overflow-visible px-4 py-1 ${
         isCompactHeight ? "min-h-[40px]" : "min-h-[calc(var(--card-h)*0.7)]"
@@ -624,6 +645,8 @@ export function PlayerHand() {
               key={obj.id}
               objectId={obj.id}
               cardName={obj.name}
+              oracleId={obj.printed_ref?.oracle_id}
+              faceName={obj.printed_ref?.face_name}
               manaCost={obj.mana_cost}
               unimplementedMechanics={obj.unimplemented_mechanics}
               index={i}
@@ -753,13 +776,24 @@ export function PlayerHand() {
           </motion.div>
         </motion.div>
       )}
-    </div>
+      </div>
+      <MobileHeldHandCard
+        gesture={mobileHandGesture}
+        object={
+          mobileHandGesture && objects[mobileHandGesture.objectId]
+            ? objects[mobileHandGesture.objectId]
+            : null
+        }
+      />
+    </>
   );
 }
 
 interface HandCardProps {
   objectId: number;
   cardName: string;
+  oracleId?: string;
+  faceName?: string;
   manaCost: ManaCost;
   unimplementedMechanics?: string[];
   index: number;
@@ -790,6 +824,8 @@ interface HandCardProps {
 const HandCard = memo(function HandCard({
   objectId,
   cardName,
+  oracleId,
+  faceName,
   manaCost,
   unimplementedMechanics,
   index,
@@ -818,6 +854,11 @@ const HandCard = memo(function HandCard({
 }: HandCardProps) {
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setDragging = useUiStore((s) => s.setDragging);
+  const isMobileDragged = useUiStore(
+    (s) =>
+      s.mobileHandGesture?.phase === "drag"
+      && s.mobileHandGesture.objectId === objectId,
+  );
 
   // Slide-apart displacement: derive this card's signed x offset from the shared
   // insertion signal. useTransform updates imperatively when the MotionValues
@@ -928,11 +969,15 @@ const HandCard = memo(function HandCard({
       }}
       onMouseEnter={() => onMouseEnter(objectId)}
       onMouseLeave={onMouseLeave}
+      data-hand-held-source={isMobileDragged || undefined}
+      aria-hidden={isMobileDragged || undefined}
       className={`relative cursor-pointer leading-[0] select-none ${
+        isMobileDragged ? "w-0 overflow-hidden opacity-0" : ""
+      } ${
         isMobile ? "pointer-events-none" : ""
       }`}
       style={{
-        marginLeft,
+        marginLeft: isMobileDragged ? 0 : marginLeft,
         // Selected card sits above every non-selected hand card. Offset by
         // handSize (not a fixed 20) so it still wins in a Commander-sized hand
         // whose plain indices can exceed 20.
@@ -947,6 +992,8 @@ const HandCard = memo(function HandCard({
         <CardImage
           cardName={cardName}
           size="normal"
+          oracleId={oracleId}
+          faceName={faceName}
           unimplementedMechanics={unimplementedMechanics}
           className="!w-[var(--hand-card-w)] !h-[var(--hand-card-h)]"
         />
@@ -1002,8 +1049,8 @@ interface ZoneFanCardProps {
 // HandCard's resting animation (arc + tilt + hover lift) for visual continuity
 // but is deliberately NOT part of the reorder system: no `data-card-hover`, no
 // insertion-slot wiring, no displacement spring. Its sole drag gesture is
-// flick-up-to-cast (CR-agnostic UI gating, same DRAG_PLAY_THRESHOLD as the hand
-// and the commander zone). Per-source drag policy lives here — a zone card can
+// flick-up-to-cast (CR-agnostic UI gating, same generic DRAG_PLAY_THRESHOLD as
+// the commander zone). Per-source drag policy lives here — a zone card can
 // be flung up to cast but can never be dropped into the middle of the hand.
 const ZoneFanCard = memo(function ZoneFanCard({
   objectId,

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -41,6 +41,7 @@ import {
   handFanVerticalMetrics,
   playerHandFanSizingStyle,
 } from "./handFanPresentation.ts";
+import { useHandScrubPreview } from "./useHandScrubPreview.ts";
 
 // Stable empty lookup so an undefined `objects` (pre-game) never busts the
 // organizer's filter memo with a fresh `{}` each render.
@@ -82,6 +83,10 @@ export function PlayerHand() {
   const setMobileHandOpen = useUiStore((s) => s.setMobileHandOpen);
   const isMobile = useIsMobile();
   const isCompactHeight = useIsCompactHeight();
+  const {
+    handlers: handScrubHandlers,
+    consumeClick: consumeHandScrubClick,
+  } = useHandScrubPreview(handContainerRef, isMobile);
 
   const [expanded, setExpanded] = useState(false);
   const [selectedCardId, setSelectedCardId] = useState<number | null>(null);
@@ -431,6 +436,9 @@ export function PlayerHand() {
 
   const handleContainerClick = useCallback(
     (e: React.MouseEvent) => {
+      // A completed hold-and-scrub produces a synthetic click after pointerup.
+      // Consume only that click; ordinary short taps still open the drawer.
+      if (consumeHandScrubClick()) return;
       // On mobile the fanned cards are `pointer-events-none` (the drawer is the
       // interaction surface), so every tap in the hand area falls through to this
       // container — or to the inner lift wrapper, which bubbles here. Any such tap
@@ -448,7 +456,7 @@ export function PlayerHand() {
         setExpanded((prev) => !prev);
       }
     },
-    [isMobile, setMobileHandOpen],
+    [consumeHandScrubClick, isMobile, setMobileHandOpen],
   );
 
   const handleDragStart = useCallback(
@@ -514,12 +522,13 @@ export function PlayerHand() {
       ref={handContainerRef}
       className={`relative flex items-end justify-center overflow-visible px-4 py-1 ${
         isCompactHeight ? "min-h-[40px]" : "min-h-[calc(var(--card-h)*0.7)]"
-      }`}
+      } ${isMobile ? "touch-none" : ""}`}
       style={{
         perspective: "800px",
         ...playerHandFanSizingStyle(totalFanCards),
         zIndex: draggingCardId != null || expanded ? 40 : undefined,
       }}
+      {...handScrubHandlers}
       onClick={handleContainerClick}
       onMouseLeave={() => {
         setExpanded(false);

--- a/client/src/components/hand/__tests__/MobileHeldHandCard.test.tsx
+++ b/client/src/components/hand/__tests__/MobileHeldHandCard.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
+import type { MobileHandGesture } from "../../../stores/uiStore.ts";
+import { buildGameObject } from "../../../test/factories/gameObjectFactory.ts";
+import { MobileHeldHandCard } from "../MobileHeldHandCard.tsx";
+
+vi.mock("../../card/CardImage.tsx", () => ({
+  CardImage: ({ cardName }: { cardName: string }) => <div>{cardName}</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+  usePreferencesStore.setState({ animationSpeedMultiplier: 1 });
+});
+
+describe("MobileHeldHandCard", () => {
+  const object = buildGameObject({ id: 11, zone: "Hand", name: "Lightning Bolt" });
+  const gesture: MobileHandGesture = {
+    objectId: object.id,
+    phase: "drag",
+    sourceOrigin: {
+      bottom: 748,
+      centerX: 280,
+      height: 168,
+      rotation: 0,
+      top: 580,
+      width: 120,
+    },
+    offsetX: 12,
+    offsetY: -90,
+    playable: true,
+    castReady: true,
+  };
+
+  it("portals a hand-sized gold card at the finger's direct displacement", () => {
+    render(<MobileHeldHandCard gesture={gesture} object={object} />);
+
+    const heldCard = document.querySelector<HTMLElement>("[data-mobile-held-card]");
+    expect(heldCard).not.toBeNull();
+    expect(heldCard).toHaveAttribute("data-mobile-held-card-state", "cast-ready");
+    expect(heldCard).toHaveAttribute("data-mobile-held-card-motion", "velocity");
+    expect(heldCard).toHaveClass("ring-amber-300");
+    expect(heldCard?.style.left).toBe("232px");
+    expect(heldCard?.style.top).toBe("490px");
+    expect(heldCard?.style.width).toBe("120px");
+    expect(heldCard?.style.height).toBe("168px");
+  });
+
+  it("does not render during the stationary large-preview phase", () => {
+    render(
+      <MobileHeldHandCard
+        gesture={{ ...gesture, phase: "preview", castReady: false }}
+        object={object}
+      />,
+    );
+
+    expect(document.querySelector("[data-mobile-held-card]")).toBeNull();
+  });
+
+  it("disables velocity tilt when animations are disabled", () => {
+    usePreferencesStore.setState({ animationSpeedMultiplier: 0 });
+
+    render(<MobileHeldHandCard gesture={gesture} object={object} />);
+
+    expect(document.querySelector("[data-mobile-held-card]")).not.toHaveAttribute(
+      "data-mobile-held-card-motion",
+    );
+  });
+});

--- a/client/src/components/hand/__tests__/useHandScrubPreview.test.tsx
+++ b/client/src/components/hand/__tests__/useHandScrubPreview.test.tsx
@@ -1,0 +1,159 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { useHandScrubPreview } from "../useHandScrubPreview.ts";
+
+function rect(left: number, right: number): DOMRect {
+  return {
+    bottom: 180,
+    height: 140,
+    left,
+    right,
+    top: 40,
+    width: right - left,
+    x: left,
+    y: 40,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function ScrubHarness({ onOpen }: { onOpen: () => void }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { handlers, consumeClick } = useHandScrubPreview(ref, true);
+
+  return (
+    <div
+      ref={ref}
+      data-testid="hand"
+      {...handlers}
+      onClick={() => {
+        if (!consumeClick()) onOpen();
+      }}
+    >
+      <div data-testid="card-11" data-hand-card data-object-id="11" />
+      <div data-testid="card-12" data-hand-card data-object-id="12" />
+    </div>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  useUiStore.getState().dismissPreview();
+});
+
+describe("useHandScrubPreview", () => {
+  it("holds to preview, scrubs adjacent cards, and suppresses the release click", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    render(<ScrubHarness onOpen={onOpen} />);
+    const hand = screen.getByTestId("hand");
+    const first = screen.getByTestId("card-11");
+    const second = screen.getByTestId("card-12");
+    first.getBoundingClientRect = () => rect(0, 100);
+    second.getBoundingClientRect = () => rect(70, 170);
+
+    fireEvent.pointerDown(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(400));
+
+    expect(useUiStore.getState().inspectedObjectId).toBe(11);
+    expect(useUiStore.getState().previewSticky).toBe(true);
+    expect(first).toHaveAttribute("data-hand-touch-active", "true");
+
+    fireEvent.pointerMove(hand, {
+      clientX: 140,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: "touch",
+    });
+
+    expect(useUiStore.getState().inspectedObjectId).toBe(12);
+    expect(first).not.toHaveAttribute("data-hand-touch-active");
+    expect(second).toHaveAttribute("data-hand-touch-active", "true");
+
+    fireEvent.pointerUp(hand, {
+      button: 0,
+      clientX: 140,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 7,
+      pointerType: "touch",
+    });
+    fireEvent.click(hand);
+
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+    expect(second).not.toHaveAttribute("data-hand-touch-active");
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("keeps a short tap available for opening the hand drawer", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    render(<ScrubHarness onOpen={onOpen} />);
+    const hand = screen.getByTestId("hand");
+
+    fireEvent.pointerDown(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 8,
+      pointerType: "touch",
+    });
+    fireEvent.pointerUp(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 8,
+      pointerType: "touch",
+    });
+    fireEvent.click(hand);
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+  });
+
+  it("does not consume a long tap that starts outside a card", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    render(<ScrubHarness onOpen={onOpen} />);
+    const hand = screen.getByTestId("hand");
+    const first = screen.getByTestId("card-11");
+    const second = screen.getByTestId("card-12");
+    first.getBoundingClientRect = () => rect(0, 100);
+    second.getBoundingClientRect = () => rect(70, 170);
+
+    fireEvent.pointerDown(hand, {
+      button: 0,
+      clientX: 240,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 9,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(400));
+    fireEvent.pointerUp(hand, {
+      button: 0,
+      clientX: 240,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 9,
+      pointerType: "touch",
+    });
+    fireEvent.click(hand);
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+  });
+});

--- a/client/src/components/hand/__tests__/useHandScrubPreview.test.tsx
+++ b/client/src/components/hand/__tests__/useHandScrubPreview.test.tsx
@@ -19,9 +19,23 @@ function rect(left: number, right: number): DOMRect {
   } as DOMRect;
 }
 
-function ScrubHarness({ onOpen }: { onOpen: () => void }) {
+function ScrubHarness({
+  onOpen,
+  isPlayable,
+  canReleaseToCast,
+  onReleaseToCast,
+}: {
+  onOpen: () => void;
+  isPlayable?: (objectId: number) => boolean;
+  canReleaseToCast?: (objectId: number) => boolean;
+  onReleaseToCast?: (objectId: number) => void;
+}) {
   const ref = useRef<HTMLDivElement | null>(null);
-  const { handlers, consumeClick } = useHandScrubPreview(ref, true);
+  const { handlers, consumeClick } = useHandScrubPreview(ref, true, {
+    isPlayable,
+    canReleaseToCast,
+    onReleaseToCast,
+  });
 
   return (
     <div
@@ -89,11 +103,240 @@ describe("useHandScrubPreview", () => {
       pointerId: 7,
       pointerType: "touch",
     });
+    act(() => vi.advanceTimersByTime(100));
     fireEvent.click(hand);
 
     expect(useUiStore.getState().inspectedObjectId).toBeNull();
     expect(second).not.toHaveAttribute("data-hand-touch-active");
     expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("allows a deliberate tap after consuming a held preview's delayed click", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    render(<ScrubHarness onOpen={onOpen} />);
+    const hand = screen.getByTestId("hand");
+    const first = screen.getByTestId("card-11");
+    first.getBoundingClientRect = () => rect(0, 100);
+
+    fireEvent.pointerDown(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 10,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(400));
+    fireEvent.pointerUp(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 10,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.click(hand);
+
+    fireEvent.pointerDown(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 11,
+      pointerType: "touch",
+    });
+    fireEvent.pointerUp(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 11,
+      pointerType: "touch",
+    });
+    fireEvent.click(hand);
+
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("moves a playable held preview and casts only after it enters the gold range", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    const onReleaseToCast = vi.fn();
+    render(
+      <ScrubHarness
+        onOpen={onOpen}
+        isPlayable={(objectId) => objectId === 11}
+        canReleaseToCast={(objectId) => objectId === 11}
+        onReleaseToCast={onReleaseToCast}
+      />,
+    );
+    const hand = screen.getByTestId("hand");
+    const first = screen.getByTestId("card-11");
+    hand.getBoundingClientRect = () => rect(0, 200);
+    first.getBoundingClientRect = () => rect(0, 100);
+
+    fireEvent.pointerDown(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 15,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(400));
+
+    expect(useUiStore.getState().mobileHandGesture).toMatchObject({
+      objectId: 11,
+      phase: "preview",
+      sourceOrigin: {
+        bottom: 180,
+        centerX: 50,
+        height: 140,
+        rotation: 0,
+        top: 40,
+        width: 100,
+      },
+      offsetX: 0,
+      offsetY: 0,
+      playable: true,
+      castReady: false,
+    });
+
+    fireEvent.pointerMove(hand, {
+      clientX: 45,
+      clientY: 88,
+      isPrimary: true,
+      pointerId: 15,
+      pointerType: "touch",
+    });
+
+    expect(useUiStore.getState().mobileHandGesture).toMatchObject({
+      objectId: 11,
+      phase: "preview",
+      castReady: false,
+    });
+
+    // Crossing above the hand is not sufficient by itself: the card remains
+    // blue until the larger hand-specific cast distance is also crossed.
+    fireEvent.pointerMove(hand, {
+      clientX: 48,
+      clientY: 39,
+      isPrimary: true,
+      pointerId: 15,
+      pointerType: "touch",
+    });
+
+    expect(useUiStore.getState().mobileHandGesture).toMatchObject({
+      objectId: 11,
+      phase: "drag",
+      castReady: false,
+    });
+
+    fireEvent.pointerMove(hand, {
+      clientX: 52,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 15,
+      pointerType: "touch",
+    });
+
+    expect(useUiStore.getState().mobileHandGesture).toMatchObject({
+      objectId: 11,
+      phase: "drag",
+      offsetX: 12,
+      offsetY: -90,
+      playable: true,
+      castReady: true,
+    });
+
+    fireEvent.pointerUp(hand, {
+      button: 0,
+      clientX: 52,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 15,
+      pointerType: "touch",
+    });
+
+    expect(onReleaseToCast).toHaveBeenCalledOnce();
+    expect(onReleaseToCast).toHaveBeenCalledWith(11);
+    expect(useUiStore.getState().mobileHandGesture).toBeNull();
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("disarms casting after returning toward the hand, including at pointer release", () => {
+    vi.useFakeTimers();
+    const onReleaseToCast = vi.fn();
+    render(
+      <ScrubHarness
+        onOpen={vi.fn()}
+        isPlayable={(objectId) => objectId === 11}
+        canReleaseToCast={(objectId) => objectId === 11}
+        onReleaseToCast={onReleaseToCast}
+      />,
+    );
+    const hand = screen.getByTestId("hand");
+    const first = screen.getByTestId("card-11");
+    hand.getBoundingClientRect = () => rect(0, 200);
+    first.getBoundingClientRect = () => rect(0, 100);
+
+    fireEvent.pointerDown(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 16,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(400));
+
+    fireEvent.pointerMove(hand, {
+      clientX: 52,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 16,
+      pointerType: "touch",
+    });
+    expect(useUiStore.getState().mobileHandGesture).toMatchObject({
+      phase: "drag",
+      castReady: true,
+    });
+
+    fireEvent.pointerMove(hand, {
+      clientX: 52,
+      clientY: 90,
+      isPrimary: true,
+      pointerId: 16,
+      pointerType: "touch",
+    });
+    expect(useUiStore.getState().mobileHandGesture).toMatchObject({
+      phase: "drag",
+      castReady: false,
+    });
+
+    // Arm it again, then release back near the hand without a final move event.
+    // The pointerup coordinates must be authoritative rather than the stale
+    // gold state from the preceding pointermove.
+    fireEvent.pointerMove(hand, {
+      clientX: 52,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 16,
+      pointerType: "touch",
+    });
+    fireEvent.pointerUp(hand, {
+      button: 0,
+      clientX: 52,
+      clientY: 90,
+      isPrimary: true,
+      pointerId: 16,
+      pointerType: "touch",
+    });
+
+    expect(onReleaseToCast).not.toHaveBeenCalled();
+    expect(useUiStore.getState().mobileHandGesture).toBeNull();
   });
 
   it("keeps a short tap available for opening the hand drawer", () => {
@@ -122,6 +365,38 @@ describe("useHandScrubPreview", () => {
 
     expect(onOpen).toHaveBeenCalledOnce();
     expect(useUiStore.getState().inspectedObjectId).toBeNull();
+  });
+
+  it("claims native touch movement on the hand without consuming a short tap", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    render(<ScrubHarness onOpen={onOpen} />);
+    const hand = screen.getByTestId("hand");
+
+    fireEvent.pointerDown(hand, {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 13,
+      pointerType: "touch",
+    });
+
+    const touchMove = new Event("touchmove", { bubbles: true, cancelable: true });
+    hand.dispatchEvent(touchMove);
+    expect(touchMove.defaultPrevented).toBe(true);
+
+    fireEvent.pointerUp(hand, {
+      button: 0,
+      clientX: 42,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 13,
+      pointerType: "touch",
+    });
+    fireEvent.click(hand);
+
+    expect(onOpen).toHaveBeenCalledOnce();
   });
 
   it("does not consume a long tap that starts outside a card", () => {

--- a/client/src/components/hand/useHandScrubPreview.ts
+++ b/client/src/components/hand/useHandScrubPreview.ts
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useRef } from "react";
 import type { PointerEvent as ReactPointerEvent, RefObject } from "react";
 
+import { HAND_DRAG_PLAY_THRESHOLD } from "../../hooks/useDragToCast.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 
 const HOLD_DELAY_MS = 400;
 const PRE_HOLD_MOVE_THRESHOLD_PX = 12;
+// A held finger naturally drifts a few CSS pixels. Require a deliberate lift
+// before replacing the large inspection preview with the movable hand card.
+const HELD_CARD_DRAG_START_PX = 16;
 const VERTICAL_SCRUB_TOLERANCE_PX = 28;
+const RELEASE_CLICK_SUPPRESSION_MS = 750;
 
 function cardAtPoint(container: HTMLElement, x: number, y: number): HTMLElement | null {
   const candidates = Array.from(
@@ -35,7 +40,8 @@ function cardAtPoint(container: HTMLElement, x: number, y: number): HTMLElement 
  * - a short tap remains available to open the full hand drawer;
  * - holding activates a non-blocking preview;
  * - horizontal movement while held scrubs across adjacent fanned cards;
- * - release dismisses the preview and never casts the card.
+ * - dragging a directly castable card above the hand arms release-to-cast;
+ * - release elsewhere dismisses the preview without casting.
  *
  * The fan cards stay pointer-events-none on mobile, so this hook owns one stable
  * pointer-captured surface instead of moving the gesture target as cards animate.
@@ -43,17 +49,44 @@ function cardAtPoint(container: HTMLElement, x: number, y: number): HTMLElement 
 export function useHandScrubPreview(
   containerRef: RefObject<HTMLElement | null>,
   enabled: boolean,
+  options: {
+    isPlayable?: (objectId: number) => boolean;
+    canReleaseToCast?: (objectId: number) => boolean;
+    onReleaseToCast?: (objectId: number) => void;
+  } = {},
 ) {
+  const { isPlayable, canReleaseToCast, onReleaseToCast } = options;
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
   const dismissPreview = useUiStore((s) => s.dismissPreview);
+  const setMobileHandGesture = useUiStore((s) => s.setMobileHandGesture);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pointerIdRef = useRef<number | null>(null);
   const startRef = useRef({ x: 0, y: 0 });
   const scrubbingRef = useRef(false);
   const activeCardRef = useRef<HTMLElement | null>(null);
+  const activeObjectIdRef = useRef<number | null>(null);
+  const cardGrabOffsetXRef = useRef(0);
+  const sourceOriginRef = useRef({
+    bottom: 0,
+    centerX: 0,
+    height: 0,
+    rotation: 0,
+    top: 0,
+    width: 0,
+  });
+  const draggingCardRef = useRef(false);
+  const castReadyRef = useRef(false);
   const suppressClickRef = useRef(false);
   const suppressResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearClickSuppression = useCallback(() => {
+    suppressClickRef.current = false;
+    if (suppressResetRef.current != null) {
+      clearTimeout(suppressResetRef.current);
+      suppressResetRef.current = null;
+    }
+  }, []);
 
   const clearHoldTimer = useCallback(() => {
     if (timerRef.current != null) {
@@ -65,56 +98,124 @@ export function useHandScrubPreview(
   const clearActiveCard = useCallback(() => {
     activeCardRef.current?.removeAttribute("data-hand-touch-active");
     activeCardRef.current = null;
+    activeObjectIdRef.current = null;
+    castReadyRef.current = false;
+    draggingCardRef.current = false;
   }, []);
 
   const inspectAtPoint = useCallback(
     (x: number, y: number) => {
       const container = containerRef.current;
-      if (!container) return false;
+      if (!container) return null;
       const card = cardAtPoint(container, x, y);
-      if (!card) return false;
-      if (card === activeCardRef.current) return true;
+      if (!card) return activeObjectIdRef.current;
+      if (card === activeCardRef.current) return activeObjectIdRef.current;
 
       const objectId = Number(card.dataset.objectId);
-      if (!Number.isFinite(objectId)) return false;
+      if (!Number.isFinite(objectId)) return activeObjectIdRef.current;
 
       clearActiveCard();
       card.dataset.handTouchActive = "true";
       activeCardRef.current = card;
+      activeObjectIdRef.current = objectId;
+      const rect = card.getBoundingClientRect();
+      const centerX = (rect.left + rect.right) / 2;
+      const rotation = Number(card.dataset.handRotation);
+      const height = card.offsetHeight || rect.height;
+      sourceOriginRef.current = {
+        bottom: rect.bottom,
+        centerX,
+        height,
+        rotation: Number.isFinite(rotation) ? rotation : 0,
+        top: rect.bottom - height,
+        width: card.offsetWidth || rect.width,
+      };
+      cardGrabOffsetXRef.current = x - centerX;
       inspectObject(objectId, undefined, "immediate");
       setPreviewSticky(true);
-      return true;
+      return objectId;
     },
     [clearActiveCard, containerRef, inspectObject, setPreviewSticky],
   );
 
-  const finishScrub = useCallback(() => {
+  const updateGesture = useCallback(
+    (objectId: number, x: number, y: number, phase: "preview" | "drag") => {
+      const container = containerRef.current;
+      if (!activeCardRef.current || !container) return;
+      const bounds = container.getBoundingClientRect();
+      const playable = isPlayable?.(objectId) ?? false;
+      const offsetY = Math.min(0, y - startRef.current.y);
+      const castReady = Boolean(
+        phase === "drag"
+        && playable
+        && canReleaseToCast?.(objectId)
+        && offsetY < HAND_DRAG_PLAY_THRESHOLD
+        && y < bounds.top,
+      );
+      castReadyRef.current = castReady;
+      setMobileHandGesture({
+        objectId,
+        phase,
+        sourceOrigin: sourceOriginRef.current,
+        offsetX: x - sourceOriginRef.current.centerX - cardGrabOffsetXRef.current,
+        offsetY,
+        playable,
+        castReady,
+      });
+    },
+    [canReleaseToCast, containerRef, isPlayable, setMobileHandGesture],
+  );
+
+  const finishScrub = useCallback((allowCast = false) => {
     const wasScrubbing = scrubbingRef.current;
+    const castObjectId =
+      allowCast && castReadyRef.current ? activeObjectIdRef.current : null;
     clearHoldTimer();
     scrubbingRef.current = false;
     pointerIdRef.current = null;
     clearActiveCard();
+    setMobileHandGesture(null);
     if (wasScrubbing) {
       dismissPreview();
       suppressClickRef.current = true;
       if (suppressResetRef.current != null) clearTimeout(suppressResetRef.current);
-      // The synthetic click follows pointerup synchronously. Clear the guard on
-      // the next task so a later real tap still opens the drawer.
-      suppressResetRef.current = setTimeout(() => {
-        suppressClickRef.current = false;
-        suppressResetRef.current = null;
-      }, 0);
+      // WKWebView can dispatch the compatibility click well after pointerup.
+      // Keep the guard alive long enough to consume it; a new pointer gesture
+      // clears the guard immediately so a deliberate follow-up tap still works.
+      suppressResetRef.current = setTimeout(
+        clearClickSuppression,
+        RELEASE_CLICK_SUPPRESSION_MS,
+      );
     }
-  }, [clearActiveCard, clearHoldTimer, dismissPreview]);
+    if (castObjectId != null) onReleaseToCast?.(castObjectId);
+  }, [clearActiveCard, clearClickSuppression, clearHoldTimer, dismissPreview, onReleaseToCast, setMobileHandGesture]);
 
   useEffect(() => {
     return () => {
       clearHoldTimer();
       clearActiveCard();
-      if (suppressResetRef.current != null) clearTimeout(suppressResetRef.current);
+      clearClickSuppression();
+      setMobileHandGesture(null);
       if (scrubbingRef.current) dismissPreview();
     };
-  }, [clearActiveCard, clearHoldTimer, dismissPreview]);
+  }, [clearActiveCard, clearClickSuppression, clearHoldTimer, dismissPreview, setMobileHandGesture]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!enabled || !container) return;
+
+    // `touch-action: none` is the declarative guard, but iOS Safari/WKWebView
+    // can still begin rubber-banding while the long-press timer is pending.
+    // Claim touch movement that started on the hand with a non-passive native
+    // listener so the browser cannot move the viewport before scrubbing starts.
+    const preventNativeHandPan = (event: TouchEvent) => {
+      if (pointerIdRef.current == null || !event.cancelable) return;
+      event.preventDefault();
+    };
+
+    container.addEventListener("touchmove", preventNativeHandPan, { passive: false });
+    return () => container.removeEventListener("touchmove", preventNativeHandPan);
+  }, [containerRef, enabled]);
 
   const onPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
@@ -122,7 +223,9 @@ export function useHandScrubPreview(
         return;
       }
 
+      clearClickSuppression();
       clearHoldTimer();
+      setMobileHandGesture(null);
       pointerIdRef.current = event.pointerId;
       startRef.current = { x: event.clientX, y: event.clientY };
       try {
@@ -134,15 +237,22 @@ export function useHandScrubPreview(
       const { x, y } = startRef.current;
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
-        scrubbingRef.current = inspectAtPoint(x, y);
+        const objectId = inspectAtPoint(x, y);
+        scrubbingRef.current = objectId != null;
+        if (objectId != null) updateGesture(objectId, x, y, "preview");
       }, HOLD_DELAY_MS);
     },
-    [clearHoldTimer, enabled, inspectAtPoint],
+    [clearClickSuppression, clearHoldTimer, enabled, inspectAtPoint, setMobileHandGesture, updateGesture],
   );
 
   const onPointerMove = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
       if (pointerIdRef.current !== event.pointerId) return;
+
+      // Claim the gesture throughout the hold delay as well as during active
+      // scrubbing. Waiting until the preview opens lets WebKit start a native
+      // pan that pointer capture cannot take back.
+      event.preventDefault();
 
       if (!scrubbingRef.current) {
         const dx = event.clientX - startRef.current.x;
@@ -156,39 +266,58 @@ export function useHandScrubPreview(
         return;
       }
 
-      event.preventDefault();
-      inspectAtPoint(event.clientX, event.clientY);
+      const offsetY = event.clientY - startRef.current.y;
+      if (offsetY <= -HELD_CARD_DRAG_START_PX) draggingCardRef.current = true;
+      const objectId = draggingCardRef.current
+        ? activeObjectIdRef.current
+        : inspectAtPoint(event.clientX, event.clientY);
+      if (objectId != null) {
+        updateGesture(
+          objectId,
+          event.clientX,
+          event.clientY,
+          draggingCardRef.current ? "drag" : "preview",
+        );
+      }
     },
-    [clearHoldTimer, inspectAtPoint],
+    [clearHoldTimer, inspectAtPoint, updateGesture],
   );
 
   const onPointerUp = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
       if (pointerIdRef.current !== event.pointerId) return;
       if (scrubbingRef.current) event.preventDefault();
+      // WebKit may deliver the finger's final position only with pointerup.
+      // Recompute from that authoritative coordinate so returning below the
+      // cast boundary always disarms release-to-cast, even when no final
+      // pointermove was emitted.
+      const objectId = activeObjectIdRef.current;
+      if (scrubbingRef.current && draggingCardRef.current && objectId != null) {
+        updateGesture(objectId, event.clientX, event.clientY, "drag");
+      }
       try {
         event.currentTarget.releasePointerCapture(event.pointerId);
       } catch {
         // Ignore capture-release mismatches from WebKit and test harnesses.
       }
-      finishScrub();
+      finishScrub(true);
     },
-    [finishScrub],
+    [finishScrub, updateGesture],
   );
 
   const onPointerCancel = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
       if (pointerIdRef.current !== event.pointerId) return;
-      finishScrub();
+      finishScrub(false);
     },
     [finishScrub],
   );
 
   const consumeClick = useCallback(() => {
     if (!suppressClickRef.current) return false;
-    suppressClickRef.current = false;
+    clearClickSuppression();
     return true;
-  }, []);
+  }, [clearClickSuppression]);
 
   return {
     handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },

--- a/client/src/components/hand/useHandScrubPreview.ts
+++ b/client/src/components/hand/useHandScrubPreview.ts
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { PointerEvent as ReactPointerEvent, RefObject } from "react";
+
+import { useUiStore } from "../../stores/uiStore.ts";
+
+const HOLD_DELAY_MS = 400;
+const PRE_HOLD_MOVE_THRESHOLD_PX = 12;
+const VERTICAL_SCRUB_TOLERANCE_PX = 28;
+
+function cardAtPoint(container: HTMLElement, x: number, y: number): HTMLElement | null {
+  const candidates = Array.from(
+    container.querySelectorAll<HTMLElement>("[data-hand-card][data-object-id]"),
+  )
+    .map((element) => ({ element, rect: element.getBoundingClientRect() }))
+    .filter(({ rect }) =>
+      x >= rect.left
+      && x <= rect.right
+      && y >= rect.top - VERTICAL_SCRUB_TOLERANCE_PX
+      && y <= rect.bottom + VERTICAL_SCRUB_TOLERANCE_PX
+    );
+
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => {
+    const aDistance = Math.abs(x - (a.rect.left + a.rect.right) / 2);
+    const bDistance = Math.abs(x - (b.rect.left + b.rect.right) / 2);
+    return aDistance - bDistance;
+  });
+  return candidates[0].element;
+}
+
+/**
+ * Mobile hand interaction matching Arena's gesture split:
+ *
+ * - a short tap remains available to open the full hand drawer;
+ * - holding activates a non-blocking preview;
+ * - horizontal movement while held scrubs across adjacent fanned cards;
+ * - release dismisses the preview and never casts the card.
+ *
+ * The fan cards stay pointer-events-none on mobile, so this hook owns one stable
+ * pointer-captured surface instead of moving the gesture target as cards animate.
+ */
+export function useHandScrubPreview(
+  containerRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+) {
+  const inspectObject = useUiStore((s) => s.inspectObject);
+  const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
+  const dismissPreview = useUiStore((s) => s.dismissPreview);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pointerIdRef = useRef<number | null>(null);
+  const startRef = useRef({ x: 0, y: 0 });
+  const scrubbingRef = useRef(false);
+  const activeCardRef = useRef<HTMLElement | null>(null);
+  const suppressClickRef = useRef(false);
+  const suppressResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearHoldTimer = useCallback(() => {
+    if (timerRef.current != null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const clearActiveCard = useCallback(() => {
+    activeCardRef.current?.removeAttribute("data-hand-touch-active");
+    activeCardRef.current = null;
+  }, []);
+
+  const inspectAtPoint = useCallback(
+    (x: number, y: number) => {
+      const container = containerRef.current;
+      if (!container) return false;
+      const card = cardAtPoint(container, x, y);
+      if (!card) return false;
+      if (card === activeCardRef.current) return true;
+
+      const objectId = Number(card.dataset.objectId);
+      if (!Number.isFinite(objectId)) return false;
+
+      clearActiveCard();
+      card.dataset.handTouchActive = "true";
+      activeCardRef.current = card;
+      inspectObject(objectId, undefined, "immediate");
+      setPreviewSticky(true);
+      return true;
+    },
+    [clearActiveCard, containerRef, inspectObject, setPreviewSticky],
+  );
+
+  const finishScrub = useCallback(() => {
+    const wasScrubbing = scrubbingRef.current;
+    clearHoldTimer();
+    scrubbingRef.current = false;
+    pointerIdRef.current = null;
+    clearActiveCard();
+    if (wasScrubbing) {
+      dismissPreview();
+      suppressClickRef.current = true;
+      if (suppressResetRef.current != null) clearTimeout(suppressResetRef.current);
+      // The synthetic click follows pointerup synchronously. Clear the guard on
+      // the next task so a later real tap still opens the drawer.
+      suppressResetRef.current = setTimeout(() => {
+        suppressClickRef.current = false;
+        suppressResetRef.current = null;
+      }, 0);
+    }
+  }, [clearActiveCard, clearHoldTimer, dismissPreview]);
+
+  useEffect(() => {
+    return () => {
+      clearHoldTimer();
+      clearActiveCard();
+      if (suppressResetRef.current != null) clearTimeout(suppressResetRef.current);
+      if (scrubbingRef.current) dismissPreview();
+    };
+  }, [clearActiveCard, clearHoldTimer, dismissPreview]);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (!enabled || event.pointerType === "mouse" || !event.isPrimary || event.button !== 0) {
+        return;
+      }
+
+      clearHoldTimer();
+      pointerIdRef.current = event.pointerId;
+      startRef.current = { x: event.clientX, y: event.clientY };
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+      } catch {
+        // Pointer capture is best-effort on older WKWebView versions.
+      }
+
+      const { x, y } = startRef.current;
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        scrubbingRef.current = inspectAtPoint(x, y);
+      }, HOLD_DELAY_MS);
+    },
+    [clearHoldTimer, enabled, inspectAtPoint],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (pointerIdRef.current !== event.pointerId) return;
+
+      if (!scrubbingRef.current) {
+        const dx = event.clientX - startRef.current.x;
+        const dy = event.clientY - startRef.current.y;
+        if (
+          dx * dx + dy * dy
+          > PRE_HOLD_MOVE_THRESHOLD_PX * PRE_HOLD_MOVE_THRESHOLD_PX
+        ) {
+          clearHoldTimer();
+        }
+        return;
+      }
+
+      event.preventDefault();
+      inspectAtPoint(event.clientX, event.clientY);
+    },
+    [clearHoldTimer, inspectAtPoint],
+  );
+
+  const onPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (pointerIdRef.current !== event.pointerId) return;
+      if (scrubbingRef.current) event.preventDefault();
+      try {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      } catch {
+        // Ignore capture-release mismatches from WebKit and test harnesses.
+      }
+      finishScrub();
+    },
+    [finishScrub],
+  );
+
+  const onPointerCancel = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (pointerIdRef.current !== event.pointerId) return;
+      finishScrub();
+    },
+    [finishScrub],
+  );
+
+  const consumeClick = useCallback(() => {
+    if (!suppressClickRef.current) return false;
+    suppressClickRef.current = false;
+    return true;
+  }, []);
+
+  return {
+    handlers: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+    consumeClick,
+  };
+}

--- a/client/src/game/__tests__/sessionCleanup.test.ts
+++ b/client/src/game/__tests__/sessionCleanup.test.ts
@@ -12,6 +12,7 @@ describe("clearPromptOverlayState", () => {
       pendingAbilityChoice: null,
       enchantmentsDialogPlayer: null,
       manualManaOverride: false,
+      mobileHandGesture: null,
     });
   });
 
@@ -69,5 +70,30 @@ describe("clearPromptOverlayState", () => {
     clearPromptOverlayState();
 
     expect(useUiStore.getState().handFilter).toBe("none");
+  });
+
+  it("clears an in-flight mobile hand gesture at a game boundary", () => {
+    useUiStore.setState({
+      mobileHandGesture: {
+        objectId: 1,
+        phase: "drag",
+        sourceOrigin: {
+          bottom: 180,
+          centerX: 50,
+          height: 140,
+          rotation: 0,
+          top: 40,
+          width: 100,
+        },
+        offsetX: 12,
+        offsetY: -80,
+        playable: true,
+        castReady: true,
+      },
+    });
+
+    clearPromptOverlayState();
+
+    expect(useUiStore.getState().mobileHandGesture).toBeNull();
   });
 });

--- a/client/src/game/sessionCleanup.ts
+++ b/client/src/game/sessionCleanup.ts
@@ -28,6 +28,7 @@ export function clearPromptOverlayState(): void {
   useUiStore.getState().setPendingAbilityChoice(null);
   useUiStore.getState().setEnchantmentsDialogPlayer(null);
   useUiStore.getState().setAttachmentFanHost(null);
+  useUiStore.getState().setMobileHandGesture(null);
   // The per-game "Manual mana" toggle must never leak into the next game.
   useUiStore.getState().setManualManaOverride(false);
   // The ephemeral hand hide-filter is a per-game focus aid — reset it too.

--- a/client/src/hooks/__tests__/useCardImage.test.tsx
+++ b/client/src/hooks/__tests__/useCardImage.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 function jsonResponse(data: unknown): Response {
@@ -146,5 +146,50 @@ describe("useCardImage", () => {
       subtypes: undefined,
       toughness: null,
     });
+  });
+
+  it("never returns the previous card's image after a rapid request change", async () => {
+    let resolveFirst: ((asset: { src: string; isRotated: boolean }) => void) | undefined;
+    let resolveSecond: ((asset: { src: string; isRotated: boolean }) => void) | undefined;
+    const fetchCardImageAsset = vi.fn((name: string) =>
+      new Promise<{ src: string; isRotated: boolean }>((resolve) => {
+        if (name === "First Card") resolveFirst = resolve;
+        else resolveSecond = resolve;
+      })
+    );
+    vi.doMock("../../services/scryfall.ts", () => ({
+      fetchCardImageAsset,
+      fetchCardImageAssetByOracleId: vi.fn(),
+      fetchTokenImageByRef: vi.fn(),
+      fetchTokenImageUrl: vi.fn(),
+      findPrintingById: vi.fn(),
+      getCardPrintings: vi.fn().mockResolvedValue([]),
+      isCardImageFlipLayoutSync: vi.fn().mockReturnValue(false),
+      isCardImageRotatedSync: vi.fn().mockReturnValue(false),
+      pickOldestPrinting: vi.fn(),
+      resolveFaceIndexSync: vi.fn().mockReturnValue(null),
+      resolveOracleIdSync: vi.fn().mockReturnValue(null),
+      resolvePrintingImageUrl: vi.fn(),
+    }));
+
+    const { useCardImage } = await import("../useCardImage");
+    const { result, rerender } = renderHook(
+      ({ name }) => useCardImage(name),
+      { initialProps: { name: "First Card" } },
+    );
+
+    await act(async () => {
+      resolveFirst?.({ src: "first.png", isRotated: false });
+    });
+    expect(result.current.src).toBe("first.png");
+
+    rerender({ name: "Second Card" });
+    expect(result.current.src).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    await act(async () => {
+      resolveSecond?.({ src: "second.png", isRotated: false });
+    });
+    expect(result.current.src).toBe("second.png");
   });
 });

--- a/client/src/hooks/useCardImage.ts
+++ b/client/src/hooks/useCardImage.ts
@@ -375,6 +375,7 @@ export function useCardImage(
   const [isRotated, setIsRotated] = useState(false);
   const [isFlip, setIsFlip] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [stateRequestKey, setStateRequestKey] = useState<string | null>(null);
   const [, setArtCacheTick] = useState(0);
 
   const resolvedOracleId = oracleId || resolveOracleIdSync(cardName) || "";
@@ -459,6 +460,7 @@ export function useCardImage(
 
   useEffect(() => {
     if (overrideUrl) {
+      setStateRequestKey(requestKey);
       setSrc(overrideUrl);
       setIsRotated(isCardImageRotatedSync(resolvedOracleId, cardName));
       setIsFlip(isCardImageFlipLayoutSync(resolvedOracleId, cardName));
@@ -467,6 +469,7 @@ export function useCardImage(
     }
 
     if (!cardName && !oracleId) {
+      setStateRequestKey(requestKey);
       setSrc(null);
       setIsRotated(false);
       setIsFlip(false);
@@ -477,8 +480,17 @@ export function useCardImage(
     let cancelled = false;
 
     async function loadImage() {
-      setIsLoading(true);
-      setSrc(null);
+      const cachedEntry = imageRequestCache.get(requestKey);
+      setStateRequestKey(requestKey);
+      if (cachedEntry && !cachedEntry.promise) {
+        setSrc(cachedEntry.asset?.src ?? null);
+        setIsRotated(cachedEntry.asset?.isRotated ?? false);
+        setIsFlip(isCardImageFlipLayoutSync(resolvedOracleId, cardName));
+        setIsLoading(false);
+      } else {
+        setIsLoading(true);
+        setSrc(null);
+      }
 
       try {
         const imageAsset = await acquireCachedImageSrc(
@@ -535,6 +547,35 @@ export function useCardImage(
     resolvedOracleId,
     size,
   ]);
+
+  // Effects reset the state after render, so a component reused for a new card
+  // would otherwise expose the previous card's src for one frame. Hand previews
+  // intentionally keep one mounted component while scrubbing; gate the result
+  // by request identity and synchronously reuse the hand card's cached asset
+  // when available.
+  if (stateRequestKey !== requestKey) {
+    if (overrideUrl) {
+      return {
+        src: overrideUrl,
+        isLoading: false,
+        isRotated: isCardImageRotatedSync(resolvedOracleId, cardName),
+        isFlip: isCardImageFlipLayoutSync(resolvedOracleId, cardName),
+      };
+    }
+    if (!cardName && !oracleId) {
+      return { src: null, isLoading: false, isRotated: false, isFlip: false };
+    }
+    const cachedEntry = imageRequestCache.get(requestKey);
+    if (cachedEntry && !cachedEntry.promise) {
+      return {
+        src: cachedEntry.asset?.src ?? null,
+        isLoading: false,
+        isRotated: cachedEntry.asset?.isRotated ?? false,
+        isFlip: isCardImageFlipLayoutSync(resolvedOracleId, cardName),
+      };
+    }
+    return { src: null, isLoading: true, isRotated: false, isFlip: false };
+  }
 
   return { src, isLoading, isRotated, isFlip };
 }

--- a/client/src/hooks/useDragToCast.ts
+++ b/client/src/hooks/useDragToCast.ts
@@ -10,6 +10,13 @@ import { dispatchAction } from "../game/dispatch.ts";
  */
 export const DRAG_PLAY_THRESHOLD = -20;
 
+/**
+ * Hand cards need a larger upward commitment than other draggable cast
+ * surfaces. This leaves room for lateral hand reordering without a small
+ * upward component accidentally becoming a cast.
+ */
+export const HAND_DRAG_PLAY_THRESHOLD = -64;
+
 interface UseDragToCastOptions {
   hasPriority: boolean;
   isInSourceZone?: (info: PanInfo) => boolean;

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -411,6 +411,7 @@ export function GamePage() {
         if (hasConcededRef.current) break;
         // Server-initiated game end (concede, disconnect timeout, etc.)
         // Map the server's authoritative winner into the store so GameOverScreen renders.
+        clearPromptOverlayState();
         if (gameId) clearGame(gameId);
         useGameStore.setState({
           waitingFor: { type: "GameOver", data: { winner: event.winner } },
@@ -618,6 +619,7 @@ export function GamePage() {
         useMultiplayerStore.setState({ playerSlots: event.slots });
         break;
       case "gameOver":
+        clearPromptOverlayState();
         if (gameId) clearGame(gameId);
         useGameStore.setState({
           waitingFor: { type: "GameOver", data: { winner: event.winner } },

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1329,20 +1329,23 @@ function GamePageContent({
           gridTemplateColumns: "1fr",
         }}
       >
-        {/* Row 1: Opponent hand + zone piles (flow layout — piles take real space) */}
+        {/* Row 1: Opponent hand + zone piles. Equal flexible side tracks keep
+            the focused hand centered on the viewport while the piles remain
+            right-aligned; split layouts render their hands inside seat panes. */}
         <div
-          className={`relative z-20 min-w-0 flex w-full ${splitBoardActive ? "overflow-hidden" : "overflow-visible"}`}
+          className={`relative z-20 min-w-0 w-full ${renderFocusedOpponentTopRow ? "grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)]" : "flex"} ${splitBoardActive ? "overflow-hidden" : "overflow-visible"}`}
           data-flex-zone="opp-row"
         >
           {renderFocusedOpponentTopRow && (
             <>
-              <div className="min-w-0 flex-1">
+              <div aria-hidden />
+              <div className="min-w-0">
                 <OpponentHand showCards={showAiHand} />
               </div>
               <DraggableWidget
                 target={{ kind: "widget", key: "opponentPiles" }}
                 flexZone="opponentPiles"
-                className="flex shrink-0 items-start gap-1.5 px-1 py-1"
+                className="flex items-start justify-self-end gap-1.5 px-1 py-1"
                 style={playerZoneRailStyle}
               >
                 {activeOpponentId != null ? (

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -18,6 +18,7 @@ import { MemoryRouter, Route, Routes } from "react-router";
 import { GamePage } from "../GamePage";
 import type { FormatConfig } from "../../adapter/types";
 import type { WsAdapterEvent } from "../../adapter/ws-adapter";
+import type { P2PAdapterEvent } from "../../adapter/p2p-adapter";
 
 // ── Hoisted variables (must be declared before vi.mock hoisting) ─────────────
 
@@ -25,6 +26,11 @@ import type { WsAdapterEvent } from "../../adapter/ws-adapter";
 let capturedOnNoDeck: ((reason?: string, bracketViolation?: boolean) => void) | undefined;
 let capturedFormatConfig: FormatConfig | undefined;
 let capturedOnWsEvent: ((event: WsAdapterEvent) => void) | undefined;
+let capturedOnP2PEvent: ((event: P2PAdapterEvent) => void) | undefined;
+
+const { mockClearPromptOverlayState } = vi.hoisted(() => ({
+  mockClearPromptOverlayState: vi.fn(),
+}));
 
 const { mockMultiplayerState: _mockMultiplayerState, mockUseMultiplayerStore } = vi.hoisted(() => {
   const mockMultiplayerState = {
@@ -64,18 +70,25 @@ vi.mock("../../providers/GameProvider", () => ({
     children,
     onNoDeck,
     onWsEvent,
+    onP2PEvent,
     formatConfig,
   }: {
     children: React.ReactNode;
     onNoDeck?: (reason?: string, bracketViolation?: boolean) => void;
     onWsEvent?: (event: WsAdapterEvent) => void;
+    onP2PEvent?: (event: P2PAdapterEvent) => void;
     formatConfig?: FormatConfig;
   }) => {
     capturedOnNoDeck = onNoDeck;
     capturedOnWsEvent = onWsEvent;
+    capturedOnP2PEvent = onP2PEvent;
     capturedFormatConfig = formatConfig;
     return <>{children}</>;
   },
+}));
+
+vi.mock("../../game/sessionCleanup.ts", () => ({
+  clearPromptOverlayState: mockClearPromptOverlayState,
 }));
 
 // useGameDispatch moved out of GameProvider into its own hook module; mock it
@@ -238,6 +251,7 @@ beforeEach(() => {
   capturedOnNoDeck = undefined;
   capturedFormatConfig = undefined;
   capturedOnWsEvent = undefined;
+  capturedOnP2PEvent = undefined;
   vi.clearAllMocks();
 });
 
@@ -246,6 +260,23 @@ afterEach(() => {
 });
 
 describe("GamePage — cEDH bracket-violation blocking modal", () => {
+  it("clears prompt overlays before websocket and P2P game-over displays", () => {
+    renderGamePage("/game/test-game-123?mode=online");
+
+    act(() => {
+      capturedOnWsEvent?.({ type: "gameOver", winner: 0, reason: "conceded" });
+    });
+
+    cleanup();
+    renderGamePage("/game/test-game-123?mode=p2p-host");
+
+    act(() => {
+      capturedOnP2PEvent?.({ type: "gameOver", winner: 0, reason: "conceded" });
+    });
+
+    expect(mockClearPromptOverlayState).toHaveBeenCalledTimes(2);
+  });
+
   it("renders the connection-lost banner when a native engine error arrives before close", () => {
     renderGamePage();
 

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -28,8 +28,9 @@ let capturedFormatConfig: FormatConfig | undefined;
 let capturedOnWsEvent: ((event: WsAdapterEvent) => void) | undefined;
 let capturedOnP2PEvent: ((event: P2PAdapterEvent) => void) | undefined;
 
-const { mockClearPromptOverlayState } = vi.hoisted(() => ({
+const { mockClearPromptOverlayState, mockSetGameState } = vi.hoisted(() => ({
   mockClearPromptOverlayState: vi.fn(),
+  mockSetGameState: vi.fn(),
 }));
 
 const { mockMultiplayerState: _mockMultiplayerState, mockUseMultiplayerStore } = vi.hoisted(() => {
@@ -112,20 +113,23 @@ vi.mock("../../game/dispatch.ts", () => ({
 }));
 
 vi.mock("../../stores/gameStore", () => ({
-  useGameStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
-    selector({
-      gameState: null,
-      waitingFor: null,
-      legalActions: [],
-      autoPassRecommended: false,
-      spellCosts: {},
-      legalActionsByObject: {},
-      events: [],
-      eventHistory: [],
-      logHistory: [],
-      adapter: null,
-      lobbyProgress: null,
-    }),
+  useGameStore: Object.assign(
+    vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+      selector({
+        gameState: null,
+        waitingFor: null,
+        legalActions: [],
+        autoPassRecommended: false,
+        spellCosts: {},
+        legalActionsByObject: {},
+        events: [],
+        eventHistory: [],
+        logHistory: [],
+        adapter: null,
+        lobbyProgress: null,
+      }),
+    ),
+    { setState: mockSetGameState },
   ),
   clearGame: vi.fn(),
   loadActiveGame: vi.fn(() => null),
@@ -261,7 +265,7 @@ afterEach(() => {
 
 describe("GamePage — cEDH bracket-violation blocking modal", () => {
   it("clears prompt overlays before websocket and P2P game-over displays", () => {
-    renderGamePage("/game/test-game-123?mode=online");
+    renderGamePage("/game/test-game-123?mode=host");
 
     act(() => {
       capturedOnWsEvent?.({ type: "gameOver", winner: 0, reason: "conceded" });
@@ -275,6 +279,12 @@ describe("GamePage — cEDH bracket-violation blocking modal", () => {
     });
 
     expect(mockClearPromptOverlayState).toHaveBeenCalledTimes(2);
+    expect(mockSetGameState).toHaveBeenNthCalledWith(1, {
+      waitingFor: { type: "GameOver", data: { winner: 0 } },
+    });
+    expect(mockSetGameState).toHaveBeenNthCalledWith(2, {
+      waitingFor: { type: "GameOver", data: { winner: 0 } },
+    });
   });
 
   it("renders the connection-lost banner when a native engine error arrives before close", () => {

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -42,6 +42,26 @@ export type DiceRollPayload =
       context: "startingPlayer" | "ability";
     };
 
+/** Direct-manipulation state for the mobile hand's held-card preview. The
+ * engine-authored action set determines `playable` / whether `castReady` may
+ * ever become true; offsets and the release threshold are presentation only. */
+export interface MobileHandGesture {
+  objectId: ObjectId;
+  phase: "preview" | "drag";
+  sourceOrigin: {
+    bottom: number;
+    centerX: number;
+    height: number;
+    rotation: number;
+    top: number;
+    width: number;
+  };
+  offsetX: number;
+  offsetY: number;
+  playable: boolean;
+  castReady: boolean;
+}
+
 // Guard against spurious mouseleave events caused by Framer Motion layout
 // recalculations or pointer-events-auto overlays stealing focus from the card.
 // Clears are deferred — if the cursor is still over a card/preview element
@@ -170,6 +190,7 @@ interface UiStoreState {
    *  use the modal AttachmentsDialog). Cleared by `clearPromptOverlayState`. */
   attachmentFanHostId: ObjectId | null;
   mobileHandOpen: boolean;
+  mobileHandGesture: MobileHandGesture | null;
   /** Ephemeral hide-filter for the player's own hand (display-only). Lives here
    *  rather than in `preferencesStore` so it resets each game (cleared by
    *  `clearPromptOverlayState`) — a per-game focus aid, not a durable
@@ -258,6 +279,7 @@ interface UiStoreActions {
   setEnchantmentsDialogPlayer: (id: number | null) => void;
   setAttachmentFanHost: (id: ObjectId | null) => void;
   setMobileHandOpen: (open: boolean) => void;
+  setMobileHandGesture: (gesture: MobileHandGesture | null) => void;
   setHandFilter: (filter: FilterKey) => void;
   toggleDebugPanel: () => void;
   setDebugPanelTab: (tab: "console" | "actions") => void;
@@ -314,6 +336,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   enchantmentsDialogPlayer: null,
   attachmentFanHostId: null,
   mobileHandOpen: false,
+  mobileHandGesture: null,
   handFilter: "none",
   debugPanelOpen: false,
   debugPanelTab: "console",
@@ -419,7 +442,13 @@ export const useUiStore = create<UiStore>()((set, get) => ({
       pendingClearTimer = null;
     }
     cancelPendingShow();
-    set({ inspectedObjectId: null, inspectedFaceIndex: 0, previewSticky: false, altHeld: false });
+    set({
+      inspectedObjectId: null,
+      inspectedFaceIndex: 0,
+      previewSticky: false,
+      altHeld: false,
+      mobileHandGesture: null,
+    });
   },
 
   addSelectedCard: (cardId) =>
@@ -579,6 +608,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   setEnchantmentsDialogPlayer: (id) => set({ enchantmentsDialogPlayer: id }),
   setAttachmentFanHost: (id) => set({ attachmentFanHostId: id }),
   setMobileHandOpen: (open) => set({ mobileHandOpen: open }),
+  setMobileHandGesture: (gesture) => set({ mobileHandGesture: gesture }),
   setHandFilter: (filter) => set({ handFilter: filter }),
   toggleDebugPanel: () => set((state) => ({ debugPanelOpen: !state.debugPanelOpen })),
   setDebugPanelTab: (tab) => set({ debugPanelTab: tab }),

--- a/client/src/viewmodel/__tests__/cardActionChoice.test.ts
+++ b/client/src/viewmodel/__tests__/cardActionChoice.test.ts
@@ -5,6 +5,7 @@ import {
   collectObjectActions,
   isManaObjectAction,
   requiresConfirmation,
+  resolveDirectPlayOrCastAction,
   resolveSingleActionDispatch,
 } from "../cardActionChoice.ts";
 import { abilityChoiceLabel } from "../costLabel.ts";
@@ -283,6 +284,41 @@ describe("resolveSingleActionDispatch", () => {
   it("returns null for a lone CastPreparedCopy", () => {
     const preparedAction: GameAction = { type: "CastPreparedCopy", data: { source: 1 } };
     expect(resolveSingleActionDispatch([preparedAction], makeGameObject())).toBeNull();
+  });
+});
+
+describe("resolveDirectPlayOrCastAction", () => {
+  const playLandAction: GameAction = {
+    type: "PlayLand",
+    data: { object_id: 1, card_id: 100 },
+  };
+  const cyclingAction: GameAction = {
+    type: "ActivateAbility",
+    data: { source_id: 1, ability_index: 0 },
+  };
+
+  it("returns the one unambiguous engine-provided play action", () => {
+    expect(
+      resolveDirectPlayOrCastAction({ "1": [playLandAction] }, makeGameObject()),
+    ).toBe(playLandAction);
+  });
+
+  it("does not promise release-to-cast when another action requires a choice", () => {
+    expect(
+      resolveDirectPlayOrCastAction(
+        { "1": [playLandAction, cyclingAction] },
+        makeGameObject(),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not classify a lone non-cast ability as release-to-cast", () => {
+    expect(
+      resolveDirectPlayOrCastAction(
+        { "1": [cyclingAction] },
+        makeGameObject({ abilities: [{ consumes_source: false }] }),
+      ),
+    ).toBeNull();
   });
 });
 

--- a/client/src/viewmodel/cardActionChoice.ts
+++ b/client/src/viewmodel/cardActionChoice.ts
@@ -94,10 +94,36 @@ export function playOrCastActionsForObject(
 ): GameAction[] {
   return collectObjectActions(legalActionsByObject, objectId).filter((a) =>
     a.type === "CastSpell"
+    || a.type === "CastSpellForFree"
     || a.type === "CastSpellAsSneak"
     || a.type === "CastSpellAsWebSlinging"
     || a.type === "CastSpellAsMiracle"
     || a.type === "CastSpellAsMadness"
+    || a.type === "PlayFaceDown"
     || a.type === "PlayLand"
   );
+}
+
+/**
+ * Resolve the one action that a release-to-cast gesture may dispatch directly.
+ *
+ * The engine-provided per-object bucket is the authority for legality. We then
+ * reuse the existing auto-dispatch guard (single action, no confirmation) and
+ * the shared play/cast family projection. A card with another hand action or
+ * multiple casting modes therefore stays inspectable/playable, but never turns
+ * gold with a promise that releasing will cast immediately.
+ */
+export function resolveDirectPlayOrCastAction(
+  legalActionsByObject: Record<string, GameAction[]> | undefined,
+  object: GameObject | undefined,
+): GameAction | null {
+  if (!object) return null;
+  const directAction = resolveSingleActionDispatch(
+    collectObjectActions(legalActionsByObject, object.id),
+    object,
+  );
+  if (!directAction) return null;
+  return playOrCastActionsForObject(legalActionsByObject, object.id).includes(directAction)
+    ? directAction
+    : null;
 }


### PR DESCRIPTION
## Summary

- add press-and-hold previews and horizontal hand scrubbing on mobile
- transition a deliberately lifted card into a hand-sized drag visual with playable and cast-ready feedback
- preserve the existing tap-to-open hand modal for ambiguous actions, unsupported direct casts, and users who prefer the established mobile flow
- stabilize fast scrubbing, preview image identity, opponent-hand alignment, and gesture cleanup


https://github.com/user-attachments/assets/1da09d82-fd9f-40df-87ab-00aafdc61692




## Behavior

A short tap still opens the normal mobile hand modal. Holding a card opens the same large, bottom-pinned preview used by the desktop hand fan, and moving horizontally scrubs across adjacent cards without reflowing the fan.

A deliberate upward lift transitions from previewing to dragging the source card. Playable cards retain the cyan affordance and become gold only while they are in the cast-ready zone. Returning the card toward the hand disarms the cast, and releasing there restores it to its original slot.

Release-to-cast is intentionally limited to cards for which the engine exposes exactly one direct play/cast action. Other or ambiguous actions continue through the hand modal rather than being guessed by the frontend.

The PWA cannot fully suppress iOS system edge gestures, so direct dragging is an enhancement rather than the only interaction path; the tap-to-modal fallback remains available.

## Additional fixes

- prevent a reused preview component from briefly showing the previous card's image while scrubbing quickly
- pass stable printed-card identifiers through hand cards so cached PWA card art resolves consistently
- clear in-progress mobile hand gestures during session cleanup
- use a higher hand-specific cast threshold to reduce accidental casts while moving within the fan
- respect reduced-motion and disabled-animation preferences for preview and held-card motion

## Validation

- full frontend suite: 262 files passed, 2,254 tests passed (4 files skipped, 18 todos)
- focused hand/preview/image/session suite: 7 files passed, 62 tests passed
- TypeScript project check passed
- ESLint passed for all changed TypeScript/TSX files
- `git diff --check` passed
- pre-push `cargo fmt --check` and Clippy passed; the unrelated release card-data phase was skipped after Clippy completed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile hand hold-and-scrub interactions for card previewing and browsing adjacent cards.
  * Added a held-card drag overlay with motion/tilt visuals, readiness highlights, and mana cost display.
  * Added “release-to-cast” behavior for eligible cards during the mobile scrub gesture.
* **Bug Fixes**
  * Prevented stale card artwork and mobile preview trails during rapid scrubbing.
  * Improved mobile preview overlay rendering and ensured gesture state is cleared when dismissing previews or changing game state.
  * Reduced unintended casts by increasing the required upward drag distance for hand cards.
* **Style**
  * Refined opponent hand and zone pile alignment for the focused opponent top row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->