### PR TITLE
fix: clarify replacement modal choices

### DIFF
--- a/client/src/components/mana/ManaSymbol.tsx
+++ b/client/src/components/mana/ManaSymbol.tsx
@@ -12,6 +12,16 @@ const SIZE_CLASSES = {
 } as const;
 
 const SCRYFALL_SVG_BASE = "https://svgs.scryfall.io/card-symbols";
+const SINGLE_SYMBOL_CODES = new Set([
+  "W", "U", "B", "R", "G", "C", "S", "T", "Q", "E", "P", "X", "Y", "Z", "A", "∞", "½", "CHAOS",
+]);
+
+/** True when `shard` has a corresponding Scryfall card-symbol SVG. */
+export function isManaSymbolShard(shard: string): boolean {
+  if (/^\d+$/.test(shard) || SINGLE_SYMBOL_CODES.has(shard)) return true;
+  const parts = shard.split("/");
+  return parts.length > 1 && parts.every((part) => SINGLE_SYMBOL_CODES.has(part) || /^\d+$/.test(part));
+}
 
 /** Map our internal shard notation to the Scryfall SVG filename (without .svg). */
 function shardToScryfallCode(shard: string): string {

--- a/client/src/components/mana/ManaSymbol.tsx
+++ b/client/src/components/mana/ManaSymbol.tsx
@@ -15,12 +15,18 @@ const SCRYFALL_SVG_BASE = "https://svgs.scryfall.io/card-symbols";
 const SINGLE_SYMBOL_CODES = new Set([
   "W", "U", "B", "R", "G", "C", "S", "T", "Q", "E", "P", "X", "Y", "Z", "A", "∞", "½", "CHAOS",
 ]);
+const COMPOSITE_SYMBOL_CODES = new Set([
+  "W/U", "W/B", "U/B", "U/R", "B/R", "B/G", "R/W", "R/G", "G/W", "G/U",
+  "2/W", "2/U", "2/B", "2/R", "2/G",
+  "W/P", "U/P", "B/P", "R/P", "G/P",
+  "W/U/P", "W/B/P", "U/B/P", "U/R/P", "B/R/P", "B/G/P", "R/W/P", "R/G/P", "G/W/P", "G/U/P",
+  "C/W", "C/U", "C/B", "C/R", "C/G",
+]);
 
 /** True when `shard` has a corresponding Scryfall card-symbol SVG. */
 export function isManaSymbolShard(shard: string): boolean {
   if (/^\d+$/.test(shard) || SINGLE_SYMBOL_CODES.has(shard)) return true;
-  const parts = shard.split("/");
-  return parts.length > 1 && parts.every((part) => SINGLE_SYMBOL_CODES.has(part) || /^\d+$/.test(part));
+  return COMPOSITE_SYMBOL_CODES.has(shard);
 }
 
 /** Map our internal shard notation to the Scryfall SVG filename (without .svg). */

--- a/client/src/components/mana/RichLabel.tsx
+++ b/client/src/components/mana/RichLabel.tsx
@@ -1,4 +1,4 @@
-import { ManaSymbol } from "./ManaSymbol.tsx";
+import { isManaSymbolShard, ManaSymbol } from "./ManaSymbol.tsx";
 
 interface RichLabelProps {
   text: string;
@@ -12,13 +12,11 @@ export function RichLabel({ text, size = "sm", className }: RichLabelProps) {
   return (
     <span className={className}>
       {/* ChoiceModal uses brace-delimited mana/tap notation like {W} and {T}. */}
-      {text.split(SYMBOL_PATTERN).map((part, i) =>
-        i % 2 === 0 ? (
-          part
-        ) : (
-          <ManaSymbol key={i} shard={part} size={size} className="align-[-0.125em]" />
-        ),
-      )}
+      {text.split(SYMBOL_PATTERN).map((part, i) => {
+        if (i % 2 === 0) return part;
+        if (!isManaSymbolShard(part)) return `{${part}}`;
+        return <ManaSymbol key={i} shard={part} size={size} className="align-[-0.125em]" />;
+      })}
     </span>
   );
 }

--- a/client/src/components/mana/__tests__/ManaSymbol.test.tsx
+++ b/client/src/components/mana/__tests__/ManaSymbol.test.tsx
@@ -1,32 +1,32 @@
-import { render, screen } from "@testing-library/react";
+import { render, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { RichLabel } from "../RichLabel.tsx";
 
 describe("RichLabel", () => {
   it("renders valid mana notation as a symbol", () => {
-    render(<RichLabel text="Pay {G}." />);
+    const { container } = render(<RichLabel text="Pay {G}." />);
 
-    expect(screen.getByAltText("G")).toBeInTheDocument();
+    expect(within(container).getByAltText("G")).toBeInTheDocument();
   });
 
   it("keeps non-mana brace content as text", () => {
-    render(<RichLabel text="Pay Fixed { value: 2 } life" />);
+    const { container } = render(<RichLabel text="Pay Fixed { value: 2 } life" />);
 
-    expect(screen.getByText("Pay Fixed { value: 2 } life")).toBeInTheDocument();
-    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(within(container).getByText("Pay Fixed { value: 2 } life")).toBeInTheDocument();
+    expect(within(container).queryByRole("img")).not.toBeInTheDocument();
   });
 
   it.each(["2/W", "W/U/P"])("renders supported composite notation %s as a symbol", (shard) => {
-    render(<RichLabel text={`Pay {${shard}}.`} />);
+    const { container } = render(<RichLabel text={`Pay {${shard}}.`} />);
 
-    expect(screen.getByAltText(shard)).toBeInTheDocument();
+    expect(within(container).getByAltText(shard)).toBeInTheDocument();
   });
 
   it.each(["W/X", "2/X"])("keeps unsupported composite notation %s as text", (shard) => {
-    render(<RichLabel text={`Pay {${shard}}.`} />);
+    const { container } = render(<RichLabel text={`Pay {${shard}}.`} />);
 
-    expect(screen.getByText(`Pay {${shard}}.`)).toBeInTheDocument();
-    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(within(container).getByText(`Pay {${shard}}.`)).toBeInTheDocument();
+    expect(within(container).queryByRole("img")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/mana/__tests__/ManaSymbol.test.tsx
+++ b/client/src/components/mana/__tests__/ManaSymbol.test.tsx
@@ -13,7 +13,20 @@ describe("RichLabel", () => {
   it("keeps non-mana brace content as text", () => {
     render(<RichLabel text="Pay Fixed { value: 2 } life" />);
 
-    expect(screen.getByText("{ value: 2 }")).toBeInTheDocument();
+    expect(screen.getByText("Pay Fixed { value: 2 } life")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it.each(["2/W", "W/U/P"])("renders supported composite notation %s as a symbol", (shard) => {
+    render(<RichLabel text={`Pay {${shard}}.`} />);
+
+    expect(screen.getByAltText(shard)).toBeInTheDocument();
+  });
+
+  it.each(["W/X", "2/X"])("keeps unsupported composite notation %s as text", (shard) => {
+    render(<RichLabel text={`Pay {${shard}}.`} />);
+
+    expect(screen.getByText(`Pay {${shard}}.`)).toBeInTheDocument();
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/mana/__tests__/ManaSymbol.test.tsx
+++ b/client/src/components/mana/__tests__/ManaSymbol.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RichLabel } from "../RichLabel.tsx";
+
+describe("RichLabel", () => {
+  it("renders valid mana notation as a symbol", () => {
+    render(<RichLabel text="Pay {G}." />);
+
+    expect(screen.getByAltText("G")).toBeInTheDocument();
+  });
+
+  it("keeps non-mana brace content as text", () => {
+    render(<RichLabel text="Pay Fixed { value: 2 } life" />);
+
+    expect(screen.getByText("{ value: 2 }")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/viewmodel/__tests__/cardActionChoice.test.ts
+++ b/client/src/viewmodel/__tests__/cardActionChoice.test.ts
@@ -345,7 +345,7 @@ describe("abilityChoiceLabel", () => {
     ).toBe("Tap for {1}");
   });
 
-  it("labels TapLandForMana as Tap for Mana", () => {
+  it("labels TapLandForMana with the engine-selected mana", () => {
     const object = makeGameObject({
       name: "Emergence Zone",
       card_types: {
@@ -360,7 +360,14 @@ describe("abilityChoiceLabel", () => {
         tapLandAction(1),
         object,
       ).label,
-    ).toBe("Tap for Mana");
+    ).toBe("Tap for {G}");
+  });
+
+  it("labels an atomic mana combination with every mana it produces", () => {
+    const action = tapLandAction(1);
+    action.data.selection.atomic_combination = ["White", "Blue"];
+
+    expect(abilityChoiceLabel(action, makeGameObject()).label).toBe("Tap for {W}{U}");
   });
 
   it("labels the spell face cast action with the front-face name", () => {

--- a/client/src/viewmodel/__tests__/cardActionChoice.test.ts
+++ b/client/src/viewmodel/__tests__/cardActionChoice.test.ts
@@ -58,7 +58,7 @@ function makeGameObject(overrides: Partial<GameObject> = {}): GameObject {
   };
 }
 
-function tapLandAction(objectId: number): GameAction {
+function tapLandAction(objectId: number): Extract<GameAction, { type: "TapLandForMana" }> {
   return {
     type: "TapLandForMana",
     data: {

--- a/client/src/viewmodel/costLabel.ts
+++ b/client/src/viewmodel/costLabel.ts
@@ -402,6 +402,14 @@ export function abilityChoiceLabel(
       description: `Tap ${object.name} to help pay this spell's cost.`,
     };
   }
+  if (action.type === "TapLandForMana") {
+    const mana = action.data.selection.atomic_combination ?? [action.data.selection.mana_type];
+    const symbols = mana
+      .map((manaType) => MANA_COLOR_ABBREVIATION[manaType] ?? "C")
+      .map((symbol) => `{${symbol}}`)
+      .join("");
+    return { label: `Tap for ${symbols}` };
+  }
   if (action.type === "ActivateAbility") {
     const ability = object.abilities[action.data.ability_index];
     // For mana abilities, show what they produce (e.g., "Add {U}") instead of just the cost

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -10417,17 +10417,17 @@ mod tests {
                 cost: AbilityCost::PayLife {
                     amount: QuantityExpr::Fixed { value: amount },
                 },
-                decline: Some(
-                    Box::new(AbilityDefinition::new(
+                decline: Some(Box::new(
+                    AbilityDefinition::new(
                         AbilityKind::Spell,
                         Effect::SetTapState {
                             target: TargetFilter::SelfRef,
                             scope: EffectScope::Single,
                             state: TapStateChange::Tap,
                         },
-                    ))
+                    )
                     .description("It enters tapped".to_string()),
-                ),
+                )),
             })
             .valid_card(TargetFilter::SelfRef)
     }

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -900,123 +900,77 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
                         .iter()
                         .all(|candidate| candidate.is_optional);
                 let count = pending_replacement_option_count(state, p);
-                let cands: Vec<ReplacementCandidateSummary> =
-                    if p.is_optional && !p.search_found_candidates.is_empty() {
-                        let candidate = &p.search_found_candidates[0];
-                        vec![
-                            ReplacementCandidateSummary {
-                                source_id: candidate.disposition.source.object_id,
-                                source_name: candidate.source_name.clone(),
-                                description: candidate.description.clone(),
-                            },
-                            ReplacementCandidateSummary {
-                                source_id: candidate.disposition.source.object_id,
-                                source_name: candidate.source_name.clone(),
-                                description: "Decline".to_string(),
-                            },
-                        ]
-                    } else if !p.search_found_candidates.is_empty() {
-                        let mut candidates: Vec<_> = p
-                            .search_found_candidates
-                            .iter()
-                            .map(|candidate| ReplacementCandidateSummary {
-                                source_id: candidate.disposition.source.object_id,
-                                source_name: candidate.source_name.clone(),
-                                description: candidate.description.clone(),
-                            })
-                            .collect();
-                        if all_search_found_candidates_optional {
-                            candidates.push(ReplacementCandidateSummary {
-                                source_id: ObjectId(0),
-                                source_name: String::new(),
-                                description: "Use the original found-card destination".to_string(),
-                            });
-                        }
-                        candidates
-                    } else if p.is_optional {
-                        // CR 616.1: replacement-effect choices belong to the affected
-                        // object's controller/owner or the affected player. An optional
-                        // "you may" is one source shown as two branches — both carry
-                        // `candidates[0].source`.
-                        let source_id = p.candidates.first().map(|rid| rid.source);
-                        let (accept_desc, decline_desc) = p
-                            .candidates
-                            .first()
-                            .and_then(|rid| replacement_definition_for_id(state, *rid))
-                            .map(|repl| match &repl.mode {
-                                ReplacementMode::MayCost { cost, .. } => {
-                                    (replacement_cost_description(cost), "Decline".to_string())
-                                }
-                                // CR 702.136a (Riot) / CR 702.98a (Unleash): label an
-                                // Optional replacement's accept branch by the
-                                // replacement's own `description` (which names its source
-                                // keyword, e.g. "Riot — ..." / "Unleash — ..."), falling
-                                // back to the `execute` effect text when there is none.
-                                // The decline branch, when it is a distinct outcome
-                                // (e.g. Riot's "It gains haste"), is labeled by that
-                                // outcome rather than a bare "Decline" — the reported
-                                // bug was that declining silently granted haste with no
-                                // indication; a decline-less Optional (Unleash) keeps a
-                                // plain "Decline".
-                                ReplacementMode::Optional { decline } => {
-                                    let accept = if repl.event
-                                        == crate::types::replacements::ReplacementEvent::Draw
-                                    {
-                                        "Accept".to_string()
-                                    } else {
-                                        repl.description
-                                            .clone()
-                                            .or_else(|| {
-                                                repl.execute
-                                                    .as_ref()
-                                                    .and_then(|e| e.description.clone())
-                                            })
-                                            .unwrap_or_else(|| "Accept".to_string())
-                                    };
-                                    let decline_label = decline
-                                        .as_ref()
-                                        .and_then(|d| d.description.clone())
-                                        .unwrap_or_else(|| "Decline".to_string());
-                                    (accept, decline_label)
-                                }
-                                ReplacementMode::Mandatory => (
-                                    repl.description
-                                        .clone()
-                                        .unwrap_or_else(|| "Accept".to_string()),
-                                    "Decline".to_string(),
-                                ),
-                            })
-                            .unwrap_or_else(|| ("Accept".to_string(), "Decline".to_string()));
-                        let source_id = source_id.unwrap_or(ObjectId(0));
-                        let source_name = name_of(source_id);
-                        vec![
-                            ReplacementCandidateSummary {
-                                source_id,
-                                source_name: source_name.clone(),
-                                description: accept_desc,
-                            },
-                            ReplacementCandidateSummary {
-                                source_id,
-                                source_name,
-                                description: decline_desc,
-                            },
-                        ]
-                    } else {
-                        // CR 616.1 / CR 614.1c / CR 614.1d: each candidate gets an
-                        // outcome-descriptive label derived from its `execute`
-                        // effect, or from its synthetic shield-counter kind.
-                        // `map` (not `filter_map`) guarantees the vec is never
-                        // shorter than `candidate_count`, so the frontend index
-                        // lookup stays aligned.
-                        p.candidates
-                            .iter()
-                            .map(|rid| ReplacementCandidateSummary {
-                                source_id: rid.source,
-                                source_name: name_of(rid.source),
-                                description: replacement_choice_label_for_rid(state, *rid),
-                            })
-                            .collect()
-                    };
+                let cands: Vec<ReplacementCandidateSummary> = if p.is_optional
+                    && !p.search_found_candidates.is_empty()
+                {
+                    let candidate = &p.search_found_candidates[0];
+                    vec![
+                        ReplacementCandidateSummary {
+                            source_id: candidate.disposition.source.object_id,
+                            source_name: candidate.source_name.clone(),
+                            description: candidate.description.clone(),
+                        },
+                        ReplacementCandidateSummary {
+                            source_id: candidate.disposition.source.object_id,
+                            source_name: candidate.source_name.clone(),
+                            description: "Decline".to_string(),
+                        },
+                    ]
+                } else if !p.search_found_candidates.is_empty() {
+                    let mut candidates: Vec<_> = p
+                        .search_found_candidates
+                        .iter()
+                        .map(|candidate| ReplacementCandidateSummary {
+                            source_id: candidate.disposition.source.object_id,
+                            source_name: candidate.source_name.clone(),
+                            description: candidate.description.clone(),
+                        })
+                        .collect();
+                    if all_search_found_candidates_optional {
+                        candidates.push(ReplacementCandidateSummary {
+                            source_id: ObjectId(0),
+                            source_name: String::new(),
+                            description: "Use the original found-card destination".to_string(),
+                        });
+                    }
+                    candidates
+                } else if p.is_optional {
+                    // CR 616.1: replacement-effect choices belong to the affected
+                    // object's controller/owner or the affected player. An optional
+                    // "you may" is one source shown as two branches — both carry
+                    // `candidates[0].source`.
+                    let source_id = p.candidates.first().map(|rid| rid.source);
+                    let (accept_desc, decline_desc) = optional_replacement_choice_labels(state, p);
+                    let source_id = source_id.unwrap_or(ObjectId(0));
+                    let source_name = name_of(source_id);
+                    vec![
+                        ReplacementCandidateSummary {
+                            source_id,
+                            source_name: source_name.clone(),
+                            description: accept_desc,
+                        },
+                        ReplacementCandidateSummary {
+                            source_id,
+                            source_name,
+                            description: decline_desc,
+                        },
+                    ]
+                } else {
+                    // CR 616.1 / CR 614.1c / CR 614.1d: each candidate gets an
+                    // outcome-descriptive label derived from its `execute`
+                    // effect, or from its synthetic shield-counter kind.
+                    // `map` (not `filter_map`) guarantees the vec is never
+                    // shorter than `candidate_count`, so the frontend index
+                    // lookup stays aligned.
+                    p.candidates
+                        .iter()
+                        .map(|rid| ReplacementCandidateSummary {
+                            source_id: rid.source,
+                            source_name: name_of(rid.source),
+                            description: replacement_choice_label_for_rid(state, *rid),
+                        })
+                        .collect()
+                };
                 (count, cands)
             }
         })
@@ -1058,14 +1012,97 @@ pub fn park_waiting_for(state: &mut GameState, player: PlayerId) {
     state.waiting_for = replacement_choice_waiting_for(player, state);
 }
 
-/// CR 614.12a: Human-readable accept-label for a `MayCost` replacement prompt.
+/// Labels the two outcomes of an optional replacement choice.
+fn optional_replacement_choice_labels(
+    state: &GameState,
+    pending: &PendingReplacement,
+) -> (String, String) {
+    let Some(replacement_id) = pending.candidates.first().copied() else {
+        return ("Accept".to_string(), "Decline".to_string());
+    };
+
+    if is_commander_hand_or_library_return_replacement(replacement_id) {
+        // CR 903.9b: this rules-source replacement redirects the commander to
+        // the command zone instead of the proposed hand/library destination.
+        return match &pending.proposed {
+            ProposedEvent::ZoneChange { to: Zone::Hand, .. } => (
+                "Move to command zone".to_string(),
+                "Put into hand".to_string(),
+            ),
+            ProposedEvent::ZoneChange {
+                to: Zone::Library, ..
+            } => (
+                "Move to command zone".to_string(),
+                "Put into library".to_string(),
+            ),
+            _ => ("Accept".to_string(), "Decline".to_string()),
+        };
+    }
+
+    replacement_definition_for_id(state, replacement_id)
+        .map(|replacement| match &replacement.mode {
+            ReplacementMode::MayCost { cost, .. } => {
+                (replacement_cost_description(cost), "Decline".to_string())
+            }
+            // CR 702.136a (Riot) / CR 702.98a (Unleash): label an optional
+            // replacement's accept branch by its source description, falling
+            // back to its execute effect. A distinct decline outcome names that
+            // outcome rather than using a bare "Decline".
+            ReplacementMode::Optional { decline } => {
+                let accept = if replacement.event == ReplacementEvent::Draw {
+                    "Accept".to_string()
+                } else {
+                    replacement
+                        .description
+                        .clone()
+                        .or_else(|| {
+                            replacement
+                                .execute
+                                .as_ref()
+                                .and_then(|effect| effect.description.clone())
+                        })
+                        .unwrap_or_else(|| "Accept".to_string())
+                };
+                let decline = decline
+                    .as_ref()
+                    .and_then(|effect| effect.description.clone())
+                    .unwrap_or_else(|| "Decline".to_string());
+                (accept, decline)
+            }
+            ReplacementMode::Mandatory => (
+                replacement
+                    .description
+                    .clone()
+                    .unwrap_or_else(|| "Accept".to_string()),
+                "Decline".to_string(),
+            ),
+        })
+        .unwrap_or_else(|| ("Accept".to_string(), "Decline".to_string()))
+}
+
+/// Human-readable accept-label for a `MayCost` replacement prompt.
 /// Returns a complete imperative phrase (the caller no longer prepends "Pay ")
 /// so non-mana costs read naturally. Exhaustive — a new `AbilityCost` variant
 /// forces a deliberate label decision here.
 fn replacement_cost_description(cost: &AbilityCost) -> String {
     match cost {
-        AbilityCost::Mana { cost } => format!("Pay {cost:?}"),
-        AbilityCost::PayLife { amount } => format!("Pay {amount:?} life"),
+        AbilityCost::Mana { cost } => match cost {
+            crate::types::mana::ManaCost::NoCost => "Pay no mana".to_string(),
+            crate::types::mana::ManaCost::Cost { shards, generic } => {
+                let generic = (*generic > 0).then(|| format!("{{{generic}}}"));
+                let symbols = shards.iter().map(|shard| format!("{{{}}}", shard.symbol()));
+                format!("Pay {}", generic.into_iter().chain(symbols).collect::<String>())
+            }
+            crate::types::mana::ManaCost::SelfManaCost => "Pay its mana cost".to_string(),
+            crate::types::mana::ManaCost::SelfManaValue => "Pay its mana value".to_string(),
+            crate::types::mana::ManaCost::SelfManaCostReduced { reduction } => {
+                format!("Pay its mana cost reduced by {{{reduction}}}")
+            }
+        },
+        AbilityCost::PayLife {
+            amount: QuantityExpr::Fixed { value },
+        } => format!("Pay {value} life"),
+        AbilityCost::PayLife { .. } => "Pay life".to_string(),
         // CR 614.12a: Karoo self-ETB cost lands.
         AbilityCost::Sacrifice(cost) => match &cost.requirement {
             crate::types::ability::SacrificeRequirement::Count { count } => {
@@ -11592,6 +11629,50 @@ mod tests {
         assert!(
             candidates.iter().all(|c| c.source_id == ObjectId(20)),
             "both accept and decline must carry the source object (ObjectId(20))"
+        );
+    }
+
+    #[test]
+    fn commander_library_replacement_labels_both_destinations() {
+        let commander = ObjectId(21);
+        let mut state = test_state_with_object(commander, Zone::Battlefield, vec![]);
+        state.pending_replacement = Some(PendingReplacement {
+            proposed: ProposedEvent::zone_change(commander, Zone::Battlefield, Zone::Library, None),
+            sacrifice_provenance: None,
+            candidates: vec![commander_hand_or_library_return_replacement_id(commander)],
+            search_found_candidates: Vec::new(),
+            depth: 0,
+            is_optional: true,
+            library_placement: None,
+            excess_recipient: None,
+            lifelink_bonus: 0,
+            may_cost_paid: false,
+            may_cost_remaining: None,
+        });
+
+        let WaitingFor::ReplacementChoice { candidates, .. } =
+            replacement_choice_waiting_for(PlayerId(0), &state)
+        else {
+            panic!("expected commander replacement choice");
+        };
+
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.description.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Move to command zone", "Put into library"],
+            "CR 903.9b choices must name the resulting zone, not generic accept/decline"
+        );
+    }
+
+    #[test]
+    fn fixed_life_may_cost_uses_a_display_label() {
+        assert_eq!(
+            replacement_cost_description(&AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+            }),
+            "Pay 2 life"
         );
     }
 

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -10468,7 +10468,9 @@ mod tests {
             result,
             ReplacementResult::NeedsChoice(PlayerId(0))
         ));
-        let WaitingFor::ReplacementChoice { candidates, .. } = &state.waiting_for else {
+        let WaitingFor::ReplacementChoice { candidates, .. } =
+            replacement_choice_waiting_for(PlayerId(0), &state)
+        else {
             panic!("expected replacement choice prompt");
         };
         assert_eq!(

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1041,8 +1041,12 @@ fn optional_replacement_choice_labels(
 
     replacement_definition_for_id(state, replacement_id)
         .map(|replacement| match &replacement.mode {
-            ReplacementMode::MayCost { cost, .. } => {
-                (replacement_cost_description(cost), "Decline".to_string())
+            ReplacementMode::MayCost { cost, decline } => {
+                let decline = decline
+                    .as_ref()
+                    .and_then(|effect| effect.description.clone())
+                    .unwrap_or_else(|| "Decline".to_string());
+                (replacement_cost_description(cost), decline)
             }
             // CR 702.136a (Riot) / CR 702.98a (Unleash): label an optional
             // replacement's accept branch by its source description, falling
@@ -10413,14 +10417,17 @@ mod tests {
                 cost: AbilityCost::PayLife {
                     amount: QuantityExpr::Fixed { value: amount },
                 },
-                decline: Some(Box::new(AbilityDefinition::new(
-                    AbilityKind::Spell,
-                    Effect::SetTapState {
-                        target: TargetFilter::SelfRef,
-                        scope: EffectScope::Single,
-                        state: TapStateChange::Tap,
-                    },
-                ))),
+                decline: Some(
+                    Box::new(AbilityDefinition::new(
+                        AbilityKind::Spell,
+                        Effect::SetTapState {
+                            target: TargetFilter::SelfRef,
+                            scope: EffectScope::Single,
+                            state: TapStateChange::Tap,
+                        },
+                    ))
+                    .description("It enters tapped".to_string()),
+                ),
             })
             .valid_card(TargetFilter::SelfRef)
     }
@@ -10461,6 +10468,17 @@ mod tests {
             result,
             ReplacementResult::NeedsChoice(PlayerId(0))
         ));
+        let WaitingFor::ReplacementChoice { candidates, .. } = &state.waiting_for else {
+            panic!("expected replacement choice prompt");
+        };
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| candidate.description.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Pay 2 life", "It enters tapped"],
+            "the decline choice must describe its branch outcome"
+        );
 
         let result = continue_replacement(&mut state, 1, &mut events);
         let ReplacementResult::Execute(ProposedEvent::ZoneChange { enter_tapped, .. }) = result
@@ -11633,37 +11651,47 @@ mod tests {
     }
 
     #[test]
-    fn commander_library_replacement_labels_both_destinations() {
+    fn commander_hand_or_library_replacement_labels_both_destinations() {
         let commander = ObjectId(21);
-        let mut state = test_state_with_object(commander, Zone::Battlefield, vec![]);
-        state.pending_replacement = Some(PendingReplacement {
-            proposed: ProposedEvent::zone_change(commander, Zone::Battlefield, Zone::Library, None),
-            sacrifice_provenance: None,
-            candidates: vec![commander_hand_or_library_return_replacement_id(commander)],
-            search_found_candidates: Vec::new(),
-            depth: 0,
-            is_optional: true,
-            library_placement: None,
-            excess_recipient: None,
-            lifelink_bonus: 0,
-            may_cost_paid: false,
-            may_cost_remaining: None,
-        });
+        for (destination, decline_label) in [
+            (Zone::Hand, "Put into hand"),
+            (Zone::Library, "Put into library"),
+        ] {
+            let mut state = test_state_with_object(commander, Zone::Battlefield, vec![]);
+            state.pending_replacement = Some(PendingReplacement {
+                proposed: ProposedEvent::zone_change(
+                    commander,
+                    Zone::Battlefield,
+                    destination,
+                    None,
+                ),
+                sacrifice_provenance: None,
+                candidates: vec![commander_hand_or_library_return_replacement_id(commander)],
+                search_found_candidates: Vec::new(),
+                depth: 0,
+                is_optional: true,
+                library_placement: None,
+                excess_recipient: None,
+                lifelink_bonus: 0,
+                may_cost_paid: false,
+                may_cost_remaining: None,
+            });
 
-        let WaitingFor::ReplacementChoice { candidates, .. } =
-            replacement_choice_waiting_for(PlayerId(0), &state)
-        else {
-            panic!("expected commander replacement choice");
-        };
+            let WaitingFor::ReplacementChoice { candidates, .. } =
+                replacement_choice_waiting_for(PlayerId(0), &state)
+            else {
+                panic!("expected commander replacement choice for {destination:?}");
+            };
 
-        assert_eq!(
-            candidates
-                .iter()
-                .map(|candidate| candidate.description.as_str())
-                .collect::<Vec<_>>(),
-            vec!["Move to command zone", "Put into library"],
-            "CR 903.9b choices must name the resulting zone, not generic accept/decline"
-        );
+            assert_eq!(
+                candidates
+                    .iter()
+                    .map(|candidate| candidate.description.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["Move to command zone", decline_label],
+                "CR 903.9b choices must name the resulting zone, not generic accept/decline"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mana-tapping actions now display the exact mana produced, including multiple mana symbols.
  * Optional replacement choices for commander cards now clearly describe moving cards to the command zone or returning them to hand or library.
  * Replacement costs now use clearer, more human-readable labels, including life-payment costs.

* **Bug Fixes**
  * Unrecognized brace-delimited text is preserved as plain text instead of being incorrectly rendered as a mana symbol.

* **Tests**
  * Added coverage for mana rendering, mana-tapping labels, commander replacement choices, and cost descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->