### PR TITLE
fix(engine): carry the sacrificed-permanent quality on Devour (Famished Worldsire)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8323,20 +8323,23 @@ fn is_bloodthirst_x_etb_replacement(replacement: &ReplacementDefinition) -> bool
 /// creature sacrificed"). `PreviousEffectAmount` is NOT used — it reads
 /// `last_effect_amount`, which the ranged Sacrifice never stamps.
 ///
-/// CR 702.82c "Devour [quality]" variant: `Keyword::Devour(u32)` carries only
-/// N, not a quality filter. This synthesizer hard-codes the CR 702.82a default
-/// (sacrifice creatures). A future card needing the quality axis requires
-/// parameterizing the keyword to `Devour { n, quality }`.
+/// CR 702.82c "Devour [quality]" variant: `Keyword::Devour { n, quality }`
+/// carries both N and the sacrifice-pool quality. `quality: TypeFilter::Creature`
+/// is the CR 702.82a default (plain "Devour N"); a non-creature quality (Land for
+/// Famished Worldsire, Artifact for Caprichrome, Subtype("Food") for Feasting
+/// Hobbit) narrows the sacrifice pool per CR 702.82c. The counter math (CR 122.1a,
+/// N per permanent sacrificed) is identical across qualities — only the
+/// `Sacrifice` target and its `ObjectCount` bound switch to `quality`.
 ///
 /// CR 113.2c: each Devour instance functions independently. Per-N idempotency
 /// (`is_devour_etb_replacement`) emits only the delta so re-running synthesis
 /// is a no-op.
 pub fn synthesize_devour(face: &mut CardFace) {
-    let devour_values: Vec<u32> = face
+    let devour_values: Vec<(u32, TypeFilter)> = face
         .keywords
         .iter()
         .filter_map(|kw| match kw {
-            Keyword::Devour(n) => Some(*n),
+            Keyword::Devour { n, quality } => Some((*n, quality.clone())),
             _ => None,
         })
         .collect();
@@ -8344,16 +8347,33 @@ pub fn synthesize_devour(face: &mut CardFace) {
         return;
     }
 
-    for &n in &devour_values {
-        let needed = devour_values.iter().filter(|m| **m == n).count();
+    for (n, quality) in &devour_values {
+        let n = *n;
+        // CR 113.2c: dedup on the FULL (n, quality) key — a card carrying both a
+        // land-quality and a creature-quality Devour of the same N synthesizes
+        // BOTH replacements; the count alone would false-merge them.
+        let needed = devour_values
+            .iter()
+            .filter(|(m, q)| *m == n && q == quality)
+            .count();
         let existing = face
             .replacements
             .iter()
-            .filter(|r| is_devour_etb_replacement(r, n))
+            .filter(|r| is_devour_etb_replacement(r, n, quality))
             .count();
         if existing >= needed {
             continue;
         }
+
+        // CR 702.82a / CR 702.82c: display noun for the sacrifice pool. Cosmetic —
+        // the idempotency predicate keys on structure, not this text.
+        let quality_noun = match quality {
+            TypeFilter::Creature => "creature".to_string(),
+            TypeFilter::Land => "land".to_string(),
+            TypeFilter::Artifact => "artifact".to_string(),
+            TypeFilter::Subtype(s) => s.to_lowercase(),
+            other => format!("{other:?}").to_lowercase(),
+        };
 
         // CR 122.1: N +1/+1 counters per creature sacrificed this way. The
         // per-creature count is `EventContextAmount` (resolves to the number
@@ -8381,17 +8401,20 @@ pub fn synthesize_devour(face: &mut CardFace) {
             },
         );
 
-        // CR 702.82a: "you may sacrifice any number of creatures" — a ranged
-        // `UpTo` choice bounded by the controller's eligible creature pool,
-        // `min_count: 0` so an empty choice is legal.
+        // CR 702.82a / CR 702.82c: "you may sacrifice any number of [quality]
+        // permanents" — a ranged `UpTo` choice bounded by the controller's
+        // eligible pool of `quality` permanents, `min_count: 0` so an empty
+        // choice is legal. `quality` is `Creature` for the CR 702.82a default.
         let sacrifice = AbilityDefinition::new(
             AbilityKind::Spell,
             Effect::Sacrifice {
-                target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+                target: TargetFilter::Typed(
+                    TypedFilter::new(quality.clone()).controller(ControllerRef::You),
+                ),
                 count: QuantityExpr::up_to(QuantityExpr::Ref {
                     qty: QuantityRef::ObjectCount {
                         filter: TargetFilter::Typed(
-                            TypedFilter::creature().controller(ControllerRef::You),
+                            TypedFilter::new(quality.clone()).controller(ControllerRef::You),
                         ),
                     },
                 }),
@@ -8399,8 +8422,8 @@ pub fn synthesize_devour(face: &mut CardFace) {
             },
         )
         .description(format!(
-            "CR 702.82a: Devour {n} — sacrifice any number of creatures; this \
-             permanent enters with {n} +1/+1 counter{} per creature sacrificed.",
+            "CR 702.82a: Devour {n} — sacrifice any number of {quality_noun}s; this \
+             permanent enters with {n} +1/+1 counter{} per {quality_noun} sacrificed.",
             if n == 1 { "" } else { "s" }
         ))
         .sub_ability(put_counters);
@@ -8413,8 +8436,8 @@ pub fn synthesize_devour(face: &mut CardFace) {
             destination_zone: Some(Zone::Battlefield),
             description: Some(format!(
                 "CR 702.82a + CR 614.1c: Devour {n} — as this creature enters, \
-                 you may sacrifice any number of creatures; it enters with {n} \
-                 +1/+1 counter{} for each creature sacrificed this way.",
+                 you may sacrifice any number of {quality_noun}s; it enters with {n} \
+                 +1/+1 counter{} for each {quality_noun} sacrificed this way.",
                 if n == 1 { "" } else { "s" }
             )),
             ..ReplacementDefinition::new(ReplacementEvent::Moved)
@@ -8425,15 +8448,24 @@ pub fn synthesize_devour(face: &mut CardFace) {
 
 /// Idempotency-shape predicate for `synthesize_devour`'s ETB replacement.
 /// True iff `replacement` is a `Moved` replacement on `SelfRef` whose `execute`
-/// chain is `Effect::Sacrifice` of your creatures (ranged `UpTo`) with a
-/// `PutCounter` of `expected_n` P1P1 counters per creature on `SelfRef` as its
-/// sub-ability.
+/// chain is `Effect::Sacrifice` of your `expected_quality` permanents (ranged
+/// `UpTo`) with a `PutCounter` of `expected_n` P1P1 counters per permanent on
+/// `SelfRef` as its sub-ability.
 ///
 /// `expected_n` is load-bearing: a card carrying both a printed enters-with-K
-/// replacement and `Keyword::Devour(N≠K)` must not dedupe — the `Multiply`
-/// factor (N) for N > 1 and the bare `EventContextAmount` (N == 1) discriminate
-/// the count.
-fn is_devour_etb_replacement(replacement: &ReplacementDefinition, expected_n: u32) -> bool {
+/// replacement and `Keyword::Devour { n: N≠K, .. }` must not dedupe — the
+/// `Multiply` factor (N) for N > 1 and the bare `EventContextAmount` (N == 1)
+/// discriminate the count.
+///
+/// `expected_quality` is equally load-bearing (CR 702.82c): a land-quality Devour
+/// and a creature-quality Devour of the SAME N are distinct replacements. Without
+/// discriminating the `Sacrifice` target's `TypeFilter`, a `Devour land 3` and a
+/// `Devour 3` on the same face would false-dedupe, dropping one pool.
+fn is_devour_etb_replacement(
+    replacement: &ReplacementDefinition,
+    expected_n: u32,
+    expected_quality: &TypeFilter,
+) -> bool {
     if !matches!(replacement.event, ReplacementEvent::Moved)
         || !matches!(replacement.valid_card, Some(TargetFilter::SelfRef))
     {
@@ -8442,7 +8474,16 @@ fn is_devour_etb_replacement(replacement: &ReplacementDefinition, expected_n: u3
     let Some(execute) = replacement.execute.as_deref() else {
         return false;
     };
-    if !matches!(&*execute.effect, Effect::Sacrifice { .. }) {
+    // CR 702.82c: the sacrifice pool's quality must match. `TypedFilter::new`
+    // mirrors the synthesizer, so a full `TargetFilter` equality check on the
+    // expected shape discriminates the quality axis.
+    let expected_target = TargetFilter::Typed(
+        TypedFilter::new(expected_quality.clone()).controller(ControllerRef::You),
+    );
+    let Effect::Sacrifice { target, .. } = &*execute.effect else {
+        return false;
+    };
+    if *target != expected_target {
         return false;
     }
     let Some(sub) = execute.sub_ability.as_deref() else {
@@ -22358,7 +22399,10 @@ mod devour_synthesis_tests {
 
     fn face_with_devour(n: u32) -> CardFace {
         let mut face = CardFace::default();
-        face.keywords.push(Keyword::Devour(n));
+        face.keywords.push(Keyword::Devour {
+            n,
+            quality: TypeFilter::Creature,
+        });
         face
     }
 
@@ -22374,7 +22418,7 @@ mod devour_synthesis_tests {
         let replacement = face
             .replacements
             .iter()
-            .find(|r| is_devour_etb_replacement(r, 1))
+            .find(|r| is_devour_etb_replacement(r, 1, &TypeFilter::Creature))
             .expect("Devour 1 must synthesize an as-enters replacement");
 
         assert!(matches!(replacement.event, ReplacementEvent::Moved));
@@ -22447,7 +22491,7 @@ mod devour_synthesis_tests {
         let replacement = face
             .replacements
             .iter()
-            .find(|r| is_devour_etb_replacement(r, 2))
+            .find(|r| is_devour_etb_replacement(r, 2, &TypeFilter::Creature))
             .expect("Devour 2 must synthesize an as-enters replacement");
         let sub = replacement
             .execute
@@ -22468,7 +22512,11 @@ mod devour_synthesis_tests {
             "Devour 2 places 2 counters per creature sacrificed (CR 702.82a)"
         );
         // A Devour-2 replacement must not be mistaken for a Devour-1 one.
-        assert!(!is_devour_etb_replacement(replacement, 1));
+        assert!(!is_devour_etb_replacement(
+            replacement,
+            1,
+            &TypeFilter::Creature
+        ));
     }
 
     /// CR 113.2c: re-running synthesis is idempotent — exactly one Devour
@@ -22481,7 +22529,7 @@ mod devour_synthesis_tests {
         let count = face
             .replacements
             .iter()
-            .filter(|r| is_devour_etb_replacement(r, 2))
+            .filter(|r| is_devour_etb_replacement(r, 2, &TypeFilter::Creature))
             .count();
         assert_eq!(count, 1, "running synthesis twice must not duplicate");
     }
@@ -22492,6 +22540,62 @@ mod devour_synthesis_tests {
         let mut face = CardFace::default();
         synthesize_devour(&mut face);
         assert!(face.replacements.is_empty());
+    }
+
+    /// CR 702.82c: the quality axis discriminates. A land-quality Devour and a
+    /// creature-quality Devour of the SAME N are DISTINCT replacements — the
+    /// idempotency predicate must not cross-match them, and a face carrying both
+    /// must synthesize BOTH pools (not false-dedupe one away).
+    ///
+    /// Revert-failing: without the `expected_quality` discrimination in
+    /// `is_devour_etb_replacement`, the creature and land replacements would
+    /// mutually match, `synthesize_devour` would emit only one, and the
+    /// cross-match assertions below would fail.
+    #[test]
+    fn synthesize_devour_discriminates_quality_axis() {
+        let mut face = CardFace::default();
+        face.keywords.push(Keyword::Devour {
+            n: 3,
+            quality: TypeFilter::Creature,
+        });
+        face.keywords.push(Keyword::Devour {
+            n: 3,
+            quality: TypeFilter::Land,
+        });
+        synthesize_devour(&mut face);
+
+        let creature_matches = face
+            .replacements
+            .iter()
+            .filter(|r| is_devour_etb_replacement(r, 3, &TypeFilter::Creature))
+            .count();
+        let land_matches = face
+            .replacements
+            .iter()
+            .filter(|r| is_devour_etb_replacement(r, 3, &TypeFilter::Land))
+            .count();
+
+        assert_eq!(
+            creature_matches, 1,
+            "the creature-quality Devour 3 must synthesize exactly one replacement"
+        );
+        assert_eq!(
+            land_matches, 1,
+            "the land-quality Devour 3 must synthesize a SEPARATE replacement — \
+             same N, different quality, must not false-dedupe"
+        );
+
+        // Cross-match must be empty: a creature-quality replacement is NOT a
+        // land-quality one and vice versa (same N).
+        let creature_repl = face
+            .replacements
+            .iter()
+            .find(|r| is_devour_etb_replacement(r, 3, &TypeFilter::Creature))
+            .expect("creature-quality Devour replacement exists");
+        assert!(
+            !is_devour_etb_replacement(creature_repl, 3, &TypeFilter::Land),
+            "a creature-quality Devour 3 replacement must NOT match the land quality"
+        );
     }
 
     fn face_with_amplify(n: u32) -> CardFace {

--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8323,6 +8323,41 @@ fn is_bloodthirst_x_etb_replacement(replacement: &ReplacementDefinition) -> bool
 /// creature sacrificed"). `PreviousEffectAmount` is NOT used — it reads
 /// `last_effect_amount`, which the ranged Sacrifice never stamps.
 ///
+fn type_filter_noun(filter: &TypeFilter, plural: bool) -> String {
+    let noun = match filter {
+        TypeFilter::Creature => "creature",
+        TypeFilter::Land => "land",
+        TypeFilter::Artifact => "artifact",
+        TypeFilter::Enchantment => "enchantment",
+        TypeFilter::Instant => "instant",
+        TypeFilter::Sorcery => "sorcery",
+        TypeFilter::Planeswalker => "planeswalker",
+        TypeFilter::Battle => "battle",
+        TypeFilter::Kindred => "kindred",
+        TypeFilter::Permanent => "permanent",
+        TypeFilter::Card => "card",
+        TypeFilter::Any => "permanent",
+        TypeFilter::Non(inner) => return format!("non-{}", type_filter_noun(inner, plural)),
+        TypeFilter::Subtype(subtype) => {
+            let noun = subtype.to_lowercase();
+            return if plural { format!("{noun}s") } else { noun };
+        }
+        TypeFilter::AnyOf(filters) => {
+            return filters
+                .iter()
+                .map(|filter| type_filter_noun(filter, plural))
+                .collect::<Vec<_>>()
+                .join(" or ");
+        }
+    };
+
+    if plural {
+        format!("{noun}s")
+    } else {
+        noun.into()
+    }
+}
+
 /// CR 702.82c "Devour [quality]" variant: `Keyword::Devour { n, quality }`
 /// carries both N and the sacrifice-pool quality. `quality: TypeFilter::Creature`
 /// is the CR 702.82a default (plain "Devour N"); a non-creature quality (Land for
@@ -8367,13 +8402,8 @@ pub fn synthesize_devour(face: &mut CardFace) {
 
         // CR 702.82a / CR 702.82c: display noun for the sacrifice pool. Cosmetic —
         // the idempotency predicate keys on structure, not this text.
-        let quality_noun = match quality {
-            TypeFilter::Creature => "creature".to_string(),
-            TypeFilter::Land => "land".to_string(),
-            TypeFilter::Artifact => "artifact".to_string(),
-            TypeFilter::Subtype(s) => s.to_lowercase(),
-            other => format!("{other:?}").to_lowercase(),
-        };
+        let quality_noun = type_filter_noun(quality, false);
+        let quality_noun_plural = type_filter_noun(quality, true);
 
         // CR 122.1: N +1/+1 counters per creature sacrificed this way. The
         // per-creature count is `EventContextAmount` (resolves to the number
@@ -8422,7 +8452,7 @@ pub fn synthesize_devour(face: &mut CardFace) {
             },
         )
         .description(format!(
-            "CR 702.82a: Devour {n} — sacrifice any number of {quality_noun}s; this \
+            "CR 702.82a: Devour {n} — sacrifice any number of {quality_noun_plural}; this \
              permanent enters with {n} +1/+1 counter{} per {quality_noun} sacrificed.",
             if n == 1 { "" } else { "s" }
         ))
@@ -8436,7 +8466,7 @@ pub fn synthesize_devour(face: &mut CardFace) {
             destination_zone: Some(Zone::Battlefield),
             description: Some(format!(
                 "CR 702.82a + CR 614.1c: Devour {n} — as this creature enters, \
-                 you may sacrifice any number of {quality_noun}s; it enters with {n} \
+                you may sacrifice any number of {quality_noun_plural}; it enters with {n} \
                  +1/+1 counter{} for each {quality_noun} sacrificed this way.",
                 if n == 1 { "" } else { "s" }
             )),

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -4566,7 +4566,7 @@ pub(crate) fn keyword_cost_reads_growing_class(kw: &Keyword) -> bool {
         | Keyword::Outlast(_)
         | Keyword::Dash(_)
         | Keyword::Warp(_)
-        | Keyword::Devour(_)
+        | Keyword::Devour { .. }
         | Keyword::Offspring(_)
         | Keyword::Splice { .. }
         | Keyword::Sunburst
@@ -4873,7 +4873,7 @@ fn scan_keyword(kw: &Keyword, mode: ScanMode) -> Axes {
         | Keyword::Bloodthirst(_)
         | Keyword::Amplify(_)
         | Keyword::Graft(_)
-        | Keyword::Devour(_)
+        | Keyword::Devour { .. }
         | Keyword::Toxic(_)
         | Keyword::Saddle(_)
         | Keyword::Teamwork(_)

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -28658,7 +28658,7 @@ pub mod tests {
             | Keyword::LivingMetal
             | Keyword::Bloodthirst(_)
             | Keyword::Amplify(_)
-            | Keyword::Devour(_)
+            | Keyword::Devour { .. }
             | Keyword::Toxic(_)
             | Keyword::Saddle(_)
             | Keyword::Teamwork(_)

--- a/crates/engine/src/game/triggers_devour_runtime_tests.rs
+++ b/crates/engine/src/game/triggers_devour_runtime_tests.rs
@@ -16,7 +16,7 @@
 use crate::database::synthesis::synthesize_all;
 use crate::game::printed_cards::apply_card_face_to_object;
 use crate::game::zones::{create_object, move_to_zone};
-use crate::types::ability::{EffectKind, PtValue, TargetFilter};
+use crate::types::ability::{EffectKind, PtValue, TargetFilter, TypeFilter};
 use crate::types::actions::GameAction;
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
@@ -36,7 +36,25 @@ fn devour_face(name: &str, n: u32) -> CardFace {
         name: name.to_string(),
         power: Some(PtValue::Fixed(3)),
         toughness: Some(PtValue::Fixed(3)),
-        keywords: vec![Keyword::Devour(n)],
+        keywords: vec![Keyword::Devour {
+            n,
+            quality: TypeFilter::Creature,
+        }],
+        ..CardFace::default()
+    };
+    face.card_type.core_types.push(CoreType::Creature);
+    synthesize_all(&mut face);
+    face
+}
+
+/// Build a creature face carrying `Keyword::Devour { n, quality }` (CR 702.82c)
+/// and run the full synthesis pipeline.
+fn devour_face_q(name: &str, n: u32, quality: TypeFilter) -> CardFace {
+    let mut face = CardFace {
+        name: name.to_string(),
+        power: Some(PtValue::Fixed(3)),
+        toughness: Some(PtValue::Fixed(3)),
+        keywords: vec![Keyword::Devour { n, quality }],
         ..CardFace::default()
     };
     face.card_type.core_types.push(CoreType::Creature);
@@ -72,6 +90,117 @@ fn battlefield_creature(state: &mut GameState, controller: PlayerId, name: &str)
     obj.base_power = Some(2);
     obj.base_toughness = Some(2);
     id
+}
+
+/// Place a basic Forest (a Land) on the battlefield under `controller`.
+fn battlefield_land(state: &mut GameState, controller: PlayerId, name: &str) -> ObjectId {
+    let card_id = CardId(state.next_object_id);
+    let id = create_object(
+        state,
+        card_id,
+        controller,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Land);
+    obj.card_types.subtypes.push("Forest".to_string());
+    obj.base_card_types = obj.card_types.clone();
+    id
+}
+
+/// Place an artifact (optionally carrying `subtypes`, e.g. "Food") on the
+/// battlefield under `controller`.
+fn battlefield_artifact(
+    state: &mut GameState,
+    controller: PlayerId,
+    name: &str,
+    subtypes: &[&str],
+) -> ObjectId {
+    let card_id = CardId(state.next_object_id);
+    let id = create_object(
+        state,
+        card_id,
+        controller,
+        name.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Artifact);
+    for s in subtypes {
+        obj.card_types.subtypes.push((*s).to_string());
+    }
+    obj.base_card_types = obj.card_types.clone();
+    id
+}
+
+/// Drive a Devour creature's Hand→Battlefield ZoneChange through the replacement
+/// pipeline after `setup` populates the battlefield, then drain the
+/// post-replacement continuation. Mirrors `drive_devour_etb_to_sacrifice_choice`
+/// but hands the caller full control of the battlefield (mixed land/creature
+/// pools) so the quality axis (CR 702.82c) is observable.
+fn drive_devour_etb_with_battlefield(
+    face: &CardFace,
+    controller: PlayerId,
+    setup: impl FnOnce(&mut GameState),
+) -> (GameState, ObjectId) {
+    assert!(
+        face.replacements
+            .iter()
+            .any(|r| matches!(r.event, ReplacementEvent::Moved)
+                && matches!(r.valid_card, Some(TargetFilter::SelfRef))),
+        "test fixture must carry a synthesized Devour ETB replacement; got {:?}",
+        face.replacements
+    );
+
+    let mut state = setup_state_with_priority(controller);
+    setup(&mut state);
+
+    let next_card = CardId(state.next_object_id);
+    let obj_id = create_object(
+        &mut state,
+        next_card,
+        controller,
+        face.name.clone(),
+        Zone::Hand,
+    );
+    {
+        let obj = state.objects.get_mut(&obj_id).unwrap();
+        apply_card_face_to_object(obj, face);
+    }
+
+    let proposed = crate::types::proposed_event::ProposedEvent::zone_change(
+        obj_id,
+        Zone::Hand,
+        Zone::Battlefield,
+        None,
+    );
+    let mut events = Vec::new();
+    let result = crate::game::replacement::replace_event(&mut state, proposed, &mut events);
+    let crate::game::replacement::ReplacementResult::Execute(event) = result else {
+        panic!("Devour ETB pipeline must return Execute, got {result:?}");
+    };
+    let crate::types::proposed_event::ProposedEvent::ZoneChange { object_id, to, .. } = event
+    else {
+        panic!("pipeline must yield a ZoneChange execute event");
+    };
+    move_to_zone(&mut state, object_id, to, &mut events);
+
+    assert!(
+        state.has_post_replacement_drain(),
+        "Devour's non-modifier execute (Effect::Sacrifice) must be stashed as a \
+         post-replacement continuation"
+    );
+    state.clear_post_replacement_source();
+    let _ = crate::game::engine_replacement::apply_pending_post_replacement_effect(
+        &mut state,
+        Some(obj_id),
+        None,
+        Some(ReplacementEvent::Moved),
+        &mut events,
+    );
+
+    (state, obj_id)
 }
 
 fn p1p1(state: &GameState, id: ObjectId) -> u32 {
@@ -294,5 +423,254 @@ fn devour_2_one_sacrifice_places_two_counters() {
         p1p1(&state, devour),
         2,
         "Devour 2 + one creature sacrificed → 2 +1/+1 counters (N per sacrifice)"
+    );
+}
+
+/// P (PRIMARY, the reported bug — Famished Worldsire "Devour land 3", CR 702.82c):
+/// the ETB sacrifice pool is the controller's LANDS; a co-present creature is
+/// EXCLUDED. Sacrificing 2 lands to Devour 3 places 3×2 = 6 +1/+1 counters.
+///
+/// Revert-sensitive: if the quality drops to the CR 702.82a creature default, the
+/// pool would offer the creature (not the lands) and this test fails on the pool
+/// membership assertions.
+#[test]
+fn devour_land_3_sacrifices_lands_not_creatures() {
+    let face = devour_face_q("Famished Worldsire", 3, TypeFilter::Land);
+
+    let mut land_ids = Vec::new();
+    let mut creature_id = ObjectId(0);
+    let (mut state, devour) = drive_devour_etb_with_battlefield(&face, PlayerId(0), |state| {
+        land_ids.push(battlefield_land(state, PlayerId(0), "Forest 1"));
+        land_ids.push(battlefield_land(state, PlayerId(0), "Forest 2"));
+        creature_id = battlefield_creature(state, PlayerId(0), "Bystander Bear");
+    });
+
+    let WaitingFor::EffectZoneChoice {
+        cards, effect_kind, ..
+    } = &state.waiting_for
+    else {
+        panic!(
+            "expected the Devour land sacrifice choice, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert_eq!(*effect_kind, EffectKind::Sacrifice);
+    for land in &land_ids {
+        assert!(
+            cards.contains(land),
+            "CR 702.82c: each controlled land must be an eligible Devour-land sacrifice; pool={cards:?}"
+        );
+    }
+    assert!(
+        !cards.contains(&creature_id),
+        "CR 702.82c: a creature must NOT be offered to a Devour-land sacrifice; pool={cards:?}"
+    );
+
+    crate::game::engine::apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: land_ids.clone(),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        state.objects.get(&devour).unwrap().zone,
+        Zone::Battlefield,
+        "the Devour-land creature enters the battlefield"
+    );
+    assert_eq!(
+        p1p1(&state, devour),
+        6,
+        "Devour 3 + two lands sacrificed → 3×2 = 6 +1/+1 counters (CR 702.82c counter math)"
+    );
+    assert_eq!(
+        state.objects.get(&creature_id).unwrap().zone,
+        Zone::Battlefield,
+        "the bystander creature was never eligible and survives"
+    );
+}
+
+/// C (CONTROL, CR 702.82a default preserved): a plain "Devour 2" creature offers
+/// its CREATURES and excludes lands. One sacrifice → 2 counters. Proves the
+/// creature default survives the parameterization.
+#[test]
+fn devour_creature_default_excludes_lands() {
+    let face = devour_face_q("Mycoloth", 2, TypeFilter::Creature);
+
+    let mut creature_ids = Vec::new();
+    let mut land_id = ObjectId(0);
+    let (mut state, devour) = drive_devour_etb_with_battlefield(&face, PlayerId(0), |state| {
+        creature_ids.push(battlefield_creature(state, PlayerId(0), "Fodder A"));
+        creature_ids.push(battlefield_creature(state, PlayerId(0), "Fodder B"));
+        land_id = battlefield_land(state, PlayerId(0), "Idle Forest");
+    });
+
+    let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for else {
+        panic!(
+            "expected the Devour creature sacrifice choice, got {:?}",
+            state.waiting_for
+        );
+    };
+    for creature in &creature_ids {
+        assert!(
+            cards.contains(creature),
+            "creatures are eligible; pool={cards:?}"
+        );
+    }
+    assert!(
+        !cards.contains(&land_id),
+        "CR 702.82a: a land must NOT be offered to a plain Devour sacrifice; pool={cards:?}"
+    );
+
+    let one = vec![creature_ids[0]];
+    crate::game::engine::apply_as_current(&mut state, GameAction::SelectCards { cards: one })
+        .unwrap();
+    assert_eq!(
+        p1p1(&state, devour),
+        2,
+        "Devour 2 + one creature → 2 counters (creature default intact)"
+    );
+}
+
+/// B (BOUNDARY, CR 702.82a "may sacrifice"): Devour land 3 with ZERO controlled
+/// lands (only creatures present) → no eligible land, so the creature still
+/// enters with 0 counters and no land is consumed.
+#[test]
+fn devour_land_3_with_no_lands_enters_with_zero_counters() {
+    let face = devour_face_q("Famished Worldsire", 3, TypeFilter::Land);
+
+    let mut creature_id = ObjectId(0);
+    let (mut state, devour) = drive_devour_etb_with_battlefield(&face, PlayerId(0), |state| {
+        creature_id = battlefield_creature(state, PlayerId(0), "Non-Land Bear");
+    });
+
+    // With an empty eligible land pool and min_count 0, a ranged sacrifice may
+    // either auto-resolve or surface an empty prompt; either way no creature is
+    // offered and the empty choice is declined.
+    if let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for {
+        assert!(
+            !cards.contains(&creature_id),
+            "CR 702.82c: a creature is never a legal Devour-land sacrifice; pool={cards:?}"
+        );
+        crate::game::engine::apply_as_current(
+            &mut state,
+            GameAction::SelectCards { cards: vec![] },
+        )
+        .unwrap();
+    }
+
+    assert_eq!(
+        state.objects.get(&devour).unwrap().zone,
+        Zone::Battlefield,
+        "CR 702.82a: the creature still enters when no land can be sacrificed"
+    );
+    assert_eq!(
+        p1p1(&state, devour),
+        0,
+        "no land sacrificed → 0 +1/+1 counters"
+    );
+    assert_eq!(
+        state.objects.get(&creature_id).unwrap().zone,
+        Zone::Battlefield,
+        "the bystander creature is untouched"
+    );
+}
+
+/// A (subtype class — Caprichrome "Devour artifact 1", CR 702.82c): the pool is
+/// the controller's ARTIFACTS; a creature is excluded. One artifact sacrificed →
+/// 1 counter.
+#[test]
+fn devour_artifact_1_sacrifices_artifacts_not_creatures() {
+    let face = devour_face_q("Caprichrome", 1, TypeFilter::Artifact);
+
+    let mut artifact_id = ObjectId(0);
+    let mut creature_id = ObjectId(0);
+    let (mut state, devour) = drive_devour_etb_with_battlefield(&face, PlayerId(0), |state| {
+        artifact_id = battlefield_artifact(state, PlayerId(0), "Trinket", &[]);
+        creature_id = battlefield_creature(state, PlayerId(0), "Bystander Bear");
+    });
+
+    let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for else {
+        panic!(
+            "expected the Devour artifact sacrifice choice, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&artifact_id),
+        "artifacts are eligible; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&creature_id),
+        "CR 702.82c: a creature must NOT be offered to a Devour-artifact sacrifice; pool={cards:?}"
+    );
+
+    crate::game::engine::apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: vec![artifact_id],
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        p1p1(&state, devour),
+        1,
+        "Devour artifact 1 + one artifact → 1 +1/+1 counter"
+    );
+}
+
+/// A (subtype class — Feasting Hobbit "Devour Food 3", CR 702.82c + CR 205.3g):
+/// the `Subtype("Food")` quality narrows the pool to FOOD artifacts only — a
+/// plain (non-Food) artifact AND a creature are both excluded. Proves the
+/// runtime `subtypes.contains("Food")` path (filter.rs) matches the canonical
+/// subtype the parser emits. One Food sacrificed → 3 counters.
+#[test]
+fn devour_food_3_sacrifices_only_food_subtype() {
+    let face = devour_face_q(
+        "Feasting Hobbit",
+        3,
+        TypeFilter::Subtype("Food".to_string()),
+    );
+
+    let mut food_id = ObjectId(0);
+    let mut plain_artifact_id = ObjectId(0);
+    let mut creature_id = ObjectId(0);
+    let (mut state, devour) = drive_devour_etb_with_battlefield(&face, PlayerId(0), |state| {
+        food_id = battlefield_artifact(state, PlayerId(0), "Food Token", &["Food"]);
+        plain_artifact_id = battlefield_artifact(state, PlayerId(0), "Trinket", &[]);
+        creature_id = battlefield_creature(state, PlayerId(0), "Bystander Bear");
+    });
+
+    let WaitingFor::EffectZoneChoice { cards, .. } = &state.waiting_for else {
+        panic!(
+            "expected the Devour Food sacrifice choice, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert!(
+        cards.contains(&food_id),
+        "the Food token is eligible; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&plain_artifact_id),
+        "CR 205.3g: a non-Food artifact is NOT a Food; pool={cards:?}"
+    );
+    assert!(
+        !cards.contains(&creature_id),
+        "a creature is NOT a Food; pool={cards:?}"
+    );
+
+    crate::game::engine::apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: vec![food_id],
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        p1p1(&state, devour),
+        3,
+        "Devour Food 3 + one Food → 3 +1/+1 counters"
     );
 }

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1286,6 +1286,35 @@ fn parse_disguise_keyword_line(text: &str) -> Option<Keyword> {
 /// Oracle text uses space-separated format: "protection from red", "ward {2}",
 /// "flashback {2}{U}". Converts to the colon format that `FromStr` expects,
 /// handling the "from" preposition used by protection keywords.
+/// CR 702.82a / CR 702.82c: "Devour [quality] N".
+///
+/// Plain "Devour N" (CR 702.82a) sacrifices creatures; the qualified form
+/// "Devour [quality] N" (CR 702.82c) sacrifices [quality] permanents. The
+/// optional type qualifier sits between the keyword name and the count, so the
+/// grammar is `"devour " (type_filter " ")? number`. `parse_type_filter_word`
+/// errors on a bare number, so `opt` yields `None` for the plain form and the
+/// quality defaults to `TypeFilter::Creature` (CR 702.82a). The word emits a
+/// canonical-case `Subtype` (e.g. Food), so the synthesized runtime filter's
+/// subtype membership test matches the canonical "Food" name. Returns
+/// `(keyword, unconsumed)`.
+fn parse_devour_keyword_line(text: &str) -> Option<(Keyword, &str)> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("devour ").parse(text).ok()?;
+    let (rest, quality) = opt((
+        crate::parser::oracle_nom::target::parse_type_filter_word,
+        tag::<_, _, OracleError<'_>>(" "),
+    ))
+    .parse(rest)
+    .ok()?;
+    let (unconsumed, n) = nom_primitives::parse_number.parse(rest).ok()?;
+    Some((
+        Keyword::Devour {
+            n,
+            quality: quality.map_or(TypeFilter::Creature, |(q, _)| q),
+        },
+        unconsumed,
+    ))
+}
+
 pub(crate) fn parse_keyword_line_core(text: &str) -> Option<(Keyword, &str)> {
     use crate::types::keywords::PartnerType;
 
@@ -1334,6 +1363,13 @@ pub(crate) fn parse_keyword_line_core(text: &str) -> Option<(Keyword, &str)> {
 
     if let Some(kw) = parse_bloodthirst_keyword_line(text) {
         return Some((kw, ""));
+    }
+
+    // CR 702.82a / CR 702.82c: "Devour [quality] N" — the optional type qualifier
+    // precedes the count, so this must run BEFORE the generic numeric-count path,
+    // which would capture only N and silently drop the quality (the reported bug).
+    if let Some(result) = parse_devour_keyword_line(text) {
+        return Some(result);
     }
 
     if let Some(kw) = parse_firebending_keyword_line(text) {
@@ -1826,28 +1862,16 @@ pub(crate) fn parse_keyword_line_core(text: &str) -> Option<(Keyword, &str)> {
     // tail is precisely what the strict router must see in order to reject
     // "<kw> N <semantic clause>" (e.g. "crew 2 if it's an artifact").
     let (param, unconsumed): (Cow<'_, str>, &str) = if is_numeric_count_keyword(name) {
-        // CR 702.82c: "Devour [quality] N" is a variant where the count follows a
-        // leading type qualifier — Famished Worldsire's "Devour land 3" enters
-        // with three +1/+1 counters per sacrificed LAND, so the numeric token
-        // sits after "land". Take the count at the head; if a non-numeric
-        // qualifier word precedes it, skip that one word and retry, so the count
-        // is captured rather than lost to the keyword's `FromStr` `unwrap_or(1)`
-        // fallback (which produced the reported Devour 1).
-        let count_src = if nom_primitives::parse_number.parse(rest).is_ok() {
-            rest
-        } else {
-            (
-                take_until::<_, _, OracleError<'_>>(" "),
-                tag::<_, _, OracleError<'_>>(" "),
-            )
-                .parse(rest)
-                .map_or(rest, |(after_qualifier, _)| after_qualifier)
-        };
-        match nom_primitives::parse_number.parse(count_src) {
+        // Bare-integer count keywords (Vanishing/Fading/Renown/Frenzy/Bushido/…):
+        // take only the leading integer and surface the trailing clause as
+        // `unconsumed` so the strict router can reject "<kw> N <semantic clause>".
+        // (CR 702.82c "Devour [quality] N" is handled upstream by
+        // `parse_devour_keyword_line`, so no qualifier-skip is needed here.)
+        match nom_primitives::parse_number.parse(rest) {
             // `remainder` is the clause the permissive contract drops on the
             // floor. Surface it; the strict router turns it into a rejection.
             Ok((remainder, _)) => (
-                Cow::Borrowed(&count_src[..count_src.len() - remainder.len()]),
+                Cow::Borrowed(&rest[..rest.len() - remainder.len()]),
                 remainder,
             ),
             // No leading integer: the whole `rest` goes to `FromStr`, so whatever
@@ -2413,7 +2437,7 @@ pub fn keyword_display_name(keyword: &Keyword) -> String {
         Keyword::Bloodthirst(_) => "bloodthirst".to_string(),
         Keyword::Amplify(_) => "amplify".to_string(),
         Keyword::Graft(_) => "graft".to_string(),
-        Keyword::Devour(_) => "devour".to_string(),
+        Keyword::Devour { .. } => "devour".to_string(),
         Keyword::Toxic(_) => "toxic".to_string(),
         Keyword::Saddle(_) => "saddle".to_string(),
         Keyword::Teamwork(_) => "teamwork".to_string(),
@@ -2814,22 +2838,42 @@ mod tests {
     }
 
     /// CR 702.82c: "Devour [quality] N" (Famished Worldsire — "Devour land 3")
-    /// puts the count after the type qualifier. The numeric-count extractor must
-    /// skip the leading qualifier word so the count is 3, not the `FromStr`
-    /// `unwrap_or(1)` fallback (which produced the reported Devour 1).
+    /// puts the count after the type qualifier. The parser must capture BOTH the
+    /// count and the quality — the quality axis is the reported bug: dropping it
+    /// yields the CR 702.82a creature default for a land-quality card.
     #[test]
     fn parse_granted_keyword_fragment_devour_quality_qualifier_count() {
+        // CR 702.82c: land quality — the discriminating case. REVERTS to
+        // `quality: Creature` (i.e. this assertion FAILS) if the qualifier is
+        // dropped, which is exactly the reported bug.
         assert_eq!(
             parse_granted_keyword_fragment("devour land 3"),
-            Some(Keyword::Devour(3))
+            Some(Keyword::Devour {
+                n: 3,
+                quality: TypeFilter::Land,
+            })
         );
-        // CR 702.82a: the plain "Devour N" form is unaffected.
+        // CR 702.82a: the plain "Devour N" form defaults to the creature quality.
         assert_eq!(
             parse_granted_keyword_fragment("devour 3"),
-            Some(Keyword::Devour(3))
+            Some(Keyword::Devour {
+                n: 3,
+                quality: TypeFilter::Creature,
+            })
         );
-        // Regression: a sibling numeric-count keyword still extracts its leading
-        // count — the qualifier-skip only fires on the parse_number-fails branch.
+        // CR 702.82c + CR 205.3g: an artifact SUBTYPE quality (Feasting Hobbit —
+        // "Devour Food 3") canonicalizes to `Subtype("Food")` so the runtime
+        // subtype membership test matches the canonical "Food" name.
+        assert_eq!(
+            parse_granted_keyword_fragment("devour food 3"),
+            Some(Keyword::Devour {
+                n: 3,
+                quality: TypeFilter::Subtype("Food".to_string()),
+            })
+        );
+        // Regression (BLOCKING 2): a sibling numeric-count keyword still extracts
+        // its leading count — the devour-qualifier path did not cannibalize the
+        // generic numeric-count branch that Vanishing/Fading/Renown rely on.
         assert_eq!(
             parse_granted_keyword_fragment("vanishing 3"),
             Some(Keyword::Vanishing(3))

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -902,10 +902,22 @@ pub enum Keyword {
     /// RUNTIME: synthesized as-enters replacement by
     /// `database/synthesis.rs::synthesize_devour` — a `ReplacementEvent::Moved`
     /// replacement on `SelfRef` whose execute chain is a ranged `Effect::Sacrifice`
-    /// over the controller's creatures + a per-sacrifice `PutCounter(+1/+1)`
-    /// sub-ability. CR 702.82a: Devour N — as it enters, you may sacrifice any
-    /// number of creatures; it enters with N +1/+1 counters per sacrifice.
-    Devour(u32),
+    /// over the controller's permanents matching `quality` + a per-sacrifice
+    /// `PutCounter(+1/+1)` sub-ability.
+    ///
+    /// CR 702.82a: "Devour N" — as it enters, you may sacrifice any number of
+    /// creatures; it enters with N +1/+1 counters per sacrifice. This is the
+    /// default and corresponds to `quality: TypeFilter::Creature`.
+    ///
+    /// CR 702.82c: "Devour [quality] N" — the quality-qualified variant sacrifices
+    /// [quality] permanents instead (e.g. Land for Famished Worldsire, Artifact for
+    /// Caprichrome, Subtype("Food") for Feasting Hobbit). Per CR 702.82c the counter
+    /// math (N +1/+1 counters per permanent sacrificed, CR 122.1a) is identical to
+    /// the plain form and independent of `quality` — only the sacrifice pool changes.
+    Devour {
+        n: u32,
+        quality: TypeFilter,
+    },
 
     /// CR 702.164: Toxic N — when this creature deals combat damage to a player,
     /// that player gets N poison counters.
@@ -1332,7 +1344,7 @@ impl Keyword {
             | Keyword::Demonstrate
             | Keyword::Bloodthirst(_)
             | Keyword::Amplify(_)
-            | Keyword::Devour(_)
+            | Keyword::Devour { .. }
             | Keyword::Teamwork(_)
             | Keyword::Backup(_)
             | Keyword::Squad(_)
@@ -1504,7 +1516,7 @@ impl Keyword {
             Keyword::Craft { .. } => KeywordKind::Craft,
             Keyword::Harmonize(_) => KeywordKind::Harmonize,
             Keyword::Warp(_) => KeywordKind::Warp,
-            Keyword::Devour(_) => KeywordKind::Devour,
+            Keyword::Devour { .. } => KeywordKind::Devour,
             Keyword::Offspring(_) => KeywordKind::Offspring,
             Keyword::Splice { .. } => KeywordKind::Splice,
             Keyword::Bargain => KeywordKind::Bargain,
@@ -2469,7 +2481,16 @@ impl FromStr for Keyword {
                 "bloodthirst" => return Ok(Keyword::Bloodthirst(parse_bloodthirst_value(p))),
                 "amplify" => return Ok(Keyword::Amplify(p.parse().unwrap_or(1))),
                 "graft" => return Ok(Keyword::Graft(p.parse().unwrap_or(1))),
-                "devour" => return Ok(Keyword::Devour(p.parse().unwrap_or(1))),
+                // CR 702.82a: the colon-form `FromStr` path carries only the count;
+                // the quality qualifier (CR 702.82c) is captured upstream by the
+                // dedicated `parse_devour_keyword_line` combinator, so this fallback
+                // builds the CR 702.82a creature default.
+                "devour" => {
+                    return Ok(Keyword::Devour {
+                        n: p.parse().unwrap_or(1),
+                        quality: TypeFilter::Creature,
+                    })
+                }
                 // CR 702.164
                 "toxic" => return Ok(Keyword::Toxic(p.parse().unwrap_or(1))),
                 // CR 702.171a
@@ -3402,7 +3423,28 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Bloodthirst" => Ok(Keyword::Bloodthirst(bloodthirst(data)?)),
         "Amplify" => Ok(Keyword::Amplify(uint(data))),
         "Graft" => Ok(Keyword::Graft(uint(data))),
-        "Devour" => Ok(Keyword::Devour(uint(data))),
+        "Devour" => {
+            // Struct variant: {"Devour": {"n": N, "quality": <TypeFilter>}}.
+            // A bare number {"Devour": N} is also accepted for back-compat with
+            // card-data serialized before the CR 702.82c quality axis existed; it
+            // deserializes to the CR 702.82a creature default. Mirrors the Crew arm.
+            if let Some(obj) = data.as_object() {
+                let n = obj.get("n").map(uint).unwrap_or(1);
+                let quality = obj
+                    .get("quality")
+                    .cloned()
+                    .map(serde_json::from_value::<TypeFilter>)
+                    .transpose()
+                    .map_err(|e| e.to_string())?
+                    .unwrap_or(TypeFilter::Creature);
+                Ok(Keyword::Devour { n, quality })
+            } else {
+                Ok(Keyword::Devour {
+                    n: uint(data),
+                    quality: TypeFilter::Creature,
+                })
+            }
+        }
         // CR 702.164 / CR 702.171a / CR 702.46 / CR 702.165
         "Toxic" => Ok(Keyword::Toxic(uint(data))),
         "Saddle" => Ok(Keyword::Saddle(uint(data))),
@@ -3564,6 +3606,46 @@ mod tests {
             CostBearingKeywordKind::Foretell.with_cost(cost.clone()),
             Keyword::Foretell(cost)
         );
+    }
+
+    /// Back-compat: card-data.json serialized before the CR 702.82c quality axis
+    /// encoded Devour as a bare number `{"Devour": 3}`. The custom Deserialize
+    /// bare-number fallback must still load such states, defaulting to the CR
+    /// 702.82a creature quality — otherwise every pre-existing saved game / cached
+    /// card-data blob would drop the keyword on reload.
+    #[test]
+    fn devour_old_form_bare_number_json_still_loads() {
+        let old: Keyword = serde_json::from_str(r#"{"Devour": 3}"#).unwrap();
+        assert_eq!(
+            old,
+            Keyword::Devour {
+                n: 3,
+                quality: TypeFilter::Creature,
+            }
+        );
+    }
+
+    /// The new struct form round-trips through serde, and a non-creature quality
+    /// (CR 702.82c) survives serialize→deserialize.
+    #[test]
+    fn devour_struct_form_round_trips_quality() {
+        for quality in [
+            TypeFilter::Creature,
+            TypeFilter::Land,
+            TypeFilter::Artifact,
+            TypeFilter::Subtype("Food".to_string()),
+        ] {
+            let kw = Keyword::Devour {
+                n: 3,
+                quality: quality.clone(),
+            };
+            let json = serde_json::to_string(&kw).unwrap();
+            let back: Keyword = serde_json::from_str(&json).unwrap();
+            assert_eq!(
+                back, kw,
+                "Devour quality must round-trip: {quality:?} via {json}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mtgish-import/src/convert/keyword.rs
+++ b/crates/mtgish-import/src/convert/keyword.rs
@@ -10,7 +10,9 @@
 //! type-system lookup; there is no semantic translation. Cost/filter
 //! keywords need real conversion logic, so they land with their phase.
 
-use engine::types::ability::{AbilityCost, CostObjectCount, QuantityExpr};
+use engine::types::ability::{
+    AbilityCost, CostObjectCount, QuantityExpr, TargetFilter, TypeFilter,
+};
 use engine::types::keywords::{
     BestowCost, BloodthirstValue, BuybackCost, CyclingCost, EscapeCost, FlashbackCost,
     HexproofFilter, ProtectionTarget, WardCost,
@@ -19,9 +21,10 @@ use engine::types::mana::{ManaColor, ManaCost};
 use engine::types::Keyword;
 
 use crate::convert::result::{ConvResult, ConversionGap};
-use crate::convert::{cost as cost_conv, quantity};
+use crate::convert::{cost as cost_conv, filter, quantity};
 use crate::schema::types::{
-    CardType, Cards, Color, Cost, CreatureType, GameNumber, Protectable, ProtectableColor, Rule,
+    CardType, Cards, Color, Cost, CreatureType, GameNumber, Permanents, Protectable,
+    ProtectableColor, Rule,
 };
 
 /// If `rule` is a keyword Rule we can translate today, return the engine
@@ -327,9 +330,17 @@ pub fn try_convert(rule: &Rule, path: &str) -> ConvResult<Option<Keyword>> {
         Rule::Firebending(g) => Keyword::Firebending(QuantityExpr::Fixed {
             value: int_or_gap(g, "Rule::Firebending", path)? as i32,
         }),
-        // CR 702.81: Devour N — engine encodes only N (the "creatures you
-        // sacrifice" filter is implicit).
-        Rule::Devour(_perm, g) => Keyword::Devour(int_or_gap(g, "Rule::Devour", path)?),
+        // CR 702.82a / CR 702.82c: Devour [quality] N — the engine now carries the
+        // sacrifice-pool quality (plain devour = creatures, CR 702.82a). The mtgish
+        // AST holds the "[quality] permanents" qualifier as `Permanents`; map it to
+        // the engine `TypeFilter` via the shared filter converter. Strict-fails
+        // rather than silently defaulting to Creature (a forbidden semantic drop —
+        // mtgish-import CLAUDE.md §1/§3) when the qualifier is not a single-type
+        // quality.
+        Rule::Devour(perm, g) => Keyword::Devour {
+            n: int_or_gap(g, "Rule::Devour", path)?,
+            quality: devour_quality(perm, path)?,
+        },
         // CR 702.160a: Prototype — alt-cost cast that uses the secondary
         // power/toughness and mana cost characteristics.
         // CR 702.176a: Impending N—{cost} — alternative cost. "You may
@@ -891,12 +902,90 @@ fn int_or_gap(g: &GameNumber, idiom: &'static str, path: &str) -> ConvResult<u32
     }
 }
 
+/// CR 702.82a / CR 702.82c: reduce a Devour `[quality]` qualifier (mtgish
+/// `Permanents`) to a single engine `TypeFilter`. Plain devour is
+/// `IsCardtype(Creature)` (CR 702.82a → `Creature`). Reuses `filter::convert`,
+/// then extracts one type: a subtype (e.g. Food, which implies Artifact) takes
+/// priority over its base type — matching the native parser's `Subtype("Food")`.
+///
+/// Strict-fails (per this crate's strict-failure discipline §1/§3 — never
+/// silently widen or default) when the qualifier does not reduce to a single,
+/// *specific* type quality. In particular a bare `permanent`/`card`/`any`
+/// reduction (e.g. `Permanents::AnyPermanent`/`IsPermanent` → `TypedFilter::
+/// permanent()` → primary type `TypeFilter::Permanent`) is a non-specific
+/// catch-all, NOT a valid Devour quality: CR 702.82c names a *specific* permanent
+/// type. Returning it would silently widen the synthesized sacrifice pool to
+/// every permanent the controller owns, so it fails loud instead of defaulting to
+/// Creature.
+fn devour_quality(perm: &Permanents, path: &str) -> ConvResult<TypeFilter> {
+    let TargetFilter::Typed(tf) = filter::convert(perm)? else {
+        return Err(ConversionGap::MalformedIdiom {
+            idiom: "Rule::Devour",
+            path: path.to_string(),
+            detail: format!("quality qualifier is not a typed filter: {perm:?}"),
+        });
+    };
+    if let Some(subtype) = tf.get_subtype() {
+        return Ok(TypeFilter::Subtype(subtype.to_string()));
+    }
+    match tf.get_primary_type() {
+        // A non-specific catch-all (`permanent`/`card`/`any`) or no type at all is
+        // not a CR 702.82c quality — fail loud rather than widen the sac pool.
+        Some(TypeFilter::Permanent | TypeFilter::Card | TypeFilter::Any) | None => {
+            Err(ConversionGap::MalformedIdiom {
+                idiom: "Rule::Devour",
+                path: path.to_string(),
+                detail: format!("quality qualifier has no single-type reduction: {perm:?}"),
+            })
+        }
+        Some(ty) => Ok(ty.clone()),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use engine::types::ability::{CountScope, QuantityExpr, QuantityRef, TypeFilter, ZoneRef};
     use engine::types::Keyword;
 
     use super::*;
+
+    /// CR 702.82a / CR 702.82c: `devour_quality` reduces a mtgish `Permanents`
+    /// qualifier to a single specific engine `TypeFilter`, and STRICT-FAILS (never
+    /// silently widens) on a non-specific catch-all. Exercised against the real
+    /// `filter::convert` output, using the exact `Permanents` shapes the Devour
+    /// rules encode (`IsCardtype(Creature)` for plain devour, `IsArtifactType(Food)`
+    /// for Feasting Hobbit, `AnyPermanent` for the catch-all defence case).
+    #[test]
+    fn devour_quality_reduces_specific_types_and_strict_fails_catch_all() {
+        use crate::schema::types::ArtifactType;
+
+        // CR 702.82a: plain devour = `IsCardtype(Creature)` → Creature.
+        // (`ConversionGap` has no `PartialEq`, so unwrap the Ok and compare the
+        // `TypeFilter` rather than the whole `Result`.)
+        assert_eq!(
+            devour_quality(&Permanents::IsCardtype(CardType::Creature), "test").unwrap(),
+            TypeFilter::Creature
+        );
+
+        // CR 702.82c + CR 205.3g: Feasting Hobbit's `IsArtifactType(Food)` reduces
+        // to the SUBTYPE (Food ⊂ Artifact), matching the native parser.
+        assert_eq!(
+            devour_quality(&Permanents::IsArtifactType(ArtifactType::Food), "test").unwrap(),
+            TypeFilter::Subtype("Food".to_string())
+        );
+
+        // Strict-failure defence: `AnyPermanent` reduces to `TypedFilter::
+        // permanent()` (primary type `Permanent`), a non-specific catch-all that is
+        // NOT a valid CR 702.82c quality. It must fail loud, not silently widen the
+        // sacrifice pool to every permanent.
+        assert!(matches!(
+            devour_quality(&Permanents::AnyPermanent, "test"),
+            Err(ConversionGap::MalformedIdiom {
+                idiom: "Rule::Devour",
+                ..
+            })
+        ));
+    }
 
     #[test]
     fn aftermath_lowers_to_keyword() {


### PR DESCRIPTION
Tier: Frontier
Model: claude-opus-4-8

Closes #6423.

## Summary

**Famished Worldsire** — *"Devour land 3 (As this creature enters, you may sacrifice any number of lands. It enters with three times that many +1/+1 counters on it.)"* — let you sacrifice **creatures** instead of **lands**. Two dropped halves of the same axis: `Keyword::Devour(u32)` carried only the count, discarding the *"[quality]"* of CR 702.82c (`land`), and `synthesize_devour` hard-coded the ETB replacement's `Effect::Sacrifice` pool to `TypedFilter::creature()`. (Merged #5362 had already captured the *count* from "Devour land 3" while discarding "land" — this is the other half.)

Parameterize the keyword with the quality axis:

- **`Keyword::Devour(u32)` → `Keyword::Devour { n: u32, quality: TypeFilter }`**, defaulting to `TypeFilter::Creature` — the CR **702.82a** plain-Devour behavior. `quality` is a non-optional `TypeFilter` (not `Option`) because CR 702.82a defines a *concrete* default quality, not an absent one; and `TypeFilter` is the one layer that spans the whole corpus — core types **and** subtypes.
- **Parser**: a dedicated `parse_devour_keyword_line` (composed nom combinators — `tag("devour ")` → `opt(parse_type_filter_word + " ")` → `parse_number`) captures the optional quality word. Plain "Devour N" → `Creature`; "Devour land N" → `Land`; "Devour artifact N" → `Artifact`; "Devour Food N" → `Subtype("Food")`.
- **Synthesizer**: threads `quality` into **both** the `Sacrifice` target and the sacrificed-count `ObjectCount` filter. Counter math (`Multiply { factor: n }` × permanents sacrificed, CR 702.82c) is unchanged. `is_devour_etb_replacement` now discriminates on the quality so a same-`N` land-quality and creature-quality replacement can't false-dedupe.

Result across the whole 4-valued corpus (24 Devour cards): **Famished Worldsire → lands, Caprichrome → artifacts, Feasting Hobbit → Foods, plain Devour (20 cards) → creatures.**

This reshape was pre-sanctioned by the codebase itself — an in-code comment at `synthesize_devour` stated *"A future card needing the quality axis requires parameterizing the keyword to `Devour { n, quality }`"*; that comment is now updated to reflect that the axis is modeled.

## Implementation method (required)

Method: /engine-implementer — plan (/engine-planner, with a run-then-delete reproduction probe confirming the base offers creatures for "Devour land 3") + the **/add-engine-variant gate** (PASS: leaf-level parameterization within CR 702.82, no sibling proliferation) → /review-engine-plan (found 3 blocking issues: a missed cross-crate `mtgish-import` fan-out site, a mis-scoped "remove dead code" step that would have regressed Vanishing/Fading, and two non-discriminating tests — all corrected) → implement (tests-first RED→GREEN) → /review-impl (Maintainer-Simulation Gate PASS after one MED: hardened the mtgish quality reduction to strict-fail on a non-specific catch-all instead of silently widening the pool). Each step in a fresh agent context.

## Gate A

`./scripts/check-parser-combinators.sh` → **Gate A PASS head=f566fc872** (Gate G PASS). The new Devour parser is pure combinators.

## Anchored on

- **`Keyword::Crew { power, once_per_turn }`** — the existing struct-variant keyword; its four touchpoints (variant def, `KeywordKind` map, `FromStr` colon-form, and the custom-`Deserialize` object-or-bare-number arm) are the exact template the Devour reshape copies, including the serde back-compat shape.
- **`parse_type_filter_word`** (`oracle_nom/target.rs`) — the single authority for a type/quality token; the Devour parser delegates to it (emitting canonical-case `Subtype("Food")` to match the runtime `subtypes.contains("Food")` check), rather than re-implementing type matching.
- **`synthesize_devour`** (`database/synthesis.rs`) — the ETB-replacement synthesizer; the two hard-coded `TypedFilter::creature()` sites (the `Sacrifice` target and the `ObjectCount` filter) now take the keyword's `quality`, and the idempotency predicate keys on `(n, quality)`.

## Verification

- `cargo fmt --all` clean; `cargo clippy -p engine --tests` **0 warnings**; `cargo build -p engine` (no missed fan-out site) + `cargo check -p mtgish-import` (the cross-crate arm compiles) both green; `cargo test -p engine --lib` **17,688 passed / 0 failed**; `cargo test -p engine --test integration -- devour` **10 passed**.
- **Production-path runtime tests** (through `from_oracle_text_with_keywords` → synthesize → ETB replacement → `EffectZoneChoice` pool + counters, verbatim Oracle text):
  - **Famished Worldsire "Devour land 3"** → pool is the **lands** (creature excluded); sacrifice 2 lands → **6** +1/+1 counters.
  - **Control (CR 702.82a)**: plain "Devour 2" (Mycoloth) → pool is **creatures** (lands excluded), 1 sac → 2 counters — stays green when the quality-thread is reverted, proving the axis flip isn't noise.
  - **Boundary**: "Devour land 3" with zero lands → enters with 0 counters.
  - **Subtype class**: Caprichrome "Devour artifact 1" → artifacts; **Feasting Hobbit "Devour Food 3"** → only the Food token eligible (non-Food artifact + creature excluded).
- **Discriminating unit tests**: `synthesize_devour_discriminates_quality_axis` (same-`N` land vs creature replacements don't false-dedupe); the granted-fragment parse test asserts `land 3`→`{n:3,Land}` / `3`→`{n:3,Creature}` / `food 3`→`{n:3,Subtype("Food")}` **plus a `vanishing 3` regression** (proving the numeric-count branch other keywords rely on is intact); an old-form `{"Devour":3}` → `{n:3,quality:Creature}` serde back-compat test.
- **Fails before, passes after**: reverting the synthesizer quality to the hard-coded `creature()` flips the Land/Artifact/Food/dedup tests to RED while the creature control stays green; restored → all green.
- **CR annotations** grep-verified against `docs/MagicCompRules.txt`: 702.82a, 702.82c (and 205.3g for Food as an artifact subtype).

## Claimed parse impact

The serde shape of `Keyword::Devour` changes from `{"Devour":3}` to `{"Devour":{"n":3,"quality":…}}`, so **every Devour card's keyword payload migrates** — a regenerated card-data shows **24 Devour payloads** move to the struct form (0 bare-number remaining): `{n,Creature}`×21, `{n:3,Land}`×1 (Famished Worldsire), `{n:1,Artifact}`×1 (Caprichrome), `{n:3,Subtype("Food")}`×1 (Feasting Hobbit). No card's *support* changes. The custom `Deserialize` keeps old bare-number states loadable (game-state/replay/multiplayer safe); no ts-rs/tsify binding reads the payload. The CI parse-diff artifact should report exactly these Devour-payload migrations.

## Scope Expansion

None. The `mtgish-import` converter arm (`convert/keyword.rs`) is a **forced compile-consequence** of the shared `Keyword` reshape (CI runs `cargo clippy --workspace`); it maps the quality qualifier the mtgish AST already carries (currently discarded) and **strict-fails** on a non-specific catch-all per that crate's discipline — never silently defaulting. It is not a mtgish feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Devour abilities that target specific permanent types or subtypes, including lands, artifacts, and Food.
  * Qualified Devour text (e.g., “Devour land 3”) now parses correctly and preserves the selected target type.
* **Bug Fixes**
  * Devour replacements now treat different qualities as distinct, preventing mismatched reuse across variants.
  * Devour sacrifice behavior now only targets matching permanents and applies the correct counter total.
  * Preserved compatibility with previously saved Devour data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->