### PR TITLE
ship/ci cache banking and janitor

### DIFF
--- a/.github/actions/mtgjson-cache-key/action.yml
+++ b/.github/actions/mtgjson-cache-key/action.yml
@@ -72,19 +72,26 @@ runs:
       # roll this key. Widen it here if draft-pool-gen ever reads more.
       run: |
         set -euo pipefail
+        paths=(
+          crates/draft-core
+          crates/engine/src/database/set_catalog.rs
+          crates/engine/src/database/set_gating.rs
+        )
+        # Validate each path INDEPENDENTLY. A combined emptiness check only
+        # catches total loss: `crates/draft-core` alone matches 13 tracked
+        # files, so renaming either single-file engine path would leave the
+        # combined output non-empty, pass the guard, and silently drop that
+        # file from the hash — the key would then stop rolling on its content
+        # for good, which is the exact staleness this guard exists to prevent.
+        for p in "${paths[@]}"; do
+          if [ -z "$(git ls-files -s "$p")" ]; then
+            echo "::error::draft-pool source path '$p' matched no tracked files — update .github/actions/mtgjson-cache-key"
+            exit 1
+          fi
+        done
         # `git ls-files -s` yields the tracked blob SHAs of the checked-out
         # tree — a content hash with no file reads.
-        srcs="$(git ls-files -s \
-          crates/draft-core \
-          crates/engine/src/database/set_catalog.rs \
-          crates/engine/src/database/set_gating.rs)"
-        # Empty means the paths were moved or renamed. Fail loudly: a constant
-        # hash silently pins every consumer to the first pool ever cached.
-        if [ -z "$srcs" ]; then
-          echo "::error::draft-pool source paths matched no tracked files — update .github/actions/mtgjson-cache-key"
-          exit 1
-        fi
-        src_hash="$(printf '%s' "$srcs" | sha256sum | cut -c1-16)"
+        src_hash="$(git ls-files -s "${paths[@]}" | sha256sum | cut -c1-16)"
         # Release gating is generation-time input, and gated sets auto-unlock
         # once their release date passes as of GATED_SETS_AS_OF (default UTC
         # today — see engine::database::set_gating). So while gating is active

--- a/.github/actions/mtgjson-cache-key/action.yml
+++ b/.github/actions/mtgjson-cache-key/action.yml
@@ -1,12 +1,19 @@
 name: MTGJSON cache key
 description: >
   Derive the mtgjson-full cache-key suffix from MTGJSON's published release
-  version, so the cache rolls exactly when new data is published.
+  version, so the cache rolls exactly when new data is published, plus the
+  paired draft-pool suffix for the artifact generated from that same data.
 
 outputs:
   suffix:
     description: Published MTGJSON version (sanitized), or a week-based fallback.
     value: ${{ steps.probe.outputs.suffix }}
+  draft_pools_suffix:
+    description: >
+      Cache-key suffix for the generated draft-pools.json — the MTGJSON data
+      version plus a hash of the sources and gating config that define the
+      output.
+    value: ${{ steps.pools.outputs.suffix }}
 
 runs:
   using: composite
@@ -44,3 +51,50 @@ runs:
           suffix="week-$(date -u +%Y-W%V)"
         fi
         echo "suffix=$suffix" >> "$GITHUB_OUTPUT"
+
+    - name: Derive draft-pool cache suffix
+      id: pools
+      shell: bash
+      env:
+        MTGJSON_SUFFIX: ${{ steps.probe.outputs.suffix }}
+      # draft-pools.json is a pure function of four inputs, and all four are in
+      # this suffix so a restored pool is current by construction:
+      #
+      #   1. the MTGJSON per-set files      → MTGJSON_SUFFIX (above)
+      #   2. the draft-core crate           → src_hash
+      #   3. engine's set catalog + gating  → src_hash
+      #   4. GATED_SETS (+ its as-of date)  → gate
+      #
+      # Deliberately narrow on the engine side: `extraction.rs` deserializes
+      # MTGJSON directly and never calls into engine, so the only engine code
+      # that can move the output is the set catalog / release gate the bin
+      # reads. Routine parser churn under crates/engine therefore does NOT
+      # roll this key. Widen it here if draft-pool-gen ever reads more.
+      run: |
+        set -euo pipefail
+        # `git ls-files -s` yields the tracked blob SHAs of the checked-out
+        # tree — a content hash with no file reads.
+        srcs="$(git ls-files -s \
+          crates/draft-core \
+          crates/engine/src/database/set_catalog.rs \
+          crates/engine/src/database/set_gating.rs)"
+        # Empty means the paths were moved or renamed. Fail loudly: a constant
+        # hash silently pins every consumer to the first pool ever cached.
+        if [ -z "$srcs" ]; then
+          echo "::error::draft-pool source paths matched no tracked files — update .github/actions/mtgjson-cache-key"
+          exit 1
+        fi
+        src_hash="$(printf '%s' "$srcs" | sha256sum | cut -c1-16)"
+        # Release gating is generation-time input, and gated sets auto-unlock
+        # once their release date passes as of GATED_SETS_AS_OF (default UTC
+        # today — see engine::database::set_gating). So while gating is active
+        # the key must roll daily, or a cached pool would keep hiding a set
+        # that has since released. Unset (the CI default) → no date in the
+        # key, and the entry survives across days. Commas are not cache-key
+        # material, so they become underscores.
+        if [ -n "${GATED_SETS:-}" ]; then
+          gate="$(printf '%s' "$GATED_SETS" | tr -d '[:space:]' | tr ',' '_')-${GATED_SETS_AS_OF:-$(date -u +%Y-%m-%d)}"
+        else
+          gate="ungated"
+        fi
+        echo "suffix=${MTGJSON_SUFFIX}-${src_hash}-${gate}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -1,0 +1,168 @@
+name: Cache janitor
+
+# Deletes Actions caches that nothing can ever restore again.
+#
+# The repo runs against a hard 10 GB cache quota; once over it, GitHub evicts by
+# least-recently-used. On 2026-07-24 the repo sat at 9.93 GB across 207 entries,
+# and the eviction pressure was almost entirely dead weight: 141 of those 207
+# entries (3.4 GB) had been written and never restored even once.
+#
+# The waste is not "old" or "big" entries — it is entries whose SCOPE is dead.
+# A cache is restorable only from its own ref or from the default branch, so:
+#
+#   * gh-readonly-queue/**  The merge queue re-synthesizes these branches on
+#                           every entry change and deletes the old ones. 58 of
+#                           58 such entries (1.00 GB) had never been read, and
+#                           27 distinct queue refs held caches while only 3 were
+#                           still live. Queue runs restore from main (their base)
+#                           anyway, so nothing is lost.
+#   * refs/pull/N/merge     Useful across pushes WITHIN a live PR (23 entries had
+#                           genuinely been re-read), and dead the moment the PR
+#                           closes. 17 of the 25 PRs holding caches were closed,
+#                           holding 1.84 GB.
+#   * refs/tags/**          Release runs happen once per tag, and a later tag is
+#                           a different ref that cannot read them. 8 of 9 (1.33
+#                           GB) had never been read.
+#
+# Deliberately NOT implemented: generational pruning ("keep the newest N per key
+# family"). It was measured first and does not pay — every rust family on main
+# already carries exactly 2 generations, so a keep-newest-2 sweep would reclaim
+# 0.13 GB, and dropping to keep-1 would delete the older generation that
+# Swatinem's rust-cache uses as its restore-keys warm-start fallback. Main's
+# caches are healthy (42 of 46 re-read); this janitor never touches them.
+#
+# Mirrors merge-queue-janitor.yml's test: ref-absence is a scope test, not a
+# liveness test. Nothing here inspects age or size on the queue path — if the
+# ref is gone, the entry is unreachable by definition.
+
+on:
+  schedule:
+    # Daily at 06:00 UTC, before the working day builds up new entries.
+    - cron: "0 6 * * *"
+  pull_request_target:
+    # Reclaim a PR's caches as soon as it closes, rather than waiting for the
+    # next nightly sweep or GitHub's 7-day idle eviction.
+    #
+    # `pull_request_target`, not `pull_request`: a fork-originated
+    # `pull_request` event gets a read-only GITHUB_TOKEN no matter what the
+    # `permissions:` block asks for, so every closed fork PR would 403 on the
+    # delete and leave a failed run behind. This repo takes fork
+    # contributions, so that is the common case, not the edge case.
+    # `pull_request_target` runs this workflow definition from the base branch
+    # with a writable token, and it is safe here because nothing in this job
+    # checks out or executes PR code — it only calls the caches API.
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be deleted without deleting it"
+        type: boolean
+        default: false
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cache-janitor
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Delete unreachable caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      # PR-close runs sweep only the PR that closed; scheduled and manual runs
+      # sweep everything.
+      CLOSED_PR: ${{ github.event_name == 'pull_request_target' && github.event.number || '' }}
+      # Tag caches are kept briefly so a re-run of the same release can still
+      # use them, then reclaimed.
+      TAG_CACHE_MAX_AGE_DAYS: "3"
+    steps:
+      - name: Delete caches whose scope can never restore them again
+        run: |
+          set -euo pipefail
+
+          # Full inventory. The REST route is paginated at 100; --paginate
+          # walks it. `.actions_caches[]` is the per-entry array. created_at is
+          # pulled here so the tag-age check needs no per-entry API call.
+          gh api --paginate "/repos/$REPO/actions/caches?per_page=100" \
+            --jq '.actions_caches[] | [.id, .ref, .size_in_bytes, .created_at, .key] | @tsv' > caches.tsv
+          echo "inventory: $(wc -l < caches.tsv) entries, $(awk -F'\t' '{s+=$3} END {printf "%.2f", s/1073741824}' caches.tsv) GB"
+
+          # Live merge-queue refs, so an in-flight queue entry is never swept.
+          gh api "/repos/$REPO/git/matching-refs/heads/gh-readonly-queue" \
+            --jq '.[].ref | sub("^refs/heads/"; "")' | sort > live_queue.txt || : > live_queue.txt
+          echo "live merge-queue refs: $(wc -l < live_queue.txt)"
+
+          # Cache-holding PR numbers -> state, resolved once each. A PR that
+          # 404s (deleted fork, bad ref) is treated as OPEN: this janitor must
+          # never delete on missing evidence.
+          : > pr_state.txt
+          for pr in $(cut -f2 caches.tsv | sed -n 's#^refs/pull/\([0-9][0-9]*\)/.*#\1#p' | sort -un); do
+            state="$(gh api "/repos/$REPO/pulls/$pr" --jq '.state' 2>/dev/null || echo open)"
+            printf '%s\t%s\n' "$pr" "$state" >> pr_state.txt
+          done
+
+          cutoff=$(date -u -d "$TAG_CACHE_MAX_AGE_DAYS days ago" +%s)
+          deleted=0
+          freed=0
+          kept=0
+          verb="DELETE"
+          [ "$DRY_RUN" = "true" ] && verb="WOULD DELETE"
+
+          while IFS=$'\t' read -r id ref size created key; do
+            reason=""
+
+            case "$ref" in
+              refs/heads/gh-readonly-queue/*)
+                # The queue branch is gone -> no run can ever check it out, so
+                # no run can ever restore this entry.
+                if ! grep -qxF "${ref#refs/heads/}" live_queue.txt; then
+                  reason="merge-queue ref no longer exists"
+                fi
+                ;;
+              refs/pull/*)
+                pr="$(printf '%s' "$ref" | sed -n 's#^refs/pull/\([0-9][0-9]*\)/.*#\1#p')"
+                if [ -n "$CLOSED_PR" ] && [ "$pr" != "$CLOSED_PR" ]; then
+                  : # PR-close run: leave every other PR alone.
+                elif [ "$(awk -F'\t' -v p="$pr" '$1==p {print $2}' pr_state.txt)" = "closed" ]; then
+                  reason="PR #$pr is closed"
+                fi
+                ;;
+              *refs/tags/*)
+                # Tag refs are single-use: the next release is a different ref
+                # and cannot read these. Keep briefly for same-tag re-runs.
+                if [ "$(date -u -d "$created" +%s)" -lt "$cutoff" ]; then
+                  reason="tag cache older than ${TAG_CACHE_MAX_AGE_DAYS}d"
+                fi
+                ;;
+            esac
+
+            if [ -z "$reason" ]; then
+              kept=$((kept + 1))
+              continue
+            fi
+
+            printf '%s  %6sMB  %s  (%s)\n' \
+              "$verb" "$((size / 1048576))" "$key" "$reason"
+            if [ "$DRY_RUN" != "true" ]; then
+              gh api -X DELETE "/repos/$REPO/actions/caches/$id" >/dev/null 2>&1 \
+                || { echo "  (already gone)"; continue; }
+            fi
+            deleted=$((deleted + 1))
+            freed=$((freed + size))
+          done < caches.tsv
+
+          echo
+          echo "kept $kept, ${DRY_RUN:+would have }deleted $deleted entries, freeing $(awk -v b="$freed" 'BEGIN {printf "%.2f", b/1073741824}') GB"
+
+      - name: Report remaining usage
+        if: ${{ always() }}
+        run: |
+          gh api "/repos/$REPO/actions/cache/usage" \
+            --jq '"after sweep: \(.active_caches_count) entries, \((.active_caches_size_in_bytes / 1073741824) * 100 | round / 100) GB of the 10 GB quota"'

--- a/.github/workflows/cache-janitor.yml
+++ b/.github/workflows/cache-janitor.yml
@@ -95,15 +95,36 @@ jobs:
           echo "inventory: $(wc -l < caches.tsv) entries, $(awk -F'\t' '{s+=$3} END {printf "%.2f", s/1073741824}' caches.tsv) GB"
 
           # Live merge-queue refs, so an in-flight queue entry is never swept.
-          gh api "/repos/$REPO/git/matching-refs/heads/gh-readonly-queue" \
-            --jq '.[].ref | sub("^refs/heads/"; "")' | sort > live_queue.txt || : > live_queue.txt
-          echo "live merge-queue refs: $(wc -l < live_queue.txt)"
+          # A FAILED lookup is missing evidence, not an empty live set: an API
+          # blip would otherwise leave this file empty, mark every queue ref
+          # orphaned, and delete the caches of entries currently in flight.
+          # matching-refs returns 200 with `[]` when nothing matches, so a
+          # genuinely empty live set still succeeds here and sweeps correctly.
+          # Only needed when the queue scope is in play — a PR-close run must
+          # not fail on an API blip for a scope it isn't going to touch.
+          : > live_queue.txt
+          if [ -z "$CLOSED_PR" ]; then
+            if ! gh api "/repos/$REPO/git/matching-refs/heads/gh-readonly-queue" \
+                 --jq '.[].ref | sub("^refs/heads/"; "")' > live_queue.raw; then
+              echo "::error::could not enumerate live merge-queue refs — refusing to sweep on missing evidence"
+              exit 1
+            fi
+            sort live_queue.raw > live_queue.txt
+            echo "live merge-queue refs: $(wc -l < live_queue.txt)"
+          fi
 
           # Cache-holding PR numbers -> state, resolved once each. A PR that
           # 404s (deleted fork, bad ref) is treated as OPEN: this janitor must
-          # never delete on missing evidence.
+          # never delete on missing evidence. On a PR-close run only the PR
+          # that closed is in scope, so resolve just that one rather than
+          # every PR holding a cache.
+          if [ -n "$CLOSED_PR" ]; then
+            prs="$CLOSED_PR"
+          else
+            prs="$(cut -f2 caches.tsv | sed -n 's#^refs/pull/\([0-9][0-9]*\)/.*#\1#p' | sort -un)"
+          fi
           : > pr_state.txt
-          for pr in $(cut -f2 caches.tsv | sed -n 's#^refs/pull/\([0-9][0-9]*\)/.*#\1#p' | sort -un); do
+          for pr in $prs; do
             state="$(gh api "/repos/$REPO/pulls/$pr" --jq '.state' 2>/dev/null || echo open)"
             printf '%s\t%s\n' "$pr" "$state" >> pr_state.txt
           done
@@ -118,11 +139,14 @@ jobs:
           while IFS=$'\t' read -r id ref size created key; do
             reason=""
 
+            # A PR-close run is scoped to that one PR — the queue and tag
+            # scopes belong to the nightly sweep, which has the live-ref
+            # evidence a PR-close run deliberately skips fetching.
             case "$ref" in
               refs/heads/gh-readonly-queue/*)
                 # The queue branch is gone -> no run can ever check it out, so
                 # no run can ever restore this entry.
-                if ! grep -qxF "${ref#refs/heads/}" live_queue.txt; then
+                if [ -z "$CLOSED_PR" ] && ! grep -qxF "${ref#refs/heads/}" live_queue.txt; then
                   reason="merge-queue ref no longer exists"
                 fi
                 ;;
@@ -137,7 +161,7 @@ jobs:
               *refs/tags/*)
                 # Tag refs are single-use: the next release is a different ref
                 # and cannot read these. Keep briefly for same-tag re-runs.
-                if [ "$(date -u -d "$created" +%s)" -lt "$cutoff" ]; then
+                if [ -z "$CLOSED_PR" ] && [ "$(date -u -d "$created" +%s)" -lt "$cutoff" ]; then
                   reason="tag cache older than ${TAG_CACHE_MAX_AGE_DAYS}d"
                 fi
                 ;;
@@ -151,15 +175,29 @@ jobs:
             printf '%s  %6sMB  %s  (%s)\n' \
               "$verb" "$((size / 1048576))" "$key" "$reason"
             if [ "$DRY_RUN" != "true" ]; then
-              gh api -X DELETE "/repos/$REPO/actions/caches/$id" >/dev/null 2>&1 \
-                || { echo "  (already gone)"; continue; }
+              # Only a 404 means the entry is genuinely gone. Swallowing every
+              # failure would report a 403 (no `actions: write`) or a secondary
+              # rate-limit as a clean sweep, and the job would exit green
+              # having reclaimed nothing. `</dev/null` keeps gh off the loop's
+              # stdin; `2>&1 >/dev/null` captures stderr and drops stdout.
+              if ! err="$(gh api -X DELETE "/repos/$REPO/actions/caches/$id" </dev/null 2>&1 >/dev/null)"; then
+                case "$err" in
+                  *"HTTP 404"*) echo "  (already gone)" ;;
+                  *) echo "::warning::delete failed for cache $id: $err" ;;
+                esac
+                continue
+              fi
             fi
             deleted=$((deleted + 1))
             freed=$((freed + size))
           done < caches.tsv
 
+          # `${DRY_RUN:+...}` would expand on every run — DRY_RUN is the string
+          # "false" on scheduled and PR-close runs, not empty.
+          would=""
+          [ "$DRY_RUN" = "true" ] && would="would have "
           echo
-          echo "kept $kept, ${DRY_RUN:+would have }deleted $deleted entries, freeing $(awk -v b="$freed" 'BEGIN {printf "%.2f", b/1073741824}') GB"
+          echo "kept $kept, ${would}deleted $deleted entries, freeing $(awk -v b="$freed" 'BEGIN {printf "%.2f", b/1073741824}') GB"
 
       - name: Report remaining usage
         if: ${{ always() }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,20 @@ jobs:
     name: Card data & R2
     if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Sized for the MTGJSON-publish day, not the steady state. When MTGJSON
+    # ships a new version the key rolls, and the first run to see it pays the
+    # whole cold path: ~6m30s of token-set downloads, two back-to-back engine
+    # compiles (~5m35s each — tokens-gen regenerates known-tokens.toml, which
+    # build.rs embeds, forcing a rebuild), ~2m20s of draft-set downloads and a
+    # ~5m30s draft-core compile. Observed 29-30m; run 30114030288 was killed at
+    # 30m12s mid-R2-upload.
+    #
+    # That kill is self-perpetuating and is why the ceiling matters more than
+    # it looks: actions/cache declares `post-if: success()`, so a timed-out run
+    # saves NOTHING. The next run recomputes the same missing key and pays the
+    # same cold path again. The budget has to clear the cold path, or the cache
+    # can never be seeded at all.
+    timeout-minutes: 50
     permissions:
       actions: write
       contents: read
@@ -64,7 +77,20 @@ jobs:
         id: mtgjson-key
         uses: ./.github/actions/mtgjson-cache-key
 
-      - name: Cache MTGJSON data
+      # ── Cache restores ─────────────────────────────────────────────────────
+      # Every cache in this job is restore-only, with an explicit save placed
+      # at the step where its data is complete — NOT the combined
+      # `actions/cache` action.
+      #
+      # The combined action registers its save as a post step declared
+      # `post-if: success()`, so a job that dies anywhere downstream saves
+      # NOTHING. That turned a routine MTGJSON publish into a self-sustaining
+      # outage on 2026-07-24: the key rolled, the run paid ~28m of cold
+      # downloads, got killed by the job timeout mid-R2-upload, saved nothing,
+      # and every following run recomputed the same missing key and paid the
+      # same 28m again (run 30114030288). Saving the instant the data is whole
+      # makes that cost one-time no matter what fails afterwards.
+      - name: Restore MTGJSON data
         # Full data/mtgjson dir under the `mtgjson-full-` namespace: this job
         # runs gen-card-data.sh, which populates every file (AtomicCards, Meta,
         # SetList, token sets, decks). Kept distinct from ci.yml's partial
@@ -78,7 +104,7 @@ jobs:
         # missing); a restore-keys fallback would pin the file-existence-gated
         # fetches to stale data forever.
         id: mtgjson-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: data/mtgjson
           key: mtgjson-full-${{ steps.mtgjson-key.outputs.suffix }}
@@ -88,8 +114,9 @@ jobs:
       # pin them to old data forever. Exact-key-only means a new day misses,
       # the scripts re-fetch, and same-day deploys reuse the fetch — cutting
       # Scryfall API load (and the Cloudflare-throttle flakiness it causes).
-      - name: Cache Scryfall bulk data
-        uses: actions/cache@v4
+      - name: Restore Scryfall bulk data
+        id: scryfall-cache
+        uses: actions/cache/restore@v4
         with:
           path: data/scryfall
           key: scryfall-${{ steps.cache-keys.outputs.day }}
@@ -118,15 +145,106 @@ jobs:
           ./scripts/gen-card-data.sh
 
       - name: Download draft set data
+        id: draft-sets
         # fetch-draft-sets.sh needs SetList.json (produced by gen-card-data.sh).
-        # Per-set files land in data/mtgjson/sets/, covered by the mtgjson cache.
-        run: ./scripts/fetch-draft-sets.sh
+        # Per-set files land in data/mtgjson/sets/, covered by the mtgjson cache
+        # (a hit downloads nothing — 244 skipped in ~2s). Left unconditional
+        # even when the pool cache below hits: this is what keeps the mtgjson
+        # entry whole, and it is the only step that repopulates sets/ after an
+        # eviction.
+        #
+        # The script treats a failed set download as non-fatal (warn, count,
+        # exit 0) so one flaky set can't kill a deploy. That makes the reported
+        # failure count load-bearing for the pool cache below: pools built from
+        # a short sets/ dir must not be frozen under an immutable key. The
+        # count is republished as a step output; the summary line is a stable
+        # contract of a script in this repo.
+        run: |
+          set -o pipefail
+          ./scripts/fetch-draft-sets.sh | tee draft-sets.log
+          failed=$(sed -n 's/^Summary: .*failed \([0-9][0-9]*\)$/\1/p' draft-sets.log | tail -1)
+          echo "failed=${failed:-0}" >> "$GITHUB_OUTPUT"
+          echo "set downloads failed: ${failed:-0}"
+
+      - name: Save MTGJSON data
+        # THE earliest point data/mtgjson is complete: fetch-draft-sets.sh is
+        # the last writer into it (gen-card-data.sh fetches AtomicCards, Meta,
+        # SetList, token sets and decks; this adds the draft sets). Saving here
+        # rather than at job end means a failure in pool generation, the
+        # semantic audit or the R2 upload never re-costs the ~9m of downloads.
+        #
+        # Not earlier: a save mid-population would freeze a partial sets/ dir
+        # under an immutable key, and the later fetches would be skipped by
+        # their own file-existence guards forever.
+        #
+        # Deliberately NOT `always()`. As an inline step this runs in sequence,
+        # so a later failure cannot cancel it — it has already banked the
+        # download. `always()` would only add the case where an *earlier* step
+        # failed, i.e. exactly when the directory is incomplete and must not be
+        # frozen under an immutable key. Default `success()` is the correct
+        # "the data is whole" gate. cache-hit gating skips a redundant save,
+        # which would otherwise just warn that the key already exists.
+        if: ${{ steps.mtgjson-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: data/mtgjson
+          key: mtgjson-full-${{ steps.mtgjson-key.outputs.suffix }}
+
+      - name: Restore draft pools
+        # Paired with the MTGJSON cache: same `mtgjson-` prefix (so
+        # /clear-caches mtgjson sweeps both) and a suffix built from the same
+        # published-data version — see the mtgjson-cache-key action, which is
+        # the single authority for both keys.
+        #
+        # A separate entry rather than folding draft-pools.json into the
+        # `data/mtgjson` path above, because actions/cache writes only on a key
+        # miss: a pool-affecting draft-core change must roll the key, and the
+        # data-version key alone cannot see source changes.
+        #
+        # NO restore-keys: every input to the output is in the key, so an
+        # inexact hit is by construction a stale pool.
+        id: draft-pools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: client/public/draft-pools.json
+          key: mtgjson-draft-pools-${{ steps.mtgjson-key.outputs.draft_pools_suffix }}
 
       - name: Generate draft pools
+        # ~2s of extraction behind a ~5m30s compile of engine + draft-core:
+        # draft-pool-gen can't take --features cli, so it never reuses the
+        # units gen-card-data.sh built and pays a full cold compile every run.
+        # Skipping that on a cache hit is the whole point of the step above.
+        #
+        # Gate on file existence, not `cache-hit` (same reasoning as "Download
+        # MTGJSON data"): a poisoned or partial entry reports a hit with no
+        # file, and skipping on that would ship a deploy with no pools at all.
+        # Absent file → regenerate, so the cache self-heals.
+        #
         # Profile `tool`, not `release`: a one-shot JSON transform. draft-pool-gen
         # lives in draft-core and can't take --features cli, so it gets its own
         # [tool,default] engine fingerprint; tool keeps that compile cheap.
-        run: cargo run --profile tool --bin draft-pool-gen
+        run: |
+          if [ -f client/public/draft-pools.json ]; then
+            echo "draft-pools.json restored from cache — skipping draft-pool-gen"
+          else
+            cargo run --profile tool --bin draft-pool-gen
+          fi
+
+      - name: Save draft pools
+        # Banked the moment the file exists, so the ~5m30s compile is never
+        # paid twice for the same inputs even if the rest of the job fails.
+        #
+        # Skipped when any set download failed. A short sets/ dir yields a pool
+        # missing those sets, and the pool key is derived from the MTGJSON data
+        # version — so caching it would pin the short pool for the whole key
+        # window. Not saving preserves the existing self-heal: sets/ is
+        # file-existence-gated, so the next run fetches only the sets that are
+        # still missing and regenerates a complete pool.
+        if: ${{ steps.draft-pools-cache.outputs.cache-hit != 'true' && steps.draft-sets.outputs.failed == '0' }}
+        uses: actions/cache/save@v4
+        with:
+          path: client/public/draft-pools.json
+          key: mtgjson-draft-pools-${{ steps.mtgjson-key.outputs.draft_pools_suffix }}
 
       - name: Validate card-data against engine schema
         # Deploy gate — parse the freshly produced card-data through the same
@@ -171,6 +289,16 @@ jobs:
           ./scripts/gen-scryfall-token-images.sh
           ./scripts/gen-scryfall-sets.sh
           ./scripts/gen-scryfall-printings.sh
+
+      - name: Save Scryfall bulk data
+        # data/scryfall is complete once the four generators have run. Banking
+        # it here keeps a later failure from re-hitting the Scryfall API on the
+        # next run — the throttle flakiness this cache exists to avoid.
+        if: ${{ steps.scryfall-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: data/scryfall
+          key: scryfall-${{ steps.cache-keys.outputs.day }}
 
       - name: Generate coverage badge endpoints
         # --profile tool --features cli matches gen-card-data.sh → cache hit.

--- a/.github/workflows/refresh-card-data.yml
+++ b/.github/workflows/refresh-card-data.yml
@@ -19,7 +19,7 @@ name: Refresh Card Data Catalogs
 # and no PR opens. So it is safe to fire on any of the triggers below.
 #
 # Triggers:
-#   - schedule: weekly on Monday, after MTGJSON's weekly publish.
+#   - schedule: daily, after MTGJSON's publish window.
 #   - workflow_dispatch: manual run from the Actions tab.
 #   - workflow_run on "Clear Caches": clearing the mtgjson/scryfall caches only
 #     DELETES them; this workflow is the thing that re-fetches, re-processes,
@@ -27,9 +27,20 @@ name: Refresh Card Data Catalogs
 
 on:
   schedule:
-    # Monday 15:00 UTC — after the ISO-week cache key rolls (Mon 00:00) and
-    # MTGJSON has published the week's data.
-    - cron: "0 15 * * 1"
+    # Daily at 15:00 UTC, after MTGJSON's publish window.
+    #
+    # Was weekly (Mondays), which under-served the actual publish cadence:
+    # MTGJSON ships roughly daily (5.3.0+20260723 -> +20260724 on consecutive
+    # days), so for six days out of seven the committed known-tokens.toml was
+    # stale. That is not cosmetic — build.rs embeds that file, so when
+    # gen-card-data.sh regenerates it mid-run the deploy has to recompile the
+    # engine a SECOND time to embed the new catalog. Measured at 5m35s on top
+    # of the first 5m39s compile (run 30114030288), on a job that was timing
+    # out at 30m. Keeping the committed catalog fresh is what removes it.
+    #
+    # Firing daily is safe by construction: the vintage write-gate above means
+    # a run against unchanged MTGJSON rewrites nothing and opens no PR.
+    - cron: "0 15 * * *"
   workflow_dispatch:
   workflow_run:
     workflows: ["Clear Caches"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,13 @@ jobs:
         id: mtgjson-key
         uses: ./.github/actions/mtgjson-cache-key
 
-      - name: Cache MTGJSON data
+      # ── Cache restores ─────────────────────────────────────────────────────
+      # Restore-only, with explicit saves placed where each cache's data is
+      # complete — NOT the combined `actions/cache` action, whose save is a
+      # post step declared `post-if: success()` and is therefore skipped
+      # entirely when the job fails or times out. See deploy.yml's copy of this
+      # note for the 2026-07-24 incident that motivated the split.
+      - name: Restore MTGJSON data
         # Full data/mtgjson dir under the `mtgjson-full-` namespace (shared with
         # deploy.yml — both run gen-card-data.sh and populate every file). Kept
         # distinct from ci.yml's partial `mtgjson-atomic-`/`mtgjson-sets-`
@@ -142,7 +148,7 @@ jobs:
         # fresh data; a restore-keys fallback would pin the file-existence-gated
         # fetches to stale data forever.
         id: mtgjson-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: data/mtgjson
           key: mtgjson-full-${{ steps.mtgjson-key.outputs.suffix }}
@@ -152,8 +158,9 @@ jobs:
       # pin them to old data forever. Exact-key-only means a new day misses,
       # the scripts re-fetch, and same-day deploys reuse the fetch — cutting
       # Scryfall API load (and the Cloudflare-throttle flakiness it causes).
-      - name: Cache Scryfall bulk data
-        uses: actions/cache@v4
+      - name: Restore Scryfall bulk data
+        id: scryfall-cache
+        uses: actions/cache/restore@v4
         with:
           path: data/scryfall
           key: scryfall-${{ steps.cache-keys.outputs.day }}
@@ -182,21 +189,97 @@ jobs:
           # data/ itself, so downstream steps can read from data/ uniformly.
 
       - name: Download draft set data
+        id: draft-sets
         # fetch-draft-sets.sh needs SetList.json (produced by gen-card-data.sh).
         # Per-set files land in data/mtgjson/sets/ which is covered by the
-        # mtgjson cache — subsequent runs skip already-downloaded sets.
-        run: ./scripts/fetch-draft-sets.sh
+        # mtgjson cache — subsequent runs skip already-downloaded sets. Left
+        # unconditional even when the pool cache below hits: this is what keeps
+        # the mtgjson entry whole, and it is the only step that repopulates
+        # sets/ after an eviction.
+        #
+        # The script treats a failed set download as non-fatal (warn, count,
+        # exit 0), so the reported count is load-bearing for the pool cache
+        # below — see deploy.yml's copy of this note.
+        run: |
+          set -o pipefail
+          ./scripts/fetch-draft-sets.sh | tee draft-sets.log
+          failed=$(sed -n 's/^Summary: .*failed \([0-9][0-9]*\)$/\1/p' draft-sets.log | tail -1)
+          echo "failed=${failed:-0}" >> "$GITHUB_OUTPUT"
+          echo "set downloads failed: ${failed:-0}"
+
+      - name: Save MTGJSON data
+        # THE earliest point data/mtgjson is complete: fetch-draft-sets.sh is
+        # the last writer into it. Saving here rather than at job end means a
+        # later failure never re-costs the ~9m of downloads.
+        #
+        # Not `always()`: as an inline step a later failure cannot cancel it,
+        # so the only case `always()` would add is an *earlier* failure — i.e.
+        # exactly when the directory is incomplete and must not be frozen under
+        # an immutable key.
+        if: ${{ steps.mtgjson-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: data/mtgjson
+          key: mtgjson-full-${{ steps.mtgjson-key.outputs.suffix }}
+
+      - name: Restore draft pools
+        # Paired with the MTGJSON cache: same `mtgjson-` prefix (so
+        # /clear-caches mtgjson sweeps both) and a suffix built from the same
+        # published-data version — see the mtgjson-cache-key action, which is
+        # the single authority for both keys, shared with deploy.yml.
+        #
+        # A separate entry rather than folding draft-pools.json into the
+        # `data/mtgjson` path above, because actions/cache writes only on a key
+        # miss: a pool-affecting draft-core change must roll the key, and the
+        # data-version key alone cannot see source changes.
+        #
+        # NO restore-keys: every input to the output is in the key, so an
+        # inexact hit is by construction a stale pool.
+        id: draft-pools-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: client/public/draft-pools.json
+          key: mtgjson-draft-pools-${{ steps.mtgjson-key.outputs.draft_pools_suffix }}
 
       - name: Generate draft pools
         # Reads data/mtgjson/sets/*.json → writes client/public/draft-pools.json.
         # Included in data-files.json manifest so it's uploaded to R2 and
         # stripped from the Pages dist automatically.
+        #
+        # ~2s of extraction behind a ~5m30s compile of engine + draft-core:
+        # draft-pool-gen never reuses the units gen-card-data.sh built (see the
+        # feature note below) and pays a full cold compile every run. Skipping
+        # that on a cache hit is the whole point of the step above.
+        #
+        # Gate on file existence, not `cache-hit` (same reasoning as "Download
+        # MTGJSON data"): a poisoned or partial entry reports a hit with no
+        # file, and skipping on that would ship a release with no pools at all.
+        # Absent file → regenerate, so the cache self-heals.
+        #
         # Profile `tool`, not `release`: this is a one-shot JSON transform, not a
         # shipped binary. `release` is the WASM-size profile (lto + codegen-units=1)
         # — the slowest compile in the repo. draft-pool-gen lives in draft-core
         # and can't take `--features cli`, so it gets its own `[tool,default]`
         # engine fingerprint regardless; `tool` just makes that compile cheap.
-        run: cargo run --profile tool --bin draft-pool-gen
+        run: |
+          if [ -f client/public/draft-pools.json ]; then
+            echo "draft-pools.json restored from cache — skipping draft-pool-gen"
+          else
+            cargo run --profile tool --bin draft-pool-gen
+          fi
+
+      - name: Save draft pools
+        # Banked the moment the file exists, so the ~5m30s compile is never
+        # paid twice for the same inputs even if the rest of the job fails.
+        #
+        # Skipped when any set download failed: a pool built from a short
+        # sets/ dir must not be frozen under a key that only rolls when MTGJSON
+        # publishes. See deploy.yml for the full reasoning.
+        if: ${{ steps.draft-pools-cache.outputs.cache-hit != 'true' && steps.draft-sets.outputs.failed == '0' }}
+        uses: actions/cache/save@v4
+        with:
+          path: client/public/draft-pools.json
+          key: mtgjson-draft-pools-${{ steps.mtgjson-key.outputs.draft_pools_suffix }}
 
       - name: Validate card-data against engine schema
         # Deploy gate — refuse to ship card-data the current engine cannot parse.
@@ -230,6 +313,16 @@ jobs:
           ./scripts/gen-scryfall-token-images.sh
           ./scripts/gen-scryfall-sets.sh
           ./scripts/gen-scryfall-printings.sh
+
+      - name: Save Scryfall bulk data
+        # data/scryfall is complete once the four generators have run. Banking
+        # it here keeps a later failure from re-hitting the Scryfall API on the
+        # next run — the throttle flakiness this cache exists to avoid.
+        if: ${{ steps.scryfall-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: data/scryfall
+          key: scryfall-${{ steps.cache-keys.outputs.day }}
 
       - name: Run semantic audit
         # Produces data/semantic-audit.json with structured findings for cards


### PR DESCRIPTION
- **ci(deploy): cache draft pools and bank caches when data is complete**
- **ci: reclaim Actions caches whose scope can never restore them**
- **ci(card-data): refresh embedded catalogs daily, not weekly**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incomplete or failed staging data from being saved to cache.
  * Reduced unnecessary re-fetching by switching to restore-then-save caching in key pipeline steps.
  * Improved cache cleanup safety by deleting entries only when they’re no longer needed.
* **New Features**
  * Added an automated cache janitor to remove stale cache entries based on ref eligibility rules.
* **Maintenance**
  * Updated refresh runs to occur daily.
  * Increased data-generation timeout and added clearer cache validation/reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->