### PR TITLE
Fix native P2P startup adapter race

### DIFF
--- a/client/src/stores/__tests__/gameStore.test.ts
+++ b/client/src/stores/__tests__/gameStore.test.ts
@@ -1,7 +1,7 @@
 import { act } from "react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { GameEvent, GameState } from "../../adapter/types";
+import type { EngineAdapter, GameEvent, GameState } from "../../adapter/types";
 import { buildEngineAdapterMock } from "../../test/factories/engineAdapterFactory";
 import {
   buildGameState,
@@ -42,6 +42,21 @@ describe("gameStore", () => {
     expect(store.gameState).toEqual(state);
     expect(store.waitingFor).toEqual(state.waiting_for);
     expect(adapter.initialize).toHaveBeenCalled();
+  });
+
+  it("binds the adapter before initializeGame can publish an initial remote snapshot", async () => {
+    const state = buildGameState();
+    let adapterDuringInitialization: EngineAdapter | null = null;
+    const adapter = buildEngineAdapterMock(state, {
+      initializeGame: vi.fn(async () => {
+        adapterDuringInitialization = useGameStore.getState().adapter;
+        return { events: [] };
+      }),
+    });
+
+    await act(() => useGameStore.getState().initGame("test-id", adapter));
+
+    expect(adapterDuringInitialization).toBe(adapter);
   });
 
   it("dispatch calls adapter.submitAction and updates state", async () => {

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -411,7 +411,26 @@ export const useGameStore = create<GameStore>()(
       // pacing (rematch started within the throughput window).
       resetStackThroughput();
       await adapter.initialize();
-      const initResult = await adapter.initializeGame(deckData, formatConfig, playerCount, matchConfig, firstPlayer);
+      // Network-backed adapters can publish the initial authoritative snapshot
+      // from inside `initializeGame`. Bind the transport before that happens so
+      // the shared remote-update path never commits a visible game state whose
+      // action dispatcher has no adapter yet.
+      set({ adapter });
+      let initResult;
+      try {
+        initResult = await adapter.initializeGame(
+          deckData,
+          formatConfig,
+          playerCount,
+          matchConfig,
+          firstPlayer,
+        );
+      } catch (error) {
+        // A failed initialization must not leave a transport that never
+        // produced a playable game attached to the store.
+        if (get().adapter === adapter) set({ adapter: null });
+        throw error;
+      }
       // Fetched AFTER the engine is initialized, so this snapshot is
       // newest-by-construction under the global counter — it always passes the
       // gate, and it drops any leftover in-flight commit from a prior match.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game initialization reliability by registering the connection before receiving initial remote updates.
  * Failed initialization attempts now clean up the connection state, preventing stale or unusable connections from being retained.

* **Tests**
  * Added coverage confirming correct connection setup order during game initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->