### PR TITLE
cr733(p2): journal cost-settlement consume-before-priority occurrences

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2384,20 +2384,28 @@ fn settle_sacrifice_for_cost_events(
     if !deferred_cost_events.is_empty() {
         crate::game::triggers::collect_triggers_into_deferred(state, &deferred_cost_events);
     }
-    state.consumed_before_priority_trigger_events.extend(
-        events[current_start..current_end]
-            .iter()
-            .enumerate()
-            .map(|(offset, event)| {
-                let index = current_start + offset;
-                crate::game::triggers::ConsumedTriggerEventOccurrence {
-                    event: event.clone(),
-                    occurrence: events[..index]
-                        .iter()
-                        .filter(|prior| *prior == event)
-                        .count(),
-                }
-            }),
+    let occurrences = events[current_start..current_end]
+        .iter()
+        .enumerate()
+        .map(|(offset, event)| {
+            let index = current_start + offset;
+            crate::game::triggers::ConsumedTriggerEventOccurrence {
+                event: event.clone(),
+                occurrence: events[..index]
+                    .iter()
+                    .filter(|prior| *prior == event)
+                    .count(),
+            }
+        })
+        .collect();
+    crate::game::triggers::resolve_and_apply_trigger_collection(
+        state,
+        crate::types::resolved_commands::ResolvedTriggerCollection::ConsumeBeforePriority {
+            occurrences,
+        },
+    )
+    .expect(
+        "sacrifice-cost settlement consumed-before-priority trigger journal cause must be live",
     );
 }
 

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -2491,20 +2491,28 @@ fn settle_mana_ability_cost_events(
     // The typed cursor has already collected the events emitted by this action.
     // Claim their exact occurrences through the normal post-action authority so
     // a Priority resume cannot scan the same events a second time.
-    state.consumed_before_priority_trigger_events.extend(
-        events
-            .iter()
-            .enumerate()
-            .skip(current_start)
-            .map(
-                |(index, event)| crate::game::triggers::ConsumedTriggerEventOccurrence {
-                    event: event.clone(),
-                    occurrence: events[..index]
-                        .iter()
-                        .filter(|prior| *prior == event)
-                        .count(),
-                },
-            ),
+    let occurrences = events
+        .iter()
+        .enumerate()
+        .skip(current_start)
+        .map(
+            |(index, event)| crate::game::triggers::ConsumedTriggerEventOccurrence {
+                event: event.clone(),
+                occurrence: events[..index]
+                    .iter()
+                    .filter(|prior| *prior == event)
+                    .count(),
+            },
+        )
+        .collect();
+    super::triggers::resolve_and_apply_trigger_collection(
+        state,
+        crate::types::resolved_commands::ResolvedTriggerCollection::ConsumeBeforePriority {
+            occurrences,
+        },
+    )
+    .expect(
+        "mana-ability cost-settlement consumed-before-priority trigger journal cause must be live",
     );
 }
 

--- a/crates/engine/tests/integration/cr733_resolved_trigger_collection.rs
+++ b/crates/engine/tests/integration/cr733_resolved_trigger_collection.rs
@@ -6,17 +6,26 @@ use engine::game::triggers::{
     ConsumedTriggerEventOccurrence, PendingTrigger, PendingTriggerContext,
     PendingTriggerDispatchOrigin,
 };
-use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter, TargetRef};
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaContribution, ManaProduction,
+    QuantityExpr, ReplacementDefinition, ResolvedAbility, SacrificeCost, TargetFilter, TargetRef,
+    TriggerDefinition, TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
 use engine::types::events::{GameEvent, PlayerActionKind};
-use engine::types::game_state::GameState;
+use engine::types::game_state::{GameState, StackEntryKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
+use engine::types::replacements::ReplacementEvent;
 use engine::types::resolved_commands::{
     ResolvedCommandOrdinal, ResolvedRulesCommand, ResolvedTriggerCollection,
     ResolvedTriggerCollectionCommand, RulesExecutionNodeRef,
 };
-use engine::types::zones::Zone;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::{EtbTapState, Zone};
 
 const DIES_OBSERVER: &str = "Whenever another creature dies, you gain 1 life.";
 
@@ -79,6 +88,101 @@ fn recorded_commands(state: &GameState) -> Vec<ResolvedRulesCommand> {
         .iter()
         .filter_map(|entry| entry.command.clone())
         .collect()
+}
+
+fn current_action_occurrences(events: &[GameEvent]) -> Vec<ConsumedTriggerEventOccurrence> {
+    events
+        .iter()
+        .enumerate()
+        .map(|(index, event)| ConsumedTriggerEventOccurrence {
+            event: event.clone(),
+            occurrence: events[..index]
+                .iter()
+                .filter(|prior| *prior == event)
+                .count(),
+        })
+        .collect()
+}
+
+fn redirect_self_moved_to(destination: Zone, redirected_to: Zone) -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(destination)
+        .valid_card(TargetFilter::SelfRef)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                destination: redirected_to,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: Vec::new(),
+                conditional_enter_with_counters: Vec::new(),
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        ))
+}
+
+fn sacrifice_observer() -> TriggerDefinition {
+    TriggerDefinition::new(TriggerMode::Sacrificed)
+        .valid_card(TargetFilter::Any)
+        .trigger_zones(vec![Zone::Battlefield])
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+        ))
+}
+
+fn artifact_sacrifice_observer() -> TriggerDefinition {
+    TriggerDefinition::new(TriggerMode::Sacrificed)
+        .valid_card(TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact)))
+        .trigger_zones(vec![Zone::Battlefield])
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+        ))
+}
+
+fn run_trigger_collection_fixture(fixture: impl FnOnce() + Send + 'static) {
+    std::thread::Builder::new()
+        // Journaled zone-change LKI exceeds the default 2 MiB test-thread stack.
+        .stack_size(4 * 1024 * 1024)
+        .spawn(fixture)
+        .expect("trigger collection fixture thread starts")
+        .join()
+        .expect("trigger collection fixture completes")
+}
+
+fn assert_current_action_consumed_occurrences_were_journaled(
+    state: &GameState,
+    events: &[GameEvent],
+) {
+    let expected = current_action_occurrences(events);
+    assert!(
+        state
+            .resolved_rules_journal
+            .entries()
+            .iter()
+            .any(|entry| matches!(
+                entry.command.as_ref(),
+                Some(ResolvedRulesCommand::TriggerCollection(ResolvedTriggerCollectionCommand {
+                    collection: ResolvedTriggerCollection::ConsumeBeforePriority { occurrences },
+                    ..
+                })) if occurrences == &expected
+            )),
+        "the production cost settlement must journal its exact current-action consumed occurrences"
+    );
 }
 
 #[test]
@@ -224,5 +328,183 @@ fn real_change_zone_resolver_journals_its_collected_trigger_occurrences() {
             }) if contexts.iter().any(|context| context.pending.source_id == observer)
         )),
         "logical-zone segment collection must journal the observer context"
+    );
+}
+
+#[test]
+fn paused_mana_cost_settlement_journals_consumed_occurrences_without_recollecting() {
+    run_trigger_collection_fixture(
+        paused_mana_cost_settlement_journals_consumed_occurrences_without_recollecting_impl,
+    );
+}
+
+fn paused_mana_cost_settlement_journals_consumed_occurrences_without_recollecting_impl() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let observer = scenario
+        .add_creature(P0, "Mana cost sacrifice observer", 1, 1)
+        .with_trigger_definition(sacrifice_observer())
+        .id();
+    let source = scenario
+        .add_creature(P0, "Self-sacrifice mana replacement witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::Mana {
+                    produced: ManaProduction::Fixed {
+                        colors: vec![ManaColor::Green],
+                        contribution: ManaContribution::Base,
+                    },
+                    restrictions: Vec::new(),
+                    grants: Vec::new(),
+                    expiry: None,
+                    target: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Tap,
+                    AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1)),
+                ],
+            }),
+        )
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let mut runner = scenario.build();
+
+    let paused = runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("the mana cost reaches its real replacement choice after its tap prefix");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the replacement choice resumes the mana cost settlement");
+    assert_eq!(runner.state().objects[&source].zone, Zone::Exile);
+    assert!(resumed.events.iter().any(|event| matches!(
+        event,
+        GameEvent::ZoneChanged { object_id, .. } if *object_id == source
+    )));
+    assert_current_action_consumed_occurrences_were_journaled(runner.state(), &resumed.events);
+    assert_eq!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .filter(|entry| matches!(
+                entry.kind,
+                StackEntryKind::TriggeredAbility { source_id, .. } if source_id == observer
+            ))
+            .count(),
+        1,
+        "the settled mana-cost zone change must not be collected again at priority"
+    );
+}
+
+#[test]
+fn paused_sacrifice_cost_settlement_journals_consumed_occurrences_without_recollecting() {
+    run_trigger_collection_fixture(
+        paused_sacrifice_cost_settlement_journals_consumed_occurrences_without_recollecting_impl,
+    );
+}
+
+fn paused_sacrifice_cost_settlement_journals_consumed_occurrences_without_recollecting_impl() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let observer = scenario
+        .add_creature(P0, "Sacrifice cost artifact observer", 1, 1)
+        .with_trigger_definition(artifact_sacrifice_observer())
+        .id();
+    let source = scenario
+        .add_creature(P0, "Count-two sacrifice activation witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    player: TargetFilter::Controller,
+                },
+            )
+            .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+                TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                2,
+            ))),
+        )
+        .id();
+    let first = scenario
+        .add_creature(P0, "First sacrifice-cost witness", 1, 1)
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second sacrifice-cost replacement witness", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let mut runner = scenario.build();
+    let second_object = runner
+        .state_mut()
+        .objects
+        .get_mut(&second)
+        .expect("the second sacrifice witness exists");
+    second_object.card_types.core_types.push(CoreType::Artifact);
+    second_object.base_card_types = second_object.card_types.clone();
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("the sacrifice-cost activation begins");
+    let paused = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("the second sacrifice reaches its real replacement choice");
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    let resumed = runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("the replacement choice resumes the sacrifice cost settlement");
+    assert_eq!(runner.state().objects[&second].zone, Zone::Exile);
+    assert!(resumed.events.iter().any(|event| matches!(
+        event,
+        GameEvent::ZoneChanged { object_id, .. } if *object_id == second
+    )));
+    let current_end = resumed
+        .events
+        .iter()
+        .position(|event| {
+            matches!(
+                event,
+                GameEvent::PermanentSacrificed { object_id, .. } if *object_id == second
+            )
+        })
+        .expect("the settled second sacrifice emits its terminal sacrifice event")
+        + 1;
+    assert_current_action_consumed_occurrences_were_journaled(
+        runner.state(),
+        &resumed.events[..current_end],
+    );
+    assert_eq!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .filter(|entry| matches!(
+                entry.kind,
+                StackEntryKind::TriggeredAbility { source_id, .. } if source_id == observer
+            ))
+            .count(),
+        1,
+        "the second settled sacrifice must not be collected again at priority"
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trigger handling during sacrifice and mana-cost settlement.
  * Ensured triggered abilities are collected exactly once when replacement choices pause an action.
  * Improved journal tracking so consumed trigger events remain accurate after resuming settlement.

* **Tests**
  * Added regression coverage for paused cost settlement, replacement choices, zone changes, and trigger collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->