### PR TITLE
fix(server): accept split attack declarations

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -567,6 +567,14 @@ pub fn mark_attacker_blocked(state: &mut GameState, oid: ObjectId) -> bool {
 pub fn validate_attackers(state: &GameState, attacker_ids: &[ObjectId]) -> Result<(), String> {
     let active = state.active_player;
 
+    // CR 508.1a: choosing a creature more than once cannot produce two
+    // attackers; reject duplicate declarations before checking their other
+    // individual restrictions.
+    let mut declared = HashSet::with_capacity(attacker_ids.len());
+    if attacker_ids.iter().any(|id| !declared.insert(*id)) {
+        return Err("A creature can't be declared as an attacker more than once".to_string());
+    }
+
     // CR 508.1c: Attack restrictions make the declaration illegal if disobeyed.
     if let Some(max) = max_attackers_each_combat(state) {
         if attacker_ids.len() as u32 > max {

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -3136,4 +3136,122 @@ mod tests {
         let session = mgr.sessions.get(&code).unwrap();
         assert_eq!(session.state.players[defending_player.0 as usize].life, 20);
     }
+
+    /// CR 508.1a–e: each attacker independently chooses a defender. The
+    /// candidate enumerator only samples that combinatorial space (it lists
+    /// single-target alpha strikes), so a split declaration is legal but absent
+    /// from it — the session must admit it and let `apply()` validate. Guards
+    /// against reintroducing a candidate-membership legality gate at the
+    /// session boundary, while CR 508.1a duplicate rejection stays enforced by
+    /// `validate_attackers`.
+    #[test]
+    fn split_attack_declaration_is_admitted_and_validated_by_the_engine() {
+        use engine::game::combat::AttackTarget;
+        use engine::game::zones::create_object;
+        use engine::types::card_type::CoreType;
+        use engine::types::identifiers::CardId;
+
+        let mut mgr = SessionManager::new();
+        let (code, token0) = mgr.create_game_n_players(
+            make_deck(),
+            "Host".to_string(),
+            None,
+            3,
+            MatchConfig::default(),
+            Some(FormatConfig::standard()),
+        );
+        let _ = mgr.join_game(&code, make_deck()).unwrap();
+        let _ = mgr.join_game(&code, make_deck()).unwrap();
+
+        let attacks = {
+            let session = mgr.sessions.get_mut(&code).unwrap();
+            let first = create_object(
+                &mut session.state,
+                CardId(4000),
+                PlayerId(0),
+                "First attacker".to_string(),
+                Zone::Battlefield,
+            );
+            let second = create_object(
+                &mut session.state,
+                CardId(4001),
+                PlayerId(0),
+                "Second attacker".to_string(),
+                Zone::Battlefield,
+            );
+            for id in [first, second] {
+                session
+                    .state
+                    .objects
+                    .get_mut(&id)
+                    .unwrap()
+                    .card_types
+                    .core_types
+                    .push(CoreType::Creature);
+            }
+
+            session.state.active_player = PlayerId(0);
+            session.state.priority_player = PlayerId(0);
+            session.state.phase = Phase::DeclareAttackers;
+            session.state.waiting_for = WaitingFor::DeclareAttackers {
+                player: PlayerId(0),
+                valid_attacker_ids: vec![first, second],
+                valid_attack_targets: vec![
+                    AttackTarget::Player(PlayerId(1)),
+                    AttackTarget::Player(PlayerId(2)),
+                ],
+                valid_attack_targets_by_attacker: None,
+                attacker_constraints: Default::default(),
+            };
+
+            vec![
+                (first, AttackTarget::Player(PlayerId(1))),
+                (second, AttackTarget::Player(PlayerId(2))),
+            ]
+        };
+        let action = GameAction::DeclareAttackers {
+            attacks: attacks.clone(),
+            bands: vec![],
+        };
+
+        let enumerated = engine::ai_support::legal_actions(&mgr.sessions[&code].state);
+        assert!(
+            !enumerated.contains(&action),
+            "the finite candidate set intentionally omits this split attack: {enumerated:?}"
+        );
+
+        // The bypass must not weaken validation: a malformed freeform declaration
+        // reaches the engine and is rejected there rather than by candidate lookup.
+        let duplicate = mgr.handle_action(
+            &code,
+            &token0,
+            GameAction::DeclareAttackers {
+                attacks: vec![
+                    attacks[0],
+                    (attacks[0].0, AttackTarget::Player(PlayerId(2))),
+                ],
+                bands: vec![],
+            },
+        );
+        assert!(
+            matches!(duplicate, Err(ref error) if error.starts_with("Engine error:")),
+            "a duplicate attacker must be rejected by the engine, got: {duplicate:?}"
+        );
+
+        let result = mgr.handle_action(&code, &token0, action);
+        assert!(
+            result.is_ok(),
+            "a legal split attack must be validated by apply(), got: {result:?}"
+        );
+        let attackers = &mgr.sessions[&code].state.combat.as_ref().unwrap().attackers;
+        assert_eq!(attackers.len(), 2);
+        assert!(attackers.iter().any(|attacker| {
+            attacker.object_id == attacks[0].0
+                && attacker.attack_target == AttackTarget::Player(PlayerId(1))
+        }));
+        assert!(attackers.iter().any(|attacker| {
+            attacker.object_id == attacks[1].0
+                && attacker.attack_target == AttackTarget::Player(PlayerId(2))
+        }));
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate attackers are now rejected during combat declarations, preventing the same creature from being selected more than once.
  * Multiplayer combat submissions can now include valid attacker declarations that are not part of a precomputed candidate list.
  * Invalid or malformed attacker declarations continue to be rejected with appropriate legality checks.
* **Improvements**
  * Attacker declaration handling is now more flexible while preserving game-rule validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->