### PR TITLE
fix(engine): resolve recent hang and crash reports

### DIFF
--- a/crates/engine/src/analysis/ability_graph.rs
+++ b/crates/engine/src/analysis/ability_graph.rs
@@ -909,6 +909,7 @@ fn effect_projection(effect: &Effect) -> Projection {
         | Effect::Reveal { .. }
         | Effect::RevealTop { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::TargetOnly { .. }
         | Effect::Choose { .. }
         | Effect::SwapChosenLabels { .. }

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2948,6 +2948,15 @@ fn legacy_effect(x: &Effect) -> bool {
             player: target,
             ..
         } => legacy_quantity_expr(count) || legacy_target_filter(target),
+        Effect::ExileFaceDownPile {
+            object,
+            player,
+            count,
+        } => {
+            legacy_quantity_expr(count)
+                || legacy_target_filter(object)
+                || legacy_target_filter(player)
+        }
 
         // ---- `count`-only (QuantityExpr) ----
         Effect::Monstrosity { count }
@@ -4543,6 +4552,22 @@ fn rw_effect(
                 Zone::Exile,
             );
             p.merge(rw_quantity_expr(count));
+            (p, None)
+        }
+        Effect::ExileFaceDownPile {
+            object,
+            player,
+            count,
+        } => {
+            let mut p = ext_write(StateKind::SetMembership);
+            p.writes_external.set(StateKind::HandLibrary);
+            p.writes_membership_external_census.merge(Census::Any);
+            p.writes_membership_external_zones.merge(ZoneSpan::Any);
+            p.merge(rw_quantity_expr(count));
+            p.merge(rw_target_filter(object));
+            p.merge(rw_target_filter(player));
+            flag_legacy_write_target(&mut p, object);
+            flag_member_bound_write_target(&mut p, object);
             (p, None)
         }
         Effect::ExileFromTopUntil {

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1106,6 +1106,13 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
             acc = acc.or(scan_quantity_expr(count, mode));
             acc
         }
+        Effect::ExileFaceDownPile {
+            object,
+            player,
+            count,
+        } => scan_target_filter(object, target_ctx, mode)
+            .or(scan_target_filter(player, target_ctx, mode))
+            .or(scan_quantity_expr(count, mode)),
         Effect::TargetOnly { target } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target, target_ctx, mode));
@@ -5331,6 +5338,7 @@ fn effect_target_ctx(e: &Effect, mode: ScanMode) -> FilterReadContext {
         | Effect::Reveal { .. }
         | Effect::RevealTop { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::TargetOnly { .. }
         | Effect::Choose { .. }
         | Effect::ChooseDamageSource { .. }
@@ -5617,6 +5625,7 @@ fn effect_census_role(e: &Effect) -> CensusRole {
         | Effect::Scry { .. }
         | Effect::Surveil { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::ExileFromTopUntil { .. }
         | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::Discover { .. }
@@ -5995,6 +6004,7 @@ fn effect_resolution_choice_freedom(e: &Effect) -> ResolutionChoiceFreedom {
         | Effect::Reveal { .. }
         | Effect::RevealTop { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::TargetOnly { .. }
         | Effect::Choose { .. }
         | Effect::ChooseDamageSource { .. }
@@ -6264,6 +6274,7 @@ pub(crate) fn effect_is_randomness_bearing(e: &Effect) -> bool {
         | Effect::Reveal { .. }
         | Effect::RevealTop { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::TargetOnly { .. }
         | Effect::ChooseDamageSource { .. }
         | Effect::Suspect { .. }

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -5206,64 +5206,25 @@ fn skips_stack_targets_after_deferred_effect(effect: &Effect) -> bool {
     )
 }
 
-/// Finds the first stack-targeting instruction after an interactive effect.
-///
-/// Its own resolution-local plumbing (`ChangeZone`, `Shuffle`, and library
-/// placement) stays transparent while it remains a continuation step. A
-/// following printed instruction contributes its targets at stack time only
-/// when it is an unconditional `SequentialSibling`; a child whose target
-/// selection is deferred remains deferred even when it is a sibling.
-fn deferred_effect_stack_target_tail_depth(
-    mut sub_ability: Option<&ResolvedAbility>,
-) -> Option<usize> {
-    let mut depth = 0;
-    while let Some(sub) = sub_ability {
-        if defers_conditional_target_selection(sub) {
-            return None;
-        }
-        if sub.sub_link == SubAbilityLink::SequentialSibling {
-            return Some(depth);
-        }
-        if !skips_stack_targets_after_deferred_effect(&sub.effect) {
-            return None;
-        }
-        sub_ability = sub.sub_ability.as_deref();
-        depth += 1;
-    }
-    None
-}
-
-fn deferred_effect_stack_target_tail(
-    sub_ability: Option<&ResolvedAbility>,
-) -> Option<&ResolvedAbility> {
-    let depth = deferred_effect_stack_target_tail_depth(sub_ability)?;
-    let mut tail = sub_ability?;
-    for _ in 0..depth {
-        tail = tail.sub_ability.as_deref()?;
-    }
-    Some(tail)
-}
-
-fn deferred_effect_stack_target_tail_mut(
-    sub_ability: Option<&mut ResolvedAbility>,
-) -> Option<&mut ResolvedAbility> {
-    let depth = deferred_effect_stack_target_tail_depth(sub_ability.as_deref())?;
-    let mut tail = sub_ability?;
-    for _ in 0..depth {
-        tail = tail.sub_ability.as_deref_mut()?;
-    }
-    Some(tail)
-}
-
 fn collect_target_slots_after_deferred_effect(
     state: &GameState,
     sub_ability: Option<&ResolvedAbility>,
     acc: &mut SlotAccumulator,
 ) -> Result<(), EngineError> {
-    if let Some(sub_ability) = deferred_effect_stack_target_tail(sub_ability) {
-        collect_target_slots(state, sub_ability, acc)?;
+    let Some(sub_ability) = sub_ability else {
+        return Ok(());
+    };
+    if defers_conditional_target_selection(sub_ability) {
+        return Ok(());
     }
-    Ok(())
+    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
+        return collect_target_slots_after_deferred_effect(
+            state,
+            sub_ability.sub_ability.as_deref(),
+            acc,
+        );
+    }
+    collect_target_slots(state, sub_ability, acc)
 }
 
 fn collect_target_slot_specs_after_deferred_effect(
@@ -5272,9 +5233,22 @@ fn collect_target_slot_specs_after_deferred_effect(
     specs: &mut Vec<TargetSlotSpec>,
     next_instance: &mut usize,
 ) {
-    if let Some(sub_ability) = deferred_effect_stack_target_tail(sub_ability) {
-        collect_target_slot_specs(state, sub_ability, specs, next_instance);
+    let Some(sub_ability) = sub_ability else {
+        return;
+    };
+    if defers_conditional_target_selection(sub_ability) {
+        return;
     }
+    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
+        collect_target_slot_specs_after_deferred_effect(
+            state,
+            sub_ability.sub_ability.as_deref(),
+            specs,
+            next_instance,
+        );
+        return;
+    }
+    collect_target_slot_specs(state, sub_ability, specs, next_instance);
 }
 
 fn build_target_assignments(
@@ -6472,10 +6446,21 @@ fn assign_targets_after_deferred_effect(
     targets: &[TargetRef],
     next_target: &mut usize,
 ) -> Result<(), EngineError> {
-    if let Some(sub_ability) = deferred_effect_stack_target_tail_mut(sub_ability) {
-        assign_targets_recursive(state, sub_ability, targets, next_target)?;
+    let Some(sub_ability) = sub_ability else {
+        return Ok(());
+    };
+    if defers_conditional_target_selection(sub_ability) {
+        return Ok(());
     }
-    Ok(())
+    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
+        return assign_targets_after_deferred_effect(
+            state,
+            sub_ability.sub_ability.as_deref_mut(),
+            targets,
+            next_target,
+        );
+    }
+    assign_targets_recursive(state, sub_ability, targets, next_target)
 }
 
 fn assign_selected_slots_after_deferred_effect(
@@ -6484,10 +6469,21 @@ fn assign_selected_slots_after_deferred_effect(
     selected_slots: &[Option<TargetRef>],
     next_slot: &mut usize,
 ) -> Result<(), EngineError> {
-    if let Some(sub_ability) = deferred_effect_stack_target_tail_mut(sub_ability) {
-        assign_selected_slots_recursive(state, sub_ability, selected_slots, next_slot)?;
+    let Some(sub_ability) = sub_ability else {
+        return Ok(());
+    };
+    if defers_conditional_target_selection(sub_ability) {
+        return Ok(());
     }
-    Ok(())
+    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
+        return assign_selected_slots_after_deferred_effect(
+            state,
+            sub_ability.sub_ability.as_deref_mut(),
+            selected_slots,
+            next_slot,
+        );
+    }
+    assign_selected_slots_recursive(state, sub_ability, selected_slots, next_slot)
 }
 
 /// CR 115.3: Validate targeting constraints — e.g., different target players must be distinct.
@@ -6687,7 +6683,16 @@ fn chain_has_target_sink(ability: &ResolvedAbility) -> bool {
 }
 
 fn chain_has_target_sink_after_deferred_effect(sub_ability: Option<&ResolvedAbility>) -> bool {
-    deferred_effect_stack_target_tail(sub_ability).is_some_and(chain_has_target_sink)
+    let Some(sub_ability) = sub_ability else {
+        return false;
+    };
+    if defers_conditional_target_selection(sub_ability) {
+        return false;
+    }
+    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
+        return chain_has_target_sink_after_deferred_effect(sub_ability.sub_ability.as_deref());
+    }
+    chain_has_target_sink(sub_ability)
 }
 
 fn minimum_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -> usize {
@@ -6796,9 +6801,16 @@ fn minimum_targets_after_deferred_effect(
     state: &GameState,
     sub_ability: Option<&ResolvedAbility>,
 ) -> usize {
-    deferred_effect_stack_target_tail(sub_ability)
-        .map(|sub_ability| minimum_targets_in_chain(state, sub_ability))
-        .unwrap_or(0)
+    let Some(sub_ability) = sub_ability else {
+        return 0;
+    };
+    if defers_conditional_target_selection(sub_ability) {
+        return 0;
+    }
+    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
+        return minimum_targets_after_deferred_effect(state, sub_ability.sub_ability.as_deref());
+    }
+    minimum_targets_in_chain(state, sub_ability)
 }
 
 /// CR 700.2a: The controller of a modal spell or activated ability chooses the mode(s)
@@ -8386,7 +8398,7 @@ mod tests {
     }
 
     #[test]
-    fn deferred_effect_target_traversal_crosses_only_unconditional_sequential_siblings() {
+    fn deferred_effect_target_traversal_crosses_transparent_links_regardless_of_sub_link() {
         let mut state = GameState::new_two_player(42);
         let source = create_object(
             &mut state,
@@ -8466,88 +8478,115 @@ mod tests {
             .sub_ability(change_zone)
         };
 
-        let continuation = chain(SubAbilityLink::ContinuationStep);
-        assert!(
-            build_target_slots(&state, &continuation)
-                .expect("continuation target traversal should build")
-                .is_empty(),
-            "the deferred effect's own continuation must keep its target selection at resolution"
-        );
-        assert!(target_slot_specs(&state, &continuation).is_empty());
-        assert!(!chain_has_target_sink(&continuation));
-        assert_eq!(minimum_targets_in_chain(&state, &continuation), 0);
+        for link in [
+            SubAbilityLink::ContinuationStep,
+            SubAbilityLink::SequentialSibling,
+        ] {
+            let ability = chain(link);
+            let slots = build_target_slots(&state, &ability)
+                .expect("transparent deferred-effect links should surface the target");
+            assert_eq!(slots.len(), 1);
+            assert!(slots[0]
+                .legal_targets
+                .contains(&TargetRef::Object(creature)));
+            assert_eq!(target_slot_specs(&state, &ability).len(), 1);
+            assert!(chain_has_target_sink(&ability));
+            assert_eq!(minimum_targets_in_chain(&state, &ability), 1);
+            validate_selected_targets_for_ability(
+                &state,
+                &ability,
+                &slots,
+                &[TargetRef::Object(creature)],
+                &[],
+            )
+            .expect("the deferred-effect tail creature target should validate");
 
-        let mut continuation_assigned = continuation.clone();
-        assign_targets_in_chain(&state, &mut continuation_assigned, &[])
-            .expect("a continuation-only chain has no stack target to assign");
-        assign_selected_slots_in_chain(&state, &mut continuation_assigned, &[])
-            .expect("a continuation-only chain has no stack target slot to assign");
+            let mut compact_assigned = ability.clone();
+            assign_targets_in_chain(
+                &state,
+                &mut compact_assigned,
+                &[TargetRef::Object(creature)],
+            )
+            .expect("compact assignment must reach the deferred-effect tail");
+            assert_eq!(
+                compact_assigned
+                    .sub_ability
+                    .as_deref()
+                    .and_then(|change_zone| change_zone.sub_ability.as_deref())
+                    .and_then(|shuffle| shuffle.sub_ability.as_deref())
+                    .unwrap()
+                    .targets,
+                vec![TargetRef::Object(creature)]
+            );
 
-        let mut reflexive_sibling = chain(SubAbilityLink::SequentialSibling);
-        reflexive_sibling
+            let mut selected_assigned = ability;
+            assign_selected_slots_in_chain(
+                &state,
+                &mut selected_assigned,
+                &[Some(TargetRef::Object(creature))],
+            )
+            .expect("selected-slot assignment must reach the deferred-effect tail");
+            assert_eq!(
+                selected_assigned
+                    .sub_ability
+                    .as_deref()
+                    .and_then(|change_zone| change_zone.sub_ability.as_deref())
+                    .and_then(|shuffle| shuffle.sub_ability.as_deref())
+                    .unwrap()
+                    .targets,
+                vec![TargetRef::Object(creature)]
+            );
+        }
+
+        let mut when_you_do = chain(SubAbilityLink::ContinuationStep);
+        when_you_do
             .sub_ability
             .as_deref_mut()
             .and_then(|change_zone| change_zone.sub_ability.as_deref_mut())
             .and_then(|shuffle| shuffle.sub_ability.as_deref_mut())
             .unwrap()
             .condition = Some(AbilityCondition::WhenYouDo);
-        assert!(
-            build_target_slots(&state, &reflexive_sibling)
-                .expect("reflexive sibling traversal should build")
-                .is_empty(),
-            "a reflexive sequential sibling must keep its target selection deferred"
-        );
-        assert!(target_slot_specs(&state, &reflexive_sibling).is_empty());
-        assert!(!chain_has_target_sink(&reflexive_sibling));
-        assert_eq!(minimum_targets_in_chain(&state, &reflexive_sibling), 0);
+        let mut resolution_timing = chain(SubAbilityLink::SequentialSibling);
+        resolution_timing
+            .sub_ability
+            .as_deref_mut()
+            .and_then(|change_zone| change_zone.sub_ability.as_deref_mut())
+            .and_then(|shuffle| shuffle.sub_ability.as_deref_mut())
+            .unwrap()
+            .target_choice_timing = TargetChoiceTiming::Resolution;
 
-        let sibling = chain(SubAbilityLink::SequentialSibling);
-        let slots = build_target_slots(&state, &sibling)
-            .expect("unconditional sequential sibling target should build");
-        assert_eq!(slots.len(), 1);
-        assert_eq!(target_slot_specs(&state, &sibling).len(), 1);
-        assert!(chain_has_target_sink(&sibling));
-        assert_eq!(minimum_targets_in_chain(&state, &sibling), 1);
-        validate_selected_targets_for_ability(
-            &state,
-            &sibling,
-            &slots,
-            &[TargetRef::Object(creature)],
-            &[],
-        )
-        .expect("the sequential sibling's creature target should validate");
+        for ability in [when_you_do, resolution_timing] {
+            assert!(build_target_slots(&state, &ability)
+                .expect("deferred conditional target traversal should build")
+                .is_empty());
+            assert!(target_slot_specs(&state, &ability).is_empty());
+            assert!(!chain_has_target_sink(&ability));
+            assert_eq!(minimum_targets_in_chain(&state, &ability), 0);
 
-        let mut assigned = sibling.clone();
-        assign_targets_in_chain(&state, &mut assigned, &[TargetRef::Object(creature)])
-            .expect("the sequential sibling must receive the selected target");
-        assert_eq!(
-            assigned
+            let mut compact_assigned = ability.clone();
+            assign_targets_in_chain(&state, &mut compact_assigned, &[])
+                .expect("empty compact assignment should leave deferred targets unchosen");
+            assert!(compact_assigned
                 .sub_ability
                 .as_deref()
                 .and_then(|change_zone| change_zone.sub_ability.as_deref())
                 .and_then(|shuffle| shuffle.sub_ability.as_deref())
                 .unwrap()
-                .targets,
-            vec![TargetRef::Object(creature)]
-        );
+                .targets
+                .is_empty());
 
-        let mut assigned_slots = sibling;
-        assign_selected_slots_in_chain(
-            &state,
-            &mut assigned_slots,
-            &[Some(TargetRef::Object(creature))],
-        )
-        .expect("the selected-slot path must match compact target assignment");
-        assert_eq!(
-            assigned_slots
+            let mut selected_assigned = ability;
+            assign_selected_slots_in_chain(&state, &mut selected_assigned, &[])
+                .expect("empty selected-slot assignment should leave deferred targets unchosen");
+            assert!(selected_assigned
                 .sub_ability
                 .as_deref()
                 .and_then(|change_zone| change_zone.sub_ability.as_deref())
                 .and_then(|shuffle| shuffle.sub_ability.as_deref())
                 .unwrap()
-                .targets,
-            vec![TargetRef::Object(creature)]
-        );
+                .targets
+                .is_empty());
+        }
     }
 
     /// CR 608.2c + CR 115.1: Arcum Dagsson / #4678 — "Target artifact creature's

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -5206,25 +5206,64 @@ fn skips_stack_targets_after_deferred_effect(effect: &Effect) -> bool {
     )
 }
 
+/// Finds the first stack-targeting instruction after an interactive effect.
+///
+/// Its own resolution-local plumbing (`ChangeZone`, `Shuffle`, and library
+/// placement) stays transparent while it remains a continuation step. A
+/// following printed instruction contributes its targets at stack time only
+/// when it is an unconditional `SequentialSibling`; a child whose target
+/// selection is deferred remains deferred even when it is a sibling.
+fn deferred_effect_stack_target_tail_depth(
+    mut sub_ability: Option<&ResolvedAbility>,
+) -> Option<usize> {
+    let mut depth = 0;
+    while let Some(sub) = sub_ability {
+        if defers_conditional_target_selection(sub) {
+            return None;
+        }
+        if sub.sub_link == SubAbilityLink::SequentialSibling {
+            return Some(depth);
+        }
+        if !skips_stack_targets_after_deferred_effect(&sub.effect) {
+            return None;
+        }
+        sub_ability = sub.sub_ability.as_deref();
+        depth += 1;
+    }
+    None
+}
+
+fn deferred_effect_stack_target_tail(
+    sub_ability: Option<&ResolvedAbility>,
+) -> Option<&ResolvedAbility> {
+    let depth = deferred_effect_stack_target_tail_depth(sub_ability)?;
+    let mut tail = sub_ability?;
+    for _ in 0..depth {
+        tail = tail.sub_ability.as_deref()?;
+    }
+    Some(tail)
+}
+
+fn deferred_effect_stack_target_tail_mut(
+    sub_ability: Option<&mut ResolvedAbility>,
+) -> Option<&mut ResolvedAbility> {
+    let depth = deferred_effect_stack_target_tail_depth(sub_ability.as_deref())?;
+    let mut tail = sub_ability?;
+    for _ in 0..depth {
+        tail = tail.sub_ability.as_deref_mut()?;
+    }
+    Some(tail)
+}
+
 fn collect_target_slots_after_deferred_effect(
     state: &GameState,
     sub_ability: Option<&ResolvedAbility>,
     acc: &mut SlotAccumulator,
 ) -> Result<(), EngineError> {
-    let Some(sub_ability) = sub_ability else {
-        return Ok(());
-    };
-    if defers_conditional_target_selection(sub_ability) {
-        return Ok(());
+    if let Some(sub_ability) = deferred_effect_stack_target_tail(sub_ability) {
+        collect_target_slots(state, sub_ability, acc)?;
     }
-    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
-        return collect_target_slots_after_deferred_effect(
-            state,
-            sub_ability.sub_ability.as_deref(),
-            acc,
-        );
-    }
-    collect_target_slots(state, sub_ability, acc)
+    Ok(())
 }
 
 fn collect_target_slot_specs_after_deferred_effect(
@@ -5233,22 +5272,9 @@ fn collect_target_slot_specs_after_deferred_effect(
     specs: &mut Vec<TargetSlotSpec>,
     next_instance: &mut usize,
 ) {
-    let Some(sub_ability) = sub_ability else {
-        return;
-    };
-    if defers_conditional_target_selection(sub_ability) {
-        return;
+    if let Some(sub_ability) = deferred_effect_stack_target_tail(sub_ability) {
+        collect_target_slot_specs(state, sub_ability, specs, next_instance);
     }
-    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
-        collect_target_slot_specs_after_deferred_effect(
-            state,
-            sub_ability.sub_ability.as_deref(),
-            specs,
-            next_instance,
-        );
-        return;
-    }
-    collect_target_slot_specs(state, sub_ability, specs, next_instance);
 }
 
 fn build_target_assignments(
@@ -6446,21 +6472,10 @@ fn assign_targets_after_deferred_effect(
     targets: &[TargetRef],
     next_target: &mut usize,
 ) -> Result<(), EngineError> {
-    let Some(sub_ability) = sub_ability else {
-        return Ok(());
-    };
-    if defers_conditional_target_selection(sub_ability) {
-        return Ok(());
+    if let Some(sub_ability) = deferred_effect_stack_target_tail_mut(sub_ability) {
+        assign_targets_recursive(state, sub_ability, targets, next_target)?;
     }
-    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
-        return assign_targets_after_deferred_effect(
-            state,
-            sub_ability.sub_ability.as_deref_mut(),
-            targets,
-            next_target,
-        );
-    }
-    assign_targets_recursive(state, sub_ability, targets, next_target)
+    Ok(())
 }
 
 fn assign_selected_slots_after_deferred_effect(
@@ -6469,21 +6484,10 @@ fn assign_selected_slots_after_deferred_effect(
     selected_slots: &[Option<TargetRef>],
     next_slot: &mut usize,
 ) -> Result<(), EngineError> {
-    let Some(sub_ability) = sub_ability else {
-        return Ok(());
-    };
-    if defers_conditional_target_selection(sub_ability) {
-        return Ok(());
+    if let Some(sub_ability) = deferred_effect_stack_target_tail_mut(sub_ability) {
+        assign_selected_slots_recursive(state, sub_ability, selected_slots, next_slot)?;
     }
-    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
-        return assign_selected_slots_after_deferred_effect(
-            state,
-            sub_ability.sub_ability.as_deref_mut(),
-            selected_slots,
-            next_slot,
-        );
-    }
-    assign_selected_slots_recursive(state, sub_ability, selected_slots, next_slot)
+    Ok(())
 }
 
 /// CR 115.3: Validate targeting constraints — e.g., different target players must be distinct.
@@ -6683,16 +6687,7 @@ fn chain_has_target_sink(ability: &ResolvedAbility) -> bool {
 }
 
 fn chain_has_target_sink_after_deferred_effect(sub_ability: Option<&ResolvedAbility>) -> bool {
-    let Some(sub_ability) = sub_ability else {
-        return false;
-    };
-    if defers_conditional_target_selection(sub_ability) {
-        return false;
-    }
-    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
-        return chain_has_target_sink_after_deferred_effect(sub_ability.sub_ability.as_deref());
-    }
-    chain_has_target_sink(sub_ability)
+    deferred_effect_stack_target_tail(sub_ability).is_some_and(chain_has_target_sink)
 }
 
 fn minimum_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -> usize {
@@ -6801,16 +6796,9 @@ fn minimum_targets_after_deferred_effect(
     state: &GameState,
     sub_ability: Option<&ResolvedAbility>,
 ) -> usize {
-    let Some(sub_ability) = sub_ability else {
-        return 0;
-    };
-    if defers_conditional_target_selection(sub_ability) {
-        return 0;
-    }
-    if skips_stack_targets_after_deferred_effect(&sub_ability.effect) {
-        return minimum_targets_after_deferred_effect(state, sub_ability.sub_ability.as_deref());
-    }
-    minimum_targets_in_chain(state, sub_ability)
+    deferred_effect_stack_target_tail(sub_ability)
+        .map(|sub_ability| minimum_targets_in_chain(state, sub_ability))
+        .unwrap_or(0)
 }
 
 /// CR 700.2a: The controller of a modal spell or activated ability chooses the mode(s)
@@ -8395,6 +8383,171 @@ mod tests {
             .and_then(|shuffle| shuffle.sub_ability.as_deref())
             .expect("counter continuation must exist");
         assert_eq!(counter_step.targets, vec![TargetRef::Object(artifact)]);
+    }
+
+    #[test]
+    fn deferred_effect_target_traversal_crosses_only_unconditional_sequential_siblings() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Scrying Source".to_string(),
+            Zone::Stack,
+        );
+        let creature = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Target Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&creature)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let chain = |tail_link| {
+            let mut put_counter = ResolvedAbility::new(
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Typed(TypedFilter::creature()),
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            );
+            put_counter.sub_link = tail_link;
+
+            let shuffle = ResolvedAbility::new(
+                Effect::Shuffle {
+                    target: TargetFilter::Controller,
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            )
+            .sub_ability(put_counter);
+            let change_zone = ResolvedAbility::new(
+                Effect::ChangeZone {
+                    origin: None,
+                    destination: Zone::Exile,
+                    target: TargetFilter::Any,
+                    owner_library: false,
+                    enter_transformed: false,
+                    enters_under: None,
+                    enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                    enters_attacking: false,
+                    up_to: false,
+                    enter_with_counters: vec![],
+                    conditional_enter_with_counters: vec![],
+                    face_down_profile: None,
+                    enters_modified_if: None,
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            )
+            .sub_ability(shuffle);
+
+            ResolvedAbility::new(
+                Effect::Scry {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+                vec![],
+                source,
+                PlayerId(0),
+            )
+            .sub_ability(change_zone)
+        };
+
+        let continuation = chain(SubAbilityLink::ContinuationStep);
+        assert!(
+            build_target_slots(&state, &continuation)
+                .expect("continuation target traversal should build")
+                .is_empty(),
+            "the deferred effect's own continuation must keep its target selection at resolution"
+        );
+        assert!(target_slot_specs(&state, &continuation).is_empty());
+        assert!(!chain_has_target_sink(&continuation));
+        assert_eq!(minimum_targets_in_chain(&state, &continuation), 0);
+
+        let mut continuation_assigned = continuation.clone();
+        assign_targets_in_chain(&state, &mut continuation_assigned, &[])
+            .expect("a continuation-only chain has no stack target to assign");
+        assign_selected_slots_in_chain(&state, &mut continuation_assigned, &[])
+            .expect("a continuation-only chain has no stack target slot to assign");
+
+        let mut reflexive_sibling = chain(SubAbilityLink::SequentialSibling);
+        reflexive_sibling
+            .sub_ability
+            .as_deref_mut()
+            .and_then(|change_zone| change_zone.sub_ability.as_deref_mut())
+            .and_then(|shuffle| shuffle.sub_ability.as_deref_mut())
+            .unwrap()
+            .condition = Some(AbilityCondition::WhenYouDo);
+        assert!(
+            build_target_slots(&state, &reflexive_sibling)
+                .expect("reflexive sibling traversal should build")
+                .is_empty(),
+            "a reflexive sequential sibling must keep its target selection deferred"
+        );
+        assert!(target_slot_specs(&state, &reflexive_sibling).is_empty());
+        assert!(!chain_has_target_sink(&reflexive_sibling));
+        assert_eq!(minimum_targets_in_chain(&state, &reflexive_sibling), 0);
+
+        let sibling = chain(SubAbilityLink::SequentialSibling);
+        let slots = build_target_slots(&state, &sibling)
+            .expect("unconditional sequential sibling target should build");
+        assert_eq!(slots.len(), 1);
+        assert_eq!(target_slot_specs(&state, &sibling).len(), 1);
+        assert!(chain_has_target_sink(&sibling));
+        assert_eq!(minimum_targets_in_chain(&state, &sibling), 1);
+        validate_selected_targets_for_ability(
+            &state,
+            &sibling,
+            &slots,
+            &[TargetRef::Object(creature)],
+            &[],
+        )
+        .expect("the sequential sibling's creature target should validate");
+
+        let mut assigned = sibling.clone();
+        assign_targets_in_chain(&state, &mut assigned, &[TargetRef::Object(creature)])
+            .expect("the sequential sibling must receive the selected target");
+        assert_eq!(
+            assigned
+                .sub_ability
+                .as_deref()
+                .and_then(|change_zone| change_zone.sub_ability.as_deref())
+                .and_then(|shuffle| shuffle.sub_ability.as_deref())
+                .unwrap()
+                .targets,
+            vec![TargetRef::Object(creature)]
+        );
+
+        let mut assigned_slots = sibling;
+        assign_selected_slots_in_chain(
+            &state,
+            &mut assigned_slots,
+            &[Some(TargetRef::Object(creature))],
+        )
+        .expect("the selected-slot path must match compact target assignment");
+        assert_eq!(
+            assigned_slots
+                .sub_ability
+                .as_deref()
+                .and_then(|change_zone| change_zone.sub_ability.as_deref())
+                .and_then(|shuffle| shuffle.sub_ability.as_deref())
+                .unwrap()
+                .targets,
+            vec![TargetRef::Object(creature)]
+        );
     }
 
     /// CR 608.2c + CR 115.1: Arcum Dagsson / #4678 — "Target artifact creature's

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3601,7 +3601,6 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::Manifest { .. }
         | Effect::ManifestDread
         | Effect::Cloak { .. }
-        | Effect::ExileFaceDownPile { .. }
         | Effect::RuntimeHandled { .. }
         | Effect::ChangeTargets { .. }
         | Effect::ExchangeControl { .. }

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2301,6 +2301,15 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 d.push(("face_down".into(), "true".into()));
             }
         }
+        Effect::ExileFaceDownPile {
+            object,
+            player,
+            count,
+        } => {
+            d.push(("object".into(), fmt_target(object)));
+            d.push(("player".into(), fmt_target(player)));
+            d.push(("count".into(), fmt_quantity(count)));
+        }
         Effect::Pump {
             power,
             toughness,
@@ -3592,6 +3601,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
         | Effect::Manifest { .. }
         | Effect::ManifestDread
         | Effect::Cloak { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::RuntimeHandled { .. }
         | Effect::ChangeTargets { .. }
         | Effect::ExchangeControl { .. }

--- a/crates/engine/src/game/effects/exile_face_down_pile.rs
+++ b/crates/engine/src/game/effects/exile_face_down_pile.rs
@@ -1,0 +1,337 @@
+use rand::seq::SliceRandom;
+
+use crate::game::quantity::resolve_quantity_with_targets;
+use crate::game::zone_pipeline::{self, BatchMoveResult, ZoneMoveRequest};
+use crate::types::ability::{
+    Effect, EffectError, EffectKind, LibraryPosition, ResolvedAbility, TargetFilter,
+};
+use crate::types::events::GameEvent;
+use crate::types::game_state::{BatchCompletion, GameState};
+use crate::types::identifiers::ObjectId;
+use crate::types::zones::Zone;
+
+/// CR 406.3 + CR 608.2c: Exile the explicit object and the top N cards as one
+/// face-down pile. A short library or absent object still exiles whatever is
+/// available, but the typed completion performs the "If you do" rider only if
+/// the original, complete member set settled in exile.
+pub fn resolve(
+    state: &mut GameState,
+    ability: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Result<(), EffectError> {
+    let (object, player_filter, count) = match &ability.effect {
+        Effect::ExileFaceDownPile {
+            object,
+            player,
+            count,
+        } => (
+            object.clone(),
+            player.clone(),
+            resolve_quantity_with_targets(state, count, ability).max(0) as usize,
+        ),
+        _ => return Err(EffectError::MissingParam("ExileFaceDownPile".to_string())),
+    };
+
+    let player = super::resolve_player_for_context_ref(state, ability, &player_filter);
+    let source_object = resolve_pile_object(state, ability, &object);
+    let top_cards = state
+        .players
+        .iter()
+        .find(|candidate| candidate.id == player)
+        .ok_or(EffectError::PlayerNotFound)?
+        .library
+        .iter()
+        .take(count)
+        .copied()
+        .collect::<Vec<_>>();
+
+    let mut members = source_object.into_iter().collect::<Vec<_>>();
+    members.extend(top_cards);
+    let requests = members
+        .iter()
+        .copied()
+        .map(|member| {
+            ZoneMoveRequest::effect(member, Zone::Exile, ability.source_id).face_down_in_exile()
+        })
+        .collect();
+
+    let result = zone_pipeline::move_objects_simultaneously_then(
+        state,
+        requests,
+        Some(BatchCompletion::ExileFaceDownPileDeliveryComplete {
+            player,
+            source_id: ability.source_id,
+            members,
+            required_member_count: count + 1,
+        }),
+        events,
+    );
+    if matches!(result, BatchMoveResult::NeedsChoice) {
+        return Ok(());
+    }
+    Ok(())
+}
+
+fn resolve_pile_object(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    object: &TargetFilter,
+) -> Option<ObjectId> {
+    match object {
+        TargetFilter::SelfRef | TargetFilter::TriggeringSource => Some(ability.source_id),
+        _ => crate::game::effects::effect_object_targets(object, &ability.targets)
+            .into_iter()
+            .find(|id| state.objects.contains_key(id)),
+    }
+}
+
+/// CR 406.3 + CR 608.2c + CR 701.24a: Mark every actually exiled member face
+/// down. Only the exact full requested pile may satisfy "If you do"; a missing
+/// source, a short library, or any redirected member leaves every settled card
+/// exiled face down and skips both shuffle and return.
+pub(crate) fn complete_exile_face_down_pile_delivery(
+    state: &mut GameState,
+    player: crate::types::player::PlayerId,
+    source_id: ObjectId,
+    mut members: Vec<ObjectId>,
+    required_member_count: usize,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    let fully_exiled = members.len() == required_member_count
+        && members.iter().all(|id| {
+            state
+                .objects
+                .get(id)
+                .is_some_and(|object| object.zone == Zone::Exile)
+        });
+
+    if fully_exiled {
+        // CR 701.24a: The face-down pile, not the library, is shuffled. The
+        // resulting vector is its exact top-to-bottom return order.
+        members.shuffle(&mut state.rng);
+        for id in &members {
+            state
+                .objects
+                .get_mut(id)
+                .expect("settled pile member exists")
+                .face_down = false;
+        }
+        let requests = members
+            .iter()
+            .rev()
+            .copied()
+            .map(|id| {
+                ZoneMoveRequest::effect(id, Zone::Library, source_id)
+                    .at_library_position(LibraryPosition::Top)
+            })
+            .collect();
+        return zone_pipeline::move_objects_simultaneously_then(
+            state,
+            requests,
+            Some(BatchCompletion::ExileFaceDownPileReturnComplete { source_id }),
+            events,
+        );
+    }
+
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::ExileFaceDownPile,
+        source_id,
+        subject: None,
+    });
+    BatchMoveResult::Done
+}
+
+pub(crate) fn complete_exile_face_down_pile_return(
+    source_id: ObjectId,
+    events: &mut Vec<GameEvent>,
+) -> BatchMoveResult {
+    events.push(GameEvent::EffectResolved {
+        kind: EffectKind::ExileFaceDownPile,
+        source_id,
+        subject: None,
+    });
+    BatchMoveResult::Done
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, QuantityExpr, ReplacementDefinition, ReplacementMode,
+    };
+    use crate::types::identifiers::CardId;
+    use crate::types::player::PlayerId;
+    use crate::types::replacements::ReplacementEvent;
+    use crate::types::zones::EtbTapState;
+
+    #[test]
+    fn complete_pile_returns_exact_source_and_top_cards_to_library_top() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Triumph of Saint Katherine".to_string(),
+            Zone::Graveyard,
+        );
+        let first = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "First".to_string(),
+            Zone::Library,
+        );
+        let second = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Second".to_string(),
+            Zone::Library,
+        );
+        let bottom = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Bottom".to_string(),
+            Zone::Library,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::ExileFaceDownPile {
+                object: TargetFilter::SelfRef,
+                player: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 2 },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        let top = state.players[0]
+            .library
+            .iter()
+            .take(3)
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(top.len(), 3);
+        assert!(top.contains(&source));
+        assert!(top.contains(&first));
+        assert!(top.contains(&second));
+        assert_eq!(state.players[0].library[3], bottom);
+        assert!(top.iter().all(|id| !state.objects[id].face_down));
+    }
+
+    #[test]
+    fn short_library_leaves_partial_pile_exiled_face_down() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Triumph".to_string(),
+            Zone::Graveyard,
+        );
+        let only = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Only".to_string(),
+            Zone::Library,
+        );
+        let ability = ResolvedAbility::new(
+            Effect::ExileFaceDownPile {
+                object: TargetFilter::SelfRef,
+                player: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 2 },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        for id in [source, only] {
+            assert_eq!(state.objects[&id].zone, Zone::Exile);
+            assert!(state.objects[&id].face_down);
+        }
+        assert!(state.players[0].library.is_empty());
+    }
+
+    #[test]
+    fn delivered_member_is_concealed_before_later_pile_member_parks_for_replacement_choice() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Triumph".to_string(),
+            Zone::Graveyard,
+        );
+        let top_card = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Top card".to_string(),
+            Zone::Library,
+        );
+        let redirect_source = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Optional Exile Redirect".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&redirect_source)
+            .expect("replacement source exists")
+            .replacement_definitions
+            .push(
+                ReplacementDefinition::new(ReplacementEvent::Moved)
+                    .mode(ReplacementMode::Optional { decline: None })
+                    .valid_card(TargetFilter::SpecificObject { id: top_card })
+                    .destination_zone(Zone::Exile)
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Spell,
+                        Effect::ChangeZone {
+                            origin: None,
+                            destination: Zone::Exile,
+                            target: TargetFilter::Any,
+                            owner_library: false,
+                            enter_transformed: false,
+                            enters_under: None,
+                            enter_tapped: EtbTapState::Unspecified,
+                            enters_attacking: false,
+                            up_to: false,
+                            enter_with_counters: vec![],
+                            conditional_enter_with_counters: vec![],
+                            face_down_profile: None,
+                            enters_modified_if: None,
+                        },
+                    )),
+            );
+        let ability = ResolvedAbility::new(
+            Effect::ExileFaceDownPile {
+                object: TargetFilter::SelfRef,
+                player: TargetFilter::Controller,
+                count: QuantityExpr::Fixed { value: 1 },
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+
+        resolve(&mut state, &ability, &mut Vec::new()).expect("pile resolves until choice");
+
+        assert_eq!(state.objects[&source].zone, Zone::Exile);
+        assert!(
+            state.objects[&source].face_down,
+            "a delivered member must be concealed before a later member parks on CR 616.1"
+        );
+    }
+}

--- a/crates/engine/src/game/effects/exile_face_down_pile.rs
+++ b/crates/engine/src/game/effects/exile_face_down_pile.rs
@@ -91,7 +91,7 @@ fn resolve_pile_object(
 /// exiled face down and skips both shuffle and return.
 pub(crate) fn complete_exile_face_down_pile_delivery(
     state: &mut GameState,
-    player: crate::types::player::PlayerId,
+    _player: crate::types::player::PlayerId,
     source_id: ObjectId,
     mut members: Vec<ObjectId>,
     required_member_count: usize,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -115,6 +115,7 @@ pub mod exchange_control;
 pub mod cloak;
 pub mod exchange_life;
 pub mod exchange_life_totals;
+pub mod exile_face_down_pile;
 pub mod exile_from_top_until;
 pub mod exile_top;
 pub mod exploit;
@@ -4049,6 +4050,7 @@ pub fn resolve_effect(
         Effect::Reveal { .. } => reveal::resolve(state, ability, events),
         Effect::RevealTop { .. } => reveal_top::resolve(state, ability, events),
         Effect::ExileTop { .. } => exile_top::resolve(state, ability, events),
+        Effect::ExileFaceDownPile { .. } => exile_face_down_pile::resolve(state, ability, events),
         // CR 608.2c: `TargetOnly` is the "choose <filter>" step — targeting is
         // established at selection time, so there is nothing to mutate here. But
         // inside a `player_scope` fan-out iteration ("starting with you, each

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -1369,6 +1369,7 @@ mod tests {
                     exile_duration: None,
                     exile_tracking: crate::types::game_state::ZoneDeliveryExileTracking::None,
                     replacement_applied: HashSet::new(),
+                    face_down_in_exile: false,
                 },
                 crate::types::game_state::PendingBatchZoneMoveRequest {
                     object_id: surviving,
@@ -1384,6 +1385,7 @@ mod tests {
                     exile_duration: None,
                     exile_tracking: crate::types::game_state::ZoneDeliveryExileTracking::None,
                     replacement_applied: HashSet::new(),
+                    face_down_in_exile: false,
                 },
             ],
             attempted: vec![leaving, surviving],

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -6913,6 +6913,22 @@ pub(crate) fn run_batch_completion(
             enters_under,
             events,
         ),
+        BatchCompletion::ExileFaceDownPileDeliveryComplete {
+            player,
+            source_id,
+            members,
+            required_member_count,
+        } => effects::exile_face_down_pile::complete_exile_face_down_pile_delivery(
+            state,
+            player,
+            source_id,
+            members,
+            required_member_count,
+            events,
+        ),
+        BatchCompletion::ExileFaceDownPileReturnComplete { source_id } => {
+            effects::exile_face_down_pile::complete_exile_face_down_pile_return(source_id, events)
+        }
         BatchCompletion::CastFromZoneExileDeliveryComplete {
             ability,
             in_place_ids,

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -46,33 +46,35 @@ pub(super) fn finalize_trigger_target_selection(
         if let Some(total) =
             extract_distribution_total(state, &trigger.ability, &trigger.ability.effect)
         {
-            if dist_targets.len() == 1 {
-                trigger.ability.distribution = Some(vec![(dist_targets[0].clone(), total)]);
-            } else {
-                // CR 601.2d: Distribution still outstanding. Entry is already
-                // on the stack with empty `distribution`; mutate the on-stack
-                // ability's targets (so they match what was just chosen) and
-                // keep `pending_trigger_entry` set until division completes.
-                if !triggers::mutate_pending_trigger_entry(state, &trigger.ability) {
-                    // Unexpected dangling cursor: the entry is gone before the
-                    // division prompt could open. Recover per CR 608.2b / CR
-                    // 800.4a (a stack object that has left the stack does not
-                    // resolve) — record the diagnostic, abandon, hand back
-                    // priority. Matches the DistributeAmong-return convention
-                    // below; the next priority pass re-normalizes (CR 117.3b
-                    // would give the active player).
-                    triggers::abandon_ceased_pending_trigger(state, &trigger.ability);
+            match dist_targets.as_slice() {
+                [] => trigger.ability.distribution = Some(Vec::new()),
+                [target] => trigger.ability.distribution = Some(vec![(target.clone(), total)]),
+                _ => {
+                    // CR 601.2d: Distribution still outstanding. Entry is already
+                    // on the stack with empty `distribution`; mutate the on-stack
+                    // ability's targets (so they match what was just chosen) and
+                    // keep `pending_trigger_entry` set until division completes.
+                    if !triggers::mutate_pending_trigger_entry(state, &trigger.ability) {
+                        // Unexpected dangling cursor: the entry is gone before the
+                        // division prompt could open. Recover per CR 608.2b / CR
+                        // 800.4a (a stack object that has left the stack does not
+                        // resolve) — record the diagnostic, abandon, hand back
+                        // priority. Matches the DistributeAmong-return convention
+                        // below; the next priority pass re-normalizes (CR 117.3b
+                        // would give the active player).
+                        triggers::abandon_ceased_pending_trigger(state, &trigger.ability);
+                        priority::clear_priority_passes(state);
+                        return WaitingFor::Priority { player: controller };
+                    }
+                    state.pending_trigger = Some(trigger);
                     priority::clear_priority_passes(state);
-                    return WaitingFor::Priority { player: controller };
+                    return WaitingFor::DistributeAmong {
+                        player: controller,
+                        total,
+                        targets: dist_targets,
+                        unit,
+                    };
                 }
-                state.pending_trigger = Some(trigger);
-                priority::clear_priority_passes(state);
-                return WaitingFor::DistributeAmong {
-                    player: controller,
-                    total,
-                    targets: dist_targets,
-                    unit,
-                };
             }
         }
     }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -17274,6 +17274,7 @@ mod tests {
                 placement: None,
                 exile_links: ExileLinkSpec::default(),
                 replacement_applied: Default::default(),
+                face_down_in_exile: false,
             },
             &mut events,
         );
@@ -17339,6 +17340,7 @@ mod tests {
                 placement: None,
                 exile_links: ExileLinkSpec::default(),
                 replacement_applied: Default::default(),
+                face_down_in_exile: false,
             },
             &mut events,
         );

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -1240,6 +1240,7 @@ fn walk_effect(effect: &Effect, out: &mut Vec<String>) {
         | Effect::Reveal { .. }
         | Effect::RevealTop { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::TargetOnly { .. }
         | Effect::Choose { .. }
         | Effect::OpponentGuess { .. }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -812,6 +812,7 @@ fn keys_from_effect_kind(kind: EffectKind, push: &mut impl FnMut(TriggerEventKey
         | EffectKind::SearchLibrary
         | EffectKind::SearchOutsideGame
         | EffectKind::ExileTop
+        | EffectKind::ExileFaceDownPile
         | EffectKind::TargetOnly
         | EffectKind::Choose
         | EffectKind::ChoosePermanent

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -6589,6 +6589,9 @@ fn dispatch_pending_trigger_context(
     };
 
     if target_slots.is_empty() {
+        if trigger.distribute.is_some() {
+            trigger.ability.distribution = Some(Vec::new());
+        }
         // CR 605.1b: Triggered mana abilities don't use the stack — they resolve
         // immediately at the moment the trigger event occurs. Classify via the
         // single-authority `is_triggered_mana_ability` (ResolvedAbility form),
@@ -6660,36 +6663,40 @@ fn dispatch_pending_trigger_context(
                     // in the emit above and are not part of the division.
                     let assigned_targets =
                         super::ability_utils::distribution_targets(&trigger.ability);
-                    if assigned_targets.len() == 1 {
-                        trigger.ability.distribution =
-                            Some(vec![(assigned_targets[0].clone(), total)]);
-                    } else {
-                        // CR 601.2d + CR 603.3d: Distribute-among with targets
-                        // already chosen but division still pending. Push the
-                        // entry to the stack FIRST (ability has `targets`
-                        // populated, `distribution` still empty), then prompt
-                        // for division. `engine_stack::finalize_trigger_target_selection`
-                        // mutates the on-stack entry's `ability.distribution`
-                        // when the division choice completes.
-                        let player = trigger.controller;
-                        let pending_for_state = trigger.clone();
-                        let entry_id = push_pending_trigger_to_stack_with_event_batch(
-                            state,
-                            trigger,
-                            trigger_events.clone(),
-                            events_out,
-                        );
-                        state.pending_trigger_event_batch = trigger_events;
-                        state.pending_trigger = Some(pending_for_state);
-                        state.pending_trigger_entry = Some(entry_id);
-                        state.waiting_for = crate::types::game_state::WaitingFor::DistributeAmong {
-                            player,
-                            total,
-                            targets: assigned_targets,
-                            unit,
-                        };
-                        restore_trigger_event_context(state, context_snapshot);
-                        return TriggerDispatchDisposition::Paused;
+                    match assigned_targets.as_slice() {
+                        [] => trigger.ability.distribution = Some(Vec::new()),
+                        [target] => {
+                            trigger.ability.distribution = Some(vec![(target.clone(), total)]);
+                        }
+                        _ => {
+                            // CR 601.2d + CR 603.3d: Distribute-among with targets
+                            // already chosen but division still pending. Push the
+                            // entry to the stack FIRST (ability has `targets`
+                            // populated, `distribution` still empty), then prompt
+                            // for division. `engine_stack::finalize_trigger_target_selection`
+                            // mutates the on-stack entry's `ability.distribution`
+                            // when the division choice completes.
+                            let player = trigger.controller;
+                            let pending_for_state = trigger.clone();
+                            let entry_id = push_pending_trigger_to_stack_with_event_batch(
+                                state,
+                                trigger,
+                                trigger_events.clone(),
+                                events_out,
+                            );
+                            state.pending_trigger_event_batch = trigger_events;
+                            state.pending_trigger = Some(pending_for_state);
+                            state.pending_trigger_entry = Some(entry_id);
+                            state.waiting_for =
+                                crate::types::game_state::WaitingFor::DistributeAmong {
+                                    player,
+                                    total,
+                                    targets: assigned_targets,
+                                    unit,
+                                };
+                            restore_trigger_event_context(state, context_snapshot);
+                            return TriggerDispatchDisposition::Paused;
+                        }
                     }
                 }
             }
@@ -11347,6 +11354,35 @@ pub mod tests {
         obj.power = Some(power);
         obj.toughness = Some(toughness);
         id
+    }
+
+    fn make_divided_damage_etb_source(
+        state: &mut GameState,
+        min_targets: usize,
+        target: TargetFilter,
+    ) -> ObjectId {
+        let source = make_creature(state, PlayerId(0), "Divided Damage Source", 3, 3);
+        let mut execute = AbilityDefinition::new(
+            AbilityKind::Database,
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 4 },
+                target,
+                damage_source: None,
+                excess: None,
+            },
+        );
+        execute.multi_target = Some(MultiTargetSpec::unlimited(min_targets));
+        execute.distribute = Some(DistributionUnit::Damage);
+
+        let obj = state.objects.get_mut(&source).unwrap();
+        obj.entered_battlefield_turn = Some(1);
+        obj.trigger_definitions.push(
+            TriggerDefinition::new(TriggerMode::ChangesZone)
+                .execute(execute)
+                .valid_card(TargetFilter::SelfRef)
+                .destination(Zone::Battlefield),
+        );
+        source
     }
 
     /// CR 109.5 + CR 603.2: the `EventSourceControlledBy { Opponent }` trigger
@@ -16559,6 +16595,132 @@ pub mod tests {
         let pending = state.pending_trigger.as_ref().unwrap();
         assert_eq!(pending.source_id, trigger_creature);
         assert_eq!(pending.controller, PlayerId(0));
+    }
+
+    #[test]
+    fn divided_trigger_with_no_legal_targets_uses_empty_distribution() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        let source = make_divided_damage_etb_source(
+            &mut state,
+            0,
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent)),
+        );
+
+        process_triggers(
+            &mut state,
+            &[zone_changed_event(
+                source,
+                Zone::Hand,
+                Zone::Battlefield,
+                vec![CoreType::Creature],
+                Vec::new(),
+            )],
+        );
+
+        assert!(state.pending_trigger.is_none());
+        let StackEntryKind::TriggeredAbility { ability, .. } = &state.stack[0].kind else {
+            panic!("expected triggered ability");
+        };
+        assert_eq!(ability.distribution, Some(Vec::new()));
+
+        let mut safety_bound = 4;
+        while !state.stack.is_empty() && safety_bound > 0 {
+            let actor = state.priority_player;
+            crate::game::engine::apply(&mut state, actor, GameAction::PassPriority)
+                .expect("targetless divided trigger should resolve");
+            safety_bound -= 1;
+        }
+        assert!(state.stack.is_empty(), "targetless trigger must not hang");
+    }
+
+    #[test]
+    fn divided_trigger_auto_selects_one_target_and_assigns_full_amount() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        let target = make_creature(&mut state, PlayerId(1), "Only Target", 2, 2);
+        let source = make_divided_damage_etb_source(
+            &mut state,
+            1,
+            TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::Opponent)),
+        );
+
+        process_triggers(
+            &mut state,
+            &[zone_changed_event(
+                source,
+                Zone::Hand,
+                Zone::Battlefield,
+                vec![CoreType::Creature],
+                Vec::new(),
+            )],
+        );
+
+        assert!(state.pending_trigger.is_none());
+        let StackEntryKind::TriggeredAbility { ability, .. } = &state.stack[0].kind else {
+            panic!("expected triggered ability");
+        };
+        assert_eq!(ability.targets, vec![TargetRef::Object(target)]);
+        assert_eq!(
+            ability.distribution,
+            Some(vec![(TargetRef::Object(target), 4)])
+        );
+    }
+
+    #[test]
+    fn divided_trigger_all_decline_finalizes_with_empty_distribution() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        let source = make_divided_damage_etb_source(
+            &mut state,
+            0,
+            TargetFilter::Typed(TypedFilter::creature()),
+        );
+        let _other_target = make_creature(&mut state, PlayerId(1), "Other Target", 2, 2);
+
+        process_triggers(
+            &mut state,
+            &[zone_changed_event(
+                source,
+                Zone::Hand,
+                Zone::Battlefield,
+                vec![CoreType::Creature],
+                Vec::new(),
+            )],
+        );
+        let waiting_for = crate::game::engine::begin_pending_trigger_target_selection(&mut state)
+            .expect("begin target selection")
+            .expect("any-number trigger must prompt when targets exist");
+        state.waiting_for = waiting_for;
+
+        let result = crate::game::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::SelectTargets {
+                targets: Vec::new(),
+            },
+        )
+        .expect("declining every target should finalize the trigger");
+
+        assert!(matches!(result.waiting_for, WaitingFor::Priority { .. }));
+        assert!(state.pending_trigger.is_none());
+        assert!(state.pending_trigger_entry.is_none());
+        let StackEntryKind::TriggeredAbility { ability, .. } = &state.stack[0].kind else {
+            panic!("expected triggered ability");
+        };
+        assert_eq!(ability.distribution, Some(Vec::new()));
+
+        let mut safety_bound = 4;
+        while !state.stack.is_empty() && safety_bound > 0 {
+            let actor = state.priority_player;
+            crate::game::engine::apply(&mut state, actor, GameAction::PassPriority)
+                .expect("all-declined divided trigger should resolve");
+            safety_bound -= 1;
+        }
+        assert!(state.stack.is_empty(), "all-declined trigger must not hang");
     }
 
     /// CR 601.2d + CR 603.3d: A triggered ability with a divided effect

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -3030,7 +3030,7 @@ mod w3_library_placement_tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, ReplacementDefinition, ReplacementMode, TargetFilter,
+        AbilityDefinition, AbilityKind, ReplacementDefinition, TargetFilter,
     };
     use crate::types::identifiers::CardId;
     use crate::types::replacements::ReplacementEvent;

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -191,6 +191,11 @@ pub struct ZoneMoveRequest {
     /// CR 614.5: replacement definitions already applied to the event or
     /// modified event from which this physical-card move was derived.
     pub replacement_applied: HashSet<AppliedReplacementKey>,
+    /// CR 406.3: Mark the object face down if this delivery actually settles in
+    /// exile. This is deliberately a delivery modifier, not an effect epilogue:
+    /// a later batch member may park on CR 616.1 while earlier members must
+    /// already be hidden.
+    pub face_down_in_exile: bool,
 }
 
 impl ZoneMoveRequest {
@@ -232,6 +237,7 @@ impl ZoneMoveRequest {
             exile_duration: self.exile_links.duration,
             exile_tracking: self.exile_links.tracking,
             replacement_applied: self.replacement_applied,
+            face_down_in_exile: self.face_down_in_exile,
         }
     }
 
@@ -277,6 +283,7 @@ impl ZoneMoveRequest {
                 tracking: pending.exile_tracking,
             },
             replacement_applied: pending.replacement_applied,
+            face_down_in_exile: pending.face_down_in_exile,
         }
     }
 
@@ -290,6 +297,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -303,6 +311,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -320,6 +329,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -333,6 +343,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -356,6 +367,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: seed_applied,
+            face_down_in_exile: false,
         }
     }
 
@@ -370,6 +382,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -386,6 +399,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -400,6 +414,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -416,6 +431,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -429,6 +445,7 @@ impl ZoneMoveRequest {
             placement: None,
             exile_links: ExileLinkSpec::default(),
             replacement_applied: HashSet::new(),
+            face_down_in_exile: false,
         }
     }
 
@@ -475,6 +492,13 @@ impl ZoneMoveRequest {
     /// `NthFromTop`). Only meaningful when `to == Zone::Library`.
     pub fn at_library_position(mut self, position: LibraryPosition) -> Self {
         self.placement = Some(position);
+        self
+    }
+
+    /// CR 406.3: Conceal this card immediately if the replacement-aware move
+    /// delivers it to Exile.
+    pub fn face_down_in_exile(mut self) -> Self {
+        self.face_down_in_exile = true;
         self
     }
 
@@ -1208,11 +1232,15 @@ fn deliver_batch(
     let mut queue = reqs.into_iter();
     while let Some(req) = queue.next() {
         let destination = req.to;
+        let face_down_in_exile = req.face_down_in_exile;
         let anticipated_pause = anticipated_zone_change_delivery(state, &req);
         let delivery_start = events.len();
         let object_id = req.object_id;
         match move_object_with_terminal(state, req, events) {
             ZoneMoveTerminalResult::Completed(completion) => {
+                if face_down_in_exile {
+                    mark_face_down_if_exiled(state, object_id);
+                }
                 logical_zone_change_group
                     .record_delivery_completion(object_id, completion)
                     .expect("batch member records its exact terminal outcome");
@@ -1223,7 +1251,7 @@ fn deliver_batch(
                 // stash the rest of the batch so no object strands. The paused
                 // object rides in `state.pending_replacement` and is delivered
                 // by the resume path.
-                let paused_current = state
+                let mut paused_current = state
                     .pending_zone_change_delivery_from_replacement()
                     .or_else(|| {
                         anticipated_pause.map(|mut boundary| {
@@ -1232,6 +1260,7 @@ fn deliver_batch(
                         })
                     })
                     .expect("parked batch zone change must retain an exact boundary");
+                paused_current.face_down_in_exile = face_down_in_exile;
                 crate::game::triggers::append_and_collect_logical_zone_trigger_segment(
                     state,
                     &mut logical_zone_change_group,
@@ -1270,6 +1299,7 @@ fn deliver_batch(
                 let paused_current = anticipated_pause.map(|mut boundary| {
                     boundary.append_delivery_events(&events[delivery_start..]);
                     boundary.mark_counted();
+                    boundary.face_down_in_exile = face_down_in_exile;
                     boundary
                 });
                 crate::game::triggers::append_and_collect_logical_zone_trigger_segment(
@@ -1291,6 +1321,16 @@ fn deliver_batch(
         }
     }
     BatchDeliveryResult::Done(Box::new(logical_zone_change_group))
+}
+
+fn mark_face_down_if_exiled(state: &mut GameState, object_id: ObjectId) {
+    if let Some(object) = state
+        .objects
+        .get_mut(&object_id)
+        .filter(|object| object.zone == Zone::Exile)
+    {
+        object.face_down = true;
+    }
 }
 
 /// CR 603.10a + CR 616.1: Park the undelivered batch tail so the resume path
@@ -2990,7 +3030,7 @@ mod w3_library_placement_tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, ReplacementDefinition, TargetFilter,
+        AbilityDefinition, AbilityKind, ReplacementDefinition, ReplacementMode, TargetFilter,
     };
     use crate::types::identifiers::CardId;
     use crate::types::replacements::ReplacementEvent;

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26372,7 +26372,7 @@ fn rewrite_filter_prop_another_to_tracked_set(prop: &mut FilterProp) {
 /// | mode | whole-body recognizers | context |
 /// |---|---|---|
 /// | `Standalone` | U3-complete shared list (empty); cloak is unavailable | a fresh `default()`, discarded |
-/// | `WithContext` | the same shared list, plus `parse_exile_pile_shuffle_cloak_ir` in `parse_ability_ir` | the caller's real `ctx` |
+/// | `WithContext` | the same shared list, plus `parse_face_down_pile_ir` in `parse_ability_ir` | the caller's real `ctx` |
 ///
 /// Callers split cleanly: die-result branch bodies (`oracle_special.rs`) take
 /// `Standalone`; spell/activated dispatch takes `WithContext`.
@@ -26446,7 +26446,7 @@ fn parse_ability_ir(
         };
     }
     if let ChainLoweringMode::WithContext = mode {
-        if let Some(body) = parse_exile_pile_shuffle_cloak_ir(text, kind, ctx) {
+        if let Some(body) = parse_face_down_pile_ir(text, kind, ctx) {
             return AbilityIr {
                 source_text: text.to_string(),
                 body,
@@ -26517,6 +26517,15 @@ pub(crate) fn parse_effect_chain_with_context(
 ///
 /// The recognizer is deliberately narrow (the full pile/shuffle/cloak sentence
 /// is unique to this card) so it cannot swallow clauses on any other card.
+fn parse_face_down_pile_ir(
+    text: &str,
+    kind: AbilityKind,
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
+    parse_exile_pile_shuffle_cloak_ir(text, kind, ctx)
+        .or_else(|| parse_exile_object_and_top_face_down_pile_ir(text, kind, ctx))
+}
+
 fn parse_exile_pile_shuffle_cloak_ir(
     text: &str,
     kind: AbilityKind,
@@ -26616,6 +26625,56 @@ fn parse_exile_pile_shuffle_cloak_ir(
                 // controls the returned face-down permanents even for pile
                 // members they don't own.
                 enters_under: Some(ControllerRef::You),
+            }),
+            None,
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+    Some(EffectChainIr {
+        clauses: builder.finish(),
+        kind,
+        continuation_kind: Some(kind),
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
+        chain_rounding: None,
+        actor: ctx.actor.clone(),
+        in_trigger: ctx.in_trigger,
+        repeat_until: None,
+    })
+}
+
+/// CR 406.3 + CR 608.2c + CR 701.24a: "Exile it and the top N cards of your
+/// library in a face-down pile. If you do, shuffle that pile and put it back on
+/// top of your library." The entire sentence is one effect because the latter
+/// sentence is an all-members completion condition, not an independently valid
+/// chain step.
+fn parse_exile_object_and_top_face_down_pile_ir(
+    text: &str,
+    kind: AbilityKind,
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
+    let lower = text.to_ascii_lowercase();
+    let (rest, _) = tag("exile it and the top ").parse(lower.as_str()).ok()?;
+    let (rest, count) = nom_primitives::parse_number(rest).ok()?;
+    let (_, _) = all_consuming(terminated(
+        tag(" cards of your library in a face-down pile. if you do, shuffle that pile and put it back on top of your library"),
+        opt(tag(".")),
+    ))
+    .parse(rest)
+    .ok()?;
+
+    let mut builder = ClauseIrBuilder::new(text);
+    builder
+        .clause(
+            text,
+            parsed_clause(Effect::ExileFaceDownPile {
+                object: TargetFilter::TriggeringSource,
+                player: TargetFilter::Controller,
+                count: QuantityExpr::Fixed {
+                    value: count as i32,
+                },
             }),
             None,
             ClauseDisposition::Emit {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26656,11 +26656,15 @@ fn parse_exile_object_and_top_face_down_pile_ir(
     ctx: &ParseContext,
 ) -> Option<EffectChainIr> {
     let lower = text.to_ascii_lowercase();
-    let (rest, _) = tag("exile it and the top ").parse(lower.as_str()).ok()?;
+    let (rest, _) = tag::<_, _, OracleError<'_>>("exile it and the top ")
+        .parse(lower.as_str())
+        .ok()?;
     let (rest, count) = nom_primitives::parse_number(rest).ok()?;
     let (_, _) = all_consuming(terminated(
-        tag(" cards of your library in a face-down pile. if you do, shuffle that pile and put it back on top of your library"),
-        opt(tag(".")),
+        tag::<_, _, OracleError<'_>>(
+            " cards of your library in a face-down pile. if you do, shuffle that pile and put it back on top of your library",
+        ),
+        opt(tag::<_, _, OracleError<'_>>(".")),
     ))
     .parse(rest)
     .ok()?;

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -6114,6 +6114,7 @@ pub(super) fn clause_is_dig_lookback_transparent(effect: &Effect) -> bool {
         | Effect::Reveal { .. }
         | Effect::RevealTop { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::TargetOnly { .. }
         | Effect::Choose { .. }
         | Effect::OpponentGuess { .. }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -47122,6 +47122,26 @@ fn exile_pile_shuffle_cloak_remains_with_context_only() {
     );
 }
 
+#[test]
+fn triumph_of_saint_katherine_lowers_to_atomic_face_down_pile() {
+    let parsed = parse_oracle_text(
+        "Praesidium Protectiva — When Triumph of Saint Katherine dies, exile it and the top six cards of your library in a face-down pile. If you do, shuffle that pile and put it back on top of your library.",
+        "Triumph of Saint Katherine",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Warrior".to_string()],
+    );
+    let effect = &parsed.triggers[0].ability.effect;
+    assert!(matches!(
+        effect.as_ref(),
+        Effect::ExileFaceDownPile {
+            object: TargetFilter::TriggeringSource,
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 6 },
+        }
+    ));
+}
+
 // ── S25 P3 W1 #2 — self-and-target reanimation (Sandman / Slimefoot) ──
 
 /// Recursively report whether any node in an ability tree is `Unimplemented`.

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -47131,9 +47131,14 @@ fn triumph_of_saint_katherine_lowers_to_atomic_face_down_pile() {
         &["Creature".to_string()],
         &["Human".to_string(), "Warrior".to_string()],
     );
-    let effect = &parsed.triggers[0].ability.effect;
+    let effect = parsed.triggers[0]
+        .execute
+        .as_ref()
+        .expect("dies trigger must have an execute ability")
+        .effect
+        .as_ref();
     assert!(matches!(
-        effect.as_ref(),
+        effect,
         Effect::ExileFaceDownPile {
             object: TargetFilter::TriggeringSource,
             player: TargetFilter::Controller,

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -47123,22 +47123,21 @@ fn exile_pile_shuffle_cloak_remains_with_context_only() {
 }
 
 #[test]
-fn triumph_of_saint_katherine_lowers_to_atomic_face_down_pile() {
-    let parsed = parse_oracle_text(
-        "Praesidium Protectiva — When Triumph of Saint Katherine dies, exile it and the top six cards of your library in a face-down pile. If you do, shuffle that pile and put it back on top of your library.",
-        "Triumph of Saint Katherine",
-        &[],
-        &["Creature".to_string()],
-        &["Human".to_string(), "Warrior".to_string()],
-    );
-    let effect = parsed.triggers[0]
-        .execute
-        .as_ref()
-        .expect("dies trigger must have an execute ability")
-        .effect
-        .as_ref();
+fn triumph_of_saint_katherine_trigger_body_lowers_to_atomic_face_down_pile() {
+    // The trigger parser owns the "When ... dies" shell; this contextual body
+    // lowering is where the face-down-pile recognizer is selected.
+    let mut ctx = ParseContext {
+        in_trigger: true,
+        ..Default::default()
+    };
+    let effect = parse_effect_chain_with_context(
+        "exile it and the top six cards of your library in a face-down pile. If you do, shuffle that pile and put it back on top of your library.",
+        AbilityKind::Spell,
+        &mut ctx,
+    )
+    .effect;
     assert!(matches!(
-        effect,
+        &*effect,
         Effect::ExileFaceDownPile {
             object: TargetFilter::TriggeringSource,
             player: TargetFilter::Controller,

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -1278,6 +1278,7 @@ fn stamp_effect_printed_slot(effect: &mut Effect, slot: usize, kind: PrintedItem
         Effect::Reveal { .. } => {}
         Effect::RevealTop { .. } => {}
         Effect::ExileTop { .. } => {}
+        Effect::ExileFaceDownPile { .. } => {}
         Effect::TargetOnly { .. } => {}
         Effect::Choose { .. } => {}
         Effect::OpponentGuess { .. } => {}

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11403,6 +11403,22 @@ pub enum Effect {
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         face_down: bool,
     },
+    /// CR 406.3 + CR 608.2c: Exile one explicit object and the top `count`
+    /// cards of `player`'s library face down as one pile. The resolver keeps the
+    /// exact proposed member list through replacement resolution: the pile is
+    /// shuffled and returned only when every member actually reached exile.
+    /// This models the Triumph of Saint Katherine class's "If you do" rider
+    /// without allowing a partial pile to be returned.
+    ExileFaceDownPile {
+        /// The non-library member of the pile (normally the triggering source
+        /// in its owner's graveyard).
+        object: TargetFilter,
+        /// The player whose library supplies the top cards and receives the
+        /// completed pile back on top.
+        player: TargetFilter,
+        /// Number of top-library cards required in addition to `object`.
+        count: QuantityExpr,
+    },
     /// No-op effect that only establishes targeting for sub-abilities in the chain.
     /// Produced by Oracle text like "Choose target creature" where the sentence exists
     /// solely to designate a target referenced by subsequent sentences via "that creature".
@@ -14304,6 +14320,7 @@ impl Effect {
 
             Effect::Dig { player, .. }
             | Effect::ExileTop { player, .. }
+            | Effect::ExileFaceDownPile { player, .. }
             | Effect::ExchangeLifeWithStat { player, .. }
             | Effect::ExileFromTopUntil { player, .. }
             // CR 119.3: `GainLife.player` is a TargetFilter. `extract_target_filter_from_effect`
@@ -15291,6 +15308,7 @@ pub fn effect_variant_name(effect: &Effect) -> &str {
         Effect::Reveal { .. } => "Reveal",
         Effect::RevealTop { .. } => "RevealTop",
         Effect::ExileTop { .. } => "ExileTop",
+        Effect::ExileFaceDownPile { .. } => "ExileFaceDownPile",
         Effect::TargetOnly { .. } => "TargetOnly",
         Effect::Choose { .. } => "Choose",
         Effect::OpponentGuess { .. } => "OpponentGuess",
@@ -15610,6 +15628,7 @@ pub enum EffectKind {
     GivePlayerCounter,
     LoseAllPlayerCounters,
     ExileFromTopUntil,
+    ExileFaceDownPile,
     RevealUntil,
     Discover,
     Heist,
@@ -15888,6 +15907,7 @@ impl From<&Effect> for EffectKind {
             Effect::GivePlayerCounter { .. } => EffectKind::GivePlayerCounter,
             Effect::LoseAllPlayerCounters { .. } => EffectKind::LoseAllPlayerCounters,
             Effect::ExileFromTopUntil { .. } => EffectKind::ExileFromTopUntil,
+            Effect::ExileFaceDownPile { .. } => EffectKind::ExileFaceDownPile,
             Effect::RevealUntil { .. } => EffectKind::RevealUntil,
             Effect::Discover { .. } => EffectKind::Discover,
             Effect::Heist { .. } => EffectKind::Heist,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -14711,6 +14711,7 @@ impl Effect {
             | Effect::SearchLibrary { count, .. }
             | Effect::SearchOutsideGame { count, .. }
             | Effect::ExileTop { count, .. }
+            | Effect::ExileFaceDownPile { count, .. }
             | Effect::AddPendingETBCounters { count, .. }
             | Effect::RollDie { count, .. }
             | Effect::FlipCoins { count, .. }
@@ -14967,6 +14968,7 @@ impl Effect {
             | Effect::SearchLibrary { count, .. }
             | Effect::SearchOutsideGame { count, .. }
             | Effect::ExileTop { count, .. }
+            | Effect::ExileFaceDownPile { count, .. }
             | Effect::AddPendingETBCounters { count, .. }
             | Effect::RollDie { count, .. }
             | Effect::FlipCoins { count, .. }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -3237,6 +3237,11 @@ pub struct PendingZoneChangeDelivery {
     /// as-enters prompt is unresolved.
     pub terminal_completion: Option<ZoneMoveCompletion>,
     pub count: PausedZoneChangeDeliveryCount,
+    /// CR 406.3: A batch delivery requested concealment on an Exile landing.
+    /// It survives the replacement-choice pause so the settled member is hidden
+    /// before the next batch member is attempted.
+    #[serde(default)]
+    pub face_down_in_exile: bool,
 }
 
 impl PendingZoneChangeDelivery {
@@ -3247,6 +3252,7 @@ impl PendingZoneChangeDelivery {
             delivery_events: Vec::new(),
             terminal_completion: None,
             count: PausedZoneChangeDeliveryCount::NeedsCount,
+            face_down_in_exile: false,
         }
     }
 
@@ -4521,6 +4527,8 @@ pub struct PendingBatchZoneMoveRequest {
     pub exile_tracking: ZoneDeliveryExileTracking,
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub replacement_applied: HashSet<AppliedReplacementKey>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub face_down_in_exile: bool,
 }
 
 /// CR 701.25a / manifest dread: the post-loop cleanup a rest-pile batch must run
@@ -4570,6 +4578,18 @@ pub enum BatchCompletion {
         #[serde(default)]
         enters_under: Option<PlayerId>,
     },
+    /// CR 406.3 + CR 608.2c + CR 701.24a: A face-down pile's proposed exile
+    /// delivery settled. The exact member list is retained so the "If you do"
+    /// completion can return precisely that full pile, and never a partial one.
+    ExileFaceDownPileDeliveryComplete {
+        player: PlayerId,
+        source_id: ObjectId,
+        members: Vec<ObjectId>,
+        required_member_count: usize,
+    },
+    /// CR 406.3 + CR 608.2c: The successful pile's replacement-aware return to
+    /// library settled; emit the original effect's completion exactly once.
+    ExileFaceDownPileReturnComplete { source_id: ObjectId },
     /// CR 614.1 + CR 616.1 + CR 611.2a: A `CastFromZone` current-zone-to-Exile
     /// batch settled. Keep the resolved ability and its two target partitions
     /// so the permission is recorded only after the exile delivery, while
@@ -15178,16 +15198,33 @@ impl GameState {
         delivery_events: &[GameEvent],
         terminal_completion: ZoneMoveCompletion,
     ) -> bool {
+        let settled_in_exile = delivery_events.iter().any(|event| {
+            matches!(
+                event,
+                GameEvent::ZoneChanged {
+                    object_id,
+                    to: Zone::Exile,
+                    ..
+                } if *object_id == member.object_id
+            )
+        });
         if let Some(paused) = self
             .active_change_zone_frame_mut()
             .and_then(|frame| frame.pending.as_mut())
             .and_then(|owner| owner.paused_current.as_mut())
             .filter(|paused| paused.captures(member, expected_event))
         {
+            let conceal = paused.face_down_in_exile && settled_in_exile;
             paused.append_delivery_events(delivery_events);
             paused
                 .record_terminal_completion(terminal_completion)
                 .expect("one paused zone-change delivery has one terminal completion");
+            if conceal {
+                self.objects
+                    .get_mut(&member.object_id)
+                    .expect("settled paused pile member exists")
+                    .face_down = true;
+            }
             return true;
         }
         if let Some(paused) = self
@@ -15196,10 +15233,17 @@ impl GameState {
             .and_then(|owner| owner.paused_current.as_mut())
             .filter(|paused| paused.captures(member, expected_event))
         {
+            let conceal = paused.face_down_in_exile && settled_in_exile;
             paused.append_delivery_events(delivery_events);
             paused
                 .record_terminal_completion(terminal_completion)
                 .expect("one paused zone-change delivery has one terminal completion");
+            if conceal {
+                self.objects
+                    .get_mut(&member.object_id)
+                    .expect("settled paused pile member exists")
+                    .face_down = true;
+            }
             return true;
         }
         false

--- a/crates/phase-ai/src/policies/effect_classify.rs
+++ b/crates/phase-ai/src/policies/effect_classify.rs
@@ -283,6 +283,7 @@ pub(crate) fn effect_polarity(effect: &Effect) -> EffectPolarity {
         | Effect::ExileHaunting { .. }
         | Effect::ExileResolvingSpellInsteadOfGraveyard { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::Exploit { .. }
         | Effect::ExploreAll { .. }
         | Effect::FlipCoin { .. }

--- a/crates/phase-ai/src/policies/redundancy_avoidance.rs
+++ b/crates/phase-ai/src/policies/redundancy_avoidance.rs
@@ -478,6 +478,7 @@ fn redundancy_delta(
         | Effect::RevealHand { .. }
         | Effect::RevealTop { .. }
         | Effect::ExileTop { .. }
+        | Effect::ExileFaceDownPile { .. }
         | Effect::TargetOnly { .. }
         | Effect::Choose { .. }
         | Effect::OpponentGuess { .. }

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -715,6 +715,17 @@ pub fn emit_trace_for_candidate(
 /// debug builds panic so the gap surfaces during testing instead of silently
 /// degrading AI play into cast/cancel churn.
 fn fallback_action(state: &GameState) -> Option<GameAction> {
+    // CR 601.2c: A spell's target step must use the engine's current legal
+    // target list. `target_slots` is a historical snapshot and can be stale
+    // after earlier selections; if no current legal action remains, abort the
+    // in-flight cast rather than fabricating an illegal required-target skip.
+    if matches!(state.waiting_for, WaitingFor::TargetSelection { .. }) {
+        return engine::ai_support::legal_actions(state)
+            .into_iter()
+            .find(|action| matches!(action, GameAction::ChooseTarget { .. }))
+            .or(Some(GameAction::CancelCast));
+    }
+
     // Pending-cast states can always be escaped with CancelCast (CR 601.2).
     // Check this before the exhaustive match so every pending-cast variant
     // is covered without repeating CancelCast per-arm.
@@ -860,11 +871,10 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
             .copied()
             .map(|target| GameAction::ChooseEntryAttackTarget { target }),
 
-        // Target selection: skip optional slots, fizzle mandatory ones.
         // TriggerTargetSelection is not a pending cast — the trigger is
         // already on the stack. ChooseTarget { target: None } signals
         // "no legal target" and causes the trigger to fizzle (CR 608.2b).
-        WaitingFor::TargetSelection { .. } | WaitingFor::TriggerTargetSelection { .. } => {
+        WaitingFor::TriggerTargetSelection { .. } => {
             Some(GameAction::ChooseTarget { target: None })
         }
 
@@ -4271,6 +4281,64 @@ mod tests {
         ))
     }
 
+    fn spell_target_selection_state(
+        current_legal_targets: Vec<TargetRef>,
+        stale_slot_targets: Vec<TargetRef>,
+        optional: bool,
+    ) -> GameState {
+        let mut state = make_state();
+        let spell_id = add_spell_to_hand(&mut state, PlayerId(0), "Targeting Spell", 0);
+        let ability = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Any,
+                damage_source: None,
+                excess: None,
+            },
+            Vec::new(),
+            spell_id,
+            PlayerId(0),
+        );
+        let pending_cast = engine::types::game_state::PendingCast::new(
+            spell_id,
+            CardId(spell_id.0),
+            ability,
+            engine::types::mana::ManaCost::NoCost,
+        );
+
+        state.players[PlayerId(0).0 as usize]
+            .hand
+            .retain(|&object_id| object_id != spell_id);
+        state.objects.get_mut(&spell_id).unwrap().zone = Zone::Stack;
+        state.stack.push_back(StackEntry {
+            id: spell_id,
+            source_id: spell_id,
+            controller: PlayerId(0),
+            kind: StackEntryKind::Spell {
+                card_id: CardId(spell_id.0),
+                ability: None,
+                casting_variant: engine::types::game_state::CastingVariant::Normal,
+                actual_mana_spent: 0,
+            },
+        });
+        state.waiting_for = WaitingFor::TargetSelection {
+            player: PlayerId(0),
+            pending_cast: Box::new(pending_cast),
+            target_slots: vec![engine::types::game_state::TargetSelectionSlot {
+                legal_targets: stale_slot_targets,
+                optional,
+                chooser: None,
+            }],
+            mode_labels: Vec::new(),
+            selection: engine::types::game_state::TargetSelectionProgress {
+                current_slot: 0,
+                selected_slots: Vec::new(),
+                current_legal_targets,
+            },
+        };
+        state
+    }
+
     /// Minimal ChooseManaColor SingleColor state with the given option list and
     /// pending cast. The `context` is a degenerate `ResolvingEffect` resume — the
     /// pre-emption never inspects it, only `choice` and `state.pending_cast`.
@@ -4971,6 +5039,45 @@ mod tests {
         let action = choose_action(&state, PlayerId(0), &config, &mut rng);
 
         assert_eq!(action, Some(GameAction::ChooseTarget { target: None }));
+    }
+
+    #[test]
+    fn fallback_spell_target_selection_uses_current_legal_target_when_slot_is_stale() {
+        let target = TargetRef::Player(PlayerId(1));
+        let mut state = spell_target_selection_state(
+            vec![target.clone()],
+            vec![TargetRef::Player(PlayerId(0))],
+            false,
+        );
+
+        let action = fallback_action(&state).expect("fallback returns an action");
+        assert_eq!(
+            action,
+            GameAction::ChooseTarget {
+                target: Some(target),
+            }
+        );
+        assert!(engine::game::engine::apply_as_current(&mut state, action).is_ok());
+    }
+
+    #[test]
+    fn fallback_spell_target_selection_skips_optional_empty_current_slot() {
+        let mut state =
+            spell_target_selection_state(Vec::new(), vec![TargetRef::Player(PlayerId(1))], true);
+
+        let action = fallback_action(&state).expect("fallback returns an action");
+        assert_eq!(action, GameAction::ChooseTarget { target: None });
+        assert!(engine::game::engine::apply_as_current(&mut state, action).is_ok());
+    }
+
+    #[test]
+    fn fallback_spell_target_selection_cancels_required_empty_current_slot() {
+        let mut state =
+            spell_target_selection_state(Vec::new(), vec![TargetRef::Player(PlayerId(1))], false);
+
+        let action = fallback_action(&state).expect("fallback returns an action");
+        assert_eq!(action, GameAction::CancelCast);
+        assert!(engine::game::engine::apply_as_current(&mut state, action).is_ok());
     }
 
     /// Regression test: AI must produce DeclareBlockers action even when the

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -871,6 +871,9 @@ fn fallback_action(state: &GameState) -> Option<GameAction> {
             .copied()
             .map(|target| GameAction::ChooseEntryAttackTarget { target }),
 
+        // TargetSelection returned from the early current-legal-target branch.
+        WaitingFor::TargetSelection { .. } => unreachable!("handled before fallback match"),
+
         // TriggerTargetSelection is not a pending cast — the trigger is
         // already on the stack. ChooseTarget { target: None } signals
         // "no legal target" and causes the trigger to fizzle (CR 608.2b).

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -4310,10 +4310,6 @@ mod tests {
             engine::types::mana::ManaCost::NoCost,
         );
 
-        state.players[PlayerId(0).0 as usize]
-            .hand
-            .retain(|&object_id| object_id != spell_id);
-        state.objects.get_mut(&spell_id).unwrap().zone = Zone::Stack;
         state.stack.push_back(StackEntry {
             id: spell_id,
             source_id: spell_id,

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -4291,7 +4291,7 @@ mod tests {
     ) -> GameState {
         let mut state = make_state();
         let spell_id = add_spell_to_hand(&mut state, PlayerId(0), "Targeting Spell", 0);
-        let ability = ResolvedAbility::new(
+        let mut ability = ResolvedAbility::new(
             Effect::DealDamage {
                 amount: QuantityExpr::Fixed { value: 1 },
                 target: TargetFilter::Any,
@@ -4302,6 +4302,7 @@ mod tests {
             spell_id,
             PlayerId(0),
         );
+        ability.optional_targeting = optional;
         let pending_cast = engine::types::game_state::PendingCast::new(
             spell_id,
             CardId(spell_id.0),


### PR DESCRIPTION
- **fix(engine): finalize zero-target divided triggers**
- **fix(engine): respect sibling links after deferred effects**
- **fix(ai): use legal spell target fallback**
- **feat(engine): resolve face-down exile piles atomically**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an effect that exiles an explicit object and the top cards of a player’s library as a face-down pile.
  * After resolution, face-down pile cards return to the library in the correct order (including the shuffling/replacement flow).

* **Bug Fixes**
  * Preserves “face-down in exile” behavior across paused and resumed zone-move deliveries.
  * Fixed deferred target traversal so stack targets don’t incorrectly resolve across conditional boundaries.
  * Resolved divided-trigger 0/1-target edge cases to avoid hanging.
  * Improved spell target fallback behavior for stale vs current legal targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->