### PR TITLE
fix(parser): lower Doppelgang's inline for-each-of-target copy (#6509)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6556,6 +6556,13 @@ pub(crate) fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedE
         );
     }
     let original_lower = text.to_lowercase();
+    if let Some(mut clause) = try_parse_for_each_target_copy_token(text, &original_lower, ctx) {
+        peel_ctx.apply_optional(&mut clause.optional);
+        if clause.condition.is_none() {
+            clause.condition = peel_ctx.condition().cloned().or(unless_condition.clone());
+        }
+        return attach_unless_slots(clause, None, unless_pay_deferred);
+    }
     if let Some(mut clause) = try_parse_for_each_copy_token_source(text, &original_lower, ctx) {
         peel_ctx.apply_optional(&mut clause.optional);
         if clause.condition.is_none() {
@@ -6688,6 +6695,93 @@ fn try_parse_for_each_copy_token_source(
         extra_keywords,
         additional_modifications,
     }))
+}
+
+/// CR 115.1d + CR 601.2c + CR 707.2: "For each of <N> target <type>, create <M>
+/// tokens that are copies of that <noun>" — Doppelgang. The "for each of"
+/// distributor iterates an EXACT-count *targeted* set (`<N>` target permanents);
+/// the body creates `<M>` copy-tokens of each chosen target.
+///
+/// This is distinct from both sibling for-each copy paths:
+/// * `try_parse_for_each_copy_token_source` handles a NON-targeted object filter
+///   ("for each creature you control, …") — no target slot, no `MultiTargetSpec`.
+/// * Twinflame's "for each of them, create a token …" relies on a prior "Choose
+///   any number of target creatures" sentence to establish the target slot, then
+///   its body only recurses onto `ParentTarget`.
+///
+/// Here the target set is declared inline, so we lift the exact count onto the
+/// clause's `multi_target` and bind the copy source directly to the targeted
+/// `<type>` filter. The `CopyTokenOf` resolver iterates the ability's chosen
+/// targets and creates `count` copies of each (game/effects/token_copy.rs), so
+/// `N` targets × `M` copies = `N·M` tokens. The body's anaphor ("that permanent"
+/// lowers to `TriggeringSource`) has no trigger event on a spell, so it is
+/// discarded and replaced by the concrete targeted filter.
+fn try_parse_for_each_target_copy_token(
+    text: &str,
+    lower: &str,
+    ctx: &mut ParseContext,
+) -> Option<ParsedEffectClause> {
+    // "for each of <count> " distributor prefix over an exact-count target set.
+    let (after_prefix, _) = tag::<_, _, OracleError<'_>>("for each of ")
+        .parse(lower)
+        .ok()?;
+    let (after_count, target_count) = parse_multi_target_count_expr(after_prefix).ok()?;
+    let (after_count, _) = space1::<&str, OracleError<'_>>(after_count).ok()?;
+    // The iterated set must be a printed target ("target permanents"); require
+    // the "target " keyword so a bare "for each of them, …" (Twinflame) or a
+    // non-targeted filter never reaches this arm.
+    peek(tag::<_, _, OracleError<'_>>("target "))
+        .parse(after_count)
+        .ok()?;
+    // Split the target clause from the body at the distributor comma.
+    let (body_lower, _target_lower) =
+        terminated(take_until::<_, _, OracleError<'_>>(", "), tag(", "))
+            .parse(after_count)
+            .ok()?;
+    // Map the lowercase slices back onto the original-case `text` (ASCII Oracle
+    // text keeps byte offsets aligned).
+    let target_start = lower.len() - after_count.len();
+    let target_end = text.len() - body_lower.len() - ", ".len();
+    let target_text = &text[target_start..target_end];
+    let body = text[text.len() - body_lower.len()..].trim();
+
+    // The targeted set must resolve to a concrete typed filter with no residue.
+    let mut target_ctx = ctx.clone();
+    let (target, target_rem) = parse_target_with_ctx(target_text, &mut target_ctx);
+    if !target_rem.trim().is_empty() || !matches!(target, TargetFilter::Typed(_)) {
+        return None;
+    }
+
+    // The body must be a bare "create <M> tokens that are copies of that <noun>"
+    // whose copy source is an anaphor (no independent target of its own).
+    let mut body_ctx = ctx.clone();
+    let effect = token::try_parse_token(body_lower, body, &mut body_ctx)?;
+    let Effect::CopyTokenOf {
+        target: TargetFilter::ParentTarget | TargetFilter::SelfRef | TargetFilter::TriggeringSource,
+        owner,
+        source_filter: None,
+        enters_attacking,
+        tapped,
+        count,
+        extra_keywords,
+        additional_modifications,
+    } = effect
+    else {
+        return None;
+    };
+    *ctx = body_ctx;
+    let mut clause = parsed_clause(Effect::CopyTokenOf {
+        target,
+        owner,
+        source_filter: None,
+        enters_attacking,
+        tapped,
+        count,
+        extra_keywords,
+        additional_modifications,
+    });
+    clause.multi_target = Some(MultiTargetSpec::exact(target_count));
+    Some(clause)
 }
 
 /// Parse the residual of a "choose ..." head as a bare battlefield-object
@@ -7836,6 +7930,9 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return parsed_clause(effect);
     }
 
+    if let Some(clause) = try_parse_for_each_target_copy_token(text, &lower, ctx) {
+        return clause;
+    }
     if let Some(clause) = try_parse_for_each_copy_token_source(text, &lower, ctx) {
         return clause;
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6745,10 +6745,13 @@ fn try_parse_for_each_target_copy_token(
     if !matches!(target, TargetFilter::Typed(_)) {
         return None;
     }
-    // The distributor comma separates the target set from the body; tolerate
-    // its optional consumption by the target parser.
-    let body = target_rem.trim_start();
-    let body = body.strip_prefix(',').unwrap_or(body).trim();
+    // The distributor comma separates the target set from the body; consume it
+    // with a combinator (the target parser may or may not have already eaten
+    // it, so `opt`). `opt` never fails, so this only extracts the body slice.
+    let (body, _) = opt(tag::<_, _, OracleError<'_>>(","))
+        .parse(target_rem.trim_start())
+        .ok()?;
+    let body = body.trim();
     if body.is_empty() {
         return None;
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6733,29 +6733,31 @@ fn try_parse_for_each_target_copy_token(
     peek(tag::<_, _, OracleError<'_>>("target "))
         .parse(after_count)
         .ok()?;
-    // Split the target clause from the body at the distributor comma.
-    let (body_lower, _target_lower) =
-        terminated(take_until::<_, _, OracleError<'_>>(", "), tag(", "))
-            .parse(after_count)
-            .ok()?;
-    // Map the lowercase slices back onto the original-case `text` (ASCII Oracle
+    // Let the target parser itself consume the filter and hand back the
+    // distributor comma + body — the parser IS the detector, so a compound
+    // filter with internal commas ("target artifact, creature, or land
+    // permanent") that a naive ", " split would truncate is handled correctly.
+    // Map the lowercase offset back onto the original-case `text` (ASCII Oracle
     // text keeps byte offsets aligned).
     let target_start = lower.len() - after_count.len();
-    let target_end = text.len() - body_lower.len() - ", ".len();
-    let target_text = &text[target_start..target_end];
-    let body = text[text.len() - body_lower.len()..].trim();
-
-    // The targeted set must resolve to a concrete typed filter with no residue.
     let mut target_ctx = ctx.clone();
-    let (target, target_rem) = parse_target_with_ctx(target_text, &mut target_ctx);
-    if !target_rem.trim().is_empty() || !matches!(target, TargetFilter::Typed(_)) {
+    let (target, target_rem) = parse_target_with_ctx(&text[target_start..], &mut target_ctx);
+    if !matches!(target, TargetFilter::Typed(_)) {
         return None;
     }
+    // The distributor comma separates the target set from the body; tolerate
+    // its optional consumption by the target parser.
+    let body = target_rem.trim_start();
+    let body = body.strip_prefix(',').unwrap_or(body).trim();
+    if body.is_empty() {
+        return None;
+    }
+    let body_lower = body.to_lowercase();
 
     // The body must be a bare "create <M> tokens that are copies of that <noun>"
     // whose copy source is an anaphor (no independent target of its own).
     let mut body_ctx = ctx.clone();
-    let effect = token::try_parse_token(body_lower, body, &mut body_ctx)?;
+    let effect = token::try_parse_token(&body_lower, body, &mut body_ctx)?;
     let Effect::CopyTokenOf {
         target: TargetFilter::ParentTarget | TargetFilter::SelfRef | TargetFilter::TriggeringSource,
         owner,

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -14730,6 +14730,57 @@ fn twinflame_full_parse() {
     }
 }
 
+/// CR 115.1d + CR 601.2c + CR 707.2 (issue #6509): Doppelgang — "For each of X
+/// target permanents, create X tokens that are copies of that permanent." The
+/// single-sentence for-each-of distributor must (a) target EXACTLY X permanents
+/// (`MultiTargetSpec::exact(X)`) and (b) create X copies of each chosen target
+/// (`CopyTokenOf { target: Typed(permanent), count: X }`). Previously this
+/// resolved without effect because the inline targeted set never lowered.
+#[test]
+fn doppelgang_full_parse() {
+    use crate::types::ability::{
+        Effect, MultiTargetSpec, QuantityExpr, QuantityRef, TargetFilter, TypeFilter,
+    };
+
+    let r = parse(
+        "For each of X target permanents, create X tokens that are copies of that permanent.",
+        "Doppelgang",
+        &[],
+        &["Sorcery"],
+        &[],
+    );
+
+    assert_eq!(r.abilities.len(), 1, "expected single spell ability");
+    let ab = &r.abilities[0];
+
+    let x = QuantityExpr::Ref {
+        qty: QuantityRef::Variable {
+            name: "X".to_string(),
+        },
+    };
+
+    // Exactly X targets, each a permanent.
+    assert_eq!(
+        ab.multi_target,
+        Some(MultiTargetSpec::exact(x.clone())),
+        "Doppelgang must target exactly X permanents"
+    );
+
+    match &*ab.effect {
+        Effect::CopyTokenOf { target, count, .. } => {
+            let TargetFilter::Typed(tf) = target else {
+                panic!("copy source must be the chosen permanent targets, got {target:?}");
+            };
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Permanent),
+                "copy source must filter permanents, not resolve an anaphor"
+            );
+            assert_eq!(*count, x, "each target yields X copies");
+        }
+        other => panic!("expected CopyTokenOf, got {other:?}"),
+    }
+}
+
 // ── Mana spend restriction extensions ─────────────────────────────
 
 #[test]


### PR DESCRIPTION
fix(parser): lower Doppelgang's inline for-each-of-target copy (#6509)

"For each of X target permanents, create X tokens that are copies of that
permanent" resolved without effect because the inline targeted iteration set
never lowered. Unlike Twinflame (whose target slot comes from a prior "Choose
any number of target creatures" sentence) and unlike the non-targeted
"for each creature you control" copy path, Doppelgang declares its target set
inside the "for each of" distributor.

Add try_parse_for_each_target_copy_token: strip "for each of <count> target
<type>", lift the exact count onto the clause's MultiTargetSpec, and bind the
CopyTokenOf source directly to the targeted filter (discarding the body's
"that permanent" anaphor, which resolves to TriggeringSource and has no trigger
event on a spell). The resolver already iterates the ability's chosen targets
and creates `count` copies of each, so X targets x X copies = X*X tokens.

Closes #6509



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Oracle parsing for “for each of … target … create … copies” effects, including exact multi-target counts and target-specific copy behavior.
* **Bug Fixes**
  * Improved recognition and interpretation of targeted copy-token clauses, with correct handling of optional clause details and default conditions.
* **Tests**
  * Added a unit test for the “Doppelgang” Oracle sentence to confirm the exact target count and resulting token-copy effect are parsed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->