### PR TITLE
policy(contributor): grandfather pre-cutoff tier declarations; reap dissolved merge groups

### DIFF
--- a/.github/workflows/merge-queue-janitor.yml
+++ b/.github/workflows/merge-queue-janitor.yml
@@ -1,0 +1,78 @@
+name: Merge queue janitor
+
+# Cancels CI runs belonging to dissolved merge groups.
+#
+# Every time the merge queue gains or loses an entry it re-synthesizes the whole
+# group: the old `gh-readonly-queue/<base>/pr-<N>-<sha>` refs are deleted and new
+# ones are created, each minting a fresh full CI run. The superseded runs are NOT
+# cleaned up by `concurrency` — ci.yml keys its group on `github.ref`, which is
+# unique per synthesized ref, so `cancel-in-progress` can never match them.
+#
+# There is no way to fix this in the concurrency key itself. GitHub's expression
+# language has no regex or split, so a `concurrency.group` cannot extract the PR
+# number from the ref; and keying on the base branch would cancel LIVE speculative
+# groups, which the queue reads as a failed check and evicts the entry for.
+#
+# So the cleanup is explicit: a run whose `head_branch` no longer resolves to a ref
+# can never check out and can never report. Cancelling it is pure garbage
+# collection. On 2026-07-24 a single evening accumulated 22 such runs (~198 queued
+# jobs) against a 20-job concurrency cap.
+#
+# Ref-absence is an orphan test, NOT a liveness test — an already-completed run's
+# ref also gets reaped. Only queued/in_progress runs are considered, so a finished
+# run is never touched.
+#
+# Limitation: during a hosted-runner outage this janitor is itself queued and
+# cannot run. It prevents accumulation in normal operation, not during a stall.
+
+on:
+  merge_group:
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: merge-queue-janitor
+  cancel-in-progress: false
+
+jobs:
+  reap:
+    name: Cancel dissolved merge-group runs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Cancel runs whose merge-group ref no longer exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Live merge-group refs, one per line.
+          gh api "/repos/$REPO/git/matching-refs/heads/gh-readonly-queue" \
+            --jq '.[].ref | sub("^refs/heads/"; "")' | sort > live_refs.txt
+          echo "live merge-group refs: $(wc -l < live_refs.txt)"
+
+          reaped=0
+          for status in queued in_progress; do
+            gh api "/repos/$REPO/actions/runs?event=merge_group&status=$status&per_page=100" \
+              --jq '.workflow_runs[] | [.id, .head_branch] | @tsv' > "runs_$status.tsv" || true
+
+            while IFS=$'\t' read -r id branch; do
+              [ -n "${id:-}" ] || continue
+              if grep -qxF "$branch" live_refs.txt; then
+                continue    # group is still live — leave it alone
+              fi
+              echo "orphan ($status): $id  $branch"
+              # `cancel` is deferred for a run that never reached a runner; fall
+              # back to force-cancel, which bypasses that precondition.
+              gh api -X POST "/repos/$REPO/actions/runs/$id/cancel" --silent \
+                || gh api -X POST "/repos/$REPO/actions/runs/$id/force-cancel" --silent \
+                || echo "  could not cancel $id (already terminal?)"
+              reaped=$((reaped + 1))
+            done < "runs_$status.tsv"
+          done
+
+          echo "reaped $reaped dissolved merge-group run(s)"

--- a/docs/AI-CONTRIBUTOR.md
+++ b/docs/AI-CONTRIBUTOR.md
@@ -33,6 +33,8 @@ Skill references in this section use the `$skill` / `/skill` convention defined 
 
 If you cannot determine your model, abort — do not guess and do not proceed on the assumption that you qualify. Tier cannot satisfy the artifact gate or authorize architecture scope.
 
+**Applies to PRs opened on or after 2026-07-24.** Pull requests opened before that date are judged on their code, not their declared tier — the Standard tier was accepted policy when they were written, and a contributor who reported a Sonnet or Composer run accurately was following the rules as published. Do not close an older PR for a declaration that was correct when it was made. This grandfathering covers the declaration only: every other gate in this document applies to open PRs regardless of age.
+
 **Agentic harnesses (Cursor, and similar).** Using an agentic harness is allowed, but a `Co-authored-by: Cursor <cursoragent@cursor.com>` trailer (or equivalent) on your commits **raises the review bar rather than lowering it**, and the underlying model must still be Frontier tier. The pattern that earns an immediate close is pushing changes you have not verified and using repo CI and maintainer review as your correction loop — reverting a fix to push a diagnostic commit so CI prints a value for you, or deleting an assertion to turn a job green, are both treated as that pattern. Run the gates locally, understand the change, then push.
 
 ### 0.1.2. Pre-PR gates
@@ -74,7 +76,7 @@ Every PR body must include a single canonical line on its own line:
 Tier: Frontier
 ```
 
-`Frontier` is the only accepted value — see §0.1.1. `/pr-contribution-handler` reads this line, and it is never evidence of quality or authority on its own. A missing, malformed, or non-`Frontier` line means the PR is closed as out-of-policy without an implementation review. Do not editorialize.
+`Frontier` is the only accepted value — see §0.1.1. `/pr-contribution-handler` reads this line, and it is never evidence of quality or authority on its own. A missing, malformed, or non-`Frontier` line means the PR is closed as out-of-policy without an implementation review, subject to the 2026-07-24 cutoff in §0.1.1. Do not editorialize.
 
 ---
 


### PR DESCRIPTION
The Frontier-only tier rule landed in #6579 with no cutoff clause, so read
literally it closes PRs opened weeks earlier that declared Sonnet or Composer
accurately under the then-current Standard tier. That inverts the incentive the
disclosure rule exists to create: the only PRs the rule can find are the ones
whose authors filled the field in honestly. Scope it to PRs opened on or after
2026-07-24 and cross-reference the cutoff from the Tier-line section.

Add a janitor for dissolved merge groups. Every queue reformation deletes the
gh-readonly-queue refs and mints new ones, and ci.yml's concurrency group is
keyed on github.ref -- unique per synthesized ref -- so cancel-in-progress can
never match the superseded runs. One evening accumulated 22 such runs (~198
queued jobs) against a 20-job concurrency cap.

This cannot be fixed in the concurrency key: GitHub's expression language has no
regex or split, so a concurrency.group cannot extract the PR number from the ref,
and keying on the base branch would cancel live speculative groups -- which the
queue reads as a failed check and evicts the entry for. Cancelling runs whose ref
no longer resolves is the safe equivalent, and only queued/in_progress runs are
considered so a completed run whose ref was reaped is never touched.

Paired with a ruleset change (applied out-of-band): max_entries_to_build 5 -> 2,
since 5 speculative groups x 9 jobs requests 45 jobs against a 20-job cap; and
check_response_timeout_minutes 60 -> 120, which evicted an approved PR ten
seconds past deadline during a hosted-runner stall whose CI then passed.
