### PR TITLE
fix(engine): repeat Grindstone mill while milled cards share a color (#6091)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1357,6 +1357,7 @@ fn scope_of(target: &TargetFilter, chain_root: Option<WriteScope>) -> WriteScope
         | TargetFilter::ScopedPlayer
         | TargetFilter::AttachedTo
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
@@ -2262,6 +2263,7 @@ fn legacy_target_filter(f: &TargetFilter) -> bool {
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource
@@ -2504,6 +2506,7 @@ fn member_bound_target_filter(f: &TargetFilter) -> bool {
         | TargetFilter::ScopedPlayer
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::None
         | TargetFilter::Any
         | TargetFilter::Player
@@ -3600,9 +3603,10 @@ fn read_object_scope(scope: &ObjectScope, kind: StateKind) -> RwProfile {
 /// board `ObjectPt` characteristic read.
 fn share_quality_operand_read(f: &TargetFilter) -> RwProfile {
     match f {
-        TargetFilter::LastRevealed | TargetFilter::SelfRef | TargetFilter::SourceOrPaired => {
-            RwProfile::empty()
-        }
+        TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
+        | TargetFilter::SelfRef
+        | TargetFilter::SourceOrPaired => RwProfile::empty(),
         // Fail-closed: any other reference is a live board characteristic read.
         _ => reads_board_of(StateKind::ObjectPt),
     }
@@ -6327,6 +6331,7 @@ fn rw_target_filter(x: &TargetFilter) -> RwProfile {
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -2898,7 +2898,7 @@ fn scan_target_filter(x: &TargetFilter, ctx: FilterReadContext, mode: ScanMode) 
         TargetFilter::ScopedPlayer => Axes::NONE,
         TargetFilter::AttachedTo => Axes::NONE,
         TargetFilter::LastCreated => Axes::NONE,
-        TargetFilter::LastRevealed => Axes::NONE,
+        TargetFilter::LastRevealed | TargetFilter::LastZoneChanged => Axes::NONE,
         TargetFilter::CostPaidObject => Axes {
             event: true,
             sibling: false,

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -3172,7 +3172,7 @@ fn attach_host_filter_needs_target_slot(filter: &TargetFilter) -> bool {
     !filter.is_context_ref()
         && !matches!(
             filter,
-            TargetFilter::LastCreated | TargetFilter::LastRevealed
+            TargetFilter::LastCreated | TargetFilter::LastRevealed | TargetFilter::LastZoneChanged
         )
 }
 

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -73,6 +73,7 @@ pub(crate) fn target_filter_has_pitch_bound_x(filter: &TargetFilter) -> bool {
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
@@ -154,6 +155,7 @@ pub(crate) fn relax_pitch_bound_x_filter(filter: &TargetFilter) -> TargetFilter 
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -602,6 +602,7 @@ fn fmt_target(filter: &TargetFilter) -> String {
         TargetFilter::AttachedTo => "attached permanent".into(),
         TargetFilter::LastCreated => "last created".into(),
         TargetFilter::LastRevealed => "last revealed".into(),
+        TargetFilter::LastZoneChanged => "last zone changed".into(),
         TargetFilter::CostPaidObject => "cost-paid object".into(),
         TargetFilter::ChosenCard => "last chosen card".into(),
         TargetFilter::TriggeringSpellController => "triggering spell's controller".into(),

--- a/crates/engine/src/game/effects/discard.rs
+++ b/crates/engine/src/game/effects/discard.rs
@@ -197,6 +197,7 @@ pub fn resolve(
             TargetFilter::ParentTarget
                 | TargetFilter::ParentTargetSlot { .. }
                 | TargetFilter::LastRevealed
+                | TargetFilter::LastZoneChanged
                 | TargetFilter::SelfRef
                 | TargetFilter::TriggeringSource
                 | TargetFilter::LastCreated

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2703,14 +2703,7 @@ fn condition_depends_on_effect_performed(condition: &AbilityCondition) -> bool {
 /// resolves and `last_zone_changed_ids` reflects the moved objects. Predicate
 /// helper, not rule-implementing code.
 fn filter_contains_last_zone_changed(filter: &TargetFilter) -> bool {
-    match filter {
-        TargetFilter::LastZoneChanged => true,
-        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
-            filters.iter().any(filter_contains_last_zone_changed)
-        }
-        TargetFilter::Not { filter } => filter_contains_last_zone_changed(filter),
-        _ => false,
-    }
+    crate::game::filter::filter_contains_last_zone_changed(filter)
 }
 
 fn quantity_expr_depends_on_zone_change_this_way(expr: &QuantityExpr) -> bool {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2702,9 +2702,73 @@ fn condition_depends_on_effect_performed(condition: &AbilityCondition) -> bool {
 /// alongside the `WhenYouDo` reflexive, then re-evaluated once the choice
 /// resolves and `last_zone_changed_ids` reflects the moved objects. Predicate
 /// helper, not rule-implementing code.
+fn filter_contains_last_zone_changed(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::LastZoneChanged => true,
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_contains_last_zone_changed)
+        }
+        TargetFilter::Not { filter } => filter_contains_last_zone_changed(filter),
+        _ => false,
+    }
+}
+
+fn quantity_expr_depends_on_zone_change_this_way(expr: &QuantityExpr) -> bool {
+    match expr {
+        QuantityExpr::Ref { qty } => quantity_ref_depends_on_zone_change_this_way(qty),
+        QuantityExpr::DivideRounded { inner, .. }
+        | QuantityExpr::Multiply { inner, .. }
+        | QuantityExpr::ClampMin { inner, .. }
+        | QuantityExpr::Offset { inner, .. } => {
+            quantity_expr_depends_on_zone_change_this_way(inner)
+        }
+        QuantityExpr::Sum { exprs } | QuantityExpr::Max { exprs } => exprs
+            .iter()
+            .any(quantity_expr_depends_on_zone_change_this_way),
+        QuantityExpr::UpTo { max } => quantity_expr_depends_on_zone_change_this_way(max),
+        QuantityExpr::Power { exponent, .. } => {
+            quantity_expr_depends_on_zone_change_this_way(exponent)
+        }
+        QuantityExpr::Difference { left, right } => {
+            quantity_expr_depends_on_zone_change_this_way(left)
+                || quantity_expr_depends_on_zone_change_this_way(right)
+        }
+        QuantityExpr::Fixed { .. } => false,
+    }
+}
+
+fn quantity_ref_depends_on_zone_change_this_way(qty: &QuantityRef) -> bool {
+    match qty {
+        QuantityRef::ObjectCount { filter }
+        | QuantityRef::ObjectCountDistinct { filter, .. }
+        | QuantityRef::ObjectCountBySharedQuality { filter, .. }
+        | QuantityRef::CountersOnObjects { filter, .. }
+        | QuantityRef::Aggregate { filter, .. }
+        | QuantityRef::ControlledByEachPlayer { filter, .. }
+        | QuantityRef::DistinctColorsAmongPermanents { filter }
+        | QuantityRef::DistinctCounterKindsAmong { filter }
+        | QuantityRef::EnteredThisTurn { filter }
+        | QuantityRef::BattlefieldEntriesThisTurn { filter, .. } => {
+            filter_contains_last_zone_changed(filter)
+        }
+        QuantityRef::DistinctCardTypes {
+            source: crate::types::ability::CardTypeSetSource::Objects { filter },
+        }
+        | QuantityRef::DistinctSubtypes {
+            source: crate::types::ability::CardTypeSetSource::Objects { filter },
+            ..
+        } => filter_contains_last_zone_changed(filter),
+        _ => false,
+    }
+}
+
 fn condition_depends_on_zone_change_this_way(condition: &AbilityCondition) -> bool {
     match condition {
         AbilityCondition::ZoneChangedThisWay { .. } => true,
+        AbilityCondition::QuantityCheck { lhs, rhs, .. } => {
+            quantity_expr_depends_on_zone_change_this_way(lhs)
+                || quantity_expr_depends_on_zone_change_this_way(rhs)
+        }
         AbilityCondition::Not { condition } => condition_depends_on_zone_change_this_way(condition),
         AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => conditions
             .iter()

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -978,6 +978,24 @@ pub(crate) fn filter_contains_last_zone_changed(filter: &TargetFilter) -> bool {
         _ => false,
     }
 }
+
+/// Whether every object matching `filter` must be drawn from `last_zone_changed_ids`.
+///
+/// Positive presence only: `Or`, `Not`, and other negative contexts return false
+/// so candidate population can use ledger seeding without silently dropping objects
+/// outside the ledger (see `object_count_matching_ids`).
+pub(crate) fn filter_matching_set_subset_of_last_zone_changed(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::LastZoneChanged => true,
+        TargetFilter::And { filters } => filters
+            .iter()
+            .any(filter_matching_set_subset_of_last_zone_changed),
+        TargetFilter::TrackedSetFiltered { filter, .. } => {
+            filter_matching_set_subset_of_last_zone_changed(filter)
+        }
+        _ => false,
+    }
+}
 /// Check if an object matches a typed TargetFilter against the given context.
 ///
 /// This is the unified entry point for filter evaluation. Build a

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -76,6 +76,7 @@ pub(crate) fn affected_filter_uses_object_population(filter: &TargetFilter) -> b
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
@@ -311,6 +312,7 @@ pub(crate) fn entered_object_perturbs_affected_filter(
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
@@ -2150,6 +2152,7 @@ fn filter_inner_for_object(
             .is_some_and(|attached| attached == object_id),
         TargetFilter::LastCreated => state.last_created_token_ids.contains(&object_id),
         TargetFilter::LastRevealed => state.last_revealed_ids.contains(&object_id),
+        TargetFilter::LastZoneChanged => state.last_zone_changed_ids.contains(&object_id),
         // CR 608.2k: "the sacrificed/exiled/discarded <noun>" — the specific
         // untargeted object previously referred to by this ability. Resolve
         // through the documented `cost_paid_object → effect_context_object`
@@ -2668,6 +2671,7 @@ fn zone_change_filter_inner(
         ),
         TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
@@ -2980,6 +2984,7 @@ pub fn spell_record_matches_filter(
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
@@ -3296,6 +3301,7 @@ fn spell_object_matches_filter_inner(
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -979,23 +979,6 @@ pub(crate) fn filter_contains_last_zone_changed(filter: &TargetFilter) -> bool {
     }
 }
 
-/// Whether every object matching `filter` must be drawn from `last_zone_changed_ids`.
-///
-/// Positive presence only: `Or`, `Not`, and other negative contexts return false
-/// so candidate population can use ledger seeding without silently dropping objects
-/// outside the ledger (see `object_count_matching_ids`).
-pub(crate) fn filter_matching_set_subset_of_last_zone_changed(filter: &TargetFilter) -> bool {
-    match filter {
-        TargetFilter::LastZoneChanged => true,
-        TargetFilter::And { filters } => filters
-            .iter()
-            .any(filter_matching_set_subset_of_last_zone_changed),
-        TargetFilter::TrackedSetFiltered { filter, .. } => {
-            filter_matching_set_subset_of_last_zone_changed(filter)
-        }
-        _ => false,
-    }
-}
 /// Check if an object matches a typed TargetFilter against the given context.
 ///
 /// This is the unified entry point for filter evaluation. Build a

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -963,6 +963,21 @@ pub(crate) fn controller_ref_player(
         ControllerRef::ActivePlayer => Some(state.active_player),
     }
 }
+/// Whether `filter` references the resolution-local `last_zone_changed_ids`
+/// ledger population (bare or nested inside compound filters).
+pub(crate) fn filter_contains_last_zone_changed(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::LastZoneChanged => true,
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_contains_last_zone_changed)
+        }
+        TargetFilter::Not { filter } => filter_contains_last_zone_changed(filter),
+        TargetFilter::TrackedSetFiltered { filter, .. } => {
+            filter_contains_last_zone_changed(filter)
+        }
+        _ => false,
+    }
+}
 /// Check if an object matches a typed TargetFilter against the given context.
 ///
 /// This is the unified entry point for filter evaluation. Build a

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2992,6 +2992,7 @@ fn target_filter_reads_life_total(filter: &TargetFilter) -> bool {
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -8,7 +8,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::game::arithmetic::{u32_to_i32_saturating, usize_to_i32_saturating};
 use crate::game::filter::{
-    filter_contains_last_zone_changed, matches_target_filter,
+    filter_matching_set_subset_of_last_zone_changed, matches_target_filter,
     matches_target_filter_on_attack_declaration_record,
     matches_target_filter_on_counter_added_record, matches_target_filter_on_damage_record_source,
     matches_target_filter_on_zone_change_record, player_matches_target_filter_in_state,
@@ -1897,31 +1897,58 @@ pub(crate) fn aggregate_property_over(
     }
 }
 
+fn object_count_zone_object_ids(state: &GameState, filter: &TargetFilter) -> Vec<ObjectId> {
+    let zones = filter.extract_zones();
+    let zones = if zones.is_empty() {
+        vec![crate::types::zones::Zone::Battlefield]
+    } else {
+        zones
+    };
+    zones
+        .into_iter()
+        .flat_map(|zone| crate::game::targeting::zone_object_ids(state, zone))
+        .collect()
+}
+
 pub(crate) fn object_count_matching_ids(
     state: &GameState,
     filter: &TargetFilter,
     filter_ctx: &FilterContext<'_>,
     source_id: ObjectId,
 ) -> Vec<ObjectId> {
-    let mut ids: Vec<ObjectId> = if filter_contains_last_zone_changed(filter) {
-        state
+    let mut ids: Vec<ObjectId> = match filter {
+        TargetFilter::Or { filters } => {
+            let mut seen = HashSet::new();
+            let mut out = Vec::new();
+            for branch in filters {
+                for id in object_count_matching_ids(state, branch, filter_ctx, source_id) {
+                    if seen.insert(id) {
+                        out.push(id);
+                    }
+                }
+            }
+            out
+        }
+        TargetFilter::Not { filter: inner }
+            if matches!(inner.as_ref(), TargetFilter::LastZoneChanged) =>
+        {
+            let ledger: HashSet<ObjectId> = state.last_zone_changed_ids.iter().copied().collect();
+            object_count_zone_object_ids(state, filter)
+                .into_iter()
+                .filter(|&id| !ledger.contains(&id))
+                .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
+                .collect()
+        }
+        _ if filter_matching_set_subset_of_last_zone_changed(filter) => state
             .last_zone_changed_ids
             .iter()
             .copied()
             .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
-            .collect()
-    } else {
-        let zones = filter.extract_zones();
-        let zones = if zones.is_empty() {
-            vec![crate::types::zones::Zone::Battlefield]
-        } else {
-            zones
-        };
-        zones
+            .collect(),
+        _ => object_count_zone_object_ids(state, filter)
             .into_iter()
-            .flat_map(|zone| crate::game::targeting::zone_object_ids(state, zone))
             .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
-            .collect()
+            .collect(),
     };
     // Drop the triggering object for an "other than" filter (Valakut's "five
     // other Mountains" — the newly-entered Mountain matches the per-object filter
@@ -7786,6 +7813,118 @@ mod tests {
         let ctx = FilterContext::from_source(&state, ObjectId(0));
         let ids = object_count_matching_ids(&state, &filter, &ctx, ObjectId(0));
         assert_eq!(ids, vec![red_a, red_b]);
+    }
+
+    #[test]
+    fn object_count_matching_ids_or_last_zone_changed_includes_typed_outside_ledger() {
+        let mut state = GameState::new_two_player(46);
+        let red_a = create_object(
+            &mut state,
+            CardId(405),
+            PlayerId(1),
+            "Red A".to_string(),
+            Zone::Graveyard,
+        );
+        let red_b = create_object(
+            &mut state,
+            CardId(406),
+            PlayerId(1),
+            "Red B".to_string(),
+            Zone::Graveyard,
+        );
+        let green = create_object(
+            &mut state,
+            CardId(407),
+            PlayerId(1),
+            "Green C".to_string(),
+            Zone::Graveyard,
+        );
+        let red_on_battlefield = create_object(
+            &mut state,
+            CardId(408),
+            PlayerId(0),
+            "Red D".to_string(),
+            Zone::Battlefield,
+        );
+        for (id, color) in [
+            (red_a, ManaColor::Red),
+            (red_b, ManaColor::Red),
+            (green, ManaColor::Green),
+            (red_on_battlefield, ManaColor::Red),
+        ] {
+            state.objects.get_mut(&id).unwrap().color = vec![color];
+        }
+        state.last_zone_changed_ids = vec![red_a, red_b, green];
+
+        let filter = TargetFilter::Or {
+            filters: vec![
+                TargetFilter::LastZoneChanged,
+                TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::HasColor {
+                    color: ManaColor::Red,
+                }])),
+            ],
+        };
+        let ctx = FilterContext::from_source(&state, ObjectId(0));
+        let ids = object_count_matching_ids(&state, &filter, &ctx, ObjectId(0));
+        assert_eq!(
+            ids.len(),
+            4,
+            "Or must union ledger objects with typed reds outside the ledger"
+        );
+        assert!(ids.contains(&red_on_battlefield));
+    }
+
+    #[test]
+    fn object_count_matching_ids_not_last_zone_changed_excludes_ledger() {
+        let mut state = GameState::new_two_player(46);
+        let red_a = create_object(
+            &mut state,
+            CardId(405),
+            PlayerId(1),
+            "Red A".to_string(),
+            Zone::Graveyard,
+        );
+        let red_b = create_object(
+            &mut state,
+            CardId(406),
+            PlayerId(1),
+            "Red B".to_string(),
+            Zone::Graveyard,
+        );
+        let green = create_object(
+            &mut state,
+            CardId(407),
+            PlayerId(1),
+            "Green C".to_string(),
+            Zone::Graveyard,
+        );
+        let red_on_battlefield = create_object(
+            &mut state,
+            CardId(408),
+            PlayerId(0),
+            "Red D".to_string(),
+            Zone::Battlefield,
+        );
+        for (id, color) in [
+            (red_a, ManaColor::Red),
+            (red_b, ManaColor::Red),
+            (green, ManaColor::Green),
+            (red_on_battlefield, ManaColor::Red),
+        ] {
+            state.objects.get_mut(&id).unwrap().color = vec![color];
+        }
+        state.last_zone_changed_ids = vec![red_a, red_b, green];
+
+        let filter = TargetFilter::Not {
+            filter: Box::new(TargetFilter::LastZoneChanged),
+        };
+        let ctx = FilterContext::from_source(&state, ObjectId(0));
+        let ids = object_count_matching_ids(&state, &filter, &ctx, ObjectId(0));
+        assert_eq!(
+            ids,
+            vec![red_on_battlefield],
+            "Not(LastZoneChanged) must count battlefield objects outside the ledger"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -8,7 +8,8 @@ use std::collections::{HashMap, HashSet};
 
 use crate::game::arithmetic::{u32_to_i32_saturating, usize_to_i32_saturating};
 use crate::game::filter::{
-    matches_target_filter, matches_target_filter_on_attack_declaration_record,
+    filter_contains_last_zone_changed, matches_target_filter,
+    matches_target_filter_on_attack_declaration_record,
     matches_target_filter_on_counter_added_record, matches_target_filter_on_damage_record_source,
     matches_target_filter_on_zone_change_record, player_matches_target_filter_in_state,
     spell_record_matches_filter, type_filter_matches, FilterContext,
@@ -1902,20 +1903,26 @@ pub(crate) fn object_count_matching_ids(
     filter_ctx: &FilterContext<'_>,
     source_id: ObjectId,
 ) -> Vec<ObjectId> {
-    if matches!(filter, TargetFilter::LastZoneChanged) {
-        return state.last_zone_changed_ids.clone();
-    }
-    let zones = filter.extract_zones();
-    let zones = if zones.is_empty() {
-        vec![crate::types::zones::Zone::Battlefield]
+    let mut ids: Vec<ObjectId> = if filter_contains_last_zone_changed(filter) {
+        state
+            .last_zone_changed_ids
+            .iter()
+            .copied()
+            .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
+            .collect()
     } else {
+        let zones = filter.extract_zones();
+        let zones = if zones.is_empty() {
+            vec![crate::types::zones::Zone::Battlefield]
+        } else {
+            zones
+        };
         zones
+            .into_iter()
+            .flat_map(|zone| crate::game::targeting::zone_object_ids(state, zone))
+            .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
+            .collect()
     };
-    let mut ids: Vec<ObjectId> = zones
-        .into_iter()
-        .flat_map(|zone| crate::game::targeting::zone_object_ids(state, zone))
-        .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
-        .collect();
     // Drop the triggering object for an "other than" filter (Valakut's "five
     // other Mountains" — the newly-entered Mountain matches the per-object filter
     // as a pass-through and is removed here). The exclusion is the Oracle-text
@@ -7733,6 +7740,52 @@ mod tests {
             0,
             "colorless milled pairs produce no shared-color bucket (Max 0)"
         );
+    }
+
+    #[test]
+    fn object_count_matching_ids_applies_compound_last_zone_changed_filter() {
+        let mut state = GameState::new_two_player(46);
+        let red_a = create_object(
+            &mut state,
+            CardId(405),
+            PlayerId(1),
+            "Red A".to_string(),
+            Zone::Graveyard,
+        );
+        let red_b = create_object(
+            &mut state,
+            CardId(406),
+            PlayerId(1),
+            "Red B".to_string(),
+            Zone::Graveyard,
+        );
+        let green = create_object(
+            &mut state,
+            CardId(407),
+            PlayerId(1),
+            "Green C".to_string(),
+            Zone::Graveyard,
+        );
+        for (id, color) in [
+            (red_a, ManaColor::Red),
+            (red_b, ManaColor::Red),
+            (green, ManaColor::Green),
+        ] {
+            state.objects.get_mut(&id).unwrap().color = vec![color];
+        }
+        state.last_zone_changed_ids = vec![red_a, red_b, green];
+
+        let filter = TargetFilter::And {
+            filters: vec![
+                TargetFilter::LastZoneChanged,
+                TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::HasColor {
+                    color: ManaColor::Red,
+                }])),
+            ],
+        };
+        let ctx = FilterContext::from_source(&state, ObjectId(0));
+        let ids = object_count_matching_ids(&state, &filter, &ctx, ObjectId(0));
+        assert_eq!(ids, vec![red_a, red_b]);
     }
 
     #[test]

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1925,14 +1925,20 @@ fn object_count_candidate_universe(state: &GameState, filter: &TargetFilter) -> 
             }
             out
         }
-        TargetFilter::Not { filter: inner }
-            if matches!(inner.as_ref(), TargetFilter::LastZoneChanged) =>
-        {
-            let ledger: HashSet<ObjectId> = state.last_zone_changed_ids.iter().copied().collect();
-            object_count_zone_object_ids(state, filter)
-                .into_iter()
-                .filter(|&id| !ledger.contains(&id))
-                .collect()
+        TargetFilter::Not { filter: inner } => {
+            let mut seen = HashSet::new();
+            let mut out = Vec::new();
+            for id in object_count_zone_object_ids(state, filter) {
+                if seen.insert(id) {
+                    out.push(id);
+                }
+            }
+            for id in object_count_candidate_universe(state, inner) {
+                if seen.insert(id) {
+                    out.push(id);
+                }
+            }
+            out
         }
         TargetFilter::LastZoneChanged => state.last_zone_changed_ids.clone(),
         TargetFilter::TrackedSetFiltered { filter, .. } => {
@@ -7927,6 +7933,67 @@ mod tests {
             vec![red_on_battlefield],
             "Not(LastZoneChanged) must count battlefield objects outside the ledger"
         );
+    }
+
+    #[test]
+    fn object_count_matching_ids_not_and_last_zone_changed_includes_nonmatching_ledger() {
+        let mut state = GameState::new_two_player(46);
+        let red_a = create_object(
+            &mut state,
+            CardId(405),
+            PlayerId(1),
+            "Red A".to_string(),
+            Zone::Graveyard,
+        );
+        let red_b = create_object(
+            &mut state,
+            CardId(406),
+            PlayerId(1),
+            "Red B".to_string(),
+            Zone::Graveyard,
+        );
+        let green = create_object(
+            &mut state,
+            CardId(407),
+            PlayerId(1),
+            "Green C".to_string(),
+            Zone::Graveyard,
+        );
+        let red_on_battlefield = create_object(
+            &mut state,
+            CardId(408),
+            PlayerId(0),
+            "Red D".to_string(),
+            Zone::Battlefield,
+        );
+        for (id, color) in [
+            (red_a, ManaColor::Red),
+            (red_b, ManaColor::Red),
+            (green, ManaColor::Green),
+            (red_on_battlefield, ManaColor::Red),
+        ] {
+            state.objects.get_mut(&id).unwrap().color = vec![color];
+        }
+        state.last_zone_changed_ids = vec![red_a, red_b, green];
+
+        let filter = TargetFilter::Not {
+            filter: Box::new(TargetFilter::And {
+                filters: vec![
+                    TargetFilter::LastZoneChanged,
+                    TargetFilter::Typed(TypedFilter::card().properties(vec![
+                        FilterProp::HasColor {
+                            color: ManaColor::Red,
+                        },
+                    ])),
+                ],
+            }),
+        };
+        let ctx = FilterContext::from_source(&state, ObjectId(0));
+        let ids = object_count_matching_ids(&state, &filter, &ctx, ObjectId(0));
+        assert!(ids.contains(&green));
+        assert!(ids.contains(&red_on_battlefield));
+        assert!(!ids.contains(&red_a));
+        assert!(!ids.contains(&red_b));
     }
 
     #[test]

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -8,8 +8,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::game::arithmetic::{u32_to_i32_saturating, usize_to_i32_saturating};
 use crate::game::filter::{
-    filter_matching_set_subset_of_last_zone_changed, matches_target_filter,
-    matches_target_filter_on_attack_declaration_record,
+    matches_target_filter, matches_target_filter_on_attack_declaration_record,
     matches_target_filter_on_counter_added_record, matches_target_filter_on_damage_record_source,
     matches_target_filter_on_zone_change_record, player_matches_target_filter_in_state,
     spell_record_matches_filter, type_filter_matches, FilterContext,
@@ -1910,18 +1909,15 @@ fn object_count_zone_object_ids(state: &GameState, filter: &TargetFilter) -> Vec
         .collect()
 }
 
-pub(crate) fn object_count_matching_ids(
-    state: &GameState,
-    filter: &TargetFilter,
-    filter_ctx: &FilterContext<'_>,
-    source_id: ObjectId,
-) -> Vec<ObjectId> {
-    let mut ids: Vec<ObjectId> = match filter {
-        TargetFilter::Or { filters } => {
+/// Candidate universe for `object_count_matching_ids`: union ledger, explicit
+/// zones, and recursive branch populations for every boolean node.
+fn object_count_candidate_universe(state: &GameState, filter: &TargetFilter) -> Vec<ObjectId> {
+    match filter {
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
             let mut seen = HashSet::new();
             let mut out = Vec::new();
             for branch in filters {
-                for id in object_count_matching_ids(state, branch, filter_ctx, source_id) {
+                for id in object_count_candidate_universe(state, branch) {
                     if seen.insert(id) {
                         out.push(id);
                     }
@@ -1936,20 +1932,26 @@ pub(crate) fn object_count_matching_ids(
             object_count_zone_object_ids(state, filter)
                 .into_iter()
                 .filter(|&id| !ledger.contains(&id))
-                .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
                 .collect()
         }
-        _ if filter_matching_set_subset_of_last_zone_changed(filter) => state
-            .last_zone_changed_ids
-            .iter()
-            .copied()
-            .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
-            .collect(),
-        _ => object_count_zone_object_ids(state, filter)
-            .into_iter()
-            .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
-            .collect(),
-    };
+        TargetFilter::LastZoneChanged => state.last_zone_changed_ids.clone(),
+        TargetFilter::TrackedSetFiltered { filter, .. } => {
+            object_count_candidate_universe(state, filter)
+        }
+        _ => object_count_zone_object_ids(state, filter),
+    }
+}
+
+pub(crate) fn object_count_matching_ids(
+    state: &GameState,
+    filter: &TargetFilter,
+    filter_ctx: &FilterContext<'_>,
+    source_id: ObjectId,
+) -> Vec<ObjectId> {
+    let mut ids: Vec<ObjectId> = object_count_candidate_universe(state, filter)
+        .into_iter()
+        .filter(|&id| matches_target_filter(state, id, filter, filter_ctx))
+        .collect();
     // Drop the triggering object for an "other than" filter (Valakut's "five
     // other Mountains" — the newly-entered Mountain matches the per-object filter
     // as a pass-through and is removed here). The exclusion is the Oracle-text
@@ -7924,6 +7926,69 @@ mod tests {
             ids,
             vec![red_on_battlefield],
             "Not(LastZoneChanged) must count battlefield objects outside the ledger"
+        );
+    }
+
+    #[test]
+    fn object_count_matching_ids_and_or_last_zone_changed_includes_off_battlefield_ledger() {
+        let mut state = GameState::new_two_player(46);
+        let red_a = create_object(
+            &mut state,
+            CardId(405),
+            PlayerId(1),
+            "Red A".to_string(),
+            Zone::Graveyard,
+        );
+        let red_b = create_object(
+            &mut state,
+            CardId(406),
+            PlayerId(1),
+            "Red B".to_string(),
+            Zone::Graveyard,
+        );
+        let green = create_object(
+            &mut state,
+            CardId(407),
+            PlayerId(1),
+            "Green C".to_string(),
+            Zone::Graveyard,
+        );
+        let red_on_battlefield = create_object(
+            &mut state,
+            CardId(408),
+            PlayerId(0),
+            "Red D".to_string(),
+            Zone::Battlefield,
+        );
+        for (id, color) in [
+            (red_a, ManaColor::Red),
+            (red_b, ManaColor::Red),
+            (green, ManaColor::Green),
+            (red_on_battlefield, ManaColor::Red),
+        ] {
+            state.objects.get_mut(&id).unwrap().color = vec![color];
+        }
+        state.last_zone_changed_ids = vec![red_a, red_b, green];
+
+        let filter = TargetFilter::And {
+            filters: vec![
+                TargetFilter::Or {
+                    filters: vec![
+                        TargetFilter::LastZoneChanged,
+                        TargetFilter::Typed(TypedFilter::card()),
+                    ],
+                },
+                TargetFilter::Typed(TypedFilter::card().properties(vec![FilterProp::HasColor {
+                    color: ManaColor::Red,
+                }])),
+            ],
+        };
+        let ctx = FilterContext::from_source(&state, ObjectId(0));
+        let ids = object_count_matching_ids(&state, &filter, &ctx, ObjectId(0));
+        assert_eq!(
+            ids,
+            vec![red_a, red_b, red_on_battlefield],
+            "nested And(Or(LC, Typed), Typed) must union ledger graveyard members with typed reds"
         );
     }
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -1902,6 +1902,9 @@ pub(crate) fn object_count_matching_ids(
     filter_ctx: &FilterContext<'_>,
     source_id: ObjectId,
 ) -> Vec<ObjectId> {
+    if matches!(filter, TargetFilter::LastZoneChanged) {
+        return state.last_zone_changed_ids.clone();
+    }
     let zones = filter.extract_zones();
     let zones = if zones.is_empty() {
         vec![crate::types::zones::Zone::Battlefield]
@@ -7657,6 +7660,78 @@ mod tests {
                 ObjectId(0),
             ),
             0
+        );
+    }
+
+    #[test]
+    fn resolve_object_count_by_shared_quality_last_zone_changed_color_max() {
+        use crate::types::mana::ManaColor;
+
+        let mut state = GameState::new_two_player(44);
+        let red_a = create_object(
+            &mut state,
+            CardId(401),
+            PlayerId(1),
+            "Red A".to_string(),
+            Zone::Graveyard,
+        );
+        let red_b = create_object(
+            &mut state,
+            CardId(402),
+            PlayerId(1),
+            "Red B".to_string(),
+            Zone::Graveyard,
+        );
+        for id in [red_a, red_b] {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.color = vec![ManaColor::Red];
+        }
+        state.last_zone_changed_ids = vec![red_a, red_b];
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCountBySharedQuality {
+                filter: TargetFilter::LastZoneChanged,
+                quality: SharedQuality::Color,
+                aggregate: AggregateFunction::Max,
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(0), ObjectId(0)),
+            2,
+            "two red cards milled this way must share red (Max bucket size 2)"
+        );
+    }
+
+    #[test]
+    fn resolve_object_count_by_shared_quality_last_zone_changed_colorless_max_zero() {
+        let mut state = GameState::new_two_player(45);
+        let colorless_a = create_object(
+            &mut state,
+            CardId(403),
+            PlayerId(1),
+            "Colorless A".to_string(),
+            Zone::Graveyard,
+        );
+        let colorless_b = create_object(
+            &mut state,
+            CardId(404),
+            PlayerId(1),
+            "Colorless B".to_string(),
+            Zone::Graveyard,
+        );
+        state.last_zone_changed_ids = vec![colorless_a, colorless_b];
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCountBySharedQuality {
+                filter: TargetFilter::LastZoneChanged,
+                quality: SharedQuality::Color,
+                aggregate: AggregateFunction::Max,
+            },
+        };
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(0), ObjectId(0)),
+            0,
+            "colorless milled pairs produce no shared-color bucket (Max 0)"
         );
     }
 

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -599,6 +599,11 @@ pub fn resolve_event_context_target(
             .first()
             .copied()
             .map(TargetRef::Object),
+        TargetFilter::LastZoneChanged => state
+            .last_zone_changed_ids
+            .first()
+            .copied()
+            .map(TargetRef::Object),
         TargetFilter::DefendingPlayer
         | TargetFilter::AttachedTo
         | TargetFilter::PostReplacementSourceController
@@ -643,6 +648,13 @@ pub fn resolve_event_context_targets(
         TargetFilter::LastRevealed => {
             return state
                 .last_revealed_ids
+                .iter()
+                .map(|id| TargetRef::Object(*id))
+                .collect();
+        }
+        TargetFilter::LastZoneChanged => {
+            return state
+                .last_zone_changed_ids
                 .iter()
                 .map(|id| TargetRef::Object(*id))
                 .collect();
@@ -768,6 +780,14 @@ pub fn resolved_targets(
     if matches!(target_filter, TargetFilter::LastRevealed) {
         return state
             .last_revealed_ids
+            .iter()
+            .copied()
+            .map(TargetRef::Object)
+            .collect();
+    }
+    if matches!(target_filter, TargetFilter::LastZoneChanged) {
+        return state
+            .last_zone_changed_ids
             .iter()
             .copied()
             .map(TargetRef::Object)
@@ -987,6 +1007,7 @@ pub(crate) fn resolved_object_ids_for_filter(
             .collect(),
         TargetFilter::LastCreated => state.last_created_token_ids.clone(),
         TargetFilter::LastRevealed => state.last_revealed_ids.clone(),
+        TargetFilter::LastZoneChanged => state.last_zone_changed_ids.clone(),
         TargetFilter::TriggeringSource | TargetFilter::EventTarget | TargetFilter::AttachedTo => {
             resolve_event_context_target(state, filter, ability.source_id)
                 .and_then(|target| target_ref_object(&target))

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -835,6 +835,7 @@ pub(super) fn target_filter_matches_object(
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -1536,6 +1536,46 @@ pub(super) fn strip_coin_flip_conditional(text: &str) -> (Option<AbilityConditio
     }
 }
 
+/// CR 608.2c + CR 701.17a: Strip "if [N] cards that share a [quality] were
+/// milled this way," ahead of a "repeat this process" directive →
+/// `QuantityCheck` over `ObjectCountBySharedQuality { LastZoneChanged, Max }`.
+pub(super) fn strip_milled_shared_quality_conditional(
+    text: &str,
+) -> (Option<AbilityCondition>, String) {
+    use crate::types::ability::AggregateFunction;
+
+    let lower = text.to_lowercase();
+    match nom_on_lower(text, &lower, |i| {
+        let (i, _) = tag::<_, _, OracleError<'_>>("if ").parse(i)?;
+        let (i, n) = alt((
+            value(2i32, tag("two")),
+            map(nom_primitives::parse_number, |n| n as i32),
+        ))
+        .parse(i)?;
+        let (i, _) = tag(" cards that share a ").parse(i)?;
+        let (i, quality) = crate::parser::oracle_target::parse_shared_quality(i)?;
+        let (i, _) = tag(" were milled this way").parse(i)?;
+        let (i, _) = opt(alt((tag(","), tag(", ")))).parse(i)?;
+        Ok((i, (n, quality)))
+    }) {
+        Some(((n, quality), remainder)) => {
+            let condition = AbilityCondition::QuantityCheck {
+                lhs: QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCountBySharedQuality {
+                        filter: TargetFilter::LastZoneChanged,
+                        quality,
+                        aggregate: AggregateFunction::Max,
+                    },
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: n },
+            };
+            (Some(condition), remainder.trim_start().to_string())
+        }
+        None => (None, text.to_string()),
+    }
+}
+
 pub(super) fn strip_card_type_conditional(text: &str) -> (Option<AbilityCondition>, String) {
     if let Some((condition, remainder)) = parse_if_revealed_card_type_conditional(text) {
         return (Some(condition), remainder);
@@ -7107,8 +7147,36 @@ mod tests {
     use super::*;
     use crate::parser::oracle_nom::condition::parse_inner_condition;
     use crate::parser::parse_oracle_text;
-    use crate::types::ability::PlayerFilter;
+    use crate::types::ability::{AggregateFunction, PlayerFilter, SharedQuality};
     use crate::types::counter::{CounterMatch, CounterType};
+
+    #[test]
+    fn strip_milled_shared_quality_conditional_maps_grindstone_gate() {
+        let (cond, rest) = strip_milled_shared_quality_conditional(
+            "if two cards that share a color were milled this way, repeat this process",
+        );
+        assert_eq!(rest, "repeat this process");
+        assert!(
+            matches!(
+                cond,
+                Some(AbilityCondition::QuantityCheck {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCountBySharedQuality {
+                            filter: TargetFilter::LastZoneChanged,
+                            quality: SharedQuality::Color,
+                            aggregate: AggregateFunction::Max,
+                            ..
+                        },
+                        ..
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 2 },
+                    ..
+                })
+            ),
+            "got {cond:?}"
+        );
+    }
 
     /// CR 400.7 + CR 608.2c: S07 Batch 1 — the leading-"if" active-voice
     /// this-way gates must resolve to their typed conditions (previously they

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -25656,7 +25656,12 @@ fn try_parse_repeat_process_directive(
             if card_type.is_some() {
                 (card_type, rest)
             } else {
-                strip_leading_general_conditional(text, ctx)
+                let (milled, rest) = strip_milled_shared_quality_conditional(text);
+                if milled.is_some() {
+                    (milled, rest)
+                } else {
+                    strip_leading_general_conditional(text, ctx)
+                }
             }
         }
     };

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -44785,6 +44785,89 @@ fn repeat_process_directive_you_may_stays_controller_choice() {
     ));
 }
 
+/// CR 608.2c + CR 701.17a: Grindstone-class "if two cards that share a color
+/// were milled this way, repeat this process" → unbounded `WhileCondition` over
+/// `ObjectCountBySharedQuality { LastZoneChanged, Color, Max } >= 2`.
+#[test]
+fn repeat_process_directive_milled_shared_color_while_condition() {
+    use crate::types::ability::{AggregateFunction, RepeatContinuation, SharedQuality};
+
+    let mut ctx = ParseContext::default();
+    let outcome = try_parse_repeat_process_directive(
+        "if two cards that share a color were milled this way, repeat this process",
+        &mut ctx,
+    );
+    match outcome {
+        Some(RepeatProcessOutcome::Continuation(RepeatContinuation::WhileCondition {
+            condition,
+            max_iterations,
+        })) => {
+            assert_eq!(max_iterations, None);
+            assert!(
+                matches!(
+                    *condition,
+                    AbilityCondition::QuantityCheck {
+                        lhs: QuantityExpr::Ref {
+                            qty: QuantityRef::ObjectCountBySharedQuality {
+                                filter: TargetFilter::LastZoneChanged,
+                                quality: SharedQuality::Color,
+                                aggregate: AggregateFunction::Max,
+                                ..
+                            },
+                            ..
+                        },
+                        comparator: Comparator::GE,
+                        rhs: QuantityExpr::Fixed { value: 2 },
+                        ..
+                    }
+                ),
+                "expected LastZoneChanged shared-color quantity gate, got {condition:?}"
+            );
+        }
+        other => panic!("expected unbounded WhileCondition, got {other:?}"),
+    }
+}
+
+/// Grindstone — full-card parse drops zero `Unimplemented` nodes and the
+/// activated root carries the unbounded shared-color `WhileCondition` repeat.
+#[test]
+fn grindstone_parses_repeat_while_milled_shared_color() {
+    use crate::types::ability::RepeatContinuation;
+
+    let parsed = parse_oracle_text(
+        GRINDSTONE_ORACLE,
+        "Grindstone",
+        &[],
+        &["Artifact".to_string()],
+        &[],
+    );
+    let json = serde_json::to_string(&parsed).unwrap();
+    assert!(
+        // allow-noncombinator: test assertion scans serialized AST JSON, not parsing dispatch
+        !json.contains("\"Unimplemented\""),
+        "Grindstone must parse with zero Unimplemented nodes"
+    );
+    let activated = parsed
+        .abilities
+        .iter()
+        .find(|ability| ability.kind == AbilityKind::Activated)
+        .expect("Grindstone must expose its activated ability");
+    assert!(
+        matches!(
+            activated.repeat_until,
+            Some(RepeatContinuation::WhileCondition {
+                max_iterations: None,
+                ..
+            })
+        ),
+        "Grindstone repeat is an unbounded WhileCondition, got {:?}",
+        activated.repeat_until
+    );
+}
+
+const GRINDSTONE_ORACLE: &str = "{3}, {T}: Target player mills two cards. If two cards that \
+     share a color were milled this way, repeat this process.";
+
 /// Sin, Spira's Punishment — full-card parse drops zero `Unimplemented` nodes
 /// and the trigger's root carries the unbounded `WhileCondition` repeat.
 #[test]

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -2300,6 +2300,7 @@ fn usable_disjunctive_permission_filter(filter: &TargetFilter) -> bool {
         | TargetFilter::AttachedTo
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4795,6 +4795,11 @@ pub enum TargetFilter {
     /// (Amareth, the Lustrous) and by `AbilityCondition::ObjectsShareQuality`
     /// subject slots.
     LastRevealed,
+    /// CR 608.2c: Resolves to the card(s) most recently moved to a public zone
+    /// by the resolving spell or ability (`state.last_zone_changed_ids`). Used
+    /// by anaphoric "milled this way" / "exiled this way" quantity gates
+    /// (Grindstone) and `ObjectCountBySharedQuality` population filters.
+    LastZoneChanged,
     /// CR 400.7j + CR 608.2k: Resolves to the object paid as a cost for the
     /// resolving spell or ability. Used by effects such as "the exiled card"
     /// after an exile-as-cost clause.

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -500,6 +500,7 @@ impl EventObjectSnapshot {
             | TargetFilter::SpecificObject { .. }
             | TargetFilter::LastCreated
             | TargetFilter::LastRevealed
+            | TargetFilter::LastZoneChanged
             | TargetFilter::CostPaidObject
             | TargetFilter::ChosenCard
             | TargetFilter::TrackedSet { .. }

--- a/crates/engine/tests/integration/issue_6091_grindstone.rs
+++ b/crates/engine/tests/integration/issue_6091_grindstone.rs
@@ -1,0 +1,246 @@
+//! Issue #6091 — Grindstone repeat loop via `LastZoneChanged` ledger +
+//! `ObjectCountBySharedQuality` repeat-until gate.
+//!
+//! Verbatim Scryfall Oracle (Grindstone, Mirage):
+//!
+//!   {3}, {T}: Target player mills two cards. If two cards that share a color
+//!   were milled this way, repeat this process.
+//!
+//! Painter's Servant is verified only as combo setup: chosen red must
+//! materialize on `obj.color` through layer evaluation before activation.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::ChosenAttribute;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::PlayerId;
+
+const GRINDSTONE_ORACLE: &str = "{3}, {T}: Target player mills two cards. If two cards that \
+     share a color were milled this way, repeat this process.";
+
+const PAINTER_ORACLE: &str = "As this creature enters, choose a color.\n\
+All cards that aren't on the battlefield, spells, and permanents are the chosen color in addition to their other colors.";
+
+fn three_generic() -> Vec<ManaUnit> {
+    vec![
+        ManaUnit::new(
+            ManaType::Colorless,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        ),
+        ManaUnit::new(
+            ManaType::Colorless,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        ),
+        ManaUnit::new(
+            ManaType::Colorless,
+            engine::types::identifiers::ObjectId(0),
+            false,
+            vec![],
+        ),
+    ]
+}
+
+fn add_colored_library_card(
+    scenario: &mut GameScenario,
+    player: PlayerId,
+    name: &str,
+    shard: ManaCostShard,
+) -> engine::types::identifiers::ObjectId {
+    scenario
+        .add_spell_to_library_top(player, name, true)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![shard],
+        })
+        .id()
+}
+
+fn setup_painter_red(runner: &mut GameRunner, painter: engine::types::identifiers::ObjectId) {
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&painter)
+        .unwrap()
+        .chosen_attributes
+        .push(ChosenAttribute::Color(ManaColor::Red));
+    evaluate_layers(runner.state_mut());
+}
+
+fn activate_grindstone_mill_p1(
+    runner: &mut GameRunner,
+    grindstone: engine::types::identifiers::ObjectId,
+) {
+    runner.activate(grindstone, 0).target_player(P1).resolve();
+}
+
+#[test]
+fn grindstone_two_blues_on_top_repeat_without_painter() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let grindstone = scenario
+        .add_creature_from_oracle(P0, "Grindstone", 0, 0, GRINDSTONE_ORACLE)
+        .as_artifact()
+        .id();
+
+    add_colored_library_card(&mut scenario, P1, "Blue Top", ManaCostShard::Blue);
+    add_colored_library_card(&mut scenario, P1, "Blue Second", ManaCostShard::Blue);
+    for idx in 0..4 {
+        add_colored_library_card(
+            &mut scenario,
+            P1,
+            &format!("Blue Pad {idx}"),
+            ManaCostShard::Blue,
+        );
+    }
+    scenario.with_mana_pool(P0, three_generic());
+
+    let mut runner = scenario.build();
+
+    let lib_before = runner.state().players[P1.0 as usize].library.len();
+    activate_grindstone_mill_p1(&mut runner, grindstone);
+    let lib_after = runner.state().players[P1.0 as usize].library.len();
+    let milled = lib_before.saturating_sub(lib_after);
+
+    // Six blue cards: three shared-color iterations × 2, then the library is empty.
+    assert_eq!(
+        milled, 6,
+        "all-blue library must be milled completely through shared-color repeats (milled {milled})"
+    );
+}
+
+#[test]
+fn grindstone_stops_mid_library_when_pair_no_longer_shares_color() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let grindstone = scenario
+        .add_creature_from_oracle(P0, "Grindstone", 0, 0, GRINDSTONE_ORACLE)
+        .as_artifact()
+        .id();
+
+    // Bottom → top order after successive tops: Blue A, Blue B, Green C, Blue D.
+    // First mill: Blue D + Green C (unlike) would stop at 2 — put matching pair on top.
+    // Desired top-to-bottom: Blue, Blue, Blue, Green → mill BB (repeat), mill BG (stop) = 4.
+    add_colored_library_card(&mut scenario, P1, "Green Stop", ManaCostShard::Green);
+    add_colored_library_card(&mut scenario, P1, "Blue Third", ManaCostShard::Blue);
+    add_colored_library_card(&mut scenario, P1, "Blue Second", ManaCostShard::Blue);
+    add_colored_library_card(&mut scenario, P1, "Blue Top", ManaCostShard::Blue);
+    scenario.with_mana_pool(P0, three_generic());
+
+    let mut runner = scenario.build();
+
+    let lib_before = runner.state().players[P1.0 as usize].library.len();
+    activate_grindstone_mill_p1(&mut runner, grindstone);
+    let lib_after = runner.state().players[P1.0 as usize].library.len();
+    let milled = lib_before.saturating_sub(lib_after);
+
+    assert_eq!(
+        milled, 4,
+        "must repeat once on BB then stop on BG (milled {milled})"
+    );
+}
+
+#[test]
+fn grindstone_painter_red_mills_more_than_two() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let painter = scenario
+        .add_creature_from_oracle(P0, "Painter's Servant", 1, 3, PAINTER_ORACLE)
+        .as_artifact()
+        .id();
+
+    let grindstone = scenario
+        .add_creature_from_oracle(P0, "Grindstone", 0, 0, GRINDSTONE_ORACLE)
+        .as_artifact()
+        .id();
+
+    // One blue + one green on top: without Painter they do not share a color;
+    // with Painter red they both gain red and repeat.
+    add_colored_library_card(&mut scenario, P1, "Blue Top", ManaCostShard::Blue);
+    add_colored_library_card(&mut scenario, P1, "Green Second", ManaCostShard::Green);
+    for idx in 0..6 {
+        add_colored_library_card(
+            &mut scenario,
+            P1,
+            &format!("Blue Pad {idx}"),
+            ManaCostShard::Blue,
+        );
+    }
+
+    scenario.with_mana_pool(P0, three_generic());
+
+    let mut runner = scenario.build();
+    setup_painter_red(&mut runner, painter);
+
+    let lib_before = runner.state().players[P1.0 as usize].library.len();
+    activate_grindstone_mill_p1(&mut runner, grindstone);
+    let lib_after = runner.state().players[P1.0 as usize].library.len();
+    let milled = lib_before.saturating_sub(lib_after);
+
+    // Eight cards (blue+green + six blue pads), all share red under Painter → full mill.
+    assert_eq!(
+        milled, 8,
+        "Painter red must mill the whole library through shared-color repeats (milled {milled})"
+    );
+}
+
+#[test]
+fn grindstone_without_painter_stops_at_two_unlike_colors() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let grindstone = scenario
+        .add_creature_from_oracle(P0, "Grindstone", 0, 0, GRINDSTONE_ORACLE)
+        .as_artifact()
+        .id();
+
+    add_colored_library_card(&mut scenario, P1, "Blue Top", ManaCostShard::Blue);
+    add_colored_library_card(&mut scenario, P1, "Green Second", ManaCostShard::Green);
+    scenario.with_mana_pool(P0, three_generic());
+
+    let mut runner = scenario.build();
+
+    let lib_before = runner.state().players[P1.0 as usize].library.len();
+    activate_grindstone_mill_p1(&mut runner, grindstone);
+    let lib_after = runner.state().players[P1.0 as usize].library.len();
+    let milled = lib_before.saturating_sub(lib_after);
+
+    assert_eq!(
+        milled, 2,
+        "reach guard: blue+green without Painter must not repeat (milled {milled})"
+    );
+}
+
+#[test]
+fn grindstone_colorless_pair_stops_at_two() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let grindstone = scenario
+        .add_creature_from_oracle(P0, "Grindstone", 0, 0, GRINDSTONE_ORACLE)
+        .as_artifact()
+        .id();
+
+    scenario.add_spell_to_library_top(P1, "Colorless A", true);
+    scenario.add_spell_to_library_top(P1, "Colorless B", true);
+    scenario.with_mana_pool(P0, three_generic());
+
+    let mut runner = scenario.build();
+
+    let lib_before = runner.state().players[P1.0 as usize].library.len();
+    activate_grindstone_mill_p1(&mut runner, grindstone);
+    let lib_after = runner.state().players[P1.0 as usize].library.len();
+    let milled = lib_before.saturating_sub(lib_after);
+
+    assert_eq!(
+        milled, 2,
+        "two colorless cards produce Max 0 shared-color buckets, so the loop stops at two (milled {milled})"
+    );
+}

--- a/crates/engine/tests/integration/issue_6091_grindstone.rs
+++ b/crates/engine/tests/integration/issue_6091_grindstone.rs
@@ -12,6 +12,7 @@
 use engine::game::layers::evaluate_layers;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::ability::ChosenAttribute;
+use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::PlayerId;
@@ -69,6 +70,16 @@ fn setup_painter_red(runner: &mut GameRunner, painter: engine::types::identifier
         .chosen_attributes
         .push(ChosenAttribute::Color(ManaColor::Red));
     evaluate_layers(runner.state_mut());
+}
+
+fn assert_objects_include_red(runner: &GameRunner, object_ids: &[ObjectId]) {
+    for &id in object_ids {
+        let colors = &runner.state().objects.get(&id).unwrap().color;
+        assert!(
+            colors.contains(&ManaColor::Red),
+            "expected {id:?} to include red under Painter, got {colors:?}"
+        );
+    }
 }
 
 fn activate_grindstone_mill_p1(
@@ -161,10 +172,8 @@ fn grindstone_painter_red_mills_more_than_two() {
         .as_artifact()
         .id();
 
-    // One blue + one green on top: without Painter they do not share a color;
-    // with Painter red they both gain red and repeat.
-    add_colored_library_card(&mut scenario, P1, "Blue Top", ManaCostShard::Blue);
-    add_colored_library_card(&mut scenario, P1, "Green Second", ManaCostShard::Green);
+    // Trailing blue pads first; Blue/Green on top so the first mill is the
+    // unlike-color pair that only repeats once Painter grants shared red.
     for idx in 0..6 {
         add_colored_library_card(
             &mut scenario,
@@ -173,11 +182,15 @@ fn grindstone_painter_red_mills_more_than_two() {
             ManaCostShard::Blue,
         );
     }
+    let green_second =
+        add_colored_library_card(&mut scenario, P1, "Green Second", ManaCostShard::Green);
+    let blue_top = add_colored_library_card(&mut scenario, P1, "Blue Top", ManaCostShard::Blue);
 
     scenario.with_mana_pool(P0, three_generic());
 
     let mut runner = scenario.build();
     setup_painter_red(&mut runner, painter);
+    assert_objects_include_red(&runner, &[blue_top, green_second]);
 
     let lib_before = runner.state().players[P1.0 as usize].library.len();
     activate_grindstone_mill_p1(&mut runner, grindstone);
@@ -188,6 +201,10 @@ fn grindstone_painter_red_mills_more_than_two() {
     assert_eq!(
         milled, 8,
         "Painter red must mill the whole library through shared-color repeats (milled {milled})"
+    );
+    assert_eq!(
+        lib_after, 0,
+        "full-library mill must leave no trailing cards"
     );
 }
 
@@ -201,8 +218,16 @@ fn grindstone_without_painter_stops_at_two_unlike_colors() {
         .as_artifact()
         .id();
 
-    add_colored_library_card(&mut scenario, P1, "Blue Top", ManaCostShard::Blue);
+    for idx in 0..4 {
+        add_colored_library_card(
+            &mut scenario,
+            P1,
+            &format!("Blue Trailing {idx}"),
+            ManaCostShard::Blue,
+        );
+    }
     add_colored_library_card(&mut scenario, P1, "Green Second", ManaCostShard::Green);
+    add_colored_library_card(&mut scenario, P1, "Blue Top", ManaCostShard::Blue);
     scenario.with_mana_pool(P0, three_generic());
 
     let mut runner = scenario.build();
@@ -216,6 +241,10 @@ fn grindstone_without_painter_stops_at_two_unlike_colors() {
         milled, 2,
         "reach guard: blue+green without Painter must not repeat (milled {milled})"
     );
+    assert_eq!(
+        lib_after, 4,
+        "trailing blue cards must remain when the repeat loop does not fire"
+    );
 }
 
 #[test]
@@ -228,8 +257,10 @@ fn grindstone_colorless_pair_stops_at_two() {
         .as_artifact()
         .id();
 
-    scenario.add_spell_to_library_top(P1, "Colorless A", true);
+    scenario.add_spell_to_library_top(P1, "Colorless Trailing A", true);
+    scenario.add_spell_to_library_top(P1, "Colorless Trailing B", true);
     scenario.add_spell_to_library_top(P1, "Colorless B", true);
+    scenario.add_spell_to_library_top(P1, "Colorless A", true);
     scenario.with_mana_pool(P0, three_generic());
 
     let mut runner = scenario.build();
@@ -242,5 +273,9 @@ fn grindstone_colorless_pair_stops_at_two() {
     assert_eq!(
         milled, 2,
         "two colorless cards produce Max 0 shared-color buckets, so the loop stops at two (milled {milled})"
+    );
+    assert_eq!(
+        lib_after, 2,
+        "trailing colorless cards must remain when the repeat loop does not fire"
     );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -581,6 +581,7 @@ mod issue_5997_malcolm_treasure_trigger;
 mod issue_5999_aura_exile_host;
 mod issue_6002_neera_wild_mage_bottom_of_library;
 mod issue_6006_aminatou_veil_piercer_own_turn_miracle;
+mod issue_6091_grindstone;
 mod issue_6092_ability_block_reason;
 mod issue_6102_ragavan_exile_cast;
 mod issue_6157_gold_token_auto_mana_payment;

--- a/crates/mtgish-import/src/convert/condition.rs
+++ b/crates/mtgish-import/src/convert/condition.rs
@@ -1081,6 +1081,7 @@ fn target_filter_variant_name(f: &TargetFilter) -> &'static str {
         TargetFilter::ExiledCardByIndex { .. } => "ExiledCardByIndex",
         TargetFilter::LastCreated => "LastCreated",
         TargetFilter::LastRevealed => "LastRevealed",
+        TargetFilter::LastZoneChanged => "LastZoneChanged",
         TargetFilter::CostPaidObject => "CostPaidObject",
         TargetFilter::ChosenCard => "ChosenCard",
         TargetFilter::TrackedSet { .. } => "TrackedSet",


### PR DESCRIPTION
Closes #6091

## Shipped

- **`TargetFilter::LastZoneChanged`** — resolution-local ledger filter mirroring `LastRevealed`, wired through filter/targeting/quantity/coverage/ability_rw paths; `object_count_matching_ids` short-circuits to `last_zone_changed_ids`.
- **Repeat-until parser** — `strip_milled_shared_quality_conditional` maps `if [N] cards that share a [quality] were milled this way, repeat this process` to `RepeatContinuation::WhileCondition` over `ObjectCountBySharedQuality { LastZoneChanged, Max } >= N` (no Unimplemented repeat sub-ability).
- **Deferral predicate** — `condition_depends_on_zone_change_this_way` recurses `QuantityCheck` / `QuantityExpr` trees for `LastZoneChanged` filters (same intent as `ZoneChangedThisWay` deferral).
- **Tests** — parser building-block + full Grindstone parse; quantity ledger unit tests; activated integration tests (Painter red combo, unlike-color reach guard, colorless stop-at-two).

## Issue scope vs out of scope

| In scope (done) | Out of scope (unchanged) |
|---|---|
| Grindstone activated repeat loop | Painter's Servant parser reopen |
| `LastZoneChanged` building block | Frontend / AI / mtgish |
| Shared-color milled-this-way repeat stripper | General this-way verb taxonomy beyond structured milled+quality combinators |

## Verification

- `cargo fmt --all`
- Tilt: `clippy`, `test-engine`, `card-data` (or direct `cargo test` fallback)
- Parser combinator gate + `cargo coverage` / `cargo semantic-audit` for parser diff



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for **Last Zone Changed** targets (most recently moved to a public zone), wired through targeting, resolution, counting, and user-facing labeling.
  * Extended Oracle parsing and condition evaluation for **milled/shared-quality** “repeat this process” gates (Grindstone-style loops).

* **Bug Fixes**
  * Corrected how **Last Zone Changed** is treated across filter evaluation and special-case ability/discard/attachment logic.
  * Fixed repeat/stop behavior for shared-color and colorless scenarios, including **Painter’s Servant** interactions.

* **Tests**
  * Added integration coverage for **Issue `#6091`** Grindstone loop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->