### PR TITLE
feat: show temporary unblockable effects

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2719,6 +2719,13 @@ export interface DerivedViews {
    */
   battlefield_keyword_badges?: Record<string, Keyword[]>;
   /**
+   * CR 509.1b: live, until-end-of-turn `CantBeBlocked` grants keyed by
+   * recipient ObjectId-as-string. A null value means the grant remains live
+   * while its source is not a public, phased-in battlefield object, so the UI
+   * shows the badge without naming an unavailable source.
+   */
+  temporary_cant_be_blocked?: Record<string, ObjectId | null>;
+  /**
    * CR 613.2a + CR 707.2: battlefield permanents whose copiable values are
    * currently supplied by a copy effect (Clone, Phantasmal Image, Vesuvan
    * Doppelganger). Such a permanent renders identically to what it copied, so

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -140,7 +140,7 @@ function BlockedAbilitiesBadge({ obj }: { obj: GameObject }) {
 function CantBeBlockedBadge({ sourceName }: { sourceName?: string }) {
   const { t } = useTranslation("game");
   return (
-    <span className="group absolute bottom-1 left-1 z-30 inline-flex">
+    <span className="group absolute bottom-1 left-1/2 z-30 inline-flex -translate-x-1/2">
       <span
         className="flex items-center rounded bg-cyan-600/90 px-1 py-0.5 text-[10px] font-bold text-cyan-50 shadow ring-1 ring-cyan-200/60"
         aria-label={t("permanent.cantBeBlocked")}

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -134,6 +134,27 @@ function BlockedAbilitiesBadge({ obj }: { obj: GameObject }) {
   );
 }
 
+// CR 509.1b: compact display of the engine-authored temporary evasion marker.
+// The component only renders the derived map and resolves a supplied public
+// source object for its tooltip; it never determines whether blocking is legal.
+function CantBeBlockedBadge({ sourceName }: { sourceName?: string }) {
+  const { t } = useTranslation("game");
+  return (
+    <span className="group absolute bottom-1 left-1 z-30 inline-flex">
+      <span
+        className="flex items-center rounded bg-cyan-600/90 px-1 py-0.5 text-[10px] font-bold text-cyan-50 shadow ring-1 ring-cyan-200/60"
+        aria-label={t("permanent.cantBeBlocked")}
+      >
+        <span aria-hidden>↯</span>
+      </span>
+      <GameplayTooltip>
+        {t("permanent.cantBeBlocked")}
+        {sourceName ? ` ${t("preview.fromSource", { source: sourceName })}` : ""}
+      </GameplayTooltip>
+    </span>
+  );
+}
+
 // Subtype glyphs sit in the top-right of the peek (where the mana pips
 // would normally be) so the player can identify the attachment's role
 // without parsing the title. Glyph palette matches the original chip
@@ -260,6 +281,9 @@ export const PermanentCard = memo(function PermanentCard({
     (s) =>
       s.gameState?.derived?.battlefield_keyword_badges?.[String(objectId)]
       ?? EMPTY_KEYWORD_BADGES,
+  );
+  const temporaryCantBeBlockedSourceId = useGameStore(
+    (s) => s.gameState?.derived?.temporary_cant_be_blocked?.[String(objectId)],
   );
   // CR 613.2a + CR 707.2: whether a live copy effect supplies this permanent's
   // copiable values. Engine-classified because a copy of a permanent lives in a
@@ -571,6 +595,10 @@ export const PermanentCard = memo(function PermanentCard({
   const isCopy =
     !obj.face_down
     && ((obj.is_token === true && obj.display_source !== "Token") || isCopiedPermanent);
+  const temporaryCantBeBlockedSourceName =
+    temporaryCantBeBlockedSourceId == null
+      ? undefined
+      : gameObjects?.[String(temporaryCantBeBlockedSourceId)]?.name;
 
   // Filter out loyalty counters — shown separately as the loyalty badge
   const counters = Object.entries(obj.counters).filter((entry): entry is [string, number] => entry[1] != null && entry[0] !== "loyalty");
@@ -1049,6 +1077,10 @@ export const PermanentCard = memo(function PermanentCard({
         >
           {t("permanent.copy")}
         </div>
+      )}
+
+      {temporaryCantBeBlockedSourceId !== undefined && (
+        <CantBeBlockedBadge sourceName={temporaryCantBeBlockedSourceName} />
       )}
 
       {/* Debug-panel preview highlight — fuchsia neon ring + animated pulse.

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -207,6 +207,39 @@ describe("PermanentCard", () => {
     expect(screen.queryByText("Copy")).not.toBeInTheDocument();
   });
 
+  it("renders the engine-authored temporary can't-be-blocked badge with its public source", () => {
+    const gameState = makeState();
+    gameState.derived = { temporary_cant_be_blocked: { 1: 2 } };
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    renderPermanent();
+
+    expect(screen.getByLabelText("Can't be blocked")).toBeInTheDocument();
+    expect(screen.getByText("(from Test Equipment)")).toBeInTheDocument();
+  });
+
+  it("renders the engine-authored temporary can't-be-blocked badge on a face-down recipient without source attribution", () => {
+    const gameState = makeState();
+    gameState.objects[1].face_down = true;
+    gameState.derived = { temporary_cant_be_blocked: { 1: null } };
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    renderPermanent();
+
+    expect(screen.getByLabelText("Can't be blocked")).toBeInTheDocument();
+    expect(screen.queryByText(/\(from/)).not.toBeInTheDocument();
+  });
+
+  it("does not render a temporary can't-be-blocked badge without an engine marker", () => {
+    const gameState = makeState();
+    gameState.derived = {};
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+
+    renderPermanent();
+
+    expect(screen.queryByLabelText("Can't be blocked")).not.toBeInTheDocument();
+  });
+
   it("never badges a face-down permanent as a copy (CR 708.2)", () => {
     // A face-down permanent has only the characteristics its face-down rules
     // grant, so surfacing "Copy" would leak what it really is. The engine omits

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -214,8 +214,13 @@ describe("PermanentCard", () => {
 
     renderPermanent();
 
-    expect(screen.getByLabelText("Can't be blocked")).toBeInTheDocument();
-    expect(screen.getByText("(from Test Equipment)")).toBeInTheDocument();
+    const badge = screen.getByLabelText("Can't be blocked");
+    fireEvent.pointerEnter(badge.closest(".group")!);
+
+    expect(screen.getByRole("tooltip")).toBeVisible();
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Can't be blocked (from Test Equipment)",
+    );
   });
 
   it("renders the engine-authored temporary can't-be-blocked badge on a face-down recipient without source attribution", () => {
@@ -237,6 +242,7 @@ describe("PermanentCard", () => {
 
     renderPermanent();
 
+    expect(screen.getByLabelText("Test Creature")).toBeInTheDocument();
     expect(screen.queryByLabelText("Can't be blocked")).not.toBeInTheDocument();
   });
 

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -248,6 +248,7 @@
     "target": "Ziel",
     "copy": "Kopie",
     "copyTooltip": "Spielstein-Kopie einer echten Karte",
+    "cantBeBlocked": "Kann nicht geblockt werden",
     "ringBearer": "Ring",
     "ringBearerTooltip": "Ringträger",
     "hiddenAttachments": "+{{count}} more attached",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -249,6 +249,7 @@
     "sacrifice": "Sacrifice",
     "copy": "Copy",
     "copyTooltip": "Token copy of a real card",
+    "cantBeBlocked": "Can't be blocked",
     "ringBearer": "Ring",
     "ringBearerTooltip": "Ring-bearer",
     "hiddenAttachments": "+{{count}} more attached",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -248,6 +248,7 @@
     "target": "Objetivo",
     "copy": "Copia",
     "copyTooltip": "Ficha copia de una carta real",
+    "cantBeBlocked": "No puede ser bloqueada",
     "ringBearer": "Anillo",
     "ringBearerTooltip": "Portador del Anillo",
     "hiddenAttachments": "+{{count}} more attached",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -248,6 +248,7 @@
     "target": "Cible",
     "copy": "Copie",
     "copyTooltip": "Jeton-copie d'une vraie carte",
+    "cantBeBlocked": "Ne peut pas être bloquée",
     "ringBearer": "Anneau",
     "ringBearerTooltip": "Porteur de l'Anneau",
     "hiddenAttachments": "+{{count}} more attached",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -248,6 +248,7 @@
     "target": "Bersaglio",
     "copy": "Copia",
     "copyTooltip": "Copia pedina di una carta reale",
+    "cantBeBlocked": "Non può essere bloccata",
     "ringBearer": "Anello",
     "ringBearerTooltip": "Portatore dell'Anello",
     "hiddenAttachments": "+{{count}} more attached",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -248,6 +248,7 @@
     "target": "Cel",
     "copy": "Kopia",
     "copyTooltip": "Kopia tokenowa prawdziwej karty",
+    "cantBeBlocked": "Nie może zostać zablokowana",
     "ringBearer": "Pierścień",
     "ringBearerTooltip": "Powiernik Pierścienia",
     "hiddenAttachments": "+{{count}} more attached",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -248,6 +248,7 @@
     "target": "Alvo",
     "copy": "Cópia",
     "copyTooltip": "Cópia em ficha de uma carta real",
+    "cantBeBlocked": "Não pode ser bloqueada",
     "ringBearer": "Anel",
     "ringBearerTooltip": "Portador do Anel",
     "hiddenAttachments": "+{{count}} more attached",

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -20,9 +20,10 @@ use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::game_object::AttachTarget;
 use crate::game::stack::{effective_stack_ability, stack_display_groups, StackDisplayGroup};
 use crate::types::ability::{
-    ContinuousModification, GameRestriction, KeywordAction, ProhibitedActivity, RestrictionExpiry,
-    RestrictionPlayerScope, TargetRef,
+    ContinuousModification, Duration, GameRestriction, KeywordAction, ProhibitedActivity,
+    RestrictionExpiry, RestrictionPlayerScope, TargetRef,
 };
+use crate::types::attribution::EffectRef;
 use crate::types::card::TokenImageRef;
 use crate::types::counter::CounterType;
 use crate::types::events::GameEvent;
@@ -32,6 +33,7 @@ use crate::types::game_state::{
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
+use crate::types::layers::Layer;
 use crate::types::mana::ManaCost;
 use crate::types::player::PlayerId;
 use crate::types::statics::StaticMode;
@@ -221,6 +223,15 @@ pub struct DerivedViews {
     /// keyword.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub battlefield_keyword_badges: HashMap<ObjectId, Vec<Keyword>>,
+
+    /// CR 509.1b + CR 611.2c: creatures with a live, temporary
+    /// `CantBeBlocked` grant. The optional value is the granting source only
+    /// while that source remains a public, phased-in battlefield object; `None`
+    /// retains the badge without exposing an unavailable source.
+    ///
+    /// Keyed by recipient ObjectId; absent when no such grant is active.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub temporary_cant_be_blocked: HashMap<ObjectId, Option<ObjectId>>,
 
     /// CR 613.2a + CR 707.2: battlefield permanents whose copiable values are
     /// currently supplied by a copy effect (Layer 1a) — Clone, Phantasmal
@@ -525,6 +536,49 @@ fn object_has_copy_effect(state: &GameState, object_id: ObjectId) -> bool {
     })
 }
 
+/// CR 509.1b + CR 611.2c + CR 613.1f: return the public source for the first
+/// live, until-end-of-turn `CantBeBlocked` modification attributed to this
+/// recipient in the current ability layer. `Some(None)` means the grant is
+/// active but its source is no longer a public, phased-in battlefield object.
+///
+/// Attribution is the layer engine's authoritative record of modifications
+/// that actually applied. Reading its indexed `EffectRef` avoids re-scanning
+/// raw effect filters, which could disagree with the resolved layer recipient.
+fn temporary_cant_be_blocked_source(
+    state: &GameState,
+    object_id: ObjectId,
+) -> Option<Option<ObjectId>> {
+    let effects = state
+        .attribution
+        .get(&object_id)?
+        .by_layer
+        .get(&Layer::Ability)?;
+    effects.iter().find_map(|effect_ref| {
+        let EffectRef::Transient { id, mod_index } = effect_ref else {
+            return None;
+        };
+        let effect = state
+            .transient_continuous_effects
+            .iter()
+            .find(|effect| effect.id == *id)?;
+        (effect.duration == Duration::UntilEndOfTurn
+            && crate::game::layers::transient_effect_is_live(state, effect)
+            && matches!(
+                effect.modifications.get(*mod_index),
+                Some(ContinuousModification::AddStaticMode {
+                    mode: StaticMode::CantBeBlocked
+                })
+            ))
+        .then(|| {
+            state
+                .objects
+                .get(&effect.source_id)
+                .filter(|source| source.zone == Zone::Battlefield && source.is_phased_in())
+                .map(|_| effect.source_id)
+        })
+    })
+}
+
 pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews {
     let mut views = DerivedViews {
         unique_authorized_submitter: unique_authorized_submitter(state),
@@ -561,6 +615,9 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
             .collect();
         if !badges.is_empty() {
             views.battlefield_keyword_badges.insert(obj_id, badges);
+        }
+        if let Some(source_id) = temporary_cant_be_blocked_source(state, obj_id) {
+            views.temporary_cant_be_blocked.insert(obj_id, source_id);
         }
         // CR 613.2a + CR 707.2 / CR 708.2: see `copied_permanents`. Matched
         // through the same `matches_target_filter` the layer engine uses to

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1117,6 +1117,7 @@ mod taii_wakeen;
 mod tamiyo_inquisitive_student_flip;
 mod teamwork_keyword;
 mod teferis_puzzle_box_4241;
+mod temporary_cant_be_blocked_view;
 mod tergrid_mirrormade_copy_on_effect_entry;
 mod the_mind_stone_harness_infinity;
 mod there_are_no_permanents_state_trigger;

--- a/crates/engine/tests/integration/temporary_cant_be_blocked_view.rs
+++ b/crates/engine/tests/integration/temporary_cant_be_blocked_view.rs
@@ -5,6 +5,7 @@ use engine::game::derived_views::{
     derive_filtered_views, derive_views, ClientGameState, ClientGameStateRef,
 };
 use engine::game::filter_state_for_viewer;
+use engine::game::functioning_abilities::active_static_definitions;
 use engine::game::game_object::PhaseOutCause;
 use engine::game::layers::evaluate_layers;
 use engine::game::phasing::phase_out_object;
@@ -66,15 +67,19 @@ fn derives_only_the_live_until_end_of_turn_cant_be_blocked_attribution() {
     );
     evaluate_layers(runner.state_mut());
 
+    let state = runner.state();
     assert!(
-        runner.state().objects[&recipient]
-            .static_definitions
-            .iter()
+        active_static_definitions(state, &state.objects[&recipient])
             .any(|definition| definition.mode == StaticMode::CantBeBlocked),
         "reach guard: Layer 6 applied the temporary CantBeBlocked modification"
     );
+    assert!(
+        active_static_definitions(state, &state.objects[&permanent_recipient])
+            .any(|definition| definition.mode == StaticMode::CantBeBlocked),
+        "reach guard: Layer 6 applied the permanent CantBeBlocked modification"
+    );
 
-    let views = derive_views(runner.state(), None);
+    let views = derive_views(state, None);
     assert_eq!(
         views.temporary_cant_be_blocked.get(&recipient),
         Some(&Some(source)),

--- a/crates/engine/tests/integration/temporary_cant_be_blocked_view.rs
+++ b/crates/engine/tests/integration/temporary_cant_be_blocked_view.rs
@@ -1,0 +1,297 @@
+//! CR 509.1b + CR 611.2c + CR 613.1f: client projection for temporary
+//! `CantBeBlocked` grants, sourced only from current Layer 6 attribution.
+
+use engine::game::derived_views::{
+    derive_filtered_views, derive_views, ClientGameState, ClientGameStateRef,
+};
+use engine::game::filter_state_for_viewer;
+use engine::game::game_object::PhaseOutCause;
+use engine::game::layers::evaluate_layers;
+use engine::game::phasing::phase_out_object;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zones::move_to_zone;
+use engine::types::ability::{ContinuousModification, Duration, TargetFilter};
+use engine::types::attribution::EffectRef;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::layers::Layer;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+use engine::types::zones::Zone;
+
+fn grant_cant_be_blocked_until_end_of_turn(
+    state: &mut GameState,
+    source: engine::types::identifiers::ObjectId,
+    recipient: engine::types::identifiers::ObjectId,
+) {
+    state.add_transient_continuous_effect(
+        source,
+        P0,
+        Duration::UntilEndOfTurn,
+        TargetFilter::SpecificObject { id: recipient },
+        vec![
+            ContinuousModification::AddPower { value: 1 },
+            ContinuousModification::AddStaticMode {
+                mode: StaticMode::CantBeBlocked,
+            },
+        ],
+        None,
+    );
+}
+
+#[test]
+fn derives_only_the_live_until_end_of_turn_cant_be_blocked_attribution() {
+    let mut scenario = GameScenario::new();
+    let source = scenario.add_creature(P0, "Grant Source", 0, 1).id();
+    let recipient = scenario.add_creature(P0, "Grant Recipient", 2, 2).id();
+    let permanent_source = scenario.add_creature(P0, "Permanent Grant", 0, 1).id();
+    let permanent_recipient = scenario.add_creature(P0, "Permanent Recipient", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // The leading P/T modification proves the projection follows the exact
+    // recorded `mod_index`, not merely the owning transient effect.
+    grant_cant_be_blocked_until_end_of_turn(runner.state_mut(), source, recipient);
+    runner.state_mut().add_transient_continuous_effect(
+        permanent_source,
+        P0,
+        Duration::Permanent,
+        TargetFilter::SpecificObject {
+            id: permanent_recipient,
+        },
+        vec![ContinuousModification::AddStaticMode {
+            mode: StaticMode::CantBeBlocked,
+        }],
+        None,
+    );
+    evaluate_layers(runner.state_mut());
+
+    assert!(
+        runner.state().objects[&recipient]
+            .static_definitions
+            .iter()
+            .any(|definition| definition.mode == StaticMode::CantBeBlocked),
+        "reach guard: Layer 6 applied the temporary CantBeBlocked modification"
+    );
+
+    let views = derive_views(runner.state(), None);
+    assert_eq!(
+        views.temporary_cant_be_blocked.get(&recipient),
+        Some(&Some(source)),
+        "the first matching live UET AddStaticMode attribution carries its battlefield source"
+    );
+    assert!(
+        !views
+            .temporary_cant_be_blocked
+            .contains_key(&permanent_recipient),
+        "a permanent CantBeBlocked grant must not be presented as temporary"
+    );
+}
+
+#[test]
+fn wrapper_round_trip_keeps_the_badge_but_hides_a_departed_source() {
+    let mut scenario = GameScenario::new();
+    let source = scenario.add_creature(P0, "Grant Source", 0, 1).id();
+    let recipient = scenario.add_creature(P0, "Grant Recipient", 2, 2).id();
+    let mut runner = scenario.build();
+    grant_cant_be_blocked_until_end_of_turn(runner.state_mut(), source, recipient);
+    evaluate_layers(runner.state_mut());
+
+    let source_owner = runner.state().objects[&source].owner;
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), source, Zone::Graveyard, &mut events);
+    assert_eq!(
+        runner.state().objects[&source].owner,
+        source_owner,
+        "reach guard: moving the source preserves the tracked source object"
+    );
+    evaluate_layers(runner.state_mut());
+
+    let direct = derive_views(runner.state(), Some(P1));
+    assert_eq!(
+        direct.temporary_cant_be_blocked.get(&recipient),
+        Some(&None),
+        "the live grant keeps its recipient badge but withholds a non-battlefield source"
+    );
+
+    let filtered = filter_state_for_viewer(runner.state(), P1);
+    let filtered_views = derive_filtered_views(runner.state(), &filtered, Some(P1));
+    assert_eq!(
+        filtered_views.temporary_cant_be_blocked.get(&recipient),
+        Some(&None),
+        "filtered derivation uses the public filtered state and preserves the source-less badge"
+    );
+
+    let json = serde_json::to_string(&ClientGameStateRef::wrap_filtered(
+        runner.state(),
+        &filtered,
+        Some(P1),
+    ))
+    .expect("serialize filtered client state");
+    let wire: serde_json::Value = serde_json::from_str(&json).expect("inspect client wire shape");
+    assert!(
+        wire["derived"]["temporary_cant_be_blocked"]
+            .get(recipient.0.to_string())
+            .is_some_and(serde_json::Value::is_null),
+        "the wire map represents a departed source as null rather than leaking its id"
+    );
+    let round: ClientGameState = serde_json::from_str(&json).expect("deserialize client state");
+    assert_eq!(
+        round.derived.temporary_cant_be_blocked.get(&recipient),
+        Some(&None),
+        "the owned client wrapper round-trips the source-less badge"
+    );
+
+    let empty_json = serde_json::to_string(&ClientGameStateRef::wrap(
+        &GameState::new_two_player(42),
+        None,
+    ))
+    .expect("serialize empty client state");
+    assert!(
+        !empty_json.contains("temporary_cant_be_blocked"),
+        "the empty temporary map is omitted from the wire payload"
+    );
+}
+
+#[test]
+fn phased_out_source_keeps_the_badge_but_hides_its_attribution() {
+    let mut scenario = GameScenario::new();
+    let source = scenario.add_creature(P0, "Grant Source", 0, 1).id();
+    let recipient = scenario.add_creature(P0, "Grant Recipient", 2, 2).id();
+    let mut runner = scenario.build();
+    grant_cant_be_blocked_until_end_of_turn(runner.state_mut(), source, recipient);
+    evaluate_layers(runner.state_mut());
+
+    let mut events = Vec::new();
+    phase_out_object(
+        runner.state_mut(),
+        source,
+        PhaseOutCause::Directly,
+        &mut events,
+    );
+    evaluate_layers(runner.state_mut());
+
+    assert!(
+        runner.state().objects[&source].is_phased_out(),
+        "reach guard: the source remains in the battlefield zone while phased out"
+    );
+    assert_eq!(
+        derive_views(runner.state(), None)
+            .temporary_cant_be_blocked
+            .get(&recipient),
+        Some(&None),
+        "a phased-out source is not public attribution for a still-live temporary grant"
+    );
+}
+
+#[test]
+fn first_departed_grant_withholds_later_public_source_attribution() {
+    let mut scenario = GameScenario::new();
+    let first_source = scenario.add_creature(P0, "First Grant Source", 0, 1).id();
+    let later_source = scenario.add_creature(P0, "Later Grant Source", 0, 1).id();
+    let recipient = scenario.add_creature(P0, "Grant Recipient", 2, 2).id();
+    let mut runner = scenario.build();
+    grant_cant_be_blocked_until_end_of_turn(runner.state_mut(), first_source, recipient);
+    grant_cant_be_blocked_until_end_of_turn(runner.state_mut(), later_source, recipient);
+    evaluate_layers(runner.state_mut());
+
+    let mut events = Vec::new();
+    move_to_zone(
+        runner.state_mut(),
+        first_source,
+        Zone::Graveyard,
+        &mut events,
+    );
+    evaluate_layers(runner.state_mut());
+
+    assert!(
+        runner.state().objects[&later_source].is_phased_in(),
+        "reach guard: the later matching source remains public"
+    );
+    assert_eq!(
+        derive_views(runner.state(), None)
+            .temporary_cant_be_blocked
+            .get(&recipient),
+        Some(&None),
+        "the first matching grant remains authoritative, so its departed source withholds attribution instead of falling through to a later source"
+    );
+}
+
+const ROGUES_PASSAGE_ORACLE: &str =
+    "{T}: Add {C}.\n{4}, {T}: Target creature can't be blocked this turn.";
+
+/// CR 509.1b + CR 611.2c + CR 613.1f + CR 514.2: a resolved Rogues Passage
+/// activation registers a target-bound, Layer 6 `CantBeBlocked` grant, which
+/// remains client-visible only through this turn's cleanup.
+#[test]
+fn rogues_passage_activation_projects_only_its_target_until_cleanup() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let passage = scenario
+        .add_land_from_oracle(P0, "Rogues Passage", ROGUES_PASSAGE_ORACLE)
+        .id();
+    let target = scenario.add_creature(P0, "Target Creature", 2, 2).id();
+    let non_target = scenario.add_creature(P0, "Non-target Creature", 2, 2).id();
+    scenario.with_mana_pool(
+        P0,
+        (0..4)
+            .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+    let mut runner = scenario.build();
+
+    // The verbatim Oracle text supplies the mana ability first and the target
+    // grant second; activate the latter through the production target-selection
+    // and resolution pipeline rather than installing a synthetic effect.
+    runner.activate(passage, 1).target_object(target).resolve();
+    evaluate_layers(runner.state_mut());
+
+    let ability_attribution = runner.state().attribution[&target]
+        .by_layer
+        .get(&Layer::Ability)
+        .expect("the target must have a live Layer 6 attribution");
+    assert!(
+        ability_attribution.iter().any(|effect_ref| {
+            let EffectRef::Transient { id, mod_index } = effect_ref else {
+                return false;
+            };
+            runner
+                .state()
+                .transient_continuous_effects
+                .iter()
+                .find(|effect| effect.id == *id)
+                .is_some_and(|effect| {
+                    effect.source_id == passage
+                        && effect.duration == Duration::UntilEndOfTurn
+                        && matches!(
+                            effect.modifications.get(*mod_index),
+                            Some(ContinuousModification::AddStaticMode {
+                                mode: StaticMode::CantBeBlocked
+                            })
+                        )
+                })
+        }),
+        "the real Rogues Passage grant must be attributed as its live UET Layer 6 CantBeBlocked modification"
+    );
+
+    let views = derive_views(runner.state(), None);
+    assert_eq!(
+        views.temporary_cant_be_blocked.get(&target),
+        Some(&Some(passage)),
+        "the targeted creature carries a temporary CantBeBlocked badge attributed to Rogues Passage"
+    );
+    assert!(
+        !views.temporary_cant_be_blocked.contains_key(&non_target),
+        "a creature not selected during activation must not receive the badge"
+    );
+
+    runner.advance_to_end_step();
+    runner.advance_to_phase(Phase::Upkeep);
+    evaluate_layers(runner.state_mut());
+    assert!(
+        !derive_views(runner.state(), None)
+            .temporary_cant_be_blocked
+            .contains_key(&target),
+        "CR 514.2: the this-turn CantBeBlocked grant must disappear after cleanup"
+    );
+}

--- a/crates/engine/tests/integration/temporary_cant_be_blocked_view.rs
+++ b/crates/engine/tests/integration/temporary_cant_be_blocked_view.rs
@@ -12,6 +12,7 @@ use engine::game::phasing::phase_out_object;
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::move_to_zone;
 use engine::types::ability::{ContinuousModification, Duration, TargetFilter};
+use engine::types::actions::GameAction;
 use engine::types::attribution::EffectRef;
 use engine::types::game_state::GameState;
 use engine::types::identifiers::ObjectId;
@@ -290,8 +291,49 @@ fn rogues_passage_activation_projects_only_its_target_until_cleanup() {
         "a creature not selected during activation must not receive the badge"
     );
 
-    runner.advance_to_end_step();
-    runner.advance_to_phase(Phase::Upkeep);
+    // Cross CR 514.2 through the production action pipeline. The phase helpers
+    // may stop at an intermediate priority window; legal_actions also advances
+    // through the empty combat declarations, and the turn counter proves cleanup
+    // has actually completed.
+    let start_turn = runner.state().turn_number;
+    let mut crossed_turn = false;
+    for _ in 0..400 {
+        if runner.state().turn_number > start_turn {
+            crossed_turn = true;
+            break;
+        }
+        let actions = engine::ai_support::legal_actions(runner.state());
+        let progress = actions
+            .iter()
+            .find(|action| matches!(action, GameAction::PassPriority))
+            .or_else(|| {
+                actions.iter().find(|action| {
+                    matches!(
+                        action,
+                        GameAction::DeclareAttackers { .. }
+                            | GameAction::DeclareBlockers { .. }
+                            | GameAction::SelectCards { .. }
+                            | GameAction::ChooseTarget { .. }
+                    )
+                })
+            })
+            .cloned();
+        match progress {
+            Some(action) => {
+                if runner.act(action).is_err() {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+    assert!(
+        crossed_turn,
+        "the game must advance past the turn containing the Rogues Passage activation; parked at turn {} phase {:?} waiting {:?}",
+        runner.state().turn_number,
+        runner.state().phase,
+        runner.state().waiting_for,
+    );
     evaluate_layers(runner.state_mut());
     assert!(
         !derive_views(runner.state(), None)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Can’t be blocked” badge for permanents affected by temporary unblockable effects (until end of turn).
  * Shows the granting source when it’s publicly available.
  * Keeps the badge visible while omitting “from source” details when the source is not publicly available.
  * Added translations for English, German, Spanish, French, Italian, Polish, and Portuguese.
* **Tests**
  * Added UI tests for badge/tooltip behavior across attribution scenarios.
  * Added integration tests for the new derived projection and its lifecycle/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->