### PR TITLE
fix(client): stop rotated hand cards aliasing on Chromium at DPR 1

### DIFF
--- a/client/src/components/animation/CastArcAnimation.tsx
+++ b/client/src/components/animation/CastArcAnimation.tsx
@@ -21,7 +21,11 @@ export function CastArcAnimation({
   mode,
   onComplete,
 }: CastArcAnimationProps) {
-  const { src } = useCardImage(cardName, { size: "small" });
+  // `normal`, not `small`: this renders a bare image element with no ladder at
+  // CARD_WIDTH 80 (160 device px at DPR 2), so the real 146px asset would
+  // upscale. Requesting `normal` keeps this overlay byte-identical to before
+  // `small` became a distinct asset.
+  const { src } = useCardImage(cardName, { size: "normal" });
 
   if (mode === "resolve-spell") {
     // Instant/sorcery: fade out with scale reduction at current position

--- a/client/src/components/animation/MillRevealAnimation.tsx
+++ b/client/src/components/animation/MillRevealAnimation.tsx
@@ -36,7 +36,11 @@ function MillCardElement({
   isLast: boolean;
   onComplete: () => void;
 }) {
-  const { src } = useCardImage(card.cardName, { size: "small" });
+  // `normal`, not `small`: this renders a bare image element with no ladder at
+  // CARD_WIDTH 80 (160 device px at DPR 2), so the real 146px asset would
+  // upscale. Requesting `normal` keeps this overlay byte-identical to before
+  // `small` became a distinct asset.
+  const { src } = useCardImage(card.cardName, { size: "normal" });
   const glowColor = card.colors.length > 0
     ? card.colors[0]
     : "#6366f1";

--- a/client/src/components/card/CardImage.tsx
+++ b/client/src/components/card/CardImage.tsx
@@ -6,6 +6,7 @@ import type { TokenSearchFilters } from "../../services/scryfall.ts";
 import type { TokenImageRef } from "../../adapter/types.ts";
 import { CARD_BACK_URL } from "../../services/scryfall.ts";
 import { getBevelBorderStyle } from "./cardFrame.ts";
+import { getCardImageSrcSetProps } from "./cardImageSrcSet.ts";
 import { CardArtFallback } from "./CardArtFallback.tsx";
 import { UnimplementedMechanicsBadge } from "./UnimplementedMechanicsBadge.tsx";
 import { ManaSymbol } from "../mana/ManaSymbol.tsx";
@@ -130,6 +131,7 @@ export function CardImage({
       ) : (
         <img
           src={renderedSrc}
+          {...getCardImageSrcSetProps(renderedSrc)}
           alt={renderedAlt}
           draggable={false}
           onError={() => setImageError(true)}

--- a/client/src/components/card/__tests__/CardImage.test.tsx
+++ b/client/src/components/card/__tests__/CardImage.test.tsx
@@ -169,8 +169,33 @@ describe("CardImage art fallback (issue #6156)", () => {
     const img = document.querySelector("img");
     expect(img).not.toBeNull();
     expect(img!.getAttribute("src")).toBe(CARD_BACK_URL);
+    // The card back has no size variants, so it must never carry a ladder that
+    // could resolve to a nonexistent asset.
+    expect(img!.getAttribute("srcset")).toBeNull();
     expect(screen.queryByRole("img", { name: "Grizzly Bears" })).toBeNull();
     expect(screen.queryByText("Grizzly Bears")).toBeNull();
+  });
+
+  it("serves a Scryfall card image at both widths, lazily", () => {
+    // `srcSet`, `sizes` and `loading` must arrive together: `sizes="auto"` is
+    // valid only with `loading="lazy"`, and without it the browser silently
+    // falls back to selecting the 488px asset for every card.
+    mockUseCardImage.mockReturnValue({
+      src: "https://cards.scryfall.io/normal/front/w/r/war-room.jpg?1783905318",
+      isLoading: false,
+      isRotated: false,
+      isFlip: false,
+    });
+
+    render(<CardImage cardName="War Room" />);
+
+    const img = document.querySelector("img");
+    expect(img!.getAttribute("srcset")).toBe(
+      "https://cards.scryfall.io/small/front/w/r/war-room.jpg?1783905318 146w, "
+      + "https://cards.scryfall.io/normal/front/w/r/war-room.jpg?1783905318 488w",
+    );
+    expect(img!.getAttribute("sizes")).toBe("auto, 200px");
+    expect(img!.getAttribute("loading")).toBe("lazy");
   });
 
   it("re-tries the image when the art source changes after a load failure", () => {

--- a/client/src/components/card/__tests__/cardImageSrcSet.test.ts
+++ b/client/src/components/card/__tests__/cardImageSrcSet.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { CARD_BACK_URL } from "../../../services/scryfall.ts";
+import { getCardImageSrcSetProps } from "../cardImageSrcSet.ts";
+
+const SLUG = "front/w/r/war-room.jpg?1783905318";
+const sized = (size: string) => `https://cards.scryfall.io/${size}/${SLUG}`;
+
+describe("getCardImageSrcSetProps", () => {
+  it("offers exactly two rungs, whatever size the source URL is", () => {
+    // The regression guard for the 672px `large` asset: adding it would ship
+    // ~+51 KB and ~+90% decoded bitmap per card to Safari/iOS.
+    for (const size of ["small", "normal", "large"]) {
+      const props = getCardImageSrcSetProps(sized(size));
+
+      expect(props?.srcSet.split(",")).toHaveLength(2);
+      expect(props?.srcSet).toBe(
+        `${sized("small")} 146w, ${sized("normal")} 488w`,
+      );
+      expect(props?.srcSet).not.toContain("672w");
+    }
+  });
+
+  it("keeps srcSet, sizes and loading together", () => {
+    // `sizes="auto"` is valid only alongside `loading="lazy"`; a site that lost
+    // `loading` would silently revert to always selecting the 488px asset.
+    expect(getCardImageSrcSetProps(sized("normal"))).toEqual({
+      srcSet: `${sized("small")} 146w, ${sized("normal")} 488w`,
+      sizes: "auto, 200px",
+      loading: "lazy",
+    });
+  });
+
+  it("returns undefined for sources with no size variants", () => {
+    // `art_crop` is a crop rather than a scaled variant — its rungs would be
+    // different images, not the same image at two widths.
+    expect(getCardImageSrcSetProps(sized("art_crop"))).toBeUndefined();
+    // Face-down cards render `CARD_BACK_URL`, and `useCardImage("")` yields "".
+    expect(getCardImageSrcSetProps(CARD_BACK_URL)).toBeUndefined();
+    expect(getCardImageSrcSetProps("")).toBeUndefined();
+    expect(getCardImageSrcSetProps(null)).toBeUndefined();
+    expect(getCardImageSrcSetProps(undefined)).toBeUndefined();
+    expect(getCardImageSrcSetProps("Focused Opponent Card.png")).toBeUndefined();
+  });
+});

--- a/client/src/components/card/cardImageSrcSet.ts
+++ b/client/src/components/card/cardImageSrcSet.ts
@@ -1,0 +1,50 @@
+import { IMAGE_SIZE_WIDTHS, deriveImageUrl, imageUrlSize } from "../../services/scryfall.ts";
+
+/**
+ * The image-element attributes that offer a card image at both of Scryfall's usable
+ * widths. Returned as one object — never as loose attributes — because
+ * `sizes="auto"` is valid *only* alongside `loading="lazy"`: a call site that
+ * copied `srcSet` and `sizes` but dropped `loading` would silently revert to
+ * always picking the 488px asset, with no error anywhere to catch it.
+ */
+export interface CardImageSrcSetProps {
+  srcSet: string;
+  sizes: string;
+  loading: "lazy";
+}
+
+/**
+ * Build the two-rung `srcset` ladder for a card image URL, or `undefined` when
+ * the URL has no size variants (face-down backs, test mocks, `art_crop`, the
+ * `soon.jpg` placeholder). Consumers spread the result directly, so `undefined`
+ * makes React omit all three attributes.
+ *
+ * Rotated hand cards render ~135 CSS px wide but were served the 488px asset —
+ * a 3.6x downscale that Skia resolves with bilinear-without-mipmaps for
+ * non-axis-aligned draws, which aliases badly. Offering the 146px asset lets
+ * the browser pick it wherever the used width x DPR fits.
+ *
+ * `sizes="auto"` resolves the element's *used layout width*, so the fan
+ * rotation and hover scale are correctly ignored. The `200px` fallback is what
+ * browsers without `auto` support read (Safari, Safari iOS; `auto` is
+ * Chrome/Edge 126+ and Firefox 132+) — at both DPR 1 and DPR 2 it selects the
+ * 488w rung, keeping those browsers byte-identical to today. A bare
+ * `sizes="auto"` would be actively wrong: with no `width`/`height` attributes
+ * on these elements the spec falls back to a 300x150 default intrinsic size,
+ * which reselects 488w and silently reinstates the aliasing.
+ */
+export function getCardImageSrcSetProps(
+  src: string | null | undefined,
+): CardImageSrcSetProps | undefined {
+  if (!src) return undefined;
+  const size = imageUrlSize(src);
+  // `art_crop` is a crop, not a scaled variant — its rungs are different images.
+  if (size === null || size === "art_crop") return undefined;
+  return {
+    srcSet:
+      `${deriveImageUrl(src, "small")} ${IMAGE_SIZE_WIDTHS.small}w, `
+      + `${deriveImageUrl(src, "normal")} ${IMAGE_SIZE_WIDTHS.normal}w`,
+    sizes: "auto, 200px",
+    loading: "lazy",
+  };
+}

--- a/client/src/components/hand/CompanionFanCard.tsx
+++ b/client/src/components/hand/CompanionFanCard.tsx
@@ -4,6 +4,7 @@ import type { PanInfo } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 import type { CompanionInfo } from "../../adapter/types.ts";
+import { getCardImageSrcSetProps } from "../card/cardImageSrcSet.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { dispatchAction } from "../../game/dispatch.ts";
@@ -101,6 +102,7 @@ const CompanionFanCard = memo(function CompanionFanCard({
         {src ? (
           <img
             src={src}
+            {...getCardImageSrcSetProps(src)}
             alt={cardName}
             draggable={false}
             className="!h-[var(--hand-card-h)] !w-[var(--hand-card-w)] object-cover"

--- a/client/src/components/hand/OpponentHand.tsx
+++ b/client/src/components/hand/OpponentHand.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
+import { getCardImageSrcSetProps } from "../card/cardImageSrcSet.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useCardHover } from "../../hooks/useCardHover.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
@@ -134,6 +135,7 @@ function OpponentCardThumbnail({ cardId, cardName }: { cardId: ObjectId; cardNam
     return (
       <img
         src={src}
+        {...getCardImageSrcSetProps(src)}
         alt={cardName}
         // `pointer-events-auto` so the card is the hit-test target even when an
         // ancestor opts out of pointer events (the split-seat fan wrapper does,

--- a/client/src/services/__tests__/scryfall.test.ts
+++ b/client/src/services/__tests__/scryfall.test.ts
@@ -813,3 +813,177 @@ describe("rateLimitedFetch (token/search API)", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("image size derivation", () => {
+  // The five-path-segment shape every real `cards.scryfall.io` URL has. The
+  // mainline `makeLocalDataMap` fixture is deliberately NOT used here: it emits
+  // `https://img.example/<Name>.jpg`, a one-segment URL that is not derivable,
+  // so every assertion below would pass vacuously against it.
+  const SLUG = "front/w/r/war-room.jpg";
+  const sized = (size: string, query = "") =>
+    `https://cards.scryfall.io/${size}/${SLUG}${query}`;
+  const SIZES = ["small", "normal", "large", "art_crop"] as const;
+
+  it("derives every size from every other size", async () => {
+    const { deriveImageUrl, imageUrlSize } = await loadScryfallModule();
+
+    for (const from of SIZES) {
+      expect(imageUrlSize(sized(from))).toBe(from);
+      for (const to of SIZES) {
+        const input = sized(from);
+        const derived = deriveImageUrl(input, to);
+        expect(derived).toBe(sized(to));
+        // Non-vacuity: a broken guard that returned its input unchanged would
+        // otherwise satisfy every same-size case and look green.
+        if (from !== to) expect(derived).not.toBe(input);
+      }
+    }
+  });
+
+  it("preserves the query string", async () => {
+    const { deriveImageUrl } = await loadScryfallModule();
+
+    const input = sized("normal", "?1783905318");
+    const derived = deriveImageUrl(input, "small");
+    expect(derived).toBe(
+      "https://cards.scryfall.io/small/front/w/r/war-room.jpg?1783905318",
+    );
+    expect(derived).not.toBe(input);
+  });
+
+  it("derives back faces", async () => {
+    const { deriveImageUrl } = await loadScryfallModule();
+
+    const input = "https://cards.scryfall.io/normal/back/w/r/war-room.jpg?1783905318";
+    const derived = deriveImageUrl(input, "small");
+    expect(derived).toBe(
+      "https://cards.scryfall.io/small/back/w/r/war-room.jpg?1783905318",
+    );
+    expect(derived).not.toBe(input);
+  });
+
+  it("returns non-derivable input unchanged, without throwing", async () => {
+    const { CARD_BACK_URL, deriveImageUrl, imageUrlSize } = await loadScryfallModule();
+
+    const nonDerivable = [
+      // Every face-down card renders through `useCardImage("")`.
+      "",
+      // `OpponentHand.test.tsx` mocks bare filenames — `new URL()` throws on these.
+      "Focused Opponent Card.png",
+      // Four path segments, so the card back never gets a ladder.
+      CARD_BACK_URL,
+      // One segment. Must stay byte-identical or `isPlaceholderImageUrl`'s `===`
+      // stops gating the printing-fallback chain.
+      "https://errors.scryfall.com/soon.jpg",
+      // Six segments.
+      "https://cards.scryfall.io/normal/front/w/r/extra/war-room.jpg",
+      // Five segments but an unrecognized size.
+      "https://cards.scryfall.io/png/front/w/r/war-room.png",
+    ];
+
+    for (const input of nonDerivable) {
+      expect(deriveImageUrl(input, "small")).toBe(input);
+      expect(imageUrlSize(input)).toBeNull();
+    }
+    expect(imageUrlSize(null)).toBeNull();
+    expect(imageUrlSize(undefined)).toBeNull();
+  });
+});
+
+describe("local face size resolution", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const NORMAL = "https://cards.scryfall.io/normal/front/w/r/war-room.jpg?1783905318";
+  const SMALL = "https://cards.scryfall.io/small/front/w/r/war-room.jpg?1783905318";
+  const ART_CROP = "https://cards.scryfall.io/art_crop/front/w/r/war-room.jpg?1783905318";
+
+  function makeSizedDataMap(key: string, name: string): Response {
+    return new Response(
+      JSON.stringify({
+        [key]: {
+          oracle_id: key,
+          face_names: [name.toLowerCase()],
+          faces: [{ normal: NORMAL, art_crop: ART_CROP }],
+          layout: "normal",
+          name,
+          mana_cost: "",
+          cmc: 0,
+          type_line: "Land",
+          colors: [],
+          color_identity: [],
+          keywords: [],
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  it("serves a real small asset from the stored normal URL", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeSizedDataMap("war room", "War Room"));
+
+    const { fetchCardImageUrl } = await loadScryfallModule();
+    const url = await fetchCardImageUrl("War Room", 0, "small");
+
+    expect(url).toBe(SMALL);
+    expect(url).not.toBe(NORMAL);
+  });
+
+  it("collapses large to normal", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeSizedDataMap("war room", "War Room"));
+
+    const { fetchCardImageUrl } = await loadScryfallModule();
+
+    expect(await fetchCardImageUrl("War Room", 0, "large")).toBe(NORMAL);
+  });
+
+  it("serves art_crop untouched", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeSizedDataMap("war room", "War Room"));
+
+    const { fetchCardImageUrl } = await loadScryfallModule();
+
+    expect(await fetchCardImageUrl("War Room", 0, "art_crop")).toBe(ART_CROP);
+  });
+
+  it("serves a real small asset for local token images", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce(makeSizedDataMap("token:goblin", "Goblin"));
+
+    const { fetchTokenImageUrl } = await loadScryfallModule();
+    const url = await fetchTokenImageUrl("Goblin", "small");
+
+    expect(url).toBe(SMALL);
+    expect(url).not.toBe(NORMAL);
+    // The local hit must short-circuit the Scryfall search API entirely.
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("serves a real small asset from printings, and still rejects placeholders", async () => {
+    const { resolvePrintingImageUrl } = await loadScryfallModule();
+    const printing = {
+      id: "real-printing",
+      set: "cmm",
+      set_name: "Commander Masters",
+      collector_number: "1054",
+      released_at: "2023-08-04",
+      border_color: "black",
+      frame_effects: [],
+      full_art: false,
+      faces: [{ normal: NORMAL, art_crop: ART_CROP }],
+    };
+
+    const small = resolvePrintingImageUrl(printing, 0, "small");
+    expect(small).toBe(SMALL);
+    expect(small).not.toBe(NORMAL);
+    expect(resolvePrintingImageUrl(printing, 0, "large")).toBe(NORMAL);
+
+    const placeholder = {
+      ...printing,
+      faces: [{
+        normal: "https://errors.scryfall.com/soon.jpg",
+        art_crop: "https://errors.scryfall.com/soon.jpg",
+      }],
+    };
+    expect(resolvePrintingImageUrl(placeholder, 0, "small")).toBeNull();
+  });
+});

--- a/client/src/services/scryfall.ts
+++ b/client/src/services/scryfall.ts
@@ -122,7 +122,7 @@ export function resolvePrintingImageUrl(
   size: ImageSize,
 ): string | null {
   const face = printing.faces[faceIndex] ?? printing.faces[0];
-  const url = face?.[size === "small" || size === "large" ? "normal" : size] ?? null;
+  const url = localFaceImageUrl(face, size) ?? null;
   return url && !isPlaceholderImageUrl(url) ? url : null;
 }
 
@@ -193,7 +193,90 @@ const SCRYFALL_DELAY_MS = 100;
 const MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 1000;
 
-export type ImageSize = "small" | "normal" | "large" | "art_crop";
+const IMAGE_SIZES = ["small", "normal", "large", "art_crop"] as const;
+
+export type ImageSize = (typeof IMAGE_SIZES)[number];
+
+/**
+ * Intrinsic pixel width of each Scryfall image variant, measured from the JPEG
+ * SOF markers of the assets themselves. Only the two rungs the `srcset` ladder
+ * offers are listed — see `deriveImageUrl` for why `large` is not one of them.
+ */
+export const IMAGE_SIZE_WIDTHS: Record<"small" | "normal", number> = {
+  small: 146,
+  normal: 488,
+};
+
+/**
+ * A Scryfall CDN image URL carries exactly five path segments, the first of
+ * which is the size variant:
+ *
+ *   `https://cards.scryfall.io/normal/front/w/r/war-room.jpg?1783905318`
+ *                              └─ 1 ──┘└─ 2 ┘└3┘└4┘└──── 5 ────┘
+ *
+ * Splitting (rather than `new URL()`) is deliberate: this runs on every image
+ * the client renders, including `""` for face-down cards and bare filenames
+ * from test mocks, and `new URL()` *throws* on both. `URL.parse()` returns null
+ * instead of throwing but is Chrome 126+/Safari 18+ only — narrower than the
+ * browsers this ladder's `200px` fallback exists to serve. String splitting
+ * has no failure mode: unrecognized input simply isn't size-derivable.
+ *
+ * Returns null for anything that is not a five-segment sized URL, which
+ * correctly excludes `CARD_BACK_URL` (four segments) and the
+ * `errors.scryfall.com/soon.jpg` placeholder (one) — the latter must stay
+ * byte-identical or `isPlaceholderImageUrl`'s `===` stops gating the
+ * printing-fallback chain.
+ */
+function splitSizedImageUrl(
+  url: string | null | undefined,
+): { scheme: string; segments: string[]; size: ImageSize } | null {
+  if (!url) return null;
+  const [scheme, rest, ...extra] = url.split("://");
+  if (rest === undefined || extra.length > 0) return null;
+  // `segments[0]` is the host; the five path segments follow it.
+  const segments = rest.split("/");
+  if (segments.length !== 6) return null;
+  const size = segments[1];
+  if (!IMAGE_SIZES.includes(size as ImageSize)) return null;
+  return { scheme, segments, size: size as ImageSize };
+}
+
+/** The size variant a Scryfall image URL serves, or null if it isn't one. */
+export function imageUrlSize(url: string | null | undefined): ImageSize | null {
+  return splitSizedImageUrl(url)?.size ?? null;
+}
+
+/**
+ * Rewrite a Scryfall image URL to a different size variant, returning the input
+ * unchanged when it isn't a size-derivable URL. The query string rides on the
+ * final path segment, so it is preserved without special handling.
+ */
+export function deriveImageUrl(url: string, size: ImageSize): string {
+  const parsed = splitSizedImageUrl(url);
+  if (!parsed) return url;
+  const segments = [...parsed.segments];
+  segments[1] = size;
+  return `${parsed.scheme}://${segments.join("/")}`;
+}
+
+/**
+ * Resolve one stored local face to a URL for the requested size.
+ *
+ * `scryfall-data.json` stores only `normal` and `art_crop` per face; `small` is
+ * derived from the `normal` URL. `large` deliberately collapses to `normal`:
+ * the 672px asset is ~+51 KB and ~+90% more decoded bitmap per card, and the
+ * only `large` consumer (`AttachmentFan`) renders at 176-384 CSS px where it
+ * would buy nothing — on a platform with this app's documented Safari/iOS OOM
+ * history. Do not "fix" this without measuring that memory cost.
+ */
+function localFaceImageUrl(
+  face: { normal: string; art_crop: string } | undefined,
+  size: ImageSize,
+): string | undefined {
+  if (!face) return undefined;
+  if (size === "art_crop") return face.art_crop;
+  return size === "small" ? deriveImageUrl(face.normal, "small") : face.normal;
+}
 
 export interface CardImageAsset {
   src: string;
@@ -587,7 +670,7 @@ function resolveImageUrl(
   diagnosticName: string,
 ): string {
   const face = entry.faces[faceIndex] ?? entry.faces[0];
-  const url = face?.[size === "small" || size === "large" ? "normal" : size];
+  const url = localFaceImageUrl(face, size);
   if (!url) {
     throw new Error(`No ${size} image for "${diagnosticName}"`);
   }
@@ -722,7 +805,7 @@ async function fetchTokenImageFromLocal(
   const entry = data?.[key];
   if (!entry) return null;
   const face = entry.faces[0];
-  return face?.[size === "small" || size === "large" ? "normal" : size] ?? null;
+  return localFaceImageUrl(face, size) ?? null;
 }
 
 function buildTokenQuery(


### PR DESCRIPTION
The hand fan rotates cards ~12deg, and Skia falls back to bilinear
sampling without mipmaps for non-axis-aligned draws. Hand cards were
drawing the 488px `normal` asset into a 146px slot — a 3.34x downscale
that undersamples badly and reads as jagged edges. At DPR 2 the ratio is
~1.55x, which is why macOS looked clean; the opponent fan uses an
axis-aligned rotate(180deg) and resamples exactly, so it was unaffected.

`ImageSize` had four variants but only ever produced two URLs — both
resolution paths collapsed `small` and `large` onto `normal`. Scryfall
serves every size at the same path with only the leading segment
swapped, so `small` is derivable client-side with no card-data
regeneration and no R2 redeploy.

Card images now carry a two-rung `srcset` (146w, 488w) with
`sizes="auto, 200px"` and `loading="lazy"`, letting the browser pick the
density. This re-selects for free when the window moves between displays
of different density, where a one-time `devicePixelRatio` read would
latch the wrong asset, and it keeps the full-resolution asset available
for the hand's hover zoom at DPR 2.

`large` stays collapsed onto `normal` deliberately: its only consumer
renders at 176-384 CSS px, and the 672px asset costs ~+51 KB and ~+90%
more decoded bitmap per card on a platform with known Safari/iOS OOM
history. The two bare-image overlays that requested `small` are pinned
to `normal` so they stay byte-identical rather than starting to upscale.

The 146w candidate is derived, not validated against the CDN. If
Scryfall ever lacked a /small/ variant for an image id, that candidate
would 404 and the existing onError path would swap in the text fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Card images now use responsive image sources to select appropriate resolutions automatically.
  - Lazy loading improves image-loading efficiency where supported.
  - Card, companion, and opponent-hand images now share consistent image sizing behavior.

- **Bug Fixes**
  - Animation overlays consistently use the correct card image quality.
  - Improved handling of card-back, art-crop, token, and locally stored images.
  - Image URL handling is more reliable across supported image sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->