### PR TITLE
cr733(p2): journal resolution-frame continuation transitions

### DIFF
--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -50,10 +50,12 @@ use super::resolution::{
     ResolutionFrame, ResolutionStack, ResolutionStackError, ResolutionStateWire,
 };
 use super::resolved_commands::{
-    ManaPaymentRecipient, ResolvedInformationAudience, ResolvedInformationCommand,
-    ResolvedInformationEdit, ResolvedInformationLifetime, ResolvedInformationReplayInvariantError,
-    ResolvedManaInsertCommand, ResolvedManaReplayInvariantError, ResolvedManaSpendCommand,
-    ResolvedPlayerEdit, ResolvedPlayerEditCommand, ResolvedPlayerEditReplayInvariantError,
+    ManaPaymentRecipient, ResolvedFrameTransition, ResolvedFrameTransitionCommand,
+    ResolvedFrameTransitionReplayInvariantError, ResolvedInformationAudience,
+    ResolvedInformationCommand, ResolvedInformationEdit, ResolvedInformationLifetime,
+    ResolvedInformationReplayInvariantError, ResolvedManaInsertCommand,
+    ResolvedManaReplayInvariantError, ResolvedManaSpendCommand, ResolvedPlayerEdit,
+    ResolvedPlayerEditCommand, ResolvedPlayerEditReplayInvariantError,
     ResolvedRngReplayInvariantError, ResolvedRulesJournal, RulesExecutionNodeRef,
 };
 use super::zones::EtbTapState;
@@ -13791,12 +13793,18 @@ impl GameState {
         pending: PendingContinuation,
     ) -> Result<(), ResolutionStackError> {
         let choose_zone_trigger_context = pending.trigger_context.clone();
-        self.resolution_stack.insert_parent_of_active(
-            super::resolution::ResolutionFrame::AbilityContinuation(AbilityContinuationFrame {
-                pending,
-                choose_zone_trigger_context,
-            }),
-        )
+        self.resolve_and_apply_frame_transition(ResolvedFrameTransition::InsertParentOfActive {
+            frame: super::resolution::ResolutionFrame::AbilityContinuation(
+                AbilityContinuationFrame {
+                    pending,
+                    choose_zone_trigger_context,
+                },
+            ),
+        })
+        .map(|_| ())
+        .map_err(|error| match error {
+            ResolvedFrameTransitionReplayInvariantError::Stack(error) => error,
+        })
     }
 
     /// Inserts the continuation outside an active general-drain/draw pair so
@@ -14872,9 +14880,12 @@ impl GameState {
         let mut drains = PostReplacementDrainStack::default();
         let installed = drains.install(drain, policy);
         if self.active_multi_draw_frame().is_some() {
-            self.resolution_stack
-                .insert_parent_of_active(ResolutionFrame::PostReplacement(drains))
-                .expect("an active multi-draw frame accepts its exact post-replacement parent");
+            self.resolve_and_apply_frame_transition(
+                ResolvedFrameTransition::InsertParentOfActive {
+                    frame: ResolutionFrame::PostReplacement(drains),
+                },
+            )
+            .expect("an active multi-draw frame accepts its exact post-replacement parent");
         } else {
             self.resolution_stack.push_post_replacement(drains);
         }
@@ -15267,6 +15278,46 @@ impl GameState {
             .record_mana_insert(command)
             .expect("stamped mana must have one unique journal producer");
         Some(unit)
+    }
+
+    /// CR 608.2c: Applies one already-resolved frame transition in the
+    /// instruction order that the resolving spell or ability established.
+    pub fn apply_resolved_frame_transition(
+        &mut self,
+        command: &ResolvedFrameTransitionCommand,
+    ) -> Result<(), ResolvedFrameTransitionReplayInvariantError> {
+        let mut resolution_stack = self.resolution_stack.clone();
+        match &command.transition {
+            ResolvedFrameTransition::Push { frame } => resolution_stack.push_inner(frame.clone()),
+            ResolvedFrameTransition::InsertParentOfActive { frame } => {
+                resolution_stack.insert_parent_of_active(frame.clone())?;
+            }
+            ResolvedFrameTransition::PopExpected { kind } => {
+                let _ = resolution_stack.pop_expected(*kind)?;
+            }
+            ResolvedFrameTransition::ReplaceActive { frame } => {
+                resolution_stack.replace_active(frame.clone())?;
+            }
+        }
+        resolution_stack.validate(&self.waiting_for)?;
+        self.resolution_stack = resolution_stack;
+        Ok(())
+    }
+
+    /// Applies and journals one bounded resolution-frame transition.
+    pub fn resolve_and_apply_frame_transition(
+        &mut self,
+        transition: ResolvedFrameTransition,
+    ) -> Result<ResolvedFrameTransitionCommand, ResolvedFrameTransitionReplayInvariantError> {
+        let command = ResolvedFrameTransitionCommand {
+            transition,
+            cause: self.current_or_begin_rules_execution_node(),
+        };
+        self.apply_resolved_frame_transition(&command)?;
+        self.resolved_rules_journal
+            .record_frame_transition(command.clone())
+            .expect("resolved frame transition must have a live journal cause");
+        Ok(command)
     }
 
     /// Applies and journals one already-resolved player resource edit.

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -81,10 +81,12 @@ pub use resolution::{
 };
 pub use resolved_commands::{
     ManaPaymentRecipient, ProducedManaUnit, ResolvedCommandJournalEntry, ResolvedCommandOrdinal,
-    ResolvedLedgerEdit, ResolvedLedgerEditCommand, ResolvedLedgerEditReplayInvariantError,
-    ResolvedLibraryShuffleCommand, ResolvedLibraryShuffleReplayInvariantError,
-    ResolvedManaInsertCommand, ResolvedManaReplayInvariantError, ResolvedManaSpendCommand,
-    ResolvedManaSpentUnit, ResolvedObjectCounterCommand, ResolvedObjectCounterEdit,
+    ResolvedFrameTransition, ResolvedFrameTransitionCommand,
+    ResolvedFrameTransitionReplayInvariantError, ResolvedLedgerEdit, ResolvedLedgerEditCommand,
+    ResolvedLedgerEditReplayInvariantError, ResolvedLibraryShuffleCommand,
+    ResolvedLibraryShuffleReplayInvariantError, ResolvedManaInsertCommand,
+    ResolvedManaReplayInvariantError, ResolvedManaSpendCommand, ResolvedManaSpentUnit,
+    ResolvedObjectCounterCommand, ResolvedObjectCounterEdit,
     ResolvedObjectCounterReplayInvariantError, ResolvedObjectStatus, ResolvedObjectStatusCommand,
     ResolvedObjectStatusReplayInvariantError, ResolvedOncePerTurnPermission, ResolvedPlayerEdit,
     ResolvedPlayerEditCommand, ResolvedPlayerEditReplayInvariantError,

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -14,6 +14,7 @@ use super::game_state::SpellCastRecord;
 use super::identifiers::{ObjectId, ObjectIncarnationRef, LEGACY_INCARNATION};
 use super::mana::{ManaPipId, ManaUnit};
 use super::player::{PlayerCounterKind, PlayerId};
+use super::resolution::{FrameKind, ResolutionFrame, ResolutionStackError};
 
 /// Globally ordered identity of a resolved command.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -263,11 +264,30 @@ pub struct ResolvedLibraryShuffleCommand {
     pub cause: RulesExecutionNodeRef,
 }
 
+/// One bounded structural transition of the resolution-frame stack.
+///
+/// This carries only the primitive operation and its native operand. It never
+/// records stack positions, frame identities, or displaced frame payloads.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum ResolvedFrameTransition {
+    Push { frame: ResolutionFrame },
+    InsertParentOfActive { frame: ResolutionFrame },
+    PopExpected { kind: FrameKind },
+    ReplaceActive { frame: ResolutionFrame },
+}
+
+/// One exact resolution-frame transition under its causal rules-execution node.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedFrameTransitionCommand {
+    pub transition: ResolvedFrameTransition,
+    pub cause: RulesExecutionNodeRef,
+}
+
 /// Semantic command payload currently carried by a resolved-rules journal entry.
 ///
 /// Additional command families are intentionally added by their owning P2
 /// authority rather than by a central replay dispatcher.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum ResolvedRulesCommand {
     ManaInsert(ResolvedManaInsertCommand),
     ManaSpend(ResolvedManaSpendCommand),
@@ -277,6 +297,14 @@ pub enum ResolvedRulesCommand {
     Information(ResolvedInformationCommand),
     LedgerEdit(ResolvedLedgerEditCommand),
     LibraryShuffle(ResolvedLibraryShuffleCommand),
+    FrameTransition(Box<ResolvedFrameTransitionCommand>),
+}
+
+/// Typed failure while applying an already-resolved frame transition.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedFrameTransitionReplayInvariantError {
+    #[error(transparent)]
+    Stack(#[from] ResolutionStackError),
 }
 
 /// Typed failure while advancing the canonical ChaCha20 entropy high-water mark.
@@ -700,7 +728,7 @@ pub struct SettlementNode {
 }
 
 /// One command slot assigned to a journal node.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ResolvedCommandJournalEntry {
     pub ordinal: ResolvedCommandOrdinal,
     pub node: RulesExecutionNodeRef,
@@ -781,7 +809,7 @@ impl std::fmt::Display for ResolvedRulesJournalError {
 impl std::error::Error for ResolvedRulesJournalError {}
 
 /// Persistent resolved rules journal.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct ResolvedRulesJournal {
     next_command_ordinal: u64,
     next_settlement_node_ordinal: u64,
@@ -1116,6 +1144,17 @@ impl ResolvedRulesJournal {
         self.append_command(command.cause, ResolvedRulesCommand::LibraryShuffle(command))
     }
 
+    /// Records one exact bounded resolution-frame transition under its causal node.
+    pub fn record_frame_transition(
+        &mut self,
+        command: ResolvedFrameTransitionCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(
+            command.cause,
+            ResolvedRulesCommand::FrameTransition(Box::new(command)),
+        )
+    }
+
     fn begin_settlement(
         &mut self,
         identity_for: impl FnOnce(SettlementNodeOrdinal) -> RulesExecutionNodeRef,
@@ -1316,7 +1355,8 @@ impl ResolvedRulesJournal {
                 | ResolvedRulesCommand::ObjectCounter(_)
                 | ResolvedRulesCommand::Information(_)
                 | ResolvedRulesCommand::LedgerEdit(_)
-                | ResolvedRulesCommand::LibraryShuffle(_) => {}
+                | ResolvedRulesCommand::LibraryShuffle(_)
+                | ResolvedRulesCommand::FrameTransition(_) => {}
             }
         }
         for node in &self.nodes {
@@ -1545,6 +1585,13 @@ impl ResolvedRulesJournal {
                     return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
                         "library shuffle command has an invalid receipt or unrelated cause"
                             .to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::FrameTransition(command) => {
+                if entry.node != command.cause {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "frame-transition command has an unrelated cause".to_string(),
                     ));
                 }
             }

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -86,6 +86,11 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::Information(command) => {
             state.apply_resolved_information(command).unwrap();
         }
+        ResolvedRulesCommand::FrameTransition(command) => {
+            state
+                .apply_resolved_frame_transition(command.as_ref())
+                .unwrap();
+        }
     }
 }
 
@@ -173,7 +178,10 @@ fn exact_mana_spend_rejects_a_second_removal() {
             | ResolvedRulesCommand::ObjectCounter(_)
             | ResolvedRulesCommand::LedgerEdit(_)
             | ResolvedRulesCommand::LibraryShuffle(_)
-            | ResolvedRulesCommand::Information(_) => apply_semantic_command(&mut replay, command),
+            | ResolvedRulesCommand::Information(_)
+            | ResolvedRulesCommand::FrameTransition(_) => {
+                apply_semantic_command(&mut replay, command)
+            }
         }
     }
     assert!(

--- a/crates/engine/tests/integration/cr733_resolved_frame_transition.rs
+++ b/crates/engine/tests/integration/cr733_resolved_frame_transition.rs
@@ -1,0 +1,351 @@
+//! CR733 P2 coverage for bounded, journaled resolution-frame transitions.
+
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, PostReplacementContinuation, QuantityExpr,
+    ResolvedAbility, TargetFilter,
+};
+use engine::types::game_state::{
+    DrawSequenceStack, GameState, PendingContinuation, PostReplacementDrain,
+    PostReplacementDrainStack, ResidentDrainPolicy,
+};
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+use engine::types::resolution::{
+    FrameKind, MultiDrawFrame, PendingCoinFlip, PendingCoinFlipKind, ResolutionFrame,
+    ResolutionStackError, ResolutionStateWire,
+};
+use engine::types::resolved_commands::{
+    ResolvedCommandOrdinal, ResolvedFrameTransition, ResolvedFrameTransitionCommand,
+    ResolvedFrameTransitionReplayInvariantError, ResolvedRulesCommand, ResolvedRulesJournal,
+    RulesExecutionNodeRef,
+};
+
+fn cause() -> RulesExecutionNodeRef {
+    RulesExecutionNodeRef::Proposal(ResolvedCommandOrdinal(0))
+}
+
+fn command(transition: ResolvedFrameTransition) -> ResolvedFrameTransitionCommand {
+    ResolvedFrameTransitionCommand {
+        transition,
+        cause: cause(),
+    }
+}
+
+fn multi_draw_frame() -> ResolutionFrame {
+    ResolutionFrame::MultiDraw(MultiDrawFrame {
+        draw_sequences: DrawSequenceStack::default(),
+        connive_reentry: None,
+    })
+}
+
+fn coin_flip_frame() -> ResolutionFrame {
+    ResolutionFrame::CoinFlip(PendingCoinFlip {
+        source_id: ObjectId(91),
+        controller: PlayerId(0),
+        flipper: PlayerId(0),
+        targets: Vec::new(),
+        win_effect: None,
+        lose_effect: None,
+        kind: PendingCoinFlipKind::Single,
+    })
+}
+
+fn frames(state: &GameState) -> Vec<ResolutionFrame> {
+    state.resolution_stack.iter().cloned().collect()
+}
+
+fn assert_command_round_trip(command: &ResolvedFrameTransitionCommand) {
+    let value = serde_json::to_value(command).expect("frame transition command serializes");
+    assert_eq!(
+        serde_json::from_value::<ResolvedFrameTransitionCommand>(value)
+            .expect("frame transition command deserializes"),
+        *command
+    );
+}
+
+/// Every supported command round-trips independently and applies the native
+/// structural primitive to exactly the expected stack prefix.
+#[test]
+fn frame_transition_commands_round_trip_and_apply_exact_stack_results() {
+    let push_frame = multi_draw_frame();
+    let push = command(ResolvedFrameTransition::Push {
+        frame: push_frame.clone(),
+    });
+    assert_command_round_trip(&push);
+    let mut push_state = GameState::new_two_player(91);
+    push_state
+        .apply_resolved_frame_transition(&push)
+        .expect("push command applies");
+    assert_eq!(frames(&push_state), vec![push_frame]);
+
+    let inserted_frame = ResolutionFrame::PostReplacement(PostReplacementDrainStack::default());
+    let insert = command(ResolvedFrameTransition::InsertParentOfActive {
+        frame: inserted_frame.clone(),
+    });
+    assert_command_round_trip(&insert);
+    let mut insert_state = GameState::new_two_player(92);
+    insert_state.resolution_stack.push_inner(multi_draw_frame());
+    insert_state
+        .apply_resolved_frame_transition(&insert)
+        .expect("parent insertion command applies");
+    assert_eq!(
+        frames(&insert_state),
+        vec![inserted_frame, multi_draw_frame()]
+    );
+
+    let pop = command(ResolvedFrameTransition::PopExpected {
+        kind: FrameKind::MultiDraw,
+    });
+    assert_command_round_trip(&pop);
+    let mut pop_state = GameState::new_two_player(93);
+    pop_state.resolution_stack.push_inner(multi_draw_frame());
+    pop_state
+        .apply_resolved_frame_transition(&pop)
+        .expect("expected frame pop applies");
+    assert!(frames(&pop_state).is_empty());
+
+    let replacement_frame = ResolutionFrame::PostReplacement(PostReplacementDrainStack::default());
+    let replace = command(ResolvedFrameTransition::ReplaceActive {
+        frame: replacement_frame.clone(),
+    });
+    assert_command_round_trip(&replace);
+    let mut replace_state = GameState::new_two_player(94);
+    replace_state
+        .resolution_stack
+        .push_inner(multi_draw_frame());
+    replace_state
+        .apply_resolved_frame_transition(&replace)
+        .expect("active frame replacement applies");
+    assert_eq!(frames(&replace_state), vec![replacement_frame]);
+}
+
+/// Structural validation runs against a cloned stack, so a prompt mismatch
+/// cannot leave a partially applied direct-choice frame behind.
+#[test]
+fn malformed_prompt_coherence_errors_atomically() {
+    let mut state = GameState::new_two_player(95);
+    let before = state.resolution_stack.clone();
+
+    assert_eq!(
+        state.apply_resolved_frame_transition(&command(ResolvedFrameTransition::Push {
+            frame: coin_flip_frame(),
+        })),
+        Err(ResolvedFrameTransitionReplayInvariantError::Stack(
+            ResolutionStackError::PromptMismatch {
+                frame: FrameKind::CoinFlip,
+                waiting_for: "Priority",
+            }
+        ))
+    );
+    assert_eq!(state.resolution_stack, before);
+}
+
+/// Missing parents and wrong active kinds are typed failures; neither failure
+/// changes the existing stack.
+#[test]
+fn parentless_and_wrong_kind_frame_transitions_error_atomically() {
+    let mut parentless = GameState::new_two_player(96);
+    let parentless_before = parentless.resolution_stack.clone();
+    assert_eq!(
+        parentless.apply_resolved_frame_transition(&command(
+            ResolvedFrameTransition::InsertParentOfActive {
+                frame: ResolutionFrame::PostReplacement(PostReplacementDrainStack::default()),
+            },
+        )),
+        Err(ResolvedFrameTransitionReplayInvariantError::Stack(
+            ResolutionStackError::NoActiveChild
+        ))
+    );
+    assert_eq!(parentless.resolution_stack, parentless_before);
+
+    let mut empty = GameState::new_two_player(97);
+    let empty_before = empty.resolution_stack.clone();
+    assert_eq!(
+        empty.apply_resolved_frame_transition(&command(ResolvedFrameTransition::ReplaceActive {
+            frame: multi_draw_frame(),
+        })),
+        Err(ResolvedFrameTransitionReplayInvariantError::Stack(
+            ResolutionStackError::Empty
+        ))
+    );
+    assert_eq!(empty.resolution_stack, empty_before);
+
+    let mut wrong_kind = GameState::new_two_player(97);
+    wrong_kind.resolution_stack.push_inner(multi_draw_frame());
+    let wrong_kind_before = wrong_kind.resolution_stack.clone();
+    assert_eq!(
+        wrong_kind.apply_resolved_frame_transition(&command(
+            ResolvedFrameTransition::PopExpected {
+                kind: FrameKind::CoinFlip,
+            },
+        )),
+        Err(ResolvedFrameTransitionReplayInvariantError::Stack(
+            ResolutionStackError::UnexpectedTop {
+                expected: FrameKind::CoinFlip,
+                actual: FrameKind::MultiDraw,
+            }
+        ))
+    );
+    assert_eq!(wrong_kind.resolution_stack, wrong_kind_before);
+}
+
+/// The command's causal node is journal authority: a tampered serialized
+/// cause is rejected before it can be restored as replay input.
+#[test]
+fn serialized_frame_transition_with_tampered_cause_is_rejected() {
+    let mut state = GameState::new_two_player(98);
+    state
+        .resolve_and_apply_frame_transition(ResolvedFrameTransition::Push {
+            frame: multi_draw_frame(),
+        })
+        .expect("resolved transition journals under a proposal node");
+    let second_proposal = state
+        .resolved_rules_journal
+        .begin_proposal()
+        .expect("second valid proposal node opens");
+
+    let mut journal =
+        serde_json::to_value(&state.resolved_rules_journal).expect("journal serializes");
+    let entry = journal["entries"]
+        .as_array_mut()
+        .expect("journal has entries")
+        .iter_mut()
+        .find(|entry| entry["command"].get("FrameTransition").is_some())
+        .expect("transition command is present");
+    entry["command"]["FrameTransition"]["cause"] =
+        serde_json::to_value(second_proposal).expect("second proposal serializes");
+
+    let error = serde_json::from_value::<ResolvedRulesJournal>(journal)
+        .expect_err("a valid but unrelated cause is rejected");
+    assert!(error.to_string().contains("unrelated cause"));
+}
+
+/// Resolving a malformed transition can allocate the proposal provenance slot,
+/// but failure occurs before a semantic command is appended.
+#[test]
+fn failed_resolve_keeps_only_the_proposal_slot_without_a_semantic_entry() {
+    let mut state = GameState::new_two_player(99);
+
+    assert!(matches!(
+        state.resolve_and_apply_frame_transition(ResolvedFrameTransition::InsertParentOfActive {
+            frame: ResolutionFrame::PostReplacement(PostReplacementDrainStack::default()),
+        }),
+        Err(ResolvedFrameTransitionReplayInvariantError::Stack(
+            ResolutionStackError::NoActiveChild
+        ))
+    ));
+    assert_eq!(state.resolved_rules_journal.entries().len(), 1);
+    assert_eq!(state.resolved_rules_journal.nodes().len(), 1);
+    assert!(state.resolved_rules_journal.entries()[0].command.is_none());
+}
+
+fn pending_continuation(state: &GameState) -> PendingContinuation {
+    PendingContinuation::new(
+        Box::new(ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(100),
+            PlayerId(0),
+        )),
+        state,
+    )
+}
+
+fn post_replacement_drain() -> PostReplacementDrain {
+    PostReplacementDrain::ready(PostReplacementContinuation::Template(Box::new(
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::unimplemented("CR733 frame transition fixture", "test-only drain"),
+        ),
+    )))
+}
+
+/// The only two production parent-insertion callers now use the resolved
+/// command boundary, retain their exact adjacency, and journal that insertion.
+#[test]
+fn production_parent_insertions_preserve_adjacency_and_journal_the_transition() {
+    let mut continuation_state = GameState::new_two_player(100);
+    continuation_state
+        .resolution_stack
+        .push_inner(multi_draw_frame());
+    let pending = pending_continuation(&continuation_state);
+    continuation_state
+        .insert_ability_continuation_parent_of_active(pending)
+        .expect("active child accepts its continuation parent");
+    assert!(matches!(
+        frames(&continuation_state).as_slice(),
+        [
+            ResolutionFrame::AbilityContinuation(_),
+            ResolutionFrame::MultiDraw(_)
+        ]
+    ));
+    assert!(continuation_state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .any(|entry| matches!(
+            &entry.command,
+            Some(ResolvedRulesCommand::FrameTransition(command))
+                if matches!(
+                    &command.transition,
+                    ResolvedFrameTransition::InsertParentOfActive {
+                        frame: ResolutionFrame::AbilityContinuation(_),
+                    }
+                )
+        )));
+
+    let mut replacement_state = GameState::new_two_player(101);
+    replacement_state
+        .resolution_stack
+        .push_inner(multi_draw_frame());
+    assert!(replacement_state
+        .install_post_replacement_drain(post_replacement_drain(), ResidentDrainPolicy::Replace,));
+    assert!(matches!(
+        frames(&replacement_state).as_slice(),
+        [
+            ResolutionFrame::PostReplacement(_),
+            ResolutionFrame::MultiDraw(_)
+        ]
+    ));
+    assert!(replacement_state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .any(|entry| matches!(
+            &entry.command,
+            Some(ResolvedRulesCommand::FrameTransition(command))
+                if matches!(
+                    &command.transition,
+                    ResolvedFrameTransition::InsertParentOfActive {
+                        frame: ResolutionFrame::PostReplacement(_),
+                    }
+                )
+        )));
+}
+
+/// Frame-transition commands use the existing v2 resolution-state wire and
+/// preserve both their journal evidence and their structural stack exactly.
+#[test]
+fn resolution_state_wire_v2_round_trip_preserves_frame_transition_journal_and_stack() {
+    let mut state = GameState::new_two_player(102);
+    state
+        .resolve_and_apply_frame_transition(ResolvedFrameTransition::Push {
+            frame: multi_draw_frame(),
+        })
+        .expect("resolved transition applies");
+    let expected_journal = state.resolved_rules_journal.clone();
+    let expected_stack = frames(&state);
+
+    let wire = serde_json::to_value(ResolutionStateWire::from_game_state(state))
+        .expect("v2 resolution state serializes");
+    assert_eq!(wire["resolution_state_version"], 2);
+    let restored = serde_json::from_value::<ResolutionStateWire>(wire)
+        .expect("v2 resolution state restores")
+        .into_game_state();
+
+    assert_eq!(restored.resolved_rules_journal, expected_journal);
+    assert_eq!(frames(&restored), expected_stack);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -93,6 +93,7 @@ mod court_of_cunning_multi_target_mill;
 mod cr733_resolved_commands_p0;
 mod cr733_resolved_commands_p1;
 mod cr733_resolved_commands_p2;
+mod cr733_resolved_frame_transition;
 mod cr_annotations;
 mod craft_tithing_blade_transform;
 mod cross_line_instead_override_branch;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added journaled resolution-frame transitions for pushing, inserting, removing, and replacing active frames.
  - Added replay validation to ensure transitions match the current resolution state.
  - Added serialization and deserialization support for frame-transition commands.

- **Bug Fixes**
  - Invalid transitions now fail safely without modifying the resolution state.
  - Improved handling of ability continuations and post-replacement draws.

- **Tests**
  - Added comprehensive coverage for replay validation, journal integrity, state round-tripping, and transition error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->