### PR TITLE
chore: refresh metagame feeds

### DIFF
--- a/client/public/feeds/mtggoldfish-commander.json
+++ b/client/public/feeds/mtggoldfish-commander.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "commander",
   "version": 1,
-  "updated": "2026-07-24T00:00:00Z",
+  "updated": "2026-07-25T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/commander",
   "decks": [
     {
@@ -22,79 +22,11 @@
       "main": [
         {
           "count": 1,
-          "name": "Abomination, World Ravager"
+          "name": "Doctor Doom"
         },
         {
           "count": 1,
-          "name": "Age of Ultron"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Archnemesis"
-        },
-        {
-          "count": 1,
-          "name": "Baron Strucker, HYDRA Overlord"
-        },
-        {
-          "count": 1,
-          "name": "Batroc the Leaper"
-        },
-        {
-          "count": 1,
-          "name": "Bedevil"
-        },
-        {
-          "count": 1,
-          "name": "Black Market Connections"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Canyon Slough"
-        },
-        {
-          "count": 1,
-          "name": "Chameleon, Master of Disguise"
-        },
-        {
-          "count": 1,
-          "name": "Chaos Warp"
-        },
-        {
-          "count": 1,
-          "name": "Choked Estuary"
-        },
-        {
-          "count": 1,
-          "name": "Coastal Peak"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Containment Construct"
-        },
-        {
-          "count": 1,
-          "name": "Crumbling Necropolis"
-        },
-        {
-          "count": 1,
-          "name": "Currency Converter"
-        },
-        {
-          "count": 1,
-          "name": "Damocles Base, Sword of Kang"
+          "name": "Doctor Doom, Unrivaled"
         },
         {
           "count": 1,
@@ -102,267 +34,15 @@
         },
         {
           "count": 1,
-          "name": "Doom's Time Platform"
-        },
-        {
-          "count": 1,
-          "name": "Dragonskull Summit"
-        },
-        {
-          "count": 1,
-          "name": "Drowned Catacomb"
-        },
-        {
-          "count": 1,
-          "name": "Endless Ranks of HYDRA"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Extract Power"
-        },
-        {
-          "count": 1,
-          "name": "Fetid Pools"
-        },
-        {
-          "count": 1,
-          "name": "Foreboding Ruins"
-        },
-        {
-          "count": 1,
-          "name": "Frostboil Snarl"
-        },
-        {
-          "count": 1,
-          "name": "Glorious Purpose"
-        },
-        {
-          "count": 1,
-          "name": "Helmut Zemo, Mastermind"
-        },
-        {
-          "count": 1,
-          "name": "Iron Monger, Sadistic Tycoon"
-        },
-        {
-          "count": 4,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Kang Dynasty"
-        },
-        {
-          "count": 1,
-          "name": "Kang Prime"
-        },
-        {
-          "count": 1,
-          "name": "Kang, Temporal Tyrant"
-        },
-        {
-          "count": 1,
-          "name": "Killmonger, Ruthless Usurper"
-        },
-        {
-          "count": 1,
-          "name": "Kindred Dominance"
-        },
-        {
-          "count": 1,
-          "name": "Klaw, Master of Sound"
-        },
-        {
-          "count": 1,
-          "name": "Lady Loki, Agent of Chaos"
-        },
-        {
-          "count": 1,
-          "name": "Lethal Scheme"
-        },
-        {
-          "count": 1,
-          "name": "Living Laser"
-        },
-        {
-          "count": 1,
-          "name": "Loki's Scepter"
-        },
-        {
-          "count": 1,
-          "name": "Loki, the Deceiver"
-        },
-        {
-          "count": 1,
-          "name": "Luxury Suite"
-        },
-        {
-          "count": 1,
-          "name": "Madame Hydra"
-        },
-        {
-          "count": 1,
           "name": "Molecule Man"
         },
         {
           "count": 1,
-          "name": "Moonstone, Harsh Mistress"
-        },
-        {
-          "count": 5,
-          "name": "Mountain"
+          "name": "Leader, Super-Genius"
         },
         {
           "count": 1,
-          "name": "Night's Whisper"
-        },
-        {
-          "count": 1,
-          "name": "Patchwork Banner"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Progenitor's Icon"
-        },
-        {
-          "count": 1,
-          "name": "Propaganda"
-        },
-        {
-          "count": 1,
-          "name": "Prowler, Clawed Thief"
-        },
-        {
-          "count": 1,
-          "name": "Puppet Master, String Puller"
-        },
-        {
-          "count": 1,
-          "name": "Red Ghost, Intangible Genius"
-        },
-        {
-          "count": 1,
-          "name": "Scavenger Grounds"
-        },
-        {
-          "count": 1,
-          "name": "Scorched Geyser"
-        },
-        {
-          "count": 1,
-          "name": "Secluded Courtyard"
-        },
-        {
-          "count": 1,
-          "name": "Skullclamp"
-        },
-        {
-          "count": 1,
-          "name": "Smoldering Marsh"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Spark Double"
-        },
-        {
-          "count": 1,
-          "name": "Stilt-Man, Towering Terror"
-        },
-        {
-          "count": 1,
-          "name": "Sulfur Falls"
-        },
-        {
-          "count": 1,
-          "name": "Sunken Hollow"
-        },
-        {
-          "count": 1,
-          "name": "Superior Foes of Spider-Man"
-        },
-        {
-          "count": 6,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Syphon Mind"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Dominance"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Indulgence"
-        },
-        {
-          "count": 1,
-          "name": "Terminate"
-        },
-        {
-          "count": 1,
-          "name": "Terramorphic Expanse"
-        },
-        {
-          "count": 1,
-          "name": "The Frightful Four"
-        },
-        {
-          "count": 1,
-          "name": "The Squadron Sinister"
-        },
-        {
-          "count": 1,
-          "name": "Titan of Littjara"
-        },
-        {
-          "count": 1,
-          "name": "Titania, Proud Pummeler"
-        },
-        {
-          "count": 1,
-          "name": "Tombstone, Career Criminal"
-        },
-        {
-          "count": 1,
-          "name": "Toxic Deluge"
-        },
-        {
-          "count": 1,
-          "name": "Tri-Sentinel, Act of Vengeance"
-        },
-        {
-          "count": 1,
-          "name": "Typhoid Mary, Fractured"
-        },
-        {
-          "count": 1,
-          "name": "Ultron, Unlimited"
-        },
-        {
-          "count": 1,
-          "name": "Unclaimed Territory"
-        },
-        {
-          "count": 1,
-          "name": "Vandalblast"
+          "name": "Baron Strucker, HYDRA Overlord"
         },
         {
           "count": 1,
@@ -370,7 +50,702 @@
         },
         {
           "count": 1,
+          "name": "Iron Monger, Sadistic Tycoon"
+        },
+        {
+          "count": 1,
+          "name": "Ultron, Unlimited"
+        },
+        {
+          "count": 1,
+          "name": "Norman Osborn"
+        },
+        {
+          "count": 1,
+          "name": "Currency Converter"
+        },
+        {
+          "count": 1,
+          "name": "Monument to Endurance"
+        },
+        {
+          "count": 1,
+          "name": "Crucible of Worlds"
+        },
+        {
+          "count": 1,
+          "name": "Ledger Shredder"
+        },
+        {
+          "count": 1,
+          "name": "Black Market Connections"
+        },
+        {
+          "count": 1,
+          "name": "Toxic Deluge"
+        },
+        {
+          "count": 1,
+          "name": "Cool but Rude"
+        },
+        {
+          "count": 1,
+          "name": "Green Goblin, Nemesis"
+        },
+        {
+          "count": 1,
+          "name": "Chameleon, Master of Disguise"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Frantic Search"
+        },
+        {
+          "count": 1,
+          "name": "Faithless Looting"
+        },
+        {
+          "count": 1,
           "name": "Withering Torment"
+        },
+        {
+          "count": 1,
+          "name": "Windfall"
+        },
+        {
+          "count": 1,
+          "name": "Bone Miser"
+        },
+        {
+          "count": 1,
+          "name": "Archfiend of Ifnir"
+        },
+        {
+          "count": 1,
+          "name": "Dark Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Rhystic Study"
+        },
+        {
+          "count": 1,
+          "name": "Demonic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Cyclonic Rift"
+        },
+        {
+          "count": 1,
+          "name": "Jeska's Will"
+        },
+        {
+          "count": 1,
+          "name": "Fierce Guardianship"
+        },
+        {
+          "count": 1,
+          "name": "Underworld Breach"
+        },
+        {
+          "count": 1,
+          "name": "Prowler, Clawed Thief"
+        },
+        {
+          "count": 1,
+          "name": "Surly Badgersaur"
+        },
+        {
+          "count": 1,
+          "name": "Containment Construct"
+        },
+        {
+          "count": 1,
+          "name": "Doctor Octopus, Master Planner"
+        },
+        {
+          "count": 1,
+          "name": "Moonstone, Harsh Mistress"
+        },
+        {
+          "count": 1,
+          "name": "Roaming Throne"
+        },
+        {
+          "count": 1,
+          "name": "Spark Double"
+        },
+        {
+          "count": 1,
+          "name": "Psychic Frog"
+        },
+        {
+          "count": 1,
+          "name": "Kefka, Court Mage"
+        },
+        {
+          "count": 1,
+          "name": "Ultimate Green Goblin"
+        },
+        {
+          "count": 1,
+          "name": "Kang, Temporal Tyrant"
+        },
+        {
+          "count": 1,
+          "name": "Loki, God of Mischief"
+        },
+        {
+          "count": 1,
+          "name": "M.O.D.O.K."
+        },
+        {
+          "count": 1,
+          "name": "Sheoldred, the Apocalypse"
+        },
+        {
+          "count": 1,
+          "name": "Glint-Horn Buccaneer"
+        },
+        {
+          "count": 1,
+          "name": "Tombstone, Career Criminal"
+        },
+        {
+          "count": 1,
+          "name": "Green Goblin, Revenant"
+        },
+        {
+          "count": 1,
+          "name": "Deflecting Swat"
+        },
+        {
+          "count": 1,
+          "name": "Lethal Scheme"
+        },
+        {
+          "count": 1,
+          "name": "Bloodline Bidding"
+        },
+        {
+          "count": 1,
+          "name": "Library of Leng"
+        },
+        {
+          "count": 1,
+          "name": "Doom's Time Platform"
+        },
+        {
+          "count": 1,
+          "name": "Mystic Remora"
+        },
+        {
+          "count": 1,
+          "name": "Glorious Purpose"
+        },
+        {
+          "count": 1,
+          "name": "Construct a Cosmic Cube"
+        },
+        {
+          "count": 1,
+          "name": "Doom Reigns Supreme"
+        },
+        {
+          "count": 1,
+          "name": "Archnemesis"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 1,
+          "name": "Forgotten Cave"
+        },
+        {
+          "count": 1,
+          "name": "Spymaster's Vault"
+        },
+        {
+          "count": 1,
+          "name": "Lonely Sandbar"
+        },
+        {
+          "count": 1,
+          "name": "Command Beacon"
+        },
+        {
+          "count": 1,
+          "name": "Takenuma, Abandoned Mire"
+        },
+        {
+          "count": 1,
+          "name": "Field of the Dead"
+        },
+        {
+          "count": 1,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 1,
+          "name": "Watery Grave"
+        },
+        {
+          "count": 1,
+          "name": "Blood Crypt"
+        },
+        {
+          "count": 1,
+          "name": "Luxury Suite"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta"
+        },
+        {
+          "count": 1,
+          "name": "Xander's Lounge"
+        },
+        {
+          "count": 1,
+          "name": "Bloodstained Mire"
+        },
+        {
+          "count": 1,
+          "name": "Oscorp Industries"
+        },
+        {
+          "count": 1,
+          "name": "Morphic Pool"
+        },
+        {
+          "count": 1,
+          "name": "Scalding Tarn"
+        },
+        {
+          "count": 1,
+          "name": "Hidden Lair"
+        },
+        {
+          "count": 1,
+          "name": "Training Center"
+        },
+        {
+          "count": 1,
+          "name": "City of Brass"
+        },
+        {
+          "count": 1,
+          "name": "Dark Fortress"
+        },
+        {
+          "count": 1,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 1,
+          "name": "Reflecting Pool"
+        },
+        {
+          "count": 1,
+          "name": "Blazemire Verge"
+        },
+        {
+          "count": 1,
+          "name": "Gloomlake Verge"
+        },
+        {
+          "count": 1,
+          "name": "Marsh Flats"
+        },
+        {
+          "count": 1,
+          "name": "Coastal Peak"
+        },
+        {
+          "count": 1,
+          "name": "Turbulent Springs"
+        },
+        {
+          "count": 1,
+          "name": "Castle Doom"
+        },
+        {
+          "count": 1,
+          "name": "Prismatic Vista"
+        },
+        {
+          "count": 2,
+          "name": "Swamp"
+        },
+        {
+          "count": 2,
+          "name": "Mountain"
+        },
+        {
+          "count": 2,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Counterspell"
+        },
+        {
+          "count": 1,
+          "name": "Force of Will"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Tomb"
+        },
+        {
+          "count": 1,
+          "name": "Mysterio, Master of Illusion"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Edgar Markov",
+      "author": "MTGGoldfish",
+      "colors": [
+        "B",
+        "R",
+        "W"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Rakdos Charm"
+        },
+        {
+          "count": 1,
+          "name": "Strefan, Maurer Progenitor"
+        },
+        {
+          "count": 1,
+          "name": "Infernal Grasp"
+        },
+        {
+          "count": 1,
+          "name": "Restless Bloodseeker"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Balustrade Spy"
+        },
+        {
+          "count": 1,
+          "name": "Alluring Suitor"
+        },
+        {
+          "count": 1,
+          "name": "Falkenrath Perforator"
+        },
+        {
+          "count": 1,
+          "name": "Belligerent Guest"
+        },
+        {
+          "count": 1,
+          "name": "Edgar, Charmed Groom"
+        },
+        {
+          "count": 1,
+          "name": "Stromkirk Bloodthief"
+        },
+        {
+          "count": 1,
+          "name": "Child of Night"
+        },
+        {
+          "count": 1,
+          "name": "Humiliate"
+        },
+        {
+          "count": 1,
+          "name": "Indulgent Aristocrat"
+        },
+        {
+          "count": 1,
+          "name": "Markov Purifier"
+        },
+        {
+          "count": 1,
+          "name": "Rakdos Signet"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Vampire of the Dire Moon"
+        },
+        {
+          "count": 1,
+          "name": "Silverquill Pledgemage"
+        },
+        {
+          "count": 1,
+          "name": "Bloodthrone Vampire"
+        },
+        {
+          "count": 1,
+          "name": "Immersturm Predator"
+        },
+        {
+          "count": 1,
+          "name": "Bloodthirsty Aerialist"
+        },
+        {
+          "count": 1,
+          "name": "Captivating Vampire"
+        },
+        {
+          "count": 1,
+          "name": "Thrill of Possibility"
+        },
+        {
+          "count": 1,
+          "name": "Vanquish the Horde"
+        },
+        {
+          "count": 1,
+          "name": "Oversold Cemetery"
+        },
+        {
+          "count": 1,
+          "name": "Olivia, Crimson Bride"
+        },
+        {
+          "count": 1,
+          "name": "Vampire Spawn"
+        },
+        {
+          "count": 1,
+          "name": "Fracture"
+        },
+        {
+          "count": 1,
+          "name": "Blood Burglar"
+        },
+        {
+          "count": 1,
+          "name": "Welcoming Vampire"
+        },
+        {
+          "count": 1,
+          "name": "Ephemerate"
+        },
+        {
+          "count": 1,
+          "name": "Bladebrand"
+        },
+        {
+          "count": 1,
+          "name": "Famished Foragers"
+        },
+        {
+          "count": 1,
+          "name": "Urza's Incubator"
+        },
+        {
+          "count": 1,
+          "name": "Collective Brutality"
+        },
+        {
+          "count": 1,
+          "name": "Basilisk Collar"
+        },
+        {
+          "count": 1,
+          "name": "Day of Judgment"
+        },
+        {
+          "count": 1,
+          "name": "Bloodtithe Harvester"
+        },
+        {
+          "count": 1,
+          "name": "Village Rites"
+        },
+        {
+          "count": 1,
+          "name": "Vampire Interloper"
+        },
+        {
+          "count": 1,
+          "name": "Voldaren Ambusher"
+        },
+        {
+          "count": 1,
+          "name": "Shadow Stinger"
+        },
+        {
+          "count": 1,
+          "name": "Bloodcrazed Socialite"
+        },
+        {
+          "count": 1,
+          "name": "Markov Waltzer"
+        },
+        {
+          "count": 1,
+          "name": "Esper Sentinel"
+        },
+        {
+          "count": 1,
+          "name": "Knight of the Ebon Legion"
+        },
+        {
+          "count": 1,
+          "name": "Blood Petal Celebrant"
+        },
+        {
+          "count": 1,
+          "name": "Boros Signet"
+        },
+        {
+          "count": 1,
+          "name": "Dusk Legion Duelist"
+        },
+        {
+          "count": 1,
+          "name": "Mass Hysteria"
+        },
+        {
+          "count": 1,
+          "name": "Phyrexian Arena"
+        },
+        {
+          "count": 1,
+          "name": "Mari, the Killing Quill"
+        },
+        {
+          "count": 1,
+          "name": "Thought Vessel"
+        },
+        {
+          "count": 1,
+          "name": "Sulfuric Vortex"
+        },
+        {
+          "count": 1,
+          "name": "Thrilling Discovery"
+        },
+        {
+          "count": 1,
+          "name": "Voldaren Stinger"
+        },
+        {
+          "count": 1,
+          "name": "Condemn"
+        },
+        {
+          "count": 1,
+          "name": "Gluttonous Guest"
+        },
+        {
+          "count": 1,
+          "name": "Voldaren Epicure"
+        },
+        {
+          "count": 1,
+          "name": "Cleric of Life's Bond"
+        },
+        {
+          "count": 1,
+          "name": "Markov Retribution"
+        },
+        {
+          "count": 1,
+          "name": "Pulse Tracker"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 9,
+          "name": "Swamp"
+        },
+        {
+          "count": 6,
+          "name": "Mountain"
+        },
+        {
+          "count": 7,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Smoldering Marsh"
+        },
+        {
+          "count": 1,
+          "name": "Blood Crypt"
+        },
+        {
+          "count": 1,
+          "name": "Gemstone Mine"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Temple of Triumph"
+        },
+        {
+          "count": 1,
+          "name": "Raucous Theater"
+        },
+        {
+          "count": 1,
+          "name": "Isolated Chapel"
+        },
+        {
+          "count": 1,
+          "name": "Shadowy Backstreet"
+        },
+        {
+          "count": 1,
+          "name": "Clifftop Retreat"
+        },
+        {
+          "count": 1,
+          "name": "Foreboding Ruins"
+        },
+        {
+          "count": 1,
+          "name": "Maze of Ith"
+        },
+        {
+          "count": 1,
+          "name": "Elegant Parlor"
+        },
+        {
+          "count": 1,
+          "name": "Edgar Markov"
         }
       ],
       "sideboard": []
@@ -710,397 +1085,6 @@
         {
           "count": 1,
           "name": "Command Tower"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Edgar Markov",
-      "author": "MTGGoldfish",
-      "colors": [
-        "B",
-        "R",
-        "W"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Captivating Vampire"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Indulgent Aristocrat"
-        },
-        {
-          "count": 1,
-          "name": "Arid Mesa"
-        },
-        {
-          "count": 1,
-          "name": "Markov Baron"
-        },
-        {
-          "count": 1,
-          "name": "Legion Lieutenant"
-        },
-        {
-          "count": 1,
-          "name": "Unclaimed Territory"
-        },
-        {
-          "count": 1,
-          "name": "Cruel Celebrant"
-        },
-        {
-          "count": 1,
-          "name": "Edgar, Charmed Groom"
-        },
-        {
-          "count": 1,
-          "name": "Demonic Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Blood Crypt"
-        },
-        {
-          "count": 1,
-          "name": "Shared Animosity"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos Signet"
-        },
-        {
-          "count": 1,
-          "name": "Voldaren Estate"
-        },
-        {
-          "count": 1,
-          "name": "Anointed Procession"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Hierarchy"
-        },
-        {
-          "count": 1,
-          "name": "Luxury Suite"
-        },
-        {
-          "count": 1,
-          "name": "Twilight Prophet"
-        },
-        {
-          "count": 1,
-          "name": "Elenda, the Dusk Rose"
-        },
-        {
-          "count": 1,
-          "name": "Vanquisher's Banner"
-        },
-        {
-          "count": 1,
-          "name": "Charismatic Conqueror"
-        },
-        {
-          "count": 1,
-          "name": "Malakir Rebirth"
-        },
-        {
-          "count": 1,
-          "name": "Brightclimb Pathway"
-        },
-        {
-          "count": 1,
-          "name": "Anguished Unmaking"
-        },
-        {
-          "count": 1,
-          "name": "Anowon, the Ruin Sage"
-        },
-        {
-          "count": 1,
-          "name": "Rakish Heir"
-        },
-        {
-          "count": 1,
-          "name": "Sanctum Seeker"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Vengeful Bloodwitch"
-        },
-        {
-          "count": 1,
-          "name": "Despark"
-        },
-        {
-          "count": 1,
-          "name": "Sanguine Bond"
-        },
-        {
-          "count": 1,
-          "name": "Plateau"
-        },
-        {
-          "count": 1,
-          "name": "Patchwork Banner"
-        },
-        {
-          "count": 1,
-          "name": "Sorin, Imperious Bloodlord"
-        },
-        {
-          "count": 1,
-          "name": "Path to Exile"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Champion of Dusk"
-        },
-        {
-          "count": 1,
-          "name": "Village Rites"
-        },
-        {
-          "count": 1,
-          "name": "Vito, Thorn of the Dusk Rose"
-        },
-        {
-          "count": 1,
-          "name": "Diabolic Intent"
-        },
-        {
-          "count": 1,
-          "name": "Bloodline Keeper"
-        },
-        {
-          "count": 1,
-          "name": "Marauding Blight-Priest"
-        },
-        {
-          "count": 1,
-          "name": "Bloodstained Mire"
-        },
-        {
-          "count": 1,
-          "name": "Fetid Heath"
-        },
-        {
-          "count": 1,
-          "name": "Vault of Champions"
-        },
-        {
-          "count": 1,
-          "name": "Cathars' Crusade"
-        },
-        {
-          "count": 1,
-          "name": "Marsh Flats"
-        },
-        {
-          "count": 1,
-          "name": "Boros Charm"
-        },
-        {
-          "count": 1,
-          "name": "Secluded Courtyard"
-        },
-        {
-          "count": 1,
-          "name": "Blightstep Pathway"
-        },
-        {
-          "count": 1,
-          "name": "Gifted Aetherborn"
-        },
-        {
-          "count": 1,
-          "name": "Cavern of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Banner of Kinship"
-        },
-        {
-          "count": 1,
-          "name": "Graven Cairns"
-        },
-        {
-          "count": 1,
-          "name": "Ruthless Lawbringer"
-        },
-        {
-          "count": 1,
-          "name": "Master of Dark Rites"
-        },
-        {
-          "count": 1,
-          "name": "Blood Artist"
-        },
-        {
-          "count": 1,
-          "name": "Exquisite Blood"
-        },
-        {
-          "count": 1,
-          "name": "Cordial Vampire"
-        },
-        {
-          "count": 1,
-          "name": "Savai Triome"
-        },
-        {
-          "count": 1,
-          "name": "Phyrexian Arena"
-        },
-        {
-          "count": 1,
-          "name": "Mortify"
-        },
-        {
-          "count": 1,
-          "name": "Teferi's Protection"
-        },
-        {
-          "count": 1,
-          "name": "Vault of the Archangel"
-        },
-        {
-          "count": 1,
-          "name": "Urborg, Tomb of Yawgmoth"
-        },
-        {
-          "count": 1,
-          "name": "Bloodthirsty Conqueror"
-        },
-        {
-          "count": 1,
-          "name": "Bolas's Citadel"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Reconnaissance"
-        },
-        {
-          "count": 1,
-          "name": "Vein Ripper"
-        },
-        {
-          "count": 1,
-          "name": "Urge to Feed"
-        },
-        {
-          "count": 1,
-          "name": "Stromkirk Captain"
-        },
-        {
-          "count": 1,
-          "name": "Viscera Seer"
-        },
-        {
-          "count": 1,
-          "name": "Olivia's Wrath"
-        },
-        {
-          "count": 1,
-          "name": "Bloodletter of Aclazotz"
-        },
-        {
-          "count": 1,
-          "name": "Drana, Liberator of Malakir"
-        },
-        {
-          "count": 1,
-          "name": "Falkenrath Noble"
-        },
-        {
-          "count": 1,
-          "name": "New Blood"
-        },
-        {
-          "count": 1,
-          "name": "Florian, Voldaren Scion"
-        },
-        {
-          "count": 1,
-          "name": "Orzhov Signet"
-        },
-        {
-          "count": 1,
-          "name": "Boros Signet"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Indulgence"
-        },
-        {
-          "count": 1,
-          "name": "Godless Shrine"
-        },
-        {
-          "count": 1,
-          "name": "Needleverge Pathway"
-        },
-        {
-          "count": 1,
-          "name": "Bojuka Bog"
-        },
-        {
-          "count": 1,
-          "name": "Spectator Seating"
-        },
-        {
-          "count": 1,
-          "name": "Vampire Socialite"
-        },
-        {
-          "count": 4,
-          "name": "Swamp"
-        },
-        {
-          "count": 3,
-          "name": "Plains"
-        },
-        {
-          "count": 2,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Emeritus of Woe"
-        },
-        {
-          "count": 1,
-          "name": "Edgar Markov"
         }
       ],
       "sideboard": []
@@ -1815,6 +1799,417 @@
       "sideboard": []
     },
     {
+      "name": "The Ur-Dragon",
+      "author": "MTGGoldfish",
+      "colors": [],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Flooded Strand [KTK]"
+        },
+        {
+          "count": 1,
+          "name": "Sacred Foundry [RAV]"
+        },
+        {
+          "count": 1,
+          "name": "Patriarch's Bidding [ONS]"
+        },
+        {
+          "count": 1,
+          "name": "Plains <252> [RTR] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Living Death [V14] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Urza's Incubator [C15]"
+        },
+        {
+          "count": 1,
+          "name": "Haven of the Spirit Dragon [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Dragonlord Dromoka [PRM-PRE] (F)"
+        },
+        {
+          "count": 1,
+          "name": "The Ur-Dragon [C17] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Mountain <300> [MRD] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Bloodstained Mire [KTK]"
+        },
+        {
+          "count": 1,
+          "name": "Swamp <339> [OD] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Mountain <300> [CHK] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Ramos, Dragon Engine [C17] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Breeding Pool [GTC]"
+        },
+        {
+          "count": 1,
+          "name": "Savage Ventmaw [DTK] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Bloom Tender [EVE]"
+        },
+        {
+          "count": 1,
+          "name": "Commander's Sphere [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Birds of Paradise [CN2] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Kessig Wolf Run [ISD]"
+        },
+        {
+          "count": 1,
+          "name": "Crosis, the Purger [IN]"
+        },
+        {
+          "count": 1,
+          "name": "Plains <295> [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Forest <272> [RTR] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Stomping Ground [GTC] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Swamp <342> [MM] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Steam Vents [GPT]"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Greaves [CMD]"
+        },
+        {
+          "count": 1,
+          "name": "Bladewing the Risen [SCG]"
+        },
+        {
+          "count": 1,
+          "name": "Chromatic Lantern [RTR] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Mana Confluence [JOU]"
+        },
+        {
+          "count": 1,
+          "name": "Atarka, World Render [PRM-PRE] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Prowling Serpopard [PRM-PRE] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Godless Shrine [GTC]"
+        },
+        {
+          "count": 1,
+          "name": "Intet, the Dreamer [PLC] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Tyrant's Familiar [C14]"
+        },
+        {
+          "count": 1,
+          "name": "Skyshroud Claim [NE]"
+        },
+        {
+          "count": 1,
+          "name": "Hallowed Fountain [RTR]"
+        },
+        {
+          "count": 1,
+          "name": "Hellkite Overlord [ALA]"
+        },
+        {
+          "count": 1,
+          "name": "Sunscorch Regent [DTK]"
+        },
+        {
+          "count": 1,
+          "name": "Misty Rainforest [MM3]"
+        },
+        {
+          "count": 1,
+          "name": "Hellkite Charger [ZEN] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Scourge of Valkas [M14]"
+        },
+        {
+          "count": 1,
+          "name": "Reflecting Pool [SHM]"
+        },
+        {
+          "count": 1,
+          "name": "Cavern of Souls [AVR]"
+        },
+        {
+          "count": 1,
+          "name": "Quicksilver Amulet [M12]"
+        },
+        {
+          "count": 1,
+          "name": "Cultivate [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Kodama's Reach [C15]"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Island <298> [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Blood Crypt [RTR]"
+        },
+        {
+          "count": 1,
+          "name": "Utvara Hellkite [RTR] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Balefire Dragon [ISD] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Numot, the Devastator [PLC] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Warstorm Surge [C15]"
+        },
+        {
+          "count": 1,
+          "name": "Swamp <341> [OD] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Swamp <341> [IN] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Dragon Tempest [DTK] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Wasitora, Nekoru Queen [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Demonic Tutor [3ED]"
+        },
+        {
+          "count": 1,
+          "name": "Overgrown Tomb [RTR]"
+        },
+        {
+          "count": 1,
+          "name": "Kindred Discovery [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Scourge of the Throne [CNS]"
+        },
+        {
+          "count": 1,
+          "name": "Crux of Fate [FRF]"
+        },
+        {
+          "count": 1,
+          "name": "Yosei, the Morning Star [CHK] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Mountain <301> [MRD] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Hinterland Harbor [ISD]"
+        },
+        {
+          "count": 1,
+          "name": "Kokusho, the Evening Star [MMA] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Eternal Witness [DDJ]"
+        },
+        {
+          "count": 1,
+          "name": "Wooded Foothills [KTK]"
+        },
+        {
+          "count": 1,
+          "name": "Chrome Mox [EMA]"
+        },
+        {
+          "count": 1,
+          "name": "Scion of the Ur-Dragon [TSP]"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta [KTK]"
+        },
+        {
+          "count": 1,
+          "name": "Fierce Empath [SCG]"
+        },
+        {
+          "count": 1,
+          "name": "Dragonlord Silumgar [DTK]"
+        },
+        {
+          "count": 1,
+          "name": "Hellkite Tyrant [GTC] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Scalding Tarn [MM3]"
+        },
+        {
+          "count": 1,
+          "name": "Nicol Bolas [DRB] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Steel Hellkite [SOM]"
+        },
+        {
+          "count": 1,
+          "name": "Exploration [CNS]"
+        },
+        {
+          "count": 1,
+          "name": "Skithiryx, the Blight Dragon [SOM] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower [C13]"
+        },
+        {
+          "count": 1,
+          "name": "Temur Ascendancy [KTK]"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring [C15]"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares [C16]"
+        },
+        {
+          "count": 1,
+          "name": "Farseek [M13]"
+        },
+        {
+          "count": 1,
+          "name": "Prismatic Geoscope [C16]"
+        },
+        {
+          "count": 1,
+          "name": "Windswept Heath [KTK]"
+        },
+        {
+          "count": 1,
+          "name": "Scalelord Reckoner [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Forest <270> [RTR] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Dragonlord Kolaghan [DTK]"
+        },
+        {
+          "count": 1,
+          "name": "Watery Grave [GTC] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Teneb, the Harvester [PLC]"
+        },
+        {
+          "count": 1,
+          "name": "Boneyard Scourge [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Forest <243> [AVR] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Herald's Horn [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Mountain <265> [RTR] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Earthquake [C15]"
+        },
+        {
+          "count": 1,
+          "name": "Frontier Siege [FRF]"
+        },
+        {
+          "count": 1,
+          "name": "Temple Garden [RTR]"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Tomb [TE]"
+        }
+      ],
+      "sideboard": []
+    },
+    {
       "name": "The Unbeatable Squirrel Girl",
       "author": "MTGGoldfish",
       "colors": [
@@ -2098,6 +2493,474 @@
         }
       ],
       "sideboard": []
+    },
+    {
+      "name": "Ms. Bumbleflower",
+      "author": "MTGGoldfish",
+      "colors": [
+        "U",
+        "G",
+        "W"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Adarkar Wastes"
+        },
+        {
+          "count": 1,
+          "name": "An Offer You Can't Refuse"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Denial"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Barkchannel Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Birds of Paradise"
+        },
+        {
+          "count": 1,
+          "name": "Bloodroot Apothecary"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 1,
+          "name": "Bountiful Promenade"
+        },
+        {
+          "count": 1,
+          "name": "Brainstorm"
+        },
+        {
+          "count": 1,
+          "name": "Branchloft Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Breeding Pool"
+        },
+        {
+          "count": 1,
+          "name": "Bridgeworks Battle"
+        },
+        {
+          "count": 1,
+          "name": "Burgeoning"
+        },
+        {
+          "count": 1,
+          "name": "Byrke, Long Ear of the Law"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Communal Brewing"
+        },
+        {
+          "count": 1,
+          "name": "Dawn's Truce"
+        },
+        {
+          "count": 1,
+          "name": "Deserted Beach"
+        },
+        {
+          "count": 1,
+          "name": "Dreamroot Cascade"
+        },
+        {
+          "count": 1,
+          "name": "Dreamtide Whale"
+        },
+        {
+          "count": 1,
+          "name": "Eiganjo, Seat of the Empire"
+        },
+        {
+          "count": 1,
+          "name": "Emeritus of Ideation"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Faerie Mastermind"
+        },
+        {
+          "count": 1,
+          "name": "Farewell"
+        },
+        {
+          "count": 1,
+          "name": "Farseek"
+        },
+        {
+          "count": 1,
+          "name": "Fierce Guardianship"
+        },
+        {
+          "count": 1,
+          "name": "Flooded Strand"
+        },
+        {
+          "count": 1,
+          "name": "Folio of Fancies"
+        },
+        {
+          "count": 2,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Frantic Search"
+        },
+        {
+          "count": 1,
+          "name": "Generous Gift"
+        },
+        {
+          "count": 1,
+          "name": "Gluntch, the Bestower"
+        },
+        {
+          "count": 1,
+          "name": "Hallowed Fountain"
+        },
+        {
+          "count": 1,
+          "name": "Hengegate Pathway"
+        },
+        {
+          "count": 1,
+          "name": "High Fae Trickster"
+        },
+        {
+          "count": 1,
+          "name": "Howling Mine"
+        },
+        {
+          "count": 1,
+          "name": "Hydroelectric Specimen"
+        },
+        {
+          "count": 1,
+          "name": "Innkeeper's Talent"
+        },
+        {
+          "count": 1,
+          "name": "Into the Flood Maw"
+        },
+        {
+          "count": 2,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Jacked Rabbit"
+        },
+        {
+          "count": 1,
+          "name": "Kalonian Hydra"
+        },
+        {
+          "count": 1,
+          "name": "Kami of Whispered Hopes"
+        },
+        {
+          "count": 1,
+          "name": "Kwain, Itinerant Meddler"
+        },
+        {
+          "count": 1,
+          "name": "Ledger Shredder"
+        },
+        {
+          "count": 1,
+          "name": "Loran of the Third Path"
+        },
+        {
+          "count": 1,
+          "name": "Master of Ceremonies"
+        },
+        {
+          "count": 1,
+          "name": "Mikokoro, Center of the Sea"
+        },
+        {
+          "count": 1,
+          "name": "Mystic Gate"
+        },
+        {
+          "count": 1,
+          "name": "Nature's Lore"
+        },
+        {
+          "count": 1,
+          "name": "Noble Hierarch"
+        },
+        {
+          "count": 1,
+          "name": "Omniscience"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 1,
+          "name": "Overgrown Farmland"
+        },
+        {
+          "count": 1,
+          "name": "Path to Exile"
+        },
+        {
+          "count": 1,
+          "name": "Perch Protection"
+        },
+        {
+          "count": 2,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Pollywog Prodigy"
+        },
+        {
+          "count": 1,
+          "name": "Proft's Eidetic Memory"
+        },
+        {
+          "count": 1,
+          "name": "Psychosis Crawler"
+        },
+        {
+          "count": 1,
+          "name": "Razorgrass Ambush"
+        },
+        {
+          "count": 1,
+          "name": "Rejuvenating Springs"
+        },
+        {
+          "count": 1,
+          "name": "Reliquary Tower"
+        },
+        {
+          "count": 1,
+          "name": "Scrawling Crawler"
+        },
+        {
+          "count": 1,
+          "name": "Sea Gate Restoration"
+        },
+        {
+          "count": 1,
+          "name": "Sea of Clouds"
+        },
+        {
+          "count": 1,
+          "name": "Simic Ascendancy"
+        },
+        {
+          "count": 1,
+          "name": "Sink into Stupor"
+        },
+        {
+          "count": 1,
+          "name": "Skycloud Expanse"
+        },
+        {
+          "count": 1,
+          "name": "Smuggler's Share"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Spara's Headquarters"
+        },
+        {
+          "count": 1,
+          "name": "Starfall Invocation"
+        },
+        {
+          "count": 1,
+          "name": "Sword of War and Peace"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Tataru Taru"
+        },
+        {
+          "count": 1,
+          "name": "Teferi's Protection"
+        },
+        {
+          "count": 1,
+          "name": "Temple Garden"
+        },
+        {
+          "count": 1,
+          "name": "Tempt with Bunnies"
+        },
+        {
+          "count": 1,
+          "name": "Tempt with Discovery"
+        },
+        {
+          "count": 1,
+          "name": "Tender Wildguide"
+        },
+        {
+          "count": 1,
+          "name": "The Unagi of Kyoshi Island"
+        },
+        {
+          "count": 1,
+          "name": "Thought Vessel"
+        },
+        {
+          "count": 1,
+          "name": "Triskaidekaphile"
+        },
+        {
+          "count": 1,
+          "name": "Twenty-Toed Toad"
+        },
+        {
+          "count": 1,
+          "name": "Wear Down"
+        },
+        {
+          "count": 1,
+          "name": "Wedding Ring"
+        },
+        {
+          "count": 1,
+          "name": "Willbreaker"
+        },
+        {
+          "count": 1,
+          "name": "Willowrush Verge"
+        },
+        {
+          "count": 1,
+          "name": "Windfall"
+        },
+        {
+          "count": 1,
+          "name": "Witch Enchanter"
+        },
+        {
+          "count": 1,
+          "name": "Wizard Class"
+        },
+        {
+          "count": 1,
+          "name": "Yavimaya Coast"
+        },
+        {
+          "count": 1,
+          "name": "Ms. Bumbleflower"
+        },
+        {
+          "count": 1,
+          "name": "Preordain"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Approach of the Second Sun"
+        },
+        {
+          "count": 1,
+          "name": "Cultivate"
+        },
+        {
+          "count": 1,
+          "name": "Everybody Lives!"
+        },
+        {
+          "count": 1,
+          "name": "Forced Fruition"
+        },
+        {
+          "count": 1,
+          "name": "Iron Maiden"
+        },
+        {
+          "count": 1,
+          "name": "Jace, the Mind Sculptor"
+        },
+        {
+          "count": 1,
+          "name": "Overflowing Basin"
+        },
+        {
+          "count": 1,
+          "name": "Owlbear Cub"
+        },
+        {
+          "count": 1,
+          "name": "Pongify"
+        },
+        {
+          "count": 1,
+          "name": "Spore Frog"
+        },
+        {
+          "count": 1,
+          "name": "Swiftfoot Boots"
+        },
+        {
+          "count": 1,
+          "name": "Teferi's Ageless Insight"
+        },
+        {
+          "count": 1,
+          "name": "Tempting Contract"
+        },
+        {
+          "count": 1,
+          "name": "Tenuous Truce"
+        },
+        {
+          "count": 1,
+          "name": "Venser's Journal"
+        },
+        {
+          "count": 1,
+          "name": "View from Above"
+        }
+      ]
     },
     {
       "name": "Xyris, the Writhing Storm",
@@ -2463,425 +3326,10 @@
       "sideboard": []
     },
     {
-      "name": "Lathril, Blade of the Elves",
+      "name": "Vivi Ornitier",
       "author": "MTGGoldfish",
       "colors": [
-        "G",
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Abrupt Decay"
-        },
-        {
-          "count": 1,
-          "name": "Ad Nauseam"
-        },
-        {
-          "count": 1,
-          "name": "Allosaurus Shepherd"
-        },
-        {
-          "count": 1,
-          "name": "Aluren"
-        },
-        {
-          "count": 1,
-          "name": "Ancient Tomb"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Ashaya, Soul of the Wild"
-        },
-        {
-          "count": 1,
-          "name": "Assassin's Trophy"
-        },
-        {
-          "count": 1,
-          "name": "Autumn's Veil"
-        },
-        {
-          "count": 1,
-          "name": "Ayara, First of Locthwain"
-        },
-        {
-          "count": 1,
-          "name": "Bloom Tender"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
-        },
-        {
-          "count": 1,
-          "name": "Cabal Pit"
-        },
-        {
-          "count": 1,
-          "name": "City of Brass"
-        },
-        {
-          "count": 1,
-          "name": "Coat of Arms"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Craterhoof Behemoth"
-        },
-        {
-          "count": 1,
-          "name": "Culling Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Cultivate"
-        },
-        {
-          "count": 1,
-          "name": "Dark Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Darkbore Pathway"
-        },
-        {
-          "count": 1,
-          "name": "Deathcap Glade"
-        },
-        {
-          "count": 1,
-          "name": "Devoted Druid"
-        },
-        {
-          "count": 1,
-          "name": "Disciple of Freyalise"
-        },
-        {
-          "count": 1,
-          "name": "Dwynen, Gilt-Leaf Daen"
-        },
-        {
-          "count": 1,
-          "name": "Elderfang Venom"
-        },
-        {
-          "count": 1,
-          "name": "Elves of Deep Shadow"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Archdruid"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Champion"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Harbinger"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Mystic"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Promenade"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Spirit Guide"
-        },
-        {
-          "count": 1,
-          "name": "Emergence Zone"
-        },
-        {
-          "count": 1,
-          "name": "Endurance"
-        },
-        {
-          "count": 1,
-          "name": "Essence Warden"
-        },
-        {
-          "count": 1,
-          "name": "Eternal Witness"
-        },
-        {
-          "count": 1,
-          "name": "Evendo, Waking Haven"
-        },
-        {
-          "count": 1,
-          "name": "Finale of Devastation"
-        },
-        {
-          "count": 1,
-          "name": "Flourishing Defenses"
-        },
-        {
-          "count": 1,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Galadhrim Ambush"
-        },
-        {
-          "count": 1,
-          "name": "Gemstone Caverns"
-        },
-        {
-          "count": 1,
-          "name": "Gilt-Leaf Palace"
-        },
-        {
-          "count": 1,
-          "name": "Glissa Sunslayer"
-        },
-        {
-          "count": 1,
-          "name": "Haldir, Lorien Lieutenant"
-        },
-        {
-          "count": 1,
-          "name": "Heritage Druid"
-        },
-        {
-          "count": 1,
-          "name": "High Market"
-        },
-        {
-          "count": 1,
-          "name": "High Perfect Morcant"
-        },
-        {
-          "count": 1,
-          "name": "Imp's Mischief"
-        },
-        {
-          "count": 1,
-          "name": "Imperious Perfect"
-        },
-        {
-          "count": 1,
-          "name": "Leaf-Crowned Visionary"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Wastes"
-        },
-        {
-          "count": 1,
-          "name": "Mana Confluence"
-        },
-        {
-          "count": 1,
-          "name": "Marsh Flats"
-        },
-        {
-          "count": 1,
-          "name": "Marwyn, the Nurturer"
-        },
-        {
-          "count": 1,
-          "name": "Natural Order"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Claim"
-        },
-        {
-          "count": 1,
-          "name": "Necropotence"
-        },
-        {
-          "count": 1,
-          "name": "Nissa, Ascended Animist"
-        },
-        {
-          "count": 1,
-          "name": "Nissa, Resurgent Animist"
-        },
-        {
-          "count": 1,
-          "name": "Nurturing Peatland"
-        },
-        {
-          "count": 1,
-          "name": "Oracle of Mul Daya"
-        },
-        {
-          "count": 1,
-          "name": "Overgrown Tomb"
-        },
-        {
-          "count": 1,
-          "name": "Patchwork Banner"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Pattern of Rebirth"
-        },
-        {
-          "count": 1,
-          "name": "Phyrexian Tower"
-        },
-        {
-          "count": 1,
-          "name": "Poison-Tip Archer"
-        },
-        {
-          "count": 1,
-          "name": "Priest of Titania"
-        },
-        {
-          "count": 1,
-          "name": "Quirion Ranger"
-        },
-        {
-          "count": 1,
-          "name": "Reclamation Sage"
-        },
-        {
-          "count": 1,
-          "name": "Shaman of the Pack"
-        },
-        {
-          "count": 1,
-          "name": "Skemfar Shadowsage"
-        },
-        {
-          "count": 1,
-          "name": "Skullclamp"
-        },
-        {
-          "count": 1,
-          "name": "Snow-Covered Forest"
-        },
-        {
-          "count": 1,
-          "name": "Snow-Covered Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Staff of Domination"
-        },
-        {
-          "count": 1,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Sylvan Library"
-        },
-        {
-          "count": 1,
-          "name": "Tainted Wood"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Resilience"
-        },
-        {
-          "count": 1,
-          "name": "Three Tree City"
-        },
-        {
-          "count": 1,
-          "name": "Twilight Mire"
-        },
-        {
-          "count": 1,
-          "name": "Underground Mortuary"
-        },
-        {
-          "count": 1,
-          "name": "Undergrowth Stadium"
-        },
-        {
-          "count": 1,
-          "name": "Urborg, Tomb of Yawgmoth"
-        },
-        {
-          "count": 1,
-          "name": "Utopia Sprawl"
-        },
-        {
-          "count": 1,
-          "name": "Veil of Summer"
-        },
-        {
-          "count": 1,
-          "name": "Verdant Catacombs"
-        },
-        {
-          "count": 1,
-          "name": "Volrath's Stronghold"
-        },
-        {
-          "count": 1,
-          "name": "Wild Growth"
-        },
-        {
-          "count": 1,
-          "name": "Windswept Heath"
-        },
-        {
-          "count": 1,
-          "name": "Wirewood Lodge"
-        },
-        {
-          "count": 1,
-          "name": "Wirewood Symbiote"
-        },
-        {
-          "count": 1,
-          "name": "Yavimaya, Cradle of Growth"
-        },
-        {
-          "count": 1,
-          "name": "Yeva, Nature's Herald"
-        },
-        {
-          "count": 1,
-          "name": "Lathril, Blade of the Elves <019f70c7-65bc-7ba2-9fb3-3e40e871bc4d> [SLD]"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Kaalia of the Vast",
-      "author": "MTGGoldfish",
-      "colors": [
-        "W",
-        "B",
+        "U",
         "R"
       ],
       "tags": [
@@ -2890,203 +3338,7 @@
       "main": [
         {
           "count": 1,
-          "name": "Adarkar Valkyrie"
-        },
-        {
-          "count": 1,
-          "name": "Aegis Angel"
-        },
-        {
-          "count": 1,
-          "name": "Akroma, Angel of Fury"
-        },
-        {
-          "count": 1,
-          "name": "Akroma, Angel of Wrath"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Despair"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Serenity"
-        },
-        {
-          "count": 1,
-          "name": "Angelic Arbiter"
-        },
-        {
-          "count": 1,
-          "name": "Angelic Skirmisher"
-        },
-        {
-          "count": 1,
-          "name": "Angel of the Ruins"
-        },
-        {
-          "count": 1,
-          "name": "Archfiend of Depravity"
-        },
-        {
-          "count": 1,
-          "name": "Balor"
-        },
-        {
-          "count": 1,
-          "name": "Bladewing the Risen"
-        },
-        {
-          "count": 1,
-          "name": "Bloodgift Demon"
-        },
-        {
-          "count": 1,
-          "name": "Breathkeeper Seraph"
-        },
-        {
-          "count": 1,
-          "name": "Dawnbreak Reclaimer"
-        },
-        {
-          "count": 1,
-          "name": "Demon of Loathing"
-        },
-        {
-          "count": 1,
-          "name": "Drakuseth, Maw of Flames"
-        },
-        {
-          "count": 1,
-          "name": "Emeria Shepherd"
-        },
-        {
-          "count": 1,
-          "name": "Giada, Font of Hope"
-        },
-        {
-          "count": 1,
-          "name": "Harvester of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Indulgent Tormentor"
-        },
-        {
-          "count": 1,
-          "name": "Isshin, Two Heavens as One"
-        },
-        {
-          "count": 1,
-          "name": "Liesa, Forgotten Archangel"
-        },
-        {
-          "count": 1,
-          "name": "Overseer of the Damned"
-        },
-        {
-          "count": 1,
-          "name": "Piru, the Volatile"
-        },
-        {
-          "count": 1,
-          "name": "Resolute Archangel"
-        },
-        {
-          "count": 1,
-          "name": "Reya Dawnbringer"
-        },
-        {
-          "count": 1,
-          "name": "Sephara, Sky's Blade"
-        },
-        {
-          "count": 1,
-          "name": "Serra's Guardian"
-        },
-        {
-          "count": 1,
-          "name": "Steel Hellkite"
-        },
-        {
-          "count": 1,
-          "name": "Terror of Mount Velus"
-        },
-        {
-          "count": 1,
-          "name": "Twilight Shepherd"
-        },
-        {
-          "count": 1,
-          "name": "Victory's Herald"
-        },
-        {
-          "count": 1,
-          "name": "Ambition's Cost"
-        },
-        {
-          "count": 1,
-          "name": "Boros Charm"
-        },
-        {
-          "count": 1,
-          "name": "Crackling Doom"
-        },
-        {
-          "count": 1,
-          "name": "Despark"
-        },
-        {
-          "count": 1,
-          "name": "Fake Your Own Death"
-        },
-        {
-          "count": 1,
-          "name": "Fracture"
-        },
-        {
-          "count": 1,
-          "name": "Mortify"
-        },
-        {
-          "count": 1,
-          "name": "Return to Dust"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Terminate"
-        },
-        {
-          "count": 1,
-          "name": "Akroma's Vengeance"
-        },
-        {
-          "count": 1,
-          "name": "Diabolic Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Earthquake"
-        },
-        {
-          "count": 1,
-          "name": "Painful Truths"
-        },
-        {
-          "count": 1,
-          "name": "Read the Bones"
-        },
-        {
-          "count": 1,
-          "name": "Sign in Blood"
-        },
-        {
-          "count": 1,
-          "name": "Unburial Rites"
+          "name": "An Offer You Can't Refuse"
         },
         {
           "count": 1,
@@ -3094,71 +3346,31 @@
         },
         {
           "count": 1,
-          "name": "Boros Signet"
+          "name": "Archmage Emeritus"
         },
         {
           "count": 1,
-          "name": "Commander's Sphere"
+          "name": "Baral, Chief of Compliance"
         },
         {
           "count": 1,
-          "name": "Orzhov Signet"
+          "name": "Blasphemous Act"
         },
         {
           "count": 1,
-          "name": "Rakdos Signet"
+          "name": "Bolt Bend"
         },
         {
           "count": 1,
-          "name": "Savai Crystal"
+          "name": "Brainstorm"
         },
         {
           "count": 1,
-          "name": "Sol Ring"
+          "name": "Candy Trail"
         },
         {
           "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Conviction"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Hierarchy"
-        },
-        {
-          "count": 1,
-          "name": "Whispersilk Cloak"
-        },
-        {
-          "count": 1,
-          "name": "Firja's Retribution"
-        },
-        {
-          "count": 1,
-          "name": "Kaya's Ghostform"
-        },
-        {
-          "count": 1,
-          "name": "Liliana's Contract"
-        },
-        {
-          "count": 1,
-          "name": "Rampage of the Valkyries"
-        },
-        {
-          "count": 1,
-          "name": "Akoum Refuge"
-        },
-        {
-          "count": 1,
-          "name": "Bloodfell Caves"
-        },
-        {
-          "count": 1,
-          "name": "Boros Garrison"
+          "name": "Chaos Warp"
         },
         {
           "count": 1,
@@ -3166,7 +3378,23 @@
         },
         {
           "count": 1,
-          "name": "Evolving Wilds"
+          "name": "Curate"
+        },
+        {
+          "count": 1,
+          "name": "Curfew"
+        },
+        {
+          "count": 1,
+          "name": "Desperate Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Dizzy Spell"
+        },
+        {
+          "count": 1,
+          "name": "Dramatic Reversal"
         },
         {
           "count": 1,
@@ -3174,209 +3402,51 @@
         },
         {
           "count": 1,
-          "name": "Nomad Outpost"
+          "name": "Fading Hope"
         },
         {
           "count": 1,
-          "name": "Orzhov Basilica"
+          "name": "Fellwar Stone"
         },
         {
           "count": 1,
-          "name": "Rakdos Carnarium"
+          "name": "Fiery Islet"
         },
         {
           "count": 1,
-          "name": "Rogue's Passage"
+          "name": "Fire Magic"
         },
         {
           "count": 1,
-          "name": "Scoured Barrens"
+          "name": "Flashback"
         },
         {
           "count": 1,
-          "name": "Temple of Silence"
+          "name": "Frostboil Snarl"
         },
         {
           "count": 1,
-          "name": "Temple of Triumph"
+          "name": "Gamble"
         },
         {
           "count": 1,
-          "name": "Terramorphic Expanse"
+          "name": "Geosurge"
         },
         {
           "count": 1,
-          "name": "Wind-Scarred Crag"
-        },
-        {
-          "count": 8,
-          "name": "Plains"
-        },
-        {
-          "count": 7,
-          "name": "Swamp"
-        },
-        {
-          "count": 4,
-          "name": "Mountain"
+          "name": "Gifts Ungiven"
         },
         {
           "count": 1,
-          "name": "Kaalia of the Vast"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Winota, Joiner of Forces",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "W"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Ancient Tomb"
+          "name": "Gitaxian Probe"
         },
         {
           "count": 1,
-          "name": "Angrath's Marauders"
+          "name": "Grafdigger's Cage"
         },
         {
           "count": 1,
-          "name": "Archivist of Oghma"
-        },
-        {
-          "count": 1,
-          "name": "Archon of Emeria"
-        },
-        {
-          "count": 1,
-          "name": "Arid Mesa"
-        },
-        {
-          "count": 1,
-          "name": "Aven Interrupter"
-        },
-        {
-          "count": 1,
-          "name": "Aven Mindcensor"
-        },
-        {
-          "count": 1,
-          "name": "Battlefield Forge"
-        },
-        {
-          "count": 1,
-          "name": "Blade Historian"
-        },
-        {
-          "count": 1,
-          "name": "Bloodstained Mire"
-        },
-        {
-          "count": 1,
-          "name": "Boromir, Warden of the Tower"
-        },
-        {
-          "count": 1,
-          "name": "Cathar Commando"
-        },
-        {
-          "count": 1,
-          "name": "Cavern of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Charismatic Conqueror"
-        },
-        {
-          "count": 1,
-          "name": "Chrome Mox"
-        },
-        {
-          "count": 1,
-          "name": "City of Brass"
-        },
-        {
-          "count": 1,
-          "name": "City of Traitors"
-        },
-        {
-          "count": 1,
-          "name": "Clarion Conqueror"
-        },
-        {
-          "count": 1,
-          "name": "Combat Celebrant"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Deafening Silence"
-        },
-        {
-          "count": 1,
-          "name": "Deflecting Swat"
-        },
-        {
-          "count": 1,
-          "name": "Drannith Magistrate"
-        },
-        {
-          "count": 1,
-          "name": "Eidolon of Rhetoric"
-        },
-        {
-          "count": 1,
-          "name": "Eiganjo, Seat of the Empire"
-        },
-        {
-          "count": 1,
-          "name": "Enlightened Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Esper Sentinel"
-        },
-        {
-          "count": 1,
-          "name": "Ethersworn Canonist"
-        },
-        {
-          "count": 1,
-          "name": "Flooded Strand"
-        },
-        {
-          "count": 1,
-          "name": "Gemstone Caverns"
-        },
-        {
-          "count": 1,
-          "name": "Gingerbrute"
-        },
-        {
-          "count": 1,
-          "name": "Giver of Runes"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Rabblemaster"
-        },
-        {
-          "count": 1,
-          "name": "Grand Abolisher"
-        },
-        {
-          "count": 1,
-          "name": "Greymond, Avacyn's Stalwart"
+          "name": "Grapeshot"
         },
         {
           "count": 1,
@@ -3384,151 +3454,115 @@
         },
         {
           "count": 1,
-          "name": "Hope of Ghirapur"
+          "name": "Hullbreaker Horror"
         },
         {
           "count": 1,
-          "name": "Howlsquad Heavy"
+          "name": "Infernal Plunge"
+        },
+        {
+          "count": 14,
+          "name": "Island"
         },
         {
           "count": 1,
-          "name": "Imperial Recruiter"
+          "name": "Isochron Scepter"
         },
         {
           "count": 1,
-          "name": "Lion's Eye Diamond"
+          "name": "Izzet Signet"
         },
         {
           "count": 1,
-          "name": "Lotus Petal"
+          "name": "Kitsa, Otterball Elite"
         },
         {
           "count": 1,
-          "name": "Loyal Apprentice"
+          "name": "Lantern of the Lost"
         },
         {
           "count": 1,
-          "name": "Magus of the Moon"
+          "name": "Last Chance"
         },
         {
           "count": 1,
-          "name": "Mana Confluence"
+          "name": "Lightning Bolt"
         },
         {
           "count": 1,
-          "name": "Mana Vault"
+          "name": "Magic Damper"
         },
         {
           "count": 1,
-          "name": "Marsh Flats"
+          "name": "Mind Stone"
         },
         {
           "count": 1,
-          "name": "Memnite"
+          "name": "Miscast"
         },
         {
-          "count": 3,
+          "count": 8,
           "name": "Mountain"
         },
         {
           "count": 1,
-          "name": "Mox Diamond"
+          "name": "Muddle the Mixture"
         },
         {
           "count": 1,
-          "name": "Mox Opal"
+          "name": "Mystic Remora"
         },
         {
           "count": 1,
-          "name": "Myrel, Shield of Argive"
+          "name": "Mystic Sanctuary"
         },
         {
           "count": 1,
-          "name": "Needleverge Pathway"
+          "name": "Narset, Parter of Veils"
         },
         {
           "count": 1,
-          "name": "Orim's Chant"
+          "name": "Negate"
         },
         {
           "count": 1,
-          "name": "Ornithopter"
+          "name": "Pit of Offerings"
         },
         {
           "count": 1,
-          "name": "Path to Exile"
+          "name": "Ponder"
         },
         {
           "count": 1,
-          "name": "Phelia, Exuberant Shepherd"
+          "name": "Pongify"
         },
         {
           "count": 1,
-          "name": "Phyrexian Censor"
+          "name": "Preordain"
         },
         {
           "count": 1,
-          "name": "Phyrexian Revoker"
+          "name": "Rapid Hybridization"
         },
         {
           "count": 1,
-          "name": "Phyrexian Walker"
-        },
-        {
-          "count": 5,
-          "name": "Plains"
+          "name": "Red Elemental Blast"
         },
         {
           "count": 1,
-          "name": "Plateau"
+          "name": "Reshape"
         },
         {
           "count": 1,
-          "name": "Professional Face-Breaker"
+          "name": "Rite of Flame"
         },
         {
           "count": 1,
-          "name": "Pyroblast"
+          "name": "Seething Song"
         },
         {
           "count": 1,
-          "name": "Quicksilver, Brash Blur"
-        },
-        {
-          "count": 1,
-          "name": "Ragavan, Nimble Pilferer"
-        },
-        {
-          "count": 1,
-          "name": "Ranger-Captain of Eos"
-        },
-        {
-          "count": 1,
-          "name": "Raph & Leo, Sibling Rivals"
-        },
-        {
-          "count": 1,
-          "name": "Rionya, Fire Dancer"
-        },
-        {
-          "count": 1,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 1,
-          "name": "Sanctum Prelate"
-        },
-        {
-          "count": 1,
-          "name": "Scalding Tarn"
-        },
-        {
-          "count": 1,
-          "name": "Signal Pest"
-        },
-        {
-          "count": 1,
-          "name": "Silence"
+          "name": "Shivan Reef"
         },
         {
           "count": 1,
@@ -3536,15 +3570,7 @@
         },
         {
           "count": 1,
-          "name": "Skrelv, Defector Mite"
-        },
-        {
-          "count": 1,
-          "name": "Slicer, Hired Muscle"
-        },
-        {
-          "count": 1,
-          "name": "Sokenzan, Crucible of Defiance"
+          "name": "Snap"
         },
         {
           "count": 1,
@@ -3552,67 +3578,83 @@
         },
         {
           "count": 1,
-          "name": "Solitude"
+          "name": "Solve the Equation"
         },
         {
           "count": 1,
-          "name": "Soulless Jailer"
+          "name": "Spell Pierce"
         },
         {
           "count": 1,
-          "name": "Spectator Seating"
+          "name": "Springleaf Drum"
         },
         {
           "count": 1,
-          "name": "Spirit of the Labyrinth"
+          "name": "Storm-Kiln Artist"
         },
         {
           "count": 1,
-          "name": "Sunbaked Canyon"
+          "name": "Stormcarved Coast"
         },
         {
           "count": 1,
-          "name": "Sundering Eruption"
+          "name": "Strike It Rich"
         },
         {
           "count": 1,
-          "name": "Swords to Plowshares"
+          "name": "Stubborn Denial"
         },
         {
           "count": 1,
-          "name": "Tataru Taru"
+          "name": "Sulfur Falls"
         },
         {
           "count": 1,
-          "name": "Thalia, Guardian of Thraben"
+          "name": "Swiftfoot Boots"
         },
         {
           "count": 1,
-          "name": "Thalia, Heretic Cathar"
+          "name": "Tale's End"
         },
         {
           "count": 1,
-          "name": "Vexing Bauble"
+          "name": "Talisman of Creativity"
         },
         {
           "count": 1,
-          "name": "Windswept Heath"
+          "name": "Thorn of Amethyst"
         },
         {
           "count": 1,
-          "name": "Witch Enchanter"
+          "name": "Thought Vessel"
         },
         {
           "count": 1,
-          "name": "Wooded Foothills"
+          "name": "Tormod's Crypt"
         },
         {
           "count": 1,
-          "name": "Yuffie, Materia Hunter"
+          "name": "Tribute Mage"
         },
         {
           "count": 1,
-          "name": "Winota, Joiner of Forces"
+          "name": "Vandalblast"
+        },
+        {
+          "count": 1,
+          "name": "Wild Ride"
+        },
+        {
+          "count": 1,
+          "name": "Counterspell"
+        },
+        {
+          "count": 1,
+          "name": "Windfall"
+        },
+        {
+          "count": 1,
+          "name": "Vivi Ornitier"
         }
       ],
       "sideboard": []

--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "modern",
   "version": 1,
-  "updated": "2026-07-24T00:00:00Z",
+  "updated": "2026-07-25T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/modern",
   "decks": [
     {

--- a/client/public/feeds/mtggoldfish-pioneer.json
+++ b/client/public/feeds/mtggoldfish-pioneer.json
@@ -5,131 +5,9 @@
   "icon": "G",
   "format": "pioneer",
   "version": 1,
-  "updated": "2026-07-24T00:00:00Z",
+  "updated": "2026-07-25T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/pioneer",
   "decks": [
-    {
-      "name": "Mono-Red Prowess",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 4,
-          "name": "Soul-Scar Mage"
-        },
-        {
-          "count": 3,
-          "name": "Ramunap Ruins"
-        },
-        {
-          "count": 3,
-          "name": "Reckless Rage"
-        },
-        {
-          "count": 4,
-          "name": "Bonecrusher Giant"
-        },
-        {
-          "count": 2,
-          "name": "Den of the Bugbear"
-        },
-        {
-          "count": 4,
-          "name": "Kumano Faces Kakkazan"
-        },
-        {
-          "count": 1,
-          "name": "Sokenzan, Crucible of Defiance"
-        },
-        {
-          "count": 2,
-          "name": "Monstrous Rage"
-        },
-        {
-          "count": 4,
-          "name": "Emberheart Challenger"
-        },
-        {
-          "count": 1,
-          "name": "Rockface Village"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 4,
-          "name": "Screaming Nemesis"
-        },
-        {
-          "count": 4,
-          "name": "Mountain"
-        },
-        {
-          "count": 4,
-          "name": "Mutavault"
-        },
-        {
-          "count": 4,
-          "name": "Burst Lightning"
-        },
-        {
-          "count": 4,
-          "name": "Monastery Swiftspear"
-        },
-        {
-          "count": 4,
-          "name": "Sunspine Lynx"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Pyroclasm"
-        },
-        {
-          "count": 2,
-          "name": "Redcap Melee"
-        },
-        {
-          "count": 2,
-          "name": "Weathered Runestone"
-        },
-        {
-          "count": 3,
-          "name": "Flowstone Infusion"
-        },
-        {
-          "count": 4,
-          "name": "Magebane Lizard"
-        },
-        {
-          "count": 2,
-          "name": "Scorching Shot"
-        }
-      ]
-    },
     {
       "name": "Izzet Prowess",
       "author": "MTGGoldfish",
@@ -262,6 +140,128 @@
         {
           "count": 2,
           "name": "Quantum Riddler"
+        }
+      ]
+    },
+    {
+      "name": "Mono-Red Prowess",
+      "author": "MTGGoldfish",
+      "colors": [
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 4,
+          "name": "Soul-Scar Mage"
+        },
+        {
+          "count": 3,
+          "name": "Ramunap Ruins"
+        },
+        {
+          "count": 3,
+          "name": "Reckless Rage"
+        },
+        {
+          "count": 4,
+          "name": "Bonecrusher Giant"
+        },
+        {
+          "count": 2,
+          "name": "Den of the Bugbear"
+        },
+        {
+          "count": 4,
+          "name": "Kumano Faces Kakkazan"
+        },
+        {
+          "count": 1,
+          "name": "Sokenzan, Crucible of Defiance"
+        },
+        {
+          "count": 2,
+          "name": "Monstrous Rage"
+        },
+        {
+          "count": 4,
+          "name": "Emberheart Challenger"
+        },
+        {
+          "count": 1,
+          "name": "Rockface Village"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 4,
+          "name": "Screaming Nemesis"
+        },
+        {
+          "count": 4,
+          "name": "Mountain"
+        },
+        {
+          "count": 4,
+          "name": "Mutavault"
+        },
+        {
+          "count": 4,
+          "name": "Burst Lightning"
+        },
+        {
+          "count": 4,
+          "name": "Monastery Swiftspear"
+        },
+        {
+          "count": 4,
+          "name": "Sunspine Lynx"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 2,
+          "name": "Pyroclasm"
+        },
+        {
+          "count": 2,
+          "name": "Redcap Melee"
+        },
+        {
+          "count": 2,
+          "name": "Weathered Runestone"
+        },
+        {
+          "count": 3,
+          "name": "Flowstone Infusion"
+        },
+        {
+          "count": 4,
+          "name": "Magebane Lizard"
+        },
+        {
+          "count": 2,
+          "name": "Scorching Shot"
         }
       ]
     },
@@ -440,9 +440,9 @@
       "name": "Abzan Greasefang",
       "author": "MTGGoldfish",
       "colors": [
-        "G",
+        "W",
         "B",
-        "W"
+        "G"
       ],
       "tags": [
         "metagame"
@@ -457,16 +457,16 @@
           "name": "Concealed Courtyard"
         },
         {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
+          "count": 4,
+          "name": "Fatal Push"
         },
         {
           "count": 4,
           "name": "Cache Grab"
         },
         {
-          "count": 4,
-          "name": "Multiversal Passage"
+          "count": 1,
+          "name": "Emptiness"
         },
         {
           "count": 4,
@@ -474,11 +474,11 @@
         },
         {
           "count": 4,
-          "name": "Formidable Speaker"
+          "name": "Blooming Marsh"
         },
         {
-          "count": 1,
-          "name": "Caves of Koilos"
+          "count": 4,
+          "name": "Formidable Speaker"
         },
         {
           "count": 4,
@@ -486,7 +486,11 @@
         },
         {
           "count": 1,
-          "name": "Forest"
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Swamp"
         },
         {
           "count": 1,
@@ -497,20 +501,24 @@
           "name": "Parhelion II"
         },
         {
-          "count": 1,
-          "name": "Swamp"
+          "count": 4,
+          "name": "Multiversal Passage"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Professor of Symbology"
         },
         {
           "count": 1,
-          "name": "Jennifer Walters"
+          "name": "Takenuma, Abandoned Mire"
         },
         {
           "count": 1,
-          "name": "Takenuma, Abandoned Mire"
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
         },
         {
           "count": 3,
@@ -518,37 +526,25 @@
         },
         {
           "count": 1,
-          "name": "Emptiness"
-        },
-        {
-          "count": 4,
-          "name": "Blooming Marsh"
+          "name": "Yathan Roadwatcher"
         },
         {
           "count": 1,
-          "name": "Selfless Savior"
+          "name": "Jennifer Walters"
         },
         {
           "count": 1,
-          "name": "Plains"
+          "name": "Caves of Koilos"
         },
         {
           "count": 4,
           "name": "Temple Garden"
-        },
-        {
-          "count": 1,
-          "name": "Yathan Roadwatcher"
-        },
-        {
-          "count": 4,
-          "name": "Thoughtseize"
         }
       ],
       "sideboard": [
         {
-          "count": 2,
-          "name": "Duress"
+          "count": 1,
+          "name": "Ral Zarek, Guest Lecturer"
         },
         {
           "count": 1,
@@ -563,16 +559,12 @@
           "name": "Origin of Metalbending"
         },
         {
-          "count": 1,
-          "name": "Beza, the Bounding Spring"
-        },
-        {
-          "count": 1,
-          "name": "Remorseful Cleric"
-        },
-        {
           "count": 3,
           "name": "Abrupt Decay"
+        },
+        {
+          "count": 4,
+          "name": "Thoughtseize"
         },
         {
           "count": 1,
@@ -580,15 +572,11 @@
         },
         {
           "count": 1,
-          "name": "Ruinous Waterbending"
-        },
-        {
-          "count": 1,
-          "name": "Grand Abolisher"
+          "name": "Professor Dellian Fel"
         },
         {
           "count": 2,
-          "name": "Ral Zarek, Guest Lecturer"
+          "name": "Pest Control"
         }
       ]
     },

--- a/client/public/feeds/mtggoldfish-standard.json
+++ b/client/public/feeds/mtggoldfish-standard.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "standard",
   "version": 1,
-  "updated": "2026-07-24T00:00:00Z",
+  "updated": "2026-07-25T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/standard",
   "decks": [
     {
@@ -840,44 +840,28 @@
       ],
       "main": [
         {
-          "count": 3,
-          "name": "Bitter Triumph"
-        },
-        {
-          "count": 4,
-          "name": "Restless Reef"
-        },
-        {
-          "count": 2,
-          "name": "Day of Black Sun"
-        },
-        {
-          "count": 1,
-          "name": "Deadly Cover-Up"
+          "count": 8,
+          "name": "Swamp"
         },
         {
           "count": 4,
           "name": "Deceit"
         },
         {
-          "count": 1,
-          "name": "M.O.D.O.K."
-        },
-        {
-          "count": 2,
-          "name": "Hidden Lair"
-        },
-        {
-          "count": 2,
-          "name": "Emeritus of Ideation"
-        },
-        {
-          "count": 1,
-          "name": "Undercity Sewers"
+          "count": 3,
+          "name": "Doomsday Excruciator"
         },
         {
           "count": 4,
-          "name": "Gloomlake Verge"
+          "name": "Superior Spider-Man"
+        },
+        {
+          "count": 2,
+          "name": "Bitter Triumph"
+        },
+        {
+          "count": 3,
+          "name": "Emeritus of Ideation"
         },
         {
           "count": 4,
@@ -885,81 +869,93 @@
         },
         {
           "count": 4,
-          "name": "Duress"
+          "name": "Winternight Stories"
         },
         {
-          "count": 3,
-          "name": "Stock Up"
+          "count": 4,
+          "name": "Gloomlake Verge"
+        },
+        {
+          "count": 2,
+          "name": "Multiversal Passage"
+        },
+        {
+          "count": 2,
+          "name": "Undercity Sewers"
+        },
+        {
+          "count": 4,
+          "name": "Restless Reef"
+        },
+        {
+          "count": 4,
+          "name": "Watery Grave"
         },
         {
           "count": 1,
           "name": "Strategic Betrayal"
         },
         {
-          "count": 1,
-          "name": "Superior Spider-Man"
+          "count": 3,
+          "name": "Duress"
         },
         {
           "count": 3,
-          "name": "Doomsday Excruciator"
+          "name": "Day of Black Sun"
         },
         {
-          "count": 2,
+          "count": 3,
+          "name": "Bender's Waterskin"
+        },
+        {
+          "count": 1,
           "name": "Cavern of Souls"
         },
         {
-          "count": 2,
-          "name": "Winternight Stories"
-        },
-        {
-          "count": 3,
-          "name": "Superior Spider-Man"
-        },
-        {
-          "count": 9,
-          "name": "Swamp"
-        },
-        {
-          "count": 4,
-          "name": "Watery Grave"
+          "count": 1,
+          "name": "Stock Up"
         }
       ],
       "sideboard": [
         {
           "count": 1,
-          "name": "Deadly Cover-Up"
-        },
-        {
-          "count": 1,
-          "name": "M.O.D.O.K."
-        },
-        {
-          "count": 2,
-          "name": "Disdainful Stroke"
-        },
-        {
-          "count": 1,
           "name": "Quantum Riddler"
         },
         {
+          "count": 1,
+          "name": "Duress"
+        },
+        {
+          "count": 3,
+          "name": "Qarsi Revenant"
+        },
+        {
+          "count": 3,
+          "name": "Flashfreeze"
+        },
+        {
+          "count": 1,
+          "name": "Strategic Betrayal"
+        },
+        {
           "count": 2,
-          "name": "Malcolm, Alluring Scoundrel"
+          "name": "Stab"
+        },
+        {
+          "count": 1,
+          "name": "Spell Pierce"
         },
         {
           "count": 1,
           "name": "Negate"
         },
         {
-          "count": 4,
-          "name": "Preacher of the Schism"
-        },
-        {
-          "count": 2,
-          "name": "Oildeep Gearhulk"
+          "count": 1,
+          "name": "Ghost Vacuum"
         },
         {
           "count": 1,
-          "name": "Strategic Betrayal"
+          "name": "Petrified Hamlet"
         }
       ]
     },


### PR DESCRIPTION
Automated daily metagame feed refresh from MTGGoldfish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed MTGGoldfish deck feeds for Commander, Pioneer, Standard, and Modern.
  * Updated feed timestamps to July 25, 2026.
  * Added and revised deck lists, including Commander entries such as The Ur-Dragon and Doctor Doom.
  * Updated card quantities, sideboards, colors, and card ordering across featured Pioneer and Standard decks.
  * Modern feed metadata was refreshed without changes to its deck lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->