### PR TITLE
feat(native-engine): resumable solo games + fix Windows draft-pools boot hang

### DIFF
--- a/client/src-tauri/src/native_engine.rs
+++ b/client/src-tauri/src/native_engine.rs
@@ -342,6 +342,17 @@ impl NativeEngineFiles {
         self.key_directory(key).join("data")
     }
 
+    /// Version-independent path for the server's game-persistence database.
+    /// Keyed by channel only (not the version/fingerprint that names
+    /// `key_directory`), so saved games survive engine updates within a channel
+    /// while `preview` and `release` stay isolated — they load different
+    /// content and must not share sessions.
+    fn games_db(&self, key: &NativeEngineKey) -> PathBuf {
+        self.base
+            .join("games")
+            .join(format!("{}.db", key.channel()))
+    }
+
     fn cache_directory(&self) -> PathBuf {
         self.base.join(CACHE_DIRECTORY)
     }
@@ -618,6 +629,7 @@ fn ensure_native_engine_sync(
     let (mut child, stdin) = spawn_server(
         &binary_path,
         &files.data_directory(&key),
+        &files.games_db(&key),
         port,
         key.origin(),
     )?;
@@ -1001,16 +1013,21 @@ fn reserve_port() -> Result<u16, NativeEngineError> {
 fn spawn_server(
     binary: &Path,
     data_directory: &Path,
+    games_db: &Path,
     port: u16,
     origin: &str,
 ) -> Result<(Child, ChildStdin), NativeEngineError> {
     let mut child = Command::new(binary)
         .env("PORT", port.to_string())
         .env("PHASE_DATA_DIR", data_directory)
+        .env("PHASE_GAMES_DB", games_db)
         .args([
             "--bind",
             "127.0.0.1",
             "--exit-on-stdin-close",
+            // A desktop shell hosts one local player: keep the suspended solo
+            // game resumable until replaced (no stale purge, no reconnect expiry).
+            "--single-user",
             "--allowed-origin",
             origin,
         ])

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -281,6 +281,22 @@ export class WebSocketAdapter implements EngineAdapter {
     return this._playerId;
   }
 
+  /** Reconnect credentials for this session, or null until the server has
+   *  assigned them (i.e. game creation has completed). Solo-AI native games
+   *  persist this so a suspended game can be resumed by constructing a
+   *  `kind: "reconnect"` adapter. The player token is issued once at creation
+   *  and lives only client-side — it is the reconnect security boundary. */
+  get nativeSession(): { gameCode: string; playerId: PlayerId; playerToken: string } | null {
+    if (this._gameCode === null || this._playerId === null || this.playerToken === null) {
+      return null;
+    }
+    return {
+      gameCode: this._gameCode,
+      playerId: this._playerId,
+      playerToken: this.playerToken,
+    };
+  }
+
   onEvent(listener: WsAdapterEventListener): () => void {
     this.listeners.push(listener);
     return () => {

--- a/client/src/hooks/useResumables.ts
+++ b/client/src/hooks/useResumables.ts
@@ -5,6 +5,11 @@ import { persistedGameStateView } from "../adapter/types";
 import { loadP2PSession } from "../services/p2pSession";
 import { loadWsSession } from "../services/multiplayerSession";
 import {
+  canAttemptNativeEngine,
+  nativeEngineKeyForCurrentOrigin,
+} from "../services/nativeEngine";
+import { usePreferencesStore } from "../stores/preferencesStore";
+import {
   loadActiveQuickDraft,
   type ActiveQuickDraftMeta,
 } from "../services/quickDraftPersistence";
@@ -79,6 +84,22 @@ export function useResumables(): Resumables {
         if (session) setMatch(saved);
         else clearActiveGame();
       });
+    } else if (saved.nativeSession) {
+      // Native solo (AI) games are server-authoritative: their state lives in
+      // the local phase-server, not IndexedDB, so there is no snapshot to
+      // validate against here. The reconnect on resume is the real validation.
+      // No matchSummary — turn/life aren't available client-side until we
+      // reconnect, so the resume hero shows the match without a board snapshot.
+      //
+      // Only offer it when the native engine can actually be attached
+      // (enabled + available for this origin). Resuming routes back through the
+      // native path, which needs the engine; if it is unavailable the resume
+      // would dead-end at a fresh in-browser game. Keep the pointer silently so
+      // the resume reappears once native is available again — don't clear it.
+      const nativeAvailable =
+        canAttemptNativeEngine(usePreferencesStore.getState().nativeEngineEnabled)
+        && nativeEngineKeyForCurrentOrigin() !== null;
+      if (nativeAvailable) setMatch(saved);
     } else {
       loadGame(saved.id).then((state) => {
         if (cancelled) return;

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -651,6 +651,7 @@ export function GameProvider({
       initGame,
       resumeGame,
       resumeP2PHost,
+      resumeNativeSolo,
       reset,
       setEngineMode,
       setGameMode,
@@ -1489,62 +1490,84 @@ export function GameProvider({
         // back to WASM, so surfacing GamePage's terminal connection-lost banner
         // would paint it over a healthy local game that plays on underneath.
         let nativeSessionLive = false;
+        // A native pointer marks a server-authoritative game held by the local
+        // phase-server; it is resumed by reconnecting, not by loading a local
+        // snapshot. Presence of `nativeSession` on this game's active pointer is
+        // the resume signal (fresh games have no pointer yet at this point).
+        const activePointer = loadActiveGame();
+        const nativeResume =
+          activePointer?.id === gameId ? activePointer.nativeSession : undefined;
+        // Populated only for a fresh game; a reconnect ignores the deck entirely.
+        let deckList: DeckListPayload | undefined;
         try {
-          // Native sessions deliberately do not resume a local snapshot. A
-          // pre-existing state belongs to the established WASM path instead.
-          if (await loadGame(gameId)) {
+          // A local snapshot belongs to the established WASM path — but only for
+          // a fresh game. A native resume has no local snapshot (state lives in
+          // the phase-server), so a stray one must never hijack the reconnect.
+          if (!nativeResume && (await loadGame(gameId))) {
             setEngineMode("wasm");
             await setupLocal();
             return;
           }
           if (cancelled) return;
 
-          const activeDeckName = localStorage.getItem(ACTIVE_DECK_KEY);
-          const randomPlayerDeck = isRandomDeckSelection(activeDeckName);
-          const parsedDeck = randomPlayerDeck ? null : loadActiveDeck();
-          const suppliesDeck = formatConfig ? formatSuppliesDeck(formatConfig.format) : false;
-          if (!parsedDeck && !suppliesDeck && !randomPlayerDeck) {
-            onNoDeckRef.current?.();
-            return;
+          if (!nativeResume) {
+            const activeDeckName = localStorage.getItem(ACTIVE_DECK_KEY);
+            const randomPlayerDeck = isRandomDeckSelection(activeDeckName);
+            const parsedDeck = randomPlayerDeck ? null : loadActiveDeck();
+            const suppliesDeck = formatConfig ? formatSuppliesDeck(formatConfig.format) : false;
+            if (!parsedDeck && !suppliesDeck && !randomPlayerDeck) {
+              onNoDeckRef.current?.();
+              return;
+            }
+
+            deckList = await buildLocalAiDeckList(
+              tRef.current,
+              randomPlayerDeck ? null : (parsedDeck ?? EMPTY_PARSED_DECK),
+              playerCount ?? 2,
+              formatConfig,
+              matchConfig?.match_type,
+              loadActiveDeckBracket(),
+            );
+            if (cancelled) return;
           }
 
-          const deckList = await buildLocalAiDeckList(
-            tRef.current,
-            randomPlayerDeck ? null : (parsedDeck ?? EMPTY_PARSED_DECK),
-            playerCount ?? 2,
-            formatConfig,
-            matchConfig?.match_type,
-            loadActiveDeckBracket(),
-          );
-          if (cancelled) return;
-
-          // Native games are server-authoritative and have no client resume
-          // contract in v1, so remove the setup-page pointer before hosting.
-          clearActiveGame();
           await ensureNativeEngine(nativeEngineKey);
           if (cancelled) return;
 
+          const expectedServerVersion =
+            "release" in nativeEngineKey ? nativeEngineKey.release.version : undefined;
           nativeAdapter = new WebSocketAdapter(
             "native-engine",
             "host",
-            deckList.player,
+            deckList?.player ?? { main_deck: [], sideboard: [] },
             undefined,
             undefined,
             undefined,
             "Player",
-            {
-              nativeAi: {
-                socketFactory: () => new NativeEngineSocket(),
-                aiSeats: nativeAiSeatsFromDeckList(deckList),
-                playerCount: playerCount ?? 2,
-                formatConfig,
-                matchConfig,
-                expectedServerVersion:
-                  "release" in nativeEngineKey ? nativeEngineKey.release.version : undefined,
-              },
-            },
+            nativeResume
+              ? {
+                  nativePregame: {
+                    kind: "reconnect",
+                    gameCode: nativeResume.gameCode,
+                    playerId: nativeResume.playerId,
+                    playerToken: nativeResume.playerToken,
+                    socketFactory: () => new NativeEngineSocket(),
+                    expectedServerVersion,
+                  },
+                }
+              : {
+                  nativeAi: {
+                    socketFactory: () => new NativeEngineSocket(),
+                    aiSeats: nativeAiSeatsFromDeckList(deckList!),
+                    playerCount: playerCount ?? 2,
+                    formatConfig,
+                    matchConfig,
+                    expectedServerVersion,
+                  },
+                },
           );
-          wsUnsubscribe = nativeAdapter.onEvent((event) => {
+
+          const handleNativeEvent = (event: WsAdapterEvent) => {
             if (event.type === "stateChanged") {
               const adapter = nativeAdapter;
               if (!useGameStore.getState().adapter && adapter) {
@@ -1568,35 +1591,90 @@ export function GameProvider({
               }
               // GamePage's existing reconnect-failed/error surface is terminal
               // and provides the Return-to-Menu action for this native session.
-              // Setup failures instead reject the pending `initGame`, which the
-              // `catch` turns into a WASM fallback with no banner.
+              // Setup failures instead reject the pending init, which the
+              // `catch` turns into a fallback with no banner.
               if (nativeSessionLive) onWsEventRef.current?.(event);
             }
-          });
+          };
 
           setEngineMode("native");
-          await initGame(
-            gameId,
-            nativeAdapter,
-            undefined,
-            formatConfig,
-            playerCount,
-            matchConfig,
-          );
-          if (cancelled) {
-            nativeAdapter.dispose({ concede: true });
-            return;
+          if (nativeResume) {
+            // Reconnect and seed from the server's authoritative state. Events
+            // are wired AFTER this: `initialize()` emits the initial
+            // `stateChanged` synchronously, which `resumeNativeSolo`'s snapshot
+            // fetch already captures — a listener here would double-apply it.
+            await resumeNativeSolo(gameId, nativeAdapter);
+            if (cancelled) {
+              nativeAdapter.dispose();
+              return;
+            }
+            wsUnsubscribe = nativeAdapter.onEvent(handleNativeEvent);
+          } else {
+            wsUnsubscribe = nativeAdapter.onEvent(handleNativeEvent);
+            await initGame(
+              gameId,
+              nativeAdapter,
+              undefined,
+              formatConfig,
+              playerCount,
+              matchConfig,
+            );
+            if (cancelled) {
+              nativeAdapter.dispose();
+              return;
+            }
           }
 
           setGameMode("native-ai");
           controller = createGameLoopController({ mode: "online" });
           controller.start();
           nativeSessionLive = true;
+          // Persist the resume pointer only now that the session is live — an
+          // earlier write would strand a Resume button if setup failed midway.
+          // Suspending (navigating away) keeps this pointer; only an explicit
+          // Concede (useConcedeHandler → clearGame) removes it. The player token
+          // lives only here — it is the reconnect credential.
+          const session = nativeAdapter.nativeSession;
+          if (session) {
+            saveActiveGame(
+              nativeResume && activePointer
+                ? { ...activePointer, nativeSession: session }
+                : {
+                    id: gameId,
+                    mode: "ai",
+                    difficulty: difficulty ?? "Medium",
+                    aiSeats: deckList
+                      ? nativeAiSeatsFromDeckList(deckList).map((seat) => ({
+                          difficulty: seat.difficulty,
+                        }))
+                      : undefined,
+                    formatConfig,
+                    nativeSession: session,
+                  },
+            );
+          }
           audioManager.setContext("battlefield");
         } catch (error) {
-          nativeAdapter?.dispose({ concede: true });
+          // Setup failed before the session went live — suspend (never concede);
+          // there is nothing authoritative to end.
+          nativeAdapter?.dispose();
           nativeAdapter = null;
           if (cancelled) return;
+
+          if (nativeResume) {
+            // A resume has no local snapshot to fall back to — the state lives
+            // only in the phase-server. Surface the failure via the terminal
+            // reconnect/error banner instead of silently starting a fresh WASM
+            // game (which would look like the suspended game vanished). The
+            // pointer is kept so the player can retry once the engine is back.
+            setGameMode("ai");
+            setEngineMode("native", nativeFallbackReason(error));
+            onWsEventRef.current?.({
+              type: "error",
+              message: error instanceof Error ? error.message : String(error),
+            });
+            return;
+          }
 
           const fallbackReason = nativeFallbackReason(error);
           setGameMode("ai");
@@ -1622,7 +1700,11 @@ export function GameProvider({
         cancelled = true;
         if (controller) controller.dispose();
         if (wsUnsubscribe) wsUnsubscribe();
-        nativeAdapter?.dispose({ concede: true });
+        // Suspend, don't concede: leaving the game page keeps the server-side
+        // session alive and resumable via the persisted native pointer. Only an
+        // explicit Concede (useConcedeHandler) ends the game. `dispose()` still
+        // tears down the socket/loop; it just omits the concede frame.
+        nativeAdapter?.dispose();
         audioManager.setContext("menu");
         clearPromptOverlayState();
         scheduleStoreReset(reset);

--- a/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
+++ b/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
@@ -16,6 +16,7 @@ const {
   fetchAvatarArtUrl,
   gameStoreState,
   getSharedAdapter,
+  loadActiveGame,
   nativeAdapterInitialize,
   nativeAdapters,
   multiplayerDraftGetState,
@@ -42,9 +43,16 @@ const {
     cedhMode: false,
     nativeEngineEnabled: true,
   };
+  type NativePregameReconnect = {
+    kind: string;
+    gameCode: string;
+    playerId: number;
+    playerToken: string;
+  };
   class WebSocketAdapter {
     private listener: ((event: NativeAdapterEvent) => void) | null = null;
     readonly nativeAiOptions: { aiSeats: Array<{ difficulty: string }> } | undefined;
+    readonly nativePregameOptions: NativePregameReconnect | undefined;
     dispose = vi.fn();
     onEvent = vi.fn((listener: (event: NativeAdapterEvent) => void) => {
       this.listener = listener;
@@ -61,14 +69,30 @@ const {
       _joinPassword?: string,
       _reservationToken?: string,
       _displayName?: string,
-      options?: { nativeAi?: { aiSeats: Array<{ difficulty: string }> } },
+      options?: {
+        nativeAi?: { aiSeats: Array<{ difficulty: string }> };
+        nativePregame?: NativePregameReconnect;
+      },
     ) {
       this.nativeAiOptions = options?.nativeAi;
+      this.nativePregameOptions = options?.nativePregame;
       nativeAdapters.push(this);
     }
 
     initialize(): Promise<void> {
       return nativeAdapterInitialize();
+    }
+
+    // Reconnect adapters echo their supplied creds; a fresh game gets a stable
+    // server-issued session so the resume pointer can be persisted.
+    get nativeSession(): { gameCode: string; playerId: number; playerToken: string } {
+      return this.nativePregameOptions
+        ? {
+            gameCode: this.nativePregameOptions.gameCode,
+            playerId: this.nativePregameOptions.playerId,
+            playerToken: this.nativePregameOptions.playerToken,
+          }
+        : { gameCode: "NATIVE-SESSION", playerId: 0, playerToken: "native-token" };
     }
 
     emit(event: NativeAdapterEvent): void {
@@ -100,6 +124,11 @@ const {
     }),
     resumeGame: vi.fn(),
     resumeP2PHost: vi.fn(),
+    resumeNativeSolo: vi.fn(async (gameId: string, adapter: { initialize: () => Promise<void> }) => {
+      gameStoreState.gameId = gameId;
+      gameStoreState.adapter = adapter;
+      await adapter.initialize();
+    }),
     reset: vi.fn(),
     setEngineMode: vi.fn(),
     setGameMode: vi.fn(),
@@ -135,6 +164,7 @@ const {
     fetchAvatarArtUrl,
     gameStoreState,
     getSharedAdapter,
+    loadActiveGame: vi.fn<() => Record<string, unknown> | null>(() => null),
     nativeAdapterInitialize,
     nativeAdapters,
     multiplayerDraftGetState,
@@ -171,7 +201,7 @@ vi.mock("../../stores/gameStore", () => ({
   clearActiveGame,
   clearGame: vi.fn(),
   clearP2PHostSession: vi.fn(),
-  loadActiveGame: vi.fn(() => null),
+  loadActiveGame,
   loadGame: vi.fn(async () => null),
   loadP2PHostSession: vi.fn(),
   nextGameSessionGeneration: vi.fn(() => 1),
@@ -294,6 +324,10 @@ describe("GameProvider native AI routing", () => {
     fetchAvatarArtUrl.mockReset();
     nativeAdapterInitialize.mockReset();
     saveActiveGame.mockReset();
+    loadActiveGame.mockReset();
+    loadActiveGame.mockReturnValue(null);
+    gameStoreState.resumeNativeSolo.mockClear();
+    gameStoreState.initGame.mockClear();
     nativeAdapters.splice(0);
     wasmAdapters.splice(0);
     multiplayerDraftGetState.mockReset();
@@ -344,9 +378,9 @@ describe("GameProvider native AI routing", () => {
     );
   });
 
-  it("does not write a resume pointer for a native game and concedes on exit", async () => {
+  it("writes a native resume pointer and suspends (no concede) on exit", async () => {
     const view = render(
-      <GameProvider gameId="native-no-resume" mode="ai">
+      <GameProvider gameId="native-resume-write" mode="ai">
         <div />
       </GameProvider>,
     );
@@ -361,13 +395,94 @@ describe("GameProvider native AI routing", () => {
     expect(gameStoreState.setEngineMode.mock.invocationCallOrder[nativeEngineModeCall]).toBeLessThan(
       gameStoreState.initGame.mock.invocationCallOrder[0],
     );
-    expect(clearActiveGame).toHaveBeenCalledOnce();
-    expect(saveActiveGame).not.toHaveBeenCalled();
-    expect(multiplayerGetState).not.toHaveBeenCalled();
+
+    // A live native game persists a server-authoritative resume pointer carrying
+    // the reconnect credentials — the old no-resume contract cleared it instead.
+    await waitFor(() => {
+      expect(saveActiveGame).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "native-resume-write",
+          mode: "ai",
+          nativeSession: expect.objectContaining({
+            gameCode: "NATIVE-SESSION",
+            playerToken: "native-token",
+          }),
+        }),
+      );
+    });
+    expect(clearActiveGame).not.toHaveBeenCalled();
 
     view.unmount();
     expect(nativeAdapters).toHaveLength(1);
-    expect(nativeAdapters[0].dispose).toHaveBeenCalledWith({ concede: true });
+    // Suspend, not concede: leaving keeps the server session resumable. Only an
+    // explicit Concede (useConcedeHandler) ends the game.
+    expect(nativeAdapters[0].dispose).toHaveBeenCalledWith();
+  });
+
+  it("reconnects to a suspended native game via its resume pointer", async () => {
+    loadActiveGame.mockReturnValue({
+      id: "native-resume-read",
+      mode: "ai",
+      difficulty: "Medium",
+      nativeSession: { gameCode: "GAME-XYZ", playerId: 0, playerToken: "tok-xyz" },
+    });
+
+    render(
+      <GameProvider gameId="native-resume-read" mode="ai">
+        <div />
+      </GameProvider>,
+    );
+
+    await waitFor(() => {
+      expect(gameStoreState.resumeNativeSolo).toHaveBeenCalled();
+    });
+
+    // The adapter is built with a reconnect pregame frame carrying the persisted
+    // credentials, and the fresh-game `initGame` path is never taken.
+    expect(nativeAdapters).toHaveLength(1);
+    expect(nativeAdapters[0].nativePregameOptions).toEqual(
+      expect.objectContaining({
+        kind: "reconnect",
+        gameCode: "GAME-XYZ",
+        playerId: 0,
+        playerToken: "tok-xyz",
+      }),
+    );
+    expect(gameStoreState.resumeNativeSolo).toHaveBeenCalledWith(
+      "native-resume-read",
+      nativeAdapters[0],
+    );
+    expect(gameStoreState.initGame).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a terminal error when a native resume fails, without a WASM fallback", async () => {
+    loadActiveGame.mockReturnValue({
+      id: "native-resume-fail",
+      mode: "ai",
+      difficulty: "Medium",
+      nativeSession: { gameCode: "GONE", playerId: 0, playerToken: "tok" },
+    });
+    // The reconnect handshake fails (e.g. the server no longer holds the game).
+    nativeAdapterInitialize.mockRejectedValue(new Error("Reconnect grace period expired"));
+    const onWsEvent = vi.fn();
+
+    render(
+      <GameProvider gameId="native-resume-fail" mode="ai" onWsEvent={onWsEvent}>
+        <div />
+      </GameProvider>,
+    );
+
+    await waitFor(() => {
+      expect(onWsEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", message: "Reconnect grace period expired" }),
+      );
+    });
+    // A resume has no local snapshot, so it must NOT silently fall back to a
+    // fresh WASM game (which would look like the suspended game vanished).
+    expect(gameStoreState.initGame).not.toHaveBeenCalled();
+    expect(wasmAdapters).toHaveLength(0);
+    // The pointer is kept so the player can retry once the engine is back.
+    expect(clearActiveGame).not.toHaveBeenCalled();
   });
 
   it("uses each commander's name for native AI opponents", async () => {

--- a/client/src/services/gamePersistence.ts
+++ b/client/src/services/gamePersistence.ts
@@ -6,6 +6,7 @@ import type {
   GameState,
   MatchConfig,
   PersistedGameState,
+  PlayerId,
 } from "../adapter/types";
 import type { SeatState } from "../multiplayer/seatTypes";
 import { ACTIVE_GAME_KEY, GAME_CHECKPOINTS_PREFIX, GAME_KEY_PREFIX } from "../constants/storage";
@@ -19,6 +20,22 @@ export interface AiSeatMeta {
   difficulty: string;
   deckId?: string | null;
   deckName?: string | null;
+}
+
+/**
+ * Credentials to reconnect a suspended native-engine solo (AI) game.
+ *
+ * Native games are server-authoritative: the game state lives in the local
+ * phase-server's `games.db`, never in IndexedDB. The player token is issued
+ * once at game creation and is the reconnect security boundary — it lives only
+ * client-side, so it must be persisted here for the game to be resumable.
+ * Presence of this field is what marks an `ActiveGameMeta` as a native resume
+ * (which has no local `saveGame` snapshot to validate against).
+ */
+export interface NativeSoloSession {
+  gameCode: string;
+  playerId: PlayerId;
+  playerToken: string;
 }
 
 export interface ActiveGameMeta {
@@ -37,6 +54,11 @@ export interface ActiveGameMeta {
   formatConfig?: FormatConfig;
   /** Bare 5-char room code for P2P guest resume. */
   p2pRoomCode?: string;
+  /** Present for native-engine solo (AI) games hosted by the local
+   *  phase-server. Its presence marks this pointer as a native resume; on
+   *  resume the client reconnects to the server session rather than loading a
+   *  local snapshot. Absent for in-browser (WASM) AI games. */
+  nativeSession?: NativeSoloSession;
 }
 
 /**

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -211,6 +211,13 @@ interface GameStoreActions {
    * "Undo not supported in P2P games" guard.
    */
   resumeP2PHost: (gameId: string, adapter: EngineAdapter) => Promise<void>;
+  /**
+   * Resume a native-engine solo (AI) game. Like `resumeP2PHost` the game is
+   * server-authoritative — the local phase-server holds the state and the
+   * reconnecting adapter's `initialize()` yields it — so there is no local
+   * snapshot to `restoreState` and no undo history to rebuild.
+   */
+  resumeNativeSolo: (gameId: string, adapter: EngineAdapter) => Promise<void>;
   dispatch: (action: GameAction) => Promise<GameEvent[]>;
   undo: () => Promise<void>;
   reset: () => void;
@@ -280,6 +287,40 @@ export function nextGameSessionGeneration(): number {
 }
 
 export type GameStore = GameStoreState & GameStoreActions;
+
+/**
+ * Seed the store from a server-authoritative adapter whose `initialize()` has
+ * already produced the current game state (resumed P2P host, or a reconnected
+ * native solo game). These games have no client-side undo history and no local
+ * checkpoints — the server owns the state — so `stateHistory`/`turnCheckpoints`
+ * stay empty. Shared by `resumeP2PHost` and `resumeNativeSolo`.
+ */
+async function seedResumedServerGame(
+  get: () => GameStore,
+  gameId: string,
+  adapter: EngineAdapter,
+): Promise<void> {
+  // Reset stack-pacing throughput — resuming may load a different game than the
+  // one just played; stale churn must not carry across.
+  resetStackThroughput();
+  await adapter.initialize();
+  // Fetched after `initialize()` restored/attached the engine state, so the
+  // snapshot is newest-by-construction and always passes the commit gate.
+  const snapshot = await adapter.getSnapshot();
+  get().commitEngineSnapshot(snapshot, {
+    extraState: {
+      gameId,
+      adapter,
+      gameSessionGeneration: nextGameSessionGeneration(),
+      events: [],
+      eventHistory: [],
+      logHistory: [],
+      nextLogSeq: 0,
+      stateHistory: [],
+      turnCheckpoints: [],
+    },
+  });
+}
 
 const initialState: GameStoreState = {
   gameId: null,
@@ -438,30 +479,19 @@ export const useGameStore = create<GameStore>()(
     },
 
     resumeP2PHost: async (gameId, adapter) => {
-      // Reset stack-pacing throughput on entry to this game context.
-      resetStackThroughput();
-      // `adapter.initialize()` on a resumed P2PHostAdapter already
-      // called `wasm.resumeMultiplayerHostState(savedState)` — the
-      // engine is populated and in multiplayer mode. All we need here
-      // is to pull the state out and seed the store. No stateHistory
-      // (multiplayer = no undo); no checkpoints (P2P never saved them).
-      await adapter.initialize();
-      // Fetched after that `initialize()` (which is what restored the engine, per
-      // the note above), so the snapshot is newest-by-construction.
-      const snapshot = await adapter.getSnapshot();
-      get().commitEngineSnapshot(snapshot, {
-        extraState: {
-          gameId,
-          adapter,
-          gameSessionGeneration: nextGameSessionGeneration(),
-          events: [],
-          eventHistory: [],
-          logHistory: [],
-          nextLogSeq: 0,
-          stateHistory: [],
-          turnCheckpoints: [],
-        },
-      });
+      // `adapter.initialize()` on a resumed P2PHostAdapter already called
+      // `wasm.resumeMultiplayerHostState(savedState)` — the engine is populated
+      // and in multiplayer mode — so the shared helper just pulls the state out
+      // and seeds the store. No stateHistory (multiplayer = no undo); no
+      // checkpoints (P2P never saved them).
+      await seedResumedServerGame(get, gameId, adapter);
+    },
+
+    resumeNativeSolo: async (gameId, adapter) => {
+      // The reconnecting native adapter's `initialize()` sends a reconnect frame
+      // and resolves once the phase-server replays the current GameStarted
+      // state; the shared helper then seeds the store from that authority.
+      await seedResumedServerGame(get, gameId, adapter);
     },
 
     dispatch: async (action) => {

--- a/crates/phase-server/src/draft_pools.rs
+++ b/crates/phase-server/src/draft_pools.rs
@@ -11,8 +11,15 @@ pub struct DraftPools {
 
 impl DraftPools {
     pub fn from_path(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
-        let file = std::fs::File::open(path)?;
-        let pools: BTreeMap<String, LimitedSetPool> = serde_json::from_reader(file)?;
+        // Read the whole file, then parse from the in-memory slice. serde_json's
+        // `from_reader` over an unbuffered `File` issues a read syscall per token
+        // and is pathologically slow on Windows, where per-syscall cost is high:
+        // parsing this multi-megabyte pool file that way stalled the native-engine
+        // server past the desktop shell's 20s health-check budget, so games fell
+        // back to the in-browser engine. `from_slice` parses contiguous memory with
+        // no per-read overhead (mirrors the `BufReader` already used in card_db.rs).
+        let bytes = std::fs::read(path)?;
+        let pools: BTreeMap<String, LimitedSetPool> = serde_json::from_slice(&bytes)?;
         let pools = pools
             .into_iter()
             .map(|(code, pool)| (code.to_lowercase(), pool))

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -520,6 +520,22 @@ struct Cli {
     #[arg(short, long, default_value = "data", env = "PHASE_DATA_DIR")]
     data_dir: PathBuf,
 
+    /// Path to the SQLite game-persistence database. Defaults to
+    /// `<data_dir>/games.db`. The desktop shell points this at a
+    /// version-independent location so saved games survive native-engine
+    /// updates — the versioned `data_dir` is recreated per engine version, so a
+    /// games.db living inside it would be orphaned on every update.
+    #[arg(long, env = "PHASE_GAMES_DB")]
+    games_db: Option<PathBuf>,
+
+    /// Single-user local instance (the desktop shell). There is no seat
+    /// contention to reclaim here, so the two online-tuned session policies do
+    /// not apply: persisted sessions are never stale-purged, and reconnects
+    /// never expire. Together these let a suspended solo game stay resumable
+    /// until the player starts a new one.
+    #[arg(long, env = "PHASE_SINGLE_USER")]
+    single_user: bool,
+
     /// Signed data-manifest URL for bootstrapping a missing PHASE_DATA_DIR.
     /// This overrides the manifest resolved from the binary's embedded channel.
     #[arg(long, env = "PHASE_DATA_MANIFEST_URL")]
@@ -912,18 +928,44 @@ async fn main() {
     info!(cards = card_db.card_count(), "card database loaded");
     let db: SharedDb = Arc::new(card_db);
 
-    // Initialize SQLite persistence
-    let game_db_path = data_path.join("games.db");
-    let game_db: SharedGameDb =
-        Arc::new(persistence::GameDb::open(&game_db_path).expect("Failed to open game database"));
-    // Clean up stale sessions (>24 hours old)
-    if let Ok(deleted) = game_db.delete_stale(86400) {
-        if deleted > 0 {
-            info!(count = deleted, "cleaned up stale persisted sessions");
+    // Initialize SQLite persistence. `games_db` overrides the in-data-dir
+    // default so the shell can keep saved games outside the per-version data
+    // dir (which is recreated on every native-engine update). `Connection::open`
+    // does not create parent dirs, so ensure the target's directory exists.
+    let game_db_path = cli
+        .games_db
+        .clone()
+        .unwrap_or_else(|| data_path.join("games.db"));
+    if let Some(parent) = game_db_path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent).expect("Failed to create game database directory");
+    }
+    let retention = if cli.single_user {
+        persistence::SessionRetention::SingleUser
+    } else {
+        persistence::SessionRetention::Multiplayer
+    };
+    let game_db: SharedGameDb = Arc::new(
+        persistence::GameDb::open(&game_db_path, retention).expect("Failed to open game database"),
+    );
+    // Clean up stale sessions (>24 hours old). Skipped for a single-user local
+    // instance, where the one suspended solo game must survive until replaced.
+    if !cli.single_user {
+        if let Ok(deleted) = game_db.delete_stale(86400) {
+            if deleted > 0 {
+                info!(count = deleted, "cleaned up stale persisted sessions");
+            }
         }
     }
 
-    let state: SharedState = Arc::new(Mutex::new(SessionManager::new()));
+    // A single-user instance has no other players whose seats a grace period
+    // would free, so reconnects never expire — a game suspended for any length
+    // of time stays resumable. `with_grace_period` sets the reconnect window;
+    // ten years is effectively unbounded without risking overflow in `now + grace`.
+    let state: SharedState = Arc::new(Mutex::new(if cli.single_user {
+        SessionManager::with_grace_period(Duration::from_secs(10 * 365 * 24 * 60 * 60))
+    } else {
+        SessionManager::new()
+    }));
     let draft_sessions: SharedDraftState = Arc::new(Mutex::new(DraftSessionManager::new()));
     let draft_pools_path = data_path.join("draft-pools.json");
     let draft_pools: SharedDraftPools = match draft_pools::DraftPools::from_path(&draft_pools_path)
@@ -6401,7 +6443,10 @@ mod ranked_tests {
 
     fn test_db() -> SharedGameDb {
         let file = NamedTempFile::new().unwrap();
-        Arc::new(persistence::GameDb::open(file.path()).unwrap())
+        Arc::new(
+            persistence::GameDb::open(file.path(), persistence::SessionRetention::Multiplayer)
+                .unwrap(),
+        )
     }
 
     #[test]
@@ -6863,7 +6908,11 @@ mod issue_4548_full_create_tests {
     async fn spawn_full_mode_server() -> (String, tokio::task::JoinHandle<()>, tempfile::TempDir) {
         let temp_dir = tempfile::tempdir().expect("temp dir");
         let game_db = Arc::new(
-            persistence::GameDb::open(&temp_dir.path().join("games.db")).expect("game db"),
+            persistence::GameDb::open(
+                &temp_dir.path().join("games.db"),
+                persistence::SessionRetention::Multiplayer,
+            )
+            .expect("game db"),
         );
         let app = Router::new()
             .route("/ws", get(ws_handler))
@@ -7669,7 +7718,10 @@ mod issue_4548_deadlock_tests {
         let connections: SharedConnections = Arc::new(Mutex::new(HashMap::new()));
         let game_db = {
             let file = NamedTempFile::new().unwrap();
-            Arc::new(persistence::GameDb::open(file.path()).unwrap())
+            Arc::new(
+                persistence::GameDb::open(file.path(), persistence::SessionRetention::Multiplayer)
+                    .unwrap(),
+            )
         };
         let (tx, _rx) = mpsc::unbounded_channel::<ServerMessage>();
 
@@ -7732,7 +7784,10 @@ mod admin_auth_tests {
 
     fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
         let game_db_path = temp_dir.path().join("games.db");
-        let game_db = Arc::new(persistence::GameDb::open(&game_db_path).expect("game db"));
+        let game_db = Arc::new(
+            persistence::GameDb::open(&game_db_path, persistence::SessionRetention::Multiplayer)
+                .expect("game db"),
+        );
         AppState {
             sessions: Arc::new(Mutex::new(SessionManager::new())),
             draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
@@ -7898,7 +7953,10 @@ mod p2p_backup_delete_tests {
 
     fn test_app_state(temp_dir: &tempfile::TempDir) -> AppState {
         let game_db_path = temp_dir.path().join("games.db");
-        let game_db = Arc::new(persistence::GameDb::open(&game_db_path).expect("game db"));
+        let game_db = Arc::new(
+            persistence::GameDb::open(&game_db_path, persistence::SessionRetention::Multiplayer)
+                .expect("game db"),
+        );
         AppState {
             sessions: Arc::new(Mutex::new(SessionManager::new())),
             draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),

--- a/crates/phase-server/src/persistence.rs
+++ b/crates/phase-server/src/persistence.rs
@@ -5,6 +5,24 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use rusqlite::{params, Connection};
 use tracing::{error, info};
 
+/// How the game-session store bounds retention of `game_sessions` rows.
+///
+/// This is a property of the deployment, not of any individual save call, so it
+/// lives on the store and `save_session` is its single enforcement point.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SessionRetention {
+    /// Online server: every `game_code` persists independently. Many games run
+    /// concurrently across distinct seats, so a save only upserts its own row.
+    Multiplayer,
+    /// Single-user desktop instance: at most one solo game exists at a time.
+    /// The client tracks a single active-game pointer, so starting a new game
+    /// orphans the previous session server-side. Saving a new `game_code`
+    /// prunes every other game session, keeping the store bounded to one row
+    /// without relying on the stale-age purge (which single-user disables so a
+    /// suspended game never expires).
+    SingleUser,
+}
+
 /// SQLite-backed persistence for active game sessions.
 ///
 /// Uses `std::sync::Mutex` to make `Connection` `Send`, since
@@ -12,6 +30,7 @@ use tracing::{error, info};
 /// All operations acquire the lock briefly for a single SQL statement.
 pub struct GameDb {
     conn: Mutex<Connection>,
+    retention: SessionRetention,
 }
 
 #[derive(Debug, Clone)]
@@ -28,7 +47,7 @@ pub struct RatingDelta {
 impl GameDb {
     /// Open (or create) the game database at the given path.
     /// Enables WAL mode and creates the schema if needed.
-    pub fn open(path: &Path) -> rusqlite::Result<Self> {
+    pub fn open(path: &Path, retention: SessionRetention) -> rusqlite::Result<Self> {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL;")?;
         conn.execute_batch(
@@ -70,19 +89,34 @@ impl GameDb {
         info!("Game database opened at {}", path.display());
         Ok(Self {
             conn: Mutex::new(conn),
+            retention,
         })
     }
 
     /// Persist a game session (upsert).
+    ///
+    /// Under [`SessionRetention::SingleUser`] this also prunes every other game
+    /// session in the same transaction, enforcing the "one active solo game"
+    /// invariant: starting a new game replaces the previous (now unreachable)
+    /// one instead of leaving it to accumulate, since single-user mode disables
+    /// the stale-age purge.
     pub fn save_session(&self, game_code: &str, json: &str) -> rusqlite::Result<()> {
         let now = now_epoch();
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        if self.retention == SessionRetention::SingleUser {
+            tx.execute(
+                "DELETE FROM game_sessions WHERE game_code != ?1",
+                params![game_code],
+            )?;
+        }
+        tx.execute(
             "INSERT INTO game_sessions (game_code, session_json, updated_at)
              VALUES (?1, ?2, ?3)
              ON CONFLICT(game_code) DO UPDATE SET session_json = ?2, updated_at = ?3",
             params![game_code, json, now],
         )?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -297,7 +331,7 @@ mod tests {
 
     fn test_db() -> GameDb {
         let file = NamedTempFile::new().unwrap();
-        GameDb::open(file.path()).unwrap()
+        GameDb::open(file.path(), SessionRetention::Multiplayer).unwrap()
     }
 
     #[test]
@@ -319,6 +353,37 @@ mod tests {
         let all = db.load_all().unwrap();
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].1, "v2");
+    }
+
+    #[test]
+    fn single_user_save_prunes_other_game_sessions() {
+        let file = NamedTempFile::new().unwrap();
+        let db = GameDb::open(file.path(), SessionRetention::SingleUser).unwrap();
+
+        // First solo game.
+        db.save_session("GAME_A", "a").unwrap();
+        assert_eq!(db.load_all().unwrap().len(), 1);
+
+        // Re-saving the same game (autosave) keeps exactly one row.
+        db.save_session("GAME_A", "a2").unwrap();
+        let all = db.load_all().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].1, "a2");
+
+        // Starting a new game replaces the previous (now orphaned) session.
+        db.save_session("GAME_B", "b").unwrap();
+        let all = db.load_all().unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, "GAME_B");
+    }
+
+    #[test]
+    fn multiplayer_save_retains_every_game_session() {
+        let db = test_db(); // SessionRetention::Multiplayer
+        db.save_session("GAME_A", "a").unwrap();
+        db.save_session("GAME_B", "b").unwrap();
+        // Online mode keeps every concurrent game independently.
+        assert_eq!(db.load_all().unwrap().len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
The desktop native engine had two gaps: on Windows the server hung parsing
draft-pools.json via unbuffered serde_json::from_reader (a read syscall per
token), blowing the shell's 20s health-check budget so games fell back to the
in-browser engine; and solo (AI) games had no resume contract — leaving the
game page conceded it.

- draft_pools: parse from an in-memory slice (from_slice) instead of from_reader,
  mirroring card_db.rs's buffered read.
- Durability: shell points PHASE_GAMES_DB at a per-channel, version-independent
  path so saved games survive engine updates; --single-user disables the
  stale-age purge and gives reconnects an effectively-unbounded grace period.
- Retention: in single-user mode save_session keeps only the latest game session
  (SessionRetention::SingleUser), bounding the store to one active solo game.
- Resume: solo games persist a native pointer (game_code + reconnect token) once
  live; leaving suspends (no concede) and only an explicit Concede ends the game;
  returning reconnects via a kind:"reconnect" adapter and seeds the store from
  the server's authoritative state (resumeNativeSolo, sharing resumeP2PHost's
  seeding). useResumables offers the resume only when the native engine can be
  attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable resume support for native solo games using saved session credentials.
  - Native games now reconnect to their existing server session and restore the latest game state.
  - Separate release channels maintain isolated game data.

- **Bug Fixes**
  - Suspended native games no longer concede or lose their resume option when leaving.
  - Resume failures now show an error and preserve the session for retry.
  - Single-user game data is automatically retained to support the latest active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->