### PR TITLE
feat(engine): journal ordinary CR 111.1 token births as resolved commands

### DIFF
--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -22,12 +22,15 @@ use crate::types::game_state::{
     PendingCounterAddition, PendingCounterPostAction, PendingEffectResolutionEvent,
     TokenEntryEventEmission, WaitingFor,
 };
-use crate::types::identifiers::{CardId, ObjectId, TrackedSetId};
+use crate::types::identifiers::{CardId, ObjectId, ObjectIncarnationRef, TrackedSetId};
 use crate::types::keywords::{Keyword, WardCost};
 use crate::types::mana::{ManaColor, ManaCost};
 use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::{CopyTokenSpec, ProposedEvent, TokenSpec};
+use crate::types::resolved_commands::{
+    ResolvedTokenCreationCommand, ResolvedTokenCreationReplayInvariantError,
+};
 use crate::types::statics::CastFrequency;
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::{EtbTapState, Zone};
@@ -826,72 +829,41 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
         // Drawn before the `get_mut` borrow (`next_timestamp` takes `&mut self`).
         let entry_timestamp = state.next_timestamp();
 
-        if let Some(obj) = state.objects.get_mut(&obj_id) {
-            // CR 111.1: Mark as token for SBA cleanup (CR 704.5d)
-            obj.is_token = true;
-            // True token from a TokenSpec — image lives in the generic-token
-            // database (Treasure, Spirit, Saproling, Soldier, etc.).
-            obj.display_source = DisplaySource::Token;
-            obj.token_image_ref = token_image_ref;
-            let has_attrs = ch.power.is_some()
-                || ch.toughness.is_some()
-                || !ch.core_types.is_empty()
-                || !ch.subtypes.is_empty()
-                || !ch.supertypes.is_empty()
-                || !ch.colors.is_empty()
-                || !ch.keywords.is_empty();
-            if has_attrs {
-                obj.power = ch.power;
-                obj.toughness = ch.toughness;
-                obj.base_name = ch.display_name.clone();
-                obj.base_power = ch.power;
-                obj.base_toughness = ch.toughness;
-                obj.card_types = CardType {
-                    supertypes: ch.supertypes.clone(),
-                    core_types: ch.core_types.clone(),
-                    subtypes: ch.subtypes.clone(),
-                };
-                obj.base_card_types = obj.card_types.clone();
-                obj.color = ch.colors.clone();
-                obj.base_color = ch.colors.clone();
-                obj.keywords = ch.keywords.clone();
-                obj.base_keywords = ch.keywords.clone();
-            }
-            // CR 400.7 + CR 302.6: Tokens enter the battlefield as new objects
-            // and must run the same ETB-state reset as any other permanent
-            // (summoning sickness, echo, damage, loyalty-activated flags).
-            // Delegate to the single authority for summoning sickness and
-            // related transient flags rather than setting them ad-hoc.
-            obj.reset_for_battlefield_entry(state.turn_number, entry_timestamp);
-            obj.tapped = enter_tapped.resolve(spec.tapped);
+        // CR 614.1: the post-replacement tapped state, resolved once so the
+        // shared body installs the same value a CR 733 replay will.
+        let resulting_tapped = enter_tapped.resolve(spec.tapped);
+        let turn_number = state.turn_number;
+        let created_reference = state.objects.get_mut(&obj_id).map(|obj| {
+            materialize_token_spec_body(
+                obj,
+                &spec,
+                token_image_ref.clone(),
+                turn_number,
+                entry_timestamp,
+                resulting_tapped,
+            );
+            ObjectIncarnationRef::from_object(obj)
+        });
 
-            // CR 113.3d + CR 613.1: Apply static abilities from the token
-            // definition. Mirror onto `base_static_definitions` so the
-            // layers-reset (`base_*` → `*`) at the start of each layers pass
-            // doesn't wipe them before layer 7 reads dynamic P/T grants.
-            if !spec.static_abilities.is_empty() {
-                let static_abilities: Vec<_> = spec
-                    .static_abilities
-                    .iter()
-                    .cloned()
-                    .map(normalized_token_static_definition)
-                    .collect();
-                Arc::make_mut(&mut obj.base_static_definitions)
-                    .extend(static_abilities.iter().cloned());
-                for static_def in static_abilities {
-                    obj.static_definitions.push(static_def);
-                }
-                // CR 702.6a + CR 111.4: Only intrinsic Equip activated abilities
-                // (unconditional SelfRef `GrantAbility(Attach SelfRef → …)`)
-                // are copied onto the token object. Other grants stay in the
-                // static/layer path only.
-                let equip_abilities =
-                    intrinsic_equip_abilities_from_token_statics(&spec.static_abilities);
-                if !equip_abilities.is_empty() {
-                    Arc::make_mut(&mut obj.abilities).extend(equip_abilities.iter().cloned());
-                    Arc::make_mut(&mut obj.base_abilities).extend(equip_abilities);
-                }
-            }
+        // CR 733: journal the settled creation, after the body borrow ends.
+        // Counters, the attacking entry, and any later status change journal
+        // through their OWN families, so this command covers the birth only.
+        if let Some(object) = created_reference {
+            let cause = state.current_or_begin_rules_execution_node();
+            let command = ResolvedTokenCreationCommand {
+                object,
+                owner,
+                entry_timestamp,
+                spec: spec.clone(),
+                token_image_ref: token_image_ref.clone(),
+                resulting_tapped,
+                resulting_next_object_id: state.next_object_id,
+                cause,
+            };
+            state
+                .resolved_rules_journal
+                .record_token_creation(command)
+                .expect("resolved token creation must have a live journal cause");
         }
 
         // CR 508.4: Token enters attacking — not declared as attacker.
@@ -1052,6 +1024,148 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
     // TargetFilter::LastCreated (e.g., Job select, suspect).
     state.last_created_token_ids = created_ids;
     true
+}
+
+/// Materializes one already-resolved CR 111.1 token creation verbatim.
+///
+/// Unlike every other resolved-command applier, this one CREATES its subject
+/// rather than verifying and installing into an existing one, so its
+/// precondition is inverted: the recorded id must be ABSENT. It re-runs none of
+/// the CR 614 replacement pipeline that decided the token would be created, its
+/// count, or its tapped state — all of that was settled when the command was
+/// recorded.
+///
+/// The body is installed through the same `materialize_token_spec_body` the
+/// resolve path uses, so the two cannot drift.
+pub fn apply_resolved_token_creation(
+    state: &mut GameState,
+    command: &ResolvedTokenCreationCommand,
+) -> Result<(), ResolvedTokenCreationReplayInvariantError> {
+    let object_id = command.object.object_id;
+    if state.objects.contains_key(&object_id) {
+        return Err(ResolvedTokenCreationReplayInvariantError::ObjectAlreadyExists(object_id));
+    }
+    if !state
+        .players
+        .iter()
+        .any(|player| player.id == command.owner)
+    {
+        return Err(ResolvedTokenCreationReplayInvariantError::UnknownOwner(
+            command.owner,
+        ));
+    }
+    if object_id.0 >= command.resulting_next_object_id {
+        return Err(
+            ResolvedTokenCreationReplayInvariantError::IdAboveHighWater {
+                id: object_id,
+                high_water: command.resulting_next_object_id,
+            },
+        );
+    }
+
+    let mut object = GameObject::new(
+        object_id,
+        CardId(0),
+        command.owner,
+        command.spec.characteristics.display_name.clone(),
+        Zone::Battlefield,
+    );
+    materialize_token_spec_body(
+        &mut object,
+        &command.spec,
+        command.token_image_ref.clone(),
+        state.turn_number,
+        command.entry_timestamp,
+        command.resulting_tapped,
+    );
+
+    state.objects.insert(object_id, object);
+    // allow-raw-zone: replay materializes a token birth, which has no from-zone move (CR 111.1 + CR 614.12).
+    zones::add_to_zone(state, object_id, Zone::Battlefield, command.owner);
+    // CR 111.1: replay must not hand the same id out again to a later allocation.
+    state.next_object_id = state.next_object_id.max(command.resulting_next_object_id);
+    Ok(())
+}
+
+/// CR 111.1 + CR 113.3d: Installs an ordinary token's body onto `object`.
+///
+/// Single authority for the ordinary-token body, shared by the resolve path and
+/// the CR 733 replay applier so the two cannot drift. Operates on a `&mut
+/// GameObject` rather than on `GameState`, so it serves both orderings: the
+/// resolve path inserts first and mutates in place, while replay builds a
+/// detached object and inserts it afterwards.
+pub(crate) fn materialize_token_spec_body(
+    object: &mut GameObject,
+    spec: &TokenSpec,
+    token_image_ref: Option<crate::types::card::TokenImageRef>,
+    turn_number: u32,
+    entry_timestamp: u64,
+    tapped: bool,
+) {
+    let ch = &spec.characteristics;
+    // CR 111.1: Mark as token for SBA cleanup (CR 704.5d)
+    object.is_token = true;
+    // True token from a TokenSpec — image lives in the generic-token
+    // database (Treasure, Spirit, Saproling, Soldier, etc.).
+    object.display_source = DisplaySource::Token;
+    object.token_image_ref = token_image_ref;
+    let has_attrs = ch.power.is_some()
+        || ch.toughness.is_some()
+        || !ch.core_types.is_empty()
+        || !ch.subtypes.is_empty()
+        || !ch.supertypes.is_empty()
+        || !ch.colors.is_empty()
+        || !ch.keywords.is_empty();
+    if has_attrs {
+        object.power = ch.power;
+        object.toughness = ch.toughness;
+        object.base_name = ch.display_name.clone();
+        object.base_power = ch.power;
+        object.base_toughness = ch.toughness;
+        object.card_types = CardType {
+            supertypes: ch.supertypes.clone(),
+            core_types: ch.core_types.clone(),
+            subtypes: ch.subtypes.clone(),
+        };
+        object.base_card_types = object.card_types.clone();
+        object.color = ch.colors.clone();
+        object.base_color = ch.colors.clone();
+        object.keywords = ch.keywords.clone();
+        object.base_keywords = ch.keywords.clone();
+    }
+    // CR 400.7 + CR 302.6: Tokens enter the battlefield as new objects
+    // and must run the same ETB-state reset as any other permanent
+    // (summoning sickness, echo, damage, loyalty-activated flags).
+    // Delegate to the single authority for summoning sickness and
+    // related transient flags rather than setting them ad-hoc.
+    object.reset_for_battlefield_entry(turn_number, entry_timestamp);
+    object.tapped = tapped;
+
+    // CR 113.3d + CR 613.1: Apply static abilities from the token
+    // definition. Mirror onto `base_static_definitions` so the
+    // layers-reset (`base_*` → `*`) at the start of each layers pass
+    // doesn't wipe them before layer 7 reads dynamic P/T grants.
+    if !spec.static_abilities.is_empty() {
+        let static_abilities: Vec<_> = spec
+            .static_abilities
+            .iter()
+            .cloned()
+            .map(normalized_token_static_definition)
+            .collect();
+        Arc::make_mut(&mut object.base_static_definitions).extend(static_abilities.iter().cloned());
+        for static_def in static_abilities {
+            object.static_definitions.push(static_def);
+        }
+        // CR 702.6a + CR 111.4: Only intrinsic Equip activated abilities
+        // (unconditional SelfRef `GrantAbility(Attach SelfRef → …)`)
+        // are copied onto the token object. Other grants stay in the
+        // static/layer path only.
+        let equip_abilities = intrinsic_equip_abilities_from_token_statics(&spec.static_abilities);
+        if !equip_abilities.is_empty() {
+            Arc::make_mut(&mut object.abilities).extend(equip_abilities.iter().cloned());
+            Arc::make_mut(&mut object.base_abilities).extend(equip_abilities);
+        }
+    }
 }
 
 pub(crate) fn reserve_liminal_token_object(

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -11,12 +11,14 @@ use crate::game::game_object::AttachTarget;
 use crate::game::triggers::{ConsumedTriggerEventOccurrence, PendingTriggerContext};
 
 use super::ability::TriggerDefinitionRef;
+use super::card::TokenImageRef;
 use super::card_type::CoreType;
 use super::counter::CounterType;
 use super::game_state::{SpellCastRecord, ZoneChangeRecord};
 use super::identifiers::{ObjectId, ObjectIncarnationRef, LEGACY_INCARNATION};
 use super::mana::{ManaPipId, ManaUnit};
 use super::player::{PlayerCounterKind, PlayerId};
+use super::proposed_event::TokenSpec;
 use super::resolution::{FrameKind, ResolutionFrame, ResolutionStackError};
 use super::zones::Zone;
 
@@ -373,6 +375,55 @@ pub enum ResolvedPlayerLeaveReplayInvariantError {
     AlreadyEliminated(PlayerId),
 }
 
+/// One exact CR 111.1 token creation.
+///
+/// This is the first family whose replay MATERIALIZES an object rather than
+/// verifying and installing into one that already exists, so its precondition is
+/// inverted: the applier requires the id to be ABSENT.
+///
+/// Two allocator draws are recorded because both would otherwise be re-drawn:
+/// the `ObjectId` (from `next_object_id`) and the CR 613.7d entry timestamp.
+///
+/// SCOPE: ordinary `TokenSpec` births only. Copy tokens (CR 707.2) and meld
+/// births go through the liminal-entry path, whose `LiminalEntry` carries no
+/// body spec — `LiminalEntryKind` distinguishes Token from Meld, not Spec from
+/// Copy — so wiring them needs a new field on that shared serialized struct.
+/// They remain unjournaled for now. When they land, this struct's `spec` +
+/// `token_image_ref` pair becomes a `ResolvedTokenBody::{Spec, Copy}` payload on
+/// the SAME command: both are the CR 111.1 axis (an object came into existence
+/// and its id and timestamp were drawn), and CR 707.2 governs only how the copy
+/// body was derived upstream of this seam.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedTokenCreationCommand {
+    pub object: ObjectIncarnationRef,
+    pub owner: PlayerId,
+    pub entry_timestamp: u64,
+    /// The effect's token spec — the existing replacement-visible payload type
+    /// rather than a hand-rolled field list.
+    pub spec: Box<TokenSpec>,
+    /// `token_presets::find_exact_token_ref` READS game state to resolve this, so
+    /// it is a re-derivation rather than a spec field and must be recorded.
+    pub token_image_ref: Option<TokenImageRef>,
+    /// CR 614.1: the post-replacement tapped state the token actually entered
+    /// with, not the spec's pre-replacement request.
+    pub resulting_tapped: bool,
+    /// The `next_object_id` high-water after this token's id was drawn, so a
+    /// replay resuming from a shorter prefix cannot hand the same id out twice.
+    pub resulting_next_object_id: u64,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// Typed failure while applying one already-resolved token creation.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedTokenCreationReplayInvariantError {
+    #[error("token-creation command would overwrite live object {0:?}")]
+    ObjectAlreadyExists(ObjectId),
+    #[error("token-creation command references an unknown owner {0:?}")]
+    UnknownOwner(PlayerId),
+    #[error("token-creation id {id:?} is not below its recorded high-water {high_water}")]
+    IdAboveHighWater { id: ObjectId, high_water: u64 },
+}
+
 /// The audience that received one exact revealed-card fact.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ResolvedInformationAudience {
@@ -623,6 +674,7 @@ pub enum ResolvedRulesCommand {
     EntryProvenance(ResolvedEntryProvenanceCommand),
     ObjectCease(ResolvedObjectCeaseCommand),
     PlayerLeave(ResolvedPlayerLeaveCommand),
+    TokenCreation(Box<ResolvedTokenCreationCommand>),
     Information(ResolvedInformationCommand),
     LedgerEdit(ResolvedLedgerEditCommand),
     LibraryShuffle(ResolvedLibraryShuffleCommand),
@@ -1607,6 +1659,17 @@ impl ResolvedRulesJournal {
         self.append_command(command.cause, ResolvedRulesCommand::PlayerLeave(command))
     }
 
+    /// Records one exact CR 111.1 token creation under its causal node.
+    pub fn record_token_creation(
+        &mut self,
+        command: ResolvedTokenCreationCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(
+            command.cause,
+            ResolvedRulesCommand::TokenCreation(Box::new(command)),
+        )
+    }
+
     /// Records one exact bounded resolution-frame transition under its causal node.
     pub fn record_frame_transition(
         &mut self,
@@ -1833,6 +1896,7 @@ impl ResolvedRulesJournal {
                 | ResolvedRulesCommand::EntryProvenance(_)
                 | ResolvedRulesCommand::ObjectCease(_)
                 | ResolvedRulesCommand::PlayerLeave(_)
+                | ResolvedRulesCommand::TokenCreation(_)
                 | ResolvedRulesCommand::Information(_)
                 | ResolvedRulesCommand::LedgerEdit(_)
                 | ResolvedRulesCommand::LibraryShuffle(_)
@@ -2159,6 +2223,20 @@ impl ResolvedRulesJournal {
                 {
                     return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
                         "player-leave command is not attributed to a player-leave node".to_string(),
+                    ));
+                }
+            }
+            ResolvedRulesCommand::TokenCreation(command) => {
+                // CR 111.1: the token's id must be below the high-water its own
+                // draw established, or the record cannot describe an allocation
+                // that actually happened.
+                if entry.node != command.cause
+                    || command.object.object_id.0 >= command.resulting_next_object_id
+                {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "token-creation command has an impossible id high-water, or an \
+                         unrelated cause"
+                            .to_string(),
                     ));
                 }
             }

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -94,6 +94,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::PlayerLeave(command) => {
             engine::game::elimination::apply_resolved_player_leave(state, command).unwrap();
         }
+        ResolvedRulesCommand::TokenCreation(command) => {
+            engine::game::effects::token::apply_resolved_token_creation(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }
@@ -206,6 +209,7 @@ fn exact_mana_spend_rejects_a_second_removal() {
             | ResolvedRulesCommand::EntryProvenance(_)
             | ResolvedRulesCommand::ObjectCease(_)
             | ResolvedRulesCommand::PlayerLeave(_)
+            | ResolvedRulesCommand::TokenCreation(_)
             | ResolvedRulesCommand::LedgerEdit(_)
             | ResolvedRulesCommand::LibraryShuffle(_)
             | ResolvedRulesCommand::ZoneChange(_)

--- a/crates/engine/tests/integration/cr733_resolved_draw.rs
+++ b/crates/engine/tests/integration/cr733_resolved_draw.rs
@@ -59,6 +59,9 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
         ResolvedRulesCommand::PlayerLeave(command) => {
             engine::game::elimination::apply_resolved_player_leave(state, command).unwrap();
         }
+        ResolvedRulesCommand::TokenCreation(command) => {
+            engine::game::effects::token::apply_resolved_token_creation(state, command).unwrap();
+        }
         ResolvedRulesCommand::LedgerEdit(command) => {
             engine::game::ledger::apply_resolved_ledger_edit(state, command).unwrap();
         }

--- a/crates/engine/tests/integration/cr733_resolved_token_creation.rs
+++ b/crates/engine/tests/integration/cr733_resolved_token_creation.rs
@@ -1,0 +1,121 @@
+//! CR733 P2 coverage for ordinary token creation.
+//!
+//! This is the first family whose replay MATERIALIZES its subject rather than
+//! verifying and installing into an object that already exists, so the applier's
+//! precondition is inverted: the recorded id must be ABSENT.
+//!
+//! Two allocator draws are recorded because both would otherwise be re-drawn —
+//! the `ObjectId` (from `next_object_id`) and the CR 613.7d entry timestamp. A
+//! replay that re-drew either would hand out a colliding id or reorder the token
+//! against continuous effects in the layer system.
+//!
+//! SCOPE: ordinary `TokenSpec` births. Copy tokens (CR 707.2) and meld births go
+//! through the liminal-entry path and are not yet journaled — see the scope note
+//! on `ResolvedTokenCreationCommand`.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::ResolvedRulesCommand;
+use engine::types::zones::Zone;
+
+const SOLDIER_TOKEN_ORACLE: &str = "Create a 1/1 white Soldier creature token.";
+
+#[test]
+fn token_creation_journals_an_exact_resolved_birth() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Built from Oracle text so the real parser produces the TokenSpec the
+    // production resolver consumes — a hand-written `Effect::Token` literal would
+    // also break on every new field.
+    let spell_id = scenario
+        .add_spell_to_hand_from_oracle(P0, "Raise the Alarm", true, SOLDIER_TOKEN_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let committed = runner.cast(spell_id).commit();
+    let pre_state = committed.state().clone();
+    let journal_start = pre_state.resolved_rules_journal.entries().len();
+
+    let outcome = committed.resolve();
+    let state = outcome.state();
+
+    // CR 111.1 reach guard: a token actually came into existence on the
+    // battlefield. Without it the journal assertion could pass vacuously.
+    let token_id = *state
+        .last_created_token_ids
+        .first()
+        .expect("CR 111.1: the resolved effect must create a token");
+    let token = &state.objects[&token_id];
+    assert!(token.is_token, "the created object is a token");
+    assert_eq!(token.zone, Zone::Battlefield);
+
+    // The discriminating assertion: the birth is journaled as an exact resolved
+    // command. A raw `create_object` + in-place mutation records nothing here.
+    let births: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::TokenCreation(command)
+                if command.object.object_id == token_id =>
+            {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        births.len(),
+        1,
+        "the token authority must journal exactly one resolved creation"
+    );
+
+    let birth = &births[0];
+    assert_eq!(
+        birth.entry_timestamp, token.timestamp,
+        "CR 613.7d: the journaled timestamp is the one the token received"
+    );
+    assert!(
+        birth.resulting_next_object_id > token_id.0,
+        "the recorded high-water is above the id it allocated"
+    );
+
+    // Replay-exactness: applying the recorded command to the pre-resolution state
+    // materializes the SAME object at the SAME id with the SAME timestamp, with
+    // no re-draw from `next_object_id` or `next_timestamp`.
+    let mut replay = pre_state;
+    assert!(
+        !replay.objects.contains_key(&token_id),
+        "the token does not exist before the command is applied"
+    );
+    engine::game::effects::token::apply_resolved_token_creation(&mut replay, birth)
+        .expect("the recorded birth must replay against its captured predecessor");
+
+    let replayed = &replay.objects[&token_id];
+    assert!(replayed.is_token, "replay materializes a token");
+    assert_eq!(
+        replayed.timestamp, birth.entry_timestamp,
+        "CR 613.7d: replay installs the recorded timestamp instead of re-drawing one"
+    );
+    assert_eq!(
+        replayed.power, token.power,
+        "replay installs the same body the resolve path built"
+    );
+    assert_eq!(replayed.toughness, token.toughness);
+    assert!(
+        replay.battlefield.contains(&token_id),
+        "replay adds the token to the battlefield zone list, not just the object map"
+    );
+
+    // The inverted precondition: this applier CREATES its subject, so a second
+    // application is a typed invariant failure rather than a silent duplicate.
+    assert!(
+        engine::game::effects::token::apply_resolved_token_creation(&mut replay, birth).is_err(),
+        "a token birth is not idempotent: re-applying it must fail closed"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -100,6 +100,7 @@ mod cr733_resolved_entry_retags;
 mod cr733_resolved_frame_transition;
 mod cr733_resolved_object_cease;
 mod cr733_resolved_player_leave;
+mod cr733_resolved_token_creation;
 mod cr733_resolved_transform;
 mod cr733_resolved_trigger_collection;
 mod cr733_resolved_zone_change;


### PR DESCRIPTION
The token resolver drew an ObjectId from next_object_id and a CR 613.7d entry
timestamp, then built the body in place with raw field writes. A retained-prefix
replay had no record that the object existed at all, and re-running the resolver
would draw a different id and timestamp -- handing out a colliding id and
reordering the token against continuous effects in the layer system.

This is the first family whose replay MATERIALIZES its subject instead of
verifying and installing into an existing one, so the applier's precondition is
inverted: the recorded id must be ABSENT, and re-applying fails closed rather
than silently duplicating the token.

The ordinary-token body block is extracted into materialize_token_spec_body, a
pure function on &mut GameObject shared by the resolve path and the applier so
the two cannot drift. Operating on the object rather than on GameState lets it
serve both orderings -- resolve inserts first and mutates in place, replay builds
a detached object and inserts it afterwards -- with no restructuring of the
resolver.

Counters, the attacking entry, and later status changes stay OUT of the command:
they already journal through the counters, combat, and object-status families.

SCOPE: ordinary TokenSpec births. Copy tokens (CR 707.2) and meld births go
through the liminal-entry path, whose LiminalEntry carries no body spec
(LiminalEntryKind distinguishes Token from Meld, not Spec from Copy), so wiring
them needs a new field on that shared serialized struct. Documented on the
command as the follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recording token creation events for deterministic game replay.
  - Replays now recreate tokens with the same identity, timestamp, tapped state, characteristics, abilities, and battlefield placement.

- **Bug Fixes**
  - Prevented token details from diverging between normal gameplay and replay.
  - Duplicate application of a token creation event is now rejected.

- **Tests**
  - Added integration coverage verifying token journaling, accurate replay, and duplicate-event protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->