### PR TITLE
test(parser): verify Mephidross Vampire color+keyword compound static parsing

### DIFF
--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20957,6 +20957,21 @@ fn static_all_creatures_are_color_composes_trailing_modifications() {
             .any(|m| matches!(m, ContinuousModification::SetColor { .. }))),
         "'are red dragons' must not parse as a color static, got {def:?}"
     );
+
+    // Mephidross Vampire: "All creatures are black and have lifelink."
+    let def = parse_static_line("All creatures are black and have lifelink.").unwrap();
+    assert_eq!(def.mode, StaticMode::Continuous);
+    assert_eq!(
+        def.modifications,
+        vec![
+            ContinuousModification::SetColor {
+                colors: vec![ManaColor::Black]
+            },
+            ContinuousModification::AddKeyword {
+                keyword: Keyword::Lifelink
+            },
+        ]
+    );
 }
 
 /// CR 205.4b + CR 613.1d (Layer 4): "[subject] is/are [no longer] [supertype]"


### PR DESCRIPTION
## Summary

Adds regression test for the 'All creatures are black and have lifelink' pattern (Mephidross Vampire), verifying that compound static abilities combining color-defining effects with keyword grants are correctly parsed as two independent modifications.

## What This Tests

- Color-defining statics with trailing keyword modifications (CR 105.2 + CR 613.1e/f)
- The fix pattern from PR #5807 (Onakke Catacomb) correctly applies to Mephidross Vampire
- Dispatch ordering ensures color parsing is attempted before keyword-only parsing

## Root Cause (Already Fixed in PR #5807)

The 'all creatures are black and have lifelink' pattern combines two effects:
1. Color-changing static (Layer 5): SetColor{Black}
2. Ability-adding static (Layer 6): AddKeyword{Lifelink}

Without proper dispatch ordering, parsers would claim the line on the 'have lifelink' part and silently drop the color. PR #5807 fixed this by:
1. Adding `parse_color_and_trailing_modifications` to split color from trailing effects
2. Ensuring `parse_all_subject_are_color` is probed before `parse_continuous_gets_has`

## Files Changed

- crates/engine/src/parser/oracle_static/tests.rs — add Mephidross Vampire test case

## Verification

- Test added to regression suite for 'All <subject> are <color> and <keyword>' patterns
- Confirms SetColor + AddKeyword modifications both present
- Covers the general pattern beyond just Onakke Catacomb

Closes #6534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added parser coverage for rules text that makes all creatures black and grants them lifelink.
  * Verified that both continuous effects are parsed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->