### PR TITLE
fix(client): honor List in lobby for LobbyOnly / P2P broker hosts

### DIFF
--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -867,7 +867,8 @@ export function GameProvider({
                 hostPeerId: host.peer.id,
                 deck: deckList.player,
                 displayName: store.displayName || "Host",
-                public: true,
+                // Honor HostSetup's "List in lobby" toggle (issue #6556).
+                public: store.hostIsPublic,
                 password: null,
                 timerSeconds: null,
                 playerCount: effectivePlayerCount,

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -51,6 +51,16 @@ const p2pMocks = vi.hoisted(() => ({
   dispose: vi.fn(),
 }));
 
+const brokerMocks = vi.hoisted(() => ({
+  registerHost: vi.fn(async () => ({
+    gameCode: "PRIV1",
+    playerToken: "broker-token",
+  })),
+  updateMetadata: vi.fn(),
+  unregister: vi.fn(async () => undefined),
+  close: vi.fn(),
+}));
+
 const socketMocks = vi.hoisted(() => ({
   send: vi.fn(),
   close: vi.fn(),
@@ -111,6 +121,19 @@ vi.mock("../../services/openPhaseSocket", () => ({
   })),
   withReconnect: vi.fn(),
 }));
+
+vi.mock("../../services/brokerClient", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../services/brokerClient")>();
+  return {
+    ...actual,
+    openBrokerClient: vi.fn(async () => ({
+      registerHost: brokerMocks.registerHost,
+      updateMetadata: brokerMocks.updateMetadata,
+      unregister: brokerMocks.unregister,
+      close: brokerMocks.close,
+    })),
+  };
+});
 
 function hostingSettings(
   overrides: Partial<HostingSettings> = {},
@@ -419,6 +442,24 @@ describe("multiplayerStore", () => {
         },
       },
     });
+  });
+
+  it("registers a private LobbyOnly host without advertising it in the public list (#6556)", async () => {
+    const ok = await useMultiplayerStore.getState().startP2PHostingSession(
+      hostingSettings({ public: false }),
+      {
+        main_deck: ["Forest"],
+        sideboard: [],
+        commander: ["Goreclaw, Terror of Qal Sisma"],
+      },
+      { useBroker: true, roomName: "Private table" },
+    );
+
+    expect(ok).toBe(true);
+    expect(useMultiplayerStore.getState().hostIsPublic).toBe(false);
+    expect(brokerMocks.registerHost).toHaveBeenCalledWith(
+      expect.objectContaining({ public: false }),
+    );
   });
 
   it("does not apply setup-time AI seats when starting a team-based P2P host session", async () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -1009,7 +1009,10 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
         };
 
         set({
-          hostIsPublic: opts.useBroker,
+          // LobbyOnly hosts still register with the broker so friends can
+          // join by code; `settings.public` controls whether that entry is
+          // advertised in the public lobby list (issue #6556).
+          hostIsPublic: opts.useBroker && settings.public,
           hostingStatus: "connecting",
           hostGameCode: null,
           hostSession: {
@@ -1094,7 +1097,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
               hostPeerId: host.peer.id,
               deck: asDeckPayload(deck),
               displayName: get().displayName || "Host",
-              public: true,
+              public: settings.public,
               password: settings.password || null,
               timerSeconds: null,
               playerCount: settings.formatConfig.max_players,
@@ -1177,7 +1180,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
           destroyHostedRoom = null;
 
           set({
-            hostIsPublic: opts.useBroker,
+            hostIsPublic: opts.useBroker && settings.public,
             hostingStatus: "waiting",
             hostGameCode: host.roomCode,
             hostSession: {


### PR DESCRIPTION
## Summary
- Fixes #6556: HostSetup's **List in lobby** toggle was ignored on LobbyOnly servers (and the GameProvider broker path), which always registered with `public: true` and set `hostIsPublic` from `useBroker`.
- Private hosts still register with the broker so friends can join by code; they are no longer broadcast via `LobbyGameAdded` / `public_games()`.

## Changes
- `startP2PHostingSession`: pass `settings.public` to `registerHost`; keep `hostIsPublic = useBroker && settings.public` through both connecting and waiting states.
- `GameProvider` P2P host broker registration: use `store.hostIsPublic` instead of hardcoding `true`.
- Regression test in `multiplayerStore.test.ts`.

## Validation
- `pnpm exec vitest run src/stores/__tests__/multiplayerStore.test.ts` — 19 passed.
- Non-engine client/transport change (CONTRIBUTING narrow exception); no `crates/engine/` edits.

## Test plan
- [ ] Host against a LobbyOnly server with **List in lobby** off → room absent from public lobby list
- [ ] Join the same room by entering the code
- [ ] Host with **List in lobby** on → room appears as before

Model: Composer

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - P2P hosts now respect the “List in lobby” visibility setting when registering with the broker.
  - Private, lobby-only sessions remain hidden from the public lobby while still supporting join-by-code.
  - Host visibility status now stays consistent throughout the hosting flow.

- **Tests**
  - Added coverage verifying that private broker-hosted sessions are registered as non-public.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->