### PR TITLE
fix(desktop): replay native engine progress

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -358,7 +358,10 @@ jobs:
       card_data_hash16: ${{ needs.card-data.outputs.card_data_hash16 }}
       draft_pools_sha256: ${{ needs.card-data.outputs.draft_pools_sha256 }}
       draft_pools_hash16: ${{ needs.card-data.outputs.draft_pools_hash16 }}
-    secrets: inherit
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY: ${{ secrets.SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY }}
 
   # ── Frontend + Pages deploy (needs server artifact + card-data + WASM) ──────
   build-pages:

--- a/.github/workflows/preview-server.yml
+++ b/.github/workflows/preview-server.yml
@@ -2,6 +2,13 @@ name: Preview Server Artifacts
 
 on:
   workflow_call:
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        required: true
+      CLOUDFLARE_ACCOUNT_ID:
+        required: true
+      SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY:
+        required: true
     inputs:
       fingerprint:
         required: true

--- a/client/src-tauri/capabilities/default.json
+++ b/client/src-tauri/capabilities/default.json
@@ -29,6 +29,7 @@
       "allow-confirm-legacy-import",
       "allow-mark-remote-load-ok",
       "allow-ensure-native-engine",
+      "allow-native-engine-progress",
       "allow-stop-native-engine",
       "allow-connect-native-engine",
       "allow-native-engine-bridge-send",

--- a/client/src-tauri/permissions/legacy-storage.toml
+++ b/client/src-tauri/permissions/legacy-storage.toml
@@ -29,6 +29,11 @@ description = "Allows first-party remote content to prepare a signed native engi
 commands.allow = ["ensure_native_engine"]
 
 [[permission]]
+identifier = "allow-native-engine-progress"
+description = "Allows first-party remote content to read the latest native-engine provisioning progress."
+commands.allow = ["native_engine_progress"]
+
+[[permission]]
 identifier = "allow-stop-native-engine"
 description = "Allows first-party remote content to stop the shell-owned native engine."
 commands.allow = ["stop_native_engine"]

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -32,6 +32,7 @@ pub fn run() {
             migration::confirm_legacy_import,
             migration::mark_remote_load_ok,
             native_engine::ensure_native_engine,
+            native_engine::native_engine_progress,
             native_engine::stop_native_engine,
             native_bridge::connect_native_engine,
             native_bridge::native_engine_bridge_send,

--- a/client/src-tauri/src/native_engine.rs
+++ b/client/src-tauri/src/native_engine.rs
@@ -416,6 +416,7 @@ impl Default for NativeEngineState {
 }
 
 static ENGINE_STATE: OnceLock<Mutex<NativeEngineState>> = OnceLock::new();
+static LATEST_PROGRESS: OnceLock<Mutex<Option<NativeEngineProgress>>> = OnceLock::new();
 static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub(crate) enum NativeBridgeRegistryError {
@@ -425,6 +426,10 @@ pub(crate) enum NativeBridgeRegistryError {
 
 fn engine_state() -> &'static Mutex<NativeEngineState> {
     ENGINE_STATE.get_or_init(|| Mutex::new(NativeEngineState::default()))
+}
+
+fn latest_progress() -> &'static Mutex<Option<NativeEngineProgress>> {
+    LATEST_PROGRESS.get_or_init(|| Mutex::new(None))
 }
 
 pub(crate) fn register_native_engine_bridge(
@@ -502,6 +507,12 @@ pub async fn ensure_native_engine(
         emit_progress(&progress_app, NativeEngineProgressPhase::Failed, None);
     }
     result
+}
+
+/// Returns the latest provisioning progress for listeners that register late.
+#[tauri::command]
+pub fn native_engine_progress() -> Option<NativeEngineProgress> {
+    latest_progress().lock().ok()?.clone()
 }
 
 /// Stops the held or adopted native server and removes its persisted record.
@@ -1357,7 +1368,11 @@ fn binary_file_name() -> String {
 }
 
 fn emit_progress(app: &AppHandle, phase: NativeEngineProgressPhase, detail: Option<String>) {
-    let _ = app.emit(PROGRESS_EVENT, NativeEngineProgress { phase, detail });
+    let progress = NativeEngineProgress { phase, detail };
+    if let Ok(mut latest) = latest_progress().lock() {
+        *latest = Some(progress.clone());
+    }
+    let _ = app.emit(PROGRESS_EVENT, progress);
 }
 
 #[cfg(test)]

--- a/client/src/components/chrome/NativeEngineProgressOverlay.tsx
+++ b/client/src/components/chrome/NativeEngineProgressOverlay.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 import {
+  getNativeEngineProgress,
   type NativeEngineProgress,
   subscribeNativeEngineProgress,
 } from "../../services/nativeEngine";
@@ -40,15 +41,20 @@ export function NativeEngineProgressOverlay() {
   useEffect(() => {
     let active = true;
     let unlisten: (() => void) | undefined;
+    let receivedLiveProgress = false;
 
     void subscribeNativeEngineProgress((next) => {
+      receivedLiveProgress = true;
       if (active) setProgress(next);
     }).then((registeredUnlisten) => {
-      if (active) {
-        unlisten = registeredUnlisten;
-      } else {
+      if (!active) {
         registeredUnlisten();
+        return;
       }
+      unlisten = registeredUnlisten;
+      return getNativeEngineProgress().then((latest) => {
+        if (active && !receivedLiveProgress && latest) setProgress(latest);
+      });
     }).catch(() => {
       // The browser build has no Tauri event bridge to subscribe to.
     });
@@ -73,7 +79,7 @@ export function NativeEngineProgressOverlay() {
     <AnimatePresence>
       {progress && (
         <motion.div
-          className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+          className="pointer-events-none fixed inset-0 z-[80] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}

--- a/client/src/components/chrome/__tests__/NativeEngineProgressOverlay.test.tsx
+++ b/client/src/components/chrome/__tests__/NativeEngineProgressOverlay.test.tsx
@@ -15,11 +15,13 @@ const mocks = vi.hoisted(() => {
       listener = next;
       return unlisten;
     }),
+    getNativeEngineProgress: vi.fn(async (): Promise<NativeEngineProgress | null> => null),
     unlisten,
   };
 });
 
 vi.mock("../../../services/nativeEngine", () => ({
+  getNativeEngineProgress: mocks.getNativeEngineProgress,
   subscribeNativeEngineProgress: mocks.subscribeNativeEngineProgress,
 }));
 
@@ -61,5 +63,25 @@ describe("NativeEngineProgressOverlay", () => {
     const status = screen.getByRole("status");
     expect(status).toHaveTextContent("Native engine ready");
     expect(status).toHaveAttribute("aria-busy", "false");
+  });
+
+  it("replays progress emitted before the overlay mounted", async () => {
+    mocks.getNativeEngineProgress.mockResolvedValueOnce({ phase: "resolving" });
+
+    render(<NativeEngineProgressOverlay />);
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Finding the correct local server…");
+  });
+
+  it("keeps live progress when the replay snapshot is stale", async () => {
+    mocks.subscribeNativeEngineProgress.mockImplementationOnce(async (next) => {
+      next({ phase: "downloading_data" });
+      return mocks.unlisten;
+    });
+    mocks.getNativeEngineProgress.mockResolvedValueOnce({ phase: "resolving" });
+
+    render(<NativeEngineProgressOverlay />);
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Downloading game data…");
   });
 });

--- a/client/src/services/nativeEngine.ts
+++ b/client/src/services/nativeEngine.ts
@@ -53,6 +53,14 @@ export async function ensureNativeEngine(key: NativeEngineKey): Promise<NativeEn
   return invoke<NativeEngineReady>("ensure_native_engine", { key });
 }
 
+/** Returns progress emitted before this webview registered its listener. */
+export async function getNativeEngineProgress(): Promise<NativeEngineProgress | null> {
+  if (!isTauri()) return null;
+
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<NativeEngineProgress | null>("native_engine_progress");
+}
+
 /** Subscribes to the shell's native-engine provisioning progress. */
 export async function subscribeNativeEngineProgress(
   listener: (progress: NativeEngineProgress) => void,


### PR DESCRIPTION
Follow-up to #6546 addressing its review findings.\n\n- scopes reusable-workflow secrets explicitly\n- replays native-engine provisioning progress for late listeners\n- lets status overlay pass through pointer interaction