### PR TITLE
feat(engine): journal CR 707.2 copy-token births as resolved commands

### DIFF
--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -29,7 +29,8 @@ use crate::types::phase::Phase;
 use crate::types::player::PlayerId;
 use crate::types::proposed_event::{CopyTokenSpec, ProposedEvent, TokenSpec};
 use crate::types::resolved_commands::{
-    ResolvedTokenCreationCommand, ResolvedTokenCreationReplayInvariantError,
+    ResolvedCopyBodyModifications, ResolvedTokenBody, ResolvedTokenCreationCommand,
+    ResolvedTokenCreationReplayInvariantError,
 };
 use crate::types::statics::CastFrequency;
 use crate::types::triggers::TriggerMode;
@@ -854,8 +855,11 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
                 object,
                 owner,
                 entry_timestamp,
-                spec: spec.clone(),
-                token_image_ref: token_image_ref.clone(),
+                entry_turn: turn_number,
+                body: ResolvedTokenBody::Spec {
+                    spec: spec.clone(),
+                    token_image_ref: token_image_ref.clone(),
+                },
                 resulting_tapped,
                 resulting_next_object_id: state.next_object_id,
                 cause,
@@ -1036,8 +1040,13 @@ pub(crate) fn apply_create_token_after_replacement_with_created_ids(
 /// count, or its tapped state — all of that was settled when the command was
 /// recorded.
 ///
-/// The body is installed through the same `materialize_token_spec_body` the
-/// resolve path uses, so the two cannot drift.
+/// The body is installed through the same `materialize_token_spec_body` /
+/// `materialize_token_copy_body` the resolve paths use, so they cannot drift.
+///
+/// CR 707.9: one copy case is deliberately NOT replayable — exceptions applied
+/// after the birth by the unjournaled `apply_token_modifications` seam. That
+/// returns `UnreplayableCopyModifications` before anything is materialized,
+/// rather than installing a body that is silently missing them.
 pub fn apply_resolved_token_creation(
     state: &mut GameState,
     command: &ResolvedTokenCreationCommand,
@@ -1064,21 +1073,50 @@ pub fn apply_resolved_token_creation(
         );
     }
 
-    let mut object = GameObject::new(
-        object_id,
-        CardId(0),
-        command.owner,
-        command.spec.characteristics.display_name.clone(),
-        Zone::Battlefield,
-    );
-    materialize_token_spec_body(
-        &mut object,
-        &command.spec,
-        command.token_image_ref.clone(),
-        state.turn_number,
-        command.entry_timestamp,
-        command.resulting_tapped,
-    );
+    // CR 707.9: refuse BEFORE materializing anything, so a body we cannot
+    // reproduce exactly never reaches `state.objects`.
+    if let ResolvedTokenBody::Copy {
+        modifications: ResolvedCopyBodyModifications::DeferredToUnjournaledSeam { modifications },
+        ..
+    } = &command.body
+    {
+        return Err(
+            ResolvedTokenCreationReplayInvariantError::UnreplayableCopyModifications {
+                object: object_id,
+                count: modifications.len(),
+            },
+        );
+    }
+
+    let name = match &command.body {
+        ResolvedTokenBody::Spec { spec, .. } => spec.characteristics.display_name.clone(),
+        ResolvedTokenBody::Copy { copy, .. } => copy.values.name.clone(),
+    };
+    let mut object = GameObject::new(object_id, CardId(0), command.owner, name, Zone::Battlefield);
+    match &command.body {
+        ResolvedTokenBody::Spec {
+            spec,
+            token_image_ref,
+        } => materialize_token_spec_body(
+            &mut object,
+            spec,
+            token_image_ref.clone(),
+            command.entry_turn,
+            command.entry_timestamp,
+            command.resulting_tapped,
+        ),
+        ResolvedTokenBody::Copy {
+            copy,
+            modifications,
+        } => materialize_token_copy_body(
+            &mut object,
+            copy,
+            modifications,
+            command.entry_turn,
+            command.entry_timestamp,
+            command.resulting_tapped,
+        ),
+    }
 
     state.objects.insert(object_id, object);
     // allow-raw-zone: replay materializes a token birth, which has no from-zone move (CR 111.1 + CR 614.12).
@@ -1167,6 +1205,79 @@ pub(crate) fn materialize_token_spec_body(
             Arc::make_mut(&mut object.base_abilities).extend(equip_abilities);
         }
     }
+}
+
+/// CR 707.2 + CR 707.5: Installs a copy token's body onto `object`.
+///
+/// Single authority for the copy-token body, shared by BOTH production copy
+/// seams (the liminal build in `token_copy::apply_copy_token_*` and the direct
+/// `create_object` path) and by the CR 733 replay applier, so no two of them can
+/// drift. Like `materialize_token_spec_body` it operates on a `&mut GameObject`
+/// rather than on `GameState`, which is what lets one implementation serve the
+/// liminal build-then-insert ordering and the direct insert-then-build ordering.
+///
+/// `reset_for_battlefield_entry` touches no copiable characteristic, so running
+/// it after the keyword grant (the liminal order) is equivalent to running it
+/// before (the former direct order).
+pub(crate) fn materialize_token_copy_body(
+    object: &mut GameObject,
+    copy: &CopyTokenSpec,
+    modifications: &ResolvedCopyBodyModifications,
+    turn_number: u32,
+    entry_timestamp: u64,
+    tapped: bool,
+) {
+    // CR 111.1: Mark as token for SBA cleanup (CR 704.5d)
+    object.is_token = true;
+    // CR 707.2: the copiable values, plus the display metadata that is not
+    // itself copiable. `install_copiable_values_as_base` already installs
+    // `loyalty`/`base_loyalty` from `values.loyalty` (CR 306.5b), so no separate
+    // loyalty seed is needed here.
+    apply_copiable_values_to_liminal_object(
+        object,
+        &copy.values,
+        copy.display_source,
+        copy.printed_ref.clone(),
+        copy.token_image_ref.clone(),
+    );
+
+    // CR 707.9a + CR 702: "except it has [keyword]" — grant additional keywords
+    // on top of the copied characteristics. Twinflame's haste copies are the
+    // canonical case. Idempotent under repeats.
+    for kw in &copy.extra_keywords {
+        let already_live = object.keywords.contains(kw); // allow-raw-authority: structural live keyword insertion de-dupe, not an effective keyword query
+        if !already_live {
+            object.keywords.push(kw.clone());
+        }
+        if !object.base_keywords.contains(kw) {
+            object.base_keywords.push(kw.clone());
+        }
+    }
+
+    match modifications {
+        // CR 707.2: the copiable values are the whole body.
+        ResolvedCopyBodyModifications::NoExceptions => {}
+        // CR 707.9b/9c: exceptions stamped onto the copiable values before entry.
+        ResolvedCopyBodyModifications::Folded {
+            modifications,
+            all_creature_types,
+        } => {
+            super::token_copy::apply_immediate_copy_token_modifications_to_object(
+                object,
+                modifications,
+                all_creature_types,
+            );
+        }
+        // Owned by the unjournaled `apply_token_modifications` seam and applied
+        // after the birth, so the body here is deliberately without them. Replay
+        // refuses this case up front in `apply_resolved_token_creation`.
+        ResolvedCopyBodyModifications::DeferredToUnjournaledSeam { .. } => {}
+    }
+
+    // CR 400.7 + CR 302.6: Single authority for ETB state. Haste granted via
+    // `extra_keywords` is folded in at query time by `has_summoning_sickness`.
+    object.reset_for_battlefield_entry(turn_number, entry_timestamp);
+    object.tapped = tapped;
 }
 
 pub(crate) fn reserve_liminal_token_object(
@@ -1394,6 +1505,54 @@ pub(crate) fn commit_liminal_token_entry_with_post_actions(
         .collect();
     entry.object.tapped = enter_tapped.resolve(entry.object.tapped);
     let owner = entry.object.owner;
+
+    // CR 733: journal the settled copy-token birth at the single liminal insert
+    // seam. `copy_resume` is `Some` for every production liminal entry of kind
+    // Token (`token_copy.rs` is the only production constructor), so this covers
+    // the whole liminal copy path. Counters, the attacking entry, and later
+    // status changes journal through their OWN families — this command is the
+    // birth only, exactly as the ordinary CR 111.1 birth is.
+    if let Some(copy) = entry.copy_resume.clone() {
+        // CR 707.9b/9c: the liminal seam folds its immediate exceptions into the
+        // copiable values BEFORE entry, so the body is complete here and replay
+        // can reapply them from this record.
+        let modifications = if copy.additional_modifications.is_empty() {
+            ResolvedCopyBodyModifications::NoExceptions
+        } else {
+            ResolvedCopyBodyModifications::Folded {
+                modifications: copy.additional_modifications.clone(),
+                // Only the CR 614 replacement consult runs between the build and
+                // this commit, and it cannot resolve a type-changing effect, so
+                // the live list still matches the one the build folded against.
+                all_creature_types: state.all_creature_types.clone(),
+            }
+        };
+        let command = ResolvedTokenCreationCommand {
+            object: ObjectIncarnationRef::from_object(&entry.object),
+            owner,
+            entry_timestamp: entry.object.timestamp,
+            // CR 302.6: the entered-turn the liminal build already stamped, read
+            // back off the object rather than re-read from the live turn.
+            entry_turn: entry
+                .object
+                .entered_battlefield_turn
+                .unwrap_or(state.turn_number),
+            body: ResolvedTokenBody::Copy {
+                copy,
+                modifications,
+            },
+            resulting_tapped: entry.object.tapped,
+            // `reserve_liminal_token_object` advanced the allocator to exactly
+            // one past this id when it drew it, however many were drawn since.
+            resulting_next_object_id: entry_ref.0 + 1,
+            cause: state.current_or_begin_rules_execution_node(),
+        };
+        state
+            .resolved_rules_journal
+            .record_token_creation(command)
+            .expect("resolved copy-token creation must have a live journal cause");
+    }
+
     state.objects.insert(entry_ref, entry.object);
     // allow-raw-zone: liminal token birth has no from-zone move; TokenEntry already consults entry replacements (CR 111.2 + CR 614.12).
     zones::add_to_zone(state, entry_ref, Zone::Battlefield, owner);

--- a/crates/engine/src/game/effects/token_copy.rs
+++ b/crates/engine/src/game/effects/token_copy.rs
@@ -1,7 +1,7 @@
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::game_object::{DisplaySource, GameObject};
 use crate::game::layers::{compute_current_copiable_values, has_active_copy_layer_effects};
-use crate::game::printed_cards::{install_copiable_values_as_base, intrinsic_copiable_values};
+use crate::game::printed_cards::intrinsic_copiable_values;
 use crate::game::quantity::resolve_quantity;
 use crate::game::{targeting, zones};
 use crate::types::ability::{
@@ -17,9 +17,12 @@ use crate::types::game_state::{
     GameState, LiminalEntry, PendingCopyTokenBatch, PendingCopyTokenResolution,
     PendingCounterPostAction, PendingLiminalEntryResume,
 };
-use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::identifiers::{CardId, ObjectId, ObjectIncarnationRef};
 use crate::types::proposed_event::{
     CopyTokenSpec, EtbTapState, ProposedEvent, TokenCharacteristics,
+};
+use crate::types::resolved_commands::{
+    ResolvedCopyBodyModifications, ResolvedTokenBody, ResolvedTokenCreationCommand,
 };
 use crate::types::zones::Zone;
 use std::collections::VecDeque;
@@ -533,29 +536,38 @@ pub(crate) fn apply_copy_token_after_replacement_with_created_ids(
                 super::token::reserve_liminal_token_object(state, token_owner, name.clone());
             let entry_timestamp = state.next_timestamp();
 
-            token.is_token = true;
-            super::token::apply_copiable_values_to_liminal_object(
-                &mut token,
-                &values,
+            let copy_spec = Box::new(CopyTokenSpec {
+                values: values.clone(),
                 display_source,
-                printed_ref.clone(),
-                token_image_ref.clone(),
-            );
-            for kw in &extra_keywords {
-                if !token.keywords.contains(kw) {
-                    token.keywords.push(kw.clone());
+                printed_ref: printed_ref.clone(),
+                token_image_ref: token_image_ref.clone(),
+                extra_keywords: extra_keywords.clone(),
+                additional_modifications: additional_modifications.clone(),
+                tapped,
+                enters_attacking,
+                sacrifice_at: sacrifice_at.clone(),
+                source_id,
+                controller,
+            });
+            // CR 707.9b/9c: this seam only runs when every exception is
+            // stampable onto copiable values before entry, so the body is
+            // complete here and the CR 733 record can replay it exactly.
+            let body_modifications = if additional_modifications.is_empty() {
+                ResolvedCopyBodyModifications::NoExceptions
+            } else {
+                ResolvedCopyBodyModifications::Folded {
+                    modifications: additional_modifications.clone(),
+                    all_creature_types: state.all_creature_types.clone(),
                 }
-                if !token.base_keywords.contains(kw) {
-                    token.base_keywords.push(kw.clone());
-                }
-            }
-            apply_immediate_copy_token_modifications_to_object(
+            };
+            super::token::materialize_token_copy_body(
                 &mut token,
-                &additional_modifications,
-                &state.all_creature_types,
+                &copy_spec,
+                &body_modifications,
+                state.turn_number,
+                entry_timestamp,
+                enter_tapped.resolve(tapped),
             );
-            token.reset_for_battlefield_entry(state.turn_number, entry_timestamp);
-            token.tapped = enter_tapped.resolve(tapped);
             state.liminal_entries.insert(
                 token_id,
                 LiminalEntry {
@@ -568,19 +580,7 @@ pub(crate) fn apply_copy_token_after_replacement_with_created_ids(
                     sacrifice_at: sacrifice_at.clone(),
                     remaining_count: final_count.saturating_sub(index + 1),
                     created_ids: created_ids.clone(),
-                    copy_resume: Some(Box::new(CopyTokenSpec {
-                        values: values.clone(),
-                        display_source,
-                        printed_ref: printed_ref.clone(),
-                        token_image_ref: token_image_ref.clone(),
-                        extra_keywords: extra_keywords.clone(),
-                        additional_modifications: additional_modifications.clone(),
-                        tapped,
-                        enters_attacking,
-                        sacrifice_at: sacrifice_at.clone(),
-                        source_id,
-                        controller,
-                    })),
+                    copy_resume: Some(copy_spec),
                     spec_resume: None,
                     enter_tapped,
                     enter_with_counters: Vec::new(),
@@ -660,36 +660,69 @@ pub(crate) fn apply_copy_token_after_replacement_with_created_ids(
         // timestamp. Drawn before the `get_mut` (`next_timestamp` takes `&mut self`).
         let entry_timestamp = state.next_timestamp();
 
-        let token = state.objects.get_mut(&token_id).unwrap();
-        token.is_token = true;
-        token.display_source = display_source;
-        token.printed_ref = printed_ref.clone();
-        token.base_printed_ref = printed_ref.clone();
-        // CR 111.1 + CR 707.2: when copying a true token, carry its exact token
-        // art pointer so the copy resolves the same art (not a name fallback).
-        token.token_image_ref = token_image_ref.clone();
-        install_copiable_values_as_base(token, &values);
-        token.base_loyalty = copied_loyalty;
-        token.loyalty = copied_loyalty;
-        // CR 400.7 + CR 302.6: Single authority for ETB state. Haste granted
-        // below via `extra_keywords` (Twinflame, etc.) is folded in at query
-        // time by `has_summoning_sickness`.
-        token.reset_for_battlefield_entry(state.turn_number, entry_timestamp);
+        let copy_spec = Box::new(CopyTokenSpec {
+            values: values.clone(),
+            display_source,
+            printed_ref: printed_ref.clone(),
+            token_image_ref: token_image_ref.clone(),
+            extra_keywords: extra_keywords.clone(),
+            additional_modifications: additional_modifications.clone(),
+            tapped,
+            enters_attacking,
+            sacrifice_at: sacrifice_at.clone(),
+            source_id,
+            controller,
+        });
+        // CR 707.9: unlike the liminal seam, this one applies its exceptions
+        // AFTER the birth through `apply_token_modifications`, which is pausable,
+        // state-level, and has no resolved family of its own yet. Mark them so
+        // replay refuses instead of installing a body that is missing them.
+        let body_modifications = if additional_modifications.is_empty() {
+            ResolvedCopyBodyModifications::NoExceptions
+        } else {
+            ResolvedCopyBodyModifications::DeferredToUnjournaledSeam {
+                modifications: additional_modifications.clone(),
+            }
+        };
+        let resulting_tapped = enter_tapped.resolve(tapped);
+        let turn_number = state.turn_number;
+        // `install_copiable_values_as_base` already seeds `loyalty`/`base_loyalty`
+        // from `values.loyalty` (CR 306.5b), which is what `copied_loyalty` is,
+        // so the shared body needs no separate loyalty seed.
+        let created_reference = state.objects.get_mut(&token_id).map(|token| {
+            super::token::materialize_token_copy_body(
+                token,
+                &copy_spec,
+                &body_modifications,
+                turn_number,
+                entry_timestamp,
+                resulting_tapped,
+            );
+            ObjectIncarnationRef::from_object(token)
+        });
 
-        // CR 707.2 + CR 702: "except it has [keyword]" — grant additional
-        // keywords on top of the copied characteristics. Twinflame's haste
-        // copies are the canonical case. Idempotent under repeats.
-        for kw in &extra_keywords {
-            if !token.keywords.contains(kw) {
-                token.keywords.push(kw.clone());
-            }
-            if !token.base_keywords.contains(kw) {
-                token.base_keywords.push(kw.clone());
-            }
+        // CR 733: journal the settled copy birth, after the body borrow ends.
+        if let Some(object) = created_reference {
+            let cause = state.current_or_begin_rules_execution_node();
+            let command = ResolvedTokenCreationCommand {
+                object,
+                owner: token_owner,
+                entry_timestamp,
+                entry_turn: turn_number,
+                body: ResolvedTokenBody::Copy {
+                    copy: copy_spec.clone(),
+                    modifications: body_modifications,
+                },
+                resulting_tapped,
+                resulting_next_object_id: state.next_object_id,
+                cause,
+            };
+            state
+                .resolved_rules_journal
+                .record_token_creation(command)
+                .expect("resolved copy-token creation must have a live journal cause");
         }
 
-        token.tapped = enter_tapped.resolve(tapped);
-        let _ = token;
         let finalization = CopyTokenFinalization {
             name: name.clone(),
             enters_attacking,
@@ -709,19 +742,7 @@ pub(crate) fn apply_copy_token_after_replacement_with_created_ids(
                     state,
                     vec![PendingCounterPostAction::ContinueCopyTokenCreation {
                         owner: token_owner,
-                        copy: Box::new(CopyTokenSpec {
-                            values: values.clone(),
-                            display_source,
-                            printed_ref: printed_ref.clone(),
-                            token_image_ref: token_image_ref.clone(),
-                            extra_keywords: extra_keywords.clone(),
-                            additional_modifications: additional_modifications.clone(),
-                            tapped,
-                            enters_attacking,
-                            sacrifice_at: sacrifice_at.clone(),
-                            source_id,
-                            controller,
-                        }),
+                        copy: copy_spec.clone(),
                         enter_tapped,
                         enter_with_counters: enter_with_counters.clone(),
                         remaining_count,

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use crate::game::game_object::AttachTarget;
 use crate::game::triggers::{ConsumedTriggerEventOccurrence, PendingTriggerContext};
 
-use super::ability::TriggerDefinitionRef;
+use super::ability::{ContinuousModification, TriggerDefinitionRef};
 use super::card::TokenImageRef;
 use super::card_type::CoreType;
 use super::counter::CounterType;
@@ -20,7 +20,7 @@ use super::game_state::{
 use super::identifiers::{ObjectId, ObjectIncarnationRef, LEGACY_INCARNATION};
 use super::mana::{ManaPipId, ManaUnit};
 use super::player::{PlayerCounterKind, PlayerId};
-use super::proposed_event::TokenSpec;
+use super::proposed_event::{CopyTokenSpec, TokenSpec};
 use super::resolution::{FrameKind, ResolutionFrame, ResolutionStackError};
 use super::zones::Zone;
 
@@ -467,7 +467,62 @@ pub enum ResolvedPlayerLeaveReplayInvariantError {
     AlreadyEliminated(PlayerId),
 }
 
-/// One exact CR 111.1 token creation.
+/// How one copy token's CR 707.9 "except ..." exceptions relate to its birth.
+///
+/// The two production copy seams complete the body at different moments, and a
+/// replay has to know which one it is looking at.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolvedCopyBodyModifications {
+    /// CR 707.2: no copy exceptions — the copiable values are the whole body.
+    NoExceptions,
+    /// CR 707.9: exceptions folded into the copiable values BEFORE the token
+    /// entered (the liminal seam), so replay reapplies them from this record.
+    ///
+    /// `all_creature_types` is recorded rather than re-read because
+    /// `remove_subtype_set` consults the live list, which changeling and other
+    /// type-changing effects mutate (CR 205.3 + CR 702.73a).
+    Folded {
+        modifications: Vec<ContinuousModification>,
+        all_creature_types: Vec<String>,
+    },
+    /// Exceptions applied AFTER the birth by `apply_token_modifications`
+    /// (`game/effects/token_copy.rs`) — a pausable, state-level seam that has no
+    /// resolved family of its own yet. The birth is still journaled, but replay
+    /// REFUSES rather than installing a body that is missing them.
+    ///
+    /// Delete this variant when that seam gets its own family; the refusal in
+    /// `apply_resolved_token_creation` disappears with it.
+    DeferredToUnjournaledSeam {
+        modifications: Vec<ContinuousModification>,
+    },
+}
+
+/// How the entering object's body was built for one journaled token birth.
+///
+/// CR 111.1 is the journaled axis for BOTH variants — an object came into
+/// existence and its id and timestamp were drawn. CR 707.2 governs only how a
+/// copy body was derived upstream of this seam, so it parameterizes the body
+/// rather than forking the family.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResolvedTokenBody {
+    /// CR 111.1: an ordinary token minted from a `TokenSpec`.
+    Spec {
+        /// The effect's token spec — the existing replacement-visible payload
+        /// type rather than a hand-rolled field list.
+        spec: Box<TokenSpec>,
+        /// `token_presets::find_exact_token_ref` READS game state to resolve
+        /// this, so it is a re-derivation rather than a spec field.
+        token_image_ref: Option<TokenImageRef>,
+    },
+    /// CR 707.2: a token that entered the battlefield as a copy of an object.
+    /// The copy's own art pointer and printed ref already live on `copy`.
+    Copy {
+        copy: Box<CopyTokenSpec>,
+        modifications: ResolvedCopyBodyModifications,
+    },
+}
+
+/// One exact CR 111.1 token creation, ordinary or copy.
 ///
 /// This is the first family whose replay MATERIALIZES an object rather than
 /// verifying and installing into one that already exists, so its precondition is
@@ -476,26 +531,23 @@ pub enum ResolvedPlayerLeaveReplayInvariantError {
 /// Two allocator draws are recorded because both would otherwise be re-drawn:
 /// the `ObjectId` (from `next_object_id`) and the CR 613.7d entry timestamp.
 ///
-/// SCOPE: ordinary `TokenSpec` births only. Copy tokens (CR 707.2) and meld
-/// births go through the liminal-entry path, whose `LiminalEntry` carries no
-/// body spec — `LiminalEntryKind` distinguishes Token from Meld, not Spec from
-/// Copy — so wiring them needs a new field on that shared serialized struct.
-/// They remain unjournaled for now. When they land, this struct's `spec` +
-/// `token_image_ref` pair becomes a `ResolvedTokenBody::{Spec, Copy}` payload on
-/// the SAME command: both are the CR 111.1 axis (an object came into existence
-/// and its id and timestamp were drawn), and CR 707.2 governs only how the copy
-/// body was derived upstream of this seam.
+/// SCOPE: token births only. Meld is NOT here — `finish_meld_entry` reuses the
+/// existing component object's id and moves it through the ordinary zone
+/// pipeline, so it materializes nothing and belongs with transform/frame
+/// semantics instead.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResolvedTokenCreationCommand {
     pub object: ObjectIncarnationRef,
     pub owner: PlayerId,
     pub entry_timestamp: u64,
-    /// The effect's token spec — the existing replacement-visible payload type
-    /// rather than a hand-rolled field list.
-    pub spec: Box<TokenSpec>,
-    /// `token_presets::find_exact_token_ref` READS game state to resolve this, so
-    /// it is a re-derivation rather than a spec field and must be recorded.
-    pub token_image_ref: Option<TokenImageRef>,
+    /// CR 302.6: the turn the token entered, which backs "has been under its
+    /// controller's control continuously since their most recent turn began"
+    /// (summoning sickness). Recorded rather than re-read from
+    /// `GameState::turn_number` so the command is self-contained: a replay that
+    /// observed a different live turn would stamp the wrong entered-turn and let
+    /// a replayed creature attack when it should not.
+    pub entry_turn: u32,
+    pub body: ResolvedTokenBody,
     /// CR 614.1: the post-replacement tapped state the token actually entered
     /// with, not the spec's pre-replacement request.
     pub resulting_tapped: bool,
@@ -514,6 +566,15 @@ pub enum ResolvedTokenCreationReplayInvariantError {
     UnknownOwner(PlayerId),
     #[error("token-creation id {id:?} is not below its recorded high-water {high_water}")]
     IdAboveHighWater { id: ObjectId, high_water: u64 },
+    /// CR 707.9: the birth was journaled, but its copy exceptions were applied
+    /// after the fact by `apply_token_modifications`, which has no resolved
+    /// family yet. Refusing keeps the hole visible instead of installing a body
+    /// that is silently missing them.
+    #[error(
+        "copy-token {object:?} has {count} post-birth copy modification(s) owned by the \
+         unjournaled `apply_token_modifications` seam; replay cannot reproduce them"
+    )]
+    UnreplayableCopyModifications { object: ObjectId, count: usize },
 }
 
 /// The audience that received one exact revealed-card fact.

--- a/crates/engine/tests/integration/cr733_resolved_copy_token_creation.rs
+++ b/crates/engine/tests/integration/cr733_resolved_copy_token_creation.rs
@@ -1,0 +1,450 @@
+//! CR733 P2 coverage for copy-token births (CR 707.2).
+//!
+//! Copy births share `ResolvedTokenCreationCommand` with ordinary CR 111.1
+//! births: the journaled axis is object creation for both — an object came into
+//! existence and its id and timestamp were drawn — and CR 707.2 governs only how
+//! the body was derived upstream of that seam. So the body is parameterized
+//! (`ResolvedTokenBody::{Spec, Copy}`) rather than forked into a sibling family.
+//!
+//! Like the ordinary family this applier MATERIALIZES its subject, so its
+//! precondition is inverted: the recorded id must be ABSENT and re-application
+//! must fail closed rather than silently duplicating the token.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::counter::CounterType;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::{
+    ResolvedCopyBodyModifications, ResolvedRulesCommand, ResolvedTokenBody,
+    ResolvedTokenCreationReplayInvariantError,
+};
+use engine::types::zones::Zone;
+
+/// Replicate (Sorcery) — verbatim Oracle text. A plain copy with no CR 707.9
+/// exceptions, so it takes the liminal seam and its body is complete at entry.
+const REPLICATE_ORACLE: &str = "Create a token that's a copy of target creature you control.";
+
+#[test]
+fn copy_token_birth_journals_and_replays_exactly() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // A distinctive body so the reach guard can prove the COPY actually copied,
+    // rather than that some token merely appeared.
+    let original = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let spell_id = scenario
+        .add_spell_to_hand_from_oracle(P0, "Replicate", true, REPLICATE_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let committed = runner.cast(spell_id).target_object(original).commit();
+    let pre_state = committed.state().clone();
+    let journal_start = pre_state.resolved_rules_journal.entries().len();
+
+    let outcome = committed.resolve();
+    let state = outcome.state();
+
+    // CR 707.2 reach guard: a copy token actually came into existence AND
+    // carries the copied characteristics. Without this the journal assertion
+    // below could pass vacuously on a run that never minted a copy.
+    let token_id = *state
+        .last_created_token_ids
+        .first()
+        .expect("CR 707.2: the resolved effect must create a copy token");
+    let token = &state.objects[&token_id];
+    assert!(token.is_token, "the created object is a token");
+    assert_eq!(token.zone, Zone::Battlefield);
+    assert_eq!(
+        token.name, "Grizzly Bears",
+        "CR 707.2: the copy acquires the copiable name of the original"
+    );
+    assert_eq!(
+        (token.power, token.toughness),
+        (Some(2), Some(2)),
+        "CR 707.2: the copy acquires the original's copiable power and toughness"
+    );
+
+    // The discriminating assertion: the copy birth is journaled as an exact
+    // resolved command. Before this family the copy seams recorded nothing.
+    let births: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::TokenCreation(command)
+                if command.object.object_id == token_id =>
+            {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        births.len(),
+        1,
+        "the copy-token authority must journal exactly one resolved creation"
+    );
+
+    let birth = &births[0];
+    // Body-shape guard: this fixture must reach the COPY arm, not the ordinary
+    // spec arm, or the test would be exercising the already-covered family.
+    match &birth.body {
+        ResolvedTokenBody::Copy {
+            copy,
+            modifications,
+        } => {
+            assert_eq!(
+                copy.values.name, "Grizzly Bears",
+                "the recorded body carries the copiable values that were copied"
+            );
+            assert_eq!(
+                *modifications,
+                ResolvedCopyBodyModifications::NoExceptions,
+                "Replicate has no CR 707.9 exceptions"
+            );
+        }
+        ResolvedTokenBody::Spec { .. } => {
+            panic!("a copy token must journal a Copy body, not an ordinary Spec body")
+        }
+    }
+    assert_eq!(
+        birth.entry_timestamp, token.timestamp,
+        "CR 613.7d: the journaled timestamp is the one the copy received"
+    );
+    assert!(
+        birth.resulting_next_object_id > token_id.0,
+        "the recorded high-water is above the id it allocated"
+    );
+
+    // Replay-exactness: applying the recorded command to the pre-resolution
+    // state materializes the SAME object at the SAME id with the SAME timestamp,
+    // with no re-draw from `next_object_id` or `next_timestamp`.
+    let mut replay = pre_state;
+    assert!(
+        !replay.objects.contains_key(&token_id),
+        "the copy does not exist before the command is applied"
+    );
+    engine::game::effects::token::apply_resolved_token_creation(&mut replay, birth)
+        .expect("the recorded copy birth must replay against its captured predecessor");
+
+    let replayed = &replay.objects[&token_id];
+    assert!(replayed.is_token, "replay materializes a token");
+    assert_eq!(
+        replayed.timestamp, birth.entry_timestamp,
+        "CR 613.7d: replay installs the recorded timestamp instead of re-drawing one"
+    );
+    assert_eq!(
+        replayed.name, token.name,
+        "replay installs the same copied body the resolve path built"
+    );
+    assert_eq!(
+        (replayed.power, replayed.toughness),
+        (token.power, token.toughness)
+    );
+    assert_eq!(
+        replayed.tapped, token.tapped,
+        "CR 614.1: replay installs the recorded post-replacement tapped state"
+    );
+    assert!(
+        replay.battlefield.contains(&token_id),
+        "replay adds the copy to the battlefield zone list, not just the object map"
+    );
+
+    // The inverted precondition: this applier CREATES its subject, so a second
+    // application is a typed invariant failure rather than a silent duplicate.
+    assert_eq!(
+        engine::game::effects::token::apply_resolved_token_creation(&mut replay, birth),
+        Err(ResolvedTokenCreationReplayInvariantError::ObjectAlreadyExists(token_id)),
+        "a copy-token birth is not idempotent: re-applying it must fail closed"
+    );
+
+    // CR 302.6: the applier installs the RECORDED entry turn, never the live
+    // one. Advancing `turn_number` on the replay state before applying is what
+    // makes this non-vacuous — the assertion fails if the applier reads
+    // `state.turn_number`, which is what it did before this command carried the
+    // turn. A wrong entered-turn would let a replayed creature attack when its
+    // summoning sickness should still forbid it.
+    let mut shifted = outcome.state().clone();
+    shifted.objects.remove(&token_id);
+    shifted.battlefield.retain(|id| *id != token_id);
+    shifted.turn_number = birth.entry_turn + 5;
+    engine::game::effects::token::apply_resolved_token_creation(&mut shifted, birth)
+        .expect("the recorded birth must replay regardless of the live turn");
+    assert_eq!(
+        shifted.objects[&token_id].entered_battlefield_turn,
+        Some(birth.entry_turn),
+        "CR 302.6: replay stamps the recorded entry turn, not the live one"
+    );
+    assert_ne!(
+        shifted.objects[&token_id].entered_battlefield_turn,
+        Some(shifted.turn_number),
+        "CR 302.6: the live turn was deliberately shifted, so matching it would mean \
+         the applier re-read game state instead of the record"
+    );
+
+    // Fail-closed on a mismatched recorded allocator draw: an id at or above its
+    // own high-water cannot describe an allocation that happened.
+    let mut tampered = birth.clone();
+    tampered.resulting_next_object_id = token_id.0;
+    let mut fresh = outcome.state().clone();
+    fresh.objects.remove(&token_id);
+    assert_eq!(
+        engine::game::effects::token::apply_resolved_token_creation(&mut fresh, &tampered),
+        Err(
+            ResolvedTokenCreationReplayInvariantError::IdAboveHighWater {
+                id: token_id,
+                high_water: token_id.0,
+            }
+        ),
+        "replay verifies the recorded high-water before installing anything"
+    );
+}
+
+/// Applied Geometry (Sorcery) — verbatim Oracle text. Its CR 707.9b exceptions
+/// all parse to `SetPower` / `SetToughness` / `AddSubtype` / `AddType`, none of
+/// which force the committed-object path, and "Put six +1/+1 counters on it"
+/// parses as a SEPARATE effect rather than as entry counters. So which seam this
+/// card takes depends entirely on its TARGET: a plain permanent leaves
+/// `etb_counters` empty (liminal, `Folded`), while a permanent that itself
+/// enters with counters makes `etb_counters` non-empty (direct, `Deferred`).
+const APPLIED_GEOMETRY_ORACLE: &str = "Create a token that's a copy of target non-Aura permanent \
+     you control, except it's a 0/0 Fractal creature in addition to its other types. Put six \
+     +1/+1 counters on it.";
+
+/// Spike Feeder — verbatim Oracle text. Its intrinsic CR 614.1c entry-counter
+/// replacement is what makes a copy of it take the direct seam.
+const SPIKE_FEEDER_ORACLE: &str = "This creature enters with two +1/+1 counters on it.\n\
+     {2}, Remove a +1/+1 counter from this creature: Put a +1/+1 counter on target creature.\n\
+     Remove a +1/+1 counter from this creature: You gain 2 life.";
+
+#[test]
+fn copy_token_birth_folds_immediate_exceptions_and_replays_them() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let original = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let spell_id = scenario
+        .add_spell_to_hand_from_oracle(P0, "Applied Geometry", true, APPLIED_GEOMETRY_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let committed = runner.cast(spell_id).target_object(original).commit();
+    let pre_state = committed.state().clone();
+    let journal_start = pre_state.resolved_rules_journal.entries().len();
+
+    let outcome = committed.resolve();
+    let state = outcome.state();
+
+    // CR 707.2 reach guard: a copy token exists AND carries the copied body.
+    let token_id = *state
+        .last_created_token_ids
+        .first()
+        .expect("CR 707.2: the resolved effect must create a copy token");
+    let token = &state.objects[&token_id];
+    assert!(token.is_token, "the created object is a token");
+    assert_eq!(token.zone, Zone::Battlefield);
+    assert_eq!(
+        token.name, "Grizzly Bears",
+        "CR 707.2: the copy acquires the copiable name of the original"
+    );
+
+    // CR 707.9b reach guard: the exception actually applied to the copy. Without
+    // this the body assertion below could pass on a run whose exception never
+    // ran at all.
+    assert!(
+        token
+            .card_types
+            .subtypes
+            .iter()
+            .any(|subtype| subtype == "Fractal"),
+        "CR 707.9b: the 'in addition to its other types' exception must have applied"
+    );
+
+    let births: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::TokenCreation(command)
+                if command.object.object_id == token_id =>
+            {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(births.len(), 1, "the copy birth is journaled exactly once");
+
+    // Seam reach guard: a plain copy target leaves `etb_counters` empty, so this
+    // fixture must take the LIMINAL seam and record its exceptions as Folded —
+    // meaning the body was complete at entry and replay can reproduce it.
+    let birth = &births[0];
+    let folded = match &birth.body {
+        ResolvedTokenBody::Copy {
+            modifications: ResolvedCopyBodyModifications::Folded { modifications, .. },
+            ..
+        } => modifications.clone(),
+        other => panic!("expected a Copy body marked Folded, got {other:?}"),
+    };
+    assert!(
+        !folded.is_empty(),
+        "the folded marker must carry the exceptions it stamped onto the body"
+    );
+
+    // Replay-exactness WITH exceptions: the replayed body must carry the folded
+    // modification, not just the bare copiable values.
+    let mut replay = pre_state;
+    engine::game::effects::token::apply_resolved_token_creation(&mut replay, birth)
+        .expect("a folded copy birth must replay against its captured predecessor");
+    let replayed = &replay.objects[&token_id];
+    assert!(
+        replayed
+            .card_types
+            .subtypes
+            .iter()
+            .any(|subtype| subtype == "Fractal"),
+        "CR 707.9b: replay reapplies the folded exception from the record"
+    );
+    // The exception set the body to 0/0; the six +1/+1 counters that took the
+    // live token to 6/6 journal through the COUNTERS family, so this command
+    // must NOT reproduce them. Asserting the birth body stays 0/0 is what proves
+    // the birth command does not double-apply another family's work.
+    assert_eq!(
+        (replayed.power, replayed.toughness),
+        (Some(0), Some(0)),
+        "CR 707.9b: replay installs the exception's base body only — the CR 122.6a \
+         entry counters belong to the counters family, not to the birth command"
+    );
+    assert_eq!(
+        (token.power, token.toughness),
+        (Some(6), Some(6)),
+        "reach guard: the live token really did receive the six +1/+1 counters, so \
+         the 0/0 replay body above is a deliberate exclusion, not a missing effect"
+    );
+}
+
+#[test]
+fn copy_token_birth_with_post_birth_modifications_refuses_to_replay() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Copying a permanent that itself enters with counters (CR 614.1c) makes
+    // `etb_counters` non-empty, which routes the copy to the DIRECT seam — the
+    // one that applies its exceptions after the birth.
+    let original = scenario
+        .add_creature_from_oracle(P0, "Spike Feeder", 0, 0, SPIKE_FEEDER_ORACLE)
+        .id();
+    // Spike Feeder is printed 0/0, so it needs its two entry counters to survive
+    // CR 704.5f while the copy spell resolves.
+    scenario.with_counter(original, CounterType::Plus1Plus1, 2);
+    let spell_id = scenario
+        .add_spell_to_hand_from_oracle(P0, "Applied Geometry", true, APPLIED_GEOMETRY_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let mut runner = scenario.build();
+    let committed = runner.cast(spell_id).target_object(original).commit();
+    let pre_state = committed.state().clone();
+    let journal_start = pre_state.resolved_rules_journal.entries().len();
+
+    let outcome = committed.resolve();
+    let state = outcome.state();
+
+    // CR 707.2 reach guard: a copy token exists and copied the right source.
+    let token_id = *state
+        .last_created_token_ids
+        .first()
+        .expect("CR 707.2: the resolved effect must create a copy token");
+    let token = &state.objects[&token_id];
+    assert!(token.is_token, "the created object is a token");
+    assert_eq!(token.zone, Zone::Battlefield);
+    assert_eq!(token.name, "Spike Feeder");
+
+    // CR 707.9b reach guard: the post-birth modification actually ran on the
+    // live object, which is what makes this birth unreplayable.
+    assert!(
+        token
+            .card_types
+            .subtypes
+            .iter()
+            .any(|subtype| subtype == "Fractal"),
+        "CR 707.9b: the exception must have applied AFTER the birth, via the unjournaled seam"
+    );
+
+    let births: Vec<_> = state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .skip(journal_start)
+        .filter_map(|entry| entry.command.clone())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::TokenCreation(command)
+                if command.object.object_id == token_id =>
+            {
+                Some(command)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        births.len(),
+        1,
+        "the direct copy seam must still journal the birth even though it cannot be replayed"
+    );
+
+    // The safety-arm reach guard: this fixture must record the DEFERRED body. If
+    // it recorded NoExceptions or Folded, the refusal below would be unreachable
+    // and direct+modification births would be silently journaled as replayable —
+    // the fail-open hole this arm exists to close.
+    let birth = &births[0];
+    let deferred_count = match &birth.body {
+        ResolvedTokenBody::Copy {
+            modifications:
+                ResolvedCopyBodyModifications::DeferredToUnjournaledSeam { modifications },
+            ..
+        } => modifications.len(),
+        other => panic!(
+            "expected a Copy body marked DeferredToUnjournaledSeam, got {other:?}; the direct \
+             seam's post-birth modifications would otherwise replay as if complete"
+        ),
+    };
+    assert!(
+        deferred_count > 0,
+        "the deferred marker must carry the modifications it could not replay"
+    );
+
+    // The refusal: replay declines rather than installing a body missing the
+    // post-birth modifications.
+    let mut replay = pre_state;
+    assert!(
+        !replay.objects.contains_key(&token_id),
+        "the copy does not exist before the command is applied"
+    );
+    assert_eq!(
+        engine::game::effects::token::apply_resolved_token_creation(&mut replay, birth),
+        Err(
+            ResolvedTokenCreationReplayInvariantError::UnreplayableCopyModifications {
+                object: token_id,
+                count: deferred_count,
+            }
+        ),
+        "CR 707.9: a birth whose exceptions were applied by the unjournaled seam must fail closed"
+    );
+
+    // Fail-closed means nothing was installed — a partial materialization must
+    // not hide behind the error.
+    assert!(
+        !replay.objects.contains_key(&token_id),
+        "the refusal must materialize nothing"
+    );
+    assert!(
+        !replay.battlefield.contains(&token_id),
+        "the refusal must not touch the battlefield zone list either"
+    );
+}

--- a/crates/engine/tests/integration/cr733_resolved_token_creation.rs
+++ b/crates/engine/tests/integration/cr733_resolved_token_creation.rs
@@ -9,9 +9,10 @@
 //! replay that re-drew either would hand out a colliding id or reorder the token
 //! against continuous effects in the layer system.
 //!
-//! SCOPE: ordinary `TokenSpec` births. Copy tokens (CR 707.2) and meld births go
-//! through the liminal-entry path and are not yet journaled — see the scope note
-//! on `ResolvedTokenCreationCommand`.
+//! SCOPE: ordinary `TokenSpec` births. Copy births (CR 707.2) share this command
+//! through `ResolvedTokenBody::Copy` and are covered in
+//! `cr733_resolved_copy_token_creation`. Meld is not a birth at all — it reuses
+//! the existing component object's id — so it is not in this family.
 
 use engine::game::scenario::{GameScenario, P0};
 use engine::types::mana::ManaCost;
@@ -110,6 +111,21 @@ fn token_creation_journals_an_exact_resolved_birth() {
     assert!(
         replay.battlefield.contains(&token_id),
         "replay adds the token to the battlefield zone list, not just the object map"
+    );
+
+    // CR 302.6: the applier installs the RECORDED entry turn, never the live
+    // one. Advancing `turn_number` on the replay state before applying is what
+    // makes this non-vacuous — it fails if the applier reads `state.turn_number`.
+    let mut shifted = state.clone();
+    shifted.objects.remove(&token_id);
+    shifted.battlefield.retain(|id| *id != token_id);
+    shifted.turn_number = birth.entry_turn + 5;
+    engine::game::effects::token::apply_resolved_token_creation(&mut shifted, birth)
+        .expect("the recorded birth must replay regardless of the live turn");
+    assert_eq!(
+        shifted.objects[&token_id].entered_battlefield_turn,
+        Some(birth.entry_turn),
+        "CR 302.6: replay stamps the recorded entry turn, not the live one"
     );
 
     // The inverted precondition: this applier CREATES its subject, so a second

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -95,6 +95,7 @@ mod cr733_resolved_attachment;
 mod cr733_resolved_commands_p0;
 mod cr733_resolved_commands_p1;
 mod cr733_resolved_commands_p2;
+mod cr733_resolved_copy_token_creation;
 mod cr733_resolved_draw;
 mod cr733_resolved_enter_tapped;
 mod cr733_resolved_entry_retags;


### PR DESCRIPTION
Copy tokens were the last unjournaled token birth. Both production copy
seams now resolve-and-journal through the same command the ordinary
CR 111.1 birth uses, and replay materializes them from the record.

Parameterize, don't proliferate — copy extends ResolvedTokenCreationCommand
rather than adding a sibling variant. The journaled axis is object creation
(CR 111.1: "Some effects put tokens onto the battlefield") for BOTH bodies:
an object came into existence and its id and CR 613.7d timestamp were drawn.
CR 707.2 governs only how the body was computed upstream of that seam, so it
parameterizes the payload instead of forking the family, and the axis stays
inside a single CR section as the categorical-boundary rule requires. The
shipped scope comment on that struct already prescribed exactly this.

  spec + token_image_ref  ->  body: ResolvedTokenBody::{Spec, Copy}

One shared body authority per shape, so resolve and replay cannot drift:
materialize_token_copy_body is now called by the liminal build, the direct
create_object path, and the applier. That also removes a duplicated keyword
grant and a redundant loyalty seed (install_copiable_values_as_base already
installs values.loyalty, which is what copied_loyalty was).

Fail-closed on the case that cannot be replayed exactly. The direct seam
applies its CR 707.9 exceptions AFTER the birth via apply_token_modifications
-- pausable, state-level, and with no resolved family yet -- so those births
record DeferredToUnjournaledSeam and the applier returns
UnreplayableCopyModifications instead of installing a body silently missing
them. An absent entry is detectable; a present-but-wrong one is not. The
refusal is greppable and disappears when that seam gets its own family.

all_creature_types is recorded rather than re-read at replay: changeling
(CR 702.73a) and type-changing effects mutate it, and remove_subtype_set
consults the live list.

Which seam a copy takes is decided by its TARGET, not by its own text.
Applied Geometry's exceptions all parse to SetPower/SetToughness/AddSubtype/
AddType (all liminal-immediate) and its "Put six +1/+1 counters on it" parses
as a separate effect, so copying a plain permanent takes the liminal seam
(Folded) while copying one that itself enters with counters makes
etb_counters non-empty and takes the direct seam (Deferred). All three body
arms are covered by production-path tests on that basis.

Meld is NOT in this family. finish_meld_entry reuses the existing component
object's id and moves it through the ordinary zone pipeline -- it draws no
id, sets no is_token, and materializes nothing -- so an applier whose whole
contract is materializing a subject cannot own it.

The LiminalEntry premise that blocked this unit was wrong: it already carries
object: GameObject plus copy_resume/spec_resume, so no field was added and
no serialized contract changed. Verified copy births are the ONLY production
liminal births -- spec_resume is never set to Some, and the other
LiminalEntry constructors are under #[cfg(test)].

Follow-up rider (NOT fixed here): apply_resolved_token_creation reads
state.turn_number live rather than recording it, so a replay could observe a
different value once turn advancement is journaled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Copy-created tokens are now recorded with their full resolved body information and replayed consistently, including correct entry/entered-battlefield behavior.
  - Folded exception handling for copy creations is now represented and reproduced as part of replay.
- **Bug Fixes**
  - Replay now fails safely (with no partial installs) when copy-token post-birth modifications would be unreplayable.
- **Tests**
  - Added integration coverage for copy-token replay exactness, folded exception replay behavior, and rejection of tampered/invalid replay scenarios (including duplicate-application safeguards).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->