### PR TITLE
fix(ui): reset Alt-pinned card preview when switching to another card

### DIFF
--- a/client/src/stores/__tests__/uiStore.test.ts
+++ b/client/src/stores/__tests__/uiStore.test.ts
@@ -10,6 +10,8 @@ describe("uiStore", () => {
         selectedObjectId: null,
         hoveredObjectId: null,
         inspectedObjectId: null,
+        inspectedFaceIndex: 0,
+        altHeld: false,
         selectedCardIds: [],
         fullControl: false,
         autoPass: false,
@@ -30,6 +32,32 @@ describe("uiStore", () => {
   it("inspectObject sets inspectedObjectId", () => {
     act(() => useUiStore.getState().inspectObject(99));
     expect(useUiStore.getState().inspectedObjectId).toBe(99);
+  });
+
+  it("inspecting a different object resets a pinned altHeld", () => {
+    act(() => {
+      useUiStore.getState().inspectObject(1);
+      useUiStore.getState().setAltHeld(true);
+    });
+    expect(useUiStore.getState().altHeld).toBe(true);
+
+    // Switching to a new card dismisses the old preview — Alt must not leak.
+    act(() => useUiStore.getState().inspectObject(2));
+    expect(useUiStore.getState().inspectedObjectId).toBe(2);
+    expect(useUiStore.getState().altHeld).toBe(false);
+  });
+
+  it("re-inspecting the same object preserves a pinned altHeld", () => {
+    act(() => {
+      useUiStore.getState().inspectObject(5);
+      useUiStore.getState().setAltHeld(true);
+    });
+
+    // Re-hover / face flip on the same card keeps the reader pinned.
+    act(() => useUiStore.getState().inspectObject(5, 1));
+    expect(useUiStore.getState().inspectedObjectId).toBe(5);
+    expect(useUiStore.getState().inspectedFaceIndex).toBe(1);
+    expect(useUiStore.getState().altHeld).toBe(true);
   });
 
   it("addSelectedCard appends to selectedCardIds", () => {

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -375,7 +375,16 @@ export const useUiStore = create<UiStore>()((set, get) => ({
       }
       cancelPendingShow();
       const applyInspect = () =>
-        set({ inspectedObjectId: id, inspectedFaceIndex: faceIndex ?? 0 });
+        set((s) => ({
+          inspectedObjectId: id,
+          inspectedFaceIndex: faceIndex ?? 0,
+          // Inspecting a DIFFERENT object replaces (dismisses) the previous
+          // preview, so a pinned Alt state must not leak onto the new card —
+          // Alt has to be pressed again to expand it. Re-inspecting the SAME
+          // object (e.g. a face flip or a re-hover) preserves the pin so the
+          // reader isn't kicked out mid-scroll.
+          altHeld: s.inspectedObjectId === id ? s.altHeld : false,
+        }));
       // Configurable hover latency (cardPreviewHoverDelayMs). The delay gates only
       // the FIRST appearance on a hover-capable device: while a preview is already
       // open, sweeping to an adjacent card switches instantly, and the "shift"


### PR DESCRIPTION
inspectObject opened a new preview without touching altHeld, so an Alt-expanded
(pinned) preview leaked its Alt state onto the next card hovered — the previous
preview went away but Alt stayed on. Reset altHeld when inspecting a different
object; re-inspecting the same object (face flip / re-hover) preserves the pin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inspection pinning behavior so the Alt key state is cleared when switching to a different object.
  * Preserved the Alt key state when re-inspecting the same object.
  * Ensured the selected face updates correctly during inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->