### PR TITLE
fix(parser): bind a dig-from-among "that creature" shared-type reference to the trigger subject (Conjurer's Mantle #5900)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -4157,7 +4157,7 @@ pub(crate) fn try_parse_dig_instead_alternative(
     }
 
     let body_rest_lower = body_rest.to_lowercase();
-    let alt_continuation = parse_dig_from_among(&body_rest_lower, &body_rest)?;
+    let alt_continuation = parse_dig_from_among(&body_rest_lower, &body_rest, ctx)?;
     let ContinuationAst::DigFromAmong {
         quantity: alt_quantity,
         filter: alt_filter,

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -5128,6 +5128,22 @@ pub(super) fn parse_intrinsic_continuation_ast(
     }
 }
 
+/// CR 608.2c + CR 608.2k: Parse a Dig continuation's reveal/put filter with
+/// the enclosing context, so anaphoric references bind to a triggering subject
+/// when one exists.
+fn parse_dig_from_among_filter(filter_text: &str, ctx: &mut ParseContext) -> TargetFilter {
+    if filter_text.is_empty()
+        || filter_text == "card"
+        || filter_text == "cards"
+        || filter_text == "of them"
+    {
+        TargetFilter::Any
+    } else {
+        let (filter, _) = parse_target_with_ctx(filter_text, ctx);
+        filter
+    }
+}
+
 /// CR 701.20e + CR 608.2c: Parse "put/return up to N [filter] from among
 /// them/those cards onto the battlefield / into your hand / to your hand" into
 /// a DigFromAmong continuation that patches the preceding Dig effect. The
@@ -5272,23 +5288,7 @@ pub(super) fn parse_dig_from_among(
             )
         };
 
-        let filter = if filter_text.is_empty()
-            || filter_text == "card"
-            || filter_text == "cards"
-            || filter_text == "of them"
-        {
-            TargetFilter::Any
-        } else {
-            // CR 608.2c + CR 608.2k: parse the "from among them" reveal/put filter
-            // with the enclosing ctx so an anaphoric reference inside it (e.g.
-            // "a card that shares a creature type with that creature") binds to
-            // the trigger subject (`TriggeringSource`) when one exists — Conjurer's
-            // Mantle's "equipped creature attacks" trigger. A ctx-free parse loses
-            // the subject and mis-binds the reference to `ParentTarget`, which has
-            // no referent here (no chosen target), so it matched no card (#5900).
-            let (parsed_filter, _) = parse_target_with_ctx(filter_text, ctx);
-            parsed_filter
-        };
+        let filter = parse_dig_from_among_filter(filter_text, ctx);
         // CR 107.3c: fail honestly instead of fabricating a raw-text placeholder.
         let filter = apply_where_x_to_filter(filter, where_x_expression.as_deref())?;
 
@@ -5378,24 +5378,8 @@ pub(super) fn parse_dig_from_among(
             (PutCount::up(1), after_put)
         };
 
-        // Parse the filter from the remaining text (e.g., "creature cards with mana value 3 or less")
-        let filter = if filter_text.is_empty()
-            || filter_text == "card"
-            || filter_text == "cards"
-            || filter_text == "of them"
-        {
-            TargetFilter::Any
-        } else {
-            // CR 608.2c + CR 608.2k: parse the "from among them" reveal/put filter
-            // with the enclosing ctx so an anaphoric reference inside it (e.g.
-            // "a card that shares a creature type with that creature") binds to
-            // the trigger subject (`TriggeringSource`) when one exists — Conjurer's
-            // Mantle's "equipped creature attacks" trigger. A ctx-free parse loses
-            // the subject and mis-binds the reference to `ParentTarget`, which has
-            // no referent here (no chosen target), so it matched no card (#5900).
-            let (parsed_filter, _) = parse_target_with_ctx(filter_text, ctx);
-            parsed_filter
-        };
+        // Parse the filter from the remaining text (e.g., "creature cards with mana value 3 or less").
+        let filter = parse_dig_from_among_filter(filter_text, ctx);
         // CR 202.3 + CR 107.3i: Bind the literal `X` in the filter's `Cmc` bound
         // with the stripped "where X is <expression>" defining clause.
         // CR 107.3c: fail honestly instead of fabricating a raw-text placeholder.

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -9,7 +9,7 @@ use nom::Parser;
 use super::super::oracle_nom::bridge::nom_on_lower;
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::primitives::parse_keyword_name;
-use super::super::oracle_target::parse_target;
+use super::super::oracle_target::{parse_target, parse_target_with_ctx};
 use super::super::oracle_util::{contains_possessive, parse_count_expr, TextPair};
 use super::{apply_where_x_to_filter, strip_trailing_where_x};
 use crate::parser::oracle_ir::ast::*;
@@ -5152,7 +5152,11 @@ pub(super) fn parse_intrinsic_continuation_ast(
 /// - "you may reveal a creature card from among them and put it into your hand"
 /// - "put two of them into your hand and the rest on the bottom of your library in any order"
 /// - "put two of those cards into your hand"
-pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<ContinuationAst> {
+pub(super) fn parse_dig_from_among(
+    lower: &str,
+    original: &str,
+    ctx: &mut ParseContext,
+) -> Option<ContinuationAst> {
     // CR 202.3 + CR 107.3i: Strip a trailing "where X is <expression>" defining
     // clause before destination/count/filter parsing. `where_x_expression`
     // (when present) is applied to the parsed filter at the end.
@@ -5275,7 +5279,14 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
         {
             TargetFilter::Any
         } else {
-            let (parsed_filter, _) = parse_target(filter_text);
+            // CR 608.2c + CR 608.2k: parse the "from among them" reveal/put filter
+            // with the enclosing ctx so an anaphoric reference inside it (e.g.
+            // "a card that shares a creature type with that creature") binds to
+            // the trigger subject (`TriggeringSource`) when one exists — Conjurer's
+            // Mantle's "equipped creature attacks" trigger. A ctx-free parse loses
+            // the subject and mis-binds the reference to `ParentTarget`, which has
+            // no referent here (no chosen target), so it matched no card (#5900).
+            let (parsed_filter, _) = parse_target_with_ctx(filter_text, ctx);
             parsed_filter
         };
         // CR 107.3c: fail honestly instead of fabricating a raw-text placeholder.
@@ -5375,7 +5386,14 @@ pub(super) fn parse_dig_from_among(lower: &str, original: &str) -> Option<Contin
         {
             TargetFilter::Any
         } else {
-            let (parsed_filter, _) = parse_target(filter_text);
+            // CR 608.2c + CR 608.2k: parse the "from among them" reveal/put filter
+            // with the enclosing ctx so an anaphoric reference inside it (e.g.
+            // "a card that shares a creature type with that creature") binds to
+            // the trigger subject (`TriggeringSource`) when one exists — Conjurer's
+            // Mantle's "equipped creature attacks" trigger. A ctx-free parse loses
+            // the subject and mis-binds the reference to `ParentTarget`, which has
+            // no referent here (no chosen target), so it matched no card (#5900).
+            let (parsed_filter, _) = parse_target_with_ctx(filter_text, ctx);
             parsed_filter
         };
         // CR 202.3 + CR 107.3i: Bind the literal `X` in the filter's `Cmc` bound
@@ -6997,7 +7015,7 @@ pub(super) fn parse_followup_continuation_ast(
                     || nom_primitives::scan_contains(&lower, "to your hand")
                     || nom_primitives::scan_contains(&lower, "to their hand")) =>
         {
-            parse_dig_from_among(&lower, text)
+            parse_dig_from_among(&lower, text, ctx)
         }
         // CR 701.33: "[You may] reveal [up to] N <filter> cards from among
         // them" after Dig — the reveal-only form where the kept cards are NOT
@@ -7018,7 +7036,7 @@ pub(super) fn parse_followup_continuation_ast(
                 && !nom_primitives::scan_contains(&lower, "into your hand")
                 && !nom_primitives::scan_contains(&lower, "into their hand") =>
         {
-            parse_dig_from_among(&lower, text)
+            parse_dig_from_among(&lower, text, ctx)
         }
         // CR 508.4 / CR 614.1: "It/The token enters tapped and attacking" (singular)
         // or "They/Those tokens enter tapped and attacking" (plural)

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -6161,7 +6161,7 @@ fn parse_shared_quality_reference<'a>(
     }
 
     // CR 608.2k: a singular demonstrative back-reference ("that creature" /
-    // "that permanent" / "that card") to the trigger subject resolves to the
+    // "that permanent" / "that card" / "that token") to the trigger subject resolves to the
     // triggering object exactly like the bare pronoun "it" above — Conjurer's
     // Mantle ("Whenever equipped creature attacks, ... reveal a card that shares
     // a creature type with that creature"). Route through the same ctx-aware
@@ -6169,7 +6169,7 @@ fn parse_shared_quality_reference<'a>(
     // subject exists and stays `ParentTarget` (chosen-target anaphor) otherwise.
     // Restricted to the singular object demonstratives so a fresh noun phrase
     // ("a creature you control") still parses as its own filter below.
-    for demonstrative in ["that creature", "that permanent", "that card"] {
+    for demonstrative in ["that creature", "that permanent", "that card", "that token"] {
         if let Ok((rest, ())) = parse_word_bounded(input, demonstrative) {
             let mut ctx_mut = ctx.clone();
             return Ok((rest, resolve_pronoun_target(&mut ctx_mut, "it")));
@@ -9025,6 +9025,29 @@ mod tests {
         let (f, rest) = parse_target_with_ctx("it", &mut ctx);
         assert_eq!(f, TargetFilter::TriggeringSource);
         assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn shared_quality_that_token_with_typed_trigger_subject_binds_to_triggering_source() {
+        let mut ctx = ParseContext {
+            subject: Some(TargetFilter::Typed(TypedFilter::creature())),
+            ..Default::default()
+        };
+        let (filter, rest) =
+            parse_target_with_ctx("a card that shares a card type with that token", &mut ctx);
+        assert_eq!(rest, "");
+        let TargetFilter::Typed(filter) = filter else {
+            panic!("expected typed card filter");
+        };
+        let reference = filter
+            .properties
+            .iter()
+            .find_map(|property| match property {
+                FilterProp::SharesQuality { reference, .. } => reference.as_deref(),
+                _ => None,
+            })
+            .expect("expected shared-quality reference");
+        assert_eq!(reference, &TargetFilter::TriggeringSource);
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -6160,6 +6160,22 @@ fn parse_shared_quality_reference<'a>(
         return Ok((rest, resolve_pronoun_target(&mut ctx_mut, "it")));
     }
 
+    // CR 608.2k: a singular demonstrative back-reference ("that creature" /
+    // "that permanent" / "that card") to the trigger subject resolves to the
+    // triggering object exactly like the bare pronoun "it" above — Conjurer's
+    // Mantle ("Whenever equipped creature attacks, ... reveal a card that shares
+    // a creature type with that creature"). Route through the same ctx-aware
+    // resolver so it binds to `TriggeringSource` when a non-source trigger
+    // subject exists and stays `ParentTarget` (chosen-target anaphor) otherwise.
+    // Restricted to the singular object demonstratives so a fresh noun phrase
+    // ("a creature you control") still parses as its own filter below.
+    for demonstrative in ["that creature", "that permanent", "that card"] {
+        if let Ok((rest, ())) = parse_word_bounded(input, demonstrative) {
+            let mut ctx_mut = ctx.clone();
+            return Ok((rest, resolve_pronoun_target(&mut ctx_mut, "it")));
+        }
+    }
+
     let (filter, rest) = parse_target(input);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(

--- a/crates/engine/tests/integration/issue_5900_conjurers_mantle.rs
+++ b/crates/engine/tests/integration/issue_5900_conjurers_mantle.rs
@@ -1,0 +1,266 @@
+//! Runtime + parser regression for GitHub issue #5900 — Conjurer's Mantle fails
+//! to recognize matching creature types.
+//!
+//! https://github.com/phase-rs/phase/issues/5900
+//!
+//! Oracle (verified against client/public/card-data.json):
+//!   "Equipped creature gets +1/+1 and has vigilance.
+//!    Whenever equipped creature attacks, look at the top six cards of your
+//!    library. You may reveal a card that shares a creature type with that
+//!    creature from among them and put it into your hand. Put the rest on the
+//!    bottom of your library in a random order.
+//!    Equip {1}"
+//!
+//! Root cause: the "from among them" reveal filter ("a card that shares a
+//! creature type with that creature") was parsed via the CTX-FREE `parse_target`
+//! (`parse_dig_from_among`), so the trigger subject never reached
+//! `parse_shared_quality_reference`. There, the demonstrative "that creature"
+//! also fell through to the ctx-free `parse_target`, binding the shared-quality
+//! reference to `TargetFilter::ParentTarget` instead of `TriggeringSource`.
+//! In this attacks trigger there is no chosen target / recipient / effect-context
+//! object, so `parent_target_shared_quality_values` (game/filter.rs) returns
+//! `None` — the "shares a creature type" test then matches NO card, so no card
+//! in the top six is ever selectable, exactly the reported symptom.
+//!
+//! Fix (two parts): (1) thread the enclosing `ParseContext` through
+//! `parse_dig_from_among` so the reveal filter parses with the trigger subject
+//! in scope; (2) resolve the singular demonstrative "that creature" via the same
+//! ctx-aware `resolve_pronoun_target` the bare pronoun "it" already used, so it
+//! binds to `TriggeringSource` (the attacking equipped creature) when a
+//! non-source trigger subject exists and stays `ParentTarget` otherwise.
+
+use engine::game::combat::AttackTarget;
+use engine::game::game_object::AttachTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{Effect, FilterProp, SharedQuality, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+
+const MANTLE_ORACLE: &str = "Equipped creature gets +1/+1 and has vigilance.\nWhenever equipped creature attacks, look at the top six cards of your library. You may reveal a card that shares a creature type with that creature from among them and put it into your hand. Put the rest on the bottom of your library in a random order.\nEquip {1}";
+
+/// Turn Conjurer's Mantle (added via `add_creature_from_oracle` so its trigger
+/// parses) into a real Equipment attached to `host`.
+fn make_equipment_attached(runner: &mut GameRunner, mantle: ObjectId, host: ObjectId) {
+    {
+        let obj = runner.state_mut().objects.get_mut(&mantle).unwrap();
+        obj.card_types.core_types = vec![CoreType::Artifact];
+        obj.card_types.subtypes = vec!["Equipment".to_string()];
+        obj.base_card_types = obj.card_types.clone();
+        obj.power = None;
+        obj.toughness = None;
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![],
+            generic: 0,
+        };
+        obj.attached_to = Some(AttachTarget::Object(host));
+    }
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&host)
+        .unwrap()
+        .attachments
+        .push(mantle);
+    engine::game::layers::mark_layers_full(runner.state_mut());
+    engine::game::layers::flush_layers(runner.state_mut());
+}
+
+/// Hand P0 priority and pass until the engine reaches DeclareAttackers.
+fn advance_to_declare_attackers(runner: &mut GameRunner) {
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+    for _ in 0..24 {
+        if runner.waiting_for_kind() == "DeclareAttackers" {
+            return;
+        }
+        runner
+            .act(GameAction::PassPriority)
+            .expect("priority pass should advance toward declare attackers");
+    }
+    panic!(
+        "did not reach DeclareAttackers; waiting_for = {:?}",
+        runner.state().waiting_for
+    );
+}
+
+/// After declaring attackers, resolve the attack trigger's stack until the
+/// engine surfaces the Dig reveal-from-among choice.
+fn advance_to_dig_choice(runner: &mut GameRunner) {
+    for _ in 0..40 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::DigChoice { .. } => return,
+            WaitingFor::OrderTriggers { triggers, .. } => {
+                let order = (0..triggers.len()).collect();
+                runner
+                    .act(GameAction::OrderTriggers { order })
+                    .expect("OrderTriggers should succeed");
+            }
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("PassPriority should advance the trigger");
+            }
+            other => panic!("unexpected waiting state before DigChoice: {other:?}"),
+        }
+    }
+    panic!("attack trigger never reached the Dig reveal choice");
+}
+
+/// A Goblin card in the top six must be selectable — it shares a creature type
+/// with the attacking equipped Goblin. Pre-fix the reveal filter matched no
+/// card (reference bound to `ParentTarget`, which resolves to nothing in this
+/// trigger), so `selectable_cards` was empty.
+#[test]
+fn conjurers_mantle_reveal_matches_shared_creature_type() {
+    let mut scenario = GameScenario::new_n_player(2, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Stage P0's top six: one Goblin creature card (shares a type with the
+    // attacking Goblin) buried among five non-matching cards. `add_card_to_
+    // library_top` inserts at index 0, so add bottom-of-six first.
+    let f5 = scenario.add_card_to_library_top(P0, "Filler 5");
+    let f4 = scenario.add_card_to_library_top(P0, "Filler 4");
+    let f3 = scenario.add_card_to_library_top(P0, "Filler 3");
+    let goblin_card = scenario.add_card_to_library_top(P0, "Goblin Raider");
+    let f2 = scenario.add_card_to_library_top(P0, "Filler 2");
+    let f1 = scenario.add_card_to_library_top(P0, "Filler 1");
+
+    // The equipped creature: a Goblin so "shares a creature type with that
+    // creature" is meaningful.
+    let host = scenario
+        .add_creature(P0, "Goblin Bearer", 2, 2)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    // Conjurer's Mantle, built from real Oracle text so the attack trigger AST
+    // is the parser's own output.
+    let mantle = scenario
+        .add_creature_from_oracle(P0, "Conjurer's Mantle", 0, 0, MANTLE_ORACLE)
+        .id();
+    // A wall so P0 has a legal defender to attack.
+    scenario.add_creature(P1, "Wall", 0, 4);
+
+    let mut runner = scenario.build();
+    // CR 205.3m: "Goblin" must be a registered creature type for the
+    // shared-creature-type filter to count it (real games load this from card
+    // data; a synthetic scenario must seed it explicitly).
+    runner
+        .state_mut()
+        .all_creature_types
+        .push("Goblin".to_string());
+
+    make_equipment_attached(&mut runner, mantle, host);
+
+    // Type the staged library cards: the Goblin Raider is a Goblin creature
+    // card; the fillers are non-creature so they can never share a creature type.
+    {
+        let g = runner.state_mut().objects.get_mut(&goblin_card).unwrap();
+        g.card_types.core_types = vec![CoreType::Creature];
+        g.card_types.subtypes = vec!["Goblin".to_string()];
+        g.base_card_types = g.card_types.clone();
+    }
+    for &id in &[f1, f2, f3, f4, f5] {
+        let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+        obj.card_types.core_types = vec![CoreType::Sorcery];
+        obj.base_card_types = obj.card_types.clone();
+    }
+
+    advance_to_declare_attackers(&mut runner);
+    runner
+        .declare_attackers(&[(host, AttackTarget::Player(P1))])
+        .expect("declaring the equipped Goblin as an attacker should succeed");
+
+    advance_to_dig_choice(&mut runner);
+
+    let (cards, selectable) = match runner.state().waiting_for.clone() {
+        WaitingFor::DigChoice {
+            cards,
+            selectable_cards,
+            ..
+        } => (cards, selectable_cards),
+        other => panic!("expected DigChoice, got {other:?}"),
+    };
+
+    assert!(
+        cards.contains(&goblin_card),
+        "the Goblin card must be among the six looked-at cards; got {cards:?}"
+    );
+    assert!(
+        selectable.contains(&goblin_card),
+        "the Goblin card shares a creature type with the attacking equipped Goblin, \
+         so it MUST be selectable to reveal (issue #5900). selectable = {selectable:?}"
+    );
+    // The non-creature fillers share no creature type and must stay non-selectable.
+    for &id in &[f1, f2, f3, f4, f5] {
+        assert!(
+            !selectable.contains(&id),
+            "non-creature filler {id:?} shares no creature type and must not be selectable"
+        );
+    }
+
+    // Reveal the Goblin card → it goes to hand.
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![goblin_card],
+        })
+        .expect("selecting the shared-type Goblin card should succeed");
+    runner.advance_until_stack_empty();
+
+    assert!(
+        runner.state().players[0].hand.contains(&goblin_card),
+        "the revealed Goblin card must be put into P0's hand"
+    );
+}
+
+/// Parser-level revert guard: the reveal filter's shared-creature-type reference
+/// must bind to the trigger subject (`TriggeringSource`), not `ParentTarget`.
+#[test]
+fn conjurers_mantle_shared_type_reference_binds_to_trigger_subject() {
+    let parsed = parse_oracle_text(
+        MANTLE_ORACLE,
+        "Conjurer's Mantle",
+        &[],
+        &["Artifact".to_string()],
+        &["Equipment".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_ref())
+        .expect("Conjurer's Mantle must have an attack trigger with an execute effect");
+
+    let Effect::Dig { filter, .. } = trigger.effect.as_ref() else {
+        panic!(
+            "attack trigger must lower to a Dig, got {:?}",
+            trigger.effect
+        );
+    };
+    let TargetFilter::Typed(tf) = filter else {
+        panic!("Dig filter must be a typed card filter, got {filter:?}");
+    };
+    let shares = tf
+        .properties
+        .iter()
+        .find_map(|p| match p {
+            FilterProp::SharesQuality {
+                quality: SharedQuality::CreatureType,
+                reference,
+                ..
+            } => Some(reference.clone()),
+            _ => None,
+        })
+        .expect("Dig filter must carry a SharesQuality(CreatureType) property");
+
+    assert_eq!(
+        shares.as_deref(),
+        Some(&TargetFilter::TriggeringSource),
+        "\"that creature\" must bind to the attacking equipped creature \
+         (TriggeringSource), not ParentTarget (which resolves to nothing here); \
+         got {shares:?}"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -550,6 +550,7 @@ mod issue_581_mystic_remora_cumulative_upkeep;
 mod issue_5820_susan_foreman;
 mod issue_5821_psychic_paper_attach_choice;
 mod issue_583_vivi_ornitier_mana_source;
+mod issue_5900_conjurers_mantle;
 mod issue_5901_depthshaker_titan;
 mod issue_5910_kitchen_finks_persist;
 mod issue_5945_kellan_the_kid;


### PR DESCRIPTION
## Summary

Fixes **Conjurer's Mantle** (#5900): its attack trigger — "Whenever equipped creature attacks, look at the top six cards of your library. You may reveal a card that shares a creature type with **that creature** from among them and put it into your hand." — never let you reveal a matching card, because the shared-creature-type filter matched nothing.

## Root cause

Two layers of the same lost-context bug:

1. `parse_dig_from_among` parsed the "from among them" reveal filter with the **ctx-free** `parse_target`, so the enclosing trigger subject never reached the filter's `parse_shared_quality_reference`.
2. Even with the ctx in scope, `parse_shared_quality_reference` routed only the bare pronoun **"it"** through the ctx-aware `resolve_pronoun_target`; the singular demonstrative **"that creature"** fell through to the ctx-free `parse_target`, binding the shared-quality `reference` to `ParentTarget`.

In this attacks trigger there is no chosen target / recipient / effect-context object, so `parent_target_shared_quality_values` (game/filter.rs) returns `None` and the "shares a creature type" test matched **no** card — exactly the reported symptom (no card in the top six is ever selectable).

Sibling cards that reference the triggering creature with the pronoun "it" (Mana Echoes, the attacker anthem) already bind to `TriggeringSource`; only the demonstrative form in the dig-from-among reveal filter was missing.

## Fix

- Thread the enclosing `ParseContext` through `parse_dig_from_among` so the reveal filter parses with the trigger subject in scope.
- Resolve the singular object demonstratives ("that creature" / "that permanent" / "that card") via the same `resolve_pronoun_target` path the bare pronoun "it" already used.

With a non-source trigger subject in scope the reference now binds to `TriggeringSource` (the attacking equipped creature); without one it stays `ParentTarget`, so non-trigger dig-from-among filters are unchanged. `resolve_pronoun_target`'s existing subject discriminator (typed / `AttachedTo` subject → `TriggeringSource`; `None` / `SelfRef` / `Any` → `ParentTarget`) contains the blast radius to genuine trigger-subject contexts.

## Tests (RED pre-fix / GREEN post-fix, verified via stash)

- `conjurers_mantle_reveal_matches_shared_creature_type` — drives the equipped Goblin's attack through the real combat + Dig reveal pipeline and asserts the shared-type Goblin card in the top six is **selectable** (empty pre-fix); non-creature fillers stay non-selectable; the revealed Goblin lands in hand.
- `conjurers_mantle_shared_type_reference_binds_to_trigger_subject` — parser guard pinning the reference to `TriggeringSource` (`ParentTarget` pre-fix).

## CI parity (isolated `CARGO_TARGET_DIR`)

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings` — clean
- `cargo test -p engine --lib` — 17565 passed, 0 failed
- `cargo test -p engine --test integration` — 3837 passed, 0 failed

Closes #5900

---

Model: claude-opus-4
Tier: Standard
Thinking: high

Gate A: PASS — `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings`, `cargo test -p engine --lib` (17565 passed / 0 failed), and `cargo test -p engine --test integration` (3837 passed / 0 failed), all clean in an isolated `CARGO_TARGET_DIR`, pre- and post-rebase onto latest `origin/main`.

Anchored on:
- `crates/engine/src/parser/oracle_effect/sequence.rs` — `parse_dig_from_among` threads `ParseContext` and parses the "from among them" filter via `parse_target_with_ctx`.
- `crates/engine/src/parser/oracle_target.rs` — `parse_shared_quality_reference` routes the singular object demonstratives through the existing ctx-aware `resolve_pronoun_target`.
- `crates/engine/src/game/filter.rs` — `parent_target_shared_quality_values` / `object_shares_quality_with_reference_filter` (unchanged) resolve `TriggeringSource` from `state.current_trigger_events` (the `AttackersDeclared` event), which is why the trigger-subject binding is the correct seam.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interpretation of “from among them/those” filters so references resolve to the correct triggering object.
  - Added support for phrases such as “that creature,” “that permanent,” and “that card.”
  - Fixed card-selection behavior for effects like *Conjurer’s Mantle*, ensuring matching cards can be selected correctly.

- **Tests**
  - Added regression coverage for parsing and gameplay behavior involving creature-type filters and contextual references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->