### PR TITLE
fix(ci): sync client/src-tauri/Cargo.lock with the v0.35.2 version bump

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -2616,7 +2616,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phase-tauri"
-version = "0.35.1"
+version = "0.35.2"
 dependencies = [
  "futures-util",
  "minisign-verify",


### PR DESCRIPTION
## Problem

`tauri-check` is failing on **every open PR** whose merge ref includes the v0.35.2 release commit:

```
error: cannot update the lock file /home/runner/work/phase/phase/client/src-tauri/Cargo.lock
       because --locked was passed to prevent this
```

`release: v0.35.2` (21a53d50cb) bumped `client/src-tauri/Cargo.toml` to `0.35.2` via cargo-release's `pre-release-replacements` (root `Cargo.toml` line 27), but `client/src-tauri/` is a **separate cargo workspace with its own lockfile** that cargo-release does not manage. The lock still recorded `phase-tauri 0.35.1`, so `cargo check --locked` refused to reconcile and exited 101.

## Why this is a merge blocker, not cosmetic

`Tauri compile check` is not itself a repo-required context, but the required aggregator `Rust (fmt, clippy, test, coverage-gate)` declares `needs: [rust-lint, rust-test, card-data-gate, draft-pools, wasm-check, tauri-check]` and fails unless every result is `success` or `skipped`. So the failing job reds a required check on all affected PRs and stalls the merge queue repo-wide.

## Evidence (pass→fail flips exactly at the release commit)

| PR | run created (UTC) | tauri-check |
|----|-------------------|-------------|
| #6561 | 20:43:00Z | **pass** |
| — | 20:49:54Z | `release: v0.35.2` lands |
| #6564 | 20:56:21Z | **fail** |
| #6563 | 21:15:11Z | **fail** |

None of those three PRs touches any Cargo manifest or lockfile — the failures are entirely maintainer-caused.

## Change

One line: `phase-tauri` `0.35.1` → `0.35.2` in `client/src-tauri/Cargo.lock`. Verified byte-identical to the lock `cargo` itself produces for that manifest.

## Follow-up (deliberately not in this PR)

cargo-release should keep the nested `client/src-tauri/Cargo.lock` in sync so the next release does not re-break this. That touches release infrastructure and wants its own maintainer review — filing separately rather than bundling it into an unblock.