### PR TITLE
fix(client): use browser :hover for card-preview dismiss checks

### DIFF
--- a/client/src/hooks/usePreviewDismiss.ts
+++ b/client/src/hooks/usePreviewDismiss.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 
 import { useUiStore } from "../stores/uiStore.ts";
 
@@ -8,8 +8,9 @@ import { useUiStore } from "../stores/uiStore.ts";
  * animations (tap rotation, attack slide, layout transitions) move elements
  * out from under the cursor without firing onMouseLeave.
  *
- * Uses `document.elementFromPoint()` on a 300ms interval to verify the pointer
- * is still over an element with `[data-card-hover]`.
+ * On a 300ms interval it verifies, via the browser's own `:hover` state, that
+ * the pointer is still over an element with `[data-card-hover]` — robust to the
+ * stale JS-tracked pointer that sparse remote-desktop pointer streams produce.
  *
  * When `previewSticky` is true (set by long-press on touch devices), the
  * interval-based dismiss is skipped. A delayed capture-phase pointer listener
@@ -21,21 +22,6 @@ export function usePreviewDismiss() {
   const altHeld = useUiStore((s) => s.altHeld);
   const dismissPreview = useUiStore((s) => s.dismissPreview);
   const hoverObject = useUiStore((s) => s.hoverObject);
-  const pointerRef = useRef({ x: 0, y: 0 });
-
-  // Track pointer position (only while preview is active, mouse only)
-  useEffect(() => {
-    if (inspectedObjectId == null) return;
-
-    function onMove(e: PointerEvent) {
-      // Only track mouse pointer, not touch — touch uses sticky dismiss
-      if (e.pointerType === "touch") return;
-      pointerRef.current = { x: e.clientX, y: e.clientY };
-    }
-
-    document.addEventListener("pointermove", onMove, { passive: true });
-    return () => document.removeEventListener("pointermove", onMove);
-  }, [inspectedObjectId]);
 
   // Mouse: periodically verify the pointer is still over a card-hover element.
   // Skipped when the preview is sticky (touch-initiated) or Alt-pinned (frozen
@@ -52,14 +38,19 @@ export function usePreviewDismiss() {
         skipFirst = false;
         return;
       }
-      const { x, y } = pointerRef.current;
-      if (x === 0 && y === 0) return;
-
-      const el = document.elementFromPoint(x, y);
-      if (!el) return;
-
-      const isOverCard = el.closest("[data-card-hover]") !== null;
-      if (!isOverCard) {
+      // Ask the browser for the element it currently considers hovered rather
+      // than sampling elementFromPoint() against a JS-tracked pointer. That
+      // tracked coordinate is only as fresh as the last `pointermove`, and over
+      // sparse/coalesced pointer streams (remote-desktop / RDP webviews) it goes
+      // stale a few px off the card while the OS cursor is genuinely still on
+      // it — so a single elementFromPoint sample spuriously dismissed the
+      // just-shown preview. `:hover` is driven by the engine's own continuous
+      // hit-test and stays correct with no pointermove event at all. It matches
+      // the interactive info/parse panel too (also `[data-card-hover]`), and
+      // pointer-events-none surfaces (the preview image) never match it — the
+      // same "over a card or its info panel" test the old sample performed.
+      const stillOverTarget = document.querySelector("[data-card-hover]:hover");
+      if (stillOverTarget == null) {
         dismissPreview();
         hoverObject(null);
       }

--- a/client/src/stores/__tests__/uiStoreHoverLatency.test.ts
+++ b/client/src/stores/__tests__/uiStoreHoverLatency.test.ts
@@ -54,7 +54,9 @@ describe("uiStore inspectObject hover latency", () => {
   });
 
   it("cancels a pending show when the cursor leaves before the delay elapses", () => {
-    vi.spyOn(document, "elementFromPoint").mockReturnValue(null);
+    // The clear path asks the browser for its `:hover` element; null = the
+    // cursor is over nothing inspectable, so the deferred show is cancelled.
+    vi.spyOn(document, "querySelector").mockReturnValue(null);
     usePreferencesStore.setState({ cardPreviewHoverDelayMs: 300 });
     useUiStore.getState().inspectObject(5);
     vi.advanceTimersByTime(100);
@@ -66,7 +68,10 @@ describe("uiStore inspectObject hover latency", () => {
   it("keeps a pending show through a transient leave while the pointer remains over a card", () => {
     const hoveredCard = document.createElement("div");
     hoveredCard.dataset.cardHover = "true";
-    vi.spyOn(document, "elementFromPoint").mockReturnValue(hoveredCard);
+    // `:hover` resolves to a card element → the transient leave is ignored.
+    vi.spyOn(document, "querySelector").mockImplementation((sel) =>
+      sel === "[data-card-hover]:hover" ? hoveredCard : null,
+    );
     usePreferencesStore.setState({ cardPreviewHoverDelayMs: 300 });
 
     useUiStore.getState().inspectObject(5);
@@ -82,7 +87,11 @@ describe("uiStore inspectObject hover latency", () => {
   it("does not clear an open preview on a stale leave while the pointer remains over a card", () => {
     const hoveredCard = document.createElement("div");
     hoveredCard.dataset.cardHover = "true";
-    vi.spyOn(document, "elementFromPoint").mockReturnValue(hoveredCard);
+    // The card is still the browser's `:hover` target, so the stale mouseleave
+    // must not dismiss the open preview.
+    vi.spyOn(document, "querySelector").mockImplementation((sel) =>
+      sel === "[data-card-hover]:hover" ? hoveredCard : null,
+    );
     usePreferencesStore.setState({ cardPreviewHoverDelayMs: 300 });
 
     useUiStore.getState().inspectObject(5);

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -96,10 +96,6 @@ function flushPendingShow(): void {
   pendingShow = null;
   apply();
 }
-let lastPointer = { x: 0, y: 0 };
-if (typeof window !== "undefined") {
-  window.addEventListener("pointermove", (e) => { lastPointer = { x: e.clientX, y: e.clientY }; }, { passive: true });
-}
 
 // Serial FIFO for dice/coin overlays. Full-screen "moment" overlays are mutually
 // exclusive (you can't show two rolls at once), so simultaneous/back-to-back
@@ -438,11 +434,18 @@ export const useUiStore = create<UiStore>()((set, get) => ({
         // traverse the gap from the card to the panel and click "Report a Problem"
         // or scroll rulings. Toggling Alt off (or a click outside) still dismisses.
         if (get().altHeld) return;
-        const el = document.elementFromPoint(lastPointer.x, lastPointer.y);
         // Keep the preview (and finish a delay that already elapsed) when the
-        // pointer is still over an inspectable card or the preview panel. This
-        // makes stale leaves from Framer Motion layout updates harmless.
-        if (el?.closest("[data-card-hover], [data-card-preview]")) {
+        // pointer is still over an inspectable card. Ask the browser for its own
+        // `:hover` element rather than sampling elementFromPoint() against a
+        // JS-tracked pointer: that coordinate is only as fresh as the last
+        // `pointermove`, and over sparse/coalesced streams (remote-desktop / RDP
+        // webviews) it lands a few px off the card while the OS cursor is still
+        // on it — so a spurious Framer-Motion mouseleave's 50ms clear would
+        // false-fire and cancel a live preview (visible only with a non-zero
+        // hover delay, where the re-show is deferred rather than instant).
+        // `:hover` is the engine's continuous hit-test, correct with no
+        // pointermove event at all.
+        if (document.querySelector("[data-card-hover]:hover") != null) {
           flushPendingShow();
           return;
         }


### PR DESCRIPTION
Battlefield card previews never appeared over remote desktop (RDP) and flickered locally with a non-zero hover delay. Both timer-based dismiss checks — the 300ms poll (usePreviewDismiss) and the 50ms delayed-clear (uiStore.inspectObject) — tested "is the cursor still over a card?" by sampling document.elementFromPoint() against a JS-tracked pointer that only updates on pointermove. Over sparse/coalesced RDP pointer streams that coordinate goes stale a few px off the card while the OS cursor is genuinely on it, so the check false-negatived and dismissed (or cancelled the pending show for) a live preview.

Battlefield cards were uniquely affected: their hover element carries a Framer-Motion layoutId that emits spurious mouseleave events routed through the delayed-clear; hand cards have no layoutId and never triggered the stale-pointer check.

Switch both timer-based checks to the browser's authoritative [data-card-hover]:hover element — the engine's continuous hit-test, correct with zero pointermove events — and remove the now-dead lastPointer tracking. The pointerdown-outside handler keeps elementFromPoint (it reads fresh event coordinates).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover detection for previews and cards by relying on the browser’s active hover state.
  * Prevented previews from dismissing unexpectedly during layout changes or motion transitions.
  * Removed issues caused by stale pointer-position tracking, while preserving dismissal when clicking outside the preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->