### PR TITLE
Fix shell art and fullscreen

### DIFF
--- a/client/src-tauri/capabilities/default.json
+++ b/client/src-tauri/capabilities/default.json
@@ -3,7 +3,7 @@
     "identifier": "default",
     "description": "Local permissions for the bundled bootstrap page",
     "windows": ["main"],
-    "permissions": ["core:default", "allow-stash-legacy-storage"]
+    "permissions": ["core:default", "core:window:allow-set-fullscreen", "allow-stash-legacy-storage"]
   },
   {
     "identifier": "remote-shell",
@@ -19,6 +19,7 @@
     },
     "permissions": [
       "core:default",
+      "core:window:allow-set-fullscreen",
       "shell:allow-open",
       "process:allow-exit",
       "process:allow-restart",

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://phase-rs.dev https://app.phase-rs.dev https://preview.phase-rs.dev"
+      "csp": "default-src 'self'; img-src 'self' data: https://cards.scryfall.io https://backs.scryfall.io; connect-src 'self' https://phase-rs.dev https://app.phase-rs.dev https://preview.phase-rs.dev"
     }
   },
   "bundle": {

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -5,6 +5,7 @@ import {
   PROTOCOL_VERSION,
   WebSocketAdapter,
 } from "../ws-adapter";
+import { AdapterError } from "../types";
 import type { GameState } from "../types";
 import type { PhaseSocketTransport } from "../../services/openPhaseSocket";
 
@@ -354,6 +355,71 @@ describe("WebSocketAdapter", () => {
       );
 
       await expect(attached).rejects.toThrow("Native setup failed");
+    });
+
+    it("rejects native lifecycle waiters when disposed before the socket is attached", async () => {
+      const nativeAdapter = new WebSocketAdapter(
+        "native-engine",
+        "host",
+        { main_deck: [], sideboard: [] },
+        undefined,
+        undefined,
+        undefined,
+        "Host",
+        {
+          nativePregame: {
+            kind: "host",
+            socketFactory: () => new MockWebSocket("native-engine") as unknown as PhaseSocketTransport,
+            playerCount: 2,
+            aiSeats: [],
+          },
+        },
+      );
+
+      const attached = nativeAdapter.initializePregame();
+      const gameStarted = nativeAdapter.waitForGameStarted();
+      nativeAdapter.dispose();
+
+      await expect(attached).rejects.toMatchObject({
+        code: "WS_CLOSED",
+        recoverable: true,
+      } satisfies Partial<AdapterError>);
+      await expect(gameStarted).rejects.toMatchObject({
+        code: "WS_CLOSED",
+        recoverable: true,
+      } satisfies Partial<AdapterError>);
+    });
+
+    it("preserves the non-recoverable deck rejection code", async () => {
+      const nativeAdapter = new WebSocketAdapter(
+        "native-engine",
+        "host",
+        { main_deck: [], sideboard: [] },
+        undefined,
+        undefined,
+        undefined,
+        "Host",
+        {
+          nativePregame: {
+            kind: "host",
+            socketFactory: () => new MockWebSocket("native-engine") as unknown as PhaseSocketTransport,
+            playerCount: 2,
+            aiSeats: [],
+          },
+        },
+      );
+
+      const attached = nativeAdapter.initializePregame();
+      const nativeSocket = await completeHandshake(nativeAdapter);
+      nativeSocket.dispatchSynthetic(
+        "message",
+        JSON.stringify({ type: "Error", data: { message: "Deck not legal for this format" } }),
+      );
+
+      await expect(attached).rejects.toMatchObject({
+        code: "DECK_REJECTED",
+        recoverable: false,
+      } satisfies Partial<AdapterError>);
     });
   });
 

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -690,6 +690,9 @@ export class WebSocketAdapter implements EngineAdapter {
       clearInterval(this.pingInterval);
       this.pingInterval = null;
     }
+    this.rejectInitialization(
+      new AdapterError("WS_CLOSED", "Adapter disposed before initialization completed", true),
+    );
     if (this.ws) {
       this.ws.close();
       this.ws = null;
@@ -707,8 +710,6 @@ export class WebSocketAdapter implements EngineAdapter {
       new AdapterError("WS_CLOSED", "Adapter disposed during seat mutation", true),
     );
     this.rejectAbandon(new AdapterError("WS_CLOSED", "Adapter disposed while abandoning game", true));
-    this.initResolve = null;
-    this.initReject = null;
     this.reconnectInFlight = false;
     this._serverInfo = null;
     this.receivedGameStarted = false;
@@ -1328,17 +1329,13 @@ export class WebSocketAdapter implements EngineAdapter {
 
       case "Error": {
         const data = msg.data as { message: string };
-        this.rejectInitialization(actionRejectionError(data.message));
+        const initializationError = data.message.includes("Deck not legal")
+          ? new AdapterError("DECK_REJECTED", data.message, false)
+          : actionRejectionError(data.message);
+        this.rejectInitialization(initializationError);
         this.rejectPregameMutation(actionRejectionError(data.message));
         this.rejectAbandon(actionRejectionError(data.message));
         this.emit({ type: "error", message: data.message });
-        if (data.message.includes("Deck not legal") && this.initReject) {
-          this.initReject(
-            new AdapterError("DECK_REJECTED", data.message, false),
-          );
-          this.initResolve = null;
-          this.initReject = null;
-        }
         break;
       }
     }

--- a/client/src/components/chrome/FullscreenButton.tsx
+++ b/client/src/components/chrome/FullscreenButton.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { isTauri } from "../../services/platform";
+
 function EnterFullscreenIcon({ className }: { className?: string }) {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className={className ?? "w-5 h-5"}>
@@ -33,11 +35,20 @@ export function FullscreenButton({ variant }: FullscreenButtonProps) {
     return () => document.removeEventListener("fullscreenchange", onChange);
   }, []);
 
-  const toggle = useCallback(() => {
+  const toggle = useCallback(async () => {
+    if (isTauri()) {
+      const { getCurrentWindow } = await import("@tauri-apps/api/window");
+      const appWindow = getCurrentWindow();
+      const nextFullscreen = !(await appWindow.isFullscreen());
+      await appWindow.setFullscreen(nextFullscreen);
+      setIsFullscreen(nextFullscreen);
+      return;
+    }
+
     if (document.fullscreenElement) {
-      document.exitFullscreen();
+      await document.exitFullscreen();
     } else {
-      document.documentElement.requestFullscreen();
+      await document.documentElement.requestFullscreen();
     }
   }, []);
 
@@ -47,7 +58,7 @@ export function FullscreenButton({ variant }: FullscreenButtonProps) {
   if (variant === "game") {
     return (
       <button
-        onClick={toggle}
+        onClick={() => void toggle()}
         className="flex h-7 w-7 items-center justify-center rounded-md bg-white/6 text-gray-400 transition-colors hover:bg-white/10 hover:text-gray-200"
         aria-label={label}
         title={label}
@@ -59,7 +70,7 @@ export function FullscreenButton({ variant }: FullscreenButtonProps) {
 
   return (
     <button
-      onClick={toggle}
+      onClick={() => void toggle()}
       className="flex min-h-9 min-w-9 items-center justify-center rounded-[12px] border border-white/12 bg-black/18 text-white/46 backdrop-blur-sm transition-colors hover:text-white/72"
       aria-label={label}
       title={label}

--- a/client/src/components/chrome/FullscreenButton.tsx
+++ b/client/src/components/chrome/FullscreenButton.tsx
@@ -28,6 +28,34 @@ export function FullscreenButton({ variant }: FullscreenButtonProps) {
   const [isFullscreen, setIsFullscreen] = useState(!!document.fullscreenElement);
 
   useEffect(() => {
+    if (isTauri()) {
+      let active = true;
+      let unlisten: (() => void) | undefined;
+
+      void (async () => {
+        try {
+          const { getCurrentWindow } = await import("@tauri-apps/api/window");
+          const appWindow = getCurrentWindow();
+          const syncFullscreen = async () => {
+            const fullscreen = await appWindow.isFullscreen();
+            if (active) setIsFullscreen(fullscreen);
+          };
+
+          await syncFullscreen();
+          unlisten = await appWindow.onResized(() => {
+            void syncFullscreen();
+          });
+        } catch (error) {
+          console.warn("[phase.rs] Could not synchronize Tauri fullscreen state.", error);
+        }
+      })();
+
+      return () => {
+        active = false;
+        unlisten?.();
+      };
+    }
+
     function onChange() {
       setIsFullscreen(!!document.fullscreenElement);
     }
@@ -36,19 +64,23 @@ export function FullscreenButton({ variant }: FullscreenButtonProps) {
   }, []);
 
   const toggle = useCallback(async () => {
-    if (isTauri()) {
-      const { getCurrentWindow } = await import("@tauri-apps/api/window");
-      const appWindow = getCurrentWindow();
-      const nextFullscreen = !(await appWindow.isFullscreen());
-      await appWindow.setFullscreen(nextFullscreen);
-      setIsFullscreen(nextFullscreen);
-      return;
-    }
+    try {
+      if (isTauri()) {
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        const appWindow = getCurrentWindow();
+        const nextFullscreen = !(await appWindow.isFullscreen());
+        await appWindow.setFullscreen(nextFullscreen);
+        setIsFullscreen(nextFullscreen);
+        return;
+      }
 
-    if (document.fullscreenElement) {
-      await document.exitFullscreen();
-    } else {
-      await document.documentElement.requestFullscreen();
+      if (document.fullscreenElement) {
+        await document.exitFullscreen();
+      } else {
+        await document.documentElement.requestFullscreen();
+      }
+    } catch (error) {
+      console.warn("[phase.rs] Could not toggle fullscreen.", error);
     }
   }, []);
 

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -1237,7 +1237,7 @@ function MultiplierSlider({
           onChange={(e) => onChange(Number(e.target.value))}
           onDoubleClick={() => onChange(defaultValue)}
           aria-label={label}
-          className="h-2 flex-1 cursor-pointer rounded-full bg-slate-700 accent-cyan-500 focus-visible:ring-2 focus-visible:ring-cyan-400/70 focus-visible:outline-none"
+          className="h-2 flex-1 cursor-pointer rounded-full bg-slate-700 accent-cyan-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-cyan-200 focus-visible:outline-offset-2 focus-visible:ring-2 focus-visible:ring-cyan-400/70"
         />
         <button
           type="button"


### PR DESCRIPTION
Allows Scryfall card art in the Tauri CSP and uses Tauri's native window fullscreen API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fullscreen support for the desktop app, including synchronized fullscreen state and toggling.
  * Enabled approved card image sources for improved image loading.

* **Bug Fixes**
  * Improved connection error handling during game setup, including clearer recoverable and non-recoverable errors.
  * Ensured pending setup actions are properly resolved when a connection closes.

* **Accessibility**
  * Improved keyboard focus visibility for the preferences slider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->