### PR TITLE
fix(release): sync src-tauri Cargo.lock to phase-tauri 0.35.1

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -2616,7 +2616,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phase-tauri"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "futures-util",
  "minisign-verify",


### PR DESCRIPTION
The v0.35.1 release bumped `client/src-tauri/Cargo.toml` (0.35.0 → 0.35.1) but did not update the sibling `client/src-tauri/Cargo.lock` (excluded from the root workspace, so missed by the release lock regen).

This desync makes the CI **Tauri compile check** (`cargo check --locked --manifest-path client/src-tauri/Cargo.toml`) fail with `cannot update the lock file … because --locked was passed`, which fails the required **Rust (fmt, clippy, test, coverage-gate)** aggregator (`needs: tauri-check`, ci.yml:632) and **blocks the merge queue for all PRs** since v0.35.1 landed.

One-line fix: bump the `phase-tauri` entry in its own lockfile to match. Verified locally: `cargo metadata --locked --manifest-path client/src-tauri/Cargo.toml` now exits 0.