### PR TITLE
fix(native-engine): reuse cached server and restore saved sessions

### DIFF
--- a/client/src-tauri/src/native_engine.rs
+++ b/client/src-tauri/src/native_engine.rs
@@ -37,6 +37,7 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 const SERVER_ARTIFACT_PUBLIC_KEY: &str = "RWRDZxG2otNoKLblrgD00kM0a8U0CRZUGHpNCr3W+3ik1E84XHcB6hZe";
 const NATIVE_ENGINE_DIRECTORY: &str = "native-engine";
 const CACHE_DIRECTORY: &str = "cache/sha256";
+const LOG_DIRECTORY: &str = "logs";
 const SPAWN_RECORD_FILE: &str = "native-engine-spawn-record.json";
 const RELEASE_RATCHET_FILE: &str = "native-engine-highest-release-version.json";
 const PREVIEW_RATCHET_FILE: &str = "native-engine-preview-generated-at.json";
@@ -346,6 +347,11 @@ impl NativeEngineFiles {
         self.key_directory(key).join(binary_file_name())
     }
 
+    fn binary_signature(&self, key: &NativeEngineKey) -> PathBuf {
+        self.key_directory(key)
+            .join(format!("{}.minisig", binary_file_name()))
+    }
+
     fn data_directory(&self, key: &NativeEngineKey) -> PathBuf {
         self.key_directory(key).join("data")
     }
@@ -367,6 +373,14 @@ impl NativeEngineFiles {
 
     fn cache_blob(&self, sha256: &str) -> PathBuf {
         self.cache_directory().join(sha256)
+    }
+
+    fn log_directory(&self) -> PathBuf {
+        self.base.join(LOG_DIRECTORY)
+    }
+
+    fn startup_log(&self) -> PathBuf {
+        self.log_directory().join("server-startup.log")
     }
 
     fn spawn_record(&self) -> PathBuf {
@@ -612,22 +626,7 @@ fn ensure_native_engine_sync(
         None => resolve_artifact(app, &client, &files, &key)?,
     };
 
-    emit_progress(
-        app,
-        NativeEngineProgressPhase::DownloadingBinary,
-        Some(key.directory_name()),
-    );
-    let binary = fetch_bytes(&client, &resolved.binary_url)?;
-    let signature = fetch_bytes(&client, &resolved.binary_signature_url)?;
-    emit_progress(
-        app,
-        NativeEngineProgressPhase::Verifying,
-        Some("server binary".to_owned()),
-    );
-    verify_signature(&binary, &signature)?;
-    let binary_path = files.binary(&key);
-    write_atomically(&binary_path, &binary)?;
-    make_executable(&binary_path)?;
+    let binary_path = provision_binary(app, &client, &files, &key, &resolved)?;
 
     emit_progress(app, NativeEngineProgressPhase::DownloadingData, None);
     assemble_data(&client, Some(app), &files, &key, &resolved.data)?;
@@ -638,6 +637,8 @@ fn ensure_native_engine_sync(
         &binary_path,
         &files.data_directory(&key),
         &files.games_db(&key),
+        &files.log_directory(),
+        &files.startup_log(),
         port,
         key.origin(),
     )?;
@@ -766,6 +767,66 @@ fn fetch_verified_bytes(client: &Client, url: &str) -> Result<Vec<u8>, NativeEng
     let signature = fetch_bytes(client, &format!("{url}.minisig"))?;
     verify_signature(&bytes, &signature)?;
     Ok(bytes)
+}
+
+/// Reuses a previously verified server binary for the same typed key. The
+/// minisign signature is retained alongside the executable so every launch
+/// still verifies what it is about to execute; a missing or invalid cache is
+/// simply replaced from the first-party artifact source.
+fn provision_binary(
+    app: &AppHandle,
+    client: &Client,
+    files: &NativeEngineFiles,
+    key: &NativeEngineKey,
+    resolved: &ResolvedArtifact,
+) -> Result<PathBuf, NativeEngineError> {
+    let binary_path = files.binary(key);
+    if cached_binary_is_verified(files, key)? {
+        return Ok(binary_path);
+    }
+
+    emit_progress(
+        app,
+        NativeEngineProgressPhase::DownloadingBinary,
+        Some(key.directory_name()),
+    );
+    let binary = fetch_bytes(client, &resolved.binary_url)?;
+    let signature = fetch_bytes(client, &resolved.binary_signature_url)?;
+    emit_progress(
+        app,
+        NativeEngineProgressPhase::Verifying,
+        Some("server binary".to_owned()),
+    );
+    verify_signature(&binary, &signature)?;
+    write_atomically(&binary_path, &binary)?;
+    write_atomically(&files.binary_signature(key), &signature)?;
+    make_executable(&binary_path)?;
+    Ok(binary_path)
+}
+
+fn cached_binary_is_verified(
+    files: &NativeEngineFiles,
+    key: &NativeEngineKey,
+) -> Result<bool, NativeEngineError> {
+    cached_binary_is_verified_with_key(SERVER_ARTIFACT_PUBLIC_KEY, files, key)
+}
+
+fn cached_binary_is_verified_with_key(
+    public_key: &str,
+    files: &NativeEngineFiles,
+    key: &NativeEngineKey,
+) -> Result<bool, NativeEngineError> {
+    let binary = match fs::read(files.binary(key)) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(NativeEngineError::storage(error)),
+    };
+    let signature = match fs::read(files.binary_signature(key)) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(NativeEngineError::storage(error)),
+    };
+    Ok(verify_signature_with_key(public_key, &binary, &signature).is_ok())
 }
 
 fn fetch_bytes(client: &Client, url: &str) -> Result<Vec<u8>, NativeEngineError> {
@@ -1022,9 +1083,18 @@ fn spawn_server(
     binary: &Path,
     data_directory: &Path,
     games_db: &Path,
+    log_directory: &Path,
+    startup_log: &Path,
     port: u16,
     origin: &str,
 ) -> Result<(Child, ChildStdin), NativeEngineError> {
+    fs::create_dir_all(log_directory).map_err(NativeEngineError::storage)?;
+    let startup_log = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(startup_log)
+        .map_err(NativeEngineError::storage)?;
     let mut command = Command::new(binary);
     command
         .env("PORT", port.to_string())
@@ -1040,9 +1110,14 @@ fn spawn_server(
             "--allowed-origin",
             origin,
         ])
+        .arg("--log-dir")
+        .arg(log_directory)
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null());
+        // Early startup failures happen before phase-server initializes its
+        // structured logger. Keep the latest one beside its rolling logs so a
+        // server that exits before `/health` is diagnosable without a console.
+        .stderr(Stdio::from(startup_log));
 
     // The shell is a GUI-subsystem app but phase-server is console-subsystem, so
     // Windows would otherwise pop a console window for the child on every launch.
@@ -1535,6 +1610,23 @@ mod tests {
             verify_signature_with_key(TEST_PUBLIC_KEY, b"tampered", TEST_SIGNATURE.as_bytes())
                 .is_err()
         );
+    }
+
+    #[test]
+    fn cached_binary_requires_its_matching_signature() {
+        let files = test_files("binary-cache");
+        let key = release_key("1.2.3");
+        write_atomically(&files.binary(&key), TEST_BYTES).unwrap();
+        write_atomically(&files.binary_signature(&key), TEST_SIGNATURE.as_bytes()).unwrap();
+
+        assert!(cached_binary_is_verified_with_key(TEST_PUBLIC_KEY, &files, &key).unwrap());
+
+        write_atomically(&files.binary(&key), b"tampered").unwrap();
+        assert!(!cached_binary_is_verified_with_key(TEST_PUBLIC_KEY, &files, &key).unwrap());
+
+        remove_file_if_exists(&files.binary_signature(&key)).unwrap();
+        assert!(!cached_binary_is_verified_with_key(TEST_PUBLIC_KEY, &files, &key).unwrap());
+        fs::remove_dir_all(files.app_directory).unwrap();
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -91,6 +91,12 @@ type SharedPlayerCount = Arc<AtomicU32>;
 type SharedGameDb = Arc<persistence::GameDb>;
 type SharedDraftState = Arc<Mutex<DraftSessionManager>>;
 const SPECTATOR_PLAYER_ID: PlayerId = PlayerId(u8::MAX);
+#[cfg(windows)]
+// Windows gives the process' primary thread a comparatively small stack. A
+// persisted game is a deeply nested rules snapshot, so restore it on a
+// purpose-sized thread rather than letting one saved session prevent the
+// server from reaching its health endpoint on the next launch.
+const PERSISTED_SESSION_RESTORE_STACK_BYTES: usize = 16 * 1024 * 1024;
 type SharedDraftPools = Arc<draft_pools::DraftPools>;
 /// Spectator senders keyed by draft_code. Each spectator has a visibility + sender.
 type SharedDraftSpectators = Arc<
@@ -106,6 +112,30 @@ type SharedDraftSpectators = Arc<
 >;
 /// Spectator senders keyed by game code (live games only).
 type SharedGameSpectators = Arc<Mutex<HashMap<String, Vec<mpsc::UnboundedSender<ServerMessage>>>>>;
+
+#[cfg(windows)]
+fn restore_persisted_session(json: &str, db: SharedDb) -> Result<GameSession, String> {
+    let json = json.to_owned();
+    let restore = std::thread::Builder::new()
+        .name("phase-session-restore".to_owned())
+        .stack_size(PERSISTED_SESSION_RESTORE_STACK_BYTES)
+        .spawn(move || {
+            let persisted = serde_json::from_str::<server_core::PersistedSession>(&json)
+                .map_err(|error| error.to_string())?;
+            Ok(GameSession::from_persisted(persisted, db.as_ref()))
+        })
+        .map_err(|error| format!("could not start restore thread: {error}"))?;
+    restore
+        .join()
+        .map_err(|_| "persisted session restore thread panicked".to_owned())?
+}
+
+#[cfg(not(windows))]
+fn restore_persisted_session(json: &str, db: SharedDb) -> Result<GameSession, String> {
+    let persisted = serde_json::from_str::<server_core::PersistedSession>(json)
+        .map_err(|error| error.to_string())?;
+    Ok(GameSession::from_persisted(persisted, db.as_ref()))
+}
 
 async fn reserve_lobby_subscriber_slot(
     lobby_subscribers: &SharedLobbySubscribers,
@@ -1003,12 +1033,11 @@ async fn main() {
                 let mut restored = 0u32;
 
                 for (game_code, json) in &persisted_games {
-                    match serde_json::from_str::<server_core::PersistedSession>(json) {
-                        Ok(ps) => {
-                            let lobby_meta = ps.lobby_meta.clone();
-                            let is_started = ps.game_started;
-                            let session =
-                                server_core::session::GameSession::from_persisted(ps, db.as_ref());
+                    info!(game = %game_code, bytes = json.len(), "restoring persisted session");
+                    match restore_persisted_session(json, db.clone()) {
+                        Ok(session) => {
+                            let lobby_meta = session.lobby_meta.clone();
+                            let is_started = session.game_started;
 
                             // Register all non-AI human players as disconnected
                             // to start the 120s grace period from now


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved native server startup by reusing verified locally cached files when available.

* **Bug Fixes**
  * Improved restoration of persisted game sessions on Windows, including clearer handling of restoration failures.
  * Preserved eligible lobby registrations when restoring games that have not yet started.

* **Diagnostics**
  * Added startup logs to help investigate server launch failures before normal logging becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->