### PR TITLE
fix(ui): surface roll outcomes and turn order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -918,26 +918,47 @@ jobs:
             | { grep -v "^- chore: update coverage" || true; } \
             >> changelog.md
 
+      - name: Build release asset list
+        id: release-assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHELL_UPDATER_BRIDGE_AVAILABLE: ${{ steps.shell-updater-bridge.outputs.available }}
+        run: |
+          set -euo pipefail
+
+          # Immutable releases cannot accept a late asset upload. Include the
+          # optional bridge in the initial create/publish request, but skip it
+          # for recovery runs targeting a release that is already published.
+          release_draft=$(gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft' 2>/dev/null || echo missing)
+          include_bridge=false
+          if [ "$SHELL_UPDATER_BRIDGE_AVAILABLE" = true ] && [ "$release_draft" != false ]; then
+            include_bridge=true
+          elif [ "$SHELL_UPDATER_BRIDGE_AVAILABLE" = true ]; then
+            echo "Release $RELEASE_TAG is already published; skipping optional shell updater migration bridge."
+          fi
+
+          {
+            echo "files<<EOF"
+            cat <<'EOF'
+          artifacts/phase-server-slim-x86_64-unknown-linux-musl/phase-server-slim-x86_64-unknown-linux-musl
+          artifacts/phase-server-slim-x86_64-unknown-linux-musl/phase-server-slim-x86_64-unknown-linux-musl.minisig
+          artifacts/phase-server-slim-aarch64-apple-darwin/phase-server-slim-aarch64-apple-darwin
+          artifacts/phase-server-slim-aarch64-apple-darwin/phase-server-slim-aarch64-apple-darwin.minisig
+          artifacts/phase-server-slim-x86_64-pc-windows-msvc/phase-server-slim-x86_64-pc-windows-msvc.exe
+          artifacts/phase-server-slim-x86_64-pc-windows-msvc/phase-server-slim-x86_64-pc-windows-msvc.exe.minisig
+          release-server-${{ needs.resolve-release-ref.outputs.release_tag }}.json
+          release-server-${{ needs.resolve-release-ref.outputs.release_tag }}.json.minisig
+          EOF
+            if [ "$include_bridge" = true ]; then
+              echo "artifacts/update.json"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           body_path: changelog.md
           fail_on_unmatched_files: true
-          files: |
-            artifacts/phase-server-slim-x86_64-unknown-linux-musl/phase-server-slim-x86_64-unknown-linux-musl
-            artifacts/phase-server-slim-x86_64-unknown-linux-musl/phase-server-slim-x86_64-unknown-linux-musl.minisig
-            artifacts/phase-server-slim-aarch64-apple-darwin/phase-server-slim-aarch64-apple-darwin
-            artifacts/phase-server-slim-aarch64-apple-darwin/phase-server-slim-aarch64-apple-darwin.minisig
-            artifacts/phase-server-slim-x86_64-pc-windows-msvc/phase-server-slim-x86_64-pc-windows-msvc.exe
-            artifacts/phase-server-slim-x86_64-pc-windows-msvc/phase-server-slim-x86_64-pc-windows-msvc.exe.minisig
-            release-server-${{ needs.resolve-release-ref.outputs.release_tag }}.json
-            release-server-${{ needs.resolve-release-ref.outputs.release_tag }}.json.minisig
-
-      - name: Attach shell updater migration bridge
-        if: steps.shell-updater-bridge.outputs.available == 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.RELEASE_TAG }}
-          fail_on_unmatched_files: true
-          files: artifacts/update.json
+          files: ${{ steps.release-assets.outputs.files }}

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -2616,7 +2616,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phase-tauri"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "futures-util",
  "minisign-verify",

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2668,6 +2668,9 @@ export interface TurnOrderSlotView {
   player: PlayerId;
   slot_index: number;
   turns_from_now: number;
+  turn_number: number;
+  is_viewer?: boolean;
+  is_starting_player?: boolean;
 }
 
 /**
@@ -2749,6 +2752,8 @@ export interface DerivedViews {
    * intentional when extra turns put the same player in multiple slots.
    */
   turn_order?: TurnOrderSlotView[];
+  /** One-based projected turn position for the current viewer. */
+  viewer_turn_number?: number;
   /**
    * CR 732.2a: `∞` HUD rows — one per (engine-attributed player, pumped axis)
    * of every unbounded-resource loop. Empty/omitted when no loop is active. The

--- a/client/src/components/animation/DiceRollOverlay.tsx
+++ b/client/src/components/animation/DiceRollOverlay.tsx
@@ -18,6 +18,11 @@ const DIE_SIZE = 132;
 // Accent RGB triples (sans `rgb(...)`) so they compose into rgba()/gradients.
 const GOLD = "251,191,36"; // amber-400 — the winner / emphasis accent
 const NEUTRAL = "148,163,184"; // slate-400 — a non-decisive die
+const COIN_WON = "52,211,153"; // emerald-400 — the flipper won
+const COIN_LOST = "251,113,133"; // rose-400 — the flipper lost
+
+let nextRollKey = 1;
+const rollKeys = new WeakMap<DiceRollPayload, string>();
 
 /** Cached WebGL-availability probe. The dice overlay is the first component in
  *  the app that needs WebGL, so it must degrade gracefully where it's absent. */
@@ -51,11 +56,6 @@ export function DiceRollOverlay() {
   const skipDiceRoll = useUiStore((s) => s.skipDiceRoll);
   const shouldReduceMotion = useReducedMotion();
   const { t } = useTranslation();
-
-  // Clear any active/queued roll and its advance timer when leaving the game.
-  // The store is a module singleton that outlives this mount, so without this an
-  // in-flight roll could pop into the next game.
-  useEffect(() => () => useUiStore.getState().resetDiceRoll(), []);
 
   // Tap-to-skip via keyboard: Escape dismisses the current roll (advancing to
   // the next queued one, or clearing the overlay). Bound only while a roll is
@@ -135,9 +135,11 @@ export function DiceRollOverlay() {
 /** Stable identity for a payload so the FIFO advancing from one roll to the next
  *  remounts `DiceRollContent` instead of reconciling stale settle state. */
 function diceRollKey(payload: DiceRollPayload): string {
-  return payload.kind === "coin"
-    ? `coin-${payload.context}-${payload.playerId}-${payload.won}`
-    : `die-${payload.context}-${payload.rolls.map((r) => `${r.playerId}:${r.value}`).join(",")}`;
+  const existing = rollKeys.get(payload);
+  if (existing) return existing;
+  const key = String(nextRollKey++);
+  rollKeys.set(payload, key);
+  return key;
 }
 
 function DiceRollContent({ payload, animate }: { payload: DiceRollPayload; animate: boolean }) {
@@ -151,12 +153,16 @@ function DiceRollContent({ payload, animate }: { payload: DiceRollPayload; anima
     // No engine-named face: `won` (relative to the flipping player) maps to a
     // heads/tails depiction. We show "heads" on a win — a pure display choice.
     const face = payload.won ? "heads" : "tails";
+    const accent = payload.won ? COIN_WON : COIN_LOST;
+    const outcome = payload.won
+      ? t("diceRoll.wonCoinFlip", { name: playerLabel(payload.playerId) })
+      : t("diceRoll.lostCoinFlip", { name: playerLabel(payload.playerId) });
     return (
-      <div className="relative flex flex-col items-center gap-6 select-none">
-        <span className="text-2xl font-bold tracking-wider uppercase text-slate-200">
-          {playerLabel(payload.playerId)}
+      <div className="relative flex flex-col items-center gap-4 select-none">
+        <span className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">
+          {t("diceRoll.coinFlip")}
         </span>
-        <DieFace animate={animate} accent={NEUTRAL}>
+        <DieFace animate={animate} accent={accent} emphasize>
           {(handleSettle) =>
             animate ? (
               <Suspense fallback={<DiePlaceholder label="" />}>
@@ -173,6 +179,25 @@ function DiceRollContent({ payload, animate }: { payload: DiceRollPayload; anima
             )
           }
         </DieFace>
+        <motion.span
+          className="rounded-full border px-5 py-2 text-2xl font-extrabold uppercase tracking-wide"
+          initial={{ opacity: 0, scale: 0.82, y: 8 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          transition={{
+            delay: animate ? 1.35 / Math.max(speedMultiplier, 0.01) : 0,
+            type: "spring",
+            stiffness: 260,
+            damping: 20,
+          }}
+          style={{
+            color: `rgb(${accent})`,
+            borderColor: `rgba(${accent},0.7)`,
+            backgroundColor: `rgba(${accent},0.14)`,
+            boxShadow: `0 0 28px rgba(${accent},0.32)`,
+          }}
+        >
+          {outcome}
+        </motion.span>
       </div>
     );
   }
@@ -244,6 +269,11 @@ function ContestDice({
       ? winnerIsYou
         ? t("diceRoll.youPlayFirst")
         : t("diceRoll.playerPlaysFirst", { name: getOpponentDisplayName(winner) })
+      : null;
+  const yourTurn = payload.turnOrder?.find((slot) => slot.player === getPlayerId());
+  const yourTurnCaption =
+    yourTurn && yourTurn.turns_from_now > 0
+      ? t("diceRoll.youTakeTurn", { turn: yourTurn.turns_from_now + 1 })
       : null;
 
   return (
@@ -327,6 +357,47 @@ function ContestDice({
           )}
         </AnimatePresence>
       </div>
+      {revealed && payload.turnOrder && payload.turnOrder.length > 0 && (
+        <motion.div
+          className="flex flex-col items-center gap-2"
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.25, duration: 0.35 }}
+        >
+          <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+            {t("diceRoll.turnOrder")}
+          </span>
+          <div className="flex flex-wrap justify-center gap-2">
+            {payload.turnOrder.map((slot) => {
+              const isYou = slot.player === getPlayerId();
+              const isStartingPlayer = slot.player === winner && slot.turns_from_now === 0;
+              return (
+                <span
+                  key={slot.slot_index}
+                  className="rounded-full border px-3 py-1 text-sm font-bold"
+                  style={{
+                    color: isYou ? `rgb(${GOLD})` : "#cbd5e1",
+                    borderColor:
+                      isYou || isStartingPlayer
+                        ? `rgba(${GOLD},0.62)`
+                        : "rgba(148,163,184,0.32)",
+                    backgroundColor:
+                      isYou || isStartingPlayer ? `rgba(${GOLD},0.12)` : "rgba(15,23,42,0.7)",
+                  }}
+                >
+                  {t("diceRoll.turnOrderItem", {
+                    turn: slot.turns_from_now + 1,
+                    name: playerLabel(slot.player),
+                  })}
+                </span>
+              );
+            })}
+          </div>
+          {yourTurnCaption && (
+            <span className="text-lg font-extrabold text-amber-300">{yourTurnCaption}</span>
+          )}
+        </motion.div>
+      )}
     </div>
   );
 }

--- a/client/src/components/animation/DiceRollOverlay.tsx
+++ b/client/src/components/animation/DiceRollOverlay.tsx
@@ -270,10 +270,9 @@ function ContestDice({
         ? t("diceRoll.youPlayFirst")
         : t("diceRoll.playerPlaysFirst", { name: getOpponentDisplayName(winner) })
       : null;
-  const yourTurn = payload.turnOrder?.find((slot) => slot.player === getPlayerId());
   const yourTurnCaption =
-    yourTurn && yourTurn.turns_from_now > 0
-      ? t("diceRoll.youTakeTurn", { turn: yourTurn.turns_from_now + 1 })
+    payload.viewerTurnNumber && payload.viewerTurnNumber > 1
+      ? t("diceRoll.youTakeTurn", { turn: payload.viewerTurnNumber })
       : null;
 
   return (
@@ -369,24 +368,24 @@ function ContestDice({
           </span>
           <div className="flex flex-wrap justify-center gap-2">
             {payload.turnOrder.map((slot) => {
-              const isYou = slot.player === getPlayerId();
-              const isStartingPlayer = slot.player === winner && slot.turns_from_now === 0;
               return (
                 <span
                   key={slot.slot_index}
                   className="rounded-full border px-3 py-1 text-sm font-bold"
                   style={{
-                    color: isYou ? `rgb(${GOLD})` : "#cbd5e1",
+                    color: slot.is_viewer ? `rgb(${GOLD})` : "#cbd5e1",
                     borderColor:
-                      isYou || isStartingPlayer
+                      slot.is_viewer || slot.is_starting_player
                         ? `rgba(${GOLD},0.62)`
                         : "rgba(148,163,184,0.32)",
                     backgroundColor:
-                      isYou || isStartingPlayer ? `rgba(${GOLD},0.12)` : "rgba(15,23,42,0.7)",
+                      slot.is_viewer || slot.is_starting_player
+                        ? `rgba(${GOLD},0.12)`
+                        : "rgba(15,23,42,0.7)",
                   }}
                 >
                   {t("diceRoll.turnOrderItem", {
-                    turn: slot.turns_from_now + 1,
+                    turn: slot.turn_number,
                     name: playerLabel(slot.player),
                   })}
                 </span>

--- a/client/src/components/board/__tests__/OpponentSeatHeader.test.tsx
+++ b/client/src/components/board/__tests__/OpponentSeatHeader.test.tsx
@@ -111,7 +111,7 @@ describe("OpponentSeatHeader", () => {
       gameState: {
         ...createGameState(waitingFor),
         derived: {
-          turn_order: [{ player: 1, slot_index: 1, turns_from_now: 1 }],
+          turn_order: [{ player: 1, slot_index: 1, turns_from_now: 1, turn_number: 2 }],
         },
       },
       waitingFor,

--- a/client/src/components/hud/__tests__/NextUpBadge.test.tsx
+++ b/client/src/components/hud/__tests__/NextUpBadge.test.tsx
@@ -23,9 +23,9 @@ describe("NextUpBadge", () => {
       gameState: buildGameState({
         derived: {
           turn_order: [
-            { player: 0, slot_index: 0, turns_from_now: 0 },
-            { player: 2, slot_index: 1, turns_from_now: 1 },
-            { player: 0, slot_index: 2, turns_from_now: 2 },
+            { player: 0, slot_index: 0, turns_from_now: 0, turn_number: 1 },
+            { player: 2, slot_index: 1, turns_from_now: 1, turn_number: 2 },
+            { player: 0, slot_index: 2, turns_from_now: 2, turn_number: 3 },
           ],
         },
       }),
@@ -40,8 +40,8 @@ describe("NextUpBadge", () => {
       gameState: buildGameState({
         derived: {
           turn_order: [
-            { player: 0, slot_index: 0, turns_from_now: 0 },
-            { player: 2, slot_index: 1, turns_from_now: 1 },
+            { player: 0, slot_index: 0, turns_from_now: 0, turn_number: 1 },
+            { player: 2, slot_index: 1, turns_from_now: 1, turn_number: 2 },
           ],
         },
       }),

--- a/client/src/components/hud/__tests__/OpponentHud.test.tsx
+++ b/client/src/components/hud/__tests__/OpponentHud.test.tsx
@@ -68,7 +68,7 @@ describe("OpponentHud", () => {
     useGameStore.setState({
       gameState: createGameState({
         derived: {
-          turn_order: [{ player: 2, slot_index: 1, turns_from_now: 1 }],
+          turn_order: [{ player: 2, slot_index: 1, turns_from_now: 1, turn_number: 2 }],
         },
       }),
     });
@@ -84,9 +84,9 @@ describe("OpponentHud", () => {
         seat_order: [0, 3, 1, 2],
         derived: {
           turn_order: [
-            { player: 2, slot_index: 1, turns_from_now: 1 },
-            { player: 3, slot_index: 2, turns_from_now: 2 },
-            { player: 1, slot_index: 3, turns_from_now: 3 },
+            { player: 2, slot_index: 1, turns_from_now: 1, turn_number: 2 },
+            { player: 3, slot_index: 2, turns_from_now: 2, turn_number: 3 },
+            { player: 1, slot_index: 3, turns_from_now: 3, turn_number: 4 },
           ],
         },
       }),

--- a/client/src/components/hud/__tests__/PlayerHud.test.tsx
+++ b/client/src/components/hud/__tests__/PlayerHud.test.tsx
@@ -49,8 +49,8 @@ describe("PlayerHud", () => {
         gameState: buildGameState({
           derived: {
             turn_order: [
-              { player: 0, slot_index: 1, turns_from_now: 1 },
-              { player: 0, slot_index: 2, turns_from_now: 2 },
+              { player: 0, slot_index: 1, turns_from_now: 1, turn_number: 2 },
+              { player: 0, slot_index: 2, turns_from_now: 2, turn_number: 3 },
             ],
           },
         }),

--- a/client/src/game/__tests__/diceContest.test.ts
+++ b/client/src/game/__tests__/diceContest.test.ts
@@ -35,12 +35,17 @@ afterEach(() => {
 describe("flashStartingPlayerContest", () => {
   it("builds a startingPlayer die payload from the engine contest event", () => {
     const turnOrder = [
-      { player: 0, slot_index: 0, turns_from_now: 0 },
-      { player: 1, slot_index: 1, turns_from_now: 1 },
-      { player: 2, slot_index: 2, turns_from_now: 2 },
-      { player: 3, slot_index: 3, turns_from_now: 3 },
+      { player: 0, slot_index: 0, turns_from_now: 0, turn_number: 1, is_starting_player: true },
+      { player: 1, slot_index: 1, turns_from_now: 1, turn_number: 2 },
+      { player: 2, slot_index: 2, turns_from_now: 2, turn_number: 3, is_viewer: true },
+      { player: 3, slot_index: 3, turns_from_now: 3, turn_number: 4 },
     ];
-    flashStartingPlayerContest([contest([[[0, 17], [1, 9]]], 0), gameStarted], 0, turnOrder);
+    flashStartingPlayerContest(
+      [contest([[[0, 17], [1, 9]]], 0), gameStarted],
+      0,
+      turnOrder,
+      3,
+    );
     const d = useUiStore.getState().diceRoll;
     expect(d).toMatchObject({ kind: "die", sides: 20, context: "startingPlayer", winner: 0 });
     expect(d?.kind === "die" && d.rounds).toEqual([
@@ -55,6 +60,7 @@ describe("flashStartingPlayerContest", () => {
       { playerId: 1, value: 9 },
     ]);
     expect(d?.kind === "die" && d.turnOrder).toEqual(turnOrder);
+    expect(d?.kind === "die" && d.viewerTurnNumber).toBe(3);
   });
 
   it("preserves the per-round structure across a tie reroll", () => {

--- a/client/src/game/__tests__/diceContest.test.ts
+++ b/client/src/game/__tests__/diceContest.test.ts
@@ -34,7 +34,13 @@ afterEach(() => {
 
 describe("flashStartingPlayerContest", () => {
   it("builds a startingPlayer die payload from the engine contest event", () => {
-    flashStartingPlayerContest([contest([[[0, 17], [1, 9]]], 0), gameStarted], 0);
+    const turnOrder = [
+      { player: 0, slot_index: 0, turns_from_now: 0 },
+      { player: 1, slot_index: 1, turns_from_now: 1 },
+      { player: 2, slot_index: 2, turns_from_now: 2 },
+      { player: 3, slot_index: 3, turns_from_now: 3 },
+    ];
+    flashStartingPlayerContest([contest([[[0, 17], [1, 9]]], 0), gameStarted], 0, turnOrder);
     const d = useUiStore.getState().diceRoll;
     expect(d).toMatchObject({ kind: "die", sides: 20, context: "startingPlayer", winner: 0 });
     expect(d?.kind === "die" && d.rounds).toEqual([
@@ -48,6 +54,7 @@ describe("flashStartingPlayerContest", () => {
       { playerId: 0, value: 17 },
       { playerId: 1, value: 9 },
     ]);
+    expect(d?.kind === "die" && d.turnOrder).toEqual(turnOrder);
   });
 
   it("preserves the per-round structure across a tie reroll", () => {
@@ -72,6 +79,7 @@ describe("flashStartingPlayerContest", () => {
         gameStarted,
       ],
       0,
+      undefined,
     );
     const d = useUiStore.getState().diceRoll;
     expect(d?.kind === "die" && d.rounds).toEqual([
@@ -93,18 +101,18 @@ describe("flashStartingPlayerContest", () => {
   it("uses the engine winner, never recomputed from the rolls (lowest-seat fallback)", () => {
     // The engine's all-tied-at-cap fallback picks the lowest seat; the winner is
     // passed in, not derived from the shown dice.
-    flashStartingPlayerContest([contest([[[0, 7], [1, 7]]], 0), gameStarted], 0);
+    flashStartingPlayerContest([contest([[[0, 7], [1, 7]]], 0), gameStarted], 0, undefined);
     expect(useUiStore.getState().diceRoll).toMatchObject({ winner: 0 });
   });
 
   it("no-ops when the starter was chosen explicitly (no contest event)", () => {
-    flashStartingPlayerContest([gameStarted], 1);
+    flashStartingPlayerContest([gameStarted], 1, undefined);
     expect(useUiStore.getState().diceRoll).toBeNull();
   });
 
   it("skips the overlay entirely at instant animation speed (0)", () => {
     usePreferencesStore.setState({ animationSpeedMultiplier: 0 });
-    flashStartingPlayerContest([contest([[[0, 5], [1, 3]]], 0), gameStarted], 0);
+    flashStartingPlayerContest([contest([[[0, 5], [1, 3]]], 0), gameStarted], 0, undefined);
     expect(useUiStore.getState().diceRoll).toBeNull();
   });
 });
@@ -125,6 +133,13 @@ describe("flashInGameRolls", () => {
       won: true,
       context: "ability",
     });
+  });
+
+  it("queues every coin flip in an event batch", () => {
+    flashInGameRolls([coin(1, true), coin(1, false)]);
+    const state = useUiStore.getState();
+    expect(state.diceRoll).toMatchObject({ kind: "coin", playerId: 1, won: true });
+    expect(state.diceRollQueue).toMatchObject([{ kind: "coin", playerId: 1, won: false }]);
   });
 
   it("no-ops on a batch containing neither dice nor coins", () => {

--- a/client/src/game/__tests__/sessionCleanup.test.ts
+++ b/client/src/game/__tests__/sessionCleanup.test.ts
@@ -96,4 +96,16 @@ describe("clearPromptOverlayState", () => {
 
     expect(useUiStore.getState().mobileHandGesture).toBeNull();
   });
+
+  it("clears active and queued roll overlays at a game boundary", () => {
+    useUiStore.setState({
+      diceRoll: { kind: "coin", playerId: 1, won: true, context: "ability" },
+      diceRollQueue: [{ kind: "coin", playerId: 1, won: false, context: "ability" }],
+    });
+
+    clearPromptOverlayState();
+
+    expect(useUiStore.getState().diceRoll).toBeNull();
+    expect(useUiStore.getState().diceRollQueue).toEqual([]);
+  });
 });

--- a/client/src/game/diceContest.ts
+++ b/client/src/game/diceContest.ts
@@ -22,6 +22,7 @@ export function flashStartingPlayerContest(
   events: GameEvent[],
   startingPlayer: PlayerId,
   turnOrder: TurnOrderSlotView[] | undefined,
+  viewerTurnNumber?: number,
 ): void {
   const contest = events.find(
     (e): e is StartingPlayerContestEvent => e.type === "StartingPlayerContest",
@@ -40,6 +41,7 @@ export function flashStartingPlayerContest(
     context: "startingPlayer",
     winner: startingPlayer,
     turnOrder,
+    viewerTurnNumber,
   });
 }
 

--- a/client/src/game/diceContest.ts
+++ b/client/src/game/diceContest.ts
@@ -1,4 +1,4 @@
-import type { GameEvent, PlayerId } from "../adapter/types";
+import type { GameEvent, PlayerId, TurnOrderSlotView } from "../adapter/types";
 import { useUiStore } from "../stores/uiStore";
 
 type DieRolledEvent = Extract<GameEvent, { type: "DieRolled" }>;
@@ -18,7 +18,11 @@ type StartingPlayerContestEvent = Extract<GameEvent, { type: "StartingPlayerCont
  * equals the event's `winner` by construction. No-ops when no contest ran
  * (explicit play/draw choice).
  */
-export function flashStartingPlayerContest(events: GameEvent[], startingPlayer: PlayerId): void {
+export function flashStartingPlayerContest(
+  events: GameEvent[],
+  startingPlayer: PlayerId,
+  turnOrder: TurnOrderSlotView[] | undefined,
+): void {
   const contest = events.find(
     (e): e is StartingPlayerContestEvent => e.type === "StartingPlayerContest",
   );
@@ -35,18 +39,19 @@ export function flashStartingPlayerContest(events: GameEvent[], startingPlayer: 
     rounds,
     context: "startingPlayer",
     winner: startingPlayer,
+    turnOrder,
   });
 }
 
 /**
  * Fire the in-game roll overlay for an action's event batch. Groups all
- * `DieRolled` into one die overlay (e.g. a Krark's Thumb double) and otherwise
- * shows the first `CoinFlipped`. Always `context: "ability"`. No-ops when the
+ * `DieRolled` into one die overlay (e.g. a Krark's Thumb double) and queues
+ * every `CoinFlipped` after it. Always `context: "ability"`. No-ops when the
  * batch contains neither.
  */
 export function flashInGameRolls(events: GameEvent[]): void {
   const dice = events.filter((e): e is DieRolledEvent => e.type === "DieRolled");
-  const coin = events.find((e): e is CoinFlippedEvent => e.type === "CoinFlipped");
+  const coins = events.filter((e): e is CoinFlippedEvent => e.type === "CoinFlipped");
   const flash = useUiStore.getState().flashDiceRoll;
   // All dice in the batch group into one overlay (e.g. a Krark's Thumb double);
   // a co-occurring coin queues behind them and plays after (the overlay FIFO
@@ -64,7 +69,7 @@ export function flashInGameRolls(events: GameEvent[]): void {
       context: "ability",
     });
   }
-  if (coin) {
+  for (const coin of coins) {
     flash({ kind: "coin", playerId: coin.data.player_id, won: coin.data.won, context: "ability" });
   }
 }

--- a/client/src/game/sessionCleanup.ts
+++ b/client/src/game/sessionCleanup.ts
@@ -2,10 +2,10 @@ import { useGameStore } from "../stores/gameStore.ts";
 import { useUiStore } from "../stores/uiStore.ts";
 
 /**
- * Drop engine prompt + UI-dialog overlay state without disposing the WASM
- * adapter. Used on game-session boundaries (concede, provider unmount/remount)
- * so deferred store resets or async `initGame` cannot leave `ManaPayment` /
- * `pendingAbilityChoice` bleed into the next session (issue #2369).
+ * Drop engine prompt + UI overlay state without disposing the WASM adapter.
+ * Used on game-session boundaries (concede, provider unmount/remount) so
+ * deferred store resets or async `initGame` cannot leave `ManaPayment`,
+ * `pendingAbilityChoice`, or a roll animation bleeding into the next session.
  *
  * Documented exemption from the `commitEngineSnapshot` single-writer invariant:
  * this is a session-boundary CLEAR, not a live-game commit. It writes the prompt
@@ -29,6 +29,7 @@ export function clearPromptOverlayState(): void {
   useUiStore.getState().setEnchantmentsDialogPlayer(null);
   useUiStore.getState().setAttachmentFanHost(null);
   useUiStore.getState().setMobileHandGesture(null);
+  useUiStore.getState().resetDiceRoll();
   // The per-game "Manual mana" toggle must never leak into the next game.
   useUiStore.getState().setManualManaOverride(false);
   // The ephemeral hand hide-filter is a per-game focus aid — reset it too.

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -257,7 +257,13 @@
     "youPlayFirst": "Du beginnst",
     "playerPlaysFirst": "{{name}} beginnt",
     "heads": "Kopf",
-    "tails": "Zahl"
+    "tails": "Zahl",
+    "coinFlip": "Münzwurf",
+    "wonCoinFlip": "{{name}} hat den Münzwurf gewonnen",
+    "lostCoinFlip": "{{name}} hat den Münzwurf verloren",
+    "turnOrder": "Zugreihenfolge",
+    "turnOrderItem": "Zug {{turn}}: {{name}}",
+    "youTakeTurn": "Du bist in Zug {{turn}} dran"
   },
   "chrome": {
     "back": "Zurück",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -257,7 +257,13 @@
     "youPlayFirst": "You play first",
     "playerPlaysFirst": "{{name}} plays first",
     "heads": "Heads",
-    "tails": "Tails"
+    "tails": "Tails",
+    "coinFlip": "Coin flip",
+    "wonCoinFlip": "{{name}} won the flip",
+    "lostCoinFlip": "{{name}} lost the flip",
+    "turnOrder": "Turn order",
+    "turnOrderItem": "Turn {{turn}}: {{name}}",
+    "youTakeTurn": "You take turn {{turn}}"
   },
   "chrome": {
     "back": "Back",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -257,7 +257,13 @@
     "youPlayFirst": "Juegas primero",
     "playerPlaysFirst": "{{name}} juega primero",
     "heads": "Cara",
-    "tails": "Cruz"
+    "tails": "Cruz",
+    "coinFlip": "Lanzamiento de moneda",
+    "wonCoinFlip": "{{name}} ganó el lanzamiento",
+    "lostCoinFlip": "{{name}} perdió el lanzamiento",
+    "turnOrder": "Orden de turnos",
+    "turnOrderItem": "Turno {{turn}}: {{name}}",
+    "youTakeTurn": "Juegas el turno {{turn}}"
   },
   "chrome": {
     "back": "Atrás",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -257,7 +257,13 @@
     "youPlayFirst": "Vous jouez en premier",
     "playerPlaysFirst": "{{name}} joue en premier",
     "heads": "Face",
-    "tails": "Pile"
+    "tails": "Pile",
+    "coinFlip": "Pile ou face",
+    "wonCoinFlip": "{{name}} a gagné le pile ou face",
+    "lostCoinFlip": "{{name}} a perdu le pile ou face",
+    "turnOrder": "Ordre des tours",
+    "turnOrderItem": "Tour {{turn}} : {{name}}",
+    "youTakeTurn": "Vous jouez au tour {{turn}}"
   },
   "chrome": {
     "back": "Retour",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -257,7 +257,13 @@
     "youPlayFirst": "Giochi per primo",
     "playerPlaysFirst": "{{name}} gioca per primo",
     "heads": "Testa",
-    "tails": "Croce"
+    "tails": "Croce",
+    "coinFlip": "Lancio della moneta",
+    "wonCoinFlip": "{{name}} ha vinto il lancio",
+    "lostCoinFlip": "{{name}} ha perso il lancio",
+    "turnOrder": "Ordine dei turni",
+    "turnOrderItem": "Turno {{turn}}: {{name}}",
+    "youTakeTurn": "Giochi il turno {{turn}}"
   },
   "chrome": {
     "back": "Indietro",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -257,7 +257,13 @@
     "youPlayFirst": "Zaczynasz",
     "playerPlaysFirst": "{{name}} zaczyna",
     "heads": "Orzeł",
-    "tails": "Reszka"
+    "tails": "Reszka",
+    "coinFlip": "Rzut monetą",
+    "wonCoinFlip": "{{name}} wygrywa rzut monetą",
+    "lostCoinFlip": "{{name}} przegrywa rzut monetą",
+    "turnOrder": "Kolejność tur",
+    "turnOrderItem": "Tura {{turn}}: {{name}}",
+    "youTakeTurn": "Rozgrywasz turę {{turn}}"
   },
   "chrome": {
     "back": "Wstecz",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -257,7 +257,13 @@
     "youPlayFirst": "Você joga primeiro",
     "playerPlaysFirst": "{{name}} joga primeiro",
     "heads": "Cara",
-    "tails": "Coroa"
+    "tails": "Coroa",
+    "coinFlip": "Cara ou coroa",
+    "wonCoinFlip": "{{name}} venceu o lançamento",
+    "lostCoinFlip": "{{name}} perdeu o lançamento",
+    "turnOrder": "Ordem dos turnos",
+    "turnOrderItem": "Turno {{turn}}: {{name}}",
+    "youTakeTurn": "Você joga no turno {{turn}}"
   },
   "chrome": {
     "back": "Voltar",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -845,6 +845,9 @@ function GamePageContent({
   // double-invoke and after the clear (the re-run sees `null`).
   const startingContest = useGameStore((s) => s.startingContest);
   const openingTurnOrder = useGameStore((s) => s.gameState?.derived?.turn_order);
+  const openingViewerTurnNumber = useGameStore(
+    (s) => s.gameState?.derived?.viewer_turn_number,
+  );
   const consumedContestRef = useRef<typeof startingContest>(null);
   useEffect(() => {
     if (!startingContest || consumedContestRef.current === startingContest) return;
@@ -853,9 +856,10 @@ function GamePageContent({
       startingContest.events,
       startingContest.startingPlayer,
       openingTurnOrder,
+      openingViewerTurnNumber,
     );
     useGameStore.getState().clearStartingContest();
-  }, [openingTurnOrder, startingContest]);
+  }, [openingTurnOrder, openingViewerTurnNumber, startingContest]);
   // CR 103.1 before CR 103.5: the starting-player contest must finish before the
   // mulligan UI appears (the roll determines who's on the play, which precedes
   // drawing opening hands). True from `initGame` setting the carrier through the

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -844,13 +844,18 @@ function GamePageContent({
   // identity-ref latch makes the consume idempotent under React StrictMode's
   // double-invoke and after the clear (the re-run sees `null`).
   const startingContest = useGameStore((s) => s.startingContest);
+  const openingTurnOrder = useGameStore((s) => s.gameState?.derived?.turn_order);
   const consumedContestRef = useRef<typeof startingContest>(null);
   useEffect(() => {
     if (!startingContest || consumedContestRef.current === startingContest) return;
     consumedContestRef.current = startingContest;
-    flashStartingPlayerContest(startingContest.events, startingContest.startingPlayer);
+    flashStartingPlayerContest(
+      startingContest.events,
+      startingContest.startingPlayer,
+      openingTurnOrder,
+    );
     useGameStore.getState().clearStartingContest();
-  }, [startingContest]);
+  }, [openingTurnOrder, startingContest]);
   // CR 103.1 before CR 103.5: the starting-player contest must finish before the
   // mulligan UI appears (the roll determines who's on the play, which precedes
   // drawing opening hands). True from `initGame` setting the carrier through the

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -1036,6 +1036,7 @@ export function GameProvider({
         // sessions, clears timers, and disposes the WASM engine.
         if (p2pAdapter) p2pAdapter.dispose();
         audioManager.setContext("menu");
+        clearPromptOverlayState();
         reset();
       };
     }
@@ -1246,6 +1247,7 @@ export function GameProvider({
         useMultiplayerStore.getState().setIsSpectator(false);
         useMultiplayerStore.getState().setSpectators([]);
         audioManager.setContext("menu");
+        clearPromptOverlayState();
         reset();
       };
     }

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -722,6 +722,7 @@ export function GameProvider({
       audioManager.setContext("battlefield");
       return () => {
         audioManager.setContext("menu");
+        clearPromptOverlayState();
       };
     }
 

--- a/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
+++ b/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
@@ -279,6 +279,7 @@ vi.mock("../../services/serverDetection", () => ({
 
 import { GameProvider } from "../GameProvider";
 import { AdapterError, AdapterErrorCode } from "../../adapter/types";
+import { clearPromptOverlayState } from "../../game/sessionCleanup";
 
 describe("GameProvider native AI routing", () => {
   beforeEach(() => {
@@ -485,6 +486,23 @@ describe("GameProvider native AI routing", () => {
 
   it("disposes a native game and surfaces bridge errors as terminal", async () => {
     await expectNativeTerminalEvent({ type: "error", message: "WebSocket connection failed" });
+  });
+
+  it("clears prompt overlays when a draft match unmounts", () => {
+    gameStoreState.gameId = "draft-match";
+    gameStoreState.adapter = {} as never;
+    gameStoreState.gameState = {} as never;
+
+    const view = render(
+      <GameProvider gameId="draft-match" mode="draft-match">
+        <div />
+      </GameProvider>,
+    );
+
+    vi.mocked(clearPromptOverlayState).mockClear();
+    view.unmount();
+
+    expect(clearPromptOverlayState).toHaveBeenCalledOnce();
   });
 });
 

--- a/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
+++ b/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
@@ -18,6 +18,7 @@ const {
   getSharedAdapter,
   nativeAdapterInitialize,
   nativeAdapters,
+  multiplayerDraftGetState,
   multiplayerGetState,
   multiplayerState,
   preferences,
@@ -123,6 +124,7 @@ const {
     showToast: vi.fn(),
   };
   const multiplayerGetState = vi.fn(() => multiplayerState);
+  const multiplayerDraftGetState = vi.fn(() => ({ matchPairing: null }));
 
   return {
     NativeEngineVersionMismatchError,
@@ -135,6 +137,7 @@ const {
     getSharedAdapter,
     nativeAdapterInitialize,
     nativeAdapters,
+    multiplayerDraftGetState,
     multiplayerGetState,
     multiplayerState,
     preferences,
@@ -247,7 +250,7 @@ vi.mock("../../stores/multiplayerStore", () => ({
 }));
 
 vi.mock("../../stores/multiplayerDraftStore", () => ({
-  useMultiplayerDraftStore: { getState: vi.fn() },
+  useMultiplayerDraftStore: { getState: multiplayerDraftGetState },
 }));
 
 vi.mock("../../services/playerAvatars", () => ({
@@ -293,6 +296,8 @@ describe("GameProvider native AI routing", () => {
     saveActiveGame.mockReset();
     nativeAdapters.splice(0);
     wasmAdapters.splice(0);
+    multiplayerDraftGetState.mockReset();
+    multiplayerDraftGetState.mockReturnValue({ matchPairing: null });
     multiplayerGetState.mockReset();
     multiplayerGetState.mockReturnValue(multiplayerState);
     preferences.aiSeats = [{ difficulty: "Medium", deckId: "Random" }];
@@ -307,6 +312,9 @@ describe("GameProvider native AI routing", () => {
 
   afterEach(() => {
     cleanup();
+    gameStoreState.adapter = null;
+    gameStoreState.gameId = null;
+    gameStoreState.gameState = null;
   });
 
   it("falls back to WASM when release parity rejects the native engine", async () => {

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -30,6 +30,8 @@ export type DiceRollPayload =
        *  overlay renders this directly so every seat can see its first-turn
        *  position without reconstructing turn order from raw state. */
       turnOrder?: TurnOrderSlotView[];
+      /** Engine-authored one-based turn position for the current viewer. */
+      viewerTurnNumber?: number;
       /** Starting-player contest only (CR 103.1): the roll-off by round. Round 0
        *  is every seat; each later round is the previous round's tied-max group
        *  that rerolled. Rendered round-by-round so the winner is always the high

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -3,6 +3,7 @@ import type {
   GameAction,
   ObjectId,
   PlayerId,
+  TurnOrderSlotView,
 } from "../adapter/types";
 import { DICE_ROLL_DURATION_MS, TURN_BANNER_DURATION_MS } from "../animation/types";
 import { usePreferencesStore } from "./preferencesStore";
@@ -25,6 +26,10 @@ export type DiceRollPayload =
       context: "startingPlayer" | "ability";
       /** Starting-player contest: the high roller who takes the first turn. */
       winner?: PlayerId;
+      /** Engine-authored opening turn sequence for multiplayer games. The
+       *  overlay renders this directly so every seat can see its first-turn
+       *  position without reconstructing turn order from raw state. */
+      turnOrder?: TurnOrderSlotView[];
       /** Starting-player contest only (CR 103.1): the roll-off by round. Round 0
        *  is every seat; each later round is the previous round's tied-max group
        *  that rerolled. Rendered round-by-round so the winner is always the high

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -191,6 +191,17 @@ pub struct TurnOrderSlotView {
     pub player: PlayerId,
     pub slot_index: u8,
     pub turns_from_now: u8,
+    /// One-based display position in the projected turn order. Kept here so
+    /// clients do not turn the engine's zero-based distance into an ordinal.
+    pub turn_number: u8,
+    /// Whether this row belongs to the viewing player. Clients consume this
+    /// display classification rather than comparing player IDs themselves.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub is_viewer: bool,
+    /// Whether this projected slot is the game's starting player. It is only
+    /// true while that player is also the current turn representative.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub is_starting_player: bool,
 }
 
 /// Engine-authored projections used by the display layer. Keep this struct
@@ -312,6 +323,12 @@ pub struct DerivedViews {
     /// order from raw state.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub turn_order: Vec<TurnOrderSlotView>,
+
+    /// One-based projected turn position for the viewing player. This keeps
+    /// player-specific turn-order interpretation in the engine while allowing
+    /// the client to render "You take turn N" directly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub viewer_turn_number: Option<u8>,
 
     /// CR 732.2a: the `∞` HUD rows — one per (attributed player, pumped axis) of
     /// every unbounded-resource loop in `GameState::unbounded_resources`. The
@@ -636,7 +653,9 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
     // Commander short-circuit below).
     views.player_status = player_status_views(state);
 
-    views.turn_order = turn_order_views(state);
+    let (turn_order, viewer_turn_number) = turn_order_views(state, viewer);
+    views.turn_order = turn_order;
+    views.viewer_turn_number = viewer_turn_number;
 
     // CR 732.2a: project every unbounded-resource loop into per-(player, axis)
     // `∞` HUD rows. Runs in every format (placed BEFORE the Commander
@@ -725,7 +744,10 @@ fn unique_authorized_submitter(state: &GameState) -> Option<PlayerId> {
     (submitters.len() == 1).then(|| submitters[0])
 }
 
-fn turn_order_views(state: &GameState) -> Vec<TurnOrderSlotView> {
+fn turn_order_views(
+    state: &GameState,
+    viewer: Option<PlayerId>,
+) -> (Vec<TurnOrderSlotView>, Option<u8>) {
     let mut seen = BTreeSet::new();
     let representatives: Vec<PlayerId> = state
         .seat_order
@@ -740,10 +762,10 @@ fn turn_order_views(state: &GameState) -> Vec<TurnOrderSlotView> {
         .collect();
 
     if representatives.len() <= 2 {
-        return Vec::new();
+        return (Vec::new(), None);
     }
 
-    crate::game::turns::projected_turn_order(state, representatives.len())
+    let turn_order: Vec<_> = crate::game::turns::projected_turn_order(state, representatives.len())
         .into_iter()
         .enumerate()
         .map(|(index, player)| {
@@ -752,9 +774,18 @@ fn turn_order_views(state: &GameState) -> Vec<TurnOrderSlotView> {
                 player,
                 slot_index,
                 turns_from_now: slot_index,
+                turn_number: slot_index + 1,
+                is_viewer: viewer == Some(player),
+                is_starting_player: slot_index == 0 && player == state.current_starting_player,
             }
         })
-        .collect()
+        .collect();
+    let viewer_turn_number = turn_order
+        .iter()
+        .find(|slot| slot.is_viewer)
+        .map(|slot| slot.turn_number);
+
+    (turn_order, viewer_turn_number)
 }
 
 /// CR 732.2a: which player's HUD a pumped `axis` belongs to, given the loop's
@@ -1662,15 +1693,26 @@ mod tests {
                     player: PlayerId(0),
                     slot_index: 0,
                     turns_from_now: 0,
+                    turn_number: 1,
+                    is_viewer: false,
+                    is_starting_player: true,
                 },
                 TurnOrderSlotView {
                     player: PlayerId(0),
                     slot_index: 1,
                     turns_from_now: 1,
+                    turn_number: 2,
+                    is_viewer: false,
+                    is_starting_player: false,
                 },
             ],
             "same player can be both NOW and NEXT when an extra turn is queued"
         );
+
+        let viewer_views = derive_views(&state, Some(PlayerId(2)));
+        assert_eq!(viewer_views.viewer_turn_number, Some(3));
+        assert!(viewer_views.turn_order[2].is_viewer);
+        assert_eq!(viewer_views.turn_order[2].turn_number, 3);
 
         let json =
             serde_json::to_string(&ClientGameStateRef::wrap(&state, None)).expect("serialize");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Coin-flip overlays now use win/loss styling and display localized outcome badges.
  - Starting-player dice contests now show a turn-order panel plus a localized “your turn” message.
  - Batched ability events can now render multiple coin flips sequentially.
  - Added new dice-roll and turn-order translation strings across supported languages.
- **Bug Fixes**
  - Improved cleanup of dice/overlay state at session/game boundaries.
- **Tests**
  - Updated and extended dice contest, turn-order projection, and overlay cleanup test coverage (including multi-coin queue scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->