### PR TITLE
fix(release): regenerate client/src-tauri/Cargo.lock for v0.35.2

### DIFF
--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -2616,7 +2616,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phase-tauri"
-version = "0.35.1"
+version = "0.35.2"
 dependencies = [
  "futures-util",
  "minisign-verify",


### PR DESCRIPTION
release: v0.35.2 (21a53d50cb) bumped client/src-tauri/Cargo.toml to
0.35.2 but left client/src-tauri/Cargo.lock pinning phase-tauri 0.35.1.
The Tauri compile check runs `cargo check --locked`, which refuses to
update the lock, so the job fails on main, on every merge-group ref, and
on every open PR based on the release tip. That job is a `needs:` of the
required aggregator (.github/workflows/ci.yml:623-633), so the merge
queue ejects everything it builds.
