### PR TITLE
cr733(p2): journal logical-zone trigger collection occurrences

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -26,6 +26,10 @@ use crate::types::keywords::WardCost;
 use crate::types::keywords::{Keyword, KeywordKind};
 use crate::types::phase::Phase;
 use crate::types::player::{Player, PlayerCounterKind, PlayerId};
+use crate::types::resolved_commands::{
+    ResolvedTriggerCollection, ResolvedTriggerCollectionCommand,
+    ResolvedTriggerCollectionReplayInvariantError,
+};
 use crate::types::statics::{
     StaticMode, SuppressedTriggerEvent, TriggerCause, ZoneChangeQualifier,
 };
@@ -302,6 +306,57 @@ impl PendingTriggerContext {
             dispatch_origin: PendingTriggerDispatchOrigin::Delayed,
         }
     }
+}
+
+/// Applies exact trigger/LKI collection output without rerunning trigger matching.
+///
+/// CR 603.2 + CR 603.3b: pending contexts preserve their resolved firing and
+/// placement order. CR 603.10 + CR 603.10a: a logical zone-change final pass
+/// appends its last-known-information-aware settlement. CR 603.2c: consumed
+/// event occurrences prevent a duplicate generic priority collection.
+pub fn apply_resolved_trigger_collection(
+    state: &mut GameState,
+    command: &ResolvedTriggerCollectionCommand,
+) -> Result<(), ResolvedTriggerCollectionReplayInvariantError> {
+    match &command.collection {
+        ResolvedTriggerCollection::DeferPending { contexts } => {
+            state.deferred_triggers.extend(contexts.clone());
+        }
+        ResolvedTriggerCollection::ConsumeBeforePriority { occurrences } => {
+            state
+                .consumed_before_priority_trigger_events
+                .extend(occurrences.clone());
+        }
+    }
+    Ok(())
+}
+
+/// Resolves, applies, and journals one non-empty trigger/LKI collection append.
+///
+/// Empty vectors are no-ops, so they deliberately do not allocate a causal
+/// node or add a journal entry.
+pub fn resolve_and_apply_trigger_collection(
+    state: &mut GameState,
+    collection: ResolvedTriggerCollection,
+) -> Result<(), ResolvedTriggerCollectionReplayInvariantError> {
+    let is_empty = match &collection {
+        ResolvedTriggerCollection::DeferPending { contexts } => contexts.is_empty(),
+        ResolvedTriggerCollection::ConsumeBeforePriority { occurrences } => occurrences.is_empty(),
+    };
+    if is_empty {
+        return Ok(());
+    }
+
+    let command = ResolvedTriggerCollectionCommand {
+        collection,
+        cause: state.current_or_begin_rules_execution_node(),
+    };
+    apply_resolved_trigger_collection(state, &command)?;
+    state
+        .resolved_rules_journal
+        .record_trigger_collection(command)
+        .expect("resolved trigger collection must have a live journal cause");
+    Ok(())
 }
 
 fn matching_batched_trigger_events(
@@ -2183,7 +2238,11 @@ pub(crate) fn append_and_collect_logical_zone_trigger_segment(
         .collect();
     group.append_delivery_events(&zone_change_events)?;
     let pending = collect_logical_zone_trigger_segment(state, group, &zone_change_events);
-    state.deferred_triggers.extend(pending);
+    resolve_and_apply_trigger_collection(
+        state,
+        ResolvedTriggerCollection::DeferPending { contexts: pending },
+    )
+    .map_err(|error| error.to_string())?;
     Ok(())
 }
 
@@ -2235,7 +2294,13 @@ pub(crate) fn complete_logical_zone_trigger_collection(
     group.stamp_battlefield_departures()?;
     sync_logical_zone_change_departure_stamps(group, final_events);
     let settlement = collect_logical_zone_trigger_settlement(state, group)?;
-    state.deferred_triggers.extend(settlement);
+    resolve_and_apply_trigger_collection(
+        state,
+        ResolvedTriggerCollection::DeferPending {
+            contexts: settlement,
+        },
+    )
+    .map_err(|error| error.to_string())?;
     Ok(())
 }
 
@@ -2305,9 +2370,10 @@ pub(crate) fn mark_logical_zone_events_consumed_before_priority(
         .iter()
         .map(|occurrence| occurrence.event.clone())
         .collect();
-    state
-        .consumed_before_priority_trigger_events
-        .extend(events.iter().enumerate().filter_map(|(index, event)| {
+    let occurrences = events
+        .iter()
+        .enumerate()
+        .filter_map(|(index, event)| {
             matches!(event, GameEvent::ZoneChanged { .. })
                 .then(|| {
                     unclaimed_owned_zone_events
@@ -2322,7 +2388,13 @@ pub(crate) fn mark_logical_zone_events_consumed_before_priority(
                         occurrence: trigger_event_occurrence(events, index),
                     }
                 })
-        }));
+        })
+        .collect();
+    resolve_and_apply_trigger_collection(
+        state,
+        ResolvedTriggerCollection::ConsumeBeforePriority { occurrences },
+    )
+    .expect("consumed-before-priority trigger journal cause must be live");
 }
 
 /// Collect the one final observer pass owned by a completed logical zone-change

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -91,8 +91,10 @@ pub use resolved_commands::{
     ResolvedObjectStatusReplayInvariantError, ResolvedOncePerTurnPermission, ResolvedPlayerEdit,
     ResolvedPlayerEditCommand, ResolvedPlayerEditReplayInvariantError,
     ResolvedRngReplayInvariantError, ResolvedRulesCommand, ResolvedRulesJournal,
-    ResolvedRulesJournalError, ResolvedTriggerLedgerEdit, RulesExecutionNodeKind,
-    RulesExecutionNodeRef, SettlementNode, SettlementNodeOrdinal, SpentManaUnit,
+    ResolvedRulesJournalError, ResolvedTriggerCollection, ResolvedTriggerCollectionCommand,
+    ResolvedTriggerCollectionReplayInvariantError, ResolvedTriggerLedgerEdit,
+    RulesExecutionNodeKind, RulesExecutionNodeRef, SettlementNode, SettlementNodeOrdinal,
+    SpentManaUnit,
 };
 pub use statics::StaticMode;
 pub use stickers::{AppliedSticker, StickerKind, StickerLocator};

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -7,6 +7,8 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::game::triggers::{ConsumedTriggerEventOccurrence, PendingTriggerContext};
+
 use super::ability::TriggerDefinitionRef;
 use super::card_type::CoreType;
 use super::counter::CounterType;
@@ -283,6 +285,30 @@ pub struct ResolvedFrameTransitionCommand {
     pub cause: RulesExecutionNodeRef,
 }
 
+/// Exact trigger occurrences collected at one logical trigger/LKI boundary.
+///
+/// CR 603.2 + CR 603.3b: collected trigger contexts retain their already
+/// determined firing and placement order. CR 603.10 + CR 603.10a: final
+/// logical zone-change settlement uses the recorded pre-event authority.
+/// CR 603.2c: consumed event occurrences prevent the generic priority scan
+/// from collecting the same occurrence a second time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolvedTriggerCollection {
+    DeferPending {
+        contexts: Vec<PendingTriggerContext>,
+    },
+    ConsumeBeforePriority {
+        occurrences: Vec<ConsumedTriggerEventOccurrence>,
+    },
+}
+
+/// One exact trigger/LKI collection append under its causal rules-execution node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedTriggerCollectionCommand {
+    pub collection: ResolvedTriggerCollection,
+    pub cause: RulesExecutionNodeRef,
+}
+
 /// Semantic command payload currently carried by a resolved-rules journal entry.
 ///
 /// Additional command families are intentionally added by their owning P2
@@ -298,7 +324,15 @@ pub enum ResolvedRulesCommand {
     LedgerEdit(ResolvedLedgerEditCommand),
     LibraryShuffle(ResolvedLibraryShuffleCommand),
     FrameTransition(Box<ResolvedFrameTransitionCommand>),
+    TriggerCollection(ResolvedTriggerCollectionCommand),
 }
+
+/// An append-only trigger collection command has no replay-time precondition.
+///
+/// The uninhabited type keeps the uniform resolved-command applier signature
+/// without inventing a failure mode for a pure `Vec::extend` operation.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedTriggerCollectionReplayInvariantError {}
 
 /// Typed failure while applying an already-resolved frame transition.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -1155,6 +1189,17 @@ impl ResolvedRulesJournal {
         )
     }
 
+    /// Records one exact trigger/LKI collection append under its causal node.
+    pub fn record_trigger_collection(
+        &mut self,
+        command: ResolvedTriggerCollectionCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(
+            command.cause,
+            ResolvedRulesCommand::TriggerCollection(command),
+        )
+    }
+
     fn begin_settlement(
         &mut self,
         identity_for: impl FnOnce(SettlementNodeOrdinal) -> RulesExecutionNodeRef,
@@ -1356,7 +1401,8 @@ impl ResolvedRulesJournal {
                 | ResolvedRulesCommand::Information(_)
                 | ResolvedRulesCommand::LedgerEdit(_)
                 | ResolvedRulesCommand::LibraryShuffle(_)
-                | ResolvedRulesCommand::FrameTransition(_) => {}
+                | ResolvedRulesCommand::FrameTransition(_)
+                | ResolvedRulesCommand::TriggerCollection(_) => {}
             }
         }
         for node in &self.nodes {
@@ -1592,6 +1638,13 @@ impl ResolvedRulesJournal {
                 if entry.node != command.cause {
                     return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
                         "frame-transition command has an unrelated cause".to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::TriggerCollection(command) => {
+                if entry.node != command.cause {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "trigger-collection command has an unrelated cause".to_string(),
                     ));
                 }
             }

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -91,6 +91,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
                 .apply_resolved_frame_transition(command.as_ref())
                 .unwrap();
         }
+        ResolvedRulesCommand::TriggerCollection(command) => {
+            engine::game::triggers::apply_resolved_trigger_collection(state, command).unwrap();
+        }
     }
 }
 
@@ -179,7 +182,8 @@ fn exact_mana_spend_rejects_a_second_removal() {
             | ResolvedRulesCommand::LedgerEdit(_)
             | ResolvedRulesCommand::LibraryShuffle(_)
             | ResolvedRulesCommand::Information(_)
-            | ResolvedRulesCommand::FrameTransition(_) => {
+            | ResolvedRulesCommand::FrameTransition(_)
+            | ResolvedRulesCommand::TriggerCollection(_) => {
                 apply_semantic_command(&mut replay, command)
             }
         }

--- a/crates/engine/tests/integration/cr733_resolved_trigger_collection.rs
+++ b/crates/engine/tests/integration/cr733_resolved_trigger_collection.rs
@@ -1,0 +1,228 @@
+//! CR733 P2 coverage for journaled trigger/LKI collection appends.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::triggers::{
+    apply_resolved_trigger_collection, resolve_and_apply_trigger_collection,
+    ConsumedTriggerEventOccurrence, PendingTrigger, PendingTriggerContext,
+    PendingTriggerDispatchOrigin,
+};
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::events::{GameEvent, PlayerActionKind};
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::resolved_commands::{
+    ResolvedCommandOrdinal, ResolvedRulesCommand, ResolvedTriggerCollection,
+    ResolvedTriggerCollectionCommand, RulesExecutionNodeRef,
+};
+use engine::types::zones::Zone;
+
+const DIES_OBSERVER: &str = "Whenever another creature dies, you gain 1 life.";
+
+fn cause() -> RulesExecutionNodeRef {
+    RulesExecutionNodeRef::Proposal(ResolvedCommandOrdinal(0))
+}
+
+fn pending_context(source_id: ObjectId) -> PendingTriggerContext {
+    PendingTriggerContext {
+        pending: PendingTrigger {
+            source_id,
+            controller: PlayerId(0),
+            condition: None,
+            ability: ResolvedAbility::new(
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+                Vec::new(),
+                source_id,
+                PlayerId(0),
+            ),
+            timestamp: 0,
+            target_constraints: Vec::new(),
+            distribute: None,
+            trigger_event: None,
+            modal: None,
+            mode_abilities: Vec::new(),
+            description: None,
+            may_trigger_origin: None,
+            subject_match_count: None,
+            die_result: None,
+        },
+        trigger_events: Vec::new(),
+        dispatch_origin: PendingTriggerDispatchOrigin::Normal,
+    }
+}
+
+fn occurrence(player: PlayerId) -> ConsumedTriggerEventOccurrence {
+    ConsumedTriggerEventOccurrence {
+        event: GameEvent::PlayerPerformedAction {
+            player_id: player,
+            action: PlayerActionKind::Scry,
+        },
+        occurrence: 0,
+    }
+}
+
+fn command(collection: ResolvedTriggerCollection) -> ResolvedTriggerCollectionCommand {
+    ResolvedTriggerCollectionCommand {
+        collection,
+        cause: cause(),
+    }
+}
+
+fn recorded_commands(state: &GameState) -> Vec<ResolvedRulesCommand> {
+    state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .filter_map(|entry| entry.command.clone())
+        .collect()
+}
+
+#[test]
+fn trigger_collection_command_variants_round_trip_inside_the_journal_envelope() {
+    for command in [
+        ResolvedRulesCommand::TriggerCollection(command(ResolvedTriggerCollection::DeferPending {
+            contexts: vec![pending_context(ObjectId(11))],
+        })),
+        ResolvedRulesCommand::TriggerCollection(command(
+            ResolvedTriggerCollection::ConsumeBeforePriority {
+                occurrences: vec![occurrence(PlayerId(1))],
+            },
+        )),
+    ] {
+        let wire = serde_json::to_value(&command).expect("command serializes");
+        assert_eq!(
+            serde_json::from_value::<ResolvedRulesCommand>(wire).expect("command deserializes"),
+            command
+        );
+    }
+}
+
+#[test]
+fn apply_preserves_the_exact_append_order_for_both_trigger_collections() {
+    let first = pending_context(ObjectId(12));
+    let second = pending_context(ObjectId(13));
+    let first_occurrence = occurrence(PlayerId(0));
+    let second_occurrence = occurrence(PlayerId(1));
+    let mut state = GameState::new_two_player(0x733);
+
+    apply_resolved_trigger_collection(
+        &mut state,
+        &command(ResolvedTriggerCollection::DeferPending {
+            contexts: vec![first.clone(), second.clone()],
+        }),
+    )
+    .expect("append-only pending contexts apply");
+    apply_resolved_trigger_collection(
+        &mut state,
+        &command(ResolvedTriggerCollection::ConsumeBeforePriority {
+            occurrences: vec![first_occurrence.clone(), second_occurrence.clone()],
+        }),
+    )
+    .expect("append-only consumed occurrences apply");
+
+    assert_eq!(state.deferred_triggers, vec![first, second]);
+    assert_eq!(
+        state.consumed_before_priority_trigger_events,
+        vec![first_occurrence, second_occurrence]
+    );
+}
+
+#[test]
+fn empty_trigger_collections_are_not_applied_or_journaled() {
+    let mut state = GameState::new_two_player(0x733);
+
+    resolve_and_apply_trigger_collection(
+        &mut state,
+        ResolvedTriggerCollection::DeferPending {
+            contexts: Vec::new(),
+        },
+    )
+    .expect("empty pending collection is a no-op");
+    resolve_and_apply_trigger_collection(
+        &mut state,
+        ResolvedTriggerCollection::ConsumeBeforePriority {
+            occurrences: Vec::new(),
+        },
+    )
+    .expect("empty consumed collection is a no-op");
+
+    assert!(state.deferred_triggers.is_empty());
+    assert!(state.consumed_before_priority_trigger_events.is_empty());
+    assert!(state.resolved_rules_journal.entries().is_empty());
+    assert!(state.resolved_rules_journal.nodes().is_empty());
+}
+
+#[test]
+fn resolved_trigger_collection_records_under_its_live_journal_cause() {
+    let mut state = GameState::new_two_player(0x733);
+    resolve_and_apply_trigger_collection(
+        &mut state,
+        ResolvedTriggerCollection::DeferPending {
+            contexts: vec![pending_context(ObjectId(14))],
+        },
+    )
+    .expect("a live cause records the trigger collection");
+
+    let entry = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .find_map(|entry| match &entry.command {
+            Some(ResolvedRulesCommand::TriggerCollection(command)) => Some((entry, command)),
+            _ => None,
+        })
+        .expect("non-empty collection has a journal command");
+    assert_eq!(entry.0.node, entry.1.cause);
+}
+
+#[test]
+fn real_change_zone_resolver_journals_its_collected_trigger_occurrences() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let observer = scenario
+        .add_creature_from_oracle(P0, "Death observer", 2, 2, DIES_OBSERVER)
+        .id();
+    let victim = scenario.add_creature(P1, "Victim", 2, 2).id();
+    let mut runner = scenario.build();
+
+    let ability = ResolvedAbility::new(
+        Effect::ChangeZone {
+            origin: None,
+            destination: Zone::Graveyard,
+            target: TargetFilter::Any,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: Vec::new(),
+            conditional_enter_with_counters: Vec::new(),
+            face_down_profile: None,
+            enters_modified_if: None,
+        },
+        vec![TargetRef::Object(victim)],
+        observer,
+        P0,
+    );
+    let mut events = Vec::new();
+    engine::game::effects::change_zone::resolve(runner.state_mut(), &ability, &mut events)
+        .expect("the production ChangeZone resolver moves its selected creature");
+    assert_eq!(runner.state().objects[&victim].zone, Zone::Graveyard);
+
+    let commands = recorded_commands(runner.state());
+    assert!(
+        commands.iter().any(|command| matches!(
+            command,
+            ResolvedRulesCommand::TriggerCollection(ResolvedTriggerCollectionCommand {
+                collection: ResolvedTriggerCollection::DeferPending { contexts },
+                ..
+            }) if contexts.iter().any(|context| context.pending.source_id == observer)
+        )),
+        "logical-zone segment collection must journal the observer context"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -94,6 +94,7 @@ mod cr733_resolved_commands_p0;
 mod cr733_resolved_commands_p1;
 mod cr733_resolved_commands_p2;
 mod cr733_resolved_frame_transition;
+mod cr733_resolved_trigger_collection;
 mod cr_annotations;
 mod craft_tithing_blade_transform;
 mod cross_line_instead_override_branch;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added journaling for resolved trigger collections, including deferred triggers and events consumed before priority.
  - Trigger-collection commands can now be serialized, replayed, and applied consistently.
  - Empty trigger collections are safely treated as no-ops.

- **Bug Fixes**
  - Zone-change trigger processing now records resolved trigger effects in the rules journal, improving replay accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->