### PR TITLE
Fix desktop card art data loading

### DIFF
--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -102,4 +102,16 @@ mod tests {
             "must stay false so run()'s setup hook is the only window creator"
         );
     }
+
+    #[test]
+    fn remote_shell_can_fetch_shared_data() {
+        let raw = include_str!("../tauri.conf.json");
+        let config: serde_json::Value = serde_json::from_str(raw).unwrap();
+        let csp = config["app"]["security"]["csp"].as_str().unwrap();
+
+        assert!(
+            csp.contains("connect-src") && csp.contains("https://data.phase-rs.dev"),
+            "remote shell content fetches shared card and image data from R2"
+        );
+    }
 }

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: https://cards.scryfall.io https://backs.scryfall.io; connect-src 'self' https://phase-rs.dev https://app.phase-rs.dev https://preview.phase-rs.dev"
+      "csp": "default-src 'self'; img-src 'self' data: https://cards.scryfall.io https://backs.scryfall.io; connect-src 'self' https://phase-rs.dev https://app.phase-rs.dev https://preview.phase-rs.dev https://data.phase-rs.dev"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary\n- allow the remote shell to fetch shared R2 card/image data\n- lock that CSP requirement with a focused Tauri config test\n\n## Verification\n- cargo fmt --all\n- jq CSP assertion\n- git diff --check\n\nThe running desktop shell showed the active deck but an empty art header: its CSP allowed Scryfall image URLs but blocked the R2 Scryfall-data fetch needed to resolve them.