### PR TITLE
fix(engine): activate a zero-card "discard your hand" cost with an empty hand (Lion's Eye Diamond)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1,12 +1,12 @@
 use crate::types::ability::{
     is_variable_remove_counter_cost_count, AbilityBlockKind, AbilityBlockReason, AbilityCondition,
     AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AdditionalCost, CardPlayMode,
-    CastTimingPermission, CastingPermission, ChoiceType, ContinuousModification, CostObjectCount,
-    CostPaidObjectSnapshot, CounterCostSelection, Duration, Effect, FilterProp, GameRestriction,
-    ModalSelectionCondition, ObjectScope, PlayerFilter, PlayerScope, ProhibitedActivity,
-    QuantityExpr, QuantityRef, ResolvedAbility, RestrictionExpiry, RestrictionPlayerScope,
-    StaticCondition, StaticDefinition, SubAbilityLink, TapCreaturesRequirement, TargetFilter,
-    TargetRef,
+    CardSelectionMode, CastTimingPermission, CastingPermission, ChoiceType, ContinuousModification,
+    CostObjectCount, CostPaidObjectSnapshot, CounterCostSelection, Duration, Effect, FilterProp,
+    GameRestriction, ModalSelectionCondition, ObjectScope, PlayerFilter, PlayerScope,
+    ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility, RestrictionExpiry,
+    RestrictionPlayerScope, StaticCondition, StaticDefinition, SubAbilityLink,
+    TapCreaturesRequirement, TargetFilter, TargetRef,
 };
 use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
@@ -15240,16 +15240,21 @@ pub(super) fn find_battlefield_exile_cost(cost: &AbilityCost) -> Option<(u32, &T
     }
 }
 
+/// Sole detector for a non-self "discard from hand" cost leg. Returns the count
+/// expression, optional card filter, and the `CardSelectionMode` (player-chosen
+/// vs. game-selected) so a single authority drives both the casting/activation
+/// resolver and the mana-ability path. `SourceCard` "discard this card" is never
+/// matched (see [`resolve_non_self_discard_requirement`]); recurses `Composite`.
 pub(crate) fn find_non_self_discard(
     cost: &AbilityCost,
-) -> Option<(&QuantityExpr, Option<&TargetFilter>)> {
+) -> Option<(&QuantityExpr, Option<&TargetFilter>, CardSelectionMode)> {
     match cost {
         AbilityCost::Discard {
             count,
             filter,
             self_scope: crate::types::ability::DiscardSelfScope::FromHand,
-            ..
-        } => Some((count, filter.as_ref())),
+            selection,
+        } => Some((count, filter.as_ref(), *selection)),
         AbilityCost::Composite { costs } => costs.iter().find_map(find_non_self_discard),
         _ => None,
     }
@@ -15278,7 +15283,10 @@ pub(crate) fn resolve_non_self_discard_requirement(
     source_id: ObjectId,
     cost: &AbilityCost,
 ) -> Result<Option<(usize, Vec<ObjectId>)>, EngineError> {
-    let Some((count, filter)) = find_non_self_discard(cost) else {
+    // The activation/casting path handles ANY `FromHand` discard selection mode; the
+    // mana-ability path (see `mana_abilities::discard_cost_choice`) is the only caller
+    // that gates on `Chosen`. Keep this resolver selection-agnostic.
+    let Some((count, filter, _selection)) = find_non_self_discard(cost) else {
         return Ok(None);
     };
     let count = super::quantity::resolve_quantity(state, count, player, source_id).max(0) as usize;

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -15255,6 +15255,47 @@ pub(crate) fn find_non_self_discard(
     }
 }
 
+/// CR 601.2h + CR 701.9a: Resolve a non-self "discard" cost leg into its interactive requirement.
+///
+/// - `Ok(None)`  => there is no `FromHand` discard leg, OR the resolved count is 0. A zero-card
+///   discard — e.g. Lion's Eye Diamond's "Discard your hand" with an empty hand (its
+///   `HandSize` count resolves to 0) — is paid by doing nothing: nothing moves and no
+///   `Discarded`/`ZoneChanged` event fires (CR 701.9a moves cards hand→graveyard only when
+///   there are cards). Per CR 601.2h an unpayable cost can't be paid, but a zero-cost is not
+///   unpayable — it is trivially paid. The caller treats the leg as satisfied and proceeds to
+///   the next unpaid leg. Structural precedent: `mana_abilities::exile_cost_choice` (the
+///   interactive non-self cost sibling).
+/// - `Err(..)`   => there are fewer eligible cards than the required (nonzero) count, so
+///   CR 601.2h makes the cost unpayable.
+/// - `Ok(Some((count, eligible)))` => an interactive selection of `count` cards from `eligible`.
+///
+/// Detection is `FromHand`-only (via [`find_non_self_discard`]); a `SourceCard` "discard this
+/// card" cost is never matched here and its `count` resolves to 1, so it can never misfire
+/// through the zero-count auto-pay path.
+pub(crate) fn resolve_non_self_discard_requirement(
+    state: &GameState,
+    player: PlayerId,
+    source_id: ObjectId,
+    cost: &AbilityCost,
+) -> Result<Option<(usize, Vec<ObjectId>)>, EngineError> {
+    let Some((count, filter)) = find_non_self_discard(cost) else {
+        return Ok(None);
+    };
+    let count = super::quantity::resolve_quantity(state, count, player, source_id).max(0) as usize;
+    // CR 601.2h + CR 701.9a: A resolved zero-card discard is paid by doing nothing — never
+    // surface a dead selection prompt for it.
+    if count == 0 {
+        return Ok(None);
+    }
+    let eligible = find_eligible_discard_targets(state, player, source_id, filter);
+    if eligible.len() < count {
+        return Err(EngineError::ActionNotAllowed(
+            "Not enough cards in hand to discard".into(),
+        ));
+    }
+    Ok(Some((count, eligible)))
+}
+
 fn has_self_ref_discard_cost(cost: &AbilityCost) -> bool {
     match cost {
         AbilityCost::Discard {
@@ -16971,15 +17012,13 @@ pub fn handle_activate_ability(
             });
         }
 
-        if let Some((count, filter)) = find_non_self_discard(cost) {
-            let count =
-                super::quantity::resolve_quantity(state, count, player, source_id).max(0) as usize;
-            let eligible = find_eligible_discard_targets(state, player, source_id, filter);
-            if eligible.len() < count {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough cards in hand to discard".into(),
-                ));
-            }
+        // CR 601.2h + CR 701.9a: A resolved zero-card FromHand discard leg (e.g. Bomat
+        // Courier's "Discard your hand" on an empty hand) is paid by doing nothing — the
+        // helper returns `Ok(None)` so we FALL THROUGH to the following cost detection
+        // rather than surfacing a dead `PayCost { count: 0 }`.
+        if let Some((count, eligible)) =
+            resolve_non_self_discard_requirement(state, player, source_id, cost)?
+        {
             let mut pending_discard =
                 PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
             pending_discard.activation_cost = Some(cost.clone());

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4053,16 +4053,13 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
     };
     let source_id = pending.object_id;
 
-    if let Some((count, filter)) = super::casting::find_non_self_discard(cost) {
-        let count =
-            super::quantity::resolve_quantity(state, count, player, source_id).max(0) as usize;
-        let eligible =
-            super::casting::find_eligible_discard_targets(state, player, source_id, filter);
-        if eligible.len() < count {
-            return Err(EngineError::ActionNotAllowed(
-                "Not enough cards in hand to discard".into(),
-            ));
-        }
+    // CR 601.2h + CR 701.9a: A resolved zero-card FromHand discard leg (Lion's Eye Diamond /
+    // Bomat Courier's "Discard your hand" on an empty hand) is paid by doing nothing — the
+    // helper returns `Ok(None)` so we FALL THROUGH to the next unpaid leg (the sacrifice arm
+    // below) rather than surfacing a dead `PayCost { count: 0 }`.
+    if let Some((count, eligible)) =
+        super::casting::resolve_non_self_discard_requirement(state, player, source_id, cost)?
+    {
         return Ok(Some(WaitingFor::PayCost {
             player,
             kind: PayCostKind::Discard,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -49176,3 +49176,260 @@ fn path_of_ancestry_fires_for_a_commander_an_opponent_controls() {
         "a stolen commander is still YOUR commander (CR 903.3) — the scry must still fire"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #6494 — resolve_non_self_discard_requirement class boundary
+//
+// The shared helper backing every non-self FromHand discard cost site
+// (activation begin_cost_payment, surface_next_unpaid_interactive_activation_cost,
+// and the spell additional-cost arm). A resolved-count-0 FromHand discard is
+// paid by doing nothing (CR 601.2h + CR 701.9a) → Ok(None); a nonzero count with
+// too few eligible cards is unpayable → Err; SourceCard "discard this card" is
+// FromHand-only-excluded → Ok(None) (its own count-1 path is untouched).
+// ---------------------------------------------------------------------------
+
+fn from_hand_discard_cost(count: QuantityExpr) -> AbilityCost {
+    AbilityCost::Discard {
+        count,
+        filter: None,
+        selection: crate::types::ability::CardSelectionMode::Chosen,
+        self_scope: crate::types::ability::DiscardSelfScope::FromHand,
+    }
+}
+
+/// Issue #6494 (negative, class boundary): a fixed `Discard { count: 1 }` on an
+/// EMPTY hand is UNPAYABLE (CR 601.2h) — the helper returns `Err`, NOT `Ok(None)`.
+/// The zero-count auto-pay class is `resolved == 0` ONLY; `count >= 1` never
+/// auto-pays. Reach-guarded: the same cost with a card in hand returns
+/// `Ok(Some((1, [card])))`, proving the helper reaches its count/eligibility
+/// check rather than short-circuiting. `AbilityCost::is_payable` agrees (false
+/// on empty hand, true with the card).
+#[test]
+fn resolve_discard_requirement_fixed_one_empty_hand_is_unpayable_err() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Source".to_string(),
+        Zone::Battlefield,
+    );
+    let cost = from_hand_discard_cost(QuantityExpr::Fixed { value: 1 });
+
+    // Empty hand: unpayable, so the helper errors rather than auto-paying.
+    assert!(state.players[0].hand.is_empty());
+    assert!(matches!(
+        resolve_non_self_discard_requirement(&state, PlayerId(0), source, &cost),
+        Err(EngineError::ActionNotAllowed(_))
+    ));
+    // CR 601.2h: the payability gate excludes it too.
+    assert!(!cost.is_payable(&state, PlayerId(0), source));
+
+    // Positive reach-guard: with one eligible card the helper resolves the real
+    // interactive requirement (not a vacuous early return).
+    let card = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(0),
+        "Card".to_string(),
+        Zone::Hand,
+    );
+    match resolve_non_self_discard_requirement(&state, PlayerId(0), source, &cost) {
+        Ok(Some((count, eligible))) => {
+            assert_eq!(count, 1);
+            assert_eq!(eligible, vec![card]);
+        }
+        other => panic!("expected Ok(Some((1, [card]))), got {other:?}"),
+    }
+    assert!(cost.is_payable(&state, PlayerId(0), source));
+}
+
+/// Issue #6494 (no over-fire, casting path): a `Discard { Fixed(2) }` with THREE
+/// eligible cards resolves to `Ok(Some((2, <all 3 choices>)))` — the count stays
+/// 2 (never widened or auto-paid) and every eligible card is offered as a choice.
+#[test]
+fn resolve_discard_requirement_fixed_two_with_three_eligible_offers_all() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Source".to_string(),
+        Zone::Battlefield,
+    );
+    let c1 = create_object(
+        &mut state,
+        CardId(2),
+        PlayerId(0),
+        "A".to_string(),
+        Zone::Hand,
+    );
+    let c2 = create_object(
+        &mut state,
+        CardId(3),
+        PlayerId(0),
+        "B".to_string(),
+        Zone::Hand,
+    );
+    let c3 = create_object(
+        &mut state,
+        CardId(4),
+        PlayerId(0),
+        "C".to_string(),
+        Zone::Hand,
+    );
+
+    let cost = from_hand_discard_cost(QuantityExpr::Fixed { value: 2 });
+    match resolve_non_self_discard_requirement(&state, PlayerId(0), source, &cost) {
+        Ok(Some((count, eligible))) => {
+            assert_eq!(count, 2);
+            assert_eq!(eligible.len(), 3);
+            for card in [c1, c2, c3] {
+                assert!(eligible.contains(&card));
+            }
+        }
+        other => panic!("expected Ok(Some((2, 3 choices))), got {other:?}"),
+    }
+}
+
+/// Issue #6494 (SourceCard/self-discard untouched): a `Discard { self_scope:
+/// SourceCard }` ("discard this card") is FromHand-only-excluded — both the
+/// detector `find_non_self_discard` and the helper return `None`, so the
+/// SourceCard discard path never routes through the zero-count auto-pay. Reach-
+/// guarded: an otherwise-identical FromHand discard IS detected, proving the
+/// `None` is scope-driven, not a failure to match the `Discard` shape at all.
+#[test]
+fn resolve_discard_requirement_source_card_scope_is_not_auto_paid() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Channel".to_string(),
+        Zone::Hand,
+    );
+
+    let source_card_cost = AbilityCost::Discard {
+        count: QuantityExpr::Fixed { value: 1 },
+        filter: None,
+        selection: crate::types::ability::CardSelectionMode::Chosen,
+        self_scope: crate::types::ability::DiscardSelfScope::SourceCard,
+    };
+    // FromHand-only detection: SourceCard is invisible to both the detector and
+    // the helper, so it can never reach the zero-count auto-pay branch.
+    assert!(find_non_self_discard(&source_card_cost).is_none());
+    assert!(matches!(
+        resolve_non_self_discard_requirement(&state, PlayerId(0), source, &source_card_cost),
+        Ok(None)
+    ));
+
+    // Positive reach-guard: the same shape as FromHand IS detected (so the None
+    // above is the SourceCard scope, not a shape mismatch).
+    let from_hand_cost = from_hand_discard_cost(QuantityExpr::Fixed { value: 1 });
+    assert!(find_non_self_discard(&from_hand_cost).is_some());
+}
+
+/// Issue #6494 (site 3 — activation `begin_cost_payment` discard emitter, casting
+/// path class): Bomat Courier's activated ability
+/// "{R}, Discard your hand, Sacrifice this creature: Put all cards exiled with
+/// this creature into their owners' hands." must be activatable with an EMPTY
+/// hand — the "Discard your hand" leg is a zero-card discard paid by doing
+/// nothing (CR 601.2h + CR 701.9a).
+///
+/// Built from Bomat Courier's VERBATIM parsed cost
+/// (`Composite[Mana {R}, Discard { HandSize, FromHand }, Sacrifice(SelfRef, 1)]`),
+/// driven through the production `handle_activate_ability` entry. A stand-in
+/// `Draw 1` effect isolates the cost-payment path (the exiled-card return is the
+/// card's effect, not the cost under repair). Revert-sensitive: at base the
+/// discard leg surfaces `PayCost { Discard, count: 0 }`, so the activation never
+/// reaches the stack, the self-sacrifice never fires, and nothing is drawn.
+#[test]
+fn bomat_courier_activates_empty_handed_casting_path() {
+    let mut state = setup_game_at_main_phase();
+    add_mana(&mut state, PlayerId(0), ManaType::Red, 1);
+
+    let bomat = create_object(
+        &mut state,
+        CardId(6494),
+        PlayerId(0),
+        "Bomat Courier".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&bomat).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.card_types.core_types.push(CoreType::Creature);
+    }
+    // A card in library so the stand-in Draw is observable.
+    let lib_card = create_object(
+        &mut state,
+        CardId(6495),
+        PlayerId(0),
+        "Library Card".to_string(),
+        Zone::Library,
+    );
+
+    // Bomat Courier's EXACT parsed activated-ability cost.
+    let bomat_cost = AbilityCost::Composite {
+        costs: vec![
+            AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    shards: vec![ManaCostShard::Red],
+                    generic: 0,
+                },
+            },
+            AbilityCost::Discard {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::HandSize {
+                        player: crate::types::ability::PlayerScope::Controller,
+                    },
+                },
+                filter: None,
+                selection: crate::types::ability::CardSelectionMode::Chosen,
+                self_scope: crate::types::ability::DiscardSelfScope::FromHand,
+            },
+            AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1)),
+        ],
+    };
+    Arc::make_mut(&mut state.objects.get_mut(&bomat).unwrap().abilities).push(
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        )
+        .cost(bomat_cost),
+    );
+
+    assert!(state.players[0].hand.is_empty());
+
+    let mut events = Vec::new();
+    let waiting = handle_activate_ability(&mut state, PlayerId(0), bomat, 0, &mut events)
+        .expect("empty-hand Bomat Courier activation must not error");
+    state.waiting_for = waiting;
+
+    // Drive cost payment + resolution. The driver must NEVER see a discard prompt.
+    for _ in 0..10 {
+        if state.stack.is_empty() && matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+            break;
+        }
+        assert!(
+            !matches!(
+                state.waiting_for,
+                WaitingFor::PayCost {
+                    kind: PayCostKind::Discard,
+                    ..
+                }
+            ),
+            "a dead PayCost {{ Discard }} was surfaced on the casting path"
+        );
+        apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    }
+
+    // The self-sacrifice cost leg fired (Bomat left the battlefield to graveyard).
+    assert_eq!(state.objects[&bomat].zone, Zone::Graveyard);
+    // Positive reach-guard: the ability resolved (the stand-in Draw drew the card).
+    assert!(state.stack.is_empty(), "the ability must fully resolve");
+    assert_eq!(state.objects[&lib_card].zone, Zone::Hand);
+}

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -3571,6 +3571,16 @@ fn discard_cost_choice(
 ) -> Option<(usize, Vec<ObjectId>)> {
     let (count, filter) = find_non_self_discard_cost(cost.as_ref()?)?;
     let resolved = super::quantity::resolve_quantity(state, count, player, source_id).max(0);
+    // CR 601.2h + CR 701.9a: A resolved zero-card discard (Lion's Eye Diamond's "Discard
+    // your hand" with an empty hand — `HandSize` -> 0) is paid by doing nothing; nothing
+    // moves and no `Discarded` event fires. Surfacing a `PayCost { count: 0 }` prompt here
+    // stalls the activation forever, because submitting the empty prompt re-enters with a
+    // still-empty `chosen_discards` and re-emits the same dead prompt. Returning `None`
+    // makes the caller skip the discard leg and proceed to the source sacrifice + mana.
+    // Structural precedent: `exile_cost_choice` (the interactive non-self cost sibling).
+    if resolved == 0 {
+        return None;
+    }
     let cards = super::casting::find_eligible_discard_targets(state, player, source_id, filter);
     Some((resolved as usize, cards))
 }
@@ -6407,6 +6417,205 @@ mod tests {
         .unwrap();
 
         assert_eq!(state.players[0].mana_pool.count_color(ManaType::Red), 3);
+    }
+
+    /// CR 605.1a + CR 106.1: Build a Lion's-Eye-Diamond-shaped mana ability —
+    /// `Composite[Discard { HandSize }, Sacrifice(SelfRef)]` producing three mana
+    /// of one chosen color. Mirrors the real card's parsed cost
+    /// (`Discard { count: Ref HandSize(Controller), self_scope: FromHand }` +
+    /// `Sacrifice(SelfRef, 1)`), so a name change alone re-targets it to any card
+    /// in the same "discard your hand, sacrifice ~: add three mana" class.
+    fn discard_hand_sacrifice_three_mana_ability() -> AbilityDefinition {
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::AnyOneColor {
+                    count: QuantityExpr::Fixed { value: 3 },
+                    color_options: vec![
+                        ManaColor::White,
+                        ManaColor::Blue,
+                        ManaColor::Black,
+                        ManaColor::Red,
+                        ManaColor::Green,
+                    ],
+                    contribution: ManaContribution::Base,
+                },
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Composite {
+            costs: vec![
+                AbilityCost::Discard {
+                    count: QuantityExpr::Ref {
+                        qty: crate::types::ability::QuantityRef::HandSize {
+                            player: crate::types::ability::PlayerScope::Controller,
+                        },
+                    },
+                    filter: None,
+                    selection: crate::types::ability::CardSelectionMode::Chosen,
+                    self_scope: crate::types::ability::DiscardSelfScope::FromHand,
+                },
+                AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1)),
+            ],
+        })
+    }
+
+    /// Issue #6494 (PRIMARY revert-guard, mana path): Lion's Eye Diamond with an
+    /// EMPTY hand must be activatable — its "Discard your hand" leg with an empty
+    /// hand is a zero-card discard, paid by doing nothing (CR 601.2h + CR 701.9a).
+    ///
+    /// Oracle (Scryfall-verified): "Discard your hand, Sacrifice this artifact:
+    /// Add three mana of any one color. Activate only as an instant."
+    ///
+    /// At base the activation surfaces `WaitingFor::PayCost { Discard, count: 0 }`
+    /// (a dead prompt that re-emits forever), so the `ChooseManaColor` assertion
+    /// fails with `left: PayCost right: ChooseManaColor` — revert-sensitive to the
+    /// `mana_abilities::discard_cost_choice` `resolved == 0` guard. The 3-mana
+    /// assertion is a positive reach-guard (proves production, not a vacuous halt);
+    /// the sacrifice assertion proves the guard consumes ONLY the discard leg and
+    /// the self-sacrifice still fires.
+    #[test]
+    fn lions_eye_diamond_activates_empty_handed_and_produces_chosen_color() {
+        let mut state = GameState::new_two_player(42);
+        let led = create_object(
+            &mut state,
+            CardId(30),
+            PlayerId(0),
+            "Lion's Eye Diamond".to_string(),
+            Zone::Battlefield,
+        );
+        // No cards in hand — HandSize(Controller) resolves to 0.
+        assert!(state.players[0].hand.is_empty());
+
+        let ability = discard_hand_sacrifice_three_mana_ability();
+        Arc::make_mut(&mut state.objects.get_mut(&led).unwrap().abilities).push(ability.clone());
+
+        let mut events = Vec::new();
+        let waiting = activate_mana_ability(
+            &mut state,
+            led,
+            PlayerId(0),
+            0,
+            &ability,
+            &mut events,
+            ManaAbilityResume::Priority,
+            None,
+        )
+        .unwrap();
+
+        // CR 601.2h + CR 701.9a: no dead PayCost { Discard, count: 0 } — the
+        // activation advances straight to the color choice.
+        let pending = match waiting {
+            WaitingFor::ChooseManaColor {
+                player,
+                choice: ManaChoicePrompt::SingleColor { options },
+                context,
+            } => {
+                assert_eq!(player, PlayerId(0));
+                assert_eq!(options.len(), 5);
+                *expect_mana_ability_context(context)
+            }
+            other => panic!("expected ChooseManaColor, got {other:?}"),
+        };
+
+        // CR 701.9a: nothing was discarded — the hand stays empty.
+        assert!(state.players[0].hand.is_empty());
+        // The self-sacrifice leg still fired — LED left the battlefield for the
+        // graveyard, and it is the ONLY card there (the zero-card discard added
+        // nothing), proving the guard consumed only the discard leg.
+        assert_eq!(state.players[0].graveyard.len(), 1);
+        assert!(state.players[0].graveyard.contains(&led));
+        assert_ne!(
+            state.objects.get(&led).map(|obj| obj.zone),
+            Some(Zone::Battlefield)
+        );
+
+        handle_choose_mana_color(
+            &mut state,
+            &pending,
+            &ManaChoicePrompt::SingleColor {
+                options: vec![
+                    ManaType::White,
+                    ManaType::Blue,
+                    ManaType::Black,
+                    ManaType::Red,
+                    ManaType::Green,
+                ],
+            },
+            ManaChoice::SingleColor(ManaType::Red),
+            &mut events,
+        )
+        .unwrap();
+
+        // Positive reach-guard: production actually ran (not a vacuous halt).
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Red), 3);
+    }
+
+    /// Issue #6494 (mana path, class not card): Diamond Lion shares Lion's Eye
+    /// Diamond's "Discard your hand, Sacrifice ~: Add three mana of any one color"
+    /// shape, so the empty-hand fix is class-wide, not keyed to one card. Only the
+    /// object name differs from the LED case above.
+    #[test]
+    fn diamond_lion_activates_empty_handed_and_produces_chosen_color() {
+        let mut state = GameState::new_two_player(7);
+        let lion = create_object(
+            &mut state,
+            CardId(40),
+            PlayerId(0),
+            "Diamond Lion".to_string(),
+            Zone::Battlefield,
+        );
+        assert!(state.players[0].hand.is_empty());
+
+        let ability = discard_hand_sacrifice_three_mana_ability();
+        Arc::make_mut(&mut state.objects.get_mut(&lion).unwrap().abilities).push(ability.clone());
+
+        let mut events = Vec::new();
+        let waiting = activate_mana_ability(
+            &mut state,
+            lion,
+            PlayerId(0),
+            0,
+            &ability,
+            &mut events,
+            ManaAbilityResume::Priority,
+            None,
+        )
+        .unwrap();
+
+        let pending = match waiting {
+            WaitingFor::ChooseManaColor {
+                choice: ManaChoicePrompt::SingleColor { .. },
+                context,
+                ..
+            } => *expect_mana_ability_context(context),
+            other => panic!("expected ChooseManaColor, got {other:?}"),
+        };
+        assert_ne!(
+            state.objects.get(&lion).map(|obj| obj.zone),
+            Some(Zone::Battlefield)
+        );
+
+        handle_choose_mana_color(
+            &mut state,
+            &pending,
+            &ManaChoicePrompt::SingleColor {
+                options: vec![
+                    ManaType::White,
+                    ManaType::Blue,
+                    ManaType::Black,
+                    ManaType::Red,
+                    ManaType::Green,
+                ],
+            },
+            ManaChoice::SingleColor(ManaType::Green),
+            &mut events,
+        )
+        .unwrap();
+        assert_eq!(state.players[0].mana_pool.count_color(ManaType::Green), 3);
     }
 
     /// Helper: build a Pit-of-Offerings-style permanent with a `{T}: Add one mana

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1,8 +1,8 @@
 use crate::game::functioning_abilities::static_kind_present;
 use crate::types::ability::{
-    AbilityCondition, AbilityCost, AbilityDefinition, ChoiceValue, ChosenAttribute,
-    ContinuousModification, CostPaidObjectSnapshot, Effect, ManaProduction, QuantityExpr,
-    QuantityRef, ResolvedAbility, TargetFilter, REMOVE_COUNTER_COST_ALL,
+    AbilityCondition, AbilityCost, AbilityDefinition, CardSelectionMode, ChoiceValue,
+    ChosenAttribute, ContinuousModification, CostPaidObjectSnapshot, Effect, ManaProduction,
+    QuantityExpr, QuantityRef, ResolvedAbility, TargetFilter, REMOVE_COUNTER_COST_ALL,
     REMOVE_COUNTER_COST_ANY_NUMBER,
 };
 use crate::types::counter::{CounterMatch, CounterType};
@@ -3569,20 +3569,24 @@ fn discard_cost_choice(
     source_id: ObjectId,
     cost: &Option<AbilityCost>,
 ) -> Option<(usize, Vec<ObjectId>)> {
-    let (count, filter) = find_non_self_discard_cost(cost.as_ref()?)?;
-    let resolved = super::quantity::resolve_quantity(state, count, player, source_id).max(0);
-    // CR 601.2h + CR 701.9a: A resolved zero-card discard (Lion's Eye Diamond's "Discard
-    // your hand" with an empty hand — `HandSize` -> 0) is paid by doing nothing; nothing
-    // moves and no `Discarded` event fires. Surfacing a `PayCost { count: 0 }` prompt here
-    // stalls the activation forever, because submitting the empty prompt re-enters with a
-    // still-empty `chosen_discards` and re-emits the same dead prompt. Returning `None`
-    // makes the caller skip the discard leg and proceed to the source sacrifice + mana.
-    // Structural precedent: `exile_cost_choice` (the interactive non-self cost sibling).
-    if resolved == 0 {
+    let cost = cost.as_ref()?;
+    // Mana-ability interactive discard applies only to a player-CHOSEN discard leg; a
+    // non-Chosen discard (e.g. random / top-of-hand) is not a mid-activation card selection,
+    // so this interactive surfacing does not handle it. (Pre-existing scope; keeps blast
+    // radius nil.) `find_non_self_discard` is the single detector shared with the
+    // casting/activation path; the `Chosen` gate below is the ONLY mana-specific divergence.
+    let (_count, _filter, selection) = super::casting::find_non_self_discard(cost)?;
+    if selection != CardSelectionMode::Chosen {
         return None;
     }
-    let cards = super::casting::find_eligible_discard_targets(state, player, source_id, filter);
-    Some((resolved as usize, cards))
+    // Single authority for the zero-count auto-pay + payability rules (CR 601.2h + CR 701.9a):
+    // delegate to `resolve_non_self_discard_requirement` so the mana path stays aligned with the
+    // activation path in one place. `Ok(Some)` => interactive selection; `Ok(None)` => zero-card
+    // discard paid by doing nothing (skip the leg). `Err` (fewer eligible cards than the nonzero
+    // count) is unreachable here because `cost_payability` already gated activation on hand size,
+    // so `unwrap_or_default()`'s `None` fallback is the correct "no selection to surface" result.
+    super::casting::resolve_non_self_discard_requirement(state, player, source_id, cost)
+        .unwrap_or_default()
 }
 
 /// CR 117.1 + CR 118.3: Match non-self `AbilityCost::Exile` shapes. Returns
@@ -3678,21 +3682,6 @@ fn sacrifice_cost_choice(
     let permanents =
         super::casting::find_eligible_sacrifice_targets(state, player, source_id, filter);
     Some((count as usize, permanents))
-}
-
-fn find_non_self_discard_cost(
-    cost: &AbilityCost,
-) -> Option<(&crate::types::ability::QuantityExpr, Option<&TargetFilter>)> {
-    match cost {
-        AbilityCost::Discard {
-            count,
-            filter,
-            self_scope: crate::types::ability::DiscardSelfScope::FromHand,
-            selection: crate::types::ability::CardSelectionMode::Chosen,
-        } => Some((count, filter.as_ref())),
-        AbilityCost::Composite { costs } => costs.iter().find_map(find_non_self_discard_cost),
-        _ => None,
-    }
 }
 
 fn tap_selected_creature_for_mana_cost(
@@ -6473,7 +6462,8 @@ mod tests {
     /// At base the activation surfaces `WaitingFor::PayCost { Discard, count: 0 }`
     /// (a dead prompt that re-emits forever), so the `ChooseManaColor` assertion
     /// fails with `left: PayCost right: ChooseManaColor` — revert-sensitive to the
-    /// `mana_abilities::discard_cost_choice` `resolved == 0` guard. The 3-mana
+    /// zero-count auto-pay guard `discard_cost_choice` now inherits from the shared
+    /// `casting::resolve_non_self_discard_requirement` authority. The 3-mana
     /// assertion is a positive reach-guard (proves production, not a vacuous halt);
     /// the sacrifice assertion proves the guard consumes ONLY the discard leg and
     /// the self-sacrifice still fires.
@@ -10844,5 +10834,84 @@ mod tests {
             !can_activate_mana_ability_now(&state, player, prism, 0, &def),
             "Pentad Prism must not be activatable without charge counters"
         );
+    }
+
+    /// Issue #6494 (shared seam): `casting::find_non_self_discard` is the SOLE
+    /// detector for FromHand discard cost legs and no longer filters by selection
+    /// mode — it returns the `CardSelectionMode` for BOTH `Chosen` and `Random`
+    /// legs (and recurses into `Composite`, e.g. Lion's Eye Diamond's shape). The
+    /// mana path's only divergence from the casting/activation path is the explicit
+    /// `Chosen` gate in `discard_cost_choice`, which routes accepted legs through
+    /// the shared `resolve_non_self_discard_requirement` authority so the zero-count
+    /// auto-pay + payability rules live in one place.
+    ///
+    /// Revert-sensitive: fails if `find_non_self_discard` re-adds a selection filter
+    /// (the `Random` assertions go `None`), or if `discard_cost_choice` drops its
+    /// `Chosen` gate (the `Random` leg would then surface an interactive selection).
+    #[test]
+    fn find_non_self_discard_is_sole_detector_mana_path_gates_on_chosen() {
+        use crate::types::ability::{CardSelectionMode, DiscardSelfScope};
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        // One card in hand so a `Chosen` discard resolves to an interactive selection.
+        let card = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Card".to_string(),
+            Zone::Hand,
+        );
+
+        let discard_leg = |selection| AbilityCost::Discard {
+            count: QuantityExpr::Fixed { value: 1 },
+            filter: None,
+            selection,
+            self_scope: DiscardSelfScope::FromHand,
+        };
+        let chosen_leg = discard_leg(CardSelectionMode::Chosen);
+        let random_leg = discard_leg(CardSelectionMode::Random);
+        // LED-shaped composite: the Chosen discard leg lives beside a self-sacrifice.
+        let chosen_in_composite = AbilityCost::Composite {
+            costs: vec![
+                chosen_leg.clone(),
+                AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::SelfRef, 1)),
+            ],
+        };
+
+        // Sole detector: reports the selection mode for BOTH variants (no selection
+        // filter), including inside a Composite.
+        let detect = crate::game::casting::find_non_self_discard;
+        assert!(matches!(
+            detect(&chosen_leg),
+            Some((_, _, CardSelectionMode::Chosen))
+        ));
+        assert!(matches!(
+            detect(&chosen_in_composite),
+            Some((_, _, CardSelectionMode::Chosen))
+        ));
+        assert!(matches!(
+            detect(&random_leg),
+            Some((_, _, CardSelectionMode::Random))
+        ));
+
+        // Mana selection gate: only a Chosen leg surfaces an interactive discard,
+        // and it does so through the shared resolver (Some((1, [card]))).
+        match discard_cost_choice(&state, PlayerId(0), source, &Some(chosen_in_composite)) {
+            Some((count, cards)) => {
+                assert_eq!(count, 1);
+                assert_eq!(cards, vec![card]);
+            }
+            None => panic!("Chosen FromHand discard with a card in hand must surface a selection"),
+        }
+        // A non-Chosen (Random) FromHand discard is not a mid-activation card
+        // selection: the gate returns None even though the sole detector matched it.
+        assert!(discard_cost_choice(&state, PlayerId(0), source, &Some(random_leg)).is_none());
     }
 }


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8

Closes #6494.

## Summary

**Lion's Eye Diamond** — *"Discard your hand, Sacrifice this artifact: Add three mana of any one color. Activate only as an instant."* — could not be activated with an empty hand. Discarding your hand with no cards is a cost paid by doing nothing (CR 601.2h — a zero-card cost is not unpayable, it is trivially paid; CR 701.9a moves cards hand→graveyard only when cards exist), so LED **is** activatable empty-handed — its canonical competitive use (crack it in response holding zero cards for three mana). Instead the activation stalled forever on a dead `WaitingFor::PayCost { kind: Discard, count: 0, choices: [], min_count: 0 }`.

Root cause is runtime, **not** the parser — LED's cost parses faithfully as `Composite[ Discard { count: HandSize(Controller) }, Sacrifice(SelfRef) ]`. `legal_actions` correctly offered LED (`cost_payability.rs` computes `0 >= 0` → payable), but the interactive **cost-surfacing** paths resolved the same `HandSize = 0` and unconditionally emitted a `PayCost { Discard, count: 0 }` — a prompt with nothing to select. Submitting the empty selection left the "not yet paid" sentinel unchanged and re-entered the same surfacing, re-emitting the dead prompt: an infinite stall. The divergence: payability short-circuits `count == 0`, the surfacing paths did not — unlike the sibling zero-quantity cost paths (e.g. `mana_abilities::exile_cost_choice`).

Class-level fix, not an LED special case: **a resolved-count-0 non-self "discard from hand" leg is paid by doing nothing and the engine surfaces the next unpaid leg** (here, the sacrifice) instead of a dead prompt. This is applied through a single shared authority so the mana-ability path and the activated-ability path resolve the same rule:

- **New `resolve_non_self_discard_requirement`** (`game/casting.rs`) — the tri-state authority for a non-self `FromHand` discard leg: `Ok(None)` (no such leg, or resolved count 0 → auto-paid), `Err` (fewer eligible cards than the required nonzero count → CR 601.2h unpayable), `Ok(Some((count, eligible)))` (interactive selection). It replaces the duplicated detect→resolve→error→`PayCost` blocks at the two activation cost-surfacing sites.
- **`discard_cost_choice`** (`game/mana_abilities.rs`, the LED/Diamond Lion mana-ability path) returns `None` on a resolved count of 0, mirroring the `count == 0` skip its exile sibling already uses — the discard leg is skipped and the self-sacrifice + mana proceed to `ChooseManaColor`.

Class members fixed: **Lion's Eye Diamond** and **Diamond Lion** (mana-ability path), **Bomat Courier** (*"{R}, Discard your hand, Sacrifice Bomat Courier: …"*, activated-ability path) — each now activatable with an empty hand. A **fixed** `Discard { 1 }` ("Discard a card") on an empty hand is unchanged: it resolves count 1, `0 >= 1` is false, so it stays unpayable and is never offered — the guard fires only on a resolved count of **0**, never on `count >= 1`.

## Deliberately out of scope

The spell **additional-cost** discard arm (`pay_additional_cost_with_source`) is intentionally left unchanged. A genuine "discard your hand" spell additional cost resolves to ≥1 while the spell is still in hand, so it never reaches count 0. The only real cards that reach that arm with count 0 are Firestorm / Abandon Hope / Nahiri's Wrath, whose *"discard X cards"* additional cost currently **misparses** to `Discard { Fixed(0) }` while the correct count is X — auto-paying there would silently cast them without the discard, masking a parser bug as a rules-incorrect free cast. That `Discard { Fixed(0) }` misparse of "discard X cards" is a **separate parser issue** and should be fixed at the parser seam; I did not paper over it at the cost-resolution layer. (Happy to file/take that as a follow-up.)

## Implementation method (required)

Method: /engine-implementer — plan (/engine-planner) → /review-engine-plan (adversarial; corrected the seam to the mana-ability `discard_cost_choice`, tightened the class to resolved-count-0 only, and named the real corpus cards) → implement (tests-first RED→GREEN) → /review-impl (Maintainer-Simulation Gate; **it flagged the spell-additional-cost arm as a rules-incorrect Firestorm-misparse mask — that arm and its synthetic test were reverted**, leaving the two genuinely-reachable seams). Each step in a fresh agent context. Final read-only /review-impl on the retained diff: **PASS**.

## Gate A

`./scripts/check-parser-combinators.sh` → **Gate A PASS head=d633cf026** (Gate G PASS). No files under `crates/engine/src/parser/` are touched — the change is pure runtime cost-resolution.

## Anchored on

- `game/mana_abilities.rs` `exile_cost_choice` — the interactive non-self cost sibling in the same mana-ability surfacing prefix; `discard_cost_choice` now applies the identical resolved-count-0 skip, so a zero-quantity leg is treated as paid and the next leg (the self-sacrifice in `continue_mana_ability_cost_payment`) is surfaced.
- `game/cost_payability.rs` Discard arm — the payability side already short-circuits `count == 0` (`0 >= 0` → offered); this change brings the surfacing side into agreement, closing the payable-but-un-surfaceable gap that caused the stall.
- `game/casting.rs` `find_non_self_discard` / `find_eligible_discard_targets` — the existing `FromHand` discard-leg detector + eligible-card query, now composed once inside `resolve_non_self_discard_requirement` and reused at both activation surfacing sites (`surface_next_unpaid_interactive_activation_cost` and `handle_activate_ability`'s `begin_cost_payment`).

## Verification

- `cargo fmt --all` clean; `cargo clippy -p engine --tests` **0 warnings**; `cargo test -p engine --lib` **17,631 passed / 0 failed**.
- **7 new/updated tests** (all through production entries — `activate_mana_ability`, `handle_activate_ability` — with verbatim Oracle text; LED/Diamond Lion are mana abilities and do **not** use the stack):
  - `lions_eye_diamond_activates_empty_handed_and_produces_chosen_color` — empty hand → result is `ChooseManaColor` (**not** `PayCost{Discard}`); LED is sacrificed (sole card in graveyard); `handle_choose_mana_color(Red)` → exactly 3 Red mana. The reported bug; revert-guard.
  - `diamond_lion_activates_empty_handed_and_produces_chosen_color` — same class, second real card (proves class-not-card).
  - `lions_eye_diamond_discards_hand_and_then_produces_chosen_color` (existing control) — 2 cards in hand → still surfaces `PayCost{Discard,count:2}`, both discarded, LED sacrificed, 3 mana (guard: the `count == 0` skip must not over-fire on `count > 0`).
  - `bomat_courier_activates_empty_handed_casting_path` — Bomat Courier's verbatim ability, empty hand → no dead `PayCost{Discard}`, self-sacrifice fires, ability resolves.
  - `resolve_discard_requirement_fixed_one_empty_hand_is_unpayable_err` — Fixed `Discard{1}` + empty hand → `Err` (unpayable), not `Ok(None)`; reach-guarded with a card in hand → `Ok(Some((1,[card])))`.
  - `resolve_discard_requirement_fixed_two_with_three_eligible_offers_all` — `Discard{2}` + 3 eligible → `Ok(Some((2, 3 choices)))` (interactive prompt still built for count > 0).
  - `resolve_discard_requirement_source_card_scope_is_not_auto_paid` — a `SourceCard` "discard this card" cost is `FromHand`-excluded (helper returns `None`, count resolves to 1) so it can never hit zero-count auto-pay; reach-guarded that the `FromHand` shape **is** detected.
- **Fails before, passes after** — reverting the `discard_cost_choice` `resolved == 0` skip flips the LED/Diamond Lion tests (`left: PayCost { Discard, count: 0, choices: [] }`, `right: ChooseManaColor`); reverting the helper's `count == 0` skip flips the Bomat test (a dead `PayCost{Discard}` is surfaced on the casting path). The control and boundary tests stay green across both reverts.
- **CR annotations** grep-verified against `docs/MagicCompRules.txt`: 601.2h, 701.9a, 601.2b, 605.1a, 106.1, 601.2a.

## Claimed parse impact

**None.** No parser or type files are touched — this is a pure runtime cost-resolution fix; LED already parsed faithfully. The CI parse-diff artifact should report zero card-parse changes.

## Scope Expansion

None. (The spell additional-cost arm was explicitly excluded — see *Deliberately out of scope* — to avoid masking the separate `Discard { Fixed(0) }` parser misparse.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of **empty-hand** “discard from hand” costs by auto-completing the requirement without presenting a zero-card discard prompt.
  * Abilities now correctly proceed to subsequent cost steps (for example, sacrificing the source card and then choosing mana) instead of stalling on an invalid pay-cost interaction.
  * Non-self discard requirements correctly remain unpayable when there aren’t enough eligible cards.
  * Discard selection now accurately lists all eligible choices and avoids unintended auto-expansion or autopayment.

* **Tests**
  * Added regression coverage for these discard-cost and mana-activation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->