### PR TITLE
fix(client): gate card hover on pointerType, not hover capability

### DIFF
--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -11,7 +11,6 @@ import { ArtCropCard } from "../card/ArtCropCard.tsx";
 import { CardImage } from "../card/CardImage.tsx";
 import { PTBox } from "./PTBox.tsx";
 import { useCardHover } from "../../hooks/useCardHover.ts";
-import { useCanHover } from "../../hooks/useCanHover.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useLongPress } from "../../hooks/useLongPress.ts";
@@ -277,7 +276,6 @@ export const PermanentCard = memo(function PermanentCard({
 }: PermanentCardProps) {
   const { t } = useTranslation("game");
   const isMobile = useIsMobile();
-  const canHover = useCanHover();
   const playerId = usePlayerId();
   const gameObjects = useGameStore((s) => s.gameState?.objects);
   const obj = useGameStore((s) => s.gameState?.objects[objectId]);
@@ -429,21 +427,6 @@ export const PermanentCard = memo(function PermanentCard({
 
   const isUndoableTap = undoableTapObjectIds.has(objectId);
 
-  // On touch-only devices, skip mouse events — synthesized mouseenter from touch fires
-  // inspectObject every touch, opening the full-screen MobilePreviewOverlay
-  // and blocking combat interactions (blocker/attacker selection).
-  const handleMouseEnter = useCallback(() => {
-    if (isMobile || !canHover) return;
-    hoverObject(objectId); inspectObject(objectId);
-  }, [canHover, hoverObject, inspectObject, isMobile, objectId]);
-
-  const handleMouseLeave = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    if (isMobile || !canHover) return;
-    const nextObjectId = objectIdFromRelatedTarget(event.relatedTarget);
-    hoverObject(nextObjectId);
-    inspectObject(nextObjectId);
-  }, [canHover, hoverObject, inspectObject, isMobile]);
-
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
   const { handlers: longPressHandlers, firedRef: longPressFired } = useLongPress(
     useCallback(() => {
@@ -451,6 +434,32 @@ export const PermanentCard = memo(function PermanentCard({
       setPreviewSticky(true);
     }, [inspectObject, setPreviewSticky, objectId]),
   );
+
+  // Gate on the event's own `pointerType`, not on a `(any-hover: hover)` media
+  // query. The hazard is a touch-synthesized enter — it fires inspectObject on
+  // every touch, opening the full-screen MobilePreviewOverlay and blocking
+  // combat interactions (blocker/attacker selection) — and `pointerType`
+  // reports that per-event. Capability metadata lies on hosts that still
+  // deliver honest pointer events: a remote-desktop session advertises no
+  // hover-capable input while sending `pointerType: "mouse"`. See useCardHover
+  // for why this is a denylist on "touch" rather than a "mouse" allowlist.
+  const handlePointerEnter = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (isMobile || event.pointerType === "touch") return;
+    hoverObject(objectId); inspectObject(objectId);
+  }, [hoverObject, inspectObject, isMobile, objectId]);
+
+  // Composes with useLongPress's own `onPointerLeave` instead of replacing it —
+  // this handler wins the key collision in the spread below, so dropping the
+  // delegation would leave the long-press timer running after the pointer
+  // slides off the card.
+  const cancelLongPress = longPressHandlers.onPointerLeave;
+  const handlePointerLeave = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    cancelLongPress(event);
+    if (isMobile || event.pointerType === "touch") return;
+    const nextObjectId = objectIdFromRelatedTarget(event.relatedTarget);
+    hoverObject(nextObjectId);
+    inspectObject(nextObjectId);
+  }, [cancelLongPress, hoverObject, inspectObject, isMobile]);
 
   const controllerIdentity = useGameStore(
     (s) => obj && s.gameState?.players?.find((p) => p.id === obj.controller)?.commander_color_identity,
@@ -777,9 +786,9 @@ export const PermanentCard = memo(function PermanentCard({
       }}
       transition={{ type: "spring", stiffness: 300, damping: 20 }}
       onClick={handleClick}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
       {...longPressHandlers}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
     >
       {isManaPaymentPreviewSource && (
         <div

--- a/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
+++ b/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
@@ -216,7 +216,7 @@ describe("BattlefieldZoneOverflow", () => {
     const drawerCard = document.querySelector('[data-object-id="1"]');
     expect(drawerCard).not.toBeNull();
 
-    fireEvent.mouseEnter(drawerCard as Element);
+    fireEvent.pointerEnter(drawerCard as Element, { pointerType: "mouse" });
 
     expect(useUiStore.getState().inspectedObjectId).toBe(1);
     expect(screen.getAllByAltText("Permanent 1").length).toBeGreaterThan(0);
@@ -230,7 +230,7 @@ describe("BattlefieldZoneOverflow", () => {
     const drawerCard = document.querySelector('[data-object-id="1"]');
     expect(drawerCard).not.toBeNull();
 
-    fireEvent.mouseEnter(drawerCard as Element);
+    fireEvent.pointerEnter(drawerCard as Element, { pointerType: "mouse" });
     fireEvent.mouseMove(drawerCard as Element, { clientX: 24, clientY: 24 });
 
     expect(useUiStore.getState().inspectedObjectId).toBeNull();

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -317,7 +317,7 @@ describe("PermanentCard", () => {
     expect(attachmentLayer.style.zIndex).toBe("5");
     expect(nestedAttachmentLayer.style.zIndex).toBe("5");
 
-    fireEvent.mouseEnter(host);
+    fireEvent.pointerEnter(host, { pointerType: "mouse" });
 
     expect(host.style.zIndex).toBe("80");
     expect(attachmentLayer.style.zIndex).toBe("5");
@@ -329,7 +329,7 @@ describe("PermanentCard", () => {
     const host = container.querySelector('[data-object-id="1"]') as HTMLElement;
     const nestedAttachment = container.querySelector('[data-object-id="3"]') as HTMLElement;
 
-    fireEvent.mouseEnter(nestedAttachment);
+    fireEvent.pointerEnter(nestedAttachment, { pointerType: "mouse" });
 
     expect(host.style.zIndex).toBe("80");
   });
@@ -378,7 +378,7 @@ describe("PermanentCard", () => {
     });
     expect(container.querySelector('[data-object-id="4"]')).toBeNull();
 
-    fireEvent.mouseEnter(container.querySelector('[data-object-id="1"]') as HTMLElement);
+    fireEvent.pointerEnter(container.querySelector('[data-object-id="1"]') as HTMLElement, { pointerType: "mouse" });
     expect(container.querySelector('[data-object-id="4"]')).toBeNull();
 
     act(() => {
@@ -641,7 +641,7 @@ describe("PermanentCard", () => {
     expect(queryByLabelText("Exiled Two")).toBeNull();
     expect(container.textContent).toContain("+1");
 
-    fireEvent.mouseEnter(container.querySelector('[data-object-id="1"]') as HTMLElement);
+    fireEvent.pointerEnter(container.querySelector('[data-object-id="1"]') as HTMLElement, { pointerType: "mouse" });
 
     expect(queryByLabelText("Exiled Two")).not.toBeNull();
   });
@@ -651,15 +651,94 @@ describe("PermanentCard", () => {
     const host = container.querySelector('[data-object-id="1"]') as HTMLElement;
     const attachment = container.querySelector('[data-object-id="2"]') as HTMLElement;
 
-    fireEvent.mouseEnter(host);
+    fireEvent.pointerEnter(host, { pointerType: "mouse" });
     expect(useUiStore.getState().inspectedObjectId).toBe(1);
 
-    fireEvent.mouseEnter(attachment);
+    fireEvent.pointerEnter(attachment, { pointerType: "mouse" });
     expect(useUiStore.getState().inspectedObjectId).toBe(2);
 
-    fireEvent.mouseLeave(attachment, { relatedTarget: host });
+    fireEvent.pointerLeave(attachment, { pointerType: "mouse", relatedTarget: host });
     expect(useUiStore.getState().inspectedObjectId).toBe(1);
     expect(useUiStore.getState().hoveredObjectId).toBe(1);
+  });
+
+  // A remote-desktop session does not enumerate the local mouse as a HID, so the
+  // guest browser reports no hover-capable input — while still delivering honest
+  // `pointerenter` events with `pointerType: "mouse"`. Gating on the capability
+  // query killed battlefield hover outright on those hosts; gating on the event's
+  // own pointerType is what makes this environment work.
+  it("previews on a host whose hover capability queries all report false", () => {
+    window.matchMedia = ((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+    Object.defineProperty(navigator, "maxTouchPoints", { configurable: true, value: 0 });
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1920 });
+
+    const { container } = renderPermanent();
+    const host = container.querySelector('[data-object-id="1"]') as HTMLElement;
+
+    fireEvent.pointerEnter(host, { pointerType: "mouse" });
+
+    expect(useUiStore.getState().inspectedObjectId).toBe(1);
+    // The card-lift/z-index hover state is a second, independent symptom: it
+    // rides on hoverObject, which only this inline gate calls.
+    expect(useUiStore.getState().hoveredObjectId).toBe(1);
+    expect(host.style.zIndex).toBe("80");
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1024 });
+  });
+
+  it("clears the hover lift when the pointer leaves for a non-card element", () => {
+    const { container } = renderPermanent();
+    const host = container.querySelector('[data-object-id="1"]') as HTMLElement;
+
+    fireEvent.pointerEnter(host, { pointerType: "mouse" });
+    expect(useUiStore.getState().hoveredObjectId).toBe(1);
+
+    fireEvent.pointerLeave(host, { pointerType: "mouse", relatedTarget: document.body });
+
+    expect(useUiStore.getState().hoveredObjectId).toBeNull();
+  });
+
+  it("ignores a touch-synthesized pointer enter", () => {
+    const { container } = renderPermanent();
+    const host = container.querySelector('[data-object-id="1"]') as HTMLElement;
+
+    fireEvent.pointerEnter(host, { pointerType: "touch" });
+
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+    expect(useUiStore.getState().hoveredObjectId).toBeNull();
+  });
+
+  it("still cancels the long-press timer through the merged pointer-leave handler", () => {
+    // useLongPress owns an onPointerLeave of its own and the hover handler wins
+    // the key collision, so it must delegate — otherwise the timer survives the
+    // leave and opens a sticky preview over whatever the pointer moved on to.
+    vi.useFakeTimers();
+    const { container } = renderPermanent();
+    const host = container.querySelector('[data-object-id="1"]') as HTMLElement;
+
+    fireEvent.pointerDown(host, {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    fireEvent.pointerLeave(host, { pointerId: 1, pointerType: "touch", relatedTarget: document.body });
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+    expect(useUiStore.getState().previewSticky).toBe(false);
+    vi.useRealTimers();
   });
 
   it("targets the attached permanent itself when the attachment is clicked", () => {

--- a/client/src/hooks/__tests__/useCardHover.test.tsx
+++ b/client/src/hooks/__tests__/useCardHover.test.tsx
@@ -1,0 +1,147 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCardHover } from "../useCardHover.ts";
+import { usePreferencesStore } from "../../stores/preferencesStore.ts";
+import { useUiStore } from "../../stores/uiStore.ts";
+
+const OBJECT_ID = 7;
+
+function CardHoverHarness() {
+  const { handlers } = useCardHover(OBJECT_ID);
+  return <div data-testid="card" {...handlers} />;
+}
+
+// React derives onPointerEnter/onPointerLeave from pointerover/pointerout, which
+// is what fireEvent.pointerEnter/pointerLeave fire — a hand-built
+// `new PointerEvent("pointerenter")` would reach no handler at all.
+describe("useCardHover", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1920 });
+    usePreferencesStore.setState({ cardPreviewMode: "follow", cardPreviewHoverDelayMs: 0 });
+    useUiStore.setState({ inspectedObjectId: null, hoveredObjectId: null, previewSticky: false });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  // A pen genuinely hovers, so it is deliberately treated like a mouse; only
+  // touch — where the enter is synthesized from a tap — is suppressed.
+  for (const pointerType of ["mouse", "pen"] as const) {
+    it(`opens the preview for a ${pointerType} pointer`, () => {
+      render(<CardHoverHarness />);
+
+      fireEvent.pointerEnter(screen.getByTestId("card"), { pointerType });
+
+      expect(useUiStore.getState().inspectedObjectId).toBe(OBJECT_ID);
+    });
+  }
+
+  it("closes the preview when a mouse pointer leaves", () => {
+    render(<CardHoverHarness />);
+    const card = screen.getByTestId("card");
+
+    fireEvent.pointerEnter(card, { pointerType: "mouse" });
+    fireEvent.pointerLeave(card, { pointerType: "mouse", relatedTarget: document.body });
+
+    // The clear is deferred so a spurious leave from a layout shift can be
+    // cancelled by a re-enter in the same frame.
+    act(() => vi.advanceTimersByTime(50));
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+  });
+
+  it("ignores a touch-synthesized enter but still previews on long press", () => {
+    render(<CardHoverHarness />);
+    const card = screen.getByTestId("card");
+
+    fireEvent.pointerEnter(card, { pointerType: "touch" });
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+
+    fireEvent.pointerDown(card, {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(useUiStore.getState().inspectedObjectId).toBe(OBJECT_ID);
+    expect(useUiStore.getState().previewSticky).toBe(true);
+  });
+
+  it("still cancels the long-press timer through the merged pointer-leave handler", () => {
+    // useLongPress owns an onPointerLeave of its own. The hover handler wins the
+    // key collision, so it must delegate — otherwise the timer survives a leave
+    // and fires a sticky preview over whatever the pointer moved on to.
+    render(<CardHoverHarness />);
+    const card = screen.getByTestId("card");
+
+    fireEvent.pointerDown(card, {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    fireEvent.pointerLeave(card, { pointerId: 1, pointerType: "touch", relatedTarget: document.body });
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+    expect(useUiStore.getState().previewSticky).toBe(false);
+  });
+
+  it("keeps the long-press preview open when the finger lifts", () => {
+    // The leave handler's touch guard is load-bearing on a tablet: lifting the
+    // finger fires a leave, which without the guard would immediately wipe the
+    // sticky preview that the same gesture just opened.
+    render(<CardHoverHarness />);
+    const card = screen.getByTestId("card");
+
+    fireEvent.pointerDown(card, {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(500));
+    expect(useUiStore.getState().inspectedObjectId).toBe(OBJECT_ID);
+
+    fireEvent.pointerLeave(card, { pointerId: 1, pointerType: "touch", relatedTarget: document.body });
+    act(() => vi.advanceTimersByTime(50));
+
+    expect(useUiStore.getState().inspectedObjectId).toBe(OBJECT_ID);
+    expect(useUiStore.getState().previewSticky).toBe(true);
+  });
+
+  it("previews on a host that reports no hover-capable input", () => {
+    // The regression guard for the reported bug. A remote-desktop session
+    // answers every hover capability query false while still delivering
+    // `pointerType: "mouse"`; the preview must follow the event, not the
+    // metadata. happy-dom would otherwise report `(any-hover: hover)` true,
+    // so the RDP host has to be stubbed explicitly.
+    vi.spyOn(window, "matchMedia").mockImplementation((media: string) => ({
+      matches: false,
+      media,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList);
+
+    render(<CardHoverHarness />);
+    fireEvent.pointerEnter(screen.getByTestId("card"), { pointerType: "mouse" });
+
+    expect(useUiStore.getState().inspectedObjectId).toBe(OBJECT_ID);
+  });
+});

--- a/client/src/hooks/useCardHover.ts
+++ b/client/src/hooks/useCardHover.ts
@@ -1,7 +1,6 @@
 import { useCallback } from "react";
 
 import { useLongPress } from "./useLongPress.ts";
-import { useCanHover } from "./useCanHover.ts";
 import { useIsMobile } from "./useIsMobile.ts";
 import { useUiStore } from "../stores/uiStore.ts";
 
@@ -19,7 +18,6 @@ export function useCardHover(objectId: number | null) {
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setPreviewSticky = useUiStore((s) => s.setPreviewSticky);
   const isMobile = useIsMobile();
-  const canHover = useCanHover();
 
   const { handlers: longPressHandlers, firedRef } = useLongPress(
     useCallback(() => {
@@ -33,27 +31,47 @@ export function useCardHover(objectId: number | null) {
     }, [inspectObject, setPreviewSticky, objectId]),
   );
 
-  const onMouseEnter = useCallback(() => {
+  // Gate on the event's own `pointerType`, not on a `(any-hover: hover)` media
+  // query: a touch-synthesized enter is the actual hazard (it fires the preview
+  // on every tap, creating an un-dismissable loop), and `pointerType` reports it
+  // per-event. Capability metadata lies on hosts that deliver honest pointer
+  // events anyway — a remote-desktop session advertises no hover-capable input
+  // while sending `pointerType: "mouse"`.
+  //
+  // Deliberately a denylist on "touch" rather than the allowlist idiom used by
+  // useHorizontalScroll and the deck builder's hoverPreview: those fail closed
+  // on an unrecognized pointerType, which is precisely the failure this fix
+  // exists to remove. Chromium reports "" for an unknown pointer, and such a
+  // device should hover rather than be silently locked out again.
+  const onPointerEnter = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === "touch") return;
     if (objectId != null) inspectObject(objectId);
   }, [inspectObject, objectId]);
 
-  const onMouseLeave = useCallback(() => {
+  // `useLongPress` owns an `onPointerLeave` of its own, so this must compose
+  // with it rather than replace it — otherwise the long-press timer never
+  // cancels when the pointer slides off the card.
+  const cancelLongPress = longPressHandlers.onPointerLeave;
+  const onPointerLeave = useCallback((e: React.PointerEvent) => {
+    cancelLongPress(e);
+    // The touch guard matters most here: on a tablet the finger-lift fires a
+    // leave, which would wipe the sticky preview the long-press just opened.
+    if (e.pointerType === "touch") return;
     inspectObject(null);
-  }, [inspectObject]);
+  }, [cancelLongPress, inspectObject]);
 
-  // On touch-only devices, skip mouse events — synthesized mouseenter from touch fires
-  // the preview every time the user touches a card, creating an
-  // un-dismissable loop. Long-press is the only mobile preview trigger.
-  //
-  // `data-card-hover` is required for usePreviewDismiss's elementFromPoint
-  // poll — without this attribute the 300ms dismiss loop clears the preview
-  // while the cursor is still over the card. Injecting it here ensures every
+  // `data-card-hover` is required for usePreviewDismiss's `:hover` poll —
+  // without this attribute the 300ms dismiss loop clears the preview while the
+  // cursor is still over the card. Injecting it here ensures every
   // useCardHover consumer is tagged by construction, so new callsites can't
   // silently regress the invariant by forgetting the manual annotation.
+  //
+  // The long-press spread comes FIRST so the composed handlers above
+  // deterministically win the `onPointerLeave` key collision.
   return {
-    handlers: isMobile || !canHover
+    handlers: isMobile
       ? { ...longPressHandlers, "data-card-hover": true }
-      : { onMouseEnter, onMouseLeave, ...longPressHandlers, "data-card-hover": true },
+      : { ...longPressHandlers, onPointerEnter, onPointerLeave, "data-card-hover": true },
     firedRef,
   };
 }


### PR DESCRIPTION
Battlefield hover previews were dead over remote desktop — in Chrome,
Firefox and the Tauri shell alike — while hand hover and avatar hover
kept working on the same box.

The hover handlers gated on `useCanHover()`, i.e. the `(any-hover:
hover)` media query. A remote-desktop session advertises no hover-capable
input, so the query answers false, and the enter handler returned before
ever opening the preview. It still delivers perfectly honest pointer
events with `pointerType: "mouse"`. The media query is descriptive
capability metadata, not an event gate, and it is exactly the sort of
metadata a virtualized input stack gets wrong.

The real hazard was never "no hover capability" — it was a
touch-synthesized enter, which fires the preview on every tap and (on the
battlefield) opens the full-screen overlay that blocks blocker and
attacker selection. `PointerEvent.pointerType` reports that per event, so
the handlers now gate on it directly and the mouse/pen paths are
untouched.

This is deliberately a denylist on "touch" rather than the "mouse"
allowlist used elsewhere in the client: an allowlist fails closed on an
unrecognized pointerType, which is the precise failure being fixed here.
Chromium reports "" for an unknown pointer, and such a device should
hover rather than be silently locked out again.

Switching from onMouseEnter/onMouseLeave to the pointer equivalents
collides with the `onPointerLeave` that `useLongPress` already returns,
and the later key in a JSX spread silently wins. Both call sites now
spread the long-press handlers first and explicitly delegate to the
captured `onPointerLeave`, so the long-press timer still cancels on
leave. Depending on that captured method rather than the handlers object
also restores the useCallback memoization, since useLongPress returns a
fresh object literal every render.

`useInspectHoverProps` still gates on `(any-hover: hover)`, so its 42
call sites remain affected; merging its branches also requires removing
the duplicate `useLongPress` in ZoneViewer and LibraryPile, so it is left
for a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved card previews across mouse, pen, touch, and remote-desktop interactions.
  * Prevented touch-generated hover events from opening unintended previews.
  * Ensured long-press previews remain active appropriately and cancel cleanly when leaving a card.
  * Fixed hover previews when no hover-capable device is detected.
* **Tests**
  * Expanded coverage for pointer interactions, touch behavior, long-press handling, and preview transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->