### PR TITLE
ship/cr733 attach

### DIFF
--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -8,8 +8,11 @@ use crate::types::ability::{
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
-use crate::types::identifiers::ObjectId;
+use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
 use crate::types::player::PlayerId;
+use crate::types::resolved_commands::{
+    ResolvedAttachmentCommand, ResolvedAttachmentReplayInvariantError,
+};
 use crate::types::zones::Zone;
 
 /// CR 701.3a + CR 701.3b: Attach — to place an Aura, Equipment, or Fortification on another object or player.
@@ -205,14 +208,6 @@ pub(crate) fn target_ref_from_attach_target(target: AttachTarget) -> TargetRef {
         AttachTarget::Object(id) => TargetRef::Object(id),
         AttachTarget::Player(id) => TargetRef::Player(id),
     }
-}
-
-fn current_attachment_target(state: &GameState, attachment_id: ObjectId) -> Option<TargetRef> {
-    state
-        .objects
-        .get(&attachment_id)
-        .and_then(|obj| obj.attached_to)
-        .map(target_ref_from_attach_target)
 }
 
 fn attachment_tree_contains(state: &GameState, root_id: ObjectId, candidate_id: ObjectId) -> bool {
@@ -565,9 +560,12 @@ pub fn attach_to(
     // CR 613.7e + CR 701.3b/c: read the UNFILTERED prior host once. The timestamp
     // bump (below) must distinguish first-attach (None) from a same-host re-attach
     // (Some(host)); `old_target` collapses both to `None` and cannot. `old_target`
-    // is just the filtered view, so derive it from the single read rather than
-    // querying the attachment's host twice.
-    let prior_host = current_attachment_target(state, attachment_id);
+    // and the CR 733 command's `expected_old_host` are both views of this one read
+    // rather than repeat queries of the attachment's host.
+    let attachment_object = state.objects.get(&attachment_id);
+    let reference = attachment_object.map(ObjectIncarnationRef::from_object);
+    let expected_old_host = attachment_object.and_then(|obj| obj.attached_to);
+    let prior_host = expected_old_host.map(target_ref_from_attach_target);
     // Discriminate the timestamp bump (below) before `filter` consumes `prior_host`:
     // `==` borrows, `Option::filter` moves. True on first-attach (None) or a move to a
     // different host; false only on a same-host re-attach (CR 701.3b keeps the stamp).
@@ -597,12 +595,13 @@ pub fn attach_to(
 
     // CR 613.7e + CR 701.3c: first attach (None) or a move to a different host
     // bumps the timestamp; a same-host re-attach (CR 701.3b) does not.
-    if moving_to_new_host {
+    let resulting_timestamp = moving_to_new_host.then(|| {
         let ts = state.next_timestamp();
         if let Some(attachment) = state.objects.get_mut(&attachment_id) {
             attachment.timestamp = ts;
         }
-    }
+        ts
+    });
 
     // Add to target's attachments list
     if let Some(target) = state.objects.get_mut(&target_id) {
@@ -613,7 +612,42 @@ pub fn attach_to(
 
     crate::game::layers::mark_layers_full(state);
     crate::game::layers::flush_layers(state);
+
+    // CR 733: journal the settled edit through its owning family. A same-host
+    // re-attach (CR 701.3b) leaves every field above unchanged, so only a real
+    // host transition is recorded.
+    if let Some(reference) = reference.filter(|_| moving_to_new_host) {
+        record_attachment_edit(
+            state,
+            reference,
+            expected_old_host,
+            Some(AttachTarget::Object(target_id)),
+            resulting_timestamp,
+        );
+    }
     old_target
+}
+
+/// Stamps one settled attachment-graph edit into the CR 733 resolved-command
+/// journal on behalf of the three attachment authorities.
+fn record_attachment_edit(
+    state: &mut GameState,
+    attachment: ObjectIncarnationRef,
+    expected_old_host: Option<AttachTarget>,
+    resulting_host: Option<AttachTarget>,
+    resulting_timestamp: Option<u64>,
+) {
+    let cause = state.current_or_begin_rules_execution_node();
+    state
+        .resolved_rules_journal
+        .record_attachment(ResolvedAttachmentCommand {
+            attachment,
+            expected_old_host,
+            resulting_host,
+            resulting_timestamp,
+            cause,
+        })
+        .expect("resolved attachment must have a live journal cause");
 }
 
 /// Why a host forbids an attachment, independent of the Enchant filter and zone.
@@ -1186,9 +1220,13 @@ pub fn attach_to_player(
 
     // CR 613.7e + CR 701.3b/c: read the UNFILTERED prior host once so a first-attach
     // (None) and a same-player re-attach (Some(player)) are distinguishable —
-    // `old_target` collapses both to `None`. Derive the filtered view from the
-    // single read rather than querying the attachment's host twice.
-    let prior_host = current_attachment_target(state, attachment_id);
+    // `old_target` collapses both to `None`. The filtered view and the CR 733
+    // command's `expected_old_host` both derive from this single read rather than
+    // querying the attachment's host again.
+    let attachment_object = state.objects.get(&attachment_id);
+    let reference = attachment_object.map(ObjectIncarnationRef::from_object);
+    let expected_old_host = attachment_object.and_then(|obj| obj.attached_to);
+    let prior_host = expected_old_host.map(target_ref_from_attach_target);
     // Discriminate the timestamp bump (below) before `filter` consumes `prior_host`:
     // `==` borrows, `Option::filter` moves. True on first-attach (None) or a move to a
     // different player; false only on a same-player re-attach (CR 701.3b keeps the stamp).
@@ -1214,15 +1252,29 @@ pub fn attach_to_player(
 
     // CR 613.7e + CR 701.3c: first attach (None) or a move to a different player
     // host bumps the timestamp; a same-player re-attach (CR 701.3b) does not.
-    if moving_to_new_host {
+    let resulting_timestamp = moving_to_new_host.then(|| {
         let ts = state.next_timestamp();
         if let Some(attachment) = state.objects.get_mut(&attachment_id) {
             attachment.timestamp = ts;
         }
-    }
+        ts
+    });
 
     crate::game::layers::mark_layers_full(state);
     crate::game::layers::flush_layers(state);
+
+    // CR 733: journal the settled edit through its owning family, on the same
+    // terms as the object-host authority — a same-player re-attach (CR 701.3b)
+    // changed nothing and is not recorded.
+    if let Some(reference) = reference.filter(|_| moving_to_new_host) {
+        record_attachment_edit(
+            state,
+            reference,
+            expected_old_host,
+            Some(AttachTarget::Player(target_player)),
+            resulting_timestamp,
+        );
+    }
     old_target
 }
 
@@ -1230,14 +1282,16 @@ pub fn attach_to_player(
 /// to while it remains on the battlefield. This is the single graph update
 /// primitive for explicit unattach costs and effects.
 pub(crate) fn unattach(state: &mut GameState, attachment_id: ObjectId) -> Option<TargetRef> {
-    let old_target = current_attachment_target(state, attachment_id)?;
-    let old_target_id = state
-        .objects
-        .get(&attachment_id)
-        .and_then(|obj| obj.attached_to)
-        .and_then(|target| target.as_object());
+    // One read serves the returned host, the old host's list cleanup, and the
+    // CR 733 command's `expected_old_host`. The `?` means an already-unattached
+    // attachment returns before any mutation, so every reachable path below is a
+    // real host transition.
+    let attachment_object = state.objects.get(&attachment_id)?;
+    let reference = ObjectIncarnationRef::from_object(attachment_object);
+    let expected_old_host = attachment_object.attached_to?;
+    let old_target = target_ref_from_attach_target(expected_old_host);
 
-    if let Some(old_target_id) = old_target_id {
+    if let Some(old_target_id) = expected_old_host.as_object() {
         if let Some(old_target) = state.objects.get_mut(&old_target_id) {
             old_target.attachments.retain(|&id| id != attachment_id);
         }
@@ -1247,7 +1301,78 @@ pub(crate) fn unattach(state: &mut GameState, attachment_id: ObjectId) -> Option
     }
     crate::game::layers::mark_layers_full(state);
     crate::game::layers::flush_layers(state);
+
+    // CR 733 + CR 701.3d: an unattach installs no host and, unlike an attach,
+    // draws no new timestamp (CR 613.7e applies to attaching to a new host).
+    record_attachment_edit(state, reference, Some(expected_old_host), None, None);
     Some(old_target)
+}
+
+/// Installs one already-resolved CR 701.3 attachment edit verbatim.
+///
+/// Deliberately re-runs NONE of the CR 301.5 / CR 303.4 / CR 702.16 attach
+/// legality guards: those decided at resolve time whether this edit happened at
+/// all, and re-evaluating them against a replayed board could reject an edit the
+/// game already made. The applier only verifies that the state it is installing
+/// into is the state the command was resolved from, then performs the structural
+/// graph move and installs the recorded timestamp.
+pub fn apply_resolved_attachment(
+    state: &mut GameState,
+    command: &ResolvedAttachmentCommand,
+) -> Result<(), ResolvedAttachmentReplayInvariantError> {
+    let attachment_id = command.attachment.object_id;
+    let attachment = state.objects.get(&attachment_id).ok_or(
+        ResolvedAttachmentReplayInvariantError::UnknownAttachment(attachment_id),
+    )?;
+    let found = ObjectIncarnationRef::from_object(attachment);
+    if found != command.attachment {
+        return Err(ResolvedAttachmentReplayInvariantError::StaleAttachment {
+            expected: command.attachment,
+            found,
+        });
+    }
+    if attachment.attached_to != command.expected_old_host {
+        return Err(
+            ResolvedAttachmentReplayInvariantError::HostPreconditionMismatch {
+                expected: command.expected_old_host,
+                found: attachment.attached_to,
+            },
+        );
+    }
+    // CR 303.4f: the recorded host must still be an object the graph can point
+    // at, checked before any mutation so a rejected command leaves no partial edit.
+    if let Some(new_host_id) = command.resulting_host.and_then(|host| host.as_object()) {
+        if !state.objects.contains_key(&new_host_id) {
+            return Err(ResolvedAttachmentReplayInvariantError::UnknownHost(
+                new_host_id,
+            ));
+        }
+    }
+
+    if let Some(old_host_id) = command.expected_old_host.and_then(|host| host.as_object()) {
+        if let Some(old_host) = state.objects.get_mut(&old_host_id) {
+            old_host.attachments.retain(|&id| id != attachment_id);
+        }
+    }
+    if let Some(attachment) = state.objects.get_mut(&attachment_id) {
+        attachment.attached_to = command.resulting_host;
+        // CR 613.7e + CR 701.3c: install the timestamp the authority drew rather
+        // than re-drawing one, which would reorder the layer system.
+        if let Some(timestamp) = command.resulting_timestamp {
+            attachment.timestamp = timestamp;
+        }
+    }
+    if let Some(new_host_id) = command.resulting_host.and_then(|host| host.as_object()) {
+        if let Some(new_host) = state.objects.get_mut(&new_host_id) {
+            if !new_host.attachments.contains(&attachment_id) {
+                new_host.attachments.push(attachment_id);
+            }
+        }
+    }
+
+    crate::game::layers::mark_layers_full(state);
+    crate::game::layers::flush_layers(state);
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -5,6 +5,9 @@ use crate::types::game_state::{ActiveSearchDecisionAuthority, GameState, Waiting
 use crate::types::identifiers::ObjectIncarnationRef;
 use crate::types::match_config::MatchPhase;
 use crate::types::player::PlayerId;
+use crate::types::resolved_commands::{
+    ResolvedPlayerLeaveCommand, ResolvedPlayerLeaveReplayInvariantError,
+};
 use crate::types::zones::Zone;
 
 use super::players;
@@ -578,13 +581,23 @@ fn do_eliminate(
     let planar_handoff =
         crate::game::planechase::prepare_player_left_game_handoff(state, player, leaving_set);
 
-    // Mark as eliminated
-    if let Some(p) = state.players.iter_mut().find(|p| p.id == player) {
-        p.is_eliminated = true;
-    }
-    if !state.eliminated_players.contains(&player) {
-        state.eliminated_players.push(player);
-    }
+    // CR 733 + CR 800.4: open the leave's own execution node BEFORE the sweep, so
+    // every command it settles below — the owned-object exiles, the control
+    // reversions — is attributed to the departure rather than to whatever rules
+    // work happened to be live when the state-based action fired. The node stays
+    // active for the remainder of this function.
+    let leave_node = state.begin_player_leave_journal_node();
+    let enclosing_node = state.active_rules_execution_node.replace(leave_node);
+    let command = ResolvedPlayerLeaveCommand {
+        player,
+        cause: leave_node,
+    };
+    apply_resolved_player_leave(state, &command)
+        .expect("a living player must satisfy their own departure precondition");
+    state
+        .resolved_rules_journal
+        .record_player_leave(command)
+        .expect("resolved player leave must have a live journal cause");
 
     abandon_source_bound_resolution_prompt(state, player);
     retire_pending_zone_change_contexts_owned_by(state, player);
@@ -948,6 +961,38 @@ fn do_eliminate(
     }
 
     events.push(GameEvent::PlayerEliminated { player_id: player });
+
+    // The leave node covers this sweep only. Restoring the enclosing scope keeps
+    // a later, unrelated command from being attributed to the departure.
+    state.active_rules_execution_node = enclosing_node;
+}
+
+/// CR 800.4 + CR 104.3a: Installs one already-resolved player departure verbatim.
+///
+/// Deliberately re-runs none of the CR 104 loss conditions that produced the
+/// departure: whether this player lost was settled when the command was
+/// recorded.
+pub fn apply_resolved_player_leave(
+    state: &mut GameState,
+    command: &ResolvedPlayerLeaveCommand,
+) -> Result<(), ResolvedPlayerLeaveReplayInvariantError> {
+    let player = state
+        .players
+        .iter_mut()
+        .find(|p| p.id == command.player)
+        .ok_or(ResolvedPlayerLeaveReplayInvariantError::UnknownPlayer(
+            command.player,
+        ))?;
+    if player.is_eliminated {
+        return Err(ResolvedPlayerLeaveReplayInvariantError::AlreadyEliminated(
+            command.player,
+        ));
+    }
+    player.is_eliminated = true;
+    if !state.eliminated_players.contains(&command.player) {
+        state.eliminated_players.push(command.player);
+    }
+    Ok(())
 }
 
 /// CR 800.4a: A paused carrier retains trigger-source contexts from the

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -2479,9 +2479,11 @@ pub(crate) fn deliver_replaced_zone_change(
         // visible at ETB trigger fire-time (CR 603.4).
         if to == Zone::Battlefield {
             if let Some(src) = source_id {
-                if let Some(obj) = state.objects.get_mut(&object_id) {
-                    obj.entered_via_ability_source = Some(src);
-                }
+                // CR 733: route the stamp through its single authority so the
+                // provenance is captured as a resolved command instead of written
+                // raw. The authority keeps the prior silent skip when the object
+                // is no longer present.
+                zones::stamp_battlefield_entry_provenance(state, object_id, src);
             }
         }
         // CR 110.2a: Apply controller override if the effect specifies

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -1918,11 +1918,6 @@ pub(crate) fn apply_battlefield_entry_controller_override(
     let expected_old_base_controller = object_snapshot.and_then(|obj| obj.base_controller);
     let expected_old_controller = object_snapshot.map(|obj| obj.controller);
 
-    if let Some(obj) = state.objects.get_mut(&object_id) {
-        obj.base_controller = Some(controller);
-        obj.controller = controller;
-    }
-
     // Resolve the snapshot POSITIONS rather than mutating through a scan: the
     // position is what the CR 733 command records, so replay retags the same
     // record instead of re-running a last-match scan (CR 400.7 permits the same
@@ -1931,21 +1926,35 @@ pub(crate) fn apply_battlefield_entry_controller_override(
         .zone_changes_this_turn
         .iter()
         .rposition(|record| record.object_id == object_id && record.to_zone == Zone::Battlefield);
-    if let Some(record) =
-        zone_change_index.and_then(|index| state.zone_changes_this_turn.get_mut(index))
-    {
-        record.controller = controller;
-        record.sync_trigger_source_context();
-    }
-
     let battlefield_entry_index = state
         .battlefield_entries_this_turn
         .iter()
         .rposition(|record| record.object_id == object_id);
-    if let Some(record) =
-        battlefield_entry_index.and_then(|index| state.battlefield_entries_this_turn.get_mut(index))
-    {
-        record.controller = controller;
+
+    // CR 733: the retag itself is performed by the command applier, so resolve and
+    // replay install through one body instead of two copies that can drift. An
+    // absent object has nothing to retag on the object side but still retags its
+    // snapshots, exactly as before.
+    let command = reference.zip(expected_old_controller).map(|(object, old)| {
+        ResolvedControllerOverrideCommand {
+            object,
+            expected_old_base_controller,
+            expected_old_controller: old,
+            resulting_controller: controller,
+            zone_change_index,
+            battlefield_entry_index,
+            cause: state.current_or_begin_rules_execution_node(),
+        }
+    });
+    match &command {
+        Some(command) => apply_resolved_controller_override(state, command)
+            .expect("the freshly read object must satisfy its own override precondition"),
+        None => retag_battlefield_entry_snapshots(
+            state,
+            zone_change_index,
+            battlefield_entry_index,
+            controller,
+        ),
     }
 
     if let Some(GameEvent::ZoneChanged { record, .. }) = events.iter_mut().rev().find(|event| {
@@ -1962,31 +1971,45 @@ pub(crate) fn apply_battlefield_entry_controller_override(
         record.sync_trigger_source_context();
     }
 
-    // CR 733: journal the settled override through its owning authority. The
-    // event fix-up above is deliberately NOT part of the command — events are
-    // transient carriers consumed by the same resolution, not persistent state a
-    // replay reconstructs.
+    // CR 733: journal the settled override. The event fix-up above is deliberately
+    // NOT part of the command — events are transient carriers consumed by the same
+    // resolution, not persistent state a replay reconstructs.
     // CR 110.2a: an override onto the controller the object already had, with the
     // base controller already pinned there, retagged nothing and is not recorded.
-    let Some((reference, expected_old_controller)) = reference.zip(expected_old_controller) else {
+    let Some(command) = command else {
         return;
     };
-    if expected_old_base_controller == Some(controller) && expected_old_controller == controller {
+    if command.expected_old_base_controller == Some(controller)
+        && command.expected_old_controller == controller
+    {
         return;
     }
-    let cause = state.current_or_begin_rules_execution_node();
     state
         .resolved_rules_journal
-        .record_controller_override(ResolvedControllerOverrideCommand {
-            object: reference,
-            expected_old_base_controller,
-            expected_old_controller,
-            resulting_controller: controller,
-            zone_change_index,
-            battlefield_entry_index,
-            cause,
-        })
+        .record_controller_override(command)
         .expect("resolved controller override must have a live journal cause");
+}
+
+/// Retags the CR 400.7 zone-change and CR 403.3 battlefield-entry snapshots at
+/// the exact recorded positions. Shared by the resolve-time authority and the
+/// replay applier so both install the same retag.
+fn retag_battlefield_entry_snapshots(
+    state: &mut GameState,
+    zone_change_index: Option<usize>,
+    battlefield_entry_index: Option<usize>,
+    controller: PlayerId,
+) {
+    if let Some(record) =
+        zone_change_index.and_then(|index| state.zone_changes_this_turn.get_mut(index))
+    {
+        record.controller = controller;
+        record.sync_trigger_source_context();
+    }
+    if let Some(record) =
+        battlefield_entry_index.and_then(|index| state.battlefield_entries_this_turn.get_mut(index))
+    {
+        record.controller = controller;
+    }
 }
 
 /// Installs one already-resolved CR 110.2a controller override verbatim.
@@ -2053,19 +2076,12 @@ pub fn apply_resolved_controller_override(
         obj.base_controller = Some(command.resulting_controller);
         obj.controller = command.resulting_controller;
     }
-    if let Some(record) = command
-        .zone_change_index
-        .and_then(|index| state.zone_changes_this_turn.get_mut(index))
-    {
-        record.controller = command.resulting_controller;
-        record.sync_trigger_source_context();
-    }
-    if let Some(record) = command
-        .battlefield_entry_index
-        .and_then(|index| state.battlefield_entries_this_turn.get_mut(index))
-    {
-        record.controller = command.resulting_controller;
-    }
+    retag_battlefield_entry_snapshots(
+        state,
+        command.zone_change_index,
+        command.battlefield_entry_index,
+        command.resulting_controller,
+    );
     Ok(())
 }
 

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -8,7 +8,8 @@ use crate::types::player::PlayerId;
 use crate::types::resolved_commands::{
     ResolvedControllerOverrideCommand, ResolvedControllerOverrideReplayInvariantError,
     ResolvedEntryProvenanceCommand, ResolvedEntryProvenanceReplayInvariantError,
-    ResolvedZoneChangeCommand, ResolvedZoneChangeReplayInvariantError,
+    ResolvedObjectCeaseCommand, ResolvedObjectCeaseReplayInvariantError, ResolvedZoneChangeCommand,
+    ResolvedZoneChangeReplayInvariantError,
 };
 use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
@@ -1737,8 +1738,63 @@ pub(crate) fn cease_object(
     zone: Zone,
     owner: PlayerId,
 ) {
-    remove_from_zone(state, object_id, zone, owner);
+    // CR 733: capture the occurrence BEFORE the removal — after it there is no
+    // object left to reference. A caller that passes an already-absent object
+    // keeps the prior silent behavior and journals nothing.
+    let Some(object) = state.objects.get(&object_id) else {
+        remove_from_zone(state, object_id, zone, owner);
+        return;
+    };
+    let command = ResolvedObjectCeaseCommand {
+        object: ObjectIncarnationRef::from_object(object),
+        expected_zone: zone,
+        owner,
+        cause: state.current_or_begin_rules_execution_node(),
+    };
+    apply_resolved_object_cease(state, &command)
+        .expect("the freshly read object must satisfy its own cease precondition");
+    state
+        .resolved_rules_journal
+        .record_object_cease(command)
+        .expect("resolved cease-to-exist must have a live journal cause");
+}
+
+/// Installs one already-resolved CR 704.5d cease-to-exist removal verbatim.
+///
+/// Deliberately re-runs none of the CR 704.5d/e eligibility scan: whether this
+/// object was a token outside the battlefield was settled by the SBA sweep that
+/// recorded the command.
+pub fn apply_resolved_object_cease(
+    state: &mut GameState,
+    command: &ResolvedObjectCeaseCommand,
+) -> Result<(), ResolvedObjectCeaseReplayInvariantError> {
+    let object_id = command.object.object_id;
+    let object = state.objects.get(&object_id).ok_or(
+        ResolvedObjectCeaseReplayInvariantError::UnknownObject(object_id),
+    )?;
+    let found = ObjectIncarnationRef::from_object(object);
+    if found != command.object {
+        return Err(ResolvedObjectCeaseReplayInvariantError::StaleObject {
+            expected: command.object,
+            found,
+        });
+    }
+    if object.zone != command.expected_zone {
+        return Err(ResolvedObjectCeaseReplayInvariantError::ZoneMismatch {
+            expected: command.expected_zone,
+            found: object.zone,
+        });
+    }
+    if object.owner != command.owner {
+        return Err(ResolvedObjectCeaseReplayInvariantError::OwnerMismatch {
+            expected: command.owner,
+            found: object.owner,
+        });
+    }
+
+    remove_from_zone(state, object_id, command.expected_zone, command.owner);
     state.objects.remove(&object_id);
+    Ok(())
 }
 
 /// Add an ObjectId to the appropriate zone collection.

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -6,6 +6,8 @@ use crate::types::game_state::{
 use crate::types::identifiers::{CardId, ObjectId, ObjectIncarnationRef};
 use crate::types::player::PlayerId;
 use crate::types::resolved_commands::{
+    ResolvedControllerOverrideCommand, ResolvedControllerOverrideReplayInvariantError,
+    ResolvedEntryProvenanceCommand, ResolvedEntryProvenanceReplayInvariantError,
     ResolvedZoneChangeCommand, ResolvedZoneChangeReplayInvariantError,
 };
 use crate::types::statics::StaticMode;
@@ -1852,26 +1854,40 @@ pub(crate) fn apply_battlefield_entry_controller_override(
     object_id: ObjectId,
     controller: PlayerId,
 ) {
+    // Read the pre-override identity and controllers once: they are the CR 733
+    // command's occurrence reference and preconditions. An absent object still
+    // retags the snapshots below, exactly as before, and simply journals nothing.
+    let object_snapshot = state.objects.get(&object_id);
+    let reference = object_snapshot.map(ObjectIncarnationRef::from_object);
+    let expected_old_base_controller = object_snapshot.and_then(|obj| obj.base_controller);
+    let expected_old_controller = object_snapshot.map(|obj| obj.controller);
+
     if let Some(obj) = state.objects.get_mut(&object_id) {
         obj.base_controller = Some(controller);
         obj.controller = controller;
     }
 
-    if let Some(record) = state
+    // Resolve the snapshot POSITIONS rather than mutating through a scan: the
+    // position is what the CR 733 command records, so replay retags the same
+    // record instead of re-running a last-match scan (CR 400.7 permits the same
+    // object to hold several entries in one turn).
+    let zone_change_index = state
         .zone_changes_this_turn
-        .iter_mut()
-        .rev()
-        .find(|record| record.object_id == object_id && record.to_zone == Zone::Battlefield)
+        .iter()
+        .rposition(|record| record.object_id == object_id && record.to_zone == Zone::Battlefield);
+    if let Some(record) =
+        zone_change_index.and_then(|index| state.zone_changes_this_turn.get_mut(index))
     {
         record.controller = controller;
         record.sync_trigger_source_context();
     }
 
-    if let Some(record) = state
+    let battlefield_entry_index = state
         .battlefield_entries_this_turn
-        .iter_mut()
-        .rev()
-        .find(|record| record.object_id == object_id)
+        .iter()
+        .rposition(|record| record.object_id == object_id);
+    if let Some(record) =
+        battlefield_entry_index.and_then(|index| state.battlefield_entries_this_turn.get_mut(index))
     {
         record.controller = controller;
     }
@@ -1889,6 +1905,181 @@ pub(crate) fn apply_battlefield_entry_controller_override(
         record.controller = controller;
         record.sync_trigger_source_context();
     }
+
+    // CR 733: journal the settled override through its owning authority. The
+    // event fix-up above is deliberately NOT part of the command — events are
+    // transient carriers consumed by the same resolution, not persistent state a
+    // replay reconstructs.
+    // CR 110.2a: an override onto the controller the object already had, with the
+    // base controller already pinned there, retagged nothing and is not recorded.
+    let Some((reference, expected_old_controller)) = reference.zip(expected_old_controller) else {
+        return;
+    };
+    if expected_old_base_controller == Some(controller) && expected_old_controller == controller {
+        return;
+    }
+    let cause = state.current_or_begin_rules_execution_node();
+    state
+        .resolved_rules_journal
+        .record_controller_override(ResolvedControllerOverrideCommand {
+            object: reference,
+            expected_old_base_controller,
+            expected_old_controller,
+            resulting_controller: controller,
+            zone_change_index,
+            battlefield_entry_index,
+            cause,
+        })
+        .expect("resolved controller override must have a live journal cause");
+}
+
+/// Installs one already-resolved CR 110.2a controller override verbatim.
+///
+/// Deliberately re-runs none of the entry-time decision that produced the
+/// override: whether the permanent enters under another player's control was
+/// settled when the command was recorded. The applier verifies the state it is
+/// installing into, then retags the object and the exact snapshots the authority
+/// retagged.
+pub fn apply_resolved_controller_override(
+    state: &mut GameState,
+    command: &ResolvedControllerOverrideCommand,
+) -> Result<(), ResolvedControllerOverrideReplayInvariantError> {
+    let object_id = command.object.object_id;
+    let object = state
+        .objects
+        .get(&object_id)
+        .ok_or(ResolvedControllerOverrideReplayInvariantError::UnknownObject(object_id))?;
+    let found = ObjectIncarnationRef::from_object(object);
+    if found != command.object {
+        return Err(
+            ResolvedControllerOverrideReplayInvariantError::StaleObject {
+                expected: command.object,
+                found,
+            },
+        );
+    }
+    if object.base_controller != command.expected_old_base_controller {
+        return Err(
+            ResolvedControllerOverrideReplayInvariantError::BaseControllerPreconditionMismatch {
+                expected: command.expected_old_base_controller,
+                found: object.base_controller,
+            },
+        );
+    }
+    if object.controller != command.expected_old_controller {
+        return Err(
+            ResolvedControllerOverrideReplayInvariantError::ControllerPreconditionMismatch {
+                expected: command.expected_old_controller,
+                found: object.controller,
+            },
+        );
+    }
+    // Both recorded snapshot positions are checked before any mutation so a
+    // rejected command leaves no partial retag.
+    if let Some(index) = command.zone_change_index {
+        if index >= state.zone_changes_this_turn.len() {
+            return Err(
+                ResolvedControllerOverrideReplayInvariantError::MissingZoneChangeRecord(index),
+            );
+        }
+    }
+    if let Some(index) = command.battlefield_entry_index {
+        if index >= state.battlefield_entries_this_turn.len() {
+            return Err(
+                ResolvedControllerOverrideReplayInvariantError::MissingBattlefieldEntryRecord(
+                    index,
+                ),
+            );
+        }
+    }
+
+    if let Some(obj) = state.objects.get_mut(&object_id) {
+        obj.base_controller = Some(command.resulting_controller);
+        obj.controller = command.resulting_controller;
+    }
+    if let Some(record) = command
+        .zone_change_index
+        .and_then(|index| state.zone_changes_this_turn.get_mut(index))
+    {
+        record.controller = command.resulting_controller;
+        record.sync_trigger_source_context();
+    }
+    if let Some(record) = command
+        .battlefield_entry_index
+        .and_then(|index| state.battlefield_entries_this_turn.get_mut(index))
+    {
+        record.controller = command.resulting_controller;
+    }
+    Ok(())
+}
+
+/// CR 603.6a: Stamps the entering permanent with the ability that put it onto
+/// the battlefield, so anti-recursion intervening-ifs ("if it wasn't put onto
+/// the battlefield with this ability") can exclude the permanents that very
+/// ability placed.
+///
+/// This is the single authority for the stamp: the delivery tail wrote the field
+/// raw, leaving a CR 733 replay with no record that the permanent's entry was
+/// ability-driven.
+pub(crate) fn stamp_battlefield_entry_provenance(
+    state: &mut GameState,
+    object_id: ObjectId,
+    source_id: ObjectId,
+) {
+    let Some(object) = state.objects.get(&object_id) else {
+        return;
+    };
+    let reference = ObjectIncarnationRef::from_object(object);
+    let expected_old_source = object.entered_via_ability_source;
+    // CR 603.6a: re-stamping the source already recorded changes nothing.
+    if expected_old_source == Some(source_id) {
+        return;
+    }
+
+    let command = ResolvedEntryProvenanceCommand {
+        object: reference,
+        expected_old_source,
+        resulting_source: source_id,
+        cause: state.current_or_begin_rules_execution_node(),
+    };
+    apply_resolved_entry_provenance(state, &command)
+        .expect("the freshly read object must satisfy its own provenance precondition");
+    state
+        .resolved_rules_journal
+        .record_entry_provenance(command)
+        .expect("resolved entry provenance must have a live journal cause");
+}
+
+/// Installs one already-resolved CR 603.6a provenance stamp verbatim.
+pub fn apply_resolved_entry_provenance(
+    state: &mut GameState,
+    command: &ResolvedEntryProvenanceCommand,
+) -> Result<(), ResolvedEntryProvenanceReplayInvariantError> {
+    let object_id = command.object.object_id;
+    let object = state.objects.get(&object_id).ok_or(
+        ResolvedEntryProvenanceReplayInvariantError::UnknownObject(object_id),
+    )?;
+    let found = ObjectIncarnationRef::from_object(object);
+    if found != command.object {
+        return Err(ResolvedEntryProvenanceReplayInvariantError::StaleObject {
+            expected: command.object,
+            found,
+        });
+    }
+    if object.entered_via_ability_source != command.expected_old_source {
+        return Err(
+            ResolvedEntryProvenanceReplayInvariantError::SourcePreconditionMismatch {
+                expected: command.expected_old_source,
+                found: object.entered_via_ability_source,
+            },
+        );
+    }
+    state
+        .objects
+        .get_mut(&object_id)
+        .expect("the validated object must remain present")
+        .entered_via_ability_source = Some(command.resulting_source);
+    Ok(())
 }
 
 /// CR 614.1d: Check if any active CantEnterBattlefieldFrom static prevents this

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -15770,6 +15770,16 @@ impl GameState {
         })
     }
 
+    /// CR 800.4: Begin the distinct execution node for one player leaving the
+    /// game, so every mutation the leave sweep performs is attributed to the
+    /// leave rather than to whatever rules work was in flight when the
+    /// state-based action fired.
+    pub(crate) fn begin_player_leave_journal_node(&mut self) -> RulesExecutionNodeRef {
+        self.resolved_rules_journal
+            .begin_player_leave()
+            .expect("resolved-rules journal command ordinal overflow")
+    }
+
     /// CR 605.3b: Begin the distinct, immediate execution node for one
     /// activated mana ability. A nested activation records its active parent as
     /// the causal dependency without changing activation behavior.

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::game::game_object::AttachTarget;
 use crate::game::triggers::{ConsumedTriggerEventOccurrence, PendingTriggerContext};
 
 use super::ability::TriggerDefinitionRef;
@@ -180,6 +181,53 @@ pub enum ResolvedObjectTransformReplayInvariantError {
     TransformedPreconditionMismatch { expected: bool, found: bool },
     #[error("transform command object {0:?} has no back face to swap")]
     MissingBackFace(ObjectId),
+}
+
+/// One exact CR 701.3 attachment-graph edit.
+///
+/// The three production authorities — `attach_to`, `attach_to_player`, and
+/// `unattach` — perform the same graph mutation parameterized by the resulting
+/// host, so they share one command instead of three sibling variants:
+/// `Some(Object)` (CR 301.5 / CR 303.4f), `Some(Player)` (CR 303.4), and `None`
+/// (CR 701.3d unattach) are leaf values of the `Option<AttachTarget>` the object
+/// already stores.
+///
+/// CR 613.7e + CR 701.3c: attaching to a DIFFERENT host draws a new timestamp,
+/// which orders the attachment against continuous effects in the layer system; a
+/// same-host re-attach (CR 701.3b) and an unattach draw none. `resulting_timestamp`
+/// is therefore `Some` exactly when the authority drew one, and replay installs
+/// that value — mirroring the transform and zone-change families — instead of
+/// re-drawing from `GameState::next_timestamp` and silently reordering layers.
+///
+/// The host-side `attachments` list is not recorded: removing the attachment from
+/// its old host and pushing it onto the new one is a structural consequence of the
+/// recorded host transition, not a re-selection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedAttachmentCommand {
+    pub attachment: ObjectIncarnationRef,
+    pub expected_old_host: Option<AttachTarget>,
+    pub resulting_host: Option<AttachTarget>,
+    pub resulting_timestamp: Option<u64>,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// Typed failure while applying one already-resolved attachment edit.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedAttachmentReplayInvariantError {
+    #[error("attachment command references an unknown object {0:?}")]
+    UnknownAttachment(ObjectId),
+    #[error("attachment occurrence mismatch: expected {expected:?}, found {found:?}")]
+    StaleAttachment {
+        expected: ObjectIncarnationRef,
+        found: ObjectIncarnationRef,
+    },
+    #[error("attachment host precondition mismatch: expected {expected:?}, found {found:?}")]
+    HostPreconditionMismatch {
+        expected: Option<AttachTarget>,
+        found: Option<AttachTarget>,
+    },
+    #[error("attachment command references an unknown host object {0:?}")]
+    UnknownHost(ObjectId),
 }
 
 /// The audience that received one exact revealed-card fact.
@@ -427,6 +475,7 @@ pub enum ResolvedRulesCommand {
     ObjectStatus(ResolvedObjectStatusCommand),
     ObjectCounter(ResolvedObjectCounterCommand),
     ObjectTransform(ResolvedObjectTransformCommand),
+    Attachment(ResolvedAttachmentCommand),
     Information(ResolvedInformationCommand),
     LedgerEdit(ResolvedLedgerEditCommand),
     LibraryShuffle(ResolvedLibraryShuffleCommand),
@@ -1329,6 +1378,14 @@ impl ResolvedRulesJournal {
         )
     }
 
+    /// Records one exact CR 701.3 attachment-graph edit under its causal node.
+    pub fn record_attachment(
+        &mut self,
+        command: ResolvedAttachmentCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(command.cause, ResolvedRulesCommand::Attachment(command))
+    }
+
     /// Records one exact bounded resolution-frame transition under its causal node.
     pub fn record_frame_transition(
         &mut self,
@@ -1550,6 +1607,7 @@ impl ResolvedRulesJournal {
                 | ResolvedRulesCommand::ObjectStatus(_)
                 | ResolvedRulesCommand::ObjectCounter(_)
                 | ResolvedRulesCommand::ObjectTransform(_)
+                | ResolvedRulesCommand::Attachment(_)
                 | ResolvedRulesCommand::Information(_)
                 | ResolvedRulesCommand::LedgerEdit(_)
                 | ResolvedRulesCommand::LibraryShuffle(_)
@@ -1805,6 +1863,24 @@ impl ResolvedRulesJournal {
                     return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
                         "transform command does not change the displayed face, or has an \
                          unrelated cause"
+                            .to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::Attachment(command) => {
+                // CR 701.3b: re-attaching to the host it is already attached to
+                // does nothing, so a recorded edit that leaves the host unchanged
+                // is not an edit that ever happened.
+                // CR 613.7e + CR 701.3c/d: a move to a new host draws a timestamp
+                // and an unattach does not, so the drawn value is present on
+                // exactly the commands that installed a host.
+                if entry.node != command.cause
+                    || command.expected_old_host == command.resulting_host
+                    || command.resulting_timestamp.is_some() != command.resulting_host.is_some()
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "attachment command does not change the host, mismatches its timestamp \
+                         draw, or has an unrelated cause"
                             .to_string(),
                     ));
                 }

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -230,6 +230,90 @@ pub enum ResolvedAttachmentReplayInvariantError {
     UnknownHost(ObjectId),
 }
 
+/// One exact CR 110.2a + CR 603.6a "under your control" battlefield-entry
+/// controller override.
+///
+/// The override retags the live object AND the two turn-record snapshots the
+/// entry created, so a replay that installed only the object's controller would
+/// leave "entered under whose control" look-back queries answering with the
+/// pre-override controller.
+///
+/// The record positions are RECORDED rather than re-found at replay time,
+/// mirroring `ResolvedZoneChangeCommand::turn_zone_change_index`: the resolve-time
+/// authority knows exactly which snapshot it retagged, and re-running a
+/// last-match scan against a replayed board could land on a different entry when
+/// the same object entered twice in one turn. They are `Option` because the
+/// override also runs for entries whose snapshots are absent (CR 603.6a
+/// leaves-the-battlefield reconstruction, and the elimination path).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedControllerOverrideCommand {
+    pub object: ObjectIncarnationRef,
+    pub expected_old_base_controller: Option<PlayerId>,
+    pub expected_old_controller: PlayerId,
+    pub resulting_controller: PlayerId,
+    pub zone_change_index: Option<usize>,
+    pub battlefield_entry_index: Option<usize>,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// Typed failure while applying one already-resolved controller override.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedControllerOverrideReplayInvariantError {
+    #[error("controller-override command references an unknown object {0:?}")]
+    UnknownObject(ObjectId),
+    #[error("controller-override occurrence mismatch: expected {expected:?}, found {found:?}")]
+    StaleObject {
+        expected: ObjectIncarnationRef,
+        found: ObjectIncarnationRef,
+    },
+    #[error("controller-override base-controller precondition mismatch: expected {expected:?}, found {found:?}")]
+    BaseControllerPreconditionMismatch {
+        expected: Option<PlayerId>,
+        found: Option<PlayerId>,
+    },
+    #[error("controller-override controller precondition mismatch: expected {expected:?}, found {found:?}")]
+    ControllerPreconditionMismatch { expected: PlayerId, found: PlayerId },
+    #[error("controller-override references a missing zone-change record at {0}")]
+    MissingZoneChangeRecord(usize),
+    #[error("controller-override references a missing battlefield-entry record at {0}")]
+    MissingBattlefieldEntryRecord(usize),
+}
+
+/// One exact CR 603.6a battlefield-entry provenance stamp.
+///
+/// The entering permanent records which ability put it there so anti-recursion
+/// intervening-ifs ("if it wasn't put onto the battlefield with this ability")
+/// can exclude the permanents that very ability placed. A replay that dropped the
+/// stamp would let those abilities re-trigger off their own output.
+///
+/// `resulting_source` is not an `Option`: the delivery tail stamps only
+/// ability-driven entries, and `reset_for_battlefield_entry` has already cleared
+/// the field, so a recorded stamp always installs a concrete source.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedEntryProvenanceCommand {
+    pub object: ObjectIncarnationRef,
+    pub expected_old_source: Option<ObjectId>,
+    pub resulting_source: ObjectId,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// Typed failure while applying one already-resolved entry-provenance stamp.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedEntryProvenanceReplayInvariantError {
+    #[error("entry-provenance command references an unknown object {0:?}")]
+    UnknownObject(ObjectId),
+    #[error("entry-provenance occurrence mismatch: expected {expected:?}, found {found:?}")]
+    StaleObject {
+        expected: ObjectIncarnationRef,
+        found: ObjectIncarnationRef,
+    },
+    #[error("entry-provenance precondition mismatch: expected {expected:?}, found {found:?}")]
+    SourcePreconditionMismatch {
+        expected: Option<ObjectId>,
+        found: Option<ObjectId>,
+    },
+}
+
 /// The audience that received one exact revealed-card fact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResolvedInformationAudience {
@@ -476,6 +560,8 @@ pub enum ResolvedRulesCommand {
     ObjectCounter(ResolvedObjectCounterCommand),
     ObjectTransform(ResolvedObjectTransformCommand),
     Attachment(ResolvedAttachmentCommand),
+    ControllerOverride(ResolvedControllerOverrideCommand),
+    EntryProvenance(ResolvedEntryProvenanceCommand),
     Information(ResolvedInformationCommand),
     LedgerEdit(ResolvedLedgerEditCommand),
     LibraryShuffle(ResolvedLibraryShuffleCommand),
@@ -1386,6 +1472,28 @@ impl ResolvedRulesJournal {
         self.append_command(command.cause, ResolvedRulesCommand::Attachment(command))
     }
 
+    /// Records one exact CR 110.2a controller override under its causal node.
+    pub fn record_controller_override(
+        &mut self,
+        command: ResolvedControllerOverrideCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(
+            command.cause,
+            ResolvedRulesCommand::ControllerOverride(command),
+        )
+    }
+
+    /// Records one exact CR 603.6a entry-provenance stamp under its causal node.
+    pub fn record_entry_provenance(
+        &mut self,
+        command: ResolvedEntryProvenanceCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(
+            command.cause,
+            ResolvedRulesCommand::EntryProvenance(command),
+        )
+    }
+
     /// Records one exact bounded resolution-frame transition under its causal node.
     pub fn record_frame_transition(
         &mut self,
@@ -1608,6 +1716,8 @@ impl ResolvedRulesJournal {
                 | ResolvedRulesCommand::ObjectCounter(_)
                 | ResolvedRulesCommand::ObjectTransform(_)
                 | ResolvedRulesCommand::Attachment(_)
+                | ResolvedRulesCommand::ControllerOverride(_)
+                | ResolvedRulesCommand::EntryProvenance(_)
                 | ResolvedRulesCommand::Information(_)
                 | ResolvedRulesCommand::LedgerEdit(_)
                 | ResolvedRulesCommand::LibraryShuffle(_)
@@ -1881,6 +1991,34 @@ impl ResolvedRulesJournal {
                     return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
                         "attachment command does not change the host, mismatches its timestamp \
                          draw, or has an unrelated cause"
+                            .to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::ControllerOverride(command) => {
+                // CR 110.2a: an override that leaves both the derived and the
+                // pinned controller exactly as they were retagged nothing, so it
+                // is not an override that ever happened.
+                if entry.node != command.cause
+                    || (command.expected_old_base_controller == Some(command.resulting_controller)
+                        && command.expected_old_controller == command.resulting_controller)
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "controller-override command changes no controller, or has an unrelated \
+                         cause"
+                            .to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::EntryProvenance(command) => {
+                // CR 603.6a: a stamp that names the source the object was already
+                // stamped with recorded nothing.
+                if entry.node != command.cause
+                    || command.expected_old_source == Some(command.resulting_source)
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "entry-provenance command re-stamps the same source, or has an unrelated \
+                         cause"
                             .to_string(),
                     ));
                 }

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -347,6 +347,32 @@ pub enum ResolvedObjectCeaseReplayInvariantError {
     OwnerMismatch { expected: PlayerId, found: PlayerId },
 }
 
+/// One exact CR 800.4 player departure.
+///
+/// The departure itself is two writes — the player's `is_eliminated` flag and
+/// their append to `eliminated_players` — that always move together, so they are
+/// one command rather than two. Everything the CR 800.4 sweep does afterwards
+/// (exiling owned objects, reverting control effects, clearing the stack)
+/// already journals through its own family; this command carries the departure,
+/// and the surrounding `PlayerLeave` node carries the causal grouping.
+///
+/// There is no `expected_old` field: "was still in the game" is the precondition,
+/// and a stored copy could only ever hold one value.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedPlayerLeaveCommand {
+    pub player: PlayerId,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// Typed failure while applying one already-resolved player departure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedPlayerLeaveReplayInvariantError {
+    #[error("player-leave command references an unknown player {0:?}")]
+    UnknownPlayer(PlayerId),
+    #[error("player-leave command re-eliminates player {0:?}, who had already left")]
+    AlreadyEliminated(PlayerId),
+}
+
 /// The audience that received one exact revealed-card fact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResolvedInformationAudience {
@@ -596,6 +622,7 @@ pub enum ResolvedRulesCommand {
     ControllerOverride(ResolvedControllerOverrideCommand),
     EntryProvenance(ResolvedEntryProvenanceCommand),
     ObjectCease(ResolvedObjectCeaseCommand),
+    PlayerLeave(ResolvedPlayerLeaveCommand),
     Information(ResolvedInformationCommand),
     LedgerEdit(ResolvedLedgerEditCommand),
     LibraryShuffle(ResolvedLibraryShuffleCommand),
@@ -1271,6 +1298,42 @@ impl ResolvedRulesJournal {
         Ok(identity)
     }
 
+    /// CR 800.4: Begin the distinct execution node for one player leaving the
+    /// game.
+    ///
+    /// A leave is not a proposal: every mutation the CR 800.4 sweep performs —
+    /// the owned-object exiles, the control-effect reversions, the stack
+    /// removals — is caused by the leave itself, not by whatever rules work
+    /// happened to be in flight when the state-based action fired. Giving the
+    /// leave its own node keeps those commands attributed to it, so a replay can
+    /// identify the sweep as one causal unit.
+    pub fn begin_player_leave(
+        &mut self,
+    ) -> Result<RulesExecutionNodeRef, ResolvedRulesJournalError> {
+        self.ensure_command_capacity()?;
+        self.ensure_node_capacity()?;
+        let command = self.allocate_command();
+        let ordinal = self.allocate_node();
+        let identity = RulesExecutionNodeRef::PlayerLeave(command);
+        self.entries.push(ResolvedCommandJournalEntry {
+            ordinal: command,
+            node: identity,
+            command: None,
+        });
+        self.nodes.push(SettlementNode {
+            ordinal,
+            identity,
+            kind: RulesExecutionNodeKind::PlayerLeave,
+            caused_by: None,
+            depends_on: Vec::new(),
+            bundle_parent: None,
+            produced_pips: Vec::new(),
+            spent_pips: Vec::new(),
+            journal_ordinals: vec![command],
+        });
+        Ok(identity)
+    }
+
     pub fn begin_activated_mana(
         &mut self,
         source: ObjectIncarnationRef,
@@ -1536,6 +1599,14 @@ impl ResolvedRulesJournal {
         self.append_command(command.cause, ResolvedRulesCommand::ObjectCease(command))
     }
 
+    /// Records one exact CR 800.4 player departure under its causal node.
+    pub fn record_player_leave(
+        &mut self,
+        command: ResolvedPlayerLeaveCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(command.cause, ResolvedRulesCommand::PlayerLeave(command))
+    }
+
     /// Records one exact bounded resolution-frame transition under its causal node.
     pub fn record_frame_transition(
         &mut self,
@@ -1761,6 +1832,7 @@ impl ResolvedRulesJournal {
                 | ResolvedRulesCommand::ControllerOverride(_)
                 | ResolvedRulesCommand::EntryProvenance(_)
                 | ResolvedRulesCommand::ObjectCease(_)
+                | ResolvedRulesCommand::PlayerLeave(_)
                 | ResolvedRulesCommand::Information(_)
                 | ResolvedRulesCommand::LedgerEdit(_)
                 | ResolvedRulesCommand::LibraryShuffle(_)
@@ -2076,6 +2148,17 @@ impl ResolvedRulesJournal {
                         "cease command names a zone objects never cease from, or has an \
                          unrelated cause"
                             .to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::PlayerLeave(command) => {
+                // CR 800.4: a departure is caused by the leave node opened for
+                // it, never by an unrelated proposal that happened to be live.
+                if entry.node != command.cause
+                    || !matches!(command.cause, RulesExecutionNodeRef::PlayerLeave(_))
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "player-leave command is not attributed to a player-leave node".to_string(),
                     ));
                 }
             }

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -314,6 +314,39 @@ pub enum ResolvedEntryProvenanceReplayInvariantError {
     },
 }
 
+/// One exact CR 704.5d / CR 704.5e cease-to-exist removal.
+///
+/// Ceasing to exist is NOT a zone change (CR 400.7) — no event is emitted and no
+/// "whenever exiled" trigger fires — so it cannot ride the zone-change family. It
+/// is the only production path that deletes an object outright, and a replay that
+/// omitted it would leave a token alive in a zone the rules already swept it from.
+///
+/// No characteristics are recorded: replay removes the object the retained prefix
+/// already reconstructed rather than rebuilding a deleted one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedObjectCeaseCommand {
+    pub object: ObjectIncarnationRef,
+    pub expected_zone: Zone,
+    pub owner: PlayerId,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// Typed failure while applying one already-resolved cease-to-exist removal.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedObjectCeaseReplayInvariantError {
+    #[error("cease command references an unknown object {0:?}")]
+    UnknownObject(ObjectId),
+    #[error("cease occurrence mismatch: expected {expected:?}, found {found:?}")]
+    StaleObject {
+        expected: ObjectIncarnationRef,
+        found: ObjectIncarnationRef,
+    },
+    #[error("cease zone mismatch: expected {expected:?}, found {found:?}")]
+    ZoneMismatch { expected: Zone, found: Zone },
+    #[error("cease owner mismatch: expected {expected:?}, found {found:?}")]
+    OwnerMismatch { expected: PlayerId, found: PlayerId },
+}
+
 /// The audience that received one exact revealed-card fact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResolvedInformationAudience {
@@ -562,6 +595,7 @@ pub enum ResolvedRulesCommand {
     Attachment(ResolvedAttachmentCommand),
     ControllerOverride(ResolvedControllerOverrideCommand),
     EntryProvenance(ResolvedEntryProvenanceCommand),
+    ObjectCease(ResolvedObjectCeaseCommand),
     Information(ResolvedInformationCommand),
     LedgerEdit(ResolvedLedgerEditCommand),
     LibraryShuffle(ResolvedLibraryShuffleCommand),
@@ -1494,6 +1528,14 @@ impl ResolvedRulesJournal {
         )
     }
 
+    /// Records one exact CR 704.5d cease-to-exist removal under its causal node.
+    pub fn record_object_cease(
+        &mut self,
+        command: ResolvedObjectCeaseCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(command.cause, ResolvedRulesCommand::ObjectCease(command))
+    }
+
     /// Records one exact bounded resolution-frame transition under its causal node.
     pub fn record_frame_transition(
         &mut self,
@@ -1718,6 +1760,7 @@ impl ResolvedRulesJournal {
                 | ResolvedRulesCommand::Attachment(_)
                 | ResolvedRulesCommand::ControllerOverride(_)
                 | ResolvedRulesCommand::EntryProvenance(_)
+                | ResolvedRulesCommand::ObjectCease(_)
                 | ResolvedRulesCommand::Information(_)
                 | ResolvedRulesCommand::LedgerEdit(_)
                 | ResolvedRulesCommand::LibraryShuffle(_)
@@ -2019,6 +2062,19 @@ impl ResolvedRulesJournal {
                     return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
                         "entry-provenance command re-stamps the same source, or has an unrelated \
                          cause"
+                            .to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::ObjectCease(command) => {
+                // CR 704.5d/e: only a token or a copy of a card ceases to exist,
+                // and never from the battlefield or the stack.
+                if entry.node != command.cause
+                    || matches!(command.expected_zone, Zone::Battlefield | Zone::Stack)
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "cease command names a zone objects never cease from, or has an \
+                         unrelated cause"
                             .to_string(),
                     ));
                 }

--- a/crates/engine/tests/integration/cr733_resolved_attachment.rs
+++ b/crates/engine/tests/integration/cr733_resolved_attachment.rs
@@ -1,0 +1,235 @@
+//! CR733 P2 coverage for the attachment family.
+//!
+//! `attach::attach_to`, `attach::attach_to_player`, and `attach::unattach` are
+//! the three authorities every production attachment edit funnels through — the
+//! `Attach` effect, equip and bestow resolution, ETB "enters attached", token
+//! creation, counter-driven attach, `return_as_aura`, and the unattach costs —
+//! but each wrote its mutation raw. A retained-prefix replay therefore had no
+//! record of who was attached to whom.
+//!
+//! The three authorities share ONE command rather than three sibling variants:
+//! they are the same graph mutation parameterized by the resulting host, and
+//! `Option<AttachTarget>` — the type the object already stores — expresses
+//! object host, player host, and unattached as leaf values.
+//!
+//! CR 613.7e + CR 701.3c is why the timestamp must be recorded: attaching to a
+//! different host draws a NEW timestamp that orders the attachment against
+//! continuous effects, so a replay that re-draws one silently reorders the layer
+//! system.
+//!
+//! The test drives the REAL pipeline — a `GameAction::ActivateAbility` equip
+//! activation resolving off the stack — so the edit is produced by the
+//! production resolver, not by a direct call to the authority. The Equipment is
+//! already on the battlefield, so its incarnation is stable across the action and
+//! the recorded command can be replayed against the captured predecessor state.
+
+use engine::game::game_object::AttachTarget;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{Effect, TargetFilter, TypedFilter};
+use engine::types::actions::GameAction;
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::ResolvedRulesCommand;
+
+const EQUIP_ORACLE: &str = "Equipped creature gets +1/+1.\nEquip {0}";
+
+#[test]
+fn equip_journals_an_exact_resolved_attachment() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let creature = scenario.add_vanilla(P0, 2, 2);
+    let equipment = scenario
+        .add_creature(P0, "Test Blade", 0, 1)
+        .as_artifact()
+        .with_subtypes(vec!["Equipment"])
+        .from_oracle_text(EQUIP_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Captured before the activation so the recorded command can be replayed
+    // against the exact predecessor state it was resolved from.
+    let pre_state = runner.state().clone();
+    let journal_start = runner.state().resolved_rules_journal.entries().len();
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: equipment,
+            ability_index: 0,
+        })
+        .expect("Equip {0} is activatable at sorcery speed with a legal host");
+    runner.advance_until_stack_empty();
+
+    // CR 301.5f: the Equipment is attached to the creature. Without these reach
+    // guards the journal assertion below could pass vacuously on an equip that
+    // never resolved.
+    let state = runner.state();
+    assert_eq!(
+        state.objects[&equipment].attached_to,
+        Some(AttachTarget::Object(creature)),
+        "CR 301.5f: the resolved equip must attach the Equipment to the creature"
+    );
+    assert!(
+        state.objects[&creature].attachments.contains(&equipment),
+        "the host must list the Equipment as attached"
+    );
+
+    // The discriminating assertion: the edit is journaled as an exact resolved
+    // command. A raw mutation records nothing here.
+    let attachments: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::Attachment(command)
+                if command.attachment.object_id == equipment =>
+            {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        attachments.len(),
+        1,
+        "the attachment authority must journal exactly one resolved edit"
+    );
+
+    let attachment = &attachments[0];
+    assert_eq!(
+        attachment.expected_old_host, None,
+        "CR 701.3c: the recorded transition is unattached -> the chosen host"
+    );
+    assert_eq!(
+        attachment.resulting_host,
+        Some(AttachTarget::Object(creature)),
+        "the recorded host is the creature the equip resolved onto"
+    );
+    // CR 613.7e: the recorded timestamp is the one the attachment actually
+    // received, not a value re-derived at replay time.
+    assert_eq!(
+        attachment.resulting_timestamp,
+        Some(state.objects[&equipment].timestamp),
+        "the journaled timestamp is the timestamp the attach installed"
+    );
+
+    // Replay-exactness: applying the recorded command to the pre-activation state
+    // reproduces the same host and timestamp with no re-derivation — in
+    // particular without drawing a fresh timestamp from `next_timestamp`.
+    let mut replay = pre_state;
+    engine::game::effects::attach::apply_resolved_attachment(&mut replay, attachment)
+        .expect("the recorded attachment must replay against its captured predecessor");
+    assert_eq!(
+        replay.objects[&equipment].attached_to,
+        Some(AttachTarget::Object(creature)),
+        "replay installs the exact recorded host"
+    );
+    assert!(
+        replay.objects[&creature].attachments.contains(&equipment),
+        "replay installs the host-side attachment edge"
+    );
+    assert_eq!(
+        replay.objects[&equipment].timestamp,
+        attachment
+            .resulting_timestamp
+            .expect("an attach draws a timestamp"),
+        "CR 613.7e: replay installs the recorded timestamp instead of re-drawing one"
+    );
+}
+
+/// CR 701.3d: an unattach records the mirror-image edit — a host precondition
+/// with no resulting host — and draws no timestamp, which is what makes the
+/// timestamp `Option` a checkable invariant rather than an always-present field.
+/// Driven through a real `Effect::UnattachAll` cast so the edit comes from the
+/// production resolver.
+#[test]
+fn unattach_journals_a_host_removal_without_a_timestamp_draw() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let creature = scenario.add_vanilla(P0, 2, 2);
+    let equipment = scenario
+        .add_creature(P0, "Test Blade", 0, 1)
+        .as_artifact()
+        .with_subtypes(vec!["Equipment"])
+        .from_oracle_text(EQUIP_ORACLE)
+        .id();
+
+    let mut spell = scenario.add_spell_to_hand(P0, "Disarm", true);
+    spell.with_ability(Effect::UnattachAll {
+        attachment: TargetFilter::Any,
+        target: TargetFilter::Typed(TypedFilter::creature()),
+    });
+    let spell_id = spell.id();
+
+    let mut runner = scenario.build();
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: equipment,
+            ability_index: 0,
+        })
+        .expect("Equip {0} is activatable at sorcery speed with a legal host");
+    runner.advance_until_stack_empty();
+
+    let attached_state = runner.state().clone();
+    let journal_start = attached_state.resolved_rules_journal.entries().len();
+    let attached_timestamp = attached_state.objects[&equipment].timestamp;
+
+    let outcome = runner.cast(spell_id).target_object(creature).resolve();
+
+    let state = outcome.state();
+    assert_eq!(
+        state.objects[&equipment].attached_to, None,
+        "CR 701.3d: the unattach authority clears the host"
+    );
+
+    let removals: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::Attachment(command)
+                if command.attachment.object_id == equipment =>
+            {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        removals.len(),
+        1,
+        "the unattach authority must journal exactly one resolved edit"
+    );
+    let removal = &removals[0];
+    assert_eq!(
+        removal.expected_old_host,
+        Some(AttachTarget::Object(creature)),
+        "the recorded precondition is the host the attachment was on"
+    );
+    assert_eq!(removal.resulting_host, None, "CR 701.3d: no resulting host");
+    assert_eq!(
+        removal.resulting_timestamp, None,
+        "CR 613.7e applies to attaching to a new host, so an unattach draws none"
+    );
+
+    let mut replay = attached_state;
+    engine::game::effects::attach::apply_resolved_attachment(&mut replay, removal)
+        .expect("the recorded unattach must replay against its captured predecessor");
+    assert_eq!(
+        replay.objects[&equipment].attached_to, None,
+        "replay clears the host"
+    );
+    assert!(
+        !replay.objects[&creature].attachments.contains(&equipment),
+        "replay removes the host-side attachment edge"
+    );
+    assert_eq!(
+        replay.objects[&equipment].timestamp, attached_timestamp,
+        "CR 613.7e: an unattach replay must not disturb the attachment's timestamp"
+    );
+}

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -79,6 +79,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::ObjectTransform(command) => {
             engine::game::transform::apply_resolved_transform(state, command).unwrap();
         }
+        ResolvedRulesCommand::Attachment(command) => {
+            engine::game::effects::attach::apply_resolved_attachment(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }
@@ -186,6 +189,7 @@ fn exact_mana_spend_rejects_a_second_removal() {
             | ResolvedRulesCommand::ObjectStatus(_)
             | ResolvedRulesCommand::ObjectCounter(_)
             | ResolvedRulesCommand::ObjectTransform(_)
+            | ResolvedRulesCommand::Attachment(_)
             | ResolvedRulesCommand::LedgerEdit(_)
             | ResolvedRulesCommand::LibraryShuffle(_)
             | ResolvedRulesCommand::ZoneChange(_)

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -82,6 +82,12 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::Attachment(command) => {
             engine::game::effects::attach::apply_resolved_attachment(state, command).unwrap();
         }
+        ResolvedRulesCommand::ControllerOverride(command) => {
+            engine::game::zones::apply_resolved_controller_override(state, command).unwrap();
+        }
+        ResolvedRulesCommand::EntryProvenance(command) => {
+            engine::game::zones::apply_resolved_entry_provenance(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }
@@ -190,6 +196,8 @@ fn exact_mana_spend_rejects_a_second_removal() {
             | ResolvedRulesCommand::ObjectCounter(_)
             | ResolvedRulesCommand::ObjectTransform(_)
             | ResolvedRulesCommand::Attachment(_)
+            | ResolvedRulesCommand::ControllerOverride(_)
+            | ResolvedRulesCommand::EntryProvenance(_)
             | ResolvedRulesCommand::LedgerEdit(_)
             | ResolvedRulesCommand::LibraryShuffle(_)
             | ResolvedRulesCommand::ZoneChange(_)

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -91,6 +91,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::ObjectCease(command) => {
             engine::game::zones::apply_resolved_object_cease(state, command).unwrap();
         }
+        ResolvedRulesCommand::PlayerLeave(command) => {
+            engine::game::elimination::apply_resolved_player_leave(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }
@@ -202,6 +205,7 @@ fn exact_mana_spend_rejects_a_second_removal() {
             | ResolvedRulesCommand::ControllerOverride(_)
             | ResolvedRulesCommand::EntryProvenance(_)
             | ResolvedRulesCommand::ObjectCease(_)
+            | ResolvedRulesCommand::PlayerLeave(_)
             | ResolvedRulesCommand::LedgerEdit(_)
             | ResolvedRulesCommand::LibraryShuffle(_)
             | ResolvedRulesCommand::ZoneChange(_)

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -88,6 +88,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::EntryProvenance(command) => {
             engine::game::zones::apply_resolved_entry_provenance(state, command).unwrap();
         }
+        ResolvedRulesCommand::ObjectCease(command) => {
+            engine::game::zones::apply_resolved_object_cease(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }
@@ -198,6 +201,7 @@ fn exact_mana_spend_rejects_a_second_removal() {
             | ResolvedRulesCommand::Attachment(_)
             | ResolvedRulesCommand::ControllerOverride(_)
             | ResolvedRulesCommand::EntryProvenance(_)
+            | ResolvedRulesCommand::ObjectCease(_)
             | ResolvedRulesCommand::LedgerEdit(_)
             | ResolvedRulesCommand::LibraryShuffle(_)
             | ResolvedRulesCommand::ZoneChange(_)

--- a/crates/engine/tests/integration/cr733_resolved_draw.rs
+++ b/crates/engine/tests/integration/cr733_resolved_draw.rs
@@ -44,6 +44,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::ObjectTransform(command) => {
             engine::game::transform::apply_resolved_transform(state, command).unwrap();
         }
+        ResolvedRulesCommand::Attachment(command) => {
+            engine::game::effects::attach::apply_resolved_attachment(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }

--- a/crates/engine/tests/integration/cr733_resolved_draw.rs
+++ b/crates/engine/tests/integration/cr733_resolved_draw.rs
@@ -53,6 +53,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::EntryProvenance(command) => {
             engine::game::zones::apply_resolved_entry_provenance(state, command).unwrap();
         }
+        ResolvedRulesCommand::ObjectCease(command) => {
+            engine::game::zones::apply_resolved_object_cease(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }

--- a/crates/engine/tests/integration/cr733_resolved_draw.rs
+++ b/crates/engine/tests/integration/cr733_resolved_draw.rs
@@ -47,6 +47,12 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::Attachment(command) => {
             engine::game::effects::attach::apply_resolved_attachment(state, command).unwrap();
         }
+        ResolvedRulesCommand::ControllerOverride(command) => {
+            engine::game::zones::apply_resolved_controller_override(state, command).unwrap();
+        }
+        ResolvedRulesCommand::EntryProvenance(command) => {
+            engine::game::zones::apply_resolved_entry_provenance(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }

--- a/crates/engine/tests/integration/cr733_resolved_draw.rs
+++ b/crates/engine/tests/integration/cr733_resolved_draw.rs
@@ -56,6 +56,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::ObjectCease(command) => {
             engine::game::zones::apply_resolved_object_cease(state, command).unwrap();
         }
+        ResolvedRulesCommand::PlayerLeave(command) => {
+            engine::game::elimination::apply_resolved_player_leave(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }

--- a/crates/engine/tests/integration/cr733_resolved_entry_retags.rs
+++ b/crates/engine/tests/integration/cr733_resolved_entry_retags.rs
@@ -1,0 +1,275 @@
+//! CR733 P2 coverage for the two battlefield-entry retags in the zone delivery
+//! tail: the CR 110.2a controller override and the CR 603.6a provenance stamp.
+//!
+//! Both run in the same block after the object has already been delivered, and
+//! both wrote persistent object state raw. They are separate families rather than
+//! one parameterized "entry retag" because CR 110.2a (control) and CR 603.6a
+//! (which ability placed the permanent) are different rule sections the engine
+//! resolves independently.
+//!
+//! `zones::apply_battlefield_entry_controller_override` is the single authority
+//! for CR 110.2a "enters under your control" entries (reanimation, Tergrid-class
+//! theft, `reveal_until` entries, and the elimination handoff), but it wrote FIVE
+//! fields raw: the object's `base_controller` and `controller`, plus the
+//! `controller` of the `zone_changes_this_turn` snapshot, the
+//! `battlefield_entries_this_turn` snapshot, and the in-flight `ZoneChanged`
+//! event.
+//!
+//! Only the first four are persistent state. The event fix-up is deliberately
+//! outside the command: events are transient carriers consumed by the same
+//! resolution, not state a replay reconstructs.
+//!
+//! The two snapshot POSITIONS are recorded rather than re-found, mirroring
+//! `ResolvedZoneChangeCommand::turn_zone_change_index` — CR 400.7 permits the
+//! same object to hold several entries in one turn, so a replay-time last-match
+//! scan could retag a different one.
+//!
+//! The test drives the REAL pipeline: casting a reanimation spell at an
+//! OPPONENT-owned creature card, so owner and controller genuinely diverge and
+//! an applier that skipped the override could not accidentally pass.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::ResolvedRulesCommand;
+use engine::types::zones::Zone;
+
+const REANIMATE_ORACLE: &str =
+    "Put target creature card from a graveyard onto the battlefield under your control.";
+
+#[test]
+fn entering_under_your_control_journals_an_exact_controller_override() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Owned by the OPPONENT: the override must move control to P0 while P1 stays
+    // the owner (CR 110.2), so every assertion below distinguishes the two.
+    let corpse = scenario
+        .add_creature_to_graveyard(P1, "Stolen Bear", 2, 2)
+        .id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reanimate", false, REANIMATE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    // Baseline captured AFTER the spell is on the stack: the cast itself appends a
+    // hand -> stack record to `zone_changes_this_turn`, and the resolution's
+    // zone-change command records its index relative to that. Replaying from a
+    // pre-cast state would leave the turn record one short.
+    let committed = runner.cast(spell).target_object(corpse).commit();
+    let pre_state = committed.state().clone();
+    let journal_start = pre_state.resolved_rules_journal.entries().len();
+
+    let outcome = committed.resolve();
+    let state = outcome.state();
+
+    // CR 110.2a reach guards: the card actually entered, and it entered under the
+    // caster's control rather than its owner's. Without these the journal
+    // assertion could pass vacuously on a reanimation that never resolved.
+    let object = &state.objects[&corpse];
+    assert_eq!(
+        object.zone,
+        Zone::Battlefield,
+        "the reanimation must put the card onto the battlefield"
+    );
+    assert_eq!(
+        object.controller, P0,
+        "CR 110.2a: the card enters under the caster's control"
+    );
+    assert_eq!(
+        object.owner, P1,
+        "CR 110.2: the override changes control, never ownership"
+    );
+
+    // The discriminating assertion: the override is journaled as an exact
+    // resolved command. Five raw field writes record nothing here.
+    let overrides: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::ControllerOverride(command)
+                if command.object.object_id == corpse =>
+            {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        overrides.len(),
+        1,
+        "the controller-override authority must journal exactly one resolved command"
+    );
+
+    let command = &overrides[0];
+    assert_eq!(
+        command.expected_old_controller, P1,
+        "the recorded precondition is the pre-override controller (the owner)"
+    );
+    assert_eq!(
+        command.resulting_controller, P0,
+        "the recorded result is the caster"
+    );
+
+    // The snapshot retags are part of the same command: a replay that installed
+    // only the object's controller would leave "entered under whose control"
+    // look-back queries (CR 400.7 / CR 403.3) answering with the owner.
+    let zone_change_index = command
+        .zone_change_index
+        .expect("a battlefield entry records its zone-change snapshot position");
+    assert_eq!(
+        state.zone_changes_this_turn[zone_change_index].controller, P0,
+        "CR 400.7: the zone-change snapshot is retagged to the new controller"
+    );
+    let entry_index = command
+        .battlefield_entry_index
+        .expect("a battlefield entry records its entry-snapshot position");
+    assert_eq!(
+        state.battlefield_entries_this_turn[entry_index].controller, P0,
+        "CR 403.3: the battlefield-entry snapshot is retagged to the new controller"
+    );
+
+    // Replay-exactness: every command up to and including the override, applied
+    // to the pre-cast state, must reproduce the same controller and the same
+    // retagged snapshots with no re-derivation of which records to touch.
+    let mut replay = pre_state;
+    replay.resolved_rules_journal = state.resolved_rules_journal.clone();
+    for entry in state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+    {
+        let Some(replayed) = entry.command.clone() else {
+            continue;
+        };
+        match &replayed {
+            ResolvedRulesCommand::ZoneChange(command) => {
+                engine::game::zones::apply_resolved_zone_change(&mut replay, command).unwrap();
+            }
+            ResolvedRulesCommand::ControllerOverride(command) => {
+                engine::game::zones::apply_resolved_controller_override(&mut replay, command)
+                    .unwrap();
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(
+        replay.objects[&corpse].controller, P0,
+        "replay installs the exact recorded controller"
+    );
+    assert_eq!(
+        replay.objects[&corpse].base_controller,
+        Some(P0),
+        "CR 110.2a: replay pins the base controller the override established"
+    );
+    assert_eq!(
+        replay.zone_changes_this_turn[zone_change_index].controller, P0,
+        "replay retags the exact recorded zone-change snapshot"
+    );
+    assert_eq!(
+        replay.battlefield_entries_this_turn[entry_index].controller, P0,
+        "replay retags the exact recorded battlefield-entry snapshot"
+    );
+}
+
+/// CR 603.6a: the same ability-driven entry stamps the entering permanent with
+/// the ability that placed it, so anti-recursion intervening-ifs ("if it wasn't
+/// put onto the battlefield with this ability") can exclude it. A replay that
+/// dropped the stamp would let such abilities re-trigger off their own output.
+#[test]
+fn ability_driven_entry_journals_an_exact_provenance_stamp() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let corpse = scenario
+        .add_creature_to_graveyard(P1, "Stolen Bear", 2, 2)
+        .id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reanimate", false, REANIMATE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    // Baseline captured AFTER the spell is on the stack: the cast itself appends a
+    // hand -> stack record to `zone_changes_this_turn`, and the resolution's
+    // zone-change command records its index relative to that. Replaying from a
+    // pre-cast state would leave the turn record one short.
+    let committed = runner.cast(spell).target_object(corpse).commit();
+    let pre_state = committed.state().clone();
+    let journal_start = pre_state.resolved_rules_journal.entries().len();
+
+    let outcome = committed.resolve();
+    let state = outcome.state();
+
+    // CR 603.6a reach guard: the permanent entered AND carries the placing
+    // ability's source, so the journal assertion below cannot pass vacuously.
+    let object = &state.objects[&corpse];
+    assert_eq!(object.zone, Zone::Battlefield);
+    let stamped_source = object
+        .entered_via_ability_source
+        .expect("CR 603.6a: an ability-driven entry records the placing ability's source");
+
+    let stamps: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::EntryProvenance(command)
+                if command.object.object_id == corpse =>
+            {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        stamps.len(),
+        1,
+        "the provenance authority must journal exactly one resolved stamp"
+    );
+
+    let stamp = &stamps[0];
+    assert_eq!(
+        stamp.expected_old_source, None,
+        "CR 603.6a: the entry pipeline cleared the field, so the stamp starts from unstamped"
+    );
+    assert_eq!(
+        stamp.resulting_source, stamped_source,
+        "the journaled source is the source the stamp installed"
+    );
+
+    // Replay-exactness: the recorded stamp reinstalls the same source with no
+    // re-derivation of which ability was responsible.
+    let mut replay = pre_state;
+    replay.resolved_rules_journal = state.resolved_rules_journal.clone();
+    for entry in state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+    {
+        let Some(replayed) = entry.command.clone() else {
+            continue;
+        };
+        match &replayed {
+            ResolvedRulesCommand::ZoneChange(command) => {
+                engine::game::zones::apply_resolved_zone_change(&mut replay, command).unwrap();
+            }
+            ResolvedRulesCommand::EntryProvenance(command) => {
+                engine::game::zones::apply_resolved_entry_provenance(&mut replay, command).unwrap();
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(
+        replay.objects[&corpse].entered_via_ability_source,
+        Some(stamped_source),
+        "replay installs the exact recorded placing ability"
+    );
+}

--- a/crates/engine/tests/integration/cr733_resolved_object_cease.rs
+++ b/crates/engine/tests/integration/cr733_resolved_object_cease.rs
@@ -1,0 +1,121 @@
+//! CR733 P2 coverage for the object-deletion family.
+//!
+//! `zones::cease_object` is the only production path that deletes an object
+//! outright, and the CR 704.5d SBA sweep is its single caller. It wrote
+//! `state.objects.remove` raw, so a retained-prefix replay left the token alive
+//! in a zone the rules had already swept it from.
+//!
+//! Ceasing to exist is deliberately NOT a zone change (CR 400.7): no event is
+//! emitted and no "whenever exiled" trigger fires, so this cannot ride the
+//! zone-change family — it needs its own command.
+//!
+//! The test drives the REAL pipeline: a destroy spell resolving at a token, whose
+//! move to the graveyard makes the state-based sweep delete it.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{Effect, TargetFilter, TypedFilter};
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::ResolvedRulesCommand;
+use engine::types::zones::Zone;
+
+#[test]
+fn token_cease_to_exist_journals_an_exact_resolved_removal() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let token = scenario.add_creature(P0, "Spirit Token", 1, 1).id();
+    let mut spell = scenario.add_spell_to_hand(P0, "Smite", true);
+    spell.with_ability(Effect::Destroy {
+        target: TargetFilter::Typed(TypedFilter::creature()),
+        cant_regenerate: false,
+    });
+    let spell_id = spell.id();
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&token)
+        .expect("the token exists")
+        .is_token = true;
+
+    // Baseline captured AFTER the spell is on the stack: the cast appends its own
+    // hand -> stack turn record, and the resolution's zone-change command records
+    // its index relative to that.
+    let committed = runner.cast(spell_id).target_object(token).commit();
+    let pre_state = committed.state().clone();
+    let journal_start = pre_state.resolved_rules_journal.entries().len();
+
+    let outcome = committed.resolve();
+    let state = outcome.state();
+
+    // CR 704.5d reach guard: the token is gone from `state.objects` entirely, not
+    // merely moved. Without this the journal assertion could pass vacuously.
+    assert!(
+        !state.objects.contains_key(&token),
+        "CR 704.5d: a token in a zone other than the battlefield ceases to exist"
+    );
+
+    // The discriminating assertion: the removal is journaled as an exact resolved
+    // command. A raw `objects.remove` records nothing here.
+    let ceases: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::ObjectCease(command) if command.object.object_id == token => {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        ceases.len(),
+        1,
+        "the cease-to-exist authority must journal exactly one resolved removal"
+    );
+
+    let cease = &ceases[0];
+    assert_eq!(
+        cease.expected_zone,
+        Zone::Graveyard,
+        "CR 704.5d: the token ceased from the zone the destroy put it in"
+    );
+    assert_eq!(cease.owner, P0, "the recorded owner is the token's owner");
+
+    // Replay-exactness: applying the recorded commands to the pre-cast state must
+    // delete the same object from the same zone with no re-run of the CR 704.5d
+    // eligibility scan.
+    let mut replay = pre_state;
+    replay.resolved_rules_journal = state.resolved_rules_journal.clone();
+    for entry in state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+    {
+        let Some(replayed) = entry.command.clone() else {
+            continue;
+        };
+        match &replayed {
+            ResolvedRulesCommand::ZoneChange(command) => {
+                engine::game::zones::apply_resolved_zone_change(&mut replay, command).unwrap();
+            }
+            ResolvedRulesCommand::ObjectCease(command) => {
+                engine::game::zones::apply_resolved_object_cease(&mut replay, command).unwrap();
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        !replay.objects.contains_key(&token),
+        "replay deletes the exact recorded object"
+    );
+    assert!(
+        !replay.players[usize::from(P0.0)].graveyard.contains(&token),
+        "replay also removes the token from the zone list, not just the object map"
+    );
+}

--- a/crates/engine/tests/integration/cr733_resolved_player_leave.rs
+++ b/crates/engine/tests/integration/cr733_resolved_player_leave.rs
@@ -20,14 +20,13 @@
 
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::phase::Phase;
-use engine::types::resolved_commands::{
-    ResolvedPlayerEdit, ResolvedRulesCommand, RulesExecutionNodeRef,
-};
+use engine::types::resolved_commands::{ResolvedRulesCommand, RulesExecutionNodeRef};
 
 #[test]
 fn losing_the_game_journals_an_exact_player_leave_under_its_own_node() {
     let mut scenario = GameScenario::new_n_player(3, 7);
     scenario.at_phase(Phase::PreCombatMain);
+    let bolt = scenario.add_bolt_to_hand(P0);
     let mut runner = scenario.build();
 
     // Three players so the elimination does not immediately end the game — the
@@ -38,18 +37,14 @@ fn losing_the_game_journals_an_exact_player_leave_under_its_own_node() {
         .iter_mut()
         .find(|player| player.id == P1)
         .expect("the victim is in the game")
-        .life = 1;
+        .life = 3;
 
     let journal_start = runner.state().resolved_rules_journal.entries().len();
 
-    // CR 704.5a: a player with 0 or less life loses the game. Driving the life to
-    // 0 through the ordinary resource authority makes the state-based action fire
-    // on the next check rather than poking `is_eliminated` directly.
-    runner
-        .state_mut()
-        .resolve_and_apply_player_edit(P1, ResolvedPlayerEdit::Life { delta: -1 })
-        .expect("the victim can lose their last point of life");
-    runner.advance_until_stack_empty();
+    // CR 704.5a: a player with 0 or less life loses the game. A real burn spell
+    // resolving at the victim takes them to 0 and makes the state-based action
+    // fire through the production pipeline, rather than poking `is_eliminated`.
+    runner.cast(bolt).target_player(P1).resolve();
 
     // CR 704.5a reach guard: the victim actually left. Without it the journal
     // assertions below could pass vacuously.

--- a/crates/engine/tests/integration/cr733_resolved_player_leave.rs
+++ b/crates/engine/tests/integration/cr733_resolved_player_leave.rs
@@ -1,0 +1,139 @@
+//! CR733 P2 coverage for the player-leave family.
+//!
+//! P1 defined `RulesExecutionNodeKind::PlayerLeave` and the matching node ref,
+//! but nothing in the engine ever produced one — the CR 800.4 sweep marked
+//! `is_eliminated` and appended to `eliminated_players` with raw writes, and
+//! every mutation it performed downstream (owned-object exiles, control-effect
+//! reversions) was attributed to whatever proposal happened to be live when the
+//! state-based action fired.
+//!
+//! Two things are asserted here, and they are different claims:
+//!
+//! 1. The departure itself is journaled as one exact command. The two writes
+//!    always move together, so they are one command rather than two.
+//! 2. The departure opens its OWN execution node. That is what makes the sweep
+//!    identifiable as a single causal unit on replay, instead of commands
+//!    scattered under an unrelated cause.
+//!
+//! The test drives the REAL pipeline: a player is taken to 0 life, and the
+//! CR 704.5a state-based action eliminates them.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::{
+    ResolvedPlayerEdit, ResolvedRulesCommand, RulesExecutionNodeRef,
+};
+
+#[test]
+fn losing_the_game_journals_an_exact_player_leave_under_its_own_node() {
+    let mut scenario = GameScenario::new_n_player(3, 7);
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut runner = scenario.build();
+
+    // Three players so the elimination does not immediately end the game — the
+    // leave sweep must be observable while play continues.
+    runner
+        .state_mut()
+        .players
+        .iter_mut()
+        .find(|player| player.id == P1)
+        .expect("the victim is in the game")
+        .life = 1;
+
+    let journal_start = runner.state().resolved_rules_journal.entries().len();
+
+    // CR 704.5a: a player with 0 or less life loses the game. Driving the life to
+    // 0 through the ordinary resource authority makes the state-based action fire
+    // on the next check rather than poking `is_eliminated` directly.
+    runner
+        .state_mut()
+        .resolve_and_apply_player_edit(P1, ResolvedPlayerEdit::Life { delta: -1 })
+        .expect("the victim can lose their last point of life");
+    runner.advance_until_stack_empty();
+
+    // CR 704.5a reach guard: the victim actually left. Without it the journal
+    // assertions below could pass vacuously.
+    let state = runner.state();
+    assert!(
+        state
+            .players
+            .iter()
+            .find(|player| player.id == P1)
+            .expect("the player record survives elimination")
+            .is_eliminated,
+        "CR 704.5a: a player at 0 life loses the game"
+    );
+    assert!(
+        state.eliminated_players.contains(&P1),
+        "the departure also appends to the eliminated list"
+    );
+    assert!(
+        !state
+            .players
+            .iter()
+            .find(|player| player.id == P0)
+            .expect("the survivor is in the game")
+            .is_eliminated,
+        "only the player who lost leaves"
+    );
+
+    // The discriminating assertion: the departure is journaled as an exact
+    // resolved command. Two raw field writes record nothing here.
+    let leaves: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::PlayerLeave(command) if command.player == P1 => Some(command),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        leaves.len(),
+        1,
+        "the elimination authority must journal exactly one resolved departure"
+    );
+
+    // The second claim: the departure runs under a PlayerLeave node, not under an
+    // ambient proposal. This is what lets a replay recognize the CR 800.4 sweep as
+    // one causal unit.
+    assert!(
+        matches!(leaves[0].cause, RulesExecutionNodeRef::PlayerLeave(_)),
+        "CR 800.4: the departure opens its own execution node, got {:?}",
+        leaves[0].cause
+    );
+
+    // Replay-exactness: the recorded departure reinstalls both writes, and is not
+    // idempotent — a second application is a typed invariant failure rather than a
+    // silent re-elimination.
+    let mut replay = runner.state().clone();
+    replay
+        .players
+        .iter_mut()
+        .find(|player| player.id == P1)
+        .expect("the player record survives elimination")
+        .is_eliminated = false;
+    replay.eliminated_players.retain(|player| *player != P1);
+
+    engine::game::elimination::apply_resolved_player_leave(&mut replay, &leaves[0])
+        .expect("the recorded departure must replay");
+    assert!(
+        replay
+            .players
+            .iter()
+            .find(|player| player.id == P1)
+            .expect("the player record survives elimination")
+            .is_eliminated,
+        "replay installs the recorded departure"
+    );
+    assert!(
+        replay.eliminated_players.contains(&P1),
+        "replay installs the eliminated-list append"
+    );
+    assert!(
+        engine::game::elimination::apply_resolved_player_leave(&mut replay, &leaves[0]).is_err(),
+        "a departure is not idempotent: re-applying it is a typed invariant failure"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -90,6 +90,7 @@ mod counter_anaphor_created_token_binding;
 mod counter_double_redirect_choice;
 mod counter_spell_zone_redirect;
 mod court_of_cunning_multi_target_mill;
+mod cr733_resolved_attachment;
 mod cr733_resolved_commands_p0;
 mod cr733_resolved_commands_p1;
 mod cr733_resolved_commands_p2;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -98,6 +98,7 @@ mod cr733_resolved_draw;
 mod cr733_resolved_enter_tapped;
 mod cr733_resolved_entry_retags;
 mod cr733_resolved_frame_transition;
+mod cr733_resolved_object_cease;
 mod cr733_resolved_transform;
 mod cr733_resolved_trigger_collection;
 mod cr733_resolved_zone_change;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -99,6 +99,7 @@ mod cr733_resolved_enter_tapped;
 mod cr733_resolved_entry_retags;
 mod cr733_resolved_frame_transition;
 mod cr733_resolved_object_cease;
+mod cr733_resolved_player_leave;
 mod cr733_resolved_transform;
 mod cr733_resolved_trigger_collection;
 mod cr733_resolved_zone_change;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -96,6 +96,7 @@ mod cr733_resolved_commands_p1;
 mod cr733_resolved_commands_p2;
 mod cr733_resolved_draw;
 mod cr733_resolved_enter_tapped;
+mod cr733_resolved_entry_retags;
 mod cr733_resolved_frame_transition;
 mod cr733_resolved_transform;
 mod cr733_resolved_trigger_collection;


### PR DESCRIPTION
- **feat(engine): journal CR 701.3 attachment edits as resolved commands**
- **feat(engine): journal the two battlefield-entry retags as resolved commands**
- **feat(engine): journal CR 704.5d cease-to-exist as a resolved command**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added replayable “resolved command” tracking for attachments/unattachments, including exact host/timestamp transitions.
  * Battlefield entries now preserve controller overrides and the placing ability source during replay.
  * Token/object ceases and player departures are now journaled and replayed with strict invariant checks.
* **Bug Fixes**
  * Improved correctness of replay exactness for host relationships, zone membership, controller/base-controller retagging, and provenance stamping.
* **Tests**
  * Added integration coverage for the above resolved replay cases (including player leave).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->