### PR TITLE
Fix Throne of Eldraine

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2100,7 +2100,7 @@ pub fn candidate_actions_broad_with_probe(
                     *player,
                     pending_cast.object_id,
                     cost,
-                    pending_cast.ability.context.ability_tag,
+                    pending_cast.activation_ability_index.unwrap_or(usize::MAX),
                 )
             })
             .map(|(i, _)| {
@@ -4014,6 +4014,13 @@ pub(crate) fn priority_actions_with_probe(
                     state,
                     player,
                     *ninjutsu_object_id,
+                    casting::activated_ability_definitions(state, *ninjutsu_object_id)
+                        .into_iter()
+                        .find_map(|(index, ability)| {
+                            crate::game::keywords::is_ninjutsu_family_marker_ability(&ability)
+                                .then_some(index)
+                        })
+                        .unwrap_or(usize::MAX),
                     cost,
                 );
                 if !can_afford {

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -282,7 +282,7 @@ fn cheap_reject_candidate(state: &GameState, action: &GameAction) -> bool {
                 *player,
                 pending_cast.object_id,
                 cost,
-                pending_cast.ability.context.ability_tag,
+                pending_cast.activation_ability_index.unwrap_or(usize::MAX),
             )
         }),
         (

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -718,27 +718,33 @@ pub fn synthesize_ninjutsu_family(face: &mut CardFace) {
     let abilities: Vec<AbilityDefinition> = face
         .keywords
         .iter()
-        .filter_map(|kw| {
-            let (variant, cost) = match kw {
-                Keyword::Ninjutsu(c) => (NinjutsuVariant::Ninjutsu, c),
-                Keyword::CommanderNinjutsu(c) => (NinjutsuVariant::CommanderNinjutsu, c),
-                _ => return None,
-            };
-            Some(
-                AbilityDefinition::new(
-                    AbilityKind::Activated,
-                    Effect::RuntimeHandled {
-                        handler: RuntimeHandler::NinjutsuFamily,
-                    },
-                )
-                .cost(AbilityCost::NinjutsuFamily {
-                    variant,
-                    mana_cost: cost.clone(),
-                }),
-            )
-        })
+        .filter_map(ninjutsu_family_marker_ability_for_keyword)
         .collect();
     face.abilities.extend(abilities);
+}
+
+/// CR 702.49: Build the marker activated ability for one Ninjutsu-family
+/// keyword. The runtime ability gather uses this too, so a keyword provided by
+/// a scenario or a continuous effect has the same activation identity as one
+/// synthesized while card data is loaded.
+pub fn ninjutsu_family_marker_ability_for_keyword(keyword: &Keyword) -> Option<AbilityDefinition> {
+    let (variant, cost) = match keyword {
+        Keyword::Ninjutsu(cost) => (NinjutsuVariant::Ninjutsu, cost),
+        Keyword::CommanderNinjutsu(cost) => (NinjutsuVariant::CommanderNinjutsu, cost),
+        _ => return None,
+    };
+    Some(
+        AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::RuntimeHandled {
+                handler: RuntimeHandler::NinjutsuFamily,
+            },
+        )
+        .cost(AbilityCost::NinjutsuFamily {
+            variant,
+            mana_cost: cost.clone(),
+        }),
+    )
 }
 
 // Warp is handled at runtime via Keyword::Warp(ManaCost):

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3799,6 +3799,8 @@ fn walk_definition(
         description: _,
         target_prompt: _,
         activation_restrictions: _,
+        // Payment-time only; it cannot create a resolution-time dependency.
+        activation_mana_payment_restriction: _,
         activator_filter: _,
         activation_zone: _,
         ability_tag: _,

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -4220,6 +4220,8 @@ fn ability_definition_axes(def: &AbilityDefinition, mode: ScanMode) -> Axes {
         description: _,
         target_prompt: _,
         activation_restrictions: _,
+        // Payment-time only; it cannot create a resolution-time dependency.
+        activation_mana_payment_restriction: _,
         activator_filter: _,
         activation_zone: _,
         ability_tag: _,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1,12 +1,12 @@
 use crate::types::ability::{
     is_variable_remove_counter_cost_count, AbilityBlockKind, AbilityBlockReason, AbilityCondition,
-    AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AdditionalCost, CardPlayMode,
-    CastTimingPermission, CastingPermission, ChoiceType, ContinuousModification, CostObjectCount,
-    CostPaidObjectSnapshot, CounterCostSelection, Duration, Effect, FilterProp, GameRestriction,
-    ModalSelectionCondition, ObjectScope, PlayerFilter, PlayerScope, ProhibitedActivity,
-    QuantityExpr, QuantityRef, ResolvedAbility, RestrictionExpiry, RestrictionPlayerScope,
-    StaticCondition, StaticDefinition, SubAbilityLink, TapCreaturesRequirement, TargetFilter,
-    TargetRef,
+    AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ActivationManaPaymentRestriction,
+    AdditionalCost, CardPlayMode, CastTimingPermission, CastingPermission, ChoiceType,
+    ContinuousModification, CostObjectCount, CostPaidObjectSnapshot, CounterCostSelection,
+    Duration, Effect, FilterProp, GameRestriction, ModalSelectionCondition, ObjectScope,
+    PlayerFilter, PlayerScope, ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility,
+    RestrictionExpiry, RestrictionPlayerScope, StaticCondition, StaticDefinition, SubAbilityLink,
+    TapCreaturesRequirement, TargetFilter, TargetRef,
 };
 use crate::types::actions::AlternativeCastDecision;
 use crate::types::card::LayoutKind;
@@ -21,7 +21,8 @@ use crate::types::game_state::{
 use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
 use crate::types::keywords::{FlashbackCost, Keyword, KeywordKind};
 use crate::types::mana::{
-    ManaColor, ManaCost, ManaCostShard, ManaSpellGrant, PaymentContext, SpecialAction, SpellMeta,
+    ActivationManaColorConstraint, ManaColor, ManaCost, ManaCostShard, ManaSpellGrant,
+    PaymentContext, SpecialAction, SpellMeta,
 };
 use crate::types::player::PlayerId;
 use crate::types::resolved_commands::ManaPaymentRecipient;
@@ -234,6 +235,41 @@ fn runtime_granted_top_of_library_plot_abilities(
     )]
 }
 
+/// CR 702.49: Ninjutsu-family keywords function from Hand (and commander
+/// ninjutsu from Command). Card loading normally synthesizes their marker
+/// ability, but runtime keyword sets and scenario objects need the identical
+/// effective definition so activation payment can resolve the exact index.
+fn runtime_ninjutsu_family_marker_abilities(
+    state: &GameState,
+    source_id: ObjectId,
+) -> Vec<AbilityDefinition> {
+    let Some(obj) = state.objects.get(&source_id) else {
+        return Vec::new();
+    };
+    if !matches!(obj.zone, Zone::Hand | Zone::Command) {
+        return Vec::new();
+    }
+
+    // The off-zone collector is authoritative for printed and granted
+    // characteristics. Include the object's current keyword set as well: test
+    // scenarios and runtime-only objects can deliberately provide a synthesized
+    // Ninjutsu keyword without mirroring it into `base_keywords`.
+    let mut keywords =
+        crate::game::off_zone_characteristics::effective_off_zone_keywords(state, source_id);
+    for keyword in &obj.keywords {
+        if !keywords.contains(keyword) {
+            keywords.push(keyword.clone());
+        }
+    }
+    keywords
+        .into_iter()
+        .filter_map(|keyword| {
+            crate::database::synthesis::ninjutsu_family_marker_ability_for_keyword(&keyword)
+        })
+        .filter(|candidate| !obj.abilities.iter().any(|printed| printed == candidate))
+        .collect()
+}
+
 pub fn activated_ability_definitions(
     state: &GameState,
     source_id: ObjectId,
@@ -257,6 +293,9 @@ pub fn activated_ability_definitions(
             .chain(runtime_granted_top_of_library_plot_abilities(
                 state, source_id,
             ))
+            // CR 702.49: runtime/effective Ninjutsu markers must share this
+            // index space with the payment-context lookup below.
+            .chain(runtime_ninjutsu_family_marker_abilities(state, source_id))
             // CR 702.6: statically granted equip (Bram, Bludgeon Brawl) chained
             // LAST — the identical append order is REQUIRED in
             // `activation_ability_definition` so `ability_index` stays consistent.
@@ -280,8 +319,8 @@ fn activation_ability_definition(
         // Must match the append order in `activated_ability_definitions`: printed
         // abilities first, then runtime-granted cycling, then runtime-granted
         // graveyard activated (Encore/Scavenge), then runtime-granted
-        // plot-from-library (Fblthp). Identical order is REQUIRED for
-        // `ability_index` consistency.
+        // plot-from-library (Fblthp), then Ninjutsu-family, then equip.
+        // Identical order is REQUIRED for `ability_index` consistency.
         runtime_granted_cycling_abilities(state, source_id)
             .into_iter()
             .chain(runtime_granted_graveyard_activated_abilities(
@@ -290,6 +329,7 @@ fn activation_ability_definition(
             .chain(runtime_granted_top_of_library_plot_abilities(
                 state, source_id,
             ))
+            .chain(runtime_ninjutsu_family_marker_abilities(state, source_id))
             .chain(runtime_granted_equip_abilities(state, source_id))
             .nth(offset)?
     };
@@ -1979,6 +2019,7 @@ pub(super) fn build_spell_meta(
         // still in its origin zone) a non-fused split spell is not over-combined.
         mana_value: Some(obj.spell_mana_value()),
         color_count: Some(obj.spell_colors().len() as u32),
+        colors: obj.spell_colors(),
         // CR 107.3 + CR 202.3e: structural "has {X}" property of the printed cost,
         // detected from shards (mana value alone can't reveal it — X contributes 0
         // off the stack).
@@ -2035,31 +2076,18 @@ pub fn pending_phyrexian_route_is_payable(
         return false;
     };
 
-    let (source_types, source_subtypes, activation_tag) = pending
+    let activation_context = pending
         .activation_ability_index
-        .map(|ability_index| {
-            let (types, subtypes) = activation_source_types(state, spell_object);
-            (
-                types,
-                subtypes,
-                Some(activation_ability_tag(state, spell_object, ability_index)),
-            )
-        })
-        .unwrap_or_default();
+        .map(|ability_index| activation_payment_context(state, spell_object, ability_index));
     let spell_meta = pending
         .activation_ability_index
         .is_none()
         .then(|| build_spell_meta(state, player, spell_object))
         .flatten();
-    let payment_context = if pending.activation_ability_index.is_some() {
-        Some(PaymentContext::Activation {
-            source_types: &source_types,
-            source_subtypes: &source_subtypes,
-            ability_tag: activation_tag.flatten(),
-        })
-    } else {
-        spell_meta.as_ref().map(PaymentContext::Spell)
-    };
+    let payment_context = activation_context
+        .as_ref()
+        .map(ActivationPaymentContext::as_payment_context)
+        .or_else(|| spell_meta.as_ref().map(PaymentContext::Spell));
     let any_color = player_can_spend_as_any_color_for_payment(
         state,
         player,
@@ -13964,12 +13992,14 @@ pub fn can_pay_ability_mana_cost_after_auto_tap(
     state: &GameState,
     player: PlayerId,
     source_id: ObjectId,
+    ability_index: usize,
     cost: &crate::types::mana::ManaCost,
 ) -> bool {
     can_pay_ability_mana_cost_after_auto_tap_excluding(
         state,
         player,
         source_id,
+        ability_index,
         cost,
         &HashSet::new(),
     )
@@ -13979,23 +14009,15 @@ pub fn can_pay_ability_mana_cost_after_auto_tap_excluding(
     state: &GameState,
     player: PlayerId,
     source_id: ObjectId,
+    ability_index: usize,
     cost: &crate::types::mana::ManaCost,
     excluded_sources: &HashSet<ObjectId>,
 ) -> bool {
     let mut simulated = state.clone();
     super::layers::flush_layers(&mut simulated);
 
-    let (source_types, source_subtypes) = activation_source_types(&simulated, source_id);
-    // CR 106.6: All current callers of this preview path are tag-`None`
-    // activations (mana abilities, ninjutsu, AI affordability). The real
-    // tag-scoped gate (Quinjet power-up restriction) runs at payment time in
-    // `pay_ability_mana_cost_*`, since `is_payable` defers mana affordability to
-    // the payment step (CR 601.2g).
-    let activation_ctx = PaymentContext::Activation {
-        source_types: &source_types,
-        source_subtypes: &source_subtypes,
-        ability_tag: None,
-    };
+    let activation_context = activation_payment_context(&simulated, source_id, ability_index);
+    let activation_ctx = activation_context.as_payment_context();
 
     can_pay_mana_cost_after_auto_tap_with_context(
         simulated,
@@ -14418,16 +14440,16 @@ pub(super) fn pay_ability_mana_cost(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
+    ability_index: usize,
     cost: &crate::types::mana::ManaCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EngineError> {
     pay_ability_mana_cost_excluding(
         state,
         player,
         source_id,
+        ability_index,
         cost,
-        ability_tag,
         events,
         &HashSet::new(),
         None,
@@ -14439,8 +14461,8 @@ pub(super) fn pay_ability_mana_cost_excluding(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
+    ability_index: usize,
     cost: &crate::types::mana::ManaCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
     // CR 107.4b + CR 118.10: When this ability is paying its mana sub-cost while
@@ -14453,8 +14475,8 @@ pub(super) fn pay_ability_mana_cost_excluding(
         state,
         player,
         source_id,
+        ability_index,
         cost,
-        ability_tag,
         events,
         excluded_sources,
         sub_cost_demand,
@@ -14469,8 +14491,8 @@ pub(super) fn pay_ability_mana_cost_excluding_with_parent(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
+    ability_index: usize,
     cost: &crate::types::mana::ManaCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
     sub_cost_demand: Option<&mana_payment::ColorDemand>,
@@ -14480,8 +14502,8 @@ pub(super) fn pay_ability_mana_cost_excluding_with_parent(
         state,
         player,
         source_id,
+        ability_index,
         cost,
-        ability_tag,
         None,
         events,
         excluded_sources,
@@ -14498,8 +14520,8 @@ pub(super) fn pay_ability_mana_cost_with_choices_excluding_and_resume(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
+    ability_index: usize,
     cost: &crate::types::mana::ManaCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
@@ -14510,8 +14532,8 @@ pub(super) fn pay_ability_mana_cost_with_choices_excluding_and_resume(
         state,
         player,
         source_id,
+        ability_index,
         cost,
-        ability_tag,
         phyrexian_choices,
         events,
         excluded_sources,
@@ -14526,8 +14548,8 @@ fn pay_ability_mana_cost_with_choices_excluding_and_parent(
     state: &mut GameState,
     player: PlayerId,
     source_id: ObjectId,
+    ability_index: usize,
     cost: &crate::types::mana::ManaCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
     phyrexian_choices: Option<&[crate::types::game_state::ShardChoice]>,
     events: &mut Vec<GameEvent>,
     excluded_sources: &HashSet<ObjectId>,
@@ -14537,12 +14559,8 @@ fn pay_ability_mana_cost_with_choices_excluding_and_parent(
 ) -> Result<(), EngineError> {
     super::layers::flush_layers(state);
 
-    let (source_types, source_subtypes) = activation_source_types(state, source_id);
-    let activation_ctx = PaymentContext::Activation {
-        source_types: &source_types,
-        source_subtypes: &source_subtypes,
-        ability_tag,
-    };
+    let activation_context = activation_payment_context(state, source_id, ability_index);
+    let activation_ctx = activation_context.as_payment_context();
 
     let _spent_units = auto_tap_and_pay_cost_excluding(
         state,
@@ -14959,38 +14977,72 @@ pub(super) fn mana_ability_cost_payment_is_paused(state: &GameState) -> bool {
     )
 }
 
-/// CR 106.6: Build (core-types, subtypes) slices for a `PaymentContext::Activation`
-/// from the source object. Mirrors `build_spell_meta`'s type extraction so
-/// `allows_activation` and `allows_spell` consult identically-shaped strings.
-pub(super) fn activation_source_types(
-    state: &GameState,
-    source_id: ObjectId,
-) -> (Vec<String>, Vec<String>) {
-    state
-        .objects
-        .get(&source_id)
-        .map(|obj| {
-            let types = object_type_names(obj);
-            let subtypes = obj.card_types.subtypes.clone();
-            (types, subtypes)
-        })
-        .unwrap_or_default()
+/// Owned backing for one exact activated-ability payment context. All payment
+/// routes construct this through [`activation_payment_context`] so they use the
+/// live source, actual ability index, tag, and color-payment rider together.
+pub(super) struct ActivationPaymentContext {
+    source_types: Vec<String>,
+    source_subtypes: Vec<String>,
+    ability_tag: Option<AbilityTag>,
+    mana_color_constraint: ActivationManaColorConstraint,
 }
 
-/// CR 106.6: Read the keyword tag of the ability at `ability_index` on
-/// `source_id`. Threaded into `PaymentContext::Activation` so tag-scoped mana
-/// spend restrictions (Quinjet: "spend this mana only to activate power-up
-/// abilities") can gate which mana is eligible for the activation being paid.
-pub(super) fn activation_ability_tag(
+impl ActivationPaymentContext {
+    pub(super) fn as_payment_context(&self) -> PaymentContext<'_> {
+        PaymentContext::Activation {
+            source_types: &self.source_types,
+            source_subtypes: &self.source_subtypes,
+            ability_tag: self.ability_tag,
+            mana_color_constraint: self.mana_color_constraint,
+        }
+    }
+}
+
+/// CR 106.6 + CR 602.2b: Build the sole activation-payment context from the
+/// source's live characteristics and the exact ability being activated. A
+/// missing source or a missing required chosen color fails closed. An absent
+/// definition on an otherwise live source carries no activation-cost rider;
+/// this preserves ordinary generic-cost evaluation and runtime-synthesized
+/// keyword activations.
+pub(super) fn activation_payment_context(
     state: &GameState,
     source_id: ObjectId,
     ability_index: usize,
-) -> Option<crate::types::ability::AbilityTag> {
-    state
-        .objects
-        .get(&source_id)
-        .and_then(|obj| obj.abilities.get(ability_index))
-        .and_then(|def| def.ability_tag)
+) -> ActivationPaymentContext {
+    let Some(source) = state.objects.get(&source_id) else {
+        return ActivationPaymentContext {
+            source_types: Vec::new(),
+            source_subtypes: Vec::new(),
+            ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Impossible,
+        };
+    };
+    let source_types = object_type_names(source);
+    let source_subtypes = source.card_types.subtypes.clone();
+    // Use the same effective-ability lookup as activation itself: runtime-granted
+    // cycling, graveyard, plot, Ninjutsu-family, and equip abilities live after
+    // the printed `obj.abilities` slice but retain their enumerated indices.
+    let Some(ability) = activation_ability_definition(state, source_id, ability_index) else {
+        return ActivationPaymentContext {
+            source_types,
+            source_subtypes,
+            ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Unrestricted,
+        };
+    };
+    let mana_color_constraint = match ability.activation_mana_payment_restriction {
+        None => ActivationManaColorConstraint::Unrestricted,
+        Some(ActivationManaPaymentRestriction::OnlySourceChosenColor) => source
+            .chosen_color()
+            .map(ActivationManaColorConstraint::Only)
+            .unwrap_or(ActivationManaColorConstraint::Impossible),
+    };
+    ActivationPaymentContext {
+        source_types,
+        source_subtypes,
+        ability_tag: ability.ability_tag,
+        mana_color_constraint,
+    }
 }
 
 /// CR 106.6: When mana with spell grants is spent to cast a spell, apply those
@@ -15669,11 +15721,11 @@ pub(crate) fn payable_one_of_activation_branches(
     player: PlayerId,
     source_id: ObjectId,
     costs: &[AbilityCost],
-    ability_tag: Option<crate::types::ability::AbilityTag>,
+    ability_index: usize,
 ) -> Vec<AbilityCost> {
     costs
         .iter()
-        .filter(|branch| can_pay_ability_cost_now(state, player, source_id, branch, ability_tag))
+        .filter(|branch| can_pay_ability_cost_now(state, player, source_id, branch, ability_index))
         .cloned()
         .collect()
 }
@@ -15687,10 +15739,10 @@ fn activation_cost_passes_early_affordability_gate(
     player: PlayerId,
     source_id: ObjectId,
     cost: &AbilityCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
+    ability_index: usize,
 ) -> bool {
     if find_one_of_cost(cost).is_some() {
-        can_pay_ability_cost_now(state, player, source_id, cost, ability_tag)
+        can_pay_ability_cost_now(state, player, source_id, cost, ability_index)
     } else {
         cost.is_payable(state, player, source_id)
     }
@@ -16131,7 +16183,7 @@ pub(crate) fn can_pay_ability_cost_now(
     player: PlayerId,
     source_id: ObjectId,
     cost: &AbilityCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
+    ability_index: usize,
 ) -> bool {
     let excluded_sources = ability_mana_payment_excluded_sources(cost, source_id);
     super::costs::can_pay(
@@ -16141,7 +16193,7 @@ pub(crate) fn can_pay_ability_cost_now(
         cost,
         &super::costs::PaymentScope::Activation {
             excluded_sources: &excluded_sources,
-            ability_tag,
+            ability_index,
         },
     )
 }
@@ -16293,7 +16345,7 @@ pub fn can_activate_ability_now_with_restriction_gates(
         .clone()
         .map(|cost| activation_cost_for_affordability(cost, ability_def.ability_tag));
     if affordability_cost.as_ref().is_some_and(|cost| {
-        !can_pay_ability_cost_now(state, player, source_id, cost, ability_def.ability_tag)
+        !can_pay_ability_cost_now(state, player, source_id, cost, ability_index)
     }) {
         return false;
     }
@@ -16497,12 +16549,8 @@ pub(super) fn try_finalize_pending_activation_mana_leg(
         .as_ref()
         .map(|tail| ability_mana_payment_excluded_sources(tail, pending.object_id))
         .unwrap_or_default();
-    let (source_types, source_subtypes) = activation_source_types(state, pending.object_id);
-    let activation_ctx = PaymentContext::Activation {
-        source_types: &source_types,
-        source_subtypes: &source_subtypes,
-        ability_tag: activation_ability_tag(state, pending.object_id, ability_index),
-    };
+    let activation_context = activation_payment_context(state, pending.object_id, ability_index);
+    let activation_ctx = activation_context.as_payment_context();
     pending.cost = mana_cost.clone();
     pending.activation_cost = remaining;
     pending.activation_ability_index = Some(ability_index);
@@ -16546,12 +16594,8 @@ pub(super) fn finalize_pending_activation_mana_payment(
         .as_ref()
         .map(|tail| ability_mana_payment_excluded_sources(tail, pending.object_id))
         .unwrap_or_default();
-    let (source_types, source_subtypes) = activation_source_types(state, pending.object_id);
-    let activation_ctx = PaymentContext::Activation {
-        source_types: &source_types,
-        source_subtypes: &source_subtypes,
-        ability_tag: activation_ability_tag(state, pending.object_id, ability_index),
-    };
+    let activation_context = activation_payment_context(state, pending.object_id, ability_index);
+    let activation_ctx = activation_context.as_payment_context();
     let source_id = pending.object_id;
     state.pending_cast = Some(Box::new(pending));
     if let Some(waiting) = casting_costs::maybe_pause_for_phyrexian_choice(
@@ -16687,7 +16731,7 @@ pub fn handle_activate_ability(
             player,
             source_id,
             cost,
-            ability_def.ability_tag,
+            ability_index,
         ) {
             return Err(EngineError::ActionNotAllowed(
                 "Cannot pay activation cost".to_string(),
@@ -17159,13 +17203,8 @@ pub fn handle_activate_ability(
 
         // CR 118.12a: Pre-check for OneOf costs — detour to WaitingFor before any cost payment.
         if let Some(costs) = find_one_of_cost(cost) {
-            let payable = payable_one_of_activation_branches(
-                state,
-                player,
-                source_id,
-                costs,
-                ability_def.ability_tag,
-            );
+            let payable =
+                payable_one_of_activation_branches(state, player, source_id, costs, ability_index);
             if payable.is_empty() {
                 return Err(EngineError::ActionNotAllowed(
                     "Cannot pay activation cost".to_string(),
@@ -17383,7 +17422,7 @@ pub fn handle_activate_ability(
                     player,
                     source_id,
                     cost,
-                    activation_ability_tag(state, source_id, ability_index),
+                    ability_index,
                     events,
                 )? {
                     let pending = pending_activation_after_cost_pause(
@@ -17507,14 +17546,9 @@ pub fn handle_activate_ability(
         )? {
             return Ok(waiting);
         }
-        if let PaymentOutcome::Paused { remaining_cost } = pay_ability_cost_for_activation(
-            state,
-            player,
-            source_id,
-            cost,
-            activation_ability_tag(state, source_id, ability_index),
-            events,
-        )? {
+        if let PaymentOutcome::Paused { remaining_cost } =
+            pay_ability_cost_for_activation(state, player, source_id, cost, ability_index, events)?
+        {
             let pending = pending_activation_after_cost_pause(
                 source_id,
                 resolved.clone(),

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1803,7 +1803,7 @@ fn finish_selected_return_to_hand_after_automatic(
             player,
             pending.object_id,
             &cost,
-            super::casting::activation_ability_tag(state, pending.object_id, ability_index),
+            ability_index,
             events,
         )? {
             super::casting::PaymentOutcome::Paid => {}
@@ -2032,7 +2032,7 @@ pub(crate) fn handle_activation_cost_one_of_choice(
         player,
         pending.object_id,
         chosen_cost,
-        pending.ability.context.ability_tag,
+        pending.activation_ability_index.unwrap_or(usize::MAX),
     ) {
         return Err(EngineError::ActionNotAllowed(
             "Chosen cost branch is not payable".to_string(),
@@ -2901,7 +2901,7 @@ pub(crate) fn handle_return_to_hand_for_cost(
                     player,
                     pending.object_id,
                     &cost,
-                    super::casting::activation_ability_tag(state, pending.object_id, ability_index),
+                    ability_index,
                     events,
                 )? {
                     super::casting::PaymentOutcome::Paid => {}
@@ -3066,14 +3066,12 @@ pub(crate) fn handle_remove_counter_for_cost(
             // pay the automatic residual through the outcome-aware authority.
             // If a self-move pauses, the typed continuation resumes this pending
             // activation only after the selected counter was paid exactly once.
-            let ability_tag =
-                super::casting::activation_ability_tag(state, pending.object_id, ability_index);
             match super::casting::pay_ability_cost_for_activation(
                 state,
                 player,
                 pending.object_id,
                 &cost,
-                ability_tag,
+                ability_index,
                 events,
             )? {
                 super::casting::PaymentOutcome::Paid => {}
@@ -3240,14 +3238,12 @@ pub(crate) fn handle_remove_counter_distribution_for_cost(
             // CR 601.2h + CR 602.2b: The assigned counter payment is complete
             // before an automatic residual can pause on a self-move replacement,
             // so its typed continuation cannot replay the selected distribution.
-            let ability_tag =
-                super::casting::activation_ability_tag(state, pending.object_id, ability_index);
             match super::casting::pay_ability_cost_for_activation(
                 state,
                 player,
                 pending.object_id,
                 &cost,
-                ability_tag,
+                ability_index,
                 events,
             )? {
                 super::casting::PaymentOutcome::Paid => {}
@@ -4311,7 +4307,7 @@ pub(super) fn push_activated_ability_to_stack(
                 player,
                 source_id,
                 cost,
-                super::casting::activation_ability_tag(state, source_id, ability_index),
+                ability_index,
                 events,
             )?
         {
@@ -10127,13 +10123,9 @@ fn auto_tap_mana_sources_inner(
                     excluded_sources
                 };
                 if let Some(sub_cost) = sub_cost {
-                    let (source_types, source_subtypes) =
-                        super::casting::activation_source_types(state, option.object_id);
-                    let activation_ctx = PaymentContext::Activation {
-                        source_types: &source_types,
-                        source_subtypes: &source_subtypes,
-                        ability_tag: ability_def.ability_tag,
-                    };
+                    let activation_context =
+                        super::casting::activation_payment_context(state, option.object_id, idx);
+                    let activation_ctx = activation_context.as_payment_context();
                     auto_tap_mana_sources_inner(
                         state,
                         player,
@@ -11026,17 +11018,9 @@ fn finalize_mana_payment_with_resume(
                     )
                 })
                 .unwrap_or_default();
-            let (source_types, source_subtypes) =
-                super::casting::activation_source_types(state, source_id);
-            let activation_ctx = PaymentContext::Activation {
-                source_types: &source_types,
-                source_subtypes: &source_subtypes,
-                ability_tag: super::casting::activation_ability_tag(
-                    state,
-                    source_id,
-                    ability_index,
-                ),
-            };
+            let activation_context =
+                super::casting::activation_payment_context(state, source_id, ability_index);
+            let activation_ctx = activation_context.as_payment_context();
             if let Some(waiting) = maybe_pause_for_phyrexian_choice(
                 state,
                 player,
@@ -11097,8 +11081,8 @@ fn finalize_mana_payment_with_resume(
                 state,
                 player,
                 pending.object_id,
+                ability_index,
                 &pending.cost,
-                super::casting::activation_ability_tag(state, pending.object_id, ability_index),
                 None,
                 events,
                 &excluded_sources,
@@ -11422,8 +11406,8 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                 state,
                 player,
                 pending.object_id,
+                ability_index,
                 &pending.cost,
-                super::casting::activation_ability_tag(state, pending.object_id, ability_index),
                 Some(phyrexian_choices),
                 events,
                 &excluded_sources,

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -1059,11 +1059,16 @@ fn activation_mana_payment_auto_taps_activation_only_source() {
         Zone::Battlefield,
     );
     let cost = ManaCost::generic(1);
+    Arc::make_mut(&mut state.objects.get_mut(&ability_source).unwrap().abilities).push(
+        AbilityDefinition::new(AbilityKind::Activated, Effect::Proliferate)
+            .cost(AbilityCost::Mana { cost: cost.clone() }),
+    );
 
     assert!(can_pay_ability_mana_cost_after_auto_tap(
         &state,
         PlayerId(0),
         ability_source,
+        0,
         &cost
     ));
 
@@ -1072,8 +1077,8 @@ fn activation_mana_payment_auto_taps_activation_only_source() {
         &mut state,
         PlayerId(0),
         ability_source,
+        0,
         &cost,
-        None,
         &mut events,
     )
     .unwrap();
@@ -25839,7 +25844,7 @@ fn can_pay_sacrifice_cost_with_eligible() {
         PlayerId(0),
         source,
         &cost,
-        None
+        0
     ));
 }
 
@@ -25865,7 +25870,7 @@ fn cannot_pay_sacrifice_cost_no_eligible() {
         PlayerId(0),
         source,
         &cost,
-        None
+        0
     ));
 }
 
@@ -31075,7 +31080,7 @@ fn composite_activated_pay_life_cost_deducts_life() {
     let life_before = state.players[0].life;
     let mut events = Vec::new();
 
-    pay_ability_cost_for_activation(&mut state, PlayerId(0), fetch, &cost, None, &mut events)
+    pay_ability_cost_for_activation(&mut state, PlayerId(0), fetch, &cost, 0, &mut events)
         .expect("fetchland-style composite cost should be payable");
 
     assert_eq!(state.players[0].life, life_before - 1);
@@ -33079,7 +33084,7 @@ mod remove_counter_cost {
             selection: CounterCostSelection::SingleObject,
         };
         let mut events = Vec::new();
-        pay_ability_cost_for_activation(&mut state, PlayerId(0), source, &cost, None, &mut events)
+        pay_ability_cost_for_activation(&mut state, PlayerId(0), source, &cost, 0, &mut events)
             .expect("cost should pay with 2 +1/+1 counters available");
         let remaining = state
             .objects
@@ -33121,7 +33126,7 @@ mod remove_counter_cost {
             "cost must be unpayable when the source has no +1/+1 counters"
         );
         assert!(
-            !can_pay_ability_cost_now(&state, PlayerId(0), source, &cost, None),
+            !can_pay_ability_cost_now(&state, PlayerId(0), source, &cost, 0),
             "can_pay_ability_cost_now must reject an unpayable remove-counter cost"
         );
     }
@@ -33158,7 +33163,7 @@ mod remove_counter_cost {
             selection: CounterCostSelection::SingleObject,
         };
         let mut events = Vec::new();
-        pay_ability_cost_for_activation(&mut state, PlayerId(0), source, &cost, None, &mut events)
+        pay_ability_cost_for_activation(&mut state, PlayerId(0), source, &cost, 0, &mut events)
             .unwrap();
         let removed_count = events
             .iter()
@@ -34607,7 +34612,7 @@ mod unattach_cost {
             PlayerId(0),
             equipment,
             &cost,
-            None,
+            0,
             &mut Vec::new(),
         )
         .expect("attached Equipment should be able to unattach as a cost");
@@ -36322,7 +36327,7 @@ mod exert_cost {
             PlayerId(0),
             id,
             &AbilityCost::Exert,
-            None,
+            0,
             &mut events,
         )
         .expect("exert cost pays");
@@ -36382,7 +36387,7 @@ mod exert_cost {
             PlayerId(0),
             id,
             &AbilityCost::Exert,
-            None,
+            0,
             &mut events,
         )
         .expect("first exert");
@@ -36391,7 +36396,7 @@ mod exert_cost {
             PlayerId(0),
             id,
             &AbilityCost::Exert,
-            None,
+            0,
             &mut events,
         )
         .expect("second exert");
@@ -36439,7 +36444,7 @@ mod exert_cost {
             PlayerId(0),
             id,
             &AbilityCost::Exert,
-            None,
+            0,
             &mut events,
         );
         assert!(matches!(result, Err(EngineError::ActionNotAllowed(_))));
@@ -36459,7 +36464,7 @@ mod exert_cost {
             PlayerId(0),
             id,
             &AbilityCost::Exert,
-            None,
+            0,
             &mut events,
         )
         .expect("exert cost pays");

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -214,6 +214,7 @@ impl AbilityCost {
         state: &GameState,
         player: PlayerId,
         source: ObjectId,
+        ability_index: usize,
     ) -> bool {
         match self {
             AbilityCost::Mana { cost } => {
@@ -222,6 +223,7 @@ impl AbilityCost {
                     state,
                     player,
                     source,
+                    ability_index,
                     cost,
                     &excluded_sources,
                 )
@@ -237,7 +239,9 @@ impl AbilityCost {
                     } if has_tap => {
                         has_enough_tap_creatures(state, player, source, requirement, filter, true)
                     }
-                    other => other.is_payable_for_mana_ability(state, player, source),
+                    other => {
+                        other.is_payable_for_mana_ability(state, player, source, ability_index)
+                    }
                 })
             }
             // Every other kind has no mana-pool component — defer to the

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -201,11 +201,10 @@ fn find_eligible_tap_creatures_targets(
 pub(crate) enum PaymentScope<'a> {
     Activation {
         excluded_sources: &'a HashSet<ObjectId>,
-        /// CR 106.6: Keyword tag of the activated ability whose cost is being
-        /// paid. Threaded into `PaymentContext::Activation` so tag-scoped mana
-        /// spend restrictions (Quinjet → power-up) gate eligible mana. Resolution
-        /// scope never carries a tag (resolution-time costs aren't activations).
-        ability_tag: Option<crate::types::ability::AbilityTag>,
+        /// CR 106.6: Exact activated ability whose mana cost is being paid.
+        /// This builds the live activation payment context, including any
+        /// source-chosen-color rider and keyword tag.
+        ability_index: usize,
     },
     /// `ability` is normally the PAYER-ADJUSTED `ResolvedAbility` clone
     /// (controller swapped to the resolved payer, per `effects/pay.rs`). All
@@ -573,7 +572,7 @@ pub fn pay_ability_cost_for_activation(
     player: PlayerId,
     source_id: ObjectId,
     cost: &AbilityCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
+    ability_index: usize,
     events: &mut Vec<GameEvent>,
 ) -> Result<PaymentOutcome, EngineError> {
     pay_ability_cost_for_activation_with_cost_move_replacement(
@@ -581,7 +580,7 @@ pub fn pay_ability_cost_for_activation(
         player,
         source_id,
         cost,
-        ability_tag,
+        ability_index,
         events,
     )
 }
@@ -591,7 +590,7 @@ fn pay_ability_cost_for_activation_with_cost_move_replacement(
     player: PlayerId,
     source_id: ObjectId,
     cost: &AbilityCost,
-    ability_tag: Option<crate::types::ability::AbilityTag>,
+    ability_index: usize,
     events: &mut Vec<GameEvent>,
 ) -> Result<PaymentOutcome, EngineError> {
     let excluded_sources = ability_mana_payment_excluded_sources(cost, source_id);
@@ -603,7 +602,7 @@ fn pay_ability_cost_for_activation_with_cost_move_replacement(
         events,
         &PaymentScope::Activation {
             excluded_sources: &excluded_sources,
-            ability_tag,
+            ability_index,
         },
         None,
     )?;
@@ -760,18 +759,18 @@ fn pay_ability_cost_inner(
             // source permanent's types.
             PaymentScope::Activation {
                 excluded_sources,
-                ability_tag,
+                ability_index,
                 ..
             } => {
                 if excluded_sources.is_empty() {
-                    pay_ability_mana_cost(state, player, source_id, cost, *ability_tag, events)?;
+                    pay_ability_mana_cost(state, player, source_id, *ability_index, cost, events)?;
                 } else {
                     pay_ability_mana_cost_excluding(
                         state,
                         player,
                         source_id,
+                        *ability_index,
                         cost,
-                        *ability_tag,
                         events,
                         excluded_sources,
                         // Top-level ability cost payment: no outer cost on the stack.
@@ -2241,7 +2240,7 @@ mod tests {
             let excluded = ability_mana_payment_excluded_sources(&cost, src);
             let scope = PaymentScope::Activation {
                 excluded_sources: &excluded,
-                ability_tag: None,
+                ability_index: 0,
             };
             assert!(
                 can_pay(&scenario.state, P0, src, &cost, &scope),
@@ -2270,7 +2269,7 @@ mod tests {
         let excluded = ability_mana_payment_excluded_sources(&cost, src);
         let scope = PaymentScope::Activation {
             excluded_sources: &excluded,
-            ability_tag: None,
+            ability_index: 0,
         };
         let mut events = Vec::new();
         let outcome = pay_ability_cost_inner(
@@ -2323,7 +2322,7 @@ mod tests {
             P0,
             src,
             &graveyard_cost,
-            None,
+            0,
             &mut Vec::new(),
         );
         assert!(matches!(rejected, Err(EngineError::ActionNotAllowed(_))));
@@ -2339,7 +2338,7 @@ mod tests {
             P0,
             src,
             &battlefield_cost,
-            None,
+            0,
             &mut Vec::new(),
         )
         .expect("battlefield self-return cost should be payable");
@@ -2356,7 +2355,7 @@ mod tests {
             cost,
             &PaymentScope::Activation {
                 excluded_sources: &excluded,
-                ability_tag: None,
+                ability_index: 0,
             },
         )
     }

--- a/crates/engine/src/game/effects/mana.rs
+++ b/crates/engine/src/game/effects/mana.rs
@@ -317,11 +317,26 @@ pub(crate) fn resolve_restrictions(
             ManaSpendRestriction::SpellType(t) => {
                 Some(ManaRestriction::OnlyForSpellType(t.clone()))
             }
+            // Preserve the historical behavior of this older template: it is
+            // omitted when the source has no creature-type choice. The newer
+            // `SpellOfSourceChosenColor` below deliberately differs; its
+            // missing choice must make the produced mana unspendable.
             ManaSpendRestriction::ChosenCreatureType => state
                 .objects
                 .get(&source_id)
                 .and_then(|obj| obj.chosen_creature_type())
                 .map(|ct| ManaRestriction::OnlyForCreatureType(ct.to_string())),
+            // CR 105.2 + CR 106.6: The spell's color must equal the mana
+            // source's live chosen color. A missing source/choice is not an
+            // omitted restriction; it makes this produced mana unspendable.
+            ManaSpendRestriction::SpellOfSourceChosenColor => Some(
+                state
+                    .objects
+                    .get(&source_id)
+                    .and_then(|obj| obj.chosen_color())
+                    .map(ManaRestriction::OnlyForSpellColor)
+                    .unwrap_or(ManaRestriction::Impossible),
+            ),
             // CR 106.6: Combined spell type + ability activation restriction.
             ManaSpendRestriction::SpellTypeOrAbilityActivation {
                 spell_type,
@@ -393,12 +408,12 @@ pub(crate) fn resolve_restrictions(
                     crate::types::mana::SpecialAction::TurnFaceUp,
                 ))
             }
-            // CR 106.6: Disjunction — recursively lower each branch. If every branch
-            // dropped (e.g. an unresolvable `ChosenCreatureType` with no chosen type),
-            // the disjunction has no payable cases, so drop it too.
+            // CR 106.6: Disjunction — recursively lower each branch. The
+            // chosen-color branch preserves its fail-closed `Impossible`; the
+            // legacy chosen-creature-type branch retains its historical drop.
             ManaSpendRestriction::Any(subs) => {
                 let inner = resolve_restrictions(subs, state, source_id);
-                (!inner.is_empty()).then_some(ManaRestriction::OnlyForAny(inner))
+                Some(ManaRestriction::OnlyForAny(inner))
             }
         })
         .collect()

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6154,17 +6154,9 @@ fn apply_action(
                     .ok_or_else(|| EngineError::InvalidAction("Player not found".to_string()))?;
                 let activation_ability_index = pending_ref.activation_ability_index;
                 let current_shards = if let Some(ability_index) = activation_ability_index {
-                    let (source_types, source_subtypes) =
-                        casting::activation_source_types(state, spell_object);
-                    let activation_ctx = crate::types::mana::PaymentContext::Activation {
-                        source_types: &source_types,
-                        source_subtypes: &source_subtypes,
-                        ability_tag: casting::activation_ability_tag(
-                            state,
-                            spell_object,
-                            ability_index,
-                        ),
-                    };
+                    let activation_context =
+                        casting::activation_payment_context(state, spell_object, ability_index);
+                    let activation_ctx = activation_context.as_payment_context();
                     let any_color = casting::player_can_spend_as_any_color_for_payment(
                         state,
                         player,
@@ -9578,19 +9570,11 @@ pub(super) fn handle_spend_pool_mana(
     // is correctly eligible to pin when it can legally pay the activation.
     // Owned holders so the context's borrowed slices outlive the eligibility check.
     let spell_meta;
-    let source_types;
-    let source_subtypes;
-    let ability_tag;
+    let activation_context;
     let ctx = if let Some(ability_index) = activation_ability_index {
-        let (types, subtypes) = super::casting::activation_source_types(state, object_id);
-        source_types = types;
-        source_subtypes = subtypes;
-        ability_tag = super::casting::activation_ability_tag(state, object_id, ability_index);
-        Some(crate::types::mana::PaymentContext::Activation {
-            source_types: &source_types,
-            source_subtypes: &source_subtypes,
-            ability_tag,
-        })
+        activation_context =
+            super::casting::activation_payment_context(state, object_id, ability_index);
+        Some(activation_context.as_payment_context())
     } else {
         spell_meta = super::casting::build_spell_meta(state, player, object_id);
         spell_meta
@@ -9637,7 +9621,7 @@ fn mana_unit_eligible_for_cost(
 
     // CR 106.6: a unit whose restrictions reject this context can pay nothing here.
     if let Some(ctx) = ctx {
-        if !unit.restrictions.iter().all(|r| r.allows(ctx)) {
+        if !mana_payment::mana_unit_permits_payment_context(unit, ctx) {
             return false;
         }
     }

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -2056,6 +2056,7 @@ fn unlock_door_restricted_mana_rejected_for_effect_and_spell_payments() {
         source_types: &["Artifact".to_string()],
         source_subtypes: &["Equipment".to_string()],
         ability_tag: None,
+        mana_color_constraint: crate::types::mana::ActivationManaColorConstraint::Unrestricted,
     }));
     let _ = ManaType::Red;
 }

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -709,6 +709,10 @@ pub fn activate_ninjutsu(
     // CR 702.49a/d: Extract the activation cost (validated after all other checks, paid before mutations)
     let mana_cost =
         ninjutsu_family_cost(ninjutsu_obj).ok_or("Ninjutsu-family card has no mana cost")?;
+    let ability_index = super::casting::activated_ability_definitions(state, ninjutsu_obj_id)
+        .into_iter()
+        .find_map(|(index, ability)| is_ninjutsu_family_marker_ability(&ability).then_some(index))
+        .ok_or("Ninjutsu-family card has no activated ability marker")?;
 
     // Validate timing
     if !ninjutsu_timing_ok(&state.phase, &variant) {
@@ -772,7 +776,7 @@ pub fn activate_ninjutsu(
         &AbilityCost::Mana {
             cost: effective_cost,
         },
-        None,
+        ability_index,
         events,
     )
     .map_err(|e| e.to_string())?
@@ -1978,6 +1982,18 @@ mod tests {
         }
 
         (state, attacker_id, ninja_id)
+    }
+
+    #[test]
+    fn effective_abilities_include_runtime_ninjutsu_marker() {
+        let (state, _attacker_id, ninja_id) = setup_ninjutsu_scenario();
+
+        assert!(
+            crate::game::casting::activated_ability_definitions(&state, ninja_id)
+                .into_iter()
+                .any(|(_, ability)| is_ninjutsu_family_marker_ability(&ability)),
+            "a Ninjutsu keyword without a stored marker must still occupy the effective activation space"
+        );
     }
 
     /// CR 702.49c + CR 616.1 discriminating test (fail-first): a ninja whose

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -1350,7 +1350,7 @@ fn mana_ability_ready_without_simulation_gated(
     // currently payable. is_payable_for_mana_ability's Mana arm uses auto_tap with
     // require_current_payability=false, so it does not recurse here.
     if let Some(cost) = &ability_def.cost {
-        if !cost.is_payable_for_mana_ability(state, player, source_id) {
+        if !cost.is_payable_for_mana_ability(state, player, source_id, ability_index) {
             return false;
         }
     }
@@ -1658,13 +1658,12 @@ pub(super) fn advance_mana_ability_activation(
     // 117.1d / CR 118.2).
     if pending.chosen_mana_payment.is_none() {
         if let Some(sub_cost) = mana_sub_cost_of(&ability_def.cost) {
-            let (source_types, source_subtypes) =
-                super::casting::activation_source_types(state, pending.source_id);
-            let activation_ctx = PaymentContext::Activation {
-                source_types: &source_types,
-                source_subtypes: &source_subtypes,
-                ability_tag: None,
-            };
+            let activation_context = super::casting::activation_payment_context(
+                state,
+                pending.source_id,
+                pending.ability_index,
+            );
+            let activation_ctx = activation_context.as_payment_context();
             let pool = &state.players[pending.player.0 as usize].mana_pool;
             let plans = enumerate_hybrid_payment_plans(pool, sub_cost, &activation_ctx);
             match plans.len() {
@@ -1674,6 +1673,7 @@ pub(super) fn advance_mana_ability_activation(
                         state,
                         pending.player,
                         pending.source_id,
+                        pending.ability_index,
                         sub_cost,
                         &excluded_sources,
                     )
@@ -2208,7 +2208,7 @@ fn pay_mana_ability_cost_component(
                 pending.player,
                 pending.source_id,
                 cost,
-                None,
+                pending.ability_index,
                 events,
             )? {
                 super::costs::PaymentOutcome::Paid => Ok(ManaAbilityPaymentProgress::Complete),
@@ -2289,6 +2289,7 @@ fn pay_mana_ability_cost_component(
                 state,
                 pending.source_id,
                 pending.player,
+                pending.ability_index,
                 &Some(cost.clone()),
                 events,
                 &mut tappers,
@@ -2690,6 +2691,7 @@ fn pay_mana_ability_cost_with_choices<I, J, L>(
     state: &mut GameState,
     source_id: ObjectId,
     player: PlayerId,
+    ability_index: usize,
     cost: &Option<AbilityCost>,
     events: &mut Vec<GameEvent>,
     chosen_tappers: &mut I,
@@ -2722,6 +2724,7 @@ where
                 state,
                 source_id,
                 player,
+                ability_index,
                 cost,
                 chosen_hybrid_payment,
                 events,
@@ -2893,7 +2896,12 @@ where
             };
             if matches!(
                 super::costs::pay_ability_cost_for_activation(
-                    state, player, source_id, &cost, None, events,
+                    state,
+                    player,
+                    source_id,
+                    &cost,
+                    ability_index,
+                    events,
                 )?,
                 super::costs::PaymentOutcome::Paused { .. }
             ) {
@@ -2908,7 +2916,12 @@ where
         Some(c) if is_self_contained_mana_subcost(c) => {
             if matches!(
                 super::costs::pay_ability_cost_for_activation(
-                    state, player, source_id, c, None, events,
+                    state,
+                    player,
+                    source_id,
+                    c,
+                    ability_index,
+                    events,
                 )?,
                 super::costs::PaymentOutcome::Paused { .. }
             ) {
@@ -3332,6 +3345,7 @@ fn pay_mana_sub_cost(
     state: &mut GameState,
     source_id: ObjectId,
     player: PlayerId,
+    ability_index: usize,
     cost: &ManaCost,
     hybrid_plan: Option<&[ManaType]>,
     events: &mut Vec<GameEvent>,
@@ -3352,15 +3366,12 @@ fn pay_mana_sub_cost(
         // chain, or a self-loop terminate instead of recursing infinitely.
         let mut excluded_sources = excluded_sources.clone();
         excluded_sources.insert(source_id);
-        // CR 605.1a: A mana ability never carries a power-up tag (power-up
-        // abilities can't produce mana), so the tag-scoped activation context is
-        // `None` here — Quinjet's {R}{R} must not pay another mana ability's cost.
         return super::casting::pay_ability_mana_cost_excluding_with_parent(
             state,
             player,
             source_id,
+            ability_index,
             cost,
-            None,
             events,
             &excluded_sources,
             sub_cost_demand,
@@ -3374,14 +3385,9 @@ fn pay_mana_sub_cost(
     // pool's restriction-blind `pay_cost`. Without this, activation-only
     // mana (e.g. Heart of Ramos) would silently pay through for the {R} half
     // of a hypothetical "{R}: Add {G}{G}" mana ability.
-    let (source_types, source_subtypes) = super::casting::activation_source_types(state, source_id);
-    // CR 605.1a: Mana abilities never carry a power-up tag, so `ability_tag` is
-    // `None` for the mana-ability sub-cost activation context.
-    let ctx = PaymentContext::Activation {
-        source_types: &source_types,
-        source_subtypes: &source_subtypes,
-        ability_tag: None,
-    };
+    let activation_context =
+        super::casting::activation_payment_context(state, source_id, ability_index);
+    let ctx = activation_context.as_payment_context();
     state.restamp_pool_pip_ids(player);
     let spent = select_cost_with_plan(
         &state.players[player.0 as usize].mana_pool,
@@ -4626,6 +4632,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4646,6 +4653,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4665,6 +4673,7 @@ mod tests {
             source_types: &non_elemental_types,
             source_subtypes: &non_elemental_subtypes,
             ability_tag: None,
+            mana_color_constraint: crate::types::mana::ActivationManaColorConstraint::Unrestricted,
         };
         let mut pool_clone2 = pool.clone();
         assert!(
@@ -4679,6 +4688,7 @@ mod tests {
             source_types: &non_elemental_types,
             source_subtypes: &elemental_subtypes,
             ability_tag: None,
+            mana_color_constraint: crate::types::mana::ActivationManaColorConstraint::Unrestricted,
         };
         assert!(
             pool_clone2

--- a/crates/engine/src/game/mana_payment.rs
+++ b/crates/engine/src/game/mana_payment.rs
@@ -2046,13 +2046,24 @@ pub fn land_subtype_to_mana_type(subtype: &str) -> Option<ManaType> {
 /// Arisen Necropolis). Under such a spell-payment context, real pool mana is
 /// ineligible — only convoke/delve stand-in units may pay. Layered on top of the
 /// unit's own spend restrictions so both gates apply.
-fn ctx_permits_unit(ctx: &PaymentContext<'_>, unit: &ManaUnit) -> bool {
+/// CR 106.6: Shared eligibility predicate for a concrete mana unit in a typed
+/// payment context. The ability rider checks the unit's actual mana type before
+/// unit restrictions; cost permissions such as "spend as though" are applied
+/// later and cannot make an off-color unit satisfy an activation rider.
+pub(crate) fn mana_unit_permits_payment_context(unit: &ManaUnit, ctx: &PaymentContext<'_>) -> bool {
+    if !ctx.permits_actual_mana_type(unit.color) {
+        return false;
+    }
     if let PaymentContext::Spell(meta) = ctx {
         if meta.cant_spend_mana && !unit.is_convoke_payment() {
             return false;
         }
     }
     unit.restrictions.iter().all(|r| r.allows(ctx))
+}
+
+fn ctx_permits_unit(ctx: &PaymentContext<'_>, unit: &ManaUnit) -> bool {
+    mana_unit_permits_payment_context(unit, ctx)
 }
 
 /// `ctx_permits_unit` lifted over an optional context: no context means every
@@ -2668,7 +2679,7 @@ mod tests {
     use crate::types::game_state::LayersDirty;
     use crate::types::identifiers::CardId;
     use crate::types::identifiers::ObjectId;
-    use crate::types::mana::{ManaRestriction, SpellMeta};
+    use crate::types::mana::{ManaColor, ManaRestriction, SpellMeta};
     use crate::types::zones::Zone;
 
     /// The building-block predicate must classify each shape the parser can produce.
@@ -2841,6 +2852,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana,
@@ -3840,6 +3852,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3864,6 +3877,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3914,6 +3928,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3937,6 +3952,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3981,6 +3997,7 @@ mod tests {
             source_types: &source_types,
             source_subtypes: &source_subtypes,
             ability_tag: None,
+            mana_color_constraint: crate::types::mana::ActivationManaColorConstraint::Unrestricted,
         };
         assert!(can_pay_for_spell(
             &pool,
@@ -3996,6 +4013,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4033,20 +4051,16 @@ mod tests {
         .expect("Hydraulic Helper's spend restriction must parse");
         assert_eq!(
             ast,
-            ManaSpendRestriction::SpellTypeOrAbilityActivation {
+            vec![ManaSpendRestriction::SpellTypeOrAbilityActivation {
                 spell_type: "Artifact".to_string(),
                 ability: AbilityActivationScope::Any,
-            },
+            }],
             "negative nonartifact restriction must keep ability activation unrestricted"
         );
 
         // Lower through the real runtime resolver (state-independent for this variant).
         let state = GameState::new_two_player(42);
-        let runtime = crate::game::effects::mana::resolve_restrictions(
-            std::slice::from_ref(&ast),
-            &state,
-            ObjectId(1),
-        );
+        let runtime = crate::game::effects::mana::resolve_restrictions(&ast, &state, ObjectId(1));
 
         // The produced {U} carries the lowered restriction.
         let mut pool = ManaPool::default();
@@ -4074,6 +4088,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4100,6 +4115,8 @@ mod tests {
                     source_types: &creature_types,
                     source_subtypes: &no_subtypes,
                     ability_tag: None,
+                    mana_color_constraint:
+                        crate::types::mana::ActivationManaColorConstraint::Unrestricted,
                 }),
                 crate::types::mana::CostPermissionContext::default(),
             ),
@@ -4114,6 +4131,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4215,6 +4233,7 @@ mod tests {
             cast_from_zone: Some(crate::types::zones::Zone::Graveyard),
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4238,6 +4257,7 @@ mod tests {
             cast_from_zone: Some(crate::types::zones::Zone::Hand),
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4284,6 +4304,7 @@ mod tests {
             cast_from_zone: Some(crate::types::zones::Zone::Graveyard),
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4307,6 +4328,7 @@ mod tests {
             cast_from_zone: Some(crate::types::zones::Zone::Hand),
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -4355,6 +4377,50 @@ mod tests {
                 life_colors: crate::types::mana::LifePaymentColors::EMPTY
             }
         ));
+    }
+
+    /// CR 106.6: an activation's own chosen-color rider is checked against the
+    /// actual unit before any "spend as though" permission. A blue unit cannot
+    /// pay Throne of Eldraine's draw ability after red was chosen, even when an
+    /// outside effect would otherwise let blue mana pay a red cost.
+    #[test]
+    fn chosen_color_activation_rider_rejects_off_color_even_with_any_color() {
+        let source_types = vec!["Artifact".to_string()];
+        let source_subtypes = Vec::new();
+        let context = PaymentContext::Activation {
+            source_types: &source_types,
+            source_subtypes: &source_subtypes,
+            ability_tag: None,
+            mana_color_constraint: crate::types::mana::ActivationManaColorConstraint::Only(
+                ManaColor::Red,
+            ),
+        };
+        let blue_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 0,
+        };
+        let as_though_any_color = crate::types::mana::CostPermissionContext {
+            any_color: true,
+            ..crate::types::mana::CostPermissionContext::default()
+        };
+        assert!(
+            !can_pay_for_spell(
+                &pool_with(&[(ManaType::Blue, 1)]),
+                &blue_cost,
+                Some(&context),
+                as_though_any_color,
+            ),
+            "an as-though permission must not change blue's actual mana color"
+        );
+        assert!(
+            can_pay_for_spell(
+                &pool_with(&[(ManaType::Red, 1)]),
+                &blue_cost,
+                Some(&context),
+                as_though_any_color,
+            ),
+            "a red unit remains eligible before the as-though permission matches the shard"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/planeswalker.rs
+++ b/crates/engine/src/game/planeswalker.rs
@@ -392,8 +392,15 @@ fn finalize_loyalty_activation(
     let cost = crate::types::ability::AbilityCost::Loyalty {
         amount: loyalty_cost,
     };
-    match super::casting::pay_ability_cost_for_activation(state, player, pw_id, &cost, None, events)
-        .expect("loyalty validation passed in handle_activate_loyalty")
+    match super::casting::pay_ability_cost_for_activation(
+        state,
+        player,
+        pw_id,
+        &cost,
+        ability_index,
+        events,
+    )
+    .expect("loyalty validation passed in handle_activate_loyalty")
     {
         super::casting::PaymentOutcome::Paid => {
             complete_loyalty_activation(state, player, pw_id, resolved, ability_index, events)

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1501,15 +1501,31 @@ fn pay_replacement_may_cost(
                 Ok(crate::game::costs::PaymentOutcome::Failed { .. }) | Err(_) => false,
             }
         }
-        _ => match crate::game::casting::pay_ability_cost_for_activation(
-            state, player, source_id, cost, None, events,
-        ) {
-            Ok(crate::game::costs::PaymentOutcome::Paid) => true,
-            Ok(crate::game::costs::PaymentOutcome::Paused { remaining_cost }) => {
-                return MayCostOutcome::PausedForChoice { remaining_cost };
+        // A replacement's may-cost is paid while applying the replacement; it
+        // is not an activation of `source_id`. Use the dedicated resolution
+        // payment authority so it neither invents an ability index nor applies
+        // an unrelated activation-only mana rider.
+        _ => {
+            let ability = ResolvedAbility::new(
+                crate::types::ability::Effect::PayCost {
+                    cost: cost.clone(),
+                    scale: None,
+                    payer: TargetFilter::Controller,
+                },
+                Vec::new(),
+                source_id,
+                player,
+            );
+            match crate::game::costs::pay_ability_cost_for_replacement_may_cost(
+                state, player, cost, &ability, events,
+            ) {
+                Ok(crate::game::costs::PaymentOutcome::Paid) => true,
+                Ok(crate::game::costs::PaymentOutcome::Paused { remaining_cost }) => {
+                    return MayCostOutcome::PausedForChoice { remaining_cost };
+                }
+                Ok(crate::game::costs::PaymentOutcome::Failed { .. }) | Err(_) => false,
             }
-            Ok(crate::game::costs::PaymentOutcome::Failed { .. }) | Err(_) => false,
-        },
+        }
     };
     if paid {
         MayCostOutcome::Paid

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -10,12 +10,12 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag,
-    ActivationRestriction, AdditionalCost, CastTimingPermission, CastingRestriction, ChoiceType,
-    ChosenSubtypeKind, ContinuousModification, ControllerRef, CostReduction,
-    DelayedTriggerCondition, Duration, Effect, EffectScope, FilterProp, ManaProduction,
-    ModalChoice, ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition,
-    SolveCondition, SpellCastingOption, StaticCondition, StaticDefinition, TapStateChange,
-    TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter,
+    ActivationManaPaymentRestriction, ActivationRestriction, AdditionalCost, CastTimingPermission,
+    CastingRestriction, ChoiceType, ChosenSubtypeKind, ContinuousModification, ControllerRef,
+    CostReduction, DelayedTriggerCondition, Duration, Effect, EffectScope, FilterProp,
+    ManaProduction, ModalChoice, ParsedCondition, PlayerFilter, QuantityExpr, QuantityRef,
+    ReplacementDefinition, SolveCondition, SpellCastingOption, StaticCondition, StaticDefinition,
+    TapStateChange, TargetFilter, TriggerCondition, TriggerDefinition, TypedFilter,
 };
 use crate::types::format::DeckCopyLimit;
 use crate::types::keywords::{EscapeCost, FlashbackCost, Keyword, KeywordKind};
@@ -6207,6 +6207,8 @@ fn parse_activated_ability_definition(
     current_ability_index: Option<PrintedAbilityIndex>,
     ctx: &mut ParseContext,
 ) -> (AbilityDefinition, String) {
+    let (effect_text, activation_mana_payment_restriction) =
+        strip_activated_mana_payment_restriction(effect_text);
     let (effect_text, constraints) = strip_activated_constraints(effect_text);
     // CR 207.2c / CR 207.2d: drop a leading ability-/flavor-word label so the cost
     // after the em-dash parses (covers 5–6-word Universes-Beyond flavor names that
@@ -6249,6 +6251,7 @@ fn parse_activated_ability_definition(
     if !constraints.restrictions.is_empty() {
         def.activation_restrictions = constraints.restrictions;
     }
+    def.activation_mana_payment_restriction = activation_mana_payment_restriction;
     def.activator_filter = constraints.activator_filter.or_else(|| {
         constraints
             .any_player_may_activate
@@ -6257,6 +6260,32 @@ fn parse_activated_ability_definition(
     extract_cost_reduction_from_chain(&mut def);
     extract_mana_spend_trigger_from_chain(&mut def);
     (def, effect_text)
+}
+
+/// CR 106.6: Strip the exact terminal rider "Spend only mana of the chosen
+/// color to activate this ability." from an activated ability's effect body.
+/// This is intentionally an all-consuming nom grammar: other possessives,
+/// colors, subjects, or trailing words stay in the effect text and therefore
+/// remain an explicit residual parse gap rather than weakening a cost rule.
+fn strip_activated_mana_payment_restriction(
+    text: &str,
+) -> (&str, Option<ActivationManaPaymentRestriction>) {
+    const SUFFIX: &str = ". spend only mana of the chosen color to activate this ability";
+    let lower = text.to_lowercase();
+    let parsed = nom_on_lower(text, &lower, |input| {
+        let (input, prefix) = take_until(SUFFIX).parse(input)?;
+        let (input, _) = tag(SUFFIX).parse(input)?;
+        let (input, _) = opt(tag(".")).parse(input)?;
+        let (input, _) = all_consuming(multispace0).parse(input)?;
+        Ok((input, prefix.len()))
+    });
+    match parsed {
+        Some((prefix_len, _)) => (
+            text[..prefix_len].trim_end(),
+            Some(ActivationManaPaymentRestriction::OnlySourceChosenColor),
+        ),
+        None => (text, None),
+    }
 }
 
 /// Parse Oracle text into structured ability definitions.

--- a/crates/engine/src/parser/oracle_effect/mana.rs
+++ b/crates/engine/src/parser/oracle_effect/mana.rs
@@ -1624,10 +1624,11 @@ fn split_restricted_spell_and_activation(rest: &str) -> (&str, ActivationTail) {
 /// - "spend this mana only to cast a creature spell of the chosen type" -> `ChosenCreatureType`
 /// - "spend this mana only to activate abilities" -> `ActivateOnly`
 ///
-/// Returns `(restriction, grants)` where grants are properties conferred to the spell.
+/// Returns `(restrictions, grants)` where every restriction is an AND gate on
+/// the produced mana and grants are properties conferred to the spell.
 pub(crate) fn parse_mana_spend_restriction(
     lower: &str,
-) -> Option<(ManaSpendRestriction, Vec<ManaSpellGrant>)> {
+) -> Option<(Vec<ManaSpendRestriction>, Vec<ManaSpellGrant>)> {
     // CR 106.6: Negative spend restriction — "this mana can't be spent to cast
     // non<TYPE> spells" (Karn, Legacy Reforged). The double negative ("can't
     // cast non<TYPE>") is the spell-side equivalent of "only to cast <TYPE>",
@@ -1637,7 +1638,7 @@ pub(crate) fn parse_mana_spend_restriction(
     // ability stays payable) rather than `SpellType` (spells-only), which would
     // wrongly forbid paying for abilities.
     if let Some(restriction) = parse_negative_mana_spend_restriction(lower) {
-        return Some((restriction, vec![]));
+        return Some((vec![restriction], vec![]));
     }
 
     let (_, base) = nom_on_lower(lower, lower, |i| {
@@ -1655,7 +1656,7 @@ pub(crate) fn parse_mana_spend_restriction(
     .is_some()
     {
         return Some((
-            ManaSpendRestriction::ActivateTagged(AbilityTag::PowerUp),
+            vec![ManaSpendRestriction::ActivateTagged(AbilityTag::PowerUp)],
             vec![],
         ));
     }
@@ -1666,7 +1667,7 @@ pub(crate) fn parse_mana_spend_restriction(
     })
     .is_some()
     {
-        return Some((ManaSpendRestriction::ActivateOnly, vec![]));
+        return Some((vec![ManaSpendRestriction::ActivateOnly], vec![]));
     }
 
     // "spend this mana only on costs that include/contain {X}" -- X-cost restriction
@@ -1679,7 +1680,7 @@ pub(crate) fn parse_mana_spend_restriction(
     })
     .is_some()
     {
-        return Some((ManaSpendRestriction::XCostOnly, vec![]));
+        return Some((vec![ManaSpendRestriction::XCostOnly], vec![]));
     }
 
     // CR 106.6: Activation-first disjunction — "to activate X or cast Y" (Automated
@@ -1695,7 +1696,7 @@ pub(crate) fn parse_mana_spend_restriction(
         let without_to = nom_on_lower(base, &base_lower, |i| value((), tag("to ")).parse(i))
             .map_or(base, |(_, rest)| rest);
         if let Some(restriction) = parse_disjunctive_cast_clauses(without_to.trim()) {
-            return Some((restriction, vec![]));
+            return Some((vec![restriction], vec![]));
         }
     }
 
@@ -1705,10 +1706,10 @@ pub(crate) fn parse_mana_spend_restriction(
     // the standalone special-action clauses first (Overgrown Zealot's second
     // ability is turn-face-up-only). The clause parsers tolerate the leading "to ".
     if let Some(restriction) = parse_turn_face_up_clause(base, &base_lower) {
-        return Some((restriction, vec![]));
+        return Some((vec![restriction], vec![]));
     }
     if let Some(restriction) = parse_unlock_door_clause(base, &base_lower) {
-        return Some((restriction, vec![]));
+        return Some((vec![restriction], vec![]));
     }
 
     let (_, rest) = nom_on_lower(base, &base_lower, |i| value((), tag("to cast ")).parse(i))?;
@@ -1718,22 +1719,60 @@ pub(crate) fn parse_mana_spend_restriction(
     let (rest, grants) = extract_spell_grants(rest);
     let rest = rest.trim();
 
+    // CR 105.2a + CR 106.6: This rider has two independent requirements: the
+    // spell is monocolored, and its sole color equals the source's chosen
+    // color. Keep them as two restrictions so the generic color-count and
+    // color-membership building blocks remain independently reusable.
+    if parse_monocolored_spell_of_source_chosen_color(rest) {
+        return Some((
+            vec![
+                ManaSpendRestriction::SpellWithColorCount {
+                    comparator: Comparator::EQ,
+                    count: 1,
+                },
+                ManaSpendRestriction::SpellOfSourceChosenColor,
+            ],
+            grants,
+        ));
+    }
+
     // CR 106.6: Prefer the whole-remainder single-clause reading first, so a
     // type union inside one clause ("instant or sorcery spells") stays a single
     // `SpellType` and only genuinely heterogeneous disjunctions fall through to
     // the multi-clause path below.
     if let Some(restriction) = parse_single_cast_clause(rest) {
-        return Some((restriction, grants));
+        return Some((vec![restriction], grants));
     }
 
     // CR 106.6: Disjunctive spend restriction ("cast X or Y", "cast X, Y, or
     // activate Z"). Each top-level clause is parsed independently; only when ≥2
     // clauses all parse to self-evaluable restrictions do we emit `Any`.
     if let Some(restriction) = parse_disjunctive_cast_clauses(rest) {
-        return Some((restriction, grants));
+        return Some((vec![restriction], grants));
     }
 
     None
+}
+
+/// CR 105.2a + CR 106.6: Pure, terminal grammar for "monocolored spell(s) of
+/// that color" and "... of the chosen color." The parser deliberately accepts
+/// no possessives, modifiers, or trailing text: a near miss must remain an
+/// explicit residual clause rather than weakening a mana-spend restriction.
+fn parse_monocolored_spell_of_source_chosen_color(rest: &str) -> bool {
+    let lower = rest.to_lowercase();
+    nom_on_lower(rest, &lower, |input| {
+        value(
+            (),
+            all_consuming((
+                tag("monocolored "),
+                alt((tag("spells"), tag("spell"))),
+                tag(" of "),
+                alt((tag("that color"), tag("the chosen color"))),
+            )),
+        )
+        .parse(input)
+    })
+    .is_some()
 }
 
 /// CR 106.6: Parse a single post-"to cast " clause (no grant extraction, no
@@ -3975,10 +4014,10 @@ mod tests {
                 .expect("negated nonartifact restriction must parse");
         assert_eq!(
             restriction,
-            ManaSpendRestriction::SpellTypeOrAbilityActivation {
+            vec![ManaSpendRestriction::SpellTypeOrAbilityActivation {
                 spell_type: "Artifact".to_string(),
                 ability: AbilityActivationScope::Any,
-            }
+            }]
         );
         assert!(grants.is_empty());
     }
@@ -3993,10 +4032,10 @@ mod tests {
         .expect("curly-apostrophe negated restriction must parse");
         assert_eq!(
             restriction,
-            ManaSpendRestriction::SpellTypeOrAbilityActivation {
+            vec![ManaSpendRestriction::SpellTypeOrAbilityActivation {
                 spell_type: "Artifact".to_string(),
                 ability: AbilityActivationScope::Any,
-            }
+            }]
         );
     }
 
@@ -4009,10 +4048,10 @@ mod tests {
                 .expect("negated noncreature restriction must parse");
         assert_eq!(
             restriction,
-            ManaSpendRestriction::SpellTypeOrAbilityActivation {
+            vec![ManaSpendRestriction::SpellTypeOrAbilityActivation {
                 spell_type: "Creature".to_string(),
                 ability: AbilityActivationScope::Any,
-            }
+            }]
         );
     }
 
@@ -4025,7 +4064,7 @@ mod tests {
         );
         assert_eq!(
             result.map(|(r, _)| r),
-            Some(ManaSpendRestriction::SpellMatchingCostCriteria {
+            Some(vec![ManaSpendRestriction::SpellMatchingCostCriteria {
                 spell_type: None,
                 criteria: vec![
                     SpellCostCriterion::ManaValue {
@@ -4034,7 +4073,7 @@ mod tests {
                     },
                     SpellCostCriterion::HasXInCost,
                 ],
-            })
+            }])
         );
     }
 
@@ -4047,7 +4086,7 @@ mod tests {
         );
         assert_eq!(
             result.map(|(r, _)| r),
-            Some(ManaSpendRestriction::SpellMatchingCostCriteria {
+            Some(vec![ManaSpendRestriction::SpellMatchingCostCriteria {
                 spell_type: Some("Creature".to_string()),
                 criteria: vec![
                     SpellCostCriterion::ManaValue {
@@ -4056,7 +4095,7 @@ mod tests {
                     },
                     SpellCostCriterion::HasXInCost,
                 ],
-            })
+            }])
         );
     }
 
@@ -4080,10 +4119,10 @@ mod tests {
         );
         assert_eq!(
             result.map(|(r, _)| r),
-            Some(ManaSpendRestriction::SpellWithManaValue {
+            Some(vec![ManaSpendRestriction::SpellWithManaValue {
                 comparator: Comparator::GE,
                 value: 5,
-            })
+            }])
         );
     }
 
@@ -4097,10 +4136,10 @@ mod tests {
                 "spend this mana only to cast a spell from anywhere other than your hand"
             )
             .map(|(r, _)| r),
-            Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
+            Some(vec![ManaSpendRestriction::SpellFromZone(ZoneSpend {
                 zone: Zone::Hand,
                 polarity: ZoneSpendPolarity::NotFrom,
-            }))
+            })])
         );
         // The exclusion marker must not bleed into the inclusion reading.
         assert_eq!(
@@ -4108,10 +4147,10 @@ mod tests {
                 "spend this mana only to cast a spell from your graveyard"
             )
             .map(|(r, _)| r),
-            Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
+            Some(vec![ManaSpendRestriction::SpellFromZone(ZoneSpend {
                 zone: Zone::Graveyard,
                 polarity: ZoneSpendPolarity::From,
-            }))
+            })])
         );
     }
 
@@ -4126,10 +4165,10 @@ mod tests {
         );
         assert_eq!(
             result.map(|(r, _)| r),
-            Some(ManaSpendRestriction::Any(vec![
+            Some(vec![ManaSpendRestriction::Any(vec![
                 ManaSpendRestriction::SpellType("Room".to_string()),
                 ManaSpendRestriction::UnlockDoor,
-            ]))
+            ])])
         );
     }
 
@@ -4142,10 +4181,10 @@ mod tests {
         );
         assert_eq!(
             result.map(|(r, _)| r),
-            Some(ManaSpendRestriction::Any(vec![
+            Some(vec![ManaSpendRestriction::Any(vec![
                 ManaSpendRestriction::SpellType("Room".to_string()),
                 ManaSpendRestriction::UnlockDoor,
-            ]))
+            ])])
         );
     }
 
@@ -4158,9 +4197,9 @@ mod tests {
             parse_mana_spend_restriction("spend this mana only to cast instant and sorcery spells");
         assert_eq!(
             result.map(|(r, _)| r),
-            Some(ManaSpendRestriction::SpellType(
+            Some(vec![ManaSpendRestriction::SpellType(
                 "Instant and Sorcery".to_string()
-            ))
+            )])
         );
     }
 
@@ -4179,11 +4218,11 @@ mod tests {
                 "spend this mana only to cast an enchantment spell, unlock a door, or turn a permanent face up",
             )
             .map(|(r, _)| r),
-            Some(ManaSpendRestriction::Any(vec![
+            Some(vec![ManaSpendRestriction::Any(vec![
                 ManaSpendRestriction::SpellType("Enchantment".to_string()),
                 ManaSpendRestriction::UnlockDoor,
                 ManaSpendRestriction::TurnPermanentFaceUp,
-            ])),
+            ])]),
         );
         // Tin Street Gossip: face-down spells or turn creatures face up.
         assert_eq!(
@@ -4191,16 +4230,16 @@ mod tests {
                 "spend this mana only to cast face-down spells or to turn creatures face up",
             )
             .map(|(r, _)| r),
-            Some(ManaSpendRestriction::Any(vec![
+            Some(vec![ManaSpendRestriction::Any(vec![
                 ManaSpendRestriction::FaceDownSpell,
                 ManaSpendRestriction::TurnPermanentFaceUp,
-            ])),
+            ])]),
         );
         // Overgrown Zealot: pure turn-permanents-face-up (no cast clause at all).
         assert_eq!(
             parse_mana_spend_restriction("spend this mana only to turn permanents face up")
                 .map(|(r, _)| r),
-            Some(ManaSpendRestriction::TurnPermanentFaceUp),
+            Some(vec![ManaSpendRestriction::TurnPermanentFaceUp]),
         );
     }
 
@@ -4216,10 +4255,10 @@ mod tests {
         .expect("equip abilities plural must parse");
         assert_eq!(
             restriction,
-            ManaSpendRestriction::Any(vec![
+            vec![ManaSpendRestriction::Any(vec![
                 ManaSpendRestriction::SpellType("Equipment".to_string()),
                 ManaSpendRestriction::ActivateTagged(AbilityTag::Equip),
-            ])
+            ])]
         );
         assert!(grants.is_empty());
     }
@@ -4234,11 +4273,48 @@ mod tests {
         .expect("equip ability singular must parse");
         assert_eq!(
             restriction,
-            ManaSpendRestriction::Any(vec![
+            vec![ManaSpendRestriction::Any(vec![
                 ManaSpendRestriction::SpellType("Equipment".to_string()),
                 ManaSpendRestriction::ActivateTagged(AbilityTag::Equip),
-            ])
+            ])]
         );
         assert!(grants.is_empty());
+    }
+
+    // CR 105.2a + CR 106.6: The Great Henge-style compound rider is an AND,
+    // not an alternative. The exact grammar consumes the entire subject so a
+    // trailing qualifier cannot silently widen this restriction.
+    #[test]
+    fn mana_spend_restriction_monocolored_spell_of_source_chosen_color() {
+        assert_eq!(
+            parse_mana_spend_restriction(
+                "spend this mana only to cast monocolored spells of that color",
+            )
+            .map(|(restrictions, _)| restrictions),
+            Some(vec![
+                ManaSpendRestriction::SpellWithColorCount {
+                    comparator: Comparator::EQ,
+                    count: 1,
+                },
+                ManaSpendRestriction::SpellOfSourceChosenColor,
+            ]),
+        );
+        assert_eq!(
+            parse_mana_spend_restriction(
+                "spend this mana only to cast monocolored spell of the chosen color",
+            )
+            .map(|(restrictions, _)| restrictions),
+            Some(vec![
+                ManaSpendRestriction::SpellWithColorCount {
+                    comparator: Comparator::EQ,
+                    count: 1,
+                },
+                ManaSpendRestriction::SpellOfSourceChosenColor,
+            ]),
+        );
+        assert!(parse_mana_spend_restriction(
+            "spend this mana only to cast monocolored spells of that color with mana value 3 or greater",
+        )
+        .is_none());
     }
 }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -23,8 +23,8 @@ use crate::types::ability::{
     AbilityCondition, AbilityDefinition, AbilityKind, CastingPermission, ChoiceType, Chooser,
     ContinuousModification, ControllerRef, CopyRetargetPermission, CounterSourceRider, DigSource,
     Duration, Effect, EffectScope, ExcessRecipient, FaceDownBody, FaceDownProfile, FilterProp,
-    ForEachCategoryAction, LibraryPosition, MultiTargetSpec, ObjectScope, PermissionGrantee,
-    PlayerFilter, PtValue, QuantityExpr, QuantityRef, RevealUntilDisposition,
+    ForEachCategoryAction, LibraryPosition, ManaSpendRestriction, MultiTargetSpec, ObjectScope,
+    PermissionGrantee, PlayerFilter, PtValue, QuantityExpr, QuantityRef, RevealUntilDisposition,
     SpellStackToGraveyardReplacement, StaticDefinition, TargetChoiceTiming, TargetFilter,
     TypeFilter, TypedFilter,
 };
@@ -3749,7 +3749,7 @@ pub(super) fn apply_clause_continuation(
             }
         }
         ContinuationAst::ManaRestriction {
-            restriction,
+            restrictions: new_restrictions,
             grants: new_grants,
         } => {
             let Some(previous) = defs.last_mut() else {
@@ -3761,7 +3761,7 @@ pub(super) fn apply_clause_continuation(
                 ..
             } = &mut *previous.effect
             {
-                restrictions.push(restriction);
+                restrictions.extend(new_restrictions);
                 grants.extend(new_grants);
             }
         }
@@ -6464,10 +6464,14 @@ pub(super) fn parse_followup_continuation_ast(
             // (coverage green). A dropped unsupported restriction also drops any
             // paired `grants`; that is intentional (no real card pairs a grant with
             // an unsupported restriction).
-            if let Some((restriction, grants)) = super::mana::parse_mana_spend_restriction(&lower) {
-                if restriction.is_coverage_supported() {
+            if let Some((restrictions, grants)) = super::mana::parse_mana_spend_restriction(&lower) {
+                if !restrictions.is_empty()
+                    && restrictions
+                        .iter()
+                        .all(ManaSpendRestriction::is_coverage_supported)
+                {
                     return Some(ContinuationAst::ManaRestriction {
-                        restriction,
+                        restrictions,
                         grants,
                     });
                 }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -233,7 +233,7 @@ pub(crate) enum ContinuationAst {
         choice_optional: bool,
     },
     ManaRestriction {
-        restriction: ManaSpendRestriction,
+        restrictions: Vec<ManaSpendRestriction>,
         grants: Vec<crate::types::mana::ManaSpellGrant>,
     },
     /// CR 106.6: "that spell can't be countered" — adds grants to the preceding

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -14738,7 +14738,8 @@ fn mana_spend_restriction_activate_only() {
     use crate::types::ability::ManaSpendRestriction;
     let result = parse_mana_spend_restriction("spend this mana only to activate abilities");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::ActivateOnly)
     );
 }
@@ -14749,7 +14750,8 @@ fn mana_spend_restriction_noncreature_spells() {
     use crate::types::ability::ManaSpendRestriction;
     let result = parse_mana_spend_restriction("spend this mana only to cast noncreature spells");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellType("Noncreature".to_string()))
     );
 }
@@ -14760,7 +14762,8 @@ fn mana_spend_restriction_spell_only() {
         "spend this mana only to cast spells",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellOnly)
     );
 }
@@ -14778,7 +14781,8 @@ fn mana_spend_restriction_negative_nonartifact() {
     let result =
         parse_mana_spend_restriction("this mana can't be spent to cast nonartifact spells");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Artifact".to_string(),
             ability: AbilityActivationScope::Any,
@@ -14795,7 +14799,8 @@ fn mana_spend_restriction_negative_article_singular_nonartifact() {
         "this mana can't be spent to cast a nonartifact spell",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(
             crate::types::ability::ManaSpendRestriction::SpellTypeOrAbilityActivation {
                 spell_type: "Artifact".to_string(),
@@ -14815,7 +14820,8 @@ fn mana_spend_restriction_negative_noncreature() {
     let result =
         parse_mana_spend_restriction("this mana can't be spent to cast noncreature spells");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Creature".to_string(),
             ability: AbilityActivationScope::Any,
@@ -14939,7 +14945,8 @@ fn mana_spend_restriction_x_cost_only() {
     use crate::types::ability::ManaSpendRestriction;
     let result = parse_mana_spend_restriction("spend this mana only on costs that include {x}");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::XCostOnly)
     );
 }
@@ -14951,7 +14958,8 @@ fn mana_spend_restriction_instant_or_sorcery() {
     let result =
         parse_mana_spend_restriction("spend this mana only to cast instant or sorcery spells");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellType(
             "Instant or Sorcery".to_string()
         ))
@@ -14968,7 +14976,8 @@ fn mana_spend_restriction_instant_and_sorcery() {
     let result =
         parse_mana_spend_restriction("spend this mana only to cast instant and sorcery spells");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellType(
             "Instant and Sorcery".to_string()
         ))
@@ -14983,7 +14992,8 @@ fn mana_spend_restriction_colorless_eldrazi_spell_or_activation() {
             "spend this mana only to cast colorless eldrazi spells or activate abilities of colorless eldrazi",
         );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Colorless Eldrazi".to_string(),
             ability: crate::types::mana::AbilityActivationScope::OfSpellType,
@@ -14997,7 +15007,8 @@ fn mana_spend_restriction_singular_source_ability_activation() {
             "spend this mana only to cast an artifact spell or activate an ability of an artifact source",
         );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Artifact".to_string(),
             ability: crate::types::mana::AbilityActivationScope::OfSpellType,
@@ -15011,7 +15022,8 @@ fn mana_spend_restriction_or_to_activate_source_ability() {
             "spend this mana only to cast an assassin spell or to activate an ability of an assassin source",
         );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Assassin".to_string(),
             ability: crate::types::mana::AbilityActivationScope::OfSpellType,
@@ -15029,7 +15041,8 @@ fn mana_spend_restriction_bare_activation_or_is_any_ability() {
         "spend this mana only to cast an artifact spell or activate an ability",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Artifact".to_string(),
             ability: crate::types::mana::AbilityActivationScope::Any,
@@ -15046,7 +15059,8 @@ fn mana_spend_restriction_colorless_or_to_activate_any_ability() {
         "spend this mana only to cast a colorless spell or to activate an ability",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Colorless".to_string(),
             ability: crate::types::mana::AbilityActivationScope::Any,
@@ -15060,7 +15074,8 @@ fn mana_spend_restriction_any_activation_tail_preserves_inner_or_spell_type() {
         "spend this mana only to cast an instant or sorcery spell or activate an ability",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Instant or Sorcery".to_string(),
             ability: crate::types::mana::AbilityActivationScope::Any,
@@ -15074,7 +15089,8 @@ fn mana_spend_restriction_any_activation_tail_accepts_to_activate_plural() {
         "spend this mana only to cast artifact spells or to activate abilities",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Artifact".to_string(),
             ability: crate::types::mana::AbilityActivationScope::Any,
@@ -15088,7 +15104,8 @@ fn mana_spend_restriction_ally_spell_or_source_activation() {
         "spend this mana only to cast an ally spell or activate an ability of an ally source",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellTypeOrAbilityActivation {
             spell_type: "Ally".to_string(),
             ability: crate::types::mana::AbilityActivationScope::OfSpellType,
@@ -15101,7 +15118,8 @@ fn mana_spend_restriction_flashback_spells() {
     use crate::parser::oracle_effect::mana::parse_mana_spend_restriction;
     let result = parse_mana_spend_restriction("spend this mana only to cast spells with flashback");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithKeywordKind(
             KeywordKind::Flashback,
         ))
@@ -15115,7 +15133,8 @@ fn mana_spend_restriction_flashback_spells_from_graveyard() {
         "spend this mana only to cast spells with flashback from a graveyard",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithKeywordKindFromZone {
             kind: KeywordKind::Flashback,
             zone: Zone::Graveyard,
@@ -15131,7 +15150,8 @@ fn mana_spend_restriction_mana_value_ge() {
         "spend this mana only to cast spells with mana value 5 or greater",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithManaValue {
             comparator: Comparator::GE,
             value: 5,
@@ -15147,7 +15167,8 @@ fn mana_spend_restriction_mana_value_le() {
         "spend this mana only to cast spells with mana value 3 or less",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithManaValue {
             comparator: Comparator::LE,
             value: 3,
@@ -15163,7 +15184,8 @@ fn mana_spend_restriction_mana_value_singular_spell_ge() {
         "spend this mana only to cast a spell with mana value 4 or greater",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithManaValue {
             comparator: Comparator::GE,
             value: 4,
@@ -15188,7 +15210,8 @@ fn mana_spend_restriction_color_count_exactly() {
         "spend this mana only to cast spells with exactly three colors",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithColorCount {
             comparator: Comparator::EQ,
             count: 3,
@@ -15203,7 +15226,8 @@ fn mana_spend_restriction_color_count_exactly_one_color() {
     let result =
         parse_mana_spend_restriction("spend this mana only to cast a spell with exactly one color");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithColorCount {
             comparator: Comparator::EQ,
             count: 1,
@@ -15218,7 +15242,8 @@ fn mana_spend_restriction_color_count_or_more() {
     let result =
         parse_mana_spend_restriction("spend this mana only to cast spells with two or more colors");
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithColorCount {
             comparator: Comparator::GE,
             count: 2,
@@ -15234,7 +15259,8 @@ fn mana_spend_restriction_color_count_or_fewer() {
         "spend this mana only to cast spells with two or fewer colors",
     );
     assert_eq!(
-        result.map(|(r, _)| r),
+        result.and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellWithColorCount {
             comparator: Comparator::LE,
             count: 2,
@@ -15249,7 +15275,8 @@ fn mana_spend_restriction_from_graveyard() {
         crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
             "spend this mana only to cast a spell from your graveyard"
         )
-        .map(|(r, _)| r),
+        .and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
             zone: Zone::Graveyard,
             polarity: ZoneSpendPolarity::From,
@@ -15259,7 +15286,8 @@ fn mana_spend_restriction_from_graveyard() {
         crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
             "spend this mana only to cast spells from exile"
         )
-        .map(|(r, _)| r),
+        .and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
             zone: Zone::Exile,
             polarity: ZoneSpendPolarity::From,
@@ -15276,7 +15304,8 @@ fn mana_spend_restriction_not_from_hand() {
         crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
             "spend this mana only to cast a spell from anywhere other than your hand"
         )
-        .map(|(r, _)| r),
+        .and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::SpellFromZone(ZoneSpend {
             zone: Zone::Hand,
             polarity: ZoneSpendPolarity::NotFrom,
@@ -15291,7 +15320,8 @@ fn mana_spend_restriction_on_costs_that_contain_x() {
         crate::parser::oracle_effect::mana::parse_mana_spend_restriction(
             "spend this mana only on costs that contain {x}"
         )
-        .map(|(r, _)| r),
+        .and_then(|(mut restrictions, _)| (restrictions.len() == 1)
+            .then(|| restrictions.pop().expect("one restriction"))),
         Some(ManaSpendRestriction::XCostOnly)
     );
 }
@@ -15306,10 +15336,10 @@ fn mana_spend_restriction_disjunction_two_spell_types() {
     .expect("disjunction should parse");
     assert_eq!(
         restriction,
-        ManaSpendRestriction::Any(vec![
+        vec![ManaSpendRestriction::Any(vec![
             ManaSpendRestriction::SpellType("Dragon".to_string()),
             ManaSpendRestriction::SpellType("Omen".to_string()),
-        ])
+        ])]
     );
     assert!(grants.is_empty());
 }
@@ -15326,14 +15356,14 @@ fn mana_spend_restriction_disjunction_three_way_heterogeneous() {
         .expect("three-way disjunction should parse");
     assert_eq!(
         restriction,
-        ManaSpendRestriction::Any(vec![
+        vec![ManaSpendRestriction::Any(vec![
             ManaSpendRestriction::SpellType("Assassin".to_string()),
             ManaSpendRestriction::SpellWithKeywordKind(KeywordKind::Freerunning),
             ManaSpendRestriction::SpellTypeOrAbilityActivation {
                 spell_type: "Assassin".to_string(),
                 ability: AbilityActivationScope::OfSpellType,
             },
-        ])
+        ])]
     );
 }
 
@@ -15359,7 +15389,9 @@ fn mana_spend_restriction_type_union_stays_single_clause() {
             .expect("type union should parse as a single SpellType");
     assert_eq!(
         restriction,
-        ManaSpendRestriction::SpellType("Instant or Sorcery".to_string())
+        vec![ManaSpendRestriction::SpellType(
+            "Instant or Sorcery".to_string()
+        )]
     );
 }
 
@@ -15372,7 +15404,7 @@ fn mana_spend_restriction_chosen_type_cant_be_countered() {
             "spend this mana only to cast a creature spell of the chosen type, and that spell can't be countered",
         );
     let (restriction, grants) = result.expect("should parse");
-    assert_eq!(restriction, ManaSpendRestriction::ChosenCreatureType);
+    assert_eq!(restriction, vec![ManaSpendRestriction::ChosenCreatureType]);
     assert_eq!(grants, vec![ManaSpellGrant::CantBeCountered]);
 }
 
@@ -15387,7 +15419,7 @@ fn mana_spend_restriction_legendary_cant_be_countered() {
     let (restriction, grants) = result.expect("should parse");
     assert_eq!(
         restriction,
-        ManaSpendRestriction::SpellType("Legendary".to_string())
+        vec![ManaSpendRestriction::SpellType("Legendary".to_string())]
     );
     assert_eq!(grants, vec![ManaSpellGrant::CantBeCountered]);
 }
@@ -15403,10 +15435,10 @@ fn mana_spend_restriction_activation_first_disjunction() {
     .expect("activation-first disjunction should parse");
     assert_eq!(
         restriction,
-        ManaSpendRestriction::Any(vec![
+        vec![ManaSpendRestriction::Any(vec![
             ManaSpendRestriction::ActivateOnly,
             ManaSpendRestriction::SpellType("Artifact".to_string()),
-        ])
+        ])]
     );
     assert!(grants.is_empty());
 }
@@ -22648,5 +22680,61 @@ fn bbfu10_ledger_variant_reaches_filter_prop_scan() {
     assert!(
         !super::quantity_ref_uses_filter_prop(&without_prop, &pred),
         "negative control: a prop-free ledger filter must still read false",
+    );
+}
+
+/// CR 105.2a + CR 106.6 + CR 602.2b: Throne of Eldraine owns both a
+/// source-chosen-color mana-production restriction and a differently-scoped
+/// activated-ability payment rider. Both must lower as typed data with no
+/// residual `Unimplemented` node.
+#[test]
+fn throne_of_eldraine_parses_all_chosen_color_mana_riders() {
+    use crate::types::ability::{
+        ActivationManaPaymentRestriction, Comparator, ManaSpendRestriction,
+    };
+
+    let parsed = parse_oracle_text(
+        "As Throne of Eldraine enters, choose a color.\n{T}: Add four mana of the chosen color. Spend this mana only to cast monocolored spells of that color.\n{3}, {T}: Draw two cards. Spend only mana of the chosen color to activate this ability.",
+        "Throne of Eldraine",
+        &[],
+        &["Artifact".to_string()],
+        &[],
+    );
+    assert!(
+        parsed
+            .abilities
+            .iter()
+            .all(|ability| !super::has_unimplemented(ability)),
+        "all three lines must be typed: {:#?}",
+        parsed.abilities
+    );
+
+    let mana = parsed
+        .abilities
+        .iter()
+        .find(|ability| matches!(ability.effect.as_ref(), Effect::Mana { .. }))
+        .expect("mana ability");
+    let Effect::Mana { restrictions, .. } = mana.effect.as_ref() else {
+        unreachable!();
+    };
+    assert_eq!(
+        restrictions,
+        &vec![
+            ManaSpendRestriction::SpellWithColorCount {
+                comparator: Comparator::EQ,
+                count: 1,
+            },
+            ManaSpendRestriction::SpellOfSourceChosenColor,
+        ],
+    );
+
+    let draw = parsed
+        .abilities
+        .iter()
+        .find(|ability| matches!(ability.effect.as_ref(), Effect::Draw { .. }))
+        .expect("draw ability");
+    assert_eq!(
+        draw.activation_mana_payment_restriction,
+        Some(ActivationManaPaymentRestriction::OnlySourceChosenColor),
     );
 }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2294,6 +2294,10 @@ pub enum ManaSpendRestriction {
     /// colors" (also "N or more / N or fewer"; colorless = 0). Parameterized over
     /// [`Comparator`] — one variant per color-count reading. `count` is N.
     SpellWithColorCount { comparator: Comparator, count: u32 },
+    /// CR 105.2 + CR 106.6: "Spend this mana only to cast spells of the
+    /// source's chosen color." Resolved when the mana is produced; a missing
+    /// choice lowers to `ManaRestriction::Impossible`, never to no restriction.
+    SpellOfSourceChosenColor,
     /// CR 106.6 + CR 400.7: "Spend this mana only to cast spells from your
     /// graveyard" / "from exile" ([`From`](super::mana::ZoneSpendPolarity::From))
     /// and "from anywhere other than your hand"
@@ -2399,6 +2403,7 @@ impl ManaSpendRestriction {
             | ManaSpendRestriction::SpellWithManaValue { .. }
             | ManaSpendRestriction::SpellMatchingCostCriteria { .. }
             | ManaSpendRestriction::SpellWithColorCount { .. }
+            | ManaSpendRestriction::SpellOfSourceChosenColor
             | ManaSpendRestriction::SpellFromZone(_)
             | ManaSpendRestriction::UnlockDoor => true,
             // CR 106.6: coverage for a disjunction requires every named branch to
@@ -16188,6 +16193,17 @@ pub enum ActivationRestriction {
     MatchesCardCastTiming,
 }
 
+/// CR 106.6: A restriction on which actual mana colors may pay this activated
+/// ability's mana cost. Kept separate from `ActivationRestriction`: timing and
+/// frequency gates determine whether an ability may be activated, while this
+/// gate determines whether its announced cost can be paid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ActivationManaPaymentRestriction {
+    /// "Spend only mana of the chosen color to activate this ability." The
+    /// source's live chosen color is resolved at payment time.
+    OnlySourceChosenColor,
+}
+
 /// Structured spell-casting restrictions parsed from Oracle text.
 /// These describe when — and, for `CantSpendMana`, how — a spell may be cast.
 /// Runtime enforcement can be added independently of parsing/export support.
@@ -16308,6 +16324,9 @@ pub struct AbilityDefinition {
     /// single authority for sorcery-speed timing. The legacy `sorcery_speed`
     /// JSON field is migrated into this `Vec` by the hand-written `Deserialize`.
     pub activation_restrictions: Vec<ActivationRestriction>,
+    /// CR 106.6: Mana-color payment riders attached to this activated ability.
+    /// `None` has the legacy unrestricted meaning.
+    pub activation_mana_payment_restriction: Option<ActivationManaPaymentRestriction>,
     /// CR 602.2a: Who may begin to activate this ability. `None` = only the
     /// permanent's controller. `Some(All)` = any player. `Some(Opponent)` =
     /// only opponents of the permanent's controller.
@@ -16451,6 +16470,8 @@ struct AbilityDefinitionRepr<'a> {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     activation_restrictions: &'a Vec<ActivationRestriction>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    activation_mana_payment_restriction: &'a Option<ActivationManaPaymentRestriction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     activator_filter: &'a Option<PlayerFilter>,
     #[serde(skip_serializing_if = "Option::is_none")]
     activation_zone: &'a Option<Zone>,
@@ -16517,6 +16538,7 @@ impl Serialize for AbilityDefinition {
             description,
             target_prompt,
             activation_restrictions,
+            activation_mana_payment_restriction,
             activator_filter,
             activation_zone,
             ability_tag,
@@ -16556,6 +16578,7 @@ impl Serialize for AbilityDefinition {
             description,
             target_prompt,
             activation_restrictions,
+            activation_mana_payment_restriction,
             activator_filter,
             activation_zone,
             ability_tag,
@@ -16638,6 +16661,8 @@ struct AbilityDefinitionDe {
     #[serde(default)]
     activation_restrictions: Vec<ActivationRestriction>,
     #[serde(default)]
+    activation_mana_payment_restriction: Option<ActivationManaPaymentRestriction>,
+    #[serde(default)]
     activator_filter: Option<PlayerFilter>,
     #[serde(default)]
     activation_zone: Option<Zone>,
@@ -16713,6 +16738,7 @@ impl<'de> Deserialize<'de> for AbilityDefinition {
             description: de.description,
             target_prompt: de.target_prompt,
             activation_restrictions,
+            activation_mana_payment_restriction: de.activation_mana_payment_restriction,
             activator_filter: de.activator_filter,
             activation_zone: de.activation_zone,
             ability_tag: de.ability_tag,
@@ -16867,6 +16893,7 @@ impl AbilityDefinition {
             description: None,
             target_prompt: None,
             activation_restrictions: Vec::new(),
+            activation_mana_payment_restriction: None,
             activator_filter: None,
             activation_zone: None,
             ability_tag: None,
@@ -17029,6 +17056,14 @@ impl AbilityDefinition {
 
     pub fn activation_restrictions(mut self, restrictions: Vec<ActivationRestriction>) -> Self {
         self.activation_restrictions = restrictions;
+        self
+    }
+
+    pub fn activation_mana_payment_restriction(
+        mut self,
+        restriction: ActivationManaPaymentRestriction,
+    ) -> Self {
+        self.activation_mana_payment_restriction = Some(restriction);
         self
     }
 

--- a/crates/engine/src/types/mana.rs
+++ b/crates/engine/src/types/mana.rs
@@ -253,6 +253,11 @@ pub struct SpellMeta {
     /// color-count spend restrictions (`OnlyForSpellWithColorCount`). `None` at
     /// payment sites with no associated spell.
     pub color_count: Option<u32>,
+    /// CR 105.2: The spell's exact colors, consulted by color-specific spend
+    /// restrictions. This is distinct from `color_count`: a monocolored spell
+    /// must also have the particular required color to satisfy a rider such as
+    /// "monocolored spells of that color."
+    pub colors: Vec<ManaColor>,
     /// CR 107.3 + CR 202.3e: Whether the spell's printed mana cost contains an
     /// `{X}` symbol. Consulted by the "with {X} in their mana costs" disjunct of
     /// MV/X spend restrictions (`OnlyForSpellMatchingCostCriteria`). `false` at
@@ -309,6 +314,11 @@ pub enum PaymentContext<'a> {
         source_types: &'a [String],
         source_subtypes: &'a [String],
         ability_tag: Option<AbilityTag>,
+        /// CR 106.6: An ability's own activation-cost rider can constrain the
+        /// actual mana type paid, independently of what a unit's spend
+        /// restriction allows. This is checked before unit restrictions so an
+        /// as-though payment permission cannot bypass it.
+        mana_color_constraint: ActivationManaColorConstraint,
     },
     /// Payment for a cost during spell or ability resolution. Current
     /// restriction variants name spell-casting or ability-activation use, so
@@ -323,6 +333,50 @@ pub enum PaymentContext<'a> {
     /// context variant covers every restrictable special-action class rather
     /// than a sibling per action.
     SpecialAction(SpecialAction),
+}
+
+impl PaymentContext<'_> {
+    /// CR 106.6: Whether a mana unit's actual type may be used in this payment
+    /// context before its own spend restrictions are considered. Activation
+    /// riders constrain the physical mana paid, so this gate applies equally to
+    /// unrestricted and restricted units.
+    pub fn permits_actual_mana_type(&self, mana_type: ManaType) -> bool {
+        match self {
+            Self::Activation {
+                mana_color_constraint,
+                ..
+            } => mana_color_constraint.permits(mana_type),
+            Self::Spell(_) | Self::Effect | Self::SpecialAction(_) => true,
+        }
+    }
+}
+
+/// CR 106.6: A color constraint imposed by the activated ability whose cost is
+/// being paid (for example, "Spend only mana of the chosen color to activate
+/// this ability"). This is an AND gate on the actual `ManaUnit::color`, not a
+/// conversion of the mana's type and not an as-though permission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ActivationManaColorConstraint {
+    /// The ability has no color-specific activation-payment rider.
+    #[default]
+    Unrestricted,
+    /// Every mana unit spent for this activation must have this actual color.
+    Only(ManaColor),
+    /// The rider refers to a source choice that is unavailable. Fail closed:
+    /// no mana unit may pay the activation cost.
+    Impossible,
+}
+
+impl ActivationManaColorConstraint {
+    /// CR 106.6: Whether this exact mana unit type may pay the activation
+    /// before the unit's own spend restrictions are considered.
+    pub fn permits(self, mana_type: ManaType) -> bool {
+        match self {
+            Self::Unrestricted => true,
+            Self::Only(color) => mana_type == ManaType::from(color),
+            Self::Impossible => false,
+        }
+    }
 }
 
 /// CR 116.2: A class of special action whose mana cost can be the subject of a
@@ -534,6 +588,10 @@ pub enum ManaRestriction {
     /// colors" (also "N or more / N or fewer"). `comparator` applies
     /// `spell_color_count <cmp> count`. Colorless spells have color_count 0.
     OnlyForSpellWithColorCount { comparator: Comparator, count: u32 },
+    /// CR 105.2 + CR 106.6: "Spend this mana only to cast spells of [color]."
+    /// Usually composed with `OnlyForSpellWithColorCount { EQ, 1 }` for the
+    /// stricter "monocolored spells of that color" reading.
+    OnlyForSpellColor(ManaColor),
     /// CR 106.6 + CR 400.7: "Spend this mana only to cast spells from your
     /// graveyard" / "from exile" ([`ZoneSpendPolarity::From`]) and "from anywhere
     /// other than your hand" ([`ZoneSpendPolarity::NotFrom`], Mm'menon, the Right
@@ -580,6 +638,10 @@ pub enum ManaRestriction {
     /// Parameterized over the action class so one variant covers every
     /// restrictable special action (door unlock today; extensible).
     OnlyForSpecialAction(SpecialAction),
+    /// A source-dependent template could not resolve a required choice. This
+    /// remains attached to the produced mana rather than being dropped so the
+    /// resulting unit is unspendable instead of accidentally unrestricted.
+    Impossible,
     /// CR 702.51a: Internal marker for a convoke tap that substitutes for
     /// paying mana. The payment algorithm may consume it for the current spell,
     /// but cast-spent metrics and mana-added triggers must ignore it.
@@ -730,11 +792,13 @@ fn cmp_mana_restriction(left: &ManaRestriction, right: &ManaRestriction) -> std:
             ManaRestriction::OnlyForSpellWithManaValue { .. } => 9,
             ManaRestriction::OnlyForSpellMatchingCostCriteria { .. } => 10,
             ManaRestriction::OnlyForSpellWithColorCount { .. } => 11,
-            ManaRestriction::OnlyForSpellFromZone(_) => 12,
-            ManaRestriction::OnlyForFaceDownSpell => 13,
-            ManaRestriction::OnlyForAny(_) => 14,
-            ManaRestriction::OnlyForSpecialAction(_) => 15,
-            ManaRestriction::ConvokePayment => 16,
+            ManaRestriction::OnlyForSpellColor(_) => 12,
+            ManaRestriction::OnlyForSpellFromZone(_) => 13,
+            ManaRestriction::OnlyForFaceDownSpell => 14,
+            ManaRestriction::OnlyForAny(_) => 15,
+            ManaRestriction::OnlyForSpecialAction(_) => 16,
+            ManaRestriction::Impossible => 17,
+            ManaRestriction::ConvokePayment => 18,
         }
     }
     rank(left).cmp(&rank(right)).then_with(|| match (left, right) {
@@ -803,6 +867,9 @@ fn cmp_mana_restriction(left: &ManaRestriction, right: &ManaRestriction) -> std:
         ) => comparator_rank(*a_cmp)
             .cmp(&comparator_rank(*b_cmp))
             .then_with(|| a_count.cmp(b_count)),
+        (ManaRestriction::OnlyForSpellColor(a), ManaRestriction::OnlyForSpellColor(b)) => {
+            a.cmp(b)
+        }
         (
             ManaRestriction::OnlyForSpellFromZone(a),
             ManaRestriction::OnlyForSpellFromZone(b),
@@ -1007,6 +1074,9 @@ impl ManaRestriction {
             ManaRestriction::OnlyForSpellWithColorCount { comparator, count } => meta
                 .color_count
                 .is_some_and(|cc| comparator.evaluate(cc as i32, *count as i32)),
+            ManaRestriction::OnlyForSpellColor(required_color) => {
+                meta.colors.contains(required_color)
+            }
             // CR 106.6 + CR 400.7: zone-gated spend. `From` requires the spell be
             // cast from the named zone; `NotFrom` requires it be cast from any
             // zone *except* the named one (e.g. "from anywhere other than your
@@ -1039,6 +1109,7 @@ impl ManaRestriction {
             ManaRestriction::OnlyForAny(subs) => subs.iter().any(|r| r.allows_spell(meta)),
             // CR 116.2: Special-action-only mana never pays for a spell cast.
             ManaRestriction::OnlyForSpecialAction(_) => false,
+            ManaRestriction::Impossible => false,
             ManaRestriction::ConvokePayment => true,
         }
     }
@@ -1063,11 +1134,13 @@ impl ManaRestriction {
             | ManaRestriction::OnlyForSpellWithManaValue { .. }
             | ManaRestriction::OnlyForSpellMatchingCostCriteria { .. }
             | ManaRestriction::OnlyForSpellWithColorCount { .. }
+            | ManaRestriction::OnlyForSpellColor(_)
             | ManaRestriction::OnlyForSpellFromZone(_)
             // CR 708.4: Face-down-spell-only mana never pays for ability activation.
             | ManaRestriction::OnlyForFaceDownSpell
             // CR 116.2: Special-action-only mana never pays for ability activation.
-            | ManaRestriction::OnlyForSpecialAction(_) => false,
+            | ManaRestriction::OnlyForSpecialAction(_)
+            | ManaRestriction::Impossible => false,
             // CR 106.6: The ability-activation half of the OR. `OfSpellType`
             // restricts to abilities of permanents whose type matches the
             // restriction ("Elemental sources" includes creature type Elemental —
@@ -1110,6 +1183,7 @@ impl ManaRestriction {
                 source_types,
                 source_subtypes,
                 ability_tag,
+                mana_color_constraint: _,
             } => self.allows_activation(source_types, source_subtypes, *ability_tag),
             PaymentContext::Effect => false,
             // CR 116.2: A special-action payment is permitted only by mana that
@@ -2047,16 +2121,15 @@ impl ManaPool {
     /// never spent.
     pub fn spend_for(&mut self, color: ManaType, ctx: &PaymentContext<'_>) -> Option<ManaUnit> {
         // First pass: prefer unrestricted mana of this color
-        if let Some(pos) = self
-            .mana
-            .iter()
-            .position(|m| m.color == color && m.restrictions.is_empty())
-        {
+        if let Some(pos) = self.mana.iter().position(|m| {
+            m.color == color && ctx.permits_actual_mana_type(m.color) && m.restrictions.is_empty()
+        }) {
             return Some(self.mana.swap_remove(pos));
         }
         // Second pass: restricted mana that allows this payment context
         if let Some(pos) = self.mana.iter().position(|m| {
             m.color == color
+                && ctx.permits_actual_mana_type(m.color)
                 && !m.restrictions.is_empty()
                 && m.restrictions.iter().all(|r| r.allows(ctx))
         }) {
@@ -2362,6 +2435,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2373,6 +2447,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2384,6 +2459,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2411,6 +2487,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2422,6 +2499,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2433,6 +2511,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2482,6 +2561,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2493,6 +2573,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2504,6 +2585,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2523,6 +2605,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2535,6 +2618,7 @@ mod tests {
             source_types: &source_types,
             source_subtypes: &source_subtypes,
             ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Unrestricted,
         }));
         assert!(!restriction.allows(&PaymentContext::Effect));
     }
@@ -2549,6 +2633,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2560,6 +2645,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2571,6 +2657,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2607,6 +2694,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2635,6 +2723,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2697,6 +2786,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2723,6 +2813,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2734,6 +2825,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2745,6 +2837,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2756,6 +2849,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2781,6 +2875,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2792,6 +2887,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2803,6 +2899,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2858,6 +2955,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2869,6 +2967,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2909,6 +3008,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2920,6 +3020,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2931,6 +3032,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2942,6 +3044,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2958,11 +3061,13 @@ mod tests {
             source_types: &["Creature".to_string()],
             source_subtypes: &["Human".to_string()],
             ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Unrestricted,
         }));
         assert!(restriction.allows(&PaymentContext::Activation {
             source_types: &["Land".to_string()],
             source_subtypes: &[],
             ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Unrestricted,
         }));
     }
 
@@ -2979,6 +3084,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -2990,6 +3096,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3004,11 +3111,13 @@ mod tests {
             source_types: &artifact_types,
             source_subtypes: &no_subtypes,
             ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Unrestricted,
         }));
         assert!(!restriction.allows(&PaymentContext::Activation {
             source_types: &creature_types,
             source_subtypes: &no_subtypes,
             ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Unrestricted,
         }));
         assert!(!restriction.allows(&PaymentContext::Effect));
     }
@@ -3042,6 +3151,7 @@ mod tests {
             source_types: &["Creature".to_string()],
             source_subtypes: &[],
             ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Unrestricted,
         }));
         assert!(!restriction.allows(&PaymentContext::Effect));
         assert!(!restriction.allows(&PaymentContext::SpecialAction(SpecialAction::UnlockDoor)));
@@ -3070,6 +3180,7 @@ mod tests {
             source_types: &["Creature".to_string()],
             source_subtypes: &[],
             ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Unrestricted,
         }));
         assert!(!restriction.allows(&PaymentContext::Effect));
     }
@@ -3102,6 +3213,73 @@ mod tests {
         assert!(!restriction.allows(&PaymentContext::Spell(&creature)));
     }
 
+    #[test]
+    fn source_chosen_color_mana_restriction_uses_live_spell_colors() {
+        let red_only = ManaRestriction::OnlyForSpellColor(ManaColor::Red);
+        let red = SpellMeta {
+            colors: vec![ManaColor::Red],
+            ..SpellMeta::default()
+        };
+        let blue = SpellMeta {
+            colors: vec![ManaColor::Blue],
+            ..SpellMeta::default()
+        };
+        let multicolor = SpellMeta {
+            colors: vec![ManaColor::Red, ManaColor::Blue],
+            ..SpellMeta::default()
+        };
+        let colorless = SpellMeta::default();
+        assert!(red_only.allows(&PaymentContext::Spell(&red)));
+        assert!(red_only.allows(&PaymentContext::Spell(&multicolor)));
+        assert!(!red_only.allows(&PaymentContext::Spell(&blue)));
+        assert!(!red_only.allows(&PaymentContext::Spell(&colorless)));
+        assert!(!ManaRestriction::Impossible.allows(&PaymentContext::Spell(&red)));
+    }
+
+    #[test]
+    fn activation_color_constraint_rejects_wrong_actual_mana_color() {
+        assert!(ActivationManaColorConstraint::Only(ManaColor::Red).permits(ManaType::Red));
+        assert!(!ActivationManaColorConstraint::Only(ManaColor::Red).permits(ManaType::Blue));
+        assert!(!ActivationManaColorConstraint::Only(ManaColor::Red).permits(ManaType::Colorless));
+        assert!(!ActivationManaColorConstraint::Impossible.permits(ManaType::Red));
+    }
+
+    #[test]
+    fn spend_for_enforces_activation_color_constraint_for_both_passes() {
+        let source_types = vec!["Artifact".to_string()];
+        let source_subtypes = Vec::new();
+        let context = PaymentContext::Activation {
+            source_types: &source_types,
+            source_subtypes: &source_subtypes,
+            ability_tag: None,
+            mana_color_constraint: ActivationManaColorConstraint::Only(ManaColor::Red),
+        };
+        let mut pool = ManaPool {
+            mana: vec![
+                // First pass would take this unrestricted blue unit without
+                // checking the activation's actual-color rider.
+                make_unit(ManaType::Blue),
+                // Second pass must reject it too, even though its restriction
+                // otherwise permits any activation.
+                make_restricted_unit(
+                    ManaType::Blue,
+                    ObjectId(2),
+                    vec![ManaRestriction::OnlyForActivation],
+                ),
+                make_unit(ManaType::Red),
+            ],
+        };
+
+        assert!(pool.spend_for(ManaType::Blue, &context).is_none());
+        assert_eq!(pool.total(), 3);
+        assert_eq!(
+            pool.spend_for(ManaType::Red, &context)
+                .expect("matching actual mana color should remain spendable")
+                .color,
+            ManaType::Red
+        );
+    }
+
     // CR 106.6 + CR 601.2g: "Spend this mana only to cast instant and sorcery
     // spells" (Tablet of Discovery, issue #1975) names a union of two distinct
     // spell types. Per the Melek, Izzet Paragon example (CR 601.3e), an "instant
@@ -3122,6 +3300,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3133,6 +3312,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3144,6 +3324,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3187,6 +3368,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3198,6 +3380,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3217,6 +3400,7 @@ mod tests {
         let mv_six = SpellMeta {
             mana_value: Some(6),
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3225,6 +3409,7 @@ mod tests {
         let mv_four = SpellMeta {
             mana_value: Some(4),
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3248,6 +3433,7 @@ mod tests {
         let mv_two = SpellMeta {
             mana_value: Some(2),
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3256,6 +3442,7 @@ mod tests {
         let mv_four = SpellMeta {
             mana_value: Some(4),
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3280,6 +3467,7 @@ mod tests {
         let mv_four = SpellMeta {
             mana_value: Some(4),
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3293,6 +3481,7 @@ mod tests {
         let mv_five = SpellMeta {
             mana_value: Some(5),
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3328,6 +3517,7 @@ mod tests {
         };
         let three_colors = SpellMeta {
             color_count: Some(3),
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3335,6 +3525,7 @@ mod tests {
         };
         let two_colors = SpellMeta {
             color_count: Some(2),
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3359,6 +3550,7 @@ mod tests {
         };
         let colorless = SpellMeta {
             color_count: Some(0),
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3366,6 +3558,7 @@ mod tests {
         };
         let one_color = SpellMeta {
             color_count: Some(1),
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3389,6 +3582,7 @@ mod tests {
         };
         let three_colors = SpellMeta {
             color_count: Some(3),
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3396,6 +3590,7 @@ mod tests {
         };
         let one_color = SpellMeta {
             color_count: Some(1),
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3421,6 +3616,7 @@ mod tests {
 
         let one_color = SpellMeta {
             color_count: Some(1),
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3433,6 +3629,7 @@ mod tests {
 
         let two_colors = SpellMeta {
             color_count: Some(2),
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3714,6 +3911,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,
@@ -3727,6 +3925,7 @@ mod tests {
             cast_from_zone: None,
             mana_value: None,
             color_count: None,
+            colors: vec![],
             has_x_in_cost: false,
             is_face_down: false,
             cant_spend_mana: false,

--- a/crates/engine/tests/integration/companion_special_action.rs
+++ b/crates/engine/tests/integration/companion_special_action.rs
@@ -171,6 +171,7 @@ fn companion_restricted_mana_routes_only_to_the_matching_special_action() {
         source_types: &[],
         source_subtypes: &[],
         ability_tag: None,
+        mana_color_constraint: engine::types::mana::ActivationManaColorConstraint::Unrestricted,
     }));
     assert!(!restriction.allows(&PaymentContext::Effect));
 }

--- a/crates/engine/tests/integration/issue_2862_teferi_loyalty.rs
+++ b/crates/engine/tests/integration/issue_2862_teferi_loyalty.rs
@@ -89,7 +89,7 @@ fn issue_2862_teferi_cast_minus_three_pays_loyalty_cost() {
         P0,
         teferi,
         &AbilityCost::Loyalty { amount: -3 },
-        None,
+        0,
         &mut events,
     )
     .expect("pay [-3] loyalty cost through activation payment seam");

--- a/crates/engine/tests/integration/issue_4220_agatha_soul_cauldron.rs
+++ b/crates/engine/tests/integration/issue_4220_agatha_soul_cauldron.rs
@@ -225,7 +225,7 @@ fn agatha_granted_bb_ability_affordable_via_green_auto_tap_sources() {
         generic: 0,
     };
     assert!(
-        can_pay_ability_mana_cost_after_auto_tap(&state, P0, host, &bb_cost),
+        can_pay_ability_mana_cost_after_auto_tap(&state, P0, host, ability_index, &bb_cost),
         "auto-tap planner must treat green sources as paying {{B}}{{B}} under Agatha"
     );
     assert!(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -834,6 +834,7 @@ mod the_kingpin_of_crime_combat_damage;
 mod the_ur_dragon_eminence;
 mod the_who_opponent_guess_resolution;
 mod thoughtweft_trample_regression;
+mod throne_of_eldraine_mana_riders;
 mod throw_instead_tail_class;
 mod timely_ward_regression;
 mod tinybones_joins_up_multi_target;

--- a/crates/engine/tests/integration/restricted_mana_face_down_and_face_up.rs
+++ b/crates/engine/tests/integration/restricted_mana_face_down_and_face_up.rs
@@ -120,6 +120,8 @@ fn face_down_spell_mana_rejects_every_production_context() {
                 source_types: &["Creature".to_string()],
                 source_subtypes: &[],
                 ability_tag: None,
+                mana_color_constraint:
+                    engine::types::mana::ActivationManaColorConstraint::Unrestricted,
             }
         )
         .is_none(),

--- a/crates/engine/tests/integration/restricted_mana_mv_or_x.rs
+++ b/crates/engine/tests/integration/restricted_mana_mv_or_x.rs
@@ -37,6 +37,7 @@ fn spell_meta(types: &[&str], cost: &ManaCost) -> SpellMeta {
         cast_from_zone: None,
         mana_value: Some(cost.mana_value()),
         color_count: None,
+        colors: Vec::new(),
         has_x_in_cost: cost.has_x(),
         is_face_down: false,
         cant_spend_mana: false,

--- a/crates/engine/tests/integration/restricted_mana_x_cost_only.rs
+++ b/crates/engine/tests/integration/restricted_mana_x_cost_only.rs
@@ -37,6 +37,7 @@ fn spell_meta(types: &[&str], cost: &ManaCost) -> SpellMeta {
         cast_from_zone: None,
         mana_value: Some(cost.mana_value()),
         color_count: None,
+        colors: Vec::new(),
         has_x_in_cost: cost.has_x(),
         is_face_down: false,
         cant_spend_mana: false,

--- a/crates/engine/tests/integration/throne_of_eldraine_mana_riders.rs
+++ b/crates/engine/tests/integration/throne_of_eldraine_mana_riders.rs
@@ -1,0 +1,226 @@
+//! Throne of Eldraine's source-chosen-color mana riders exercise the complete
+//! production path: Oracle parsing, mana production, cast payment, activated
+//! ability payment, and the manual pool-pin/resume interface.
+
+use engine::game::casting::activated_ability_definitions;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{ChosenAttribute, Effect, ResolvedAbility};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, GameState, PendingCast, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaColor, ManaCost, ManaPipId, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const THRONE_OF_ELDRAINE: &str = "As Throne of Eldraine enters, choose a color.\n\
+{T}: Add four mana of the chosen color. Spend this mana only to cast monocolored spells of that color.\n\
+{3}, {T}: Draw two cards. Spend only mana of the chosen color to activate this ability.";
+
+fn add_throne(scenario: &mut GameScenario) -> ObjectId {
+    scenario
+        .add_creature_from_oracle(P0, "Throne of Eldraine", 0, 1, THRONE_OF_ELDRAINE)
+        .as_artifact()
+        .id()
+}
+
+fn choose_red(state: &mut GameState, throne: ObjectId) {
+    state
+        .objects
+        .get_mut(&throne)
+        .expect("Throne must be on the battlefield")
+        .chosen_attributes
+        .push(ChosenAttribute::Color(ManaColor::Red));
+}
+
+fn throne_ability_indices(state: &GameState, throne: ObjectId) -> (usize, usize) {
+    let abilities = activated_ability_definitions(state, throne);
+    let mana = abilities
+        .iter()
+        .find(|(_, ability)| matches!(ability.effect.as_ref(), Effect::Mana { .. }))
+        .map(|(index, _)| *index)
+        .expect("Throne must have its mana ability");
+    let draw = abilities
+        .iter()
+        .find(|(_, ability)| matches!(ability.effect.as_ref(), Effect::Draw { .. }))
+        .map(|(index, _)| *index)
+        .expect("Throne must have its draw ability");
+    (mana, draw)
+}
+
+fn draw_payment_state(mana: &[ManaType]) -> (GameState, ObjectId, usize) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let throne = add_throne(&mut scenario);
+    let mut state = scenario.build().state().clone();
+    choose_red(&mut state, throne);
+    let (_, draw) = throne_ability_indices(&state, throne);
+    for (index, color) in mana.iter().copied().enumerate() {
+        state.add_mana_to_pool(
+            P0,
+            ManaUnit::new(color, ObjectId(10_000 + index as u64), false, Vec::new()),
+        );
+    }
+    (state, throne, draw)
+}
+
+/// The produced units carry the chosen color of the actual producing Throne,
+/// and that restriction is consulted by the normal cast action. Each spell has
+/// a generic cost so colored-cost matching cannot hide a spend-restriction bug.
+#[test]
+fn throne_mana_casts_only_monocolored_spells_of_its_chosen_color() {
+    for (label, colors, allowed) in [
+        ("red", vec![ManaColor::Red], true),
+        ("blue", vec![ManaColor::Blue], false),
+        ("multicolored", vec![ManaColor::Red, ManaColor::Blue], false),
+        ("colorless", vec![], false),
+    ] {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let throne = add_throne(&mut scenario);
+        let spell = scenario
+            .add_spell_to_hand_from_oracle(P0, &format!("{label} test spell"), true, "")
+            .with_mana_cost(ManaCost::generic(1))
+            .id();
+        let mut runner = scenario.build();
+        choose_red(runner.state_mut(), throne);
+        {
+            let obj = runner
+                .state_mut()
+                .objects
+                .get_mut(&spell)
+                .expect("test spell must be in hand");
+            obj.color = colors.clone();
+            obj.base_color = colors;
+        }
+
+        let (mana, _) = throne_ability_indices(runner.state(), throne);
+        let waiting = runner
+            .act(GameAction::ActivateAbility {
+                source_id: throne,
+                ability_index: mana,
+            })
+            .expect("Throne mana ability must resolve")
+            .waiting_for;
+        assert!(matches!(waiting, WaitingFor::Priority { .. }));
+        let pool = &runner.state().players[P0.0 as usize].mana_pool.mana;
+        assert_eq!(pool.len(), 4, "Throne must produce four mana");
+        assert!(
+            pool.iter()
+                .all(|unit| unit.source_id == throne && unit.color == ManaType::Red),
+            "every unit must retain the producing Throne and its chosen red color: {pool:?}"
+        );
+
+        let card_id = runner.state().objects[&spell].card_id;
+        let result = runner.act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        });
+        assert_eq!(
+            result.is_ok(),
+            allowed,
+            "a {label} spell must {} be cast with mana from the red-chosen Throne: {result:?}",
+            if allowed { "" } else { "not" }
+        );
+    }
+}
+
+/// The draw rider constrains the actual mana units used for activation. This
+/// covers automatic payment, rejection of blue/mixed pools, and the manual
+/// pin/resume route used by the interactive client.
+#[test]
+fn throne_draw_activation_uses_only_its_chosen_color_in_auto_and_manual_payment() {
+    let (red_state, red_throne, draw) =
+        draw_payment_state(&[ManaType::Red, ManaType::Red, ManaType::Red]);
+    let mut red_runner = GameRunner::from_state(red_state);
+    let red_waiting = red_runner
+        .act(GameAction::ActivateAbility {
+            source_id: red_throne,
+            ability_index: draw,
+        })
+        .expect("three red mana must pay the red-chosen Throne draw ability")
+        .waiting_for;
+    assert!(matches!(red_waiting, WaitingFor::Priority { .. }));
+    assert!(red_runner.state().objects[&red_throne].tapped);
+    assert_eq!(
+        red_runner.state().players[P0.0 as usize].mana_pool.total(),
+        0
+    );
+
+    for (label, mana) in [
+        ("blue", vec![ManaType::Blue, ManaType::Blue, ManaType::Blue]),
+        ("mixed", vec![ManaType::Red, ManaType::Red, ManaType::Blue]),
+    ] {
+        let (state, throne, draw) = draw_payment_state(&mana);
+        let mut runner = GameRunner::from_state(state);
+        assert!(
+            runner
+                .act(GameAction::ActivateAbility {
+                    source_id: throne,
+                    ability_index: draw,
+                })
+                .is_err(),
+            "a {label} pool must not pay a red-chosen Throne draw activation"
+        );
+        assert!(!runner.state().objects[&throne].tapped);
+    }
+
+    let (mut state, throne, draw) =
+        draw_payment_state(&[ManaType::Red, ManaType::Red, ManaType::Red, ManaType::Blue]);
+    let blue_pip = state.players[P0.0 as usize]
+        .mana_pool
+        .mana
+        .iter()
+        .find(|unit| unit.color == ManaType::Blue)
+        .expect("manual pool has a blue unit")
+        .pip_id;
+    let red_pip = state.players[P0.0 as usize]
+        .mana_pool
+        .mana
+        .iter()
+        .find(|unit| unit.color == ManaType::Red)
+        .expect("manual pool has a red unit")
+        .pip_id;
+    assert_ne!(
+        blue_pip,
+        ManaPipId(0),
+        "seeded pool units must have stable ids"
+    );
+
+    let draw_ability = activated_ability_definitions(&state, throne)
+        .into_iter()
+        .find(|(index, _)| *index == draw)
+        .map(|(_, ability)| ability)
+        .expect("Throne draw ability definition");
+    let mut pending = PendingCast::new(
+        throne,
+        CardId(0xED),
+        ResolvedAbility::new((*draw_ability.effect).clone(), Vec::new(), throne, P0),
+        ManaCost::generic(3),
+    );
+    pending.activation_ability_index = Some(draw);
+    state.pending_cast = Some(Box::new(pending));
+    state.objects.get_mut(&throne).unwrap().tapped = true;
+    state.waiting_for = WaitingFor::ManaPayment {
+        player: P0,
+        convoke_mode: None,
+    };
+    assert!(matches!(state.waiting_for, WaitingFor::ManaPayment { .. }));
+    let mut runner = GameRunner::from_state(state);
+    assert!(
+        runner
+            .act(GameAction::SpendPoolMana { pip_id: blue_pip })
+            .is_err(),
+        "manual payment must reject pinning blue mana for the red-chosen activation"
+    );
+    runner
+        .act(GameAction::SpendPoolMana { pip_id: red_pip })
+        .expect("manual payment must accept a red mana pin");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("pending activation must finalize from the eligible red mana");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+}

--- a/crates/phase-ai/src/policies/land_animation.rs
+++ b/crates/phase-ai/src/policies/land_animation.rs
@@ -109,7 +109,7 @@ impl TacticalPolicy for LandAnimationPolicy {
         // manland for mana to help pay its own {1}{W}{B} animation cost and
         // turns it into a useless tapped creature. Strongly disprefer any
         // activation that leaves the source tapped.
-        if animation_leaves_source_tapped(ctx, *source_id, obj, ability_def) {
+        if animation_leaves_source_tapped(ctx, *source_id, *ability_index, obj, ability_def) {
             // Route the critical penalty through the band helper (CR-equivalent
             // score contract) rather than a raw Score literal so the delta stays
             // clamped to the critical band before `activation` scaling.
@@ -277,6 +277,7 @@ fn ability_taps_source(ability: &AbilityDefinition) -> bool {
 fn animation_leaves_source_tapped(
     ctx: &PolicyContext<'_>,
     source_id: ObjectId,
+    ability_index: usize,
     source: &game_object::GameObject,
     ability: &AbilityDefinition,
 ) -> bool {
@@ -294,7 +295,7 @@ fn animation_leaves_source_tapped(
         return false;
     }
 
-    !can_pay_cost_excluding_source(ctx, source_id, cost)
+    !can_pay_cost_excluding_source(ctx, source_id, ability_index, cost)
 }
 
 /// True iff the AI can pay `cost` for `source_id`'s ability without tapping the
@@ -303,6 +304,7 @@ fn animation_leaves_source_tapped(
 fn can_pay_cost_excluding_source(
     ctx: &PolicyContext<'_>,
     source_id: ObjectId,
+    ability_index: usize,
     cost: &ManaCost,
 ) -> bool {
     let excluded = HashSet::from([source_id]);
@@ -310,6 +312,7 @@ fn can_pay_cost_excluding_source(
         ctx.state,
         ctx.ai_player,
         source_id,
+        ability_index,
         cost,
         &excluded,
     )

--- a/crates/server-core/src/game_action_payload_guard.rs
+++ b/crates/server-core/src/game_action_payload_guard.rs
@@ -176,6 +176,7 @@ fn guard_mana_restrictions_payload(
                 pending.extend(children);
             }
             ManaRestriction::OnlyForSpell
+            | ManaRestriction::OnlyForSpellColor(_)
             | ManaRestriction::OnlyForActivation
             | ManaRestriction::OnlyForTaggedActivation(_)
             | ManaRestriction::OnlyForXCosts
@@ -192,6 +193,7 @@ fn guard_mana_restrictions_payload(
             | ManaRestriction::OnlyForSpellFromZone(_)
             | ManaRestriction::OnlyForFaceDownSpell
             | ManaRestriction::OnlyForSpecialAction(_)
+            | ManaRestriction::Impossible
             | ManaRestriction::ConvokePayment => {}
         }
     }


### PR DESCRIPTION
## Summary
Fixes the chosen-color mana-restriction misparse for **Throne of Eldraine**.

## Files changed
- crates/engine/src/parser/oracle.rs
- crates/engine/src/parser/oracle_effect/mana.rs
- crates/engine/src/game/casting.rs
- crates/engine/src/game/effects/mana.rs
- crates/engine/src/game/mana_payment.rs
- crates/engine/src/types/ability.rs
- crates/engine/src/types/mana.rs
- crates/engine/tests/integration/throne_of_eldraine_mana_riders.rs
- crates/phase-ai/src/policies/land_animation.rs
- crates/server-core/src/game_action_payload_guard.rs

## CR references
- CR 105.2a
- CR 105.4
- CR 106.6 and CR 106.6a
- CR 400.7
- CR 601.2f-h
- CR 602.2b
- CR 609.4b

## Implementation method (required)
Method: /engine-implementer

## Track
Developer

## LLM
Model: gpt-5.6
Thinking: high

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- `git diff --check` — PASS
- `cargo clippy-strict` — PASS
- `cargo test -p engine` — PASS
- `./scripts/gen-card-data.sh` — PASS; generated card export promoted
- `cargo coverage` — PASS; 31,532/35,501 cards supported (88.8%)
- `cargo semantic-audit` — PASS; audit completed
- `./scripts/check-parser-combinators.sh` — PASS

## Gate A
Gate A PASS head=419172e8a88b9c5d5fa6e002ca17e962415c162e base=6895ca39a2b1017ceec96c25fb8141d0ee6847a7

## Anchored on
- crates/engine/src/game/effects/mana.rs:320 — source-chosen restriction lowering pattern
- crates/engine/src/types/mana.rs:1047 — existing spell color-count payment restriction

## Final review-impl
Final review-impl PASS head=419172e8a88b9c5d5fa6e002ca17e962415c162e

## Claimed parse impact
- Throne of Eldraine

## Validation Failures
None.

## CI Failures
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mana restrictions tied to a source’s chosen color, including activation-specific payment rules.
  * Improved enforcement of actual mana colors during activation and spell payment.
  * Added Ninjutsu-family abilities to activation and payment handling.
  * Enhanced parsing for combined and multiple mana-spend restrictions.

* **Bug Fixes**
  * Corrected affordability checks for selected activated abilities.
  * Fixed replacement-cost payment handling and restricted-mana eligibility.
  * Added regression coverage for chosen-color mana riders and Ninjutsu activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->