### PR TITLE
fix(p2p): deduplicate host initialization

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -417,6 +417,32 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(mockSetMultiplayerMode).toHaveBeenCalledTimes(1);
   });
 
+  it("retries failed initialization without duplicating guest connections", async () => {
+    const { adapter, emitConnection } = makeHost(2);
+    mockInitialize
+      .mockRejectedValueOnce(new Error("worker startup failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(adapter.initialize()).rejects.toThrow("worker startup failed");
+    await adapter.initialize();
+
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: ["Plains"], sideboard: [] } },
+    });
+    await flushPromises(20);
+
+    expect(mockInitialize).toHaveBeenCalledTimes(2);
+    expect(adapter.getPlayerSlots().map((slot) => slot.kind.type)).toEqual([
+      "HostHuman",
+      "JoinedHuman",
+    ]);
+    const messages = await guest.getSentMessages();
+    expect(messages.filter((message) => (message as { type?: string }).type === "seat_snapshot"))
+      .toHaveLength(1);
+    expect(messages.some((message) => (message as { type?: string }).type === "kick")).toBe(false);
+  });
+
   it("rejects a non-Oathbreaker guest signature spell before game setup", async () => {
     mockCheckDeckCompatibility.mockResolvedValueOnce({
       selected_format_compatible: false,

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -407,6 +407,16 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(mockSetMultiplayerMode).toHaveBeenCalledWith(true);
   });
 
+  it("does not reinitialize the host during the lobby-to-game handoff", async () => {
+    const { adapter } = makeHost(2);
+
+    await Promise.all([adapter.initialize(), adapter.initialize()]);
+    await adapter.initialize();
+
+    expect(mockInitialize).toHaveBeenCalledTimes(1);
+    expect(mockSetMultiplayerMode).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects a non-Oathbreaker guest signature spell before game setup", async () => {
     mockCheckDeckCompatibility.mockResolvedValueOnce({
       selected_format_compatible: false,

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -534,6 +534,14 @@ export class P2PHostAdapter implements EngineAdapter {
   private nativeBridge: NativeP2PBridge | null = null;
   private nativeInitialSetupPending = false;
   private listeners: P2PAdapterEventListener[] = [];
+  /**
+   * Mirrors WasmAdapter's initialization contract: setup runs exactly once,
+   * and concurrent callers share its in-flight promise. The lobby initializes
+   * the host before advertising it; the game-page handoff later calls
+   * initialize again while seeding gameStore.
+   */
+  private initialized = false;
+  private initPromise: Promise<void> | null = null;
 
   private guestSessions = new Map<PlayerId, PeerSession>();
   private guestDecks = new Map<PlayerId, DeckListPayload["player"]>();
@@ -1094,6 +1102,17 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   async initialize(): Promise<void> {
+    if (this.initialized) return;
+    if (this.initPromise) return this.initPromise;
+    const pending = this.initializeInner();
+    this.initPromise = pending;
+    pending.catch(() => {
+      if (this.initPromise === pending) this.initPromise = null;
+    });
+    return pending;
+  }
+
+  private async initializeInner(): Promise<void> {
     traceAdapter("Host", "initialize-start", { isResume: this.isResume });
     // Subscribe SYNCHRONOUSLY before any `await`. `hostRoom()` buffers
     // inbound guest connections that arrived between peer-open and the
@@ -1158,6 +1177,7 @@ export class P2PHostAdapter implements EngineAdapter {
       });
     }
     traceAdapter("Host", "initialize-complete", {});
+    this.initialized = true;
   }
 
   private handleNewConnection(conn: DataConnection): void {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -578,10 +578,7 @@ export class P2PHostAdapter implements EngineAdapter {
   private pregameOpQueue: Promise<void> = Promise.resolve();
   private resolvePregameReady!: () => void;
   private rejectPregameReady!: (err: unknown) => void;
-  private readonly pregameReady: Promise<void> = new Promise((resolve, reject) => {
-    this.resolvePregameReady = resolve;
-    this.rejectPregameReady = reject;
-  });
+  private pregameReady!: Promise<void>;
   private allowPartialStart = false;
 
   /**
@@ -1101,9 +1098,26 @@ export class P2PHostAdapter implements EngineAdapter {
     }
   }
 
+  private resetPregameReady(): void {
+    this.pregameReady = new Promise((resolve, reject) => {
+      this.resolvePregameReady = resolve;
+      this.rejectPregameReady = reject;
+    });
+    // Initialization can fail before a guest arrives to await this gate. Keep
+    // that rejection observable to a queued guest while preventing it from
+    // becoming an unhandled rejection when no guest exists yet.
+    void this.pregameReady.catch(() => {});
+  }
+
+  private unsubscribeHostConnections(): void {
+    this.hostConnectionUnsub?.();
+    this.hostConnectionUnsub = null;
+  }
+
   async initialize(): Promise<void> {
     if (this.initialized) return;
     if (this.initPromise) return this.initPromise;
+    this.resetPregameReady();
     const pending = this.initializeInner();
     this.initPromise = pending;
     pending.catch(() => {
@@ -1166,6 +1180,7 @@ export class P2PHostAdapter implements EngineAdapter {
       }
       this.resolvePregameReady();
     } catch (err) {
+      this.unsubscribeHostConnections();
       this.rejectPregameReady(err);
       throw err;
     }
@@ -1657,7 +1672,7 @@ export class P2PHostAdapter implements EngineAdapter {
    * clears the persistence before disposing.
    */
   dispose(): void {
-    if (this.hostConnectionUnsub) this.hostConnectionUnsub();
+    this.unsubscribeHostConnections();
     for (const { timer } of this.disconnectedSeats.values()) {
       if (timer !== null) clearTimeout(timer);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented multiplayer hosts from initializing more than once during the lobby-to-game transition.
  * Concurrent initialization requests now share the same setup process, reducing duplicate setup issues.
  * Failed initialization attempts can be retried automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->