### PR TITLE
fix(client): size mana cost pips to the printed cost, not a fixed px

### DIFF
--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -1102,12 +1102,12 @@ function CardImagePreview({
           />
         )}
         {displayCost && (
-          <ManaCostPips
-            cost={displayCost}
-            isReduced={displayCostReduced}
-            size="lg"
-            className="absolute right-[7.00%] top-[5.25%] z-10"
-          />
+          // @container overlay sized to the frame so the pips scale with the
+          // preview's own width, which varies from a 300px hand hover to a
+          // 472px docked preview — a fixed px size can only be right at one end.
+          <div className="pointer-events-none absolute inset-0 z-10 @container">
+            <ManaCostPips cost={displayCost} isReduced={displayCostReduced} size="fluid" />
+          </div>
         )}
         {classLevel != null && (
           <div className="absolute bottom-3 left-3 z-10">

--- a/client/src/components/hand/MobileHandDrawer.tsx
+++ b/client/src/components/hand/MobileHandDrawer.tsx
@@ -294,7 +294,7 @@ const DrawerCard = memo(function DrawerCard({
       {/* @container overlay sized to the card so the pips scale in cqi with the
           drawer card's width instead of a fixed px size. */}
       <div className="pointer-events-none absolute inset-0 @container">
-        <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" className="absolute right-[4%] top-[2%]" />
+        <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" />
       </div>
     </button>
   );

--- a/client/src/components/hand/MobileHeldHandCard.tsx
+++ b/client/src/components/hand/MobileHeldHandCard.tsx
@@ -128,12 +128,7 @@ export function MobileHeldHandCard({ gesture, object }: MobileHeldHandCardProps)
         className="!h-full !w-full"
       />
       <div className="pointer-events-none absolute inset-0 @container">
-        <ManaCostPips
-          cost={displayCost}
-          isReduced={isReduced}
-          size="fluid"
-          className="absolute right-[4%] top-[2%]"
-        />
+        <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" />
       </div>
     </motion.div>,
     document.body,

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -1015,7 +1015,7 @@ const HandCard = memo(function HandCard({
             from the card wrapper, so container-type can't collapse it); lets the
             pips scale in cqi with --hand-card-w instead of a fixed px size. */}
         <div className="pointer-events-none absolute inset-0 @container">
-          <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" className="absolute right-[4%] top-[2%]" />
+          <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" />
         </div>
       </motion.div>
     </motion.div>
@@ -1151,7 +1151,7 @@ const ZoneFanCard = memo(function ZoneFanCard({
       {/* @container overlay sized to the card so the pips scale in cqi with
           --hand-card-w (see the hand-card render above). */}
       <div className="pointer-events-none absolute inset-0 @container">
-        <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" className="absolute right-[4%] top-[2%]" />
+        <ManaCostPips cost={displayCost} isReduced={isReduced} size="fluid" />
       </div>
     </motion.div>
   );

--- a/client/src/components/mana/ManaCostPips.tsx
+++ b/client/src/components/mana/ManaCostPips.tsx
@@ -18,10 +18,14 @@ const PIP_SIZES: Record<PipSize, { container: string; gap: string; backdrop: str
   // The badge stands in for the card's PRINTED mana cost (it shows the engine's
   // effective cost), so its geometry is calibrated against that cost rather than
   // against any fixed px size. Measured on M15-frame art, a printed symbol is
-  // ~5.2% of the card's width. 7cqi keeps a legibility margin over that while
-  // still fitting inside the title bar, so even a five-symbol cost clears the
+  // ~5.2% of the card's width, so the 0.4cqi padding sizes the symbol to exactly
+  // that and the 6cqi disk reads as a thin ring around it. The printed symbols
+  // on the same card are legible at this size, which is what makes it enough.
+  //
+  // Keep the three values solving 5*container + 4*gap = 32cqi: that is the
+  // widest cost the frame carries (five symbols), and 32cqi is what clears the
   // card name instead of running through it.
-  fluid: { container: "w-[7cqi] h-[7cqi] p-[0.6cqi]", gap: "gap-[0.6cqi]", backdrop: "-inset-x-[0.6cqi] -top-[0.6cqi] -bottom-[1.2cqi]" },
+  fluid: { container: "w-[6cqi] h-[6cqi] p-[0.4cqi]", gap: "gap-[0.5cqi]", backdrop: "-inset-x-[0.5cqi] -top-[0.5cqi] -bottom-[1cqi]" },
 };
 
 // Where the printed cost sits on an M15 frame: right edge ~7% in from the card's

--- a/client/src/components/mana/ManaCostPips.tsx
+++ b/client/src/components/mana/ManaCostPips.tsx
@@ -2,23 +2,33 @@ import type { ManaCost } from "../../adapter/types.ts";
 import { manaCostToShards } from "../../viewmodel/costLabel.ts";
 import { ManaSymbol } from "./ManaSymbol.tsx";
 
-type PipSize = "2xs" | "xs" | "sm" | "md" | "lg" | "fluid";
+type PipSize = "2xs" | "xs" | "sm" | "md" | "fluid";
 
 const PIP_SIZES: Record<PipSize, { container: string; gap: string; backdrop: string }> = {
   "2xs": { container: "w-[10px] h-[10px] p-[0px]", gap: "gap-[0.5px]", backdrop: "-inset-x-[1px] top-[2px] -bottom-[3px]" },
   xs: { container: "w-[12px] h-[12px] p-[0px]", gap: "gap-[0.5px]", backdrop: "-inset-x-[1px] top-[2px] -bottom-[4px]" },
   sm: { container: "w-[18px] h-[18px] p-[0px]", gap: "gap-[1px]", backdrop: "-inset-x-[2px] top-[4px] -bottom-[8px]" },
   md: { container: "w-[22px] h-[22px] p-[2px]", gap: "gap-[1px]", backdrop: "-inset-x-[3px] -top-[2px] -bottom-[4px]" },
-  lg: { container: "w-[28px] h-[28px] py-[2px] px-[2.5px]", gap: "gap-[0.5px]", backdrop: "-inset-x-[3px] -top-[2px] -bottom-[4px]" },
   // Card-relative sizing in container-query inline units (1cqi = 1% of the
   // nearest `@container` ancestor's width). Consumers that pass `size="fluid"`
   // MUST wrap the pips in an element with `container-type: inline-size` sized to
-  // the card (e.g. an `absolute inset-0 @container` overlay). 15cqi matches the
-  // fixed `md` (22px) pip on a ~145px desktop hand card, then scales down with
-  // the card so pips never look oversized on smaller layouts. Secondary
-  // dimensions use the same md ratios (p 9.1%, gap 4.5%, backdrop 13.6/9.1/18.2%).
-  fluid: { container: "w-[15cqi] h-[15cqi] p-[1.4cqi]", gap: "gap-[0.7cqi]", backdrop: "-inset-x-[2cqi] -top-[1.4cqi] -bottom-[2.7cqi]" },
+  // the card (e.g. an `absolute inset-0 @container` overlay); the badge then
+  // anchors itself over the printed cost via FLUID_ANCHOR.
+  //
+  // The badge stands in for the card's PRINTED mana cost (it shows the engine's
+  // effective cost), so its geometry is calibrated against that cost rather than
+  // against any fixed px size. Measured on M15-frame art, a printed symbol is
+  // ~5.2% of the card's width. 7cqi keeps a legibility margin over that while
+  // still fitting inside the title bar, so even a five-symbol cost clears the
+  // card name instead of running through it.
+  fluid: { container: "w-[7cqi] h-[7cqi] p-[0.6cqi]", gap: "gap-[0.6cqi]", backdrop: "-inset-x-[0.6cqi] -top-[0.6cqi] -bottom-[1.2cqi]" },
 };
+
+// Where the printed cost sits on an M15 frame: right edge ~7% in from the card's
+// right edge, top edge ~5.4% down from its top. Owning this here keeps the
+// anchor in lockstep with the pip diameter above — the two only look right
+// together, and every card overlay wants the same placement.
+const FLUID_ANCHOR = "absolute right-[6.5%] top-[5%]";
 
 interface ManaCostPipsProps {
   cost: ManaCost;
@@ -37,7 +47,7 @@ export function ManaCostPips({ cost, isReduced, size = "md", className = "" }: M
   const s = PIP_SIZES[size];
 
   return (
-    <div className={`pointer-events-none ${className}`}>
+    <div className={`pointer-events-none ${size === "fluid" ? FLUID_ANCHOR : ""} ${className}`}>
       <div className={`relative flex ${s.gap}`}>
         <div
           data-mana-cost-backdrop

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -256,7 +256,7 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
           card's width instead of a fixed px size. */}
       {isSpell && displayManaCost && (
         <div className="pointer-events-none absolute inset-0 @container">
-          <ManaCostPips cost={displayManaCost} size="fluid" className="absolute right-[5%] top-[2.5%]" />
+          <ManaCostPips cost={displayManaCost} size="fluid" />
         </div>
       )}
 


### PR DESCRIPTION
The card-overlay mana pips were ~2.9x the size of the mana symbols
printed on the card frame they sit on, and anchored above the title bar
rather than inside it. On a desktop hand card a five-symbol cost spanned
67% of the card's width, reducing "Nissa, Ascended Animist" to "Nis".

The badge stands in for the card's PRINTED mana cost (it renders the
engine's effective cost, with a green ring when reduced), so calibrate
its geometry against that cost. Measured on M15-frame art, a printed
symbol is ~5.2% of the card's width, its right edge sits ~7% in and its
top edge ~5.4% down. The fluid pip drops 15cqi -> 6cqi with 0.4cqi
padding, which sizes the symbol to exactly the printed 5.2% and leaves
the disk as a thin ring around it; the printed symbols on the same card
are legible at that size, which is what makes it enough. The three
values solve 5 * 6cqi + 4 * 0.5cqi = 32cqi, so the widest cost the frame
carries spans 32% instead of 67%.

Fold the anchor into ManaCostPips as FLUID_ANCHOR. Diameter and anchor
only look right together, and all five fluid consumers were repeating
the placement by hand -- StackEntry had already drifted to a different
value. CardPreview was the lone fixed-px consumer at 28px, which cannot
be right for both a 300px hand hover and a 472px docked preview; give it
the same @container basis so both land on the same ratio by
construction, and drop the now-orphaned lg size.

Verified in-app on an unrotated 300px preview: symbol 5.2%, pip 6.0%,
five-symbol row 32.0%. Measurements must come from an unrotated frame --
a fan-rotated hand card's getBoundingClientRect returns an axis-aligned
bounding box that inflates the frame and understates the row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mana cost “pip” overlay positioning and scaling across card previews, hand cards, and stack entries.
  * Removed hard-coded absolute offsets so mana pips rely on container-aware sizing for more consistent alignment.
  * Updated fluid mana pip sizing behavior and anchoring for better responsiveness to the rendered card size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->