### PR TITLE
fix(client): distinguish a permanent's mana abilities and render the unbounded-counter mark in the hover panel

### DIFF
--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -15,7 +15,9 @@ import { useCanHover } from "../../hooks/useCanHover.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useLongPress } from "../../hooks/useLongPress.ts";
+import { useUnboundedCounterTypes } from "../../hooks/useUnboundedCounterTypes.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
+import { renderDescription } from "../../utils/description.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { buildGrantedKeywordSources, buildPTSources } from "../../viewmodel/attribution.ts";
@@ -75,9 +77,6 @@ const ATTACHMENT_STACK_STEP_PX = 22;
 const HOVERED_CARD_Z_INDEX = 60;
 const HOVERED_ATTACHMENT_HOST_Z_INDEX = 80;
 const EMPTY_KEYWORD_BADGES: Keyword[] = [];
-// CR 732.2a / CR 701.34a: stable empty ref for the per-object ∞-counter selector so a
-// permanent with no unbounded counter (the dominant case) never re-renders on identity churn.
-const EMPTY_UNBOUNDED_COUNTERS: string[] = [];
 
 /**
  * CR 602.5: Maps an engine `AbilityBlockKind` to its i18n reason key. Pure
@@ -112,10 +111,15 @@ function BlockedAbilitiesBadge({ obj }: { obj: GameObject }) {
       </span>
       <GameplayTooltip>
         {blocked.map((entry, i) => {
-          const abilityName =
+          // CR 201.5: `~` is the engine's self-reference token; bind it to the host
+          // object so the badge reads the card's name, not a raw tilde.
+          const rawAbilityName =
             entry.ability_index < obj.abilities.length
               ? obj.abilities[entry.ability_index]?.description
               : undefined;
+          const abilityName = rawAbilityName
+            ? renderDescription(rawAbilityName, obj.name)
+            : undefined;
           const names = (entry.sources ?? [])
             .map((id) => objects?.[String(id)]?.name)
             .filter((n): n is string => !!n);
@@ -268,14 +272,7 @@ export const PermanentCard = memo(function PermanentCard({
   const isCopiedPermanent = useGameStore((s) =>
     (s.gameState?.derived?.copied_permanents ?? []).includes(objectId),
   );
-  // CR 732.2a / CR 701.34a: the counter-type keys the engine marks as ∞ (unbounded
-  // counter-growth loop) for this object. Values match the object's `counters` map keys
-  // (e.g. "charge"); the pill renders ∞ instead of ×N for any type in this set.
-  const unboundedCounterTypes = useGameStore(
-    (s) =>
-      s.gameState?.derived?.unbounded_counters?.[String(objectId)]
-      ?? EMPTY_UNBOUNDED_COUNTERS,
-  );
+  const unboundedCounterTypes = useUnboundedCounterTypes(objectId);
   const isManaPaymentPreviewSource = useGameStore((s) =>
     s.manaPaymentPreviewSourceIds.includes(objectId),
   );

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -1410,4 +1410,38 @@ describe("PermanentCard", () => {
     // Departed source is dropped — no fromSource span renders.
     expect(screen.queryByText(/\(from/)).not.toBeInTheDocument();
   });
+
+  // CR 201.5: the engine ships `~` as the self-reference token, so the blocked-ability
+  // tooltip must bind it to the host object's name (mirrors CardPreview, the other
+  // `blocked_abilities` consumer). Description is abridged from the reported Kilo board dump
+  // (object 110) and asserted against this fixture's own name: the engine text continues "Its
+  // controller may search their library for a basic land card, put it onto the battlefield,
+  // then shuffle." — elided because that tail carries no `~` and so moves neither assertion.
+  it("substitutes ~ with the source name in the blocked-ability tooltip", () => {
+    const gameState = makeState();
+    gameState.objects[1] = {
+      ...gameState.objects[1],
+      abilities: [
+        {
+          kind: "Activated",
+          cost: { type: "Tap" },
+          description: "{T}, Sacrifice ~: Destroy target land.",
+          effect: { type: "Destroy" },
+        },
+      ] satisfies GameObject["abilities"],
+      blocked_abilities: [
+        { ability_index: 0, sources: [1], type: "CantBeActivated" },
+      ],
+    };
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    renderPermanent();
+
+    // Reach-guard: the row rendered, so the negative below is not vacuous. `GameplayTooltip`
+    // portals to document.body, hence the body-scoped negative.
+    expect(
+      screen.getByText(/\{T\}, Sacrifice Test Creature: Destroy target land\./),
+    ).toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("~");
+  });
 });

--- a/client/src/components/card/ArtCropCard.tsx
+++ b/client/src/components/card/ArtCropCard.tsx
@@ -5,6 +5,7 @@ import type { PTColor } from "../../viewmodel/cardProps";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
+import { useUnboundedCounterTypes } from "../../hooks/useUnboundedCounterTypes.ts";
 import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import { CARD_BACK_URL } from "../../services/scryfall.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
@@ -25,19 +26,10 @@ const PT_COLORS: Record<PTColor, string> = {
   white: "text-[#111]",
 };
 
-// Stable empty ref so the unbounded-counter selector returns the same value when
-// absent, avoiding a spurious re-render every state tick (mirrors PermanentCard).
-const EMPTY_UNBOUNDED_COUNTERS: string[] = [];
-
 export const ArtCropCard = memo(function ArtCropCard({ objectId }: ArtCropCardProps) {
   const { t } = useTranslation("game");
   const obj = useGameStore((s) => s.gameState?.objects[objectId]);
-  // CR 732.2a / CR 701.34a: the counter-type keys the engine marks as ∞ (unbounded
-  // counter-growth loop) for this object. Same channel PermanentCard's full-card pill
-  // reads — both battlefield display modes must agree, or the ∞ silently drops in one.
-  const unboundedCounterTypes = useGameStore(
-    (s) => s.gameState?.derived?.unbounded_counters?.[String(objectId)] ?? EMPTY_UNBOUNDED_COUNTERS,
-  );
+  const unboundedCounterTypes = useUnboundedCounterTypes(objectId);
   const isMobile = useIsMobile();
   const inspectObject = useUiStore((s) => s.inspectObject);
   const isCompactHeight = useIsCompactHeight();

--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -14,11 +14,13 @@ import { useCardImage } from "../../hooks/useCardImage.ts";
 import type { SourcePrinting } from "../../hooks/useCardImage.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useEngineCardData, useCardParseDetails, useCardRulings, type ParsedItem } from "../../hooks/useEngineCardData.ts";
+import { useUnboundedCounterTypes } from "../../hooks/useUnboundedCounterTypes.ts";
 import { tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import type { CardRuling } from "../../services/engineRuntime.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore, type MobileHandGesture } from "../../stores/uiStore.ts";
+import { renderDescription } from "../../utils/description.ts";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
 import { RichLabel } from "../mana/RichLabel.tsx";
 import { CardArtFallback } from "./CardArtFallback.tsx";
@@ -1040,7 +1042,11 @@ function CardImagePreview({
       if (action.type !== "ActivateAbility") continue;
       const ability = obj.abilities[action.data.ability_index];
       if (!ability) continue;
-      const rawLabel = abilityLabel(ability);
+      // CR 201.5: the engine ships `~` as the self-reference token; substitute the host
+      // object's name BEFORE the `seen` dedup below so the dedup key stays 1:1 with what
+      // renders. Today Pentad Prism's hover preview reads
+      // "Activate — Remove a charge counter from ~".
+      const rawLabel = renderDescription(abilityLabel(ability), obj.name);
       if (!rawLabel || seen.has(rawLabel)) continue;
       seen.add(rawLabel);
       // CR 606.1: a Loyalty ability cost renders as a mana-font badge; strip
@@ -1334,6 +1340,10 @@ function CardInfoPanel({
   const transientContinuousEffects = useGameStore(
     (s) => s.gameState?.transient_continuous_effects,
   );
+  // CR 732.2a / CR 701.34a: the ∞ mark for this object. Same engine channel
+  // PermanentCard's pill and ArtCropCard's badge read — every counter display mode
+  // must agree, or the ∞ silently drops in one of them.
+  const unboundedCounterTypes = useUnboundedCounterTypes(obj.id);
   const deref = { objects, transientContinuousEffects };
   const keywordSources = buildGrantedKeywordSources(attribution, obj.id, deref);
   const ptSources = buildPTSources(attribution, obj.id, deref);
@@ -1433,10 +1443,15 @@ function CardInfoPanel({
       {(obj.blocked_abilities?.length ?? 0) > 0 && (
         <div className="mt-1 space-y-0.5 text-amber-300/90">
           {(obj.blocked_abilities ?? []).map((entry, i) => {
-            const abilityName =
+            // CR 201.5: same `~` binding as the activate read-out above — the blocked row
+            // shows the ability's own description, so it leaks the raw token otherwise.
+            const rawAbilityName =
               entry.ability_index < obj.abilities.length
                 ? obj.abilities[entry.ability_index]?.description
                 : undefined;
+            const abilityName = rawAbilityName
+              ? renderDescription(rawAbilityName, obj.name)
+              : undefined;
             const names = (entry.sources ?? [])
               .map((id) => objects?.[String(id)]?.name)
               .filter((n): n is string => !!n);
@@ -1496,13 +1511,19 @@ function CardInfoPanel({
       {/* Counters */}
       {counters.length > 0 && (
         <div className="mt-1 flex flex-wrap gap-x-3 text-gray-400">
-          {counters.map(([type, count]) => (
-            <CounterTooltip key={type} type={type} count={count}>
-              <span>
-                {formatCounterType(type)}: {count}
-              </span>
-            </CounterTooltip>
-          ))}
+          {counters.map(([type, count]) => {
+            // CR 732.2a / CR 701.34a: an accepted counter-growth loop pumps this counter
+            // unboundedly — render ∞ instead of the (still-finite) real count, and tell the
+            // tooltip so its summary can't contradict the row.
+            const isUnbounded = unboundedCounterTypes.includes(type);
+            return (
+              <CounterTooltip key={type} type={type} count={count} isUnbounded={isUnbounded}>
+                <span>
+                  {formatCounterType(type)}: {isUnbounded ? "∞" : count}
+                </span>
+              </CounterTooltip>
+            );
+          })}
         </div>
       )}
 

--- a/client/src/components/card/__tests__/CardPreview.test.tsx
+++ b/client/src/components/card/__tests__/CardPreview.test.tsx
@@ -471,7 +471,7 @@ describe("CardPreview blocked abilities", () => {
     });
     useGameStore.setState({ gameState, spellCosts: {} });
     useUiStore.setState({ inspectedObjectId: object.id, altHeld: false });
-    render(<CardPreview cardName="Grim Monolith" position={{ x: 20, y: 20 }} />);
+    return render(<CardPreview cardName={object.name} position={{ x: 20, y: 20 }} />);
   }
 
   it("renders both prohibiting source names when two sources block one ability", () => {
@@ -527,5 +527,181 @@ describe("CardPreview blocked abilities", () => {
     inspectWith(object);
 
     expect(screen.queryByText(/\(from/)).not.toBeInTheDocument();
+  });
+
+  // CR 201.5: the blocked row labels the ability with the engine's own description, which
+  // ships `~` as the self-reference token — the same leak the activate read-out above was
+  // fixed for. Description is abridged from the reported Kilo board dump (object 110): the
+  // engine text continues "Its controller may search their library for a basic land card, put
+  // it onto the battlefield, then shuffle." — elided because that tail carries no `~` and so
+  // moves neither assertion below.
+  it("substitutes ~ with the source name in the blocked-ability read-out", () => {
+    const object = battlefieldObject({
+      id: 110,
+      name: "Ghost Quarter",
+      abilities: [
+        {
+          description: "{T}, Sacrifice ~: Destroy target land.",
+          effects: [],
+          targets: [],
+          cost: { type: "Tap" },
+          timing: "AnyTime",
+          kind: "Activated",
+        },
+      ],
+      blocked_abilities: [
+        { ability_index: 0, sources: [201], type: "CantBeActivated" },
+      ],
+    });
+    const { container } = inspectWith(object, [
+      buildGameObject({ id: 201, name: "Needle A" }),
+    ]);
+
+    // Reach-guard: proves the row rendered at all, so the negative below is not vacuous.
+    expect(container.textContent).toContain("{T}, Sacrifice Ghost Quarter: Destroy target land.");
+    expect(container.textContent).not.toContain("~");
+  });
+});
+
+// CR 732.2a / CR 701.34a: the hover status box under the full card render is the
+// THIRD counter render site (after PermanentCard's pill and ArtCropCard's badge).
+// An accepted counter-growth ∞ loop marks the pumped counter in
+// `derived.unbounded_counters` and deliberately leaves the object's real count
+// finite (engine.rs `materialize_object_growth_shortcut`: "the object's real
+// counter count is NOT mutated ... this only marks the pill to render ∞"), so a
+// site that reads `obj.counters` alone shows a stale pre-shortcut number.
+//
+// Values taken from the real 4p playtest dump where the bug was observed
+// (`.kilo-dump/game-state-turn-1-2026-07-22T20-04-12-617Z.json`): Pentad Prism is
+// object 409 with `counters = {"charge": 2}`; accepting the Kilo/Freed/Relic
+// proliferate loop marks (409, charge) unbounded — asserted end-to-end from that
+// board by the engine test
+// `kilo_accept_marks_pentad_charge_as_unbounded_display_target`.
+//
+// Matched pair: the ONLY difference between the two cases is the engine mark, so
+// it is the discriminator.
+describe("CardPreview unbounded counters", () => {
+  function inspectPentadPrism(unbounded: string[] | null) {
+    const object = battlefieldObject({
+      id: 409,
+      name: "Pentad Prism",
+      counters: { charge: 2 },
+    });
+    const gameState = gameStateWithObject(object);
+    gameState.derived = unbounded ? { unbounded_counters: { 409: unbounded } } : {};
+    useGameStore.setState({ gameState, spellCosts: {} });
+    useUiStore.setState({ inspectedObjectId: object.id, altHeld: false });
+    return render(<CardPreview cardName="Pentad Prism" position={{ x: 20, y: 20 }} />);
+  }
+
+  it("renders ∞ for a counter the engine marks as unbounded", () => {
+    const { container } = inspectPentadPrism(["charge"]);
+
+    expect(container.textContent).toContain("charge: ∞");
+    expect(container.textContent).not.toContain("charge: 2");
+  });
+
+  it("renders the finite count when the counter is not marked unbounded", () => {
+    const { container } = inspectPentadPrism(null);
+
+    expect(container.textContent).toContain("charge: 2");
+    expect(container.textContent).not.toContain("∞");
+  });
+
+  // LOW: the ∞ row and its TOOLTIP must agree — a badge saying ∞ over a tooltip
+  // interpolating the finite count contradicts itself (mirrors ArtCropCard.test.tsx:353).
+  it("the ∞ status row's tooltip agrees with the badge", () => {
+    const { container } = inspectPentadPrism(["charge"]);
+
+    // `GameplayTooltip` renders its lines through `createPortal(…, document.body)`, so the
+    // summary is NOT inside `container` — query it via `screen`, exactly as the tooltip
+    // assertion this mirrors does (ArtCropCard.test.tsx:353-368). `container` still carries
+    // the badge, so both halves of the agreement are asserted against their real roots.
+    expect(container.textContent).toContain("charge: ∞");
+    expect(screen.getByText(/∞ charge counters/i)).toBeInTheDocument();
+    expect(screen.queryByText(/2 charge counters/i)).not.toBeInTheDocument();
+  });
+
+  // KNOWN GAP (F2), not desired behaviour: `grown_generic_counter_targets`
+  // (analysis/resource.rs:1330-1331) reads the BEFORE count off the live state, so the
+  // engine can mark an (object, counter) pair the object does not carry. Every display
+  // mode iterates `obj.counters`, so such a mark renders nowhere. The frontend must NOT
+  // synthesize a counter row the engine says does not exist; if the ∞ should be visible
+  // there, the ENGINE must decide it.
+  it("KNOWN GAP: a marked counter type the object does not carry renders nowhere (F2)", () => {
+    const { container } = inspectPentadPrism(["oil"]);
+
+    expect(container.textContent).toContain("charge: 2");
+    // "nowhere" is asserted against `document.body`, not `container`: `GameplayTooltip`
+    // portals its summary lines out of the RTL container (GameplayTooltip.tsx:86-107), so
+    // a container-scoped negative could not see a tooltip that DID render the ∞.
+    expect(document.body.textContent).not.toContain("∞");
+    expect(document.body.textContent).not.toContain("oil");
+  });
+});
+
+describe("CardPreview activate labels", () => {
+  function inspect(object: GameObject, abilityIndexes: number[]) {
+    useGameStore.setState({
+      gameState: gameStateWithObject(object),
+      legalActionsByObject: {
+        [String(object.id)]: abilityIndexes.map((ability_index) => ({
+          type: "ActivateAbility" as const,
+          data: { source_id: object.id, ability_index },
+        })),
+      },
+      spellCosts: {},
+    });
+    useUiStore.setState({ inspectedObjectId: object.id, altHeld: false });
+    return render(<CardPreview cardName={object.name} position={{ x: 20, y: 20 }} />);
+  }
+
+  // CR 201.5: the engine ships the self-reference as `~`; the hover panel must show the
+  // card's own name. Live defect on the reported Kilo board: Pentad Prism read
+  // "Activate — Remove a charge counter from ~".
+  it("substitutes ~ with the source name in the activate-label list", () => {
+    const object = battlefieldObject({
+      id: 409,
+      name: "Pentad Prism",
+      abilities: [
+        {
+          description: "Remove a charge counter from ~: Add one mana of any color.",
+          effects: [], targets: [], cost: { type: "RemoveCounter" },
+          timing: "AnyTime", kind: "Activated",
+        },
+      ],
+    });
+    const { container } = inspect(object, [0]);
+
+    expect(screen.getByText(/Remove a charge counter from Pentad Prism/)).toBeInTheDocument();
+    expect(container.textContent).not.toContain("~");
+  });
+
+  // MULTI-AUTHORITY HOSTILE (Identity/Provenance contract 1): two abilities whose cost
+  // text differs ONLY by the `~` token. `activateLabels` dedups on `rawLabel`, so
+  // substitution must happen BEFORE the dedup or the panel shows two rows that render
+  // identically — one of them still carrying a raw `~`.
+  it("collapses two rows whose cost text differs only by the ~ token", () => {
+    const object = battlefieldObject({
+      id: 409,
+      name: "Pentad Prism",
+      abilities: [
+        {
+          description: "Remove a charge counter from ~: Add one mana of any color.",
+          effects: [], targets: [], cost: { type: "RemoveCounter" },
+          timing: "AnyTime", kind: "Activated",
+        },
+        {
+          description: "Remove a charge counter from Pentad Prism: Add {C}.",
+          effects: [], targets: [], cost: { type: "RemoveCounter" },
+          timing: "AnyTime", kind: "Activated",
+        },
+      ],
+    });
+    const { container } = inspect(object, [0, 1]);
+
+    // Pre-fix the two raw labels differ => 2 rows, one showing `~`.
+    expect(screen.getAllByText(/Activate/)).toHaveLength(1);
+    expect(container.textContent).not.toContain("~");
   });
 });

--- a/client/src/hooks/useUnboundedCounterTypes.ts
+++ b/client/src/hooks/useUnboundedCounterTypes.ts
@@ -1,0 +1,29 @@
+import type { ObjectId } from "../adapter/types.ts";
+import { useGameStore } from "../stores/gameStore.ts";
+
+// CR 732.2a / CR 701.34a: stable empty ref so a permanent with no unbounded counter
+// (the dominant case) never re-renders on identity churn.
+const EMPTY_UNBOUNDED_COUNTERS: string[] = [];
+
+/**
+ * CR 732.2a / CR 701.34a: the counter-type keys the engine marks as `∞` for this
+ * object (`DerivedViews::unbounded_counters`). Keys match the object's `counters`
+ * map (e.g. "charge"). DISPLAY-only — the object's real counter count is
+ * deliberately left finite (`game/engine.rs::materialize_object_growth_shortcut`),
+ * so a site that reads `obj.counters` alone shows a stale pre-shortcut number.
+ *
+ * Subscribed today by exactly three render sites: `board/PermanentCard`,
+ * `card/ArtCropCard`, and `card/CardPreview`'s `CardInfoPanel`. Two counter render
+ * sites remain unsubscribed, each with a measured blocker:
+ *   - FU-A `controls/AttackTargetPicker` (`StackLabel`) — a chip stands for N grouped
+ *     objects and the mark is per object id, so it needs an `.every()` intersection
+ *     threaded through `groupByName`/`AttackerStack` (mirroring `isUnboundedPile`),
+ *     not a representative lookup, or it renders a FALSE `∞`.
+ *   - FU-B `hud/DialogAttachmentCard` — no component test file exists for it.
+ * Do not claim this hook covers every counter render site until both land.
+ */
+export function useUnboundedCounterTypes(objectId: ObjectId): string[] {
+  return useGameStore(
+    (s) => s.gameState?.derived?.unbounded_counters?.[String(objectId)] ?? EMPTY_UNBOUNDED_COUNTERS,
+  );
+}

--- a/client/src/utils/description.ts
+++ b/client/src/utils/description.ts
@@ -1,16 +1,17 @@
 /**
  * Render engine-provided ability descriptions for display.
  *
- * The engine uses `~` as the canonical self-reference token (CR 201.4b).
+ * The engine uses `~` as the canonical self-reference token (CR 201.5; the
+ * gained-ability sub-case is CR 201.5b, the granted-source exception CR 201.5a).
  * Trigger, replacement, and static descriptions reach the client with `~`
  * in place of the source card's name — e.g. "When ~ enters, draw a card."
  * This helper substitutes `~` back to the source's display name for
  * player-facing UI.
  *
- * Matches only the standalone token (word boundary or punctuation) so it
- * will not accidentally rewrite `~` that appears inside a longer
- * identifier — not that Oracle text uses tildes elsewhere, but the guard
- * keeps the substitution robust if that ever changes.
+ * Replaces EVERY `~` occurrence, unguarded — the engine emits the token only
+ * as a self-reference, and one description can carry several ("{T}, Sacrifice
+ * ~: ~ deals 1 damage"). Callers relying on that: costLabel.ts, CardPreview,
+ * PermanentCard, StackEntry, TargetingOverlay.
  */
 export function renderDescription(description: string, sourceName: string): string {
   return description.replace(/~/g, sourceName);

--- a/client/src/viewmodel/__tests__/costLabel.test.ts
+++ b/client/src/viewmodel/__tests__/costLabel.test.ts
@@ -9,6 +9,7 @@ import {
   formatAbilityCost,
   formatCost,
   spellCostDisplay,
+  stripLoyaltyCostPrefix,
 } from "../costLabel.ts";
 
 function makeObject(overrides: Partial<GameObject> = {}): GameObject {
@@ -202,6 +203,182 @@ describe("abilityChoiceLabel per-variant formatting", () => {
     const result = abilityChoiceLabel(action, object);
     expect(result.label).toBe("{T}");
     expect(result.description).toBe("Draw a card.");
+  });
+
+  it("attaches the engine's activation cost as a mana option's description (CR 602.1a)", () => {
+    const object = makeObject({
+      name: "Relic of Legends",
+      abilities: [
+        {
+          cost: { type: "Tap" },
+          description: "{T}: Add one mana of any color.",
+          is_mana_ability: true,
+          effect: {
+            type: "Mana",
+            produced: {
+              type: "AnyOneColor",
+              count: { type: "Fixed", value: 1 },
+              color_options: ["White", "Blue", "Black", "Red", "Green"],
+            },
+          },
+        } satisfies GameObject["abilities"][number],
+      ],
+    });
+    const action: GameAction = { type: "ActivateAbility", data: { source_id: 1, ability_index: 0 } };
+    const result = abilityChoiceLabel(action, object);
+
+    expect(result.label).toBe("Add one mana of any color");
+    // CR 602.1a: everything before the colon, taken from the engine's own description.
+    expect(result.description).toBe("{T}");
+  });
+
+  it("does not attach a cost line to a loyalty ability that adds mana (CR 605.1a — Chandra, Torch of Defiance)", () => {
+    const object = makeObject({
+      name: "Chandra, Torch of Defiance",
+      abilities: [
+        {
+          cost: { type: "Loyalty", amount: 1 },
+          description: "+1: Add {R}{R}.",
+          // Pinned so a fixture that silently MISSES the mana branch cannot pass: the
+          // branch is what produces `label === "Add {R}{R}"`. A fixture falling to the
+          // tail would get stripCostPrefix's bare-loyalty arm => "Add {R}{R}." (trailing
+          // period) and the label assertion below would fail. That second assertion —
+          // not any other test — is this test's reach-guard.
+          effect: { type: "Mana", produced: { type: "Fixed", colors: ["Red", "Red"] } },
+        } satisfies GameObject["abilities"][number],
+      ],
+    });
+    const action: GameAction = { type: "ActivateAbility", data: { source_id: 1, ability_index: 0 } };
+    const result = abilityChoiceLabel(action, object);
+
+    expect(result.label).toBe("Add {R}{R}");          // reach-guard: proves the mana branch ran
+    expect(result.description).toBeUndefined();       // CR 605.1a gate: no cost line
+
+    // Mirrors pages/GamePage.tsx (`label: description ?? stripLoyaltyCostPrefix(label)`,
+    // currently :2918, inside the badge branch opened at :2912). Replicated here because
+    // mounting GamePage is prohibitively expensive; if GamePage's expression changes,
+    // update this replica with it.
+    expect(result.description ?? stripLoyaltyCostPrefix(result.label)).toBe("Add {R}{R}");
+  });
+
+  it("treats an absent is_mana_ability flag as not a mana ability", () => {
+    const object = makeObject({
+      name: "Unflagged Mana Source",
+      abilities: [
+        {
+          // CR 605.1a: the engine's verdict is the flag. Absent must read as "not a mana
+          // ability" (viewmodel/cardActionChoice.ts:29-32), never as "probably yes".
+          cost: { type: "Tap" },
+          description: "{T}: Add one mana of any color.",
+          effect: {
+            type: "Mana",
+            produced: {
+              type: "AnyOneColor",
+              count: { type: "Fixed", value: 1 },
+              color_options: ["White", "Blue", "Black", "Red", "Green"],
+            },
+          },
+        } satisfies GameObject["abilities"][number],
+      ],
+    });
+    const action: GameAction = { type: "ActivateAbility", data: { source_id: 1, ability_index: 0 } };
+    const result = abilityChoiceLabel(action, object);
+
+    expect(result.label).toBe("Add one mana of any color");  // reach-guard: the mana branch ran
+    expect(result.description).toBeUndefined();
+  });
+
+  it('attaches no cost line to a mana ability the engine gave no description (no synthesized "Activate")', () => {
+    const object = makeObject({
+      name: "Descriptionless Mana Source",
+      abilities: [
+        {
+          // `TapCreatures` has no `formatCost` arm, so without the `&& ability.description`
+          // conjunct `abilityLabel` would fall through to `formatCost`'s
+          // `default: "Activate"` (costLabel.ts:289-290) and that literal word would render
+          // as this option's subtitle. Measured: dropping the conjunct yields "Activate".
+          cost: {
+            type: "TapCreatures",
+            requirement: { type: "Count", count: 1 },
+            filter: { type: "Any" },
+          },
+          is_mana_ability: true,
+          effect: {
+            type: "Mana",
+            produced: {
+              type: "AnyOneColor",
+              count: { type: "Fixed", value: 1 },
+              color_options: ["White", "Blue", "Black", "Red", "Green"],
+            },
+          },
+        } satisfies GameObject["abilities"][number],
+      ],
+    });
+    const action: GameAction = { type: "ActivateAbility", data: { source_id: 1, ability_index: 0 } };
+    const result = abilityChoiceLabel(action, object);
+
+    expect(result.label).toBe("Add one mana of any color");  // reach-guard: the mana branch ran
+    expect(result.description).toBeUndefined();
+    expect(result.description).not.toBe("Activate");
+  });
+
+  // CR 201.5: `~` binds to the object that has the ability. The NON-mana tail of
+  // `abilityChoiceLabel` feeds the same ability-choice modal (GamePage.tsx:2899 →
+  // ChoiceModal) as the mana branch above, so both must substitute or the modal shows one
+  // substituted row next to a raw-tilde one. Both fixtures are verbatim engine descriptions
+  // from the reported Kilo board dump
+  // (`.kilo-dump/game-state-turn-1-2026-07-22T20-04-12-617Z.json`, objects 110 and 7).
+  // Census population for every count in this test: that dump's 293 `kind: "Activated"`
+  // abilities — 22 leak `~` into the cost text, 20 into the effect text. Widening to all 368
+  // abilities (i.e. adding the 75 `kind: "Spell"` rows) gives 29/27 instead, so the two
+  // number sets must not be mixed.
+  it("substitutes ~ on the non-mana activated-ability path, in both label and description (CR 201.5)", () => {
+    const action: GameAction = { type: "ActivateAbility", data: { source_id: 1, ability_index: 0 } };
+
+    // Leak site 1 — the COST text, which becomes the option's `label`.
+    const ghostQuarter = abilityChoiceLabel(
+      action,
+      makeObject({
+        name: "Ghost Quarter",
+        abilities: [
+          {
+            cost: {
+              type: "Composite",
+              costs: [{ type: "Tap" }, { type: "Sacrifice", count: 1 }],
+            },
+            description:
+              "{T}, Sacrifice ~: Destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
+            // Not `Mana`, so this fixture provably reaches the tail and not the branch at :415.
+            effect: { type: "Destroy" },
+          } satisfies GameObject["abilities"][number],
+        ],
+      }),
+    );
+    expect(ghostQuarter.label).toBe("{T}, Sacrifice Ghost Quarter");
+    expect(ghostQuarter.description).toBe(
+      "Destroy target land. Its controller may search their library for a basic land card, put it onto the battlefield, then shuffle.",
+    );
+
+    // Leak site 2 — the EFFECT text, which becomes the option's `description` after
+    // `stripCostPrefix`. Disjoint from site 1 within that same `kind: "Activated"`
+    // population: none of the 293 leaks into both. (All 7 overlaps in the wider 29/27 figures
+    // are `kind: "Spell"` rows whose descriptions carry no colon, so `abilityLabel` and
+    // `stripCostPrefix` both fall through to the whole string.)
+    const hawkeye = abilityChoiceLabel(
+      action,
+      makeObject({
+        name: "Hawkeye, Avenging Archer",
+        abilities: [
+          {
+            cost: { type: "Tap" },
+            description: "{T}: ~ deals 1 damage to any target.",
+            effect: { type: "DealDamage" },
+          } satisfies GameObject["abilities"][number],
+        ],
+      }),
+    );
+    expect(hawkeye.label).toBe("{T}");
+    expect(hawkeye.description).toBe("Hawkeye, Avenging Archer deals 1 damage to any target.");
   });
 });
 

--- a/client/src/viewmodel/__tests__/manaAbilityOptionDiscrimination.test.ts
+++ b/client/src/viewmodel/__tests__/manaAbilityOptionDiscrimination.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import type { GameAction, GameObject } from "../../adapter/types.ts";
+import { buildGameObject } from "../../test/factories/gameObjectFactory.ts";
+import { abilityChoiceLabel } from "../costLabel.ts";
+
+/**
+ * Relic of Legends' two activated mana abilities, copied VERBATIM from the real
+ * 4-player playtest dump where the bug was observed
+ * (`.kilo-dump/game-state-turn-1-2026-07-22T20-04-12-617Z.json`,
+ * `gameState.objects["402"].abilities`) — the engine's own serialized surface,
+ * not a hand-authored approximation.
+ *
+ * Both abilities produce the identical `AnyOneColor × 1`; the ONLY discriminator
+ * the engine ships is the cost (`Tap` vs `TapCreatures{legendary creature you
+ * control}`) and the per-ability `description`.
+ */
+const RELIC_OF_LEGENDS_ABILITIES = [
+  {
+    kind: "Activated",
+    effect: {
+      type: "Mana",
+      produced: {
+        type: "AnyOneColor",
+        count: { type: "Fixed", value: 1 },
+        color_options: ["White", "Blue", "Black", "Red", "Green"],
+      },
+    },
+    cost: { type: "Tap" },
+    sub_ability: null,
+    duration: null,
+    description: "{T}: Add one mana of any color.",
+    target_prompt: null,
+    condition: null,
+    optional_targeting: false,
+    optional: false,
+    forward_result: false,
+    is_mana_ability: true,
+  },
+  {
+    kind: "Activated",
+    effect: {
+      type: "Mana",
+      produced: {
+        type: "AnyOneColor",
+        count: { type: "Fixed", value: 1 },
+        color_options: ["White", "Blue", "Black", "Red", "Green"],
+      },
+    },
+    cost: {
+      type: "TapCreatures",
+      requirement: { requirement: "count", count: 1 },
+      filter: {
+        type: "Typed",
+        type_filters: ["Creature"],
+        controller: "You",
+        properties: [{ type: "HasSupertype", value: "Legendary" }],
+      },
+    },
+    sub_ability: null,
+    duration: null,
+    description: "Tap an untapped legendary creature you control: Add one mana of any color.",
+    target_prompt: null,
+    condition: null,
+    optional_targeting: false,
+    optional: false,
+    forward_result: false,
+    is_mana_ability: true,
+  },
+] as unknown as GameObject["abilities"];
+
+function relicOfLegends(): GameObject {
+  return buildGameObject({
+    id: 402,
+    card_id: 402,
+    name: "Relic of Legends",
+    zone: "Battlefield",
+    card_types: { supertypes: [], core_types: ["Artifact"], subtypes: [] },
+    back_face: null,
+    abilities: RELIC_OF_LEGENDS_ABILITIES,
+  });
+}
+
+function activate(index: number): GameAction {
+  return { type: "ActivateAbility", data: { source_id: 402, ability_index: index } };
+}
+
+/** The rendered content of one ability-choice modal option (GamePage's ChoiceModal
+ *  renders `label` plus the secondary `description`). Two options are
+ *  distinguishable to the player iff this pair differs. */
+function renderedOption(object: GameObject, index: number): string {
+  const { label, description } = abilityChoiceLabel(activate(index), object);
+  return `${label}\u0000${description ?? ""}`;
+}
+
+describe("mana-ability activation options must be distinguishable (Relic of Legends)", () => {
+  it("gives each of a permanent's mana abilities its own rendered option", () => {
+    const object = relicOfLegends();
+
+    // Discriminating: the two options must NOT render identically, or the player
+    // cannot tell "tap Relic itself" from "tap an untapped legendary creature".
+    expect(renderedOption(object, 0)).not.toBe(renderedOption(object, 1));
+  });
+
+  it("surfaces each mana ability's own activation cost from the engine", () => {
+    const object = relicOfLegends();
+    const first = abilityChoiceLabel(activate(0), object);
+    const second = abilityChoiceLabel(activate(1), object);
+
+    // The engine is the only authority on what each cost is; the option must
+    // carry that engine-provided text, not just the (identical) produced mana.
+    const firstText = `${first.label} ${first.description ?? ""}`;
+    const secondText = `${second.label} ${second.description ?? ""}`;
+    expect(firstText).toContain("{T}");
+    expect(secondText).toContain("Tap an untapped legendary creature you control");
+  });
+
+  it("still tells the player what each ability produces", () => {
+    const object = relicOfLegends();
+    for (const index of [0, 1]) {
+      const { label, description } = abilityChoiceLabel(activate(index), object);
+      expect(`${label} ${description ?? ""}`).toContain("one mana of any color");
+    }
+  });
+});

--- a/client/src/viewmodel/costLabel.ts
+++ b/client/src/viewmodel/costLabel.ts
@@ -8,6 +8,7 @@ import type {
   SerializedAbilityCost,
 } from "../adapter/types.ts";
 import { getCrewPower, getSaddlePower } from "./keywordProps.ts";
+import { renderDescription } from "../utils/description.ts";
 
 // Converts Rust ManaCostShard variant names to MTG abbreviations.
 // This is the canonical bridge between engine serialization and display—
@@ -405,24 +406,67 @@ export function abilityChoiceLabel(
   if (action.type === "ActivateAbility") {
     const ability = object.abilities[action.data.ability_index];
     // For mana abilities, show what they produce (e.g., "Add {U}") instead of just the cost
+    // DELIBERATE SPLIT PREDICATE: this branch keys on the effect AST, NOT on the engine's
+    // `is_mana_ability` flag — only the `description` below is CR 605.1a-gated. Narrowing
+    // this predicate to the flag would push a Loyalty+Mana ability (Chandra, Torch of
+    // Defiance's `+1: Add {R}{R}`) down to the tail below, whose `stripCostPrefix` renders
+    // "Add {R}{R}." — a trailing period instead of today's "Add {R}{R}". Measured, not
+    // assumed. Leaving the label branch alone keeps the loyalty path byte-identical.
     if (ability?.effect?.type === "Mana" && ability.effect.produced) {
       const produced = ability.effect.produced;
+      // CR 605.1a: `is_mana_ability` is the ENGINE's mana-ability verdict
+      // (`game/mana_abilities.rs::is_mana_ability`) — it excludes loyalty abilities AND
+      // targeted mana effects (`multi_target` / embedded `Effect::Mana{target}`).
+      // Gate on the flag, never on the effect AST: a cost line under a LoyaltyBadge would
+      // double-render the cost that GamePage's `stripLoyaltyCostPrefix` exists to suppress.
+      // The flag is optional on the wire, so `=== true` treats absent as "not a mana
+      // ability" — the convention documented at `viewmodel/cardActionChoice.ts:29-32`.
+      // Second conjunct: only ENGINE-AUTHORED cost text is worth showing. With no
+      // description `abilityLabel` falls back to `formatCost`, which is partial over the
+      // engine's cost surface — 20 of the 32 `AbilityCost` variants have no arm and answer
+      // the literal word "Activate" (`TapCreatures` and `RemoveCounter` among them, i.e.
+      // exactly the costs on Relic of Legends' second ability and on Pentad Prism), and a
+      // `Composite`/`OneOf` with no `costs` answers "". `Sacrifice` and `Composite` DO have
+      // arms ("Sacrifice", "{T}, Sacrifice") — this conjunct is not about them.
+      // Descriptionless mana abilities are the engine-synthesized intrinsics
+      // (`database/synthesis.rs`, `game/layers.rs::basic_land_mana_ability`, and the
+      // `game/effects/token.rs` predefined-token abilities) — the wire sends Island with
+      // `description: null` — and every land with two or more basic land types carries one
+      // per type, so this conjunct is what keeps a dual/triome's already-distinct
+      // "Add {W}"/"Add {U}" options from each gaining an identical, uninformative "{T}".
+      // Known bounded gap: a permanent carrying two descriptionless mana abilities of the
+      // same produced shape (Treasure + Gold) still renders two identical options; the fix
+      // is engine-authored cost text, not a second frontend parse of the cost AST.
+      // CR 602.1a: the activation cost is everything before the colon — for two abilities
+      // producing identical mana it is the ONLY discriminator the engine ships.
+      // CR 201.5: `~` binds to the object that has the ability, which is `object` here.
+      const costLine =
+        ability.is_mana_ability === true && ability.description
+          ? renderDescription(abilityLabel(ability), object.name)
+          : undefined;
       if (produced.type === "Fixed" && produced.colors?.length) {
         const symbols = produced.colors.map((c) => `{${MANA_COLOR_ABBREVIATION[c] ?? c}}`).join("");
-        return { label: `Add ${symbols}` };
+        return { label: `Add ${symbols}`, description: costLine };
       }
       if (produced.type === "Colorless") {
-        return { label: "Add {C}" };
+        return { label: "Add {C}", description: costLine };
       }
       if (produced.type === "AnyOneColor") {
         const count = formatQuantity((produced as { count?: QuantityExpr | number }).count, 1);
         return {
           label: count === "1" ? "Add one mana of any color" : `Add ${count} mana of any one color`,
+          description: costLine,
         };
       }
     }
-    const label = abilityLabel(ability);
-    const description = ability?.description ? stripCostPrefix(ability.description) : undefined;
+    // CR 201.5: the non-mana tail feeds the SAME choice modal as the mana branch above and
+    // must bind `~` to the same object, or one row renders "Sacrifice Ghost Quarter" while
+    // the next renders "Sacrifice ~". Both halves leak in the live dump (29 abilities in the
+    // cost text, 27 in the effect text, e.g. "{T}: ~ deals 1 damage to any target.").
+    const label = renderDescription(abilityLabel(ability), object.name);
+    const description = ability?.description
+      ? renderDescription(stripCostPrefix(ability.description), object.name)
+      : undefined;
     return { label, description };
   }
   if (action.type === "CastSpell") {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Fixes two display-layer defects observed on a real 4-player board (Kilo, Apogee Mind / Freed from the Real / Relic of Legends / Pentad Prism): Relic of Legends' click prompt offered two byte-identical "Add one mana of any color" rows, and the hover status box kept showing a finite counter count after an accepted counter-growth shortcut while the battlefield pill and art-crop badge correctly showed `∞`. Both are frontend-only — the engine already ships every value needed, so **zero Rust changes**.

**BUG 1.** `abilityChoiceLabel` synthesised the option label from the produced mana alone and dropped the engine's per-ability `description`, so *any* permanent with two mana abilities of the same produced shape collapsed to one indistinguishable option. The engine already ships the discriminator: the CR 602.1a activation-cost text. It is now attached as the option's `description`, gated on the engine's own CR 605.1a verdict (`is_mana_ability === true`) **and** the presence of engine-authored text.

Both conjuncts are load-bearing and measured. Gating on `effect.type === "Mana"` instead would regress loyalty mana abilities (Chandra, Torch of Defiance `+1: Add {R}{R}`) by rendering a cost line next to the `+1` LoyaltyBadge — exactly what `stripLoyaltyCostPrefix` exists to suppress. Dropping `&& ability.description` would let `formatCost`'s fallback leak the literal word `"Activate"` as secondary text (20 of 32 `AbilityCost` variants have no explicit arm), and would put an identical uninformative `{T}` under every option of a dual/shock/triome land, whose labels (`Add {W}` / `Add {U}`) already discriminate.

**BUG 2.** `CardInfoPanel` was the one counter render site with no subscription to `DerivedViews::unbounded_counters`. The finite count is deliberate — `materialize_object_growth_shortcut` is documented display-only and is already covered end-to-end from this same dump by `kilo_accept_marks_pentad_charge_as_unbounded_display_target`. The twice-duplicated selector is extracted into `useUnboundedCounterTypes` and all three sites subscribe through it (a third copy-paste was the thing to avoid).

Also substitutes the engine's `~` self-reference token (CR 201.5) on the paths this change makes user-visible: `abilityChoiceLabel`'s non-mana tail, the hover activate list, and both blocked-ability read-outs. Without this, the same cost string would render substituted in the hover preview and raw in the choice modal — an inconsistency this PR would otherwise have introduced. Census over the reported dump: 22 of 293 `kind: "Activated"` abilities leak `~` into cost text, 20 into effect text.

## Files changed

- `client/src/viewmodel/costLabel.ts` — BUG 1 gate + cost line on all three `produced` sub-cases; `~` substitution on the non-mana tail
- `client/src/hooks/useUnboundedCounterTypes.ts` **(new)** — the extracted `∞`-mark selector
- `client/src/components/card/CardPreview.tsx` — BUG 2 in `CardInfoPanel`; `~` in the activate list and the blocked-ability read-out
- `client/src/components/board/PermanentCard.tsx` — migrated onto the hook; `~` in the blocked-ability tooltip
- `client/src/components/card/ArtCropCard.tsx` — migrated onto the hook
- `client/src/utils/description.ts` — corrected CR cite (201.4b → 201.5) and a doc block that claimed a word-boundary guard the code does not implement
- `client/src/viewmodel/__tests__/costLabel.test.ts`, `client/src/viewmodel/__tests__/manaAbilityOptionDiscrimination.test.ts` **(new)**, `client/src/components/card/__tests__/CardPreview.test.tsx`, `client/src/components/board/__tests__/PermanentCard.test.tsx` — tests

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

No engine code changed; these are the rules cited in the frontend comments this PR adds or corrects. All eight verified by grep against `docs/MagicCompRules.txt`.

- `CR 201.5` (`:1322`) — `~` means the object it is on; sub-cases `CR 201.5a` (`:1324`, granted) / `CR 201.5b` (`:1327`, gained)
- `CR 602.1a` (`:2516`) — the activation cost is everything before the colon; the discriminator this PR surfaces
- `CR 605.1a` (`:2683`) — mana-ability classification, incl. the "not a loyalty ability" exclusion the gate relies on
- `CR 606.1` (`:2711`) — loyalty abilities
- `CR 732.2a` (`:6372`) — shortcut proposal procedure, the origin of the `∞` mark
- `CR 701.34a` (`:3594`) — proliferate
- `CR 201.4b` (`:1310`) — **removed**: it is split-card name choice and never described this helper

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

All commands run in the PR's own worktree on the final rebased head `a0a6e24c4`, after `pnpm install --frozen-lockfile` (exit 0).

- `pnpm exec tsc --noEmit` — exit 0, no output
- `pnpm lint` — exit 0, `✖ 23 problems (0 errors, 23 warnings)`; identical to the pre-existing baseline, and **zero** warnings in any of the 10 touched files
- `pnpm vitest run` — exit 0, `Test Files 267 passed | 4 skipped (271)`, `Tests 2312 passed | 18 todo (2330)`, **0 failed**
- `./scripts/check-parser-combinators.sh <base>` — Gate A PASS (see below); vacuous by construction, no file under `crates/engine/src/parser/` changed
- Cargo checks — **not run, and not applicable**: this PR changes zero Rust files (`git diff --name-only | grep -c '^crates/'` → 0). Per repo policy, cargo is not run from a worktree while Tilt owns the main checkout's target lock.

**Test-count reconciliation.** Base `438cad092` measured 2318 tests. This PR adds 11 (8 planned + 3 from the review round). Upstream added 1 between `438cad092` and `2c6596de9`. 2318 + 11 + 1 = **2330**. ✅

**Non-vacuity (the reason to trust the above).** The two acceptance tests were written *first* and both bugs were reproduced at tip before any fix: 3 failing assertions with their negative controls passing — the controls passing is what makes them discriminating. Every behavioural claim in this PR was independently revert-probed by a reviewer who did not write the code: reverting each edit alone turns its own test red, and each failure was checked to be attributable to that edit rather than to an upstream conjunct. Measured examples:

| Reverted edit | Measured failure |
|---|---|
| `description: costLine` | `expected 'Add one mana of any color' not to be 'Add one mana of any color'` |
| `is_mana_ability === true` conjunct | loyalty option's description becomes `'+1'` |
| `&& ability.description` conjunct | description becomes the literal `'Activate'` |
| `∞` ternary in `CardInfoPanel` | `expected 'Artifactcharge: 2' to contain 'charge: ∞'` |
| `isUnbounded` prop **only** | the `∞` badge still renders, and the tooltip test alone fails — proving the prop, not the glyph, is that test's discriminator |
| `~` substitution on the non-mana tail | `expected '{T}, Sacrifice ~' to be '{T}, Sacrifice Ghost Quarter'` |

Fixtures are engine-serialized values copied verbatim from the reported dump (`objects["402"]` Relic of Legends, `["409"]` Pentad Prism, `["110"]` Ghost Quarter, `["7"]` Hawkeye), not hand-authored approximations.

## Gate A

Gate A PASS head=a0a6e24c4ce6521892747da658a21e3b71c0d712 base=2c6596de9360ef3e8d5df1c20e863631201253aa

## Anchored on

- `client/src/viewmodel/costLabel.ts:356,373,393,403` — four sibling branches of this same function already return `{ label, description }` with the CR-annotated secondary line; BUG 1 adds a fifth case to that established shape rather than a new convention.
- `client/src/components/board/PermanentCard.tsx:941` and `client/src/components/card/ArtCropCard.tsx:216` — the two render sites that already read the engine's `unbounded_counters` channel and pass `isUnbounded` to `CounterTooltip`; BUG 2 makes `CardInfoPanel` the third consumer of that exact pattern, via the selector extracted from these two.

## Final review-impl

Final review-impl PASS head=a0a6e24c4ce6521892747da658a21e3b71c0d712

Disclosure of exactly what ran when: `/review-impl` round 2 returned **READY TO COMMIT** (0 blocker / 0 high / 0 med, 3 low) against the pre-commit tree. Two of the three lows were comment-accuracy defects and were fixed; those fixes were then independently verified by a separate agent that re-derived every census figure itself and confirmed the diff was comment-only. The rebase onto `2c6596de9` touched no line of this PR (upstream's `CardPreview.tsx` edit is in `CardImagePreview`, disjoint from all four edit regions), and all three gates were re-run green afterwards on this head.

## Claimed parse impact

None.

## Scope Expansion

The review found that `abilityChoiceLabel`'s non-mana tail and two blocked-ability read-outs leaked a raw `~`. These were folded in rather than deferred: they are the same defect class, live in files already in scope, and `GamePage.tsx` was verified as the only production caller of `abilityChoiceLabel`, so a fix in the shared function is the root-cause fix rather than a per-caller guard. Leaving them would have shipped a self-inflicted inconsistency, since this PR is what makes the substituted form visible alongside the raw one.

Deliberately **not** in scope, each with a measured blocker:

- **FU-A** `components/controls/AttackTargetPicker` — a chip stands for N grouped objects while the mark is per object id, so it needs a per-counter-type `.every()` intersection threaded through `groupByName`/`AttackerStack` (mirroring `isUnboundedPile`). A representative-only lookup would render a **false `∞`**, which is strictly worse than today's missing one — the fail-safe direction `battlefieldProps.ts` already documents in-code.
- **FU-B** `components/hud/DialogAttachmentCard` — no component test file exists, so a change there could not be made discriminating.
- **FU-C** `OptionalEffectModal` / `TriggerOrderModal` / `ReplacementModal` render engine `description` raw (51 `replacement_definitions` + 13 `static_definitions` in the dump carry `~`). Different `WaitingFor` channel, different files, each needing its own fixture.
- **F1** the real fix for the residual below: an engine-authored `cost_text`, so the frontend stops splitting Oracle text on `":"` at all.

**Disclosed residual.** The `&& ability.description` conjunct means two *descriptionless* mana abilities sharing a produced shape still collapse. Measured, not assumed: the engine has six non-parser mana-ability constructors, and two pairs qualify — Treasure + Gold and Spawn + Powerstone (`game/effects/token.rs`), reachable because `apply_token_ability_payload` extends `obj.abilities` without dedup. Those shapes collapse identically **today**, so this is not a regression; dropping the conjunct would fix them at the cost of the dual-land and `"Activate"` regressions above. The right fix is engine-side (**F4**: give those four constructors a `.description(…)`; their CR 111.10 doc comments already hold the text), subsumed by F1.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unbounded counters now display as `∞` consistently in cards, previews, and tooltips.
  * Ability labels and blocked-ability messages now replace `~` with the relevant card or source name.
  * Improved activated-ability labels, including mana ability descriptions, costs, and distinct choices.
  * Prevented unsupported or missing unbounded counters from appearing in the interface.

* **Tests**
  * Added coverage for counter display, self-reference substitution, ability labeling, and mana ability selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->