### PR TITLE
chore: refresh metagame feeds

### DIFF
--- a/client/public/feeds/mtggoldfish-commander.json
+++ b/client/public/feeds/mtggoldfish-commander.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "commander",
   "version": 1,
-  "updated": "2026-07-22T00:00:00Z",
+  "updated": "2026-07-23T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/commander",
   "decks": [
     {
@@ -2416,14 +2416,6 @@
         },
         {
           "count": 1,
-          "name": "Stormcatch Mentor"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Electromancer"
-        },
-        {
-          "count": 1,
           "name": "Tidal Barracuda"
         },
         {
@@ -2464,10 +2456,6 @@
         },
         {
           "count": 1,
-          "name": "Karn's Temporal Sundering"
-        },
-        {
-          "count": 1,
           "name": "Nexus of Fate"
         },
         {
@@ -2489,10 +2477,6 @@
         {
           "count": 1,
           "name": "Thrill of Possibility"
-        },
-        {
-          "count": 1,
-          "name": "Wizards of Thay"
         },
         {
           "count": 1,
@@ -2645,6 +2629,22 @@
         {
           "count": 1,
           "name": "Emergence Zone"
+        },
+        {
+          "count": 1,
+          "name": "Mystical Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Vampiric Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Thassa's Oracle"
+        },
+        {
+          "count": 1,
+          "name": "Demonic Tutor"
         }
       ],
       "sideboard": []

--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "modern",
   "version": 1,
-  "updated": "2026-07-22T00:00:00Z",
+  "updated": "2026-07-23T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/modern",
   "decks": [
     {

--- a/client/public/feeds/mtggoldfish-pioneer.json
+++ b/client/public/feeds/mtggoldfish-pioneer.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "pioneer",
   "version": 1,
-  "updated": "2026-07-22T00:00:00Z",
+  "updated": "2026-07-23T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/pioneer",
   "decks": [
     {

--- a/client/public/feeds/mtggoldfish-standard.json
+++ b/client/public/feeds/mtggoldfish-standard.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "standard",
   "version": 1,
-  "updated": "2026-07-22T00:00:00Z",
+  "updated": "2026-07-23T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/standard",
   "decks": [
     {


### PR DESCRIPTION
Automated daily metagame feed refresh from MTGGoldfish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Updated available deck feed timestamps to July 23, 2026.
  * Refreshed the Fire Lord Azula Commander deck list with several card changes, including new tutor and combo cards.
  * Modern, Pioneer, and Standard deck data remains otherwise unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->