### PR TITLE
feat(engine): journal CR 701.27a transforms as resolved commands

### DIFF
--- a/crates/engine/src/game/transform.rs
+++ b/crates/engine/src/game/transform.rs
@@ -1,6 +1,9 @@
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
-use crate::types::identifiers::ObjectId;
+use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
+use crate::types::resolved_commands::{
+    ResolvedObjectTransformCommand, ResolvedObjectTransformReplayInvariantError,
+};
 use crate::types::zones::Zone;
 
 use super::engine::EngineError;
@@ -97,9 +100,77 @@ pub fn transform_permanent(
     // self-transform instructions from abilities already on the stack.
     obj.transformation_count = obj.transformation_count.wrapping_add(1);
 
+    let reference = ObjectIncarnationRef::from_object(obj);
+    let resulting_transformed = obj.transformed;
+    let resulting_transformation_count = obj.transformation_count;
+
     crate::game::layers::mark_layers_full(state);
 
+    // CR 733: journal the settled transform through its owning family. Every
+    // no-op guard above returned before the swap, so only a transform that
+    // actually changed the displayed face is recorded.
+    let cause = state.current_or_begin_rules_execution_node();
+    state
+        .resolved_rules_journal
+        .record_object_transform(ResolvedObjectTransformCommand {
+            object: reference,
+            expected_old_transformed: !resulting_transformed,
+            resulting_transformed,
+            resulting_timestamp: ts,
+            resulting_transformation_count,
+            cause,
+        })
+        .expect("resolved transform must have a live journal cause");
+
     events.push(GameEvent::Transformed { object_id });
+
+    Ok(())
+}
+
+/// CR 701.27a + CR 613.7g: Apply one exact already-resolved transform.
+///
+/// This installs the recorded face swap, displayed-face flag, timestamp, and
+/// transformation count. It re-runs none of `transform_permanent`'s CR 701.27
+/// eligibility guards — those decided at resolve time, and a command only
+/// exists because the transform actually happened.
+pub fn apply_resolved_transform(
+    state: &mut GameState,
+    command: &ResolvedObjectTransformCommand,
+) -> Result<(), ResolvedObjectTransformReplayInvariantError> {
+    let object = state.objects.get(&command.object.object_id).ok_or(
+        ResolvedObjectTransformReplayInvariantError::UnknownObject(command.object.object_id),
+    )?;
+    let found = ObjectIncarnationRef::from_object(object);
+    if found != command.object {
+        return Err(ResolvedObjectTransformReplayInvariantError::StaleObject {
+            expected: command.object,
+            found,
+        });
+    }
+    if object.transformed != command.expected_old_transformed {
+        return Err(
+            ResolvedObjectTransformReplayInvariantError::TransformedPreconditionMismatch {
+                expected: command.expected_old_transformed,
+                found: object.transformed,
+            },
+        );
+    }
+    let back_face = object.back_face.clone().ok_or(
+        ResolvedObjectTransformReplayInvariantError::MissingBackFace(command.object.object_id),
+    )?;
+
+    let obj = state
+        .objects
+        .get_mut(&command.object.object_id)
+        .expect("validated transform command object remains live");
+    let displayed = snapshot_object_face(obj);
+    apply_back_face_to_object(obj, back_face);
+    obj.back_face = Some(displayed);
+    obj.transformed = command.resulting_transformed;
+    obj.timestamp = command.resulting_timestamp;
+    obj.transformation_count = command.resulting_transformation_count;
+
+    crate::game::layers::mark_layers_full(state);
 
     Ok(())
 }

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -144,6 +144,44 @@ pub struct ResolvedObjectCounterCommand {
     pub cause: RulesExecutionNodeRef,
 }
 
+/// One exact CR 701.27a transform of a double-faced permanent.
+///
+/// CR 613.7g: a permanent that transforms receives a NEW timestamp, which
+/// orders it against continuous effects in the layer system. Replay installs
+/// the exact recorded timestamp instead of re-drawing one from
+/// `GameState::next_timestamp` — mirroring the zone-change family's
+/// `entry_timestamp` — so a retained-prefix replay cannot silently reorder
+/// layer application. The face payloads are not recorded: swapping the stashed
+/// `back_face` with the displayed face is a structural operation over data the
+/// object already carries, not a re-selection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedObjectTransformCommand {
+    pub object: ObjectIncarnationRef,
+    pub expected_old_transformed: bool,
+    pub resulting_transformed: bool,
+    pub resulting_timestamp: u64,
+    /// CR 701.27f: the post-transform count used to ignore stale self-transform
+    /// instructions from abilities already on the stack.
+    pub resulting_transformation_count: u32,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// Typed failure while applying one already-resolved transform.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedObjectTransformReplayInvariantError {
+    #[error("transform command references an unknown object {0:?}")]
+    UnknownObject(ObjectId),
+    #[error("transform occurrence mismatch: expected {expected:?}, found {found:?}")]
+    StaleObject {
+        expected: ObjectIncarnationRef,
+        found: ObjectIncarnationRef,
+    },
+    #[error("transform precondition mismatch: expected transformed {expected}, found {found}")]
+    TransformedPreconditionMismatch { expected: bool, found: bool },
+    #[error("transform command object {0:?} has no back face to swap")]
+    MissingBackFace(ObjectId),
+}
+
 /// The audience that received one exact revealed-card fact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResolvedInformationAudience {
@@ -388,6 +426,7 @@ pub enum ResolvedRulesCommand {
     PlayerEdit(ResolvedPlayerEditCommand),
     ObjectStatus(ResolvedObjectStatusCommand),
     ObjectCounter(ResolvedObjectCounterCommand),
+    ObjectTransform(ResolvedObjectTransformCommand),
     Information(ResolvedInformationCommand),
     LedgerEdit(ResolvedLedgerEditCommand),
     LibraryShuffle(ResolvedLibraryShuffleCommand),
@@ -1279,6 +1318,17 @@ impl ResolvedRulesJournal {
         )
     }
 
+    /// Records one exact CR 701.27a transform under its causal node.
+    pub fn record_object_transform(
+        &mut self,
+        command: ResolvedObjectTransformCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(
+            command.cause,
+            ResolvedRulesCommand::ObjectTransform(command),
+        )
+    }
+
     /// Records one exact bounded resolution-frame transition under its causal node.
     pub fn record_frame_transition(
         &mut self,
@@ -1499,6 +1549,7 @@ impl ResolvedRulesJournal {
                 ResolvedRulesCommand::PlayerEdit(_)
                 | ResolvedRulesCommand::ObjectStatus(_)
                 | ResolvedRulesCommand::ObjectCounter(_)
+                | ResolvedRulesCommand::ObjectTransform(_)
                 | ResolvedRulesCommand::Information(_)
                 | ResolvedRulesCommand::LedgerEdit(_)
                 | ResolvedRulesCommand::LibraryShuffle(_)
@@ -1740,6 +1791,20 @@ impl ResolvedRulesJournal {
                 if entry.node != command.cause || zone_change_command_is_invalid(command) {
                     return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
                         "zone-change command has an invalid occurrence, receipt, or unrelated cause"
+                            .to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::ObjectTransform(command) => {
+                // CR 701.27a: a transform turns the permanent to its OTHER face,
+                // so a recorded transform that leaves `transformed` unchanged is
+                // not a transform that ever happened.
+                if entry.node != command.cause
+                    || command.expected_old_transformed == command.resulting_transformed
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "transform command does not change the displayed face, or has an \
+                         unrelated cause"
                             .to_string(),
                     ));
                 }

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -76,6 +76,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::ObjectCounter(command) => {
             engine::game::effects::counters::apply_resolved_counter_edit(state, command).unwrap();
         }
+        ResolvedRulesCommand::ObjectTransform(command) => {
+            engine::game::transform::apply_resolved_transform(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }
@@ -182,6 +185,7 @@ fn exact_mana_spend_rejects_a_second_removal() {
             ResolvedRulesCommand::PlayerEdit(_)
             | ResolvedRulesCommand::ObjectStatus(_)
             | ResolvedRulesCommand::ObjectCounter(_)
+            | ResolvedRulesCommand::ObjectTransform(_)
             | ResolvedRulesCommand::LedgerEdit(_)
             | ResolvedRulesCommand::LibraryShuffle(_)
             | ResolvedRulesCommand::ZoneChange(_)

--- a/crates/engine/tests/integration/cr733_resolved_draw.rs
+++ b/crates/engine/tests/integration/cr733_resolved_draw.rs
@@ -41,6 +41,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::ObjectCounter(command) => {
             engine::game::effects::counters::apply_resolved_counter_edit(state, command).unwrap();
         }
+        ResolvedRulesCommand::ObjectTransform(command) => {
+            engine::game::transform::apply_resolved_transform(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }

--- a/crates/engine/tests/integration/cr733_resolved_transform.rs
+++ b/crates/engine/tests/integration/cr733_resolved_transform.rs
@@ -1,0 +1,126 @@
+//! CR733 P2 coverage for the transform family.
+//!
+//! `transform::transform_permanent` is the single authority every production
+//! transform funnels through (the `Transform` effect, day/night shifts, meld,
+//! copy-as-transformed, and the zone delivery tail's `enter_transformed`), but
+//! it wrote its mutation raw. A retained-prefix replay therefore had no record
+//! that the permanent had turned to its other face.
+//!
+//! CR 613.7g is why this cannot ride the boolean object-status family: a
+//! transformed permanent receives a NEW timestamp drawn from
+//! `GameState::next_timestamp`, which orders it against continuous effects. A
+//! replay that re-draws that counter installs a different number and silently
+//! reorders layer application, so the drawn value must be recorded and
+//! reinstalled verbatim.
+//!
+//! The test drives the REAL pipeline — casting a spell whose effect is
+//! `Effect::Transform` at a double-faced permanent — so the transform is
+//! produced by the production resolver, not by a direct call to the authority.
+
+use engine::game::printed_cards::snapshot_object_face;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::{Effect, TargetFilter, TypedFilter};
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::ResolvedRulesCommand;
+
+#[test]
+fn transform_journals_an_exact_resolved_transform() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let dfc = scenario.add_creature(P1, "Sleeping Bear", 2, 2).id();
+    // The donor supplies the back face. Snapshotting a real object's face is
+    // what `transform_permanent` itself stores, so the fixture stays correct as
+    // `BackFaceData` gains fields — a hand-written struct literal would break on
+    // every new field.
+    let donor = scenario.add_creature(P1, "Awakened Bear", 4, 4).id();
+    let mut spell = scenario.add_spell_to_hand(P0, "Rouse", true);
+    spell.with_ability(Effect::Transform {
+        target: TargetFilter::Typed(TypedFilter::creature()),
+    });
+    let spell_id = spell.id();
+
+    let mut runner = scenario.build();
+    let back_face = snapshot_object_face(&runner.state().objects[&donor]);
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&dfc)
+        .expect("the double-faced permanent exists")
+        .back_face = Some(back_face);
+
+    // Captured before the cast so the recorded command can be replayed against
+    // the exact predecessor state it was resolved from.
+    let pre_state = runner.state().clone();
+    let journal_start = runner.state().resolved_rules_journal.entries().len();
+
+    let outcome = runner.cast(spell_id).target_object(dfc).resolve();
+    let state = outcome.state();
+
+    // CR 701.27a: the permanent turned to its other face. Without this reach
+    // guard the journal assertion below could pass vacuously on a transform
+    // that never happened.
+    let object = &state.objects[&dfc];
+    assert!(
+        object.transformed,
+        "CR 701.27a: the Transform effect must turn the permanent to its other face"
+    );
+    assert_eq!(
+        object.name, "Awakened Bear",
+        "the back face is now the displayed face"
+    );
+
+    // The discriminating assertion: the transform is journaled as an exact
+    // resolved command. A raw mutation records nothing here.
+    let transforms: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::ObjectTransform(command) if command.object.object_id == dfc => {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        transforms.len(),
+        1,
+        "the transform authority must journal exactly one resolved transform"
+    );
+
+    let transform = &transforms[0];
+    assert!(
+        !transform.expected_old_transformed && transform.resulting_transformed,
+        "CR 701.27a: the recorded transition is front face -> back face"
+    );
+    // CR 613.7g: the recorded timestamp is the one the permanent actually
+    // received, not a value re-derived at replay time.
+    assert_eq!(
+        transform.resulting_timestamp, object.timestamp,
+        "the journaled timestamp is the timestamp the transform installed"
+    );
+    assert_eq!(
+        transform.resulting_transformation_count, object.transformation_count,
+        "CR 701.27f: the journaled transformation count matches the installed count"
+    );
+
+    // Replay-exactness: applying the recorded command to the pre-cast state
+    // reproduces the same face, timestamp, and count with no re-derivation —
+    // in particular without drawing a fresh timestamp from `next_timestamp`.
+    let mut replay = pre_state;
+    engine::game::transform::apply_resolved_transform(&mut replay, transform)
+        .expect("the recorded transform must replay against its captured predecessor");
+    let replayed = &replay.objects[&dfc];
+    assert!(replayed.transformed, "replay installs the back face");
+    assert_eq!(
+        replayed.name, "Awakened Bear",
+        "replay installs the exact displayed face"
+    );
+    assert_eq!(
+        replayed.timestamp, transform.resulting_timestamp,
+        "CR 613.7g: replay installs the recorded timestamp instead of re-drawing one"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -95,6 +95,7 @@ mod cr733_resolved_commands_p1;
 mod cr733_resolved_commands_p2;
 mod cr733_resolved_draw;
 mod cr733_resolved_frame_transition;
+mod cr733_resolved_transform;
 mod cr733_resolved_trigger_collection;
 mod cr733_resolved_zone_change;
 mod cr_annotations;


### PR DESCRIPTION
`transform::transform_permanent` is the single authority every production
transform funnels through — the `Transform` effect, day/night shifts, meld,
copy-as-transformed, and the zone delivery tail's `enter_transformed` — but
it wrote its mutation raw, so a retained-prefix replay had no record that a
permanent had turned to its other face.

Add the `ObjectTransform` command family and journal at the mutation site.
CR 613.7g is why this cannot ride the boolean object-status family: a
transformed permanent receives a NEW timestamp drawn from
`GameState::next_timestamp`, which orders it against continuous effects. A
replay that re-draws that counter installs a different number and silently
reorders layer application, so the drawn value is recorded and reinstalled
verbatim — mirroring the zone-change family's `entry_timestamp`.

The face payloads are deliberately not recorded: swapping the stashed
`back_face` with the displayed face is a structural operation over data the
object already carries, not a re-selection. Every CR 701.27 eligibility
guard returns before the swap, so only a transform that actually changed
the displayed face is journaled.
