### PR TITLE
fix(engine): carry the CR 613.7 timestamp allocator past replayed values

### DIFF
--- a/crates/engine/src/game/effects/attach.rs
+++ b/crates/engine/src/game/effects/attach.rs
@@ -1362,6 +1362,11 @@ pub fn apply_resolved_attachment(
             attachment.timestamp = timestamp;
         }
     }
+    // CR 613.7e: an unattach and a same-host re-attach draw no timestamp, so
+    // only a recorded draw advances the allocator past the value it installed.
+    if let Some(timestamp) = command.resulting_timestamp {
+        state.adopt_replayed_timestamp(timestamp);
+    }
     if let Some(new_host_id) = command.resulting_host.and_then(|host| host.as_object()) {
         if let Some(new_host) = state.objects.get_mut(&new_host_id) {
             if !new_host.attachments.contains(&attachment_id) {

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -1123,6 +1123,11 @@ pub fn apply_resolved_token_creation(
     zones::add_to_zone(state, object_id, Zone::Battlefield, command.owner);
     // CR 111.1: replay must not hand the same id out again to a later allocation.
     state.next_object_id = state.next_object_id.max(command.resulting_next_object_id);
+    // CR 613.7d: the birth drew an entry timestamp alongside the object id, and
+    // the same reasoning applies to it — replay installs the recorded value, so
+    // the timestamp allocator must be carried past it or a later draw reissues
+    // it and the two objects are unordered within their CR 613 layer.
+    state.adopt_replayed_timestamp(command.entry_timestamp);
     Ok(())
 }
 

--- a/crates/engine/src/game/transform.rs
+++ b/crates/engine/src/game/transform.rs
@@ -170,6 +170,11 @@ pub fn apply_resolved_transform(
     obj.timestamp = command.resulting_timestamp;
     obj.transformation_count = command.resulting_transformation_count;
 
+    // CR 613.7g: the transform drew this timestamp during the original
+    // execution, so replay installs it rather than drawing a fresh one — and
+    // must carry the allocator past it or a later draw reissues it.
+    state.adopt_replayed_timestamp(command.resulting_timestamp);
+
     crate::game::layers::mark_layers_full(state);
 
     Ok(())

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -902,6 +902,15 @@ pub fn apply_resolved_zone_change(
         );
     }
 
+    // CR 613.7d: the battlefield entry drew this timestamp during the original
+    // execution, so replay installs it rather than drawing a fresh one — and
+    // must carry the allocator past it or a later draw reissues it. A move to
+    // any other zone drew none, which is why this is bound to the recorded
+    // `Option` rather than applied to every zone change.
+    if let Some(entry_timestamp) = command.entry_timestamp {
+        state.adopt_replayed_timestamp(entry_timestamp);
+    }
+
     let turn_zone_change_index =
         super::restrictions::record_zone_change(state, command.zone_change_record.clone());
     if turn_zone_change_index != command.turn_zone_change_index {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -16370,6 +16370,24 @@ impl GameState {
         ts
     }
 
+    /// CR 613.7: carry the timestamp allocator past a timestamp that a CR 733
+    /// replay *installed* rather than drew.
+    ///
+    /// Every applier that stamps an object with a recorded timestamp must call
+    /// this. [`GameState::next_timestamp`] is the draw counter, so an applier
+    /// that installs a recorded value without advancing it leaves the counter
+    /// behind a timestamp already in use, and a later draw hands that same
+    /// timestamp to a second object. CR 613.7 orders effects within a layer
+    /// solely by timestamp, so the two are then unordered — a corruption that
+    /// needs no forged journal, only an honest replay.
+    ///
+    /// `max` keeps the counter monotone when commands replay in an order other
+    /// than the one they were drawn in. `saturating_add` is total; its clamp is
+    /// unreachable because no game performs `u64::MAX` draws.
+    pub(crate) fn adopt_replayed_timestamp(&mut self, timestamp: u64) {
+        self.next_timestamp = self.next_timestamp.max(timestamp.saturating_add(1));
+    }
+
     pub fn may_trigger_auto_choice(&self, key: &MayTriggerAutoChoiceKey) -> Option<AutoMayChoice> {
         self.may_trigger_auto_choices
             .iter()

--- a/crates/engine/tests/integration/cr733_resolved_attachment.rs
+++ b/crates/engine/tests/integration/cr733_resolved_attachment.rs
@@ -137,6 +137,21 @@ fn equip_journals_an_exact_resolved_attachment() {
             .expect("an attach draws a timestamp"),
         "CR 613.7e: replay installs the recorded timestamp instead of re-drawing one"
     );
+
+    // CR 613.7: installing a recorded timestamp is only half the contract — the
+    // allocator must also be carried past it, or a later draw in the same replay
+    // hands the same timestamp to a second object and CR 613.7 leaves the two
+    // unordered within their layer. Asserted by DRAWING rather than by reading
+    // the counter, so this pins the observable consequence and not the field.
+    let installed = attachment
+        .resulting_timestamp
+        .expect("an attach draws a timestamp");
+    let next_drawn = replay.next_timestamp();
+    assert!(
+        next_drawn > installed,
+        "CR 613.7: replay installed timestamp {installed} but the next draw handed out \
+         {next_drawn}; two objects sharing a timestamp are unordered within their layer"
+    );
 }
 
 /// CR 701.3d: an unattach records the mirror-image edit — a host precondition
@@ -176,6 +191,7 @@ fn unattach_journals_a_host_removal_without_a_timestamp_draw() {
     let attached_state = runner.state().clone();
     let journal_start = attached_state.resolved_rules_journal.entries().len();
     let attached_timestamp = attached_state.objects[&equipment].timestamp;
+    let attached_next_timestamp = attached_state.next_timestamp;
 
     let outcome = runner.cast(spell_id).target_object(creature).resolve();
 
@@ -231,5 +247,13 @@ fn unattach_journals_a_host_removal_without_a_timestamp_draw() {
     assert_eq!(
         replay.objects[&equipment].timestamp, attached_timestamp,
         "CR 613.7e: an unattach replay must not disturb the attachment's timestamp"
+    );
+    // The other side of the allocator contract: an unattach drew no timestamp,
+    // so replaying one must not advance the draw counter either. This is what
+    // keeps the advance bound to a recorded draw rather than applied blanket to
+    // every attachment command.
+    assert_eq!(
+        replay.next_timestamp, attached_next_timestamp,
+        "CR 613.7e: an unattach draws no timestamp, so replay advances no allocator"
     );
 }

--- a/crates/engine/tests/integration/cr733_resolved_token_creation.rs
+++ b/crates/engine/tests/integration/cr733_resolved_token_creation.rs
@@ -128,6 +128,24 @@ fn token_creation_journals_an_exact_resolved_birth() {
         "CR 302.6: replay stamps the recorded entry turn, not the live one"
     );
 
+    // A birth draws from BOTH allocators, so replay must carry both past the
+    // values it installed. The object-id side is asserted by the applier's own
+    // high-water guard; this is the timestamp side, which is asserted by DRAWING
+    // so it pins the consequence rather than the counter field. Without it a
+    // later draw reissues this token's timestamp, and CR 613.7 orders effects
+    // within a layer by timestamp alone, leaving the two objects unordered.
+    let next_drawn = replay.next_timestamp();
+    assert!(
+        next_drawn > birth.entry_timestamp,
+        "CR 613.7d: replay installed entry timestamp {} but the next draw handed out {}",
+        birth.entry_timestamp,
+        next_drawn
+    );
+    assert!(
+        replay.next_object_id > token_id.0,
+        "CR 111.1: replay carries the object-id allocator past the id it installed"
+    );
+
     // The inverted precondition: this applier CREATES its subject, so a second
     // application is a typed invariant failure rather than a silent duplicate.
     assert!(

--- a/crates/engine/tests/integration/cr733_resolved_transform.rs
+++ b/crates/engine/tests/integration/cr733_resolved_transform.rs
@@ -123,4 +123,20 @@ fn transform_journals_an_exact_resolved_transform() {
         replayed.timestamp, transform.resulting_timestamp,
         "CR 613.7g: replay installs the recorded timestamp instead of re-drawing one"
     );
+
+    // CR 613.7: installing a recorded timestamp is only half the contract — the
+    // allocator must also be carried past it. `next_timestamp` is the draw
+    // counter, so an applier that installs 42 while leaving the counter at 5
+    // hands 42 out a second time later in the replay, and CR 613.7 orders
+    // effects within a layer by timestamp alone, leaving the two unordered.
+    // Asserted by DRAWING rather than by reading the counter, so this pins the
+    // observable consequence and not the field.
+    let next_drawn = replay.next_timestamp();
+    assert!(
+        next_drawn > transform.resulting_timestamp,
+        "CR 613.7: replay installed timestamp {} but the next draw handed out {}; \
+         two objects sharing a timestamp are unordered within their layer",
+        transform.resulting_timestamp,
+        next_drawn
+    );
 }

--- a/crates/engine/tests/integration/cr733_resolved_zone_change.rs
+++ b/crates/engine/tests/integration/cr733_resolved_zone_change.rs
@@ -81,6 +81,60 @@ fn zone_change_command_round_trips_and_replays_the_exact_transition_core() {
         replay.zone_changes_this_turn[command.turn_zone_change_index], command.zone_change_record,
         "replay appends the exact recorded per-turn zone-change entry"
     );
+
+    // CR 613.7: installing the recorded entry timestamp is only half the
+    // contract — the allocator must also be carried past it. `next_timestamp`
+    // is the draw counter, so an applier that installs a value while leaving
+    // the counter behind hands that same timestamp to a second object later in
+    // the replay, and CR 613.7 orders effects within a layer by timestamp
+    // alone. Asserted by DRAWING, so this pins the consequence, not the field.
+    let installed = command.entry_timestamp.expect("a battlefield entry draws");
+    let next_drawn = replay.next_timestamp();
+    assert!(
+        next_drawn > installed,
+        "CR 613.7d: replay installed entry timestamp {installed} but the next draw handed \
+         out {next_drawn}; two objects sharing a timestamp are unordered within their layer"
+    );
+}
+
+/// The other side of the CR 613.7d allocator contract: a move to a zone that
+/// grants no timestamp records none, so replaying it must advance no allocator.
+/// This is what keeps the advance bound to a recorded draw rather than applied
+/// blanket to every zone change, which would silently inflate the counter.
+#[test]
+fn a_zone_change_that_drew_no_timestamp_advances_no_allocator_on_replay() {
+    let mut scenario = GameScenario::new_n_player(2, 0x733);
+    let creature = scenario
+        .add_creature_from_oracle(P0, "Journal Entrant", 2, 2, "")
+        .id();
+    let runner = scenario.build();
+
+    // The predecessor is the state the graveyard move was recorded FROM, so the
+    // command's own incarnation and occurrence guards are satisfied on replay.
+    let pre_state = runner.state().clone();
+    let mut state = pre_state.clone();
+    let mut events = Vec::new();
+    move_to_zone(&mut state, creature, Zone::Graveyard, &mut events);
+
+    let to_graveyard = recorded_zone_change(&state, Zone::Battlefield, Zone::Graveyard);
+    assert_eq!(
+        to_graveyard.entry_timestamp, None,
+        "CR 613.7d grants a timestamp on entering the battlefield; a graveyard move draws none"
+    );
+
+    let mut replay = pre_state;
+    let before = replay.next_timestamp;
+    apply_resolved_zone_change(&mut replay, &to_graveyard)
+        .expect("the recorded graveyard move replays against the state it was recorded from");
+    assert_eq!(
+        replay.objects[&creature].zone,
+        Zone::Graveyard,
+        "reach guard: the replay actually performed the move being asserted about"
+    );
+    assert_eq!(
+        replay.next_timestamp, before,
+        "a zone change that drew no timestamp must advance no allocator on replay"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Four CR 733 appliers install a timestamp the original execution drew, but
none advanced `GameState::next_timestamp` past it. That counter is the draw
source, so a replay that installs timestamp 42 while leaving the counter at 5
hands 42 out again to the next draw. CR 613.7 orders effects within a layer
by timestamp alone, so the two objects are then unordered.

Unlike the known upper-bound weakness in the `resulting_next_*` receipts,
this needs no forged journal — an honest replay corrupts itself. The four
tests demonstrate the collision directly rather than merely tripping an
assertion:

    installed timestamp 3 but the next draw handed out 3

Adds `GameState::adopt_replayed_timestamp` as the single authority for the
advance, called from every applier that installs a drawn timestamp:

    apply_resolved_zone_change        CR 613.7d  (battlefield entry)
    apply_resolved_token_creation     CR 613.7d
    apply_resolved_attachment         CR 613.7e
    apply_resolved_transform          CR 613.7g

`apply_resolved_continuous_effect` (CR 613.7b) already advanced both of its
allocators and is unchanged — it was the only family that got this right,
which is why the gap stayed invisible.

The advance is bound to a recorded DRAW, not to the command: an unattach, a
same-host re-attach (CR 701.3b), and a move to a non-battlefield zone draw no
timestamp and advance nothing. Both negative axes are pinned by tests, so a
later "simplification" to a blanket advance is caught.

Tests assert by CALLING `next_timestamp()` after replay and requiring the
draw to exceed the installed value, so they pin the observable consequence
rather than the counter field. The token-creation test's own comment already
claimed replay happened "with no re-draw from `next_object_id` or
`next_timestamp`"; only the object-id half was ever asserted, and now both
are.

Scope: `GameState` has six allocators. `next_pip_id`, `next_tracked_set_id`,
and `next_logical_zone_change_group_id` appear nowhere in
`resolved_commands.rs`, so no shipped command carries a receipt for them —
future coverage, not a live defect.
