### PR TITLE
perf(test): cap the 3p loop-shortcut grind drives at the measured priming point

### DIFF
--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -19,7 +19,7 @@ use engine::analysis::decision_template::{
     TargetPin, TargetSchedule,
 };
 use engine::analysis::loop_check::{LoopCertificate, ShortcutProposal, ShortcutResponse, WinKind};
-use engine::analysis::resource::{BoardDelta, ResourceAxis};
+use engine::analysis::resource::{loop_states_equal_modulo_resources, BoardDelta, ResourceAxis};
 use engine::game::engine::{apply, EngineError};
 use engine::game::scenario::{GameRunner, GameScenario};
 use engine::types::ability::{Effect, TargetRef};
@@ -275,6 +275,55 @@ fn drive_collect(runner: &mut GameRunner, cap: usize) -> (Vec<GameEvent>, Waitin
         }
     }
     (all, runner.state().waiting_for.clone())
+}
+
+/// [`drive_collect`] plus a measured answer to "did the drive actually reach the board-recurrent
+/// regime inside `cap`?" — the third element is `true` once some prior in
+/// `GameState::loop_detect_ring` has compared equal to the live state modulo resources
+/// ([`loop_states_equal_modulo_resources`], the engine's own public predicate; the test does not
+/// reimplement recurrence).
+///
+/// Why that witnesses the classification: the sampler only pushes a prior while the stack is
+/// non-empty at a `Priority` beat, and `GameState`'s `PartialEq` compares both, so a ring hit
+/// forces the §3 bridge conjuncts (engine.rs) to have held at that state — i.e.
+/// `find_live_loop_winner` → `live_mandatory_loop_winner` ran on it. It is deliberately STRONGER
+/// than "the classifier ran": the classifier is called on every sampled beat, so a `false` here
+/// does not mean it never ran — it means the loop never recurred, which is the regime every
+/// no-crown assertion below assumes. Note the engine's own faller partition short-circuits
+/// (`nonfallers.len() != 1`, loop_check.rs) BEFORE its recurrence gate for these subset-lethal
+/// fixtures; the recurrence witnessed here is the state property, not that specific branch.
+///
+/// Only the equality disjunct is checked: the engine's gate is
+/// `loop_states_equal_modulo_resources || loop_states_cover_modulo_growth`, and the latter is
+/// `pub(crate)` (resource.rs), so an integration test cannot call it. Measured, both fixtures
+/// still hit the equality disjunct; a fixture that drifted entirely into the coverability regime
+/// would fail this guard and need it widened, not the cap raised.
+///
+/// Checked per beat, because recurrence is PHASE-dependent, not monotone: measured over caps
+/// {1, 2, 3, 4, 8, 24} it holds at 2 and 8 and not at 1/3/4/24 (period 6), so inspecting only
+/// the terminal state would report `false` on a perfectly primed loop. The scan short-circuits
+/// at the first hit — measured 5.6–17.5 ms per drive, priming at beat 2.
+fn drive_collect_primed(runner: &mut GameRunner, cap: usize) -> (Vec<GameEvent>, WaitingFor, bool) {
+    let mut all: Vec<GameEvent> = Vec::new();
+    let mut primed = false;
+    for _ in 0..cap {
+        if !matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. } | WaitingFor::OrderTriggers { .. }
+        ) {
+            break;
+        }
+        let (events, _) = drive_collect(runner, 1);
+        all.extend(events);
+        if !primed {
+            let state = runner.state();
+            primed = state
+                .loop_detect_ring
+                .iter()
+                .any(|prior| loop_states_equal_modulo_resources(prior, state));
+        }
+    }
+    (all, runner.state().waiting_for.clone(), primed)
 }
 
 // ────────────────────────────── T-OFF ──────────────────────────────
@@ -1122,11 +1171,26 @@ fn interactive_queued_opponent_concede_no_deadlock() {
 /// Across that whole swept range the PASS/FAIL verdict and every reach-guard of the three
 /// tests below are invariant, and each test's revert-probe still flips it to FAIL at every
 /// cap ≥ 4 (weakened `nonfallers.len() != 1`; bypassed E1-measure `live_mandatory_loop_winner`
-/// gate; removed F2 `fallers_lives_pairwise_equal` re-check). The loop is primed by beat ~4,
-/// so more beats buy zero discrimination and only burn wall clock; 24 is itself a swept value
-/// (6× margin over the measured priming point), not an interpolation. If the engine ever needs
-/// more beats to prime, the paired reach-guards ("P1 must have bled", "both opponents must
-/// have bled") FAIL LOUDLY instead of degrading silently.
+/// gate; removed F2 `fallers_lives_pairwise_equal` re-check). Board recurrence — the regime
+/// every assertion below assumes — is first observed at **beat 2** (measured over caps
+/// {1, 2, 3, 4, 8, 24}), so more beats buy zero discrimination and only burn wall clock; 24 is
+/// itself a swept value, 12× that priming point and 6× the smallest swept cap, not an
+/// interpolation.
+///
+/// The cap does NOT stand on the sweep alone: each test below carries an explicit
+/// [`drive_collect_primed`] guard that FAILS if the loop has not reached board recurrence inside
+/// the cap — proven discriminating by forcing this constant to 1, which flips all three tests to
+/// FAIL on that guard. That closes the cap-adequacy question, and only that.
+///
+/// It does NOT close a separate, pre-existing blind spot, and no cap does either. Measured:
+/// suppressing the live-detect bridge outright (make its `!loop_detect_ring.is_empty()` conjunct
+/// unreachable in engine.rs) leaves all three tests below GREEN at this cap AND at cap 500,
+/// while the offer-dependent `vito_2p_optional_offer_declare_crowns` and
+/// `interactive_queued_opponent_concede_no_deadlock` FAIL. The guard does not catch that either:
+/// the ring SAMPLER is a separate gate (engine.rs, `resolved_this_beat && …`) that the
+/// suppression does not touch, so the ring still fills and this guard still reports primed.
+/// A negative "did not crown" test cannot distinguish a refused classification from a disabled
+/// one; the positive-side tests named above are what cover it.
 const PRIMED_LOOP_BEATS: usize = 24;
 
 /// D2: a 3p loop that drains ONLY P1 (P2 a bystander, life delta 0) must NOT crown.
@@ -1146,7 +1210,7 @@ const PRIMED_LOOP_BEATS: usize = 24;
 fn interactive_3p_subset_lethal_does_not_crown() {
     let (mut runner, kickoff) = setup_3p_subset_lethal(LoopDetectionMode::Interactive);
     let _ = runner.cast(kickoff).resolve();
-    let (events, wf) = drive_collect(&mut runner, PRIMED_LOOP_BEATS);
+    let (events, wf, primed) = drive_collect_primed(&mut runner, PRIMED_LOOP_BEATS);
 
     // Positive reach-guard: the drain loop genuinely ran on P1 while P2 stayed untouched — we
     // are in the subset-lethal regime the gate must refuse, not an unrelated upstream no-op.
@@ -1176,6 +1240,19 @@ fn interactive_3p_subset_lethal_does_not_crown() {
     assert!(
         !matches!(wf, WaitingFor::LoopShortcut { .. }),
         "subset-lethal loop must NOT raise a LoopShortcut offer, got {wf:?}"
+    );
+
+    // Reach-guard on the regime itself (see `drive_collect_primed`): the drive really did reach
+    // a board-recurrent state, so `live_mandatory_loop_winner` ran on the subset-lethal loop the
+    // assertions above are about — they refused a real classification rather than never posing
+    // one. Deliberately LAST here: this test's classification and its wrongful-crown failure
+    // mode live in the same drive, so under the weakened-gate defect the crown must report as a
+    // crown (the `wf` assertion above) — measured, a guard placed first steals that panic (M1
+    // crowns at beat ~1, before recurrence) and reports the wrong cause.
+    assert!(
+        primed,
+        "the loop never reached a board-recurrent state within {PRIMED_LOOP_BEATS} beats — this \
+         is not the primed-loop regime the assertions above assume, so they passed vacuously"
     );
 }
 
@@ -1309,7 +1386,17 @@ fn vito_2p_optional_offer_declare_crowns() {
 fn injected_3p_one_faller_no_crown() {
     let (mut runner, kickoff) = setup_3p_subset_lethal(LoopDetectionMode::Interactive);
     let _ = runner.cast(kickoff).resolve();
-    let (_events, _wf) = drive_collect(&mut runner, PRIMED_LOOP_BEATS);
+    let (_events, _wf, primed) = drive_collect_primed(&mut runner, PRIMED_LOOP_BEATS);
+
+    // Reach-guard on the regime (see `drive_collect_primed`): the board reached a genuine
+    // recurrence, so the E1 clone-drive below has a real cycle to measure rather than an
+    // un-primed board. (It witnesses the live bridge's frame pair, not the E1 measure's own
+    // boundary/work pair — those are different frames.)
+    assert!(
+        primed,
+        "the loop never reached a board-recurrent state within {PRIMED_LOOP_BEATS} beats — the \
+         E1 measure below would have no primed cycle, so its no-crown assertion is vacuous"
+    );
 
     // Reach-guard: the drain loop genuinely ran (P1 bled, alive) and P2 is untouched — this
     // is the subset-lethal regime the E1 measure must refuse.
@@ -1507,11 +1594,11 @@ fn declare_illegal_pin_falls_back_legal_ingests() {
 fn injected_3p_unequal_life_pin_all_no_crown() {
     // Drive one primed cycle of a confirmed 3p both-fall drain and report the terminal
     // waiting_for.
-    fn drive_confirmed(p1_life: i32, p2_life: i32) -> WaitingFor {
+    fn drive_confirmed(p1_life: i32, p2_life: i32) -> (WaitingFor, bool) {
         let (mut runner, kickoff) =
             setup_3p_both_fall(LoopDetectionMode::Interactive, p1_life, p2_life);
         let _ = runner.cast(kickoff).resolve();
-        let (_events, _wf) = drive_collect(&mut runner, PRIMED_LOOP_BEATS);
+        let (_events, _wf, primed) = drive_collect_primed(&mut runner, PRIMED_LOOP_BEATS);
         // Reach-guard: both opponents bled equally (loop primed, both are fallers) and stay
         // pairwise-offset by the initial gap (equal deltas preserve the difference).
         assert!(
@@ -1536,11 +1623,20 @@ fn injected_3p_unequal_life_pin_all_no_crown() {
             })
             .expect("P0 declares UntilLethal");
         accept_all_opponents(&mut runner);
-        runner.state().waiting_for.clone()
+        (runner.state().waiting_for.clone(), primed)
     }
 
     // UNEQUAL absolute life (gap 50) ⇒ NO crown (F2 staggered-death veto).
-    let unequal = drive_confirmed(1000, 1050);
+    let (unequal, unequal_primed) = drive_confirmed(1000, 1050);
+    // Reach-guard on the regime (see `drive_collect_primed`) — asserted on THIS half only: the
+    // equal-life half below is measured to consume 0 beats (already crowned as the kick-off
+    // resolved), so it has no drive in which to recur. This is the half the F2 revert-probe
+    // flips, so the whole discriminator lives on the guarded side.
+    assert!(
+        unequal_primed,
+        "the loop never reached a board-recurrent state within {PRIMED_LOOP_BEATS} beats — this \
+         is not the ≥2-faller primed regime the assertions below assume"
+    );
     assert!(
         !matches!(unequal, WaitingFor::GameOver { winner: Some(_) }),
         "unequal-life ≥2-faller drain must NOT crown (CR 704.3 simultaneity), got {unequal:?}"
@@ -1551,7 +1647,7 @@ fn injected_3p_unequal_life_pin_all_no_crown() {
     );
 
     // EQUAL absolute life ⇒ CROWN (reach-guard: the F2 check is not always-reject).
-    let equal = drive_confirmed(1000, 1000);
+    let (equal, _) = drive_confirmed(1000, 1000);
     assert_eq!(
         equal,
         WaitingFor::GameOver { winner: Some(P0) },

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -194,6 +194,9 @@ fn setup_3p_draw(mode: LoopDetectionMode) -> (GameRunner, ObjectId) {
 /// partition each cycle: fallers = {P1}, non-fallers = {P0, P2} — so `live_mandatory_loop_winner`
 /// refuses to name a winner (CR 104.2a). P1 starts very high so it never dies inside the drive
 /// window: the test asserts the mid-loop grind (no crown), not a natural CR 704.5a death.
+/// The headroom is deliberate and far exceeds `PRIMED_LOOP_BEATS` — P1 ends the capped drive
+/// ~14 points below its 1000 start, hundreds of points from lethal. Do NOT trim it to match
+/// the cap; the slack is what keeps the no-death premise robust to engine drift.
 fn setup_3p_subset_lethal(mode: LoopDetectionMode) -> (GameRunner, ObjectId) {
     let mut scenario = GameScenario::new_n_player(3, 7);
     scenario.at_phase(Phase::PreCombatMain);
@@ -1099,6 +1102,33 @@ fn interactive_queued_opponent_concede_no_deadlock() {
 
 // ───────────── T-subset-lethal (D2 — nonfallers.len()==1 guard) ─────────────
 
+/// Drive cap for the three tests below. Measured beats actually consumed at this cap, per
+/// drive: `setup_3p_subset_lethal` **24/24** (both tests), `setup_3p_both_fall(1000, 1050)`
+/// **24/24**, `setup_3p_both_fall(1000, 1000)` **0/24**. The first three genuinely pay every
+/// beat — that bridge deliberately falls through to the pre-feature grind, so their drives
+/// never reach `drive_collect`'s terminal-state exit. The equal-life half is the exception and
+/// costs nothing at ANY cap: its loop is mandatory with a single non-faller, so the natural
+/// bridge already crowned `GameOver{Some(P0)}` while the kick-off resolved, and the drive
+/// returns on beat 0. That is pre-existing and cap-independent — it is why shrinking this
+/// constant speeds up three drives, not four.
+///
+/// Measured per-beat cost, `setup_3p_subset_lethal`: ~40 ms at invariant state (stack 1,
+/// 4 objects). `setup_3p_both_fall` is NOT flat — its stack grows 13 → 45 and its per-beat
+/// cost 78 → 152 ms over 200 beats — so its justification rests on verdict invariance, not on
+/// periodicity.
+///
+/// MEASURED — DO NOT CHANGE to a value outside the swept set {4, 8, 12, 16, 24, 32, 48, 64,
+/// 100} without re-running the cap sweep (an unswept *lowering* is as uncovered as a raise).
+/// Across that whole swept range the PASS/FAIL verdict and every reach-guard of the three
+/// tests below are invariant, and each test's revert-probe still flips it to FAIL at every
+/// cap ≥ 4 (weakened `nonfallers.len() != 1`; bypassed E1-measure `live_mandatory_loop_winner`
+/// gate; removed F2 `fallers_lives_pairwise_equal` re-check). The loop is primed by beat ~4,
+/// so more beats buy zero discrimination and only burn wall clock; 24 is itself a swept value
+/// (6× margin over the measured priming point), not an interpolation. If the engine ever needs
+/// more beats to prime, the paired reach-guards ("P1 must have bled", "both opponents must
+/// have bled") FAIL LOUDLY instead of degrading silently.
+const PRIMED_LOOP_BEATS: usize = 24;
+
 /// D2: a 3p loop that drains ONLY P1 (P2 a bystander, life delta 0) must NOT crown.
 /// `live_mandatory_loop_winner` (loop_check.rs) partitions living into fallers/non-fallers and
 /// requires `nonfallers.len() == 1` (CR 104.2a — determinate only when EVERY other living
@@ -1108,13 +1138,15 @@ fn interactive_queued_opponent_concede_no_deadlock() {
 /// pre-feature grind.
 ///
 /// REVERT-FAIL: weaken the `nonfallers.len() != 1` gate to an "any-faller wins" rewrite and
-/// this MANDATORY loop is wrongly crowned `GameOver{winner: Some(P0)}` — flipping the two
-/// no-crown assertions below. (Passes today, proving the gate holds.)
+/// this MANDATORY loop is wrongly crowned `GameOver{winner: Some(P0)}` — flipping the `wf`
+/// no-crown assertion below, which is the sole discriminator here: under that mutation the
+/// event-scan assertion measurably stays TRUE (no `GameOver{Some}` lands in the collected
+/// events) at every cap from 4 to 100. (Passes today, proving the gate holds.)
 #[test]
 fn interactive_3p_subset_lethal_does_not_crown() {
     let (mut runner, kickoff) = setup_3p_subset_lethal(LoopDetectionMode::Interactive);
     let _ = runner.cast(kickoff).resolve();
-    let (events, wf) = drive_collect(&mut runner, 500);
+    let (events, wf) = drive_collect(&mut runner, PRIMED_LOOP_BEATS);
 
     // Positive reach-guard: the drain loop genuinely ran on P1 while P2 stayed untouched — we
     // are in the subset-lethal regime the gate must refuse, not an unrelated upstream no-op.
@@ -1277,7 +1309,7 @@ fn vito_2p_optional_offer_declare_crowns() {
 fn injected_3p_one_faller_no_crown() {
     let (mut runner, kickoff) = setup_3p_subset_lethal(LoopDetectionMode::Interactive);
     let _ = runner.cast(kickoff).resolve();
-    let (_events, _wf) = drive_collect(&mut runner, 500);
+    let (_events, _wf) = drive_collect(&mut runner, PRIMED_LOOP_BEATS);
 
     // Reach-guard: the drain loop genuinely ran (P1 bled, alive) and P2 is untouched — this
     // is the subset-lethal regime the E1 measure must refuse.
@@ -1479,7 +1511,7 @@ fn injected_3p_unequal_life_pin_all_no_crown() {
         let (mut runner, kickoff) =
             setup_3p_both_fall(LoopDetectionMode::Interactive, p1_life, p2_life);
         let _ = runner.cast(kickoff).resolve();
-        let (_events, _wf) = drive_collect(&mut runner, 200);
+        let (_events, _wf) = drive_collect(&mut runner, PRIMED_LOOP_BEATS);
         // Reach-guard: both opponents bled equally (loop primed, both are fallers) and stay
         // pairwise-offset by the initial gap (equal deltas preserve the difference).
         assert!(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The three longest-running tests in the entire 21621-test corpus all live in `loop_shortcut.rs`, and all three spent ~99.9% of their wall clock in a `drive_collect` grind that runs *before* their assertions and never exits early. A cap sweep proves the grind buys zero discrimination past beat ~4, so this replaces the three cap literals with one measured shared constant — 49.7s/49.8s/56.1s → 2.4s/2.5s/4.8s, with every assertion, fixture, and revert-probe flip preserved.

## Files changed

- `crates/engine/tests/integration/loop_shortcut.rs` — new `PRIMED_LOOP_BEATS` const + 3 cap substitutions + doc corrections

## Track

Developer

## LLM

Model: claude-opus-4-5-20260514
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

None. No rules logic changes — test-runtime only. The three existing citations in touched doc comments (`CR 119.8`, `CR 104.2a`, `CR 704.5a`) survive verbatim; zero CR numbers added or removed (`git diff | grep -oE 'CR [0-9.]+'` on both `+` and `-` lines is empty). `docs/MagicCompRules.txt` is gitignored and absent from this worktree, so no new CR number could be verified — per CLAUDE.md, none was written.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

### Where the time went (measured, not estimated)

| probe | `drive_collect` | everything else |
|---|---|---|
| subset-lethal, 500 beats | **19.30s** | — |
| subset-lethal 500 + inject + declare + E1 drive | 19.32s | declare 3.3ms + accept/E1 **9.4ms** |
| both_fall(1000,1050), 200 beats + E1 | **22.19s** | declare 7.1ms + E1 **26.5ms** |

The behaviour actually under test costs 10–35ms. Per-beat cost is `record_loop_detect_sample()` (a full `normalize_for_loop` deep `GameState` clone, ring cap 16) plus `interactive_loop_bridge` rescanning all ≤16 priors twice — paid every beat, forever, because the subset-lethal bridge deliberately falls through to the pre-feature grind and so never reaches `drive_collect`'s terminal-state exit.

### Before / after

| test | before | after | speedup |
|---|---|---|---|
| `interactive_3p_subset_lethal_does_not_crown` | 49.672s | **2.389s** | 20.8× |
| `injected_3p_one_faller_no_crown` | 49.814s | **2.522s** | 19.8× |
| `injected_3p_unequal_life_pin_all_no_crown` | 56.062s | **4.813s** | 11.6× |

Debug build, contended (Tilt building concurrently) — upper bounds, and deliberately **not** encoded as a timing assertion.

### Why cap 24 preserves discrimination

Cap sweep over {4, 8, 12, 16, 24, 32, 48, 64, 100}, run on both a clean tree and one tree per defect:

- **Clean:** every assertion and every reach-guard `PASS` at **every** cap — including test 3's `eq_crowns` reach-guard and test 2's rolled-back `P2 == 20`.
- **Defective:** each test's revert-probe flips it to `FAIL` at **every** cap ≥ 4.

Behaviour is flat from beat 4 to beat 500, so the old 500/500/200 caps bought nothing. 24 is itself a swept value (6× margin over the measured ≤4 priming point), not an interpolation.

### Flip-proofs on the SHIPPED tests (not on probe copies)

The sweep above ran on temporary probe clones, so it was re-run against the real committed tests, one defect per build:

| defect (single mutation, reverted after) | shipped test | result |
|---|---|---|
| `loop_check.rs` — `nonfallers.len() != 1` weakened to any-faller-wins | `interactive_3p_subset_lethal_does_not_crown` | **FAILED 0.153s** — `:1165` "subset-lethal loop must NOT crown a winner (CR 104.2a), got GameOver { winner: Some(PlayerId(0)) }" |
| `engine.rs` — E1-measure `live_mandatory_loop_winner` gate bypassed | `injected_3p_one_faller_no_crown` | **FAILED 2.481s** — `:1338` "subset-lethal loop must NOT crown (CR 104.2a), got GameOver { winner: Some(PlayerId(0)) }" |
| `engine.rs` — F2 `fallers_lives_pairwise_equal` ≥2-faller re-check removed | `injected_3p_unequal_life_pin_all_no_crown` | **FAILED 4.634s** — `:1544` "unequal-life ≥2-faller drain must NOT crown (CR 704.3 simultaneity), got GameOver { winner: Some(PlayerId(0)) }" |

Every panic lands on the test's **intended discriminator**, not on a reach-guard — the optimized tests fail for the right reason, not incidentally. The production tree was verified pristine (`git diff --stat crates/engine/src/` empty) after each mutation.

### Non-vacuity

Stripping all comments from both `HEAD:` and the new file and diffing shows the *complete* non-comment delta is the new const plus three cap substitutions. Every assertion body and every fixture value (1000 / 1050 / 20, gap 50) is byte-identical.

### Commands

- `cargo nextest run -p engine -E 'test(interactive_3p_subset_lethal_does_not_crown) | test(injected_3p_one_faller_no_crown) | test(injected_3p_unequal_life_pin_all_no_crown)'` — 3 passed, 4.828s total (2.389 / 2.522 / 4.813)
- `cargo nextest run -p engine -E 'binary(integration) and test(loop_shortcut)'` — **69 passed**, 8.578s (also covers `loop_shortcut_activation` + `loop_shortcut_mana_engine`)
- `cargo clippy -p engine --all-targets -- -D warnings` — clean, 0 warnings
- `cargo fmt --all` — no reformat

All run in a dedicated worktree with its own `target/` (Tilt watches a different checkout, so `scripts/tilt-wait.sh` would return `3` = cannot-answer, not a failure).

## Gate A

Gate A PASS head=345b34be61ca53eeff81eab32698a2108c0e8904 base=2c6596de9360ef3e8d5df1c20e863631201253aa

## Anchored on

- `crates/engine/tests/integration/loop_shortcut.rs:1954` — `POISON_RIDER`, the file's existing convention of a file-scope `const` placed after a section banner, above its consuming tests (also `:2079`, `:2532`, `:2703`, `:4077`)
- `crates/engine/tests/integration/loop_shortcut.rs:253` — `drive_collect`, the unchanged shared driver whose `cap` argument is the only thing this PR re-values

## Final review-impl

Final review-impl PASS head=345b34be61ca53eeff81eab32698a2108c0e8904

## Claimed parse impact

None. No parser file touched, so no Gate A parser-combinator concern applies beyond the pre-commit gate output above.

## Scope Expansion

None. Two **pre-existing** doc errors surfaced during measurement and are corrected in place (no assertion body changed):

1. The M1 REVERT-FAIL note claimed the mutation flips "the two no-crown assertions". Measured: only the `wf` assertion discriminates — the event-scan stays `true` under that mutation at every cap 4…100. Now stated accurately. Fixing the assertion itself would require editing an assertion body, so it is disclosed rather than changed.
2. The equal-life half of `setup_3p_both_fall` consumes **0 beats** — its mandatory single-non-faller loop is already crowned by the natural bridge while the kick-off resolves. This is cap-independent, so it was equally true at the old cap 200. The const doc now carries measured per-drive beat counts (24/24, 24/24, 0/24) instead of a blanket claim.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated loop-driving scenarios to use a consistent priming interval and a fixed priming beat cap.
  * Added stronger assertions to ensure priming/loop reachability occurs within the cap, preventing vacuous no-crown outcomes.
  * Updated related injected-soundness test flows to be priming-aware and reflect the intended reachability behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->