### PR TITLE
fix(client): respect legal Adventure cast faces

### DIFF
--- a/client/src/components/modal/AdventureCastModal.tsx
+++ b/client/src/components/modal/AdventureCastModal.tsx
@@ -1,29 +1,52 @@
 import { useTranslation } from "react-i18next";
 
 import type { GameAction } from "../../adapter/types.ts";
+import { useGameDispatch } from "../../hooks/useGameDispatch.ts";
 import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { DialogShell } from "./DialogShell.tsx";
 
+type ChooseAdventureFaceAction = Extract<GameAction, { type: "ChooseAdventureFace" }>;
+
 export function AdventureCastModal() {
   const canActForWaitingState = useCanActForWaitingState();
   const waitingFor = useGameStore((s) => s.waitingFor);
-  const dispatch = useGameStore((s) => s.dispatch);
+  const legalActions = useGameStore((s) => s.legalActions);
+  const dispatch = useGameDispatch();
 
   if (waitingFor?.type !== "CastOffer" || waitingFor.data.kind.type !== "Adventure") return null;
   if (!canActForWaitingState) return null;
 
   const kind = waitingFor.data.kind;
+  const creatureAction = legalActions.find(
+    (action): action is ChooseAdventureFaceAction =>
+      action.type === "ChooseAdventureFace" && action.data.creature,
+  );
+  const adventureAction = legalActions.find(
+    (action): action is ChooseAdventureFaceAction =>
+      action.type === "ChooseAdventureFace" && !action.data.creature,
+  );
 
-  return <AdventureCastContent objectId={kind.object_id} dispatch={dispatch} />;
+  return (
+    <AdventureCastContent
+      objectId={kind.object_id}
+      creatureAction={creatureAction}
+      adventureAction={adventureAction}
+      dispatch={dispatch}
+    />
+  );
 }
 
 function AdventureCastContent({
   objectId,
+  creatureAction,
+  adventureAction,
   dispatch,
 }: {
   objectId: number;
-  dispatch: (action: GameAction) => Promise<unknown>;
+  creatureAction: ChooseAdventureFaceAction | undefined;
+  adventureAction: ChooseAdventureFaceAction | undefined;
+  dispatch: (action: GameAction) => Promise<void>;
 }) {
   const { t } = useTranslation("game");
   const obj = useGameStore((s) => s.gameState?.objects[objectId]);
@@ -41,32 +64,32 @@ function AdventureCastContent({
       previewObjectId={objectId}
     >
       <div className="flex flex-col gap-2 px-3 py-3 lg:px-5 lg:py-5">
-        <button
-          onClick={() =>
-            dispatch({ type: "ChooseAdventureFace", data: { creature: true } })
-          }
-          className="rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-cyan-400/30"
-        >
-          <span className="font-semibold text-white">
-            {t("adventureCast.castNamed", { name: creatureName })}
-          </span>
-          <span className="ml-2 text-xs text-slate-400">
-            {t("adventureCast.creatureTag")}
-          </span>
-        </button>
-        <button
-          onClick={() =>
-            dispatch({ type: "ChooseAdventureFace", data: { creature: false } })
-          }
-          className="rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-amber-400/30"
-        >
-          <span className="font-semibold text-white">
-            {t("adventureCast.castNamed", { name: adventureName })}
-          </span>
-          <span className="ml-2 text-xs text-slate-400">
-            {t("adventureCast.adventureTag")}
-          </span>
-        </button>
+        {creatureAction && (
+          <button
+            onClick={() => dispatch(creatureAction)}
+            className="rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-cyan-400/30"
+          >
+            <span className="font-semibold text-white">
+              {t("adventureCast.castNamed", { name: creatureName })}
+            </span>
+            <span className="ml-2 text-xs text-slate-400">
+              {t("adventureCast.creatureTag")}
+            </span>
+          </button>
+        )}
+        {adventureAction && (
+          <button
+            onClick={() => dispatch(adventureAction)}
+            className="rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-amber-400/30"
+          >
+            <span className="font-semibold text-white">
+              {t("adventureCast.castNamed", { name: adventureName })}
+            </span>
+            <span className="ml-2 text-xs text-slate-400">
+              {t("adventureCast.adventureTag")}
+            </span>
+          </button>
+        )}
       </div>
     </DialogShell>
   );

--- a/client/src/components/modal/__tests__/AdventureCastModal.test.tsx
+++ b/client/src/components/modal/__tests__/AdventureCastModal.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { gameObjectFactory } from "../../../test/factories/gameObjectFactory.ts";
+import {
+  castOfferWaitingForFactory,
+  gameStateFactory,
+} from "../../../test/factories/gameStateFactory.ts";
+import { setGameStoreForTest } from "../../../test/helpers/gameStoreHelpers.ts";
+import { AdventureCastModal } from "../AdventureCastModal.tsx";
+
+const dispatchMock = vi.fn();
+
+vi.mock("../../../hooks/useGameDispatch.ts", () => ({
+  useGameDispatch: () => dispatchMock,
+}));
+
+const creatureAction = {
+  type: "ChooseAdventureFace" as const,
+  data: { creature: true },
+};
+const adventureAction = {
+  type: "ChooseAdventureFace" as const,
+  data: { creature: false },
+};
+
+function adventureState(player = 0) {
+  const hildibrand = gameObjectFactory
+    .creature(2, 2)
+    .inHand()
+    .withId(157)
+    .named("Hildibrand Manderville")
+    .build();
+
+  return gameStateFactory
+    .withPlayers(0, 1)
+    .withObjects(hildibrand)
+    .waitingFor(
+      castOfferWaitingForFactory
+        .forPlayer(player)
+        .adventure(hildibrand.id, hildibrand.card_id)
+        .build(),
+    )
+    .build();
+}
+
+describe("AdventureCastModal", () => {
+  afterEach(() => {
+    cleanup();
+    dispatchMock.mockReset();
+  });
+
+  it("renders and dispatches only the engine-authorized Adventure face", () => {
+    const gameState = adventureState();
+    setGameStoreForTest({ gameState, legalActions: [adventureAction] });
+
+    render(<AdventureCastModal />);
+
+    expect(
+      screen.queryByRole("button", { name: /^Cast Hildibrand Manderville \(Creature\)$/ }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Cast Adventure \(Adventure\)$/ }));
+    expect(dispatchMock).toHaveBeenCalledWith(adventureAction);
+  });
+
+  it("renders both engine-authorized faces and preserves their exact actions", () => {
+    const gameState = adventureState();
+    setGameStoreForTest({ gameState, legalActions: [creatureAction, adventureAction] });
+
+    render(<AdventureCastModal />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Cast Hildibrand Manderville \(Creature\)$/ }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^Cast Adventure \(Adventure\)$/ }));
+
+    expect(dispatchMock).toHaveBeenNthCalledWith(1, creatureAction);
+    expect(dispatchMock).toHaveBeenNthCalledWith(2, adventureAction);
+  });
+
+  it("does not render for another player's CastOffer", () => {
+    const gameState = adventureState(1);
+    setGameStoreForTest({ gameState, legalActions: [adventureAction] });
+
+    render(<AdventureCastModal />);
+
+    expect(screen.queryByRole("heading", { name: "Choose a Face" })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/test/factories/__tests__/factories.test.ts
+++ b/client/src/test/factories/__tests__/factories.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { gameObjectFactory } from "../gameObjectFactory.ts";
-import { gameStateFactory, waitingForFactory } from "../gameStateFactory.ts";
+import {
+  castOfferWaitingForFactory,
+  gameStateFactory,
+  targetSelectionWaitingForFactory,
+  waitingForFactory,
+} from "../gameStateFactory.ts";
 
 describe("gameObjectFactory convenience methods", () => {
   it("composes card type, supertype, zone, and state methods", () => {
@@ -69,6 +74,36 @@ describe("waitingForFactory", () => {
     expect(waitingFor).toMatchObject({
       type: "TargetSelection",
       data: expect.objectContaining({ player: 1 }),
+    });
+  });
+
+  it("merges data overrides without discarding variant defaults", () => {
+    const waitingFor = targetSelectionWaitingForFactory.forPlayer(1).build();
+
+    expect(waitingFor).toMatchObject({
+      type: "TargetSelection",
+      data: {
+        player: 1,
+        pending_cast: { object_id: 1, card_id: 1 },
+        target_slots: [{ legal_targets: [], optional: false }],
+      },
+    });
+  });
+
+  it("exposes CastOffer's domain fields through chainable factory methods", () => {
+    const waitingFor = castOfferWaitingForFactory.forPlayer(1).adventure(157).build();
+
+    expect(waitingFor).toEqual({
+      type: "CastOffer",
+      data: {
+        player: 1,
+        kind: {
+          type: "Adventure",
+          object_id: 157,
+          card_id: 157,
+          payment_mode: { type: "Auto" },
+        },
+      },
     });
   });
 });

--- a/client/src/test/factories/gameStateFactory.ts
+++ b/client/src/test/factories/gameStateFactory.ts
@@ -154,7 +154,7 @@ export const buildCommanderFormatConfig = (
 
 export class PriorityWaitingForFactory extends PlayerWaitingForFactory<PriorityWaitingFor> {}
 
-export const priorityWaitingForFactory = PriorityWaitingForFactory.define<PriorityWaitingFor>(() => ({
+export const priorityWaitingForFactory = PriorityWaitingForFactory.define((): PriorityWaitingFor => ({
   type: "Priority",
   data: { player: 0 },
 }));
@@ -167,7 +167,7 @@ export const buildPriorityWaitingFor = (
 
 export class ManaPaymentWaitingForFactory extends PlayerWaitingForFactory<ManaPaymentWaitingFor> {}
 
-export const manaPaymentWaitingForFactory = ManaPaymentWaitingForFactory.define<ManaPaymentWaitingFor>(() => ({
+export const manaPaymentWaitingForFactory = ManaPaymentWaitingForFactory.define((): ManaPaymentWaitingFor => ({
   type: "ManaPayment",
   data: { player: 0 },
 }));
@@ -217,7 +217,7 @@ export const buildTargetSelectionProgress = (
 export class TargetSelectionWaitingForFactory extends PlayerWaitingForFactory<TargetSelectionWaitingFor> {}
 
 export const targetSelectionWaitingForFactory =
-  TargetSelectionWaitingForFactory.define<TargetSelectionWaitingFor>(() => ({
+  TargetSelectionWaitingForFactory.define((): TargetSelectionWaitingFor => ({
     type: "TargetSelection",
     data: {
       player: 0,
@@ -236,7 +236,7 @@ export const buildTargetSelectionWaitingFor = (
 export class TriggerTargetSelectionWaitingForFactory extends PlayerWaitingForFactory<TriggerTargetSelectionWaitingFor> {}
 
 export const triggerTargetSelectionWaitingForFactory =
-  TriggerTargetSelectionWaitingForFactory.define<TriggerTargetSelectionWaitingFor>(() => ({
+  TriggerTargetSelectionWaitingForFactory.define((): TriggerTargetSelectionWaitingFor => ({
     type: "TriggerTargetSelection",
     data: {
       player: 0,
@@ -254,7 +254,7 @@ export const buildTriggerTargetSelectionWaitingFor = (
 export class ChooseXValueWaitingForFactory extends PlayerWaitingForFactory<ChooseXValueWaitingFor> {}
 
 export const chooseXValueWaitingForFactory =
-  ChooseXValueWaitingForFactory.define<ChooseXValueWaitingFor>(() => ({
+  ChooseXValueWaitingForFactory.define((): ChooseXValueWaitingFor => ({
     type: "ChooseXValue",
     data: {
       player: 0,
@@ -280,7 +280,7 @@ export class AssistPaymentWaitingForFactory extends WaitingForFactory<AssistPaym
 }
 
 export const assistPaymentWaitingForFactory =
-  AssistPaymentWaitingForFactory.define<AssistPaymentWaitingFor>(() => ({
+  AssistPaymentWaitingForFactory.define((): AssistPaymentWaitingFor => ({
     type: "AssistPayment",
     data: {
       caster: 1,
@@ -310,7 +310,7 @@ export class CastOfferWaitingForFactory extends PlayerWaitingForFactory<CastOffe
   }
 }
 
-export const castOfferWaitingForFactory = CastOfferWaitingForFactory.define<CastOfferWaitingFor>(() => ({
+export const castOfferWaitingForFactory = CastOfferWaitingForFactory.define((): CastOfferWaitingFor => ({
   type: "CastOffer",
   data: {
     player: 0,
@@ -431,7 +431,7 @@ export class LoopShortcutWaitingForFactory extends WaitingForFactory<LoopShortcu
   }
 }
 
-export const loopShortcutWaitingForFactory = LoopShortcutWaitingForFactory.define<LoopShortcutWaitingFor>(() => ({
+export const loopShortcutWaitingForFactory = LoopShortcutWaitingForFactory.define((): LoopShortcutWaitingFor => ({
   type: "LoopShortcut",
   data: {
     proposer: 0,
@@ -479,7 +479,7 @@ export class RespondToShortcutWaitingForFactory extends PlayerWaitingForFactory<
 }
 
 export const respondToShortcutWaitingForFactory =
-  RespondToShortcutWaitingForFactory.define<RespondToShortcutWaitingFor>(() => ({
+  RespondToShortcutWaitingForFactory.define((): RespondToShortcutWaitingFor => ({
     type: "RespondToShortcut",
     data: {
       player: 0,

--- a/client/src/test/factories/gameStateFactory.ts
+++ b/client/src/test/factories/gameStateFactory.ts
@@ -154,7 +154,7 @@ export const buildCommanderFormatConfig = (
 
 export class PriorityWaitingForFactory extends PlayerWaitingForFactory<PriorityWaitingFor> {}
 
-export const priorityWaitingForFactory = PriorityWaitingForFactory.define(() => ({
+export const priorityWaitingForFactory = PriorityWaitingForFactory.define<PriorityWaitingFor>(() => ({
   type: "Priority",
   data: { player: 0 },
 }));
@@ -167,7 +167,7 @@ export const buildPriorityWaitingFor = (
 
 export class ManaPaymentWaitingForFactory extends PlayerWaitingForFactory<ManaPaymentWaitingFor> {}
 
-export const manaPaymentWaitingForFactory = ManaPaymentWaitingForFactory.define(() => ({
+export const manaPaymentWaitingForFactory = ManaPaymentWaitingForFactory.define<ManaPaymentWaitingFor>(() => ({
   type: "ManaPayment",
   data: { player: 0 },
 }));
@@ -217,7 +217,7 @@ export const buildTargetSelectionProgress = (
 export class TargetSelectionWaitingForFactory extends PlayerWaitingForFactory<TargetSelectionWaitingFor> {}
 
 export const targetSelectionWaitingForFactory =
-  TargetSelectionWaitingForFactory.define(() => ({
+  TargetSelectionWaitingForFactory.define<TargetSelectionWaitingFor>(() => ({
     type: "TargetSelection",
     data: {
       player: 0,
@@ -236,7 +236,7 @@ export const buildTargetSelectionWaitingFor = (
 export class TriggerTargetSelectionWaitingForFactory extends PlayerWaitingForFactory<TriggerTargetSelectionWaitingFor> {}
 
 export const triggerTargetSelectionWaitingForFactory =
-  TriggerTargetSelectionWaitingForFactory.define(() => ({
+  TriggerTargetSelectionWaitingForFactory.define<TriggerTargetSelectionWaitingFor>(() => ({
     type: "TriggerTargetSelection",
     data: {
       player: 0,
@@ -254,7 +254,7 @@ export const buildTriggerTargetSelectionWaitingFor = (
 export class ChooseXValueWaitingForFactory extends PlayerWaitingForFactory<ChooseXValueWaitingFor> {}
 
 export const chooseXValueWaitingForFactory =
-  ChooseXValueWaitingForFactory.define(() => ({
+  ChooseXValueWaitingForFactory.define<ChooseXValueWaitingFor>(() => ({
     type: "ChooseXValue",
     data: {
       player: 0,
@@ -280,7 +280,7 @@ export class AssistPaymentWaitingForFactory extends WaitingForFactory<AssistPaym
 }
 
 export const assistPaymentWaitingForFactory =
-  AssistPaymentWaitingForFactory.define(() => ({
+  AssistPaymentWaitingForFactory.define<AssistPaymentWaitingFor>(() => ({
     type: "AssistPayment",
     data: {
       caster: 1,
@@ -310,7 +310,7 @@ export class CastOfferWaitingForFactory extends PlayerWaitingForFactory<CastOffe
   }
 }
 
-export const castOfferWaitingForFactory = CastOfferWaitingForFactory.define(() => ({
+export const castOfferWaitingForFactory = CastOfferWaitingForFactory.define<CastOfferWaitingFor>(() => ({
   type: "CastOffer",
   data: {
     player: 0,
@@ -431,7 +431,7 @@ export class LoopShortcutWaitingForFactory extends WaitingForFactory<LoopShortcu
   }
 }
 
-export const loopShortcutWaitingForFactory = LoopShortcutWaitingForFactory.define(() => ({
+export const loopShortcutWaitingForFactory = LoopShortcutWaitingForFactory.define<LoopShortcutWaitingFor>(() => ({
   type: "LoopShortcut",
   data: {
     proposer: 0,
@@ -479,7 +479,7 @@ export class RespondToShortcutWaitingForFactory extends PlayerWaitingForFactory<
 }
 
 export const respondToShortcutWaitingForFactory =
-  RespondToShortcutWaitingForFactory.define(() => ({
+  RespondToShortcutWaitingForFactory.define<RespondToShortcutWaitingFor>(() => ({
     type: "RespondToShortcut",
     data: {
       player: 0,

--- a/client/src/test/factories/gameStateFactory.ts
+++ b/client/src/test/factories/gameStateFactory.ts
@@ -30,8 +30,37 @@ type TriggerTargetSelectionWaitingFor = Extract<
 >;
 type ChooseXValueWaitingFor = Extract<WaitingFor, { type: "ChooseXValue" }>;
 type AssistPaymentWaitingFor = Extract<WaitingFor, { type: "AssistPayment" }>;
+type CastOfferWaitingFor = Extract<WaitingFor, { type: "CastOffer" }>;
 type LoopShortcutWaitingFor = Extract<WaitingFor, { type: "LoopShortcut" }>;
 type RespondToShortcutWaitingFor = Extract<WaitingFor, { type: "RespondToShortcut" }>;
+type WaitingForWithData = Extract<WaitingFor, { data: object }>;
+
+/**
+ * Shared base for a concrete `WaitingFor` variant factory.
+ *
+ * `withData` merges top-level payload fields rather than replacing the entire
+ * `data` object, so callers retain the variant's valid defaults while changing
+ * only the fields relevant to a test.
+ */
+export abstract class WaitingForFactory<T extends WaitingForWithData> extends Factory<T> {
+  withData(data: Partial<T["data"]>) {
+    return this.afterBuild((waitingFor) => {
+      Object.assign(waitingFor.data, data);
+      return waitingFor;
+    });
+  }
+}
+
+abstract class PlayerWaitingForFactory<
+  T extends WaitingForWithData & { data: { player: PlayerId } },
+> extends WaitingForFactory<T> {
+  forPlayer(player: PlayerId) {
+    return this.afterBuild((waitingFor) => {
+      waitingFor.data.player = player;
+      return waitingFor;
+    });
+  }
+}
 
 /**
  * Convenience-method factory for `Player`:
@@ -123,7 +152,9 @@ export const buildCommanderFormatConfig = (
   });
 };
 
-export const priorityWaitingForFactory = Factory.define<PriorityWaitingFor>(() => ({
+export class PriorityWaitingForFactory extends PlayerWaitingForFactory<PriorityWaitingFor> {}
+
+export const priorityWaitingForFactory = PriorityWaitingForFactory.define(() => ({
   type: "Priority",
   data: { player: 0 },
 }));
@@ -131,10 +162,12 @@ export const priorityWaitingForFactory = Factory.define<PriorityWaitingFor>(() =
 export const buildPriorityWaitingFor = (
   overrides: Partial<PriorityWaitingFor> = {},
 ): PriorityWaitingFor => {
-  return { ...priorityWaitingForFactory.build(), ...overrides };
+  return priorityWaitingForFactory.withData(overrides.data ?? {}).build();
 };
 
-export const manaPaymentWaitingForFactory = Factory.define<ManaPaymentWaitingFor>(() => ({
+export class ManaPaymentWaitingForFactory extends PlayerWaitingForFactory<ManaPaymentWaitingFor> {}
+
+export const manaPaymentWaitingForFactory = ManaPaymentWaitingForFactory.define(() => ({
   type: "ManaPayment",
   data: { player: 0 },
 }));
@@ -142,7 +175,7 @@ export const manaPaymentWaitingForFactory = Factory.define<ManaPaymentWaitingFor
 export const buildManaPaymentWaitingFor = (
   overrides: Partial<ManaPaymentWaitingFor> = {},
 ): ManaPaymentWaitingFor => {
-  return { ...manaPaymentWaitingForFactory.build(), ...overrides };
+  return manaPaymentWaitingForFactory.withData(overrides.data ?? {}).build();
 };
 
 export const pendingCastFactory = Factory.define<PendingCast>(() => ({
@@ -181,8 +214,10 @@ export const buildTargetSelectionProgress = (
   return { ...targetSelectionProgressFactory.build(), ...overrides };
 };
 
+export class TargetSelectionWaitingForFactory extends PlayerWaitingForFactory<TargetSelectionWaitingFor> {}
+
 export const targetSelectionWaitingForFactory =
-  Factory.define<TargetSelectionWaitingFor>(() => ({
+  TargetSelectionWaitingForFactory.define(() => ({
     type: "TargetSelection",
     data: {
       player: 0,
@@ -195,11 +230,13 @@ export const targetSelectionWaitingForFactory =
 export const buildTargetSelectionWaitingFor = (
   overrides: Partial<TargetSelectionWaitingFor> = {},
 ): TargetSelectionWaitingFor => {
-  return { ...targetSelectionWaitingForFactory.build(), ...overrides };
+  return targetSelectionWaitingForFactory.withData(overrides.data ?? {}).build();
 };
 
+export class TriggerTargetSelectionWaitingForFactory extends PlayerWaitingForFactory<TriggerTargetSelectionWaitingFor> {}
+
 export const triggerTargetSelectionWaitingForFactory =
-  Factory.define<TriggerTargetSelectionWaitingFor>(() => ({
+  TriggerTargetSelectionWaitingForFactory.define(() => ({
     type: "TriggerTargetSelection",
     data: {
       player: 0,
@@ -211,11 +248,13 @@ export const triggerTargetSelectionWaitingForFactory =
 export const buildTriggerTargetSelectionWaitingFor = (
   overrides: Partial<TriggerTargetSelectionWaitingFor> = {},
 ): TriggerTargetSelectionWaitingFor => {
-  return { ...triggerTargetSelectionWaitingForFactory.build(), ...overrides };
+  return triggerTargetSelectionWaitingForFactory.withData(overrides.data ?? {}).build();
 };
 
+export class ChooseXValueWaitingForFactory extends PlayerWaitingForFactory<ChooseXValueWaitingFor> {}
+
 export const chooseXValueWaitingForFactory =
-  Factory.define<ChooseXValueWaitingFor>(() => ({
+  ChooseXValueWaitingForFactory.define(() => ({
     type: "ChooseXValue",
     data: {
       player: 0,
@@ -227,11 +266,21 @@ export const chooseXValueWaitingForFactory =
 export const buildChooseXValueWaitingFor = (
   overrides: Partial<ChooseXValueWaitingFor> = {},
 ): ChooseXValueWaitingFor => {
-  return { ...chooseXValueWaitingForFactory.build(), ...overrides };
+  return chooseXValueWaitingForFactory.withData(overrides.data ?? {}).build();
 };
 
+export class AssistPaymentWaitingForFactory extends WaitingForFactory<AssistPaymentWaitingFor> {
+  withCaster(caster: PlayerId) {
+    return this.withData({ caster });
+  }
+
+  withChosen(chosen: PlayerId) {
+    return this.withData({ chosen });
+  }
+}
+
 export const assistPaymentWaitingForFactory =
-  Factory.define<AssistPaymentWaitingFor>(() => ({
+  AssistPaymentWaitingForFactory.define(() => ({
     type: "AssistPayment",
     data: {
       caster: 1,
@@ -243,7 +292,48 @@ export const assistPaymentWaitingForFactory =
 export const buildAssistPaymentWaitingFor = (
   overrides: Partial<AssistPaymentWaitingFor> = {},
 ): AssistPaymentWaitingFor => {
-  return { ...assistPaymentWaitingForFactory.build(), ...overrides };
+  return assistPaymentWaitingForFactory.withData(overrides.data ?? {}).build();
+};
+
+export class CastOfferWaitingForFactory extends PlayerWaitingForFactory<CastOfferWaitingFor> {
+  withKind(kind: CastOfferWaitingFor["data"]["kind"]) {
+    return this.withData({ kind });
+  }
+
+  adventure(objectId: ObjectId, cardId: ObjectId = objectId) {
+    return this.withKind({
+      type: "Adventure",
+      object_id: objectId,
+      card_id: cardId,
+      payment_mode: { type: "Auto" },
+    });
+  }
+}
+
+export const castOfferWaitingForFactory = CastOfferWaitingForFactory.define(() => ({
+  type: "CastOffer",
+  data: {
+    player: 0,
+    kind: {
+      type: "Adventure",
+      object_id: 1,
+      card_id: 1,
+      payment_mode: { type: "Auto" },
+    },
+  },
+}));
+
+export const buildCastOfferWaitingFor = ({
+  player,
+  kind,
+}: {
+  player?: PlayerId;
+  kind?: CastOfferWaitingFor["data"]["kind"];
+} = {}): CastOfferWaitingFor => {
+  let factory = castOfferWaitingForFactory;
+  if (player !== undefined) factory = factory.forPlayer(player);
+  if (kind !== undefined) factory = factory.withKind(kind);
+  return factory.build();
 };
 
 interface WaitingForTransient {
@@ -260,35 +350,44 @@ interface WaitingForTransient {
  * variants never deep-merges one variant's `data` keys into another's.
  * Use one variant method per chain.
  */
-export class WaitingForFactory extends Factory<WaitingFor, WaitingForTransient> {
+export class WaitingForVariantFactory extends Factory<WaitingFor, WaitingForTransient> {
   priority(player: PlayerId = 0) {
-    return this.variant(buildPriorityWaitingFor({ data: { player } }));
+    return this.variant(priorityWaitingForFactory.forPlayer(player).build());
   }
 
   manaPayment(player: PlayerId = 0) {
-    return this.variant(buildManaPaymentWaitingFor({ data: { player } }));
+    return this.variant(manaPaymentWaitingForFactory.forPlayer(player).build());
   }
 
   targetSelection(data: Partial<TargetSelectionWaitingFor["data"]> = {}) {
-    const base = buildTargetSelectionWaitingFor();
-    return this.variant({ ...base, data: { ...base.data, ...data } });
+    return this.variant(targetSelectionWaitingForFactory.withData(data).build());
   }
 
   triggerTargetSelection(
     data: Partial<TriggerTargetSelectionWaitingFor["data"]> = {},
   ) {
-    const base = buildTriggerTargetSelectionWaitingFor();
-    return this.variant({ ...base, data: { ...base.data, ...data } });
+    return this.variant(triggerTargetSelectionWaitingForFactory.withData(data).build());
   }
 
   chooseXValue(data: Partial<ChooseXValueWaitingFor["data"]> = {}) {
-    const base = buildChooseXValueWaitingFor();
-    return this.variant({ ...base, data: { ...base.data, ...data } });
+    return this.variant(chooseXValueWaitingForFactory.withData(data).build());
   }
 
   assistPayment(data: Partial<AssistPaymentWaitingFor["data"]> = {}) {
-    const base = buildAssistPaymentWaitingFor();
-    return this.variant({ ...base, data: { ...base.data, ...data } });
+    return this.variant(assistPaymentWaitingForFactory.withData(data).build());
+  }
+
+  castOffer({
+    player,
+    kind,
+  }: {
+    player?: PlayerId;
+    kind?: CastOfferWaitingFor["data"]["kind"];
+  } = {}) {
+    let factory = castOfferWaitingForFactory;
+    if (player !== undefined) factory = factory.forPlayer(player);
+    if (kind !== undefined) factory = factory.withKind(kind);
+    return this.variant(factory.build());
   }
 
   private variant(variant: WaitingFor) {
@@ -296,11 +395,43 @@ export class WaitingForFactory extends Factory<WaitingFor, WaitingForTransient> 
   }
 }
 
-export const waitingForFactory = WaitingForFactory.define(
+export const waitingForFactory = WaitingForVariantFactory.define(
   ({ transientParams }) => transientParams.variant ?? buildPriorityWaitingFor(),
 );
 
-export const loopShortcutWaitingForFactory = Factory.define<LoopShortcutWaitingFor>(() => ({
+export class LoopShortcutWaitingForFactory extends WaitingForFactory<LoopShortcutWaitingFor> {
+  withProposer(proposer: PlayerId) {
+    return this.withData({ proposer });
+  }
+
+  withPredictedWinner(predictedWinner: PlayerId | null) {
+    return this.withData({ predicted_winner: predictedWinner });
+  }
+
+  withCertificate(certificate: Partial<LoopCertificate>) {
+    return this.afterBuild((waitingFor) => {
+      waitingFor.data.certificate = { ...waitingFor.data.certificate, ...certificate };
+      return waitingFor;
+    });
+  }
+
+  withSchema(schema: Partial<ShortcutDecisionSchema>) {
+    return this.afterBuild((waitingFor) => {
+      const mergedSchema = { ...waitingFor.data.schema, ...schema };
+      mergedSchema.convoke_tappable_count = mergedSchema.points.reduce(
+        (total, point) =>
+          typeof point.kind === "object" && "ConvokeTaps" in point.kind
+            ? total + point.kind.ConvokeTaps.tappable.length
+            : total,
+        0,
+      );
+      waitingFor.data.schema = mergedSchema;
+      return waitingFor;
+    });
+  }
+}
+
+export const loopShortcutWaitingForFactory = LoopShortcutWaitingForFactory.define(() => ({
   type: "LoopShortcut",
   data: {
     proposer: 0,
@@ -330,32 +461,25 @@ export const buildLoopShortcutWaitingFor = ({
   certificate?: Partial<LoopCertificate>;
   schema?: Partial<ShortcutDecisionSchema>;
 } = {}): LoopShortcutWaitingFor => {
-  const waitingFor = loopShortcutWaitingForFactory.build();
-  const mergedSchema = { ...waitingFor.data.schema, ...schema };
-  // The engine owns convoke_tappable_count (build_shortcut_schema sums the ConvokeTaps
-  // tappable lengths); mirror that here so overriding `points` keeps the count consistent
-  // and the modal — which reads the field directly — renders the matching value.
-  mergedSchema.convoke_tappable_count = mergedSchema.points.reduce(
-    (total, point) =>
-      typeof point.kind === "object" && "ConvokeTaps" in point.kind
-        ? total + point.kind.ConvokeTaps.tappable.length
-        : total,
-    0,
-  );
-  return {
-    ...waitingFor,
-    data: {
-      ...waitingFor.data,
-      ...(proposer === undefined ? {} : { proposer }),
-      ...(predictedWinner === undefined ? {} : { predicted_winner: predictedWinner }),
-      certificate: { ...waitingFor.data.certificate, ...certificate },
-      schema: mergedSchema,
-    },
-  };
+  let factory = loopShortcutWaitingForFactory;
+  if (proposer !== undefined) factory = factory.withProposer(proposer);
+  if (predictedWinner !== undefined) factory = factory.withPredictedWinner(predictedWinner);
+  if (certificate !== undefined) factory = factory.withCertificate(certificate);
+  if (schema !== undefined) factory = factory.withSchema(schema);
+  return factory.build();
 };
 
+export class RespondToShortcutWaitingForFactory extends PlayerWaitingForFactory<RespondToShortcutWaitingFor> {
+  withProposal(proposal: Partial<ShortcutProposal>) {
+    return this.afterBuild((waitingFor) => {
+      waitingFor.data.proposal = { ...waitingFor.data.proposal, ...proposal };
+      return waitingFor;
+    });
+  }
+}
+
 export const respondToShortcutWaitingForFactory =
-  Factory.define<RespondToShortcutWaitingFor>(() => ({
+  RespondToShortcutWaitingForFactory.define(() => ({
     type: "RespondToShortcut",
     data: {
       player: 0,
@@ -376,15 +500,10 @@ export const buildRespondToShortcutWaitingFor = ({
   player?: PlayerId;
   proposal?: Partial<ShortcutProposal>;
 } = {}): RespondToShortcutWaitingFor => {
-  const waitingFor = respondToShortcutWaitingForFactory.build();
-  return {
-    ...waitingFor,
-    data: {
-      ...waitingFor.data,
-      ...(player === undefined ? {} : { player }),
-      proposal: { ...waitingFor.data.proposal, ...proposal },
-    },
-  };
+  let factory = respondToShortcutWaitingForFactory;
+  if (player !== undefined) factory = factory.forPlayer(player);
+  if (proposal !== undefined) factory = factory.withProposal(proposal);
+  return factory.build();
 };
 
 export const stackEntryFactory = Factory.define<StackEntry>(({ sequence }) => ({
@@ -494,6 +613,16 @@ export class GameStateFactory extends Factory<GameState> {
 
   assistPayment(data: Partial<AssistPaymentWaitingFor["data"]> = {}) {
     return this.waitingFor(waitingForFactory.assistPayment(data).build());
+  }
+
+  castOffer({
+    player,
+    kind,
+  }: {
+    player?: PlayerId;
+    kind?: CastOfferWaitingFor["data"]["kind"];
+  } = {}) {
+    return this.waitingFor(waitingForFactory.castOffer({ player, kind }).build());
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adventure casting now displays only face-selection options currently available for the game state.
  - Prevented unauthorized creature or adventure choices from appearing or being submitted.
  - Improved handling of cast offers so actions are dispatched accurately and consistently.
  - Cast prompts now remain hidden when the offer belongs to another player.

- **Tests**
  - Added coverage for authorized choices, unavailable options, dispatched actions, and player-specific cast offers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->