### PR TITLE
ci: give the "Latest" release badge to the desktop installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -961,4 +961,11 @@ jobs:
           tag_name: ${{ env.RELEASE_TAG }}
           body_path: changelog.md
           fail_on_unmatched_files: true
+          # Never the "Latest" release. Every asset here is a machine artifact
+          # the desktop shell provisions for itself; the web app ships by
+          # deploy, not by download. These fire far more often than shell
+          # releases, so leaving the badge to default sends anyone visiting
+          # /releases/latest to a page of server binaries with no installer.
+          # The desktop release claims the badge instead (shell-release.yml).
+          make_latest: "false"
           files: ${{ steps.release-assets.outputs.files }}

--- a/.github/workflows/shell-release.yml
+++ b/.github/workflows/shell-release.yml
@@ -387,9 +387,12 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.SHELL_TAG }}
-          name: Phase Desktop v${{ env.SHELL_VERSION }}
+          name: phase.rs Desktop v${{ env.SHELL_VERSION }}
+          # The installer is the only thing a human comes to /releases for, so
+          # it holds the "Latest" badge; web releases opt out (release.yml).
+          make_latest: "true"
           body: |
-            ## Install Phase Desktop
+            ## Install phase.rs Desktop
 
             Download the installer for your platform:
 


### PR DESCRIPTION
Every asset on a web release is a machine artifact the desktop shell
provisions for itself, and those releases fire far more often than shell
releases — so /releases/latest showed a page of phase-server-slim
binaries with no installer on it, which is not what anyone visiting the
releases page is looking for. Web releases now opt out of the badge and
the shell release claims it.

Also names the shell release "phase.rs Desktop", matching the app's own
window title, so the download is identifiable as the desktop app rather
than as a bare tag.

The live shell-v1.0.1 release was retitled and pinned by hand; this makes
the next one do it on its own.
