### PR TITLE
cr733(p2): journal resolved library shuffles + RNG entropy receipt

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -155,21 +155,8 @@ pub(crate) fn resolve_search_continuation_attach_host(
 /// CR 701.24a: Shuffle a player's library using the game's seeded RNG.
 /// Reusable helper for auto-shuffle after zone moves to Library.
 pub fn shuffle_library(state: &mut GameState, player: PlayerId, events: &mut Vec<GameEvent>) {
-    {
-        let GameState { players, rng, .. } = state;
-        if let Some(p) = players.iter_mut().find(|p| p.id == player) {
-            crate::util::im_ext::shuffle_vector(&mut p.library, rng);
-        }
-    }
-    // CR 401.5 + CR 611.3a: shuffling changes the library's top card, so a
-    // `TopOfLibraryMatches` static must be re-evaluated (self-gated on liveness).
-    crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
-    // CR 701.24a: Emit player-action event so trigger matchers can filter
-    // by the identity of the shuffling player.
-    events.push(GameEvent::PlayerPerformedAction {
-        player_id: player,
-        action: crate::types::events::PlayerActionKind::ShuffledLibrary,
-    });
+    crate::game::library::resolve_and_apply_library_shuffle(state, player, events)
+        .expect("library auto-shuffle player must exist");
 }
 
 /// CR 608.2c: For a `TrackedSet` / `TrackedSetFiltered` target, resolve the

--- a/crates/engine/src/game/effects/shuffle.rs
+++ b/crates/engine/src/game/effects/shuffle.rs
@@ -1,5 +1,5 @@
 use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter};
-use crate::types::events::{GameEvent, PlayerActionKind};
+use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 
 /// CR 701.24a: Shuffle — randomize the cards in a library.
@@ -60,30 +60,22 @@ pub fn resolve(
         super::resolve_player_for_context_ref(state, ability, &shuffle_target)
     };
 
+    // CR 701.24a: the target player must exist before any shuffle logic runs.
+    // Validate first, unconditionally, so an unknown player is rejected even
+    // when a broad "Can't shuffle" static would otherwise suppress the shuffle.
+    if !state
+        .players
+        .iter()
+        .any(|player| player.id == target_player)
+    {
+        return Err(EffectError::PlayerNotFound);
+    }
+
     // CR 701.24: "Can't shuffle" suppresses library shuffling. Per CR 701.24d,
     // if a player would shuffle their library and can't, they don't shuffle.
     // The effect itself still resolves (EffectResolved fires below).
     let suppressed =
         crate::game::static_abilities::player_has_static_other(state, target_player, "CantShuffle");
-
-    if !suppressed {
-        let GameState { players, rng, .. } = state;
-        let player = players
-            .iter_mut()
-            .find(|p| p.id == target_player)
-            .ok_or(EffectError::PlayerNotFound)?;
-
-        // CR 701.24a: Randomize cards so that no player knows their order.
-        crate::util::im_ext::shuffle_vector(&mut player.library, rng);
-    }
-
-    // CR 401.5 + CR 611.3a: shuffling reorders the library, changing its top
-    // card, so a continuous static gated on the top (`TopOfLibraryMatches`) must
-    // be re-evaluated. Only when the shuffle actually happened and such a static
-    // is live (the helper self-gates).
-    if !suppressed {
-        crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
-    }
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::Shuffle,
@@ -91,13 +83,12 @@ pub fn resolve(
         subject: None,
     });
 
-    // CR 701.24a: Emit player-action event so trigger matchers (e.g.
-    // Cosi's Trickster: "Whenever an opponent shuffles their library")
-    // can filter by the identity of the shuffling player.
-    events.push(GameEvent::PlayerPerformedAction {
-        player_id: target_player,
-        action: PlayerActionKind::ShuffledLibrary,
-    });
+    if !suppressed {
+        // CR 701.24a: Keep the pre-existing EffectResolved → ShuffledLibrary
+        // event order while the shared resolved-command authority owns the
+        // semantic library permutation and entropy receipt.
+        crate::game::effects::change_zone::shuffle_library(state, target_player, events);
+    }
 
     Ok(())
 }
@@ -147,6 +138,12 @@ mod tests {
                 ..
             }
         )));
+        assert!(state.resolved_rules_journal.entries().iter().any(|entry| {
+            matches!(
+                entry.command.as_ref(),
+                Some(crate::types::resolved_commands::ResolvedRulesCommand::LibraryShuffle(_))
+            )
+        }));
     }
 
     #[test]

--- a/crates/engine/src/game/library.rs
+++ b/crates/engine/src/game/library.rs
@@ -1,0 +1,288 @@
+//! Final authority for resolved in-place library order mutations.
+
+use crate::types::events::{GameEvent, PlayerActionKind};
+use crate::types::game_state::GameState;
+use crate::types::player::PlayerId;
+use crate::types::resolved_commands::{
+    validate_library_shuffle_receipt, ResolvedLibraryShuffleCommand,
+    ResolvedLibraryShuffleReplayInvariantError,
+};
+
+/// Resolves, applies, and journals one library shuffle.
+///
+/// CR 701.24a: the ordinary path samples a clone of the current ChaCha20 stream
+/// to determine the final order. The real stream and library are changed only
+/// by [`apply_resolved_library_shuffle`].
+pub fn resolve_and_apply_library_shuffle(
+    state: &mut GameState,
+    player: PlayerId,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), ResolvedLibraryShuffleReplayInvariantError> {
+    let precondition_order: Vec<_> = state
+        .players
+        .iter()
+        .find(|candidate| candidate.id == player)
+        .ok_or(ResolvedLibraryShuffleReplayInvariantError::UnknownPlayer(
+            player,
+        ))?
+        .library
+        .iter()
+        .copied()
+        .collect();
+
+    // Existing random consumers may have advanced the live stream before their
+    // own P2 authority is factored. Synchronize the persisted high-water through
+    // its one monotonic primitive before capturing this receipt's predecessor.
+    state.capture_rng_word_pos();
+    let pre_word_pos = state.rng_word_pos;
+    let mut receipt_rng = state.rng.clone();
+    let mut resulting_order = im::Vector::from(precondition_order.clone());
+    crate::util::im_ext::shuffle_vector(&mut resulting_order, &mut receipt_rng);
+    let command = ResolvedLibraryShuffleCommand {
+        player,
+        precondition_order,
+        resulting_order: resulting_order.iter().copied().collect(),
+        pre_word_pos,
+        post_word_pos: receipt_rng.get_word_pos(),
+        cause: state.current_or_begin_rules_execution_node(),
+    };
+
+    apply_resolved_library_shuffle(state, &command, events)?;
+    state
+        .resolved_rules_journal
+        .record_library_shuffle(command)
+        .expect("resolved library shuffle must have a live journal cause");
+    Ok(())
+}
+
+/// Applies one exact library permutation and entropy receipt without sampling
+/// ChaCha20, inspecting a new top card, or rerunning an effect.
+pub fn apply_resolved_library_shuffle(
+    state: &mut GameState,
+    command: &ResolvedLibraryShuffleCommand,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), ResolvedLibraryShuffleReplayInvariantError> {
+    validate_library_shuffle_receipt(command)?;
+    let player_index = state
+        .players
+        .iter()
+        .position(|candidate| candidate.id == command.player)
+        .ok_or(ResolvedLibraryShuffleReplayInvariantError::UnknownPlayer(
+            command.player,
+        ))?;
+    let current_order: Vec<_> = state.players[player_index]
+        .library
+        .iter()
+        .copied()
+        .collect();
+    if current_order != command.precondition_order {
+        return Err(ResolvedLibraryShuffleReplayInvariantError::LibraryOrderPreconditionMismatch);
+    }
+    if state.rng_word_pos != command.pre_word_pos {
+        return Err(
+            ResolvedLibraryShuffleReplayInvariantError::RngWordPositionPreconditionMismatch {
+                expected: command.pre_word_pos,
+                found: state.rng_word_pos,
+            },
+        );
+    }
+    let current_word_pos = state.rng.get_word_pos();
+    if current_word_pos != command.pre_word_pos {
+        return Err(
+            ResolvedLibraryShuffleReplayInvariantError::RngCursorPositionPreconditionMismatch {
+                expected: command.pre_word_pos,
+                found: current_word_pos,
+            },
+        );
+    }
+
+    // CR 701.24a: Install the already-randomized order once. The applier never
+    // calls `shuffle_vector`, so retained-prefix replay cannot consume entropy
+    // or choose a different permutation.
+    state.players[player_index].library = im::Vector::from(command.resulting_order.clone());
+    state
+        .advance_rng_high_water(command.post_word_pos)
+        .expect("validated library entropy receipt cannot rewind the RNG");
+
+    // CR 401.5 + CR 611.3a: the changed top card can alter a live static
+    // ability. This mark is derived cache state, rebuilt from the installed
+    // order rather than stored as an independent command operand.
+    crate::game::layers::mark_layers_full_if_top_of_library_static_live(state);
+    // CR 701.24a + CR 701.24e: every library shuffle, including an identity
+    // shuffle of a zero- or one-card library, publishes one action event.
+    events.push(GameEvent::PlayerPerformedAction {
+        player_id: command.player,
+        action: PlayerActionKind::ShuffledLibrary,
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha20Rng;
+
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::identifiers::CardId;
+    use crate::types::resolved_commands::{ResolvedPlayerEdit, ResolvedRulesCommand};
+    use crate::types::zones::Zone;
+
+    fn state_with_library(seed: u64) -> GameState {
+        let mut state = GameState::new_two_player(seed);
+        for card in 1..=5 {
+            create_object(
+                &mut state,
+                CardId(card),
+                PlayerId(0),
+                format!("Card {card}"),
+                Zone::Library,
+            );
+        }
+        state
+    }
+
+    fn recorded_shuffle(state: &GameState) -> ResolvedLibraryShuffleCommand {
+        state
+            .resolved_rules_journal
+            .entries()
+            .iter()
+            .find_map(|entry| match &entry.command {
+                Some(ResolvedRulesCommand::LibraryShuffle(command)) => Some(command.clone()),
+                _ => None,
+            })
+            .expect("ordinary shuffle must record one command")
+    }
+
+    #[test]
+    fn shuffle_library_matches_seeded_pre_factor_permutation() {
+        let mut state = state_with_library(0x733);
+        let mut expected_order = state.players[0].library.clone();
+        let mut expected_rng = state.rng.clone();
+        crate::util::im_ext::shuffle_vector(&mut expected_order, &mut expected_rng);
+        let mut events = Vec::new();
+
+        crate::game::effects::change_zone::shuffle_library(&mut state, PlayerId(0), &mut events);
+
+        assert_eq!(state.players[0].library, expected_order);
+        assert_eq!(state.rng.get_word_pos(), expected_rng.get_word_pos());
+        assert_eq!(state.rng_word_pos, expected_rng.get_word_pos());
+        assert_eq!(
+            events,
+            vec![GameEvent::PlayerPerformedAction {
+                player_id: PlayerId(0),
+                action: PlayerActionKind::ShuffledLibrary,
+            }]
+        );
+    }
+
+    #[test]
+    fn replay_installs_recorded_order_without_sampling_rng_or_revealing_cards() {
+        let pre_state = state_with_library(0x733);
+        let mut ordinary = pre_state.clone();
+        let mut ordinary_events = Vec::new();
+        crate::game::effects::change_zone::shuffle_library(
+            &mut ordinary,
+            PlayerId(0),
+            &mut ordinary_events,
+        );
+        let command = recorded_shuffle(&ordinary);
+
+        let mut replay = pre_state;
+        // A different stream seed proves the applier cannot recreate the order
+        // by shuffling. Its stream position still satisfies the receipt.
+        replay.rng = ChaCha20Rng::seed_from_u64(0x0BAD_5EED);
+        replay.rng_word_pos = command.pre_word_pos;
+        let mut replay_events = Vec::new();
+        apply_resolved_library_shuffle(&mut replay, &command, &mut replay_events).unwrap();
+
+        assert_eq!(replay.players[0].library, ordinary.players[0].library);
+        assert_eq!(replay.rng_word_pos, ordinary.rng_word_pos);
+        assert_eq!(replay.rng.get_word_pos(), ordinary.rng.get_word_pos());
+        assert_eq!(replay_events, ordinary_events);
+        assert_eq!(replay.revealed_cards, ordinary.revealed_cards);
+        assert_eq!(replay.public_revealed_cards, ordinary.public_revealed_cards);
+    }
+
+    #[test]
+    fn identity_shuffle_records_a_valid_zero_card_entropy_receipt() {
+        let mut state = GameState::new_two_player(0x733);
+        let mut events = Vec::new();
+        crate::game::effects::change_zone::shuffle_library(&mut state, PlayerId(0), &mut events);
+        let command = recorded_shuffle(&state);
+
+        assert!(command.precondition_order.is_empty());
+        assert!(command.resulting_order.is_empty());
+        assert_eq!(command.pre_word_pos, command.post_word_pos);
+        assert_eq!(state.rng_word_pos, command.post_word_pos);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn replay_rejects_wrong_predecessor_or_entropy_position_before_mutation() {
+        let pre_state = state_with_library(0x733);
+        let mut ordinary = pre_state.clone();
+        crate::game::effects::change_zone::shuffle_library(
+            &mut ordinary,
+            PlayerId(0),
+            &mut Vec::new(),
+        );
+        let command = recorded_shuffle(&ordinary);
+
+        let mut wrong_order = pre_state.clone();
+        wrong_order.players[0].library.swap(0, 1);
+        let order_before = wrong_order.players[0].library.clone();
+        assert!(matches!(
+            apply_resolved_library_shuffle(&mut wrong_order, &command, &mut Vec::new()),
+            Err(ResolvedLibraryShuffleReplayInvariantError::LibraryOrderPreconditionMismatch)
+        ));
+        assert_eq!(wrong_order.players[0].library, order_before);
+
+        let mut wrong_entropy = pre_state;
+        wrong_entropy.rng_word_pos = command.pre_word_pos.saturating_add(1);
+        assert!(matches!(
+            apply_resolved_library_shuffle(&mut wrong_entropy, &command, &mut Vec::new()),
+            Err(
+                ResolvedLibraryShuffleReplayInvariantError::RngWordPositionPreconditionMismatch { .. }
+            )
+        ));
+        assert_eq!(
+            wrong_entropy.players[0]
+                .library
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            command.precondition_order
+        );
+    }
+
+    #[test]
+    fn two_shuffles_compose_before_a_scalar_edit() {
+        let mut state = state_with_library(0x733);
+        let mut events = Vec::new();
+        crate::game::effects::change_zone::shuffle_library(&mut state, PlayerId(0), &mut events);
+        let after_first = state.rng_word_pos;
+        crate::game::effects::change_zone::shuffle_library(&mut state, PlayerId(0), &mut events);
+        let after_second = state.rng_word_pos;
+        state
+            .resolve_and_apply_player_edit(PlayerId(0), ResolvedPlayerEdit::Life { delta: -2 })
+            .unwrap();
+
+        assert!(after_second >= after_first);
+        assert_eq!(state.players[0].life, 18);
+        assert_eq!(
+            state
+                .resolved_rules_journal
+                .entries()
+                .iter()
+                .filter(|entry| {
+                    matches!(
+                        entry.command.as_ref(),
+                        Some(ResolvedRulesCommand::LibraryShuffle(_))
+                    )
+                })
+                .count(),
+            2
+        );
+    }
+}

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -74,6 +74,7 @@ mod haunt_tests;
 pub mod keywords;
 pub mod layers;
 pub mod ledger;
+pub mod library;
 pub mod life_costs;
 pub mod log;
 pub mod mana_abilities;

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -52,7 +52,8 @@ use super::resolution::{
 use super::resolved_commands::{
     ManaPaymentRecipient, ResolvedManaInsertCommand, ResolvedManaReplayInvariantError,
     ResolvedManaSpendCommand, ResolvedPlayerEdit, ResolvedPlayerEditCommand,
-    ResolvedPlayerEditReplayInvariantError, ResolvedRulesJournal, RulesExecutionNodeRef,
+    ResolvedPlayerEditReplayInvariantError, ResolvedRngReplayInvariantError, ResolvedRulesJournal,
+    RulesExecutionNodeRef,
 };
 use super::zones::EtbTapState;
 use super::zones::{ExileCostSourceZone, Zone};
@@ -15187,7 +15188,9 @@ impl GameState {
     /// serializing a faithfully-restorable snapshot invoke this first; the
     /// randomness logic lives here in the engine, not in transport layers.
     pub fn capture_rng_word_pos(&mut self) {
-        self.rng_word_pos = self.rng.get_word_pos();
+        let position = self.rng.get_word_pos();
+        self.advance_rng_high_water(position)
+            .expect("capturing a live ChaCha20 position must not rewind entropy");
     }
 
     /// Reconstruct `rng` from the serialized `rng_seed` and fast-forward it to
@@ -15198,6 +15201,31 @@ impl GameState {
     pub fn rehydrate_rng(&mut self) {
         self.rng = ChaCha20Rng::seed_from_u64(self.rng_seed);
         self.rng.set_word_pos(self.rng_word_pos);
+    }
+
+    /// Advances the persisted entropy high-water without rewinding the live
+    /// ChaCha20 stream. Resolved random commands use this after installing
+    /// their recorded result, so replay never samples entropy to recreate it.
+    pub(crate) fn advance_rng_high_water(
+        &mut self,
+        requested: u128,
+    ) -> Result<(), ResolvedRngReplayInvariantError> {
+        if requested < self.rng_word_pos {
+            return Err(ResolvedRngReplayInvariantError::HighWaterRegression {
+                current: self.rng_word_pos,
+                requested,
+            });
+        }
+        let current = self.rng.get_word_pos();
+        if requested < current {
+            return Err(ResolvedRngReplayInvariantError::StreamPositionRegression {
+                current,
+                requested,
+            });
+        }
+        self.rng.set_word_pos(requested);
+        self.rng_word_pos = requested;
+        Ok(())
     }
 
     /// CR 118.3a: Mint the next stable `ManaPipId` for a pool unit. Monotonic,

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -82,14 +82,15 @@ pub use resolution::{
 pub use resolved_commands::{
     ManaPaymentRecipient, ProducedManaUnit, ResolvedCommandJournalEntry, ResolvedCommandOrdinal,
     ResolvedLedgerEdit, ResolvedLedgerEditCommand, ResolvedLedgerEditReplayInvariantError,
+    ResolvedLibraryShuffleCommand, ResolvedLibraryShuffleReplayInvariantError,
     ResolvedManaInsertCommand, ResolvedManaReplayInvariantError, ResolvedManaSpendCommand,
     ResolvedManaSpentUnit, ResolvedObjectCounterCommand, ResolvedObjectCounterEdit,
     ResolvedObjectCounterReplayInvariantError, ResolvedObjectStatus, ResolvedObjectStatusCommand,
     ResolvedObjectStatusReplayInvariantError, ResolvedOncePerTurnPermission, ResolvedPlayerEdit,
-    ResolvedPlayerEditCommand, ResolvedPlayerEditReplayInvariantError, ResolvedRulesCommand,
-    ResolvedRulesJournal, ResolvedRulesJournalError, ResolvedTriggerLedgerEdit,
-    RulesExecutionNodeKind, RulesExecutionNodeRef, SettlementNode, SettlementNodeOrdinal,
-    SpentManaUnit,
+    ResolvedPlayerEditCommand, ResolvedPlayerEditReplayInvariantError,
+    ResolvedRngReplayInvariantError, ResolvedRulesCommand, ResolvedRulesJournal,
+    ResolvedRulesJournalError, ResolvedTriggerLedgerEdit, RulesExecutionNodeKind,
+    RulesExecutionNodeRef, SettlementNode, SettlementNodeOrdinal, SpentManaUnit,
 };
 pub use statics::StaticMode;
 pub use stickers::{AppliedSticker, StickerKind, StickerLocator};

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -11,7 +11,7 @@ use super::ability::TriggerDefinitionRef;
 use super::card_type::CoreType;
 use super::counter::CounterType;
 use super::game_state::SpellCastRecord;
-use super::identifiers::{ObjectIncarnationRef, LEGACY_INCARNATION};
+use super::identifiers::{ObjectId, ObjectIncarnationRef, LEGACY_INCARNATION};
 use super::mana::{ManaPipId, ManaUnit};
 use super::player::{PlayerCounterKind, PlayerId};
 
@@ -206,6 +206,21 @@ pub struct ResolvedLedgerEditCommand {
     pub cause: RulesExecutionNodeRef,
 }
 
+/// One exact library shuffle with its consumed ChaCha20 stream span.
+///
+/// CR 701.24a: the ordinary path randomizes the captured predecessor order
+/// once. Replay installs `resulting_order` and advances only through the
+/// recorded entropy span; it never samples the RNG again.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedLibraryShuffleCommand {
+    pub player: PlayerId,
+    pub precondition_order: Vec<ObjectId>,
+    pub resulting_order: Vec<ObjectId>,
+    pub pre_word_pos: u128,
+    pub post_word_pos: u128,
+    pub cause: RulesExecutionNodeRef,
+}
+
 /// Semantic command payload currently carried by a resolved-rules journal entry.
 ///
 /// Additional command families are intentionally added by their owning P2
@@ -218,6 +233,112 @@ pub enum ResolvedRulesCommand {
     ObjectStatus(ResolvedObjectStatusCommand),
     ObjectCounter(ResolvedObjectCounterCommand),
     LedgerEdit(ResolvedLedgerEditCommand),
+    LibraryShuffle(ResolvedLibraryShuffleCommand),
+}
+
+/// Typed failure while advancing the canonical ChaCha20 entropy high-water mark.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedRngReplayInvariantError {
+    HighWaterRegression { current: u128, requested: u128 },
+    StreamPositionRegression { current: u128, requested: u128 },
+}
+
+impl std::fmt::Display for ResolvedRngReplayInvariantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HighWaterRegression { current, requested } => write!(
+                f,
+                "resolved entropy command would regress high-water from {current} to {requested}"
+            ),
+            Self::StreamPositionRegression { current, requested } => write!(
+                f,
+                "resolved entropy command would rewind the ChaCha20 stream from {current} to {requested}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ResolvedRngReplayInvariantError {}
+
+/// Typed failure while applying an already-resolved library shuffle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolvedLibraryShuffleReplayInvariantError {
+    UnknownPlayer(PlayerId),
+    LibraryOrderPreconditionMismatch,
+    RngWordPositionPreconditionMismatch {
+        expected: u128,
+        found: u128,
+    },
+    RngCursorPositionPreconditionMismatch {
+        expected: u128,
+        found: u128,
+    },
+    InvalidLibraryOrderReceipt,
+    EntropyReceiptRegression {
+        pre: u128,
+        post: u128,
+    },
+    /// CR 701.24a: A Fisher-Yates shuffle of two or more cards always consumes
+    /// at least one random draw, so a multi-card receipt whose entropy span is
+    /// empty could not have come from a real shuffle. Accepting it would install
+    /// a permutation while leaving the RNG cursor unadvanced, desynchronizing
+    /// every later entropy-backed replay.
+    MultiCardReceiptWithoutEntropy {
+        cards: usize,
+        position: u128,
+    },
+    RngHighWater(ResolvedRngReplayInvariantError),
+}
+
+impl std::fmt::Display for ResolvedLibraryShuffleReplayInvariantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownPlayer(player) => {
+                write!(
+                    f,
+                    "resolved library shuffle cannot find player {}",
+                    player.0
+                )
+            }
+            Self::LibraryOrderPreconditionMismatch => {
+                write!(
+                    f,
+                    "resolved library shuffle does not match its recorded predecessor order"
+                )
+            }
+            Self::RngWordPositionPreconditionMismatch { expected, found } => write!(
+                f,
+                "resolved library shuffle expected RNG high-water {expected}, found {found}"
+            ),
+            Self::RngCursorPositionPreconditionMismatch { expected, found } => write!(
+                f,
+                "resolved library shuffle expected ChaCha20 position {expected}, found {found}"
+            ),
+            Self::InvalidLibraryOrderReceipt => {
+                write!(
+                    f,
+                    "resolved library shuffle has an invalid ordered-card receipt"
+                )
+            }
+            Self::EntropyReceiptRegression { pre, post } => write!(
+                f,
+                "resolved library shuffle regresses entropy from {pre} to {post}"
+            ),
+            Self::MultiCardReceiptWithoutEntropy { cards, position } => write!(
+                f,
+                "resolved library shuffle permutes {cards} cards without advancing entropy past {position}"
+            ),
+            Self::RngHighWater(error) => error.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for ResolvedLibraryShuffleReplayInvariantError {}
+
+impl From<ResolvedRngReplayInvariantError> for ResolvedLibraryShuffleReplayInvariantError {
+    fn from(error: ResolvedRngReplayInvariantError) -> Self {
+        Self::RngHighWater(error)
+    }
 }
 
 /// Typed failure while applying an already-resolved mana command to a replay state.
@@ -882,6 +1003,14 @@ impl ResolvedRulesJournal {
         self.append_command(command.cause, ResolvedRulesCommand::LedgerEdit(command))
     }
 
+    /// Records one exact library order plus its already-consumed entropy span.
+    pub fn record_library_shuffle(
+        &mut self,
+        command: ResolvedLibraryShuffleCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(command.cause, ResolvedRulesCommand::LibraryShuffle(command))
+    }
+
     fn begin_settlement(
         &mut self,
         identity_for: impl FnOnce(SettlementNodeOrdinal) -> RulesExecutionNodeRef,
@@ -1080,7 +1209,8 @@ impl ResolvedRulesJournal {
                 ResolvedRulesCommand::PlayerEdit(_)
                 | ResolvedRulesCommand::ObjectStatus(_)
                 | ResolvedRulesCommand::ObjectCounter(_)
-                | ResolvedRulesCommand::LedgerEdit(_) => {}
+                | ResolvedRulesCommand::LedgerEdit(_)
+                | ResolvedRulesCommand::LibraryShuffle(_) => {}
             }
         }
         for node in &self.nodes {
@@ -1295,6 +1425,15 @@ impl ResolvedRulesJournal {
                     ));
                 }
             }
+            ResolvedRulesCommand::LibraryShuffle(command) => {
+                if entry.node != command.cause || validate_library_shuffle_receipt(command).is_err()
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "library shuffle command has an invalid receipt or unrelated cause"
+                            .to_string(),
+                    ));
+                }
+            }
         }
         Ok(())
     }
@@ -1383,6 +1522,47 @@ fn ledger_edit_has_legacy_object_identity(edit: &ResolvedLedgerEdit) -> bool {
         ResolvedLedgerEdit::TriggerFired { trigger, .. }
             if trigger.source.incarnation == LEGACY_INCARNATION
     )
+}
+
+/// Validates the closed operands of a library-order entropy receipt.
+///
+/// CR 701.24a: shuffling can only permute the same exact cards. The recorded
+/// stream span can advance or remain unchanged, but never rewind.
+pub(crate) fn validate_library_shuffle_receipt(
+    command: &ResolvedLibraryShuffleCommand,
+) -> Result<(), ResolvedLibraryShuffleReplayInvariantError> {
+    if command.post_word_pos < command.pre_word_pos {
+        return Err(
+            ResolvedLibraryShuffleReplayInvariantError::EntropyReceiptRegression {
+                pre: command.pre_word_pos,
+                post: command.post_word_pos,
+            },
+        );
+    }
+    if command.precondition_order.len() != command.resulting_order.len()
+        || has_duplicate_values(&command.precondition_order)
+        || has_duplicate_values(&command.resulting_order)
+    {
+        return Err(ResolvedLibraryShuffleReplayInvariantError::InvalidLibraryOrderReceipt);
+    }
+
+    // CR 701.24a: A shuffle of two or more cards draws at least once, so its
+    // entropy span must be non-empty. A zero-span multi-card receipt is a
+    // corrupt permutation that would leave the RNG cursor unadvanced.
+    if command.resulting_order.len() >= 2 && command.post_word_pos == command.pre_word_pos {
+        return Err(
+            ResolvedLibraryShuffleReplayInvariantError::MultiCardReceiptWithoutEntropy {
+                cards: command.resulting_order.len(),
+                position: command.pre_word_pos,
+            },
+        );
+    }
+
+    let expected: HashSet<_> = command.precondition_order.iter().copied().collect();
+    let resulting: HashSet<_> = command.resulting_order.iter().copied().collect();
+    (expected == resulting)
+        .then_some(())
+        .ok_or(ResolvedLibraryShuffleReplayInvariantError::InvalidLibraryOrderReceipt)
 }
 
 #[cfg(test)]
@@ -1641,6 +1821,72 @@ mod tests {
         command.cause = RulesExecutionNodeRef::Payment(SettlementNodeOrdinal(99));
         assert!(serde_json::from_value::<ResolvedRulesJournal>(
             serde_json::to_value(unrelated_cause).unwrap()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn library_shuffle_command_roundtrips_and_rejects_invalid_receipts() {
+        let mut journal = ResolvedRulesJournal::default();
+        let cause = journal.begin_proposal().unwrap();
+        journal
+            .record_library_shuffle(ResolvedLibraryShuffleCommand {
+                player: PlayerId(0),
+                precondition_order: vec![ObjectId(1), ObjectId(2), ObjectId(3)],
+                resulting_order: vec![ObjectId(3), ObjectId(1), ObjectId(2)],
+                pre_word_pos: 7,
+                post_word_pos: 11,
+                cause,
+            })
+            .unwrap();
+        assert_eq!(
+            serde_json::from_value::<ResolvedRulesJournal>(serde_json::to_value(&journal).unwrap())
+                .unwrap(),
+            journal
+        );
+
+        let mut missing_entropy = serde_json::to_value(&journal).unwrap();
+        missing_entropy["entries"][1]["command"]["LibraryShuffle"]
+            .as_object_mut()
+            .unwrap()
+            .remove("post_word_pos");
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(missing_entropy).is_err());
+
+        let mut duplicate_card = journal.clone();
+        let Some(ResolvedRulesCommand::LibraryShuffle(command)) =
+            duplicate_card.entries[1].command.as_mut()
+        else {
+            panic!("entry 1 must be the library shuffle");
+        };
+        command.resulting_order = vec![ObjectId(3), ObjectId(3), ObjectId(2)];
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(
+            serde_json::to_value(duplicate_card).unwrap()
+        )
+        .is_err());
+
+        let mut backwards_entropy = journal.clone();
+        let Some(ResolvedRulesCommand::LibraryShuffle(command)) =
+            backwards_entropy.entries[1].command.as_mut()
+        else {
+            panic!("entry 1 must be the library shuffle");
+        };
+        command.post_word_pos = 6;
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(
+            serde_json::to_value(backwards_entropy).unwrap()
+        )
+        .is_err());
+
+        // CR 701.24a: a three-card permutation with an empty entropy span could
+        // not have come from a real shuffle and must be rejected.
+        let mut zero_span_multi_card = journal.clone();
+        let Some(ResolvedRulesCommand::LibraryShuffle(command)) =
+            zero_span_multi_card.entries[1].command.as_mut()
+        else {
+            panic!("entry 1 must be the library shuffle");
+        };
+        command.post_word_pos = command.pre_word_pos;
+        assert!(serde_json::from_value::<ResolvedRulesJournal>(
+            serde_json::to_value(zero_span_multi_card).unwrap()
         )
         .is_err());
     }

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -79,6 +79,10 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }
+        ResolvedRulesCommand::LibraryShuffle(command) => {
+            engine::game::library::apply_resolved_library_shuffle(state, command, &mut Vec::new())
+                .unwrap();
+        }
     }
 }
 
@@ -164,7 +168,10 @@ fn exact_mana_spend_rejects_a_second_removal() {
             ResolvedRulesCommand::PlayerEdit(_)
             | ResolvedRulesCommand::ObjectStatus(_)
             | ResolvedRulesCommand::ObjectCounter(_)
-            | ResolvedRulesCommand::LedgerEdit(_) => apply_semantic_command(&mut replay, command),
+            | ResolvedRulesCommand::LedgerEdit(_)
+            | ResolvedRulesCommand::LibraryShuffle(_) => {
+                apply_semantic_command(&mut replay, command)
+            }
         }
     }
     assert!(


### PR DESCRIPTION
Adds the first Tier-A leaf command family in the re-sequenced P2 phase
(leaves-first, hub-last): a resolved library shuffle command with an exact
predecessor/resulting order fingerprint and a ChaCha20 entropy receipt
(pre/post word position). Replay installs the recorded order and advances the
RNG via set_word_pos — it never calls shuffle_vector, so retained-prefix replay
cannot consume entropy or pick a different permutation (CR 701.24a).

Introduces the reusable GameState::advance_rng_high_water primitive (monotonic
on both the persisted high-water and the live stream cursor); capture_rng_word_pos
now routes through it as the single RNG-position write path. Both
change_zone::shuffle_library and the library branch of Effect::Shuffle delegate
to game::library::{resolve_and_apply_library_shuffle, apply_resolved_library_shuffle}.

Writes only already-classified census fields (rng/rng_word_pos/players), so the
always-on P0 field-set ratchet holds against the current fixtures; the opt-in
CR733_CENSUS_STRICT line-level pins fold in at the next full fixture regen.

Authored via codex Run 9; ported code-only onto current main (campaign branch
had drifted; uncompressed .json census fixtures superseded by main's gzipped set).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deterministic in-place library shuffling with recorded shuffle outcomes for reliable replay.
  * Introduced resolved journal entries for library shuffles, including RNG position tracking.
* **Bug Fixes**
  * Improved handling when a shuffle target player cannot be found.
  * Replay now verifies preconditions (card order and RNG progression) and rejects invalid/mismatched receipts without mutating state.
* **Tests**
  * Expanded unit and integration coverage for deterministic results, receipt roundtrips, malformed receipt rejection, empty-library shuffles, and consecutive shuffle ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->