### PR TITLE
fix(menu): render active deck art in WebKit

### DIFF
--- a/client/src/components/menu/home/HomeDashboard.tsx
+++ b/client/src/components/menu/home/HomeDashboard.tsx
@@ -191,18 +191,18 @@ function ActiveDeckCard() {
     <button
       type="button"
       onClick={() => navigate("/my-decks")}
-      className="group flex cursor-pointer flex-col overflow-hidden rounded-card border border-hairline surface-card text-left transition-colors hover:border-hairline-hover"
+      className="group flex appearance-none cursor-pointer flex-col overflow-hidden rounded-card border border-hairline surface-card text-left transition-colors hover:border-hairline-hover"
     >
       {/* Art header: representative card art with the section label and the
           color-identity mana pips overlaid on a scrim — the pips carry the same
           dark backing chip so they stay legible over any artwork. */}
-      <div className="relative h-24 overflow-hidden">
+      <div className="relative isolate h-24 overflow-hidden">
         {artSrc ? (
-          <img src={artSrc} alt="" className="absolute inset-0 h-full w-full object-cover" />
+          <img src={artSrc} alt="" className="absolute inset-0 z-0 h-full w-full object-cover" />
         ) : (
-          <div className="absolute inset-0 animate-pulse bg-gray-800" />
+          <div className="absolute inset-0 z-0 animate-pulse bg-gray-800" />
         )}
-        <div className="absolute inset-0 bg-gradient-to-t from-black/85 via-black/25 to-transparent" />
+        <div className="absolute inset-0 z-[1] bg-gradient-to-t from-black/85 via-black/25 to-transparent" />
         <div className={`${SECTION_LABEL} absolute left-3 top-2.5 z-10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]`}>
           {t("home.dashboard.activeDeck")}
         </div>


### PR DESCRIPTION
## Summary
- remove native button rendering from the active-deck card
- isolate the art header and use explicit artwork/scrim layers so WebKit paints it above the card shell

## Verification
- Verified the installed Tauri preview resolves and renders the same representative card in the deck tile.
- `git diff --check`
- The shared Tilt instance watches the root checkout, not this isolated worktree (`tilt-wait` correctly returned exit 3), so it cannot verify this branch.