### PR TITLE
chore: refresh metagame feeds

### DIFF
--- a/client/public/feeds/mtggoldfish-commander.json
+++ b/client/public/feeds/mtggoldfish-commander.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "commander",
   "version": 1,
-  "updated": "2026-07-25T00:00:00Z",
+  "updated": "2026-07-26T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/commander",
   "decks": [
     {
@@ -751,345 +751,6 @@
       "sideboard": []
     },
     {
-      "name": "Fire Lord Azula",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "U",
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Fire Lord Azula"
-        },
-        {
-          "count": 1,
-          "name": "Mai, Jaded Edge"
-        },
-        {
-          "count": 1,
-          "name": "Professor Zei, Anthropologist"
-        },
-        {
-          "count": 1,
-          "name": "Fire Nation Archers"
-        },
-        {
-          "count": 1,
-          "name": "Fire Nation Cadets"
-        },
-        {
-          "count": 1,
-          "name": "Firebending Student"
-        },
-        {
-          "count": 1,
-          "name": "Bria, Riptide Rogue"
-        },
-        {
-          "count": 1,
-          "name": "Azula, Cunning Usurper"
-        },
-        {
-          "count": 1,
-          "name": "Dragonfly Swarm"
-        },
-        {
-          "count": 1,
-          "name": "Stormcatch Mentor"
-        },
-        {
-          "count": 1,
-          "name": "Pirate Peddlers"
-        },
-        {
-          "count": 1,
-          "name": "Rough Rhino Cavalry"
-        },
-        {
-          "count": 1,
-          "name": "Raven Eagle"
-        },
-        {
-          "count": 1,
-          "name": "Wartime Protestors"
-        },
-        {
-          "count": 1,
-          "name": "Fire Sages"
-        },
-        {
-          "count": 1,
-          "name": "The Mechanist, Aerial Artisan"
-        },
-        {
-          "count": 1,
-          "name": "Gogo, Mysterious Mime"
-        },
-        {
-          "count": 1,
-          "name": "The Terror of Serpent's Pass"
-        },
-        {
-          "count": 1,
-          "name": "Vindictive Warden"
-        },
-        {
-          "count": 1,
-          "name": "Zuko, Exiled Prince"
-        },
-        {
-          "count": 1,
-          "name": "Azula, On the Hunt"
-        },
-        {
-          "count": 1,
-          "name": "Fire Nation Raider"
-        },
-        {
-          "count": 1,
-          "name": "Gran-Gran"
-        },
-        {
-          "count": 1,
-          "name": "Corrupt Court Official"
-        },
-        {
-          "count": 1,
-          "name": "Merchant of Many Hats"
-        },
-        {
-          "count": 1,
-          "name": "Rowdy Snowballers"
-        },
-        {
-          "count": 1,
-          "name": "Accumulate Wisdom"
-        },
-        {
-          "count": 1,
-          "name": "Lost Days"
-        },
-        {
-          "count": 1,
-          "name": "It'll Quench Ya!"
-        },
-        {
-          "count": 1,
-          "name": "Fire Nation Attacks"
-        },
-        {
-          "count": 1,
-          "name": "Cunning Maneuver"
-        },
-        {
-          "count": 1,
-          "name": "Heartless Act"
-        },
-        {
-          "count": 1,
-          "name": "Roku's Mastery"
-        },
-        {
-          "count": 1,
-          "name": "Azula Always Lies"
-        },
-        {
-          "count": 1,
-          "name": "Run Amok"
-        },
-        {
-          "count": 1,
-          "name": "The Last Agni Kai"
-        },
-        {
-          "count": 1,
-          "name": "Big Score"
-        },
-        {
-          "count": 1,
-          "name": "Octopus Form"
-        },
-        {
-          "count": 1,
-          "name": "How to Start a Riot"
-        },
-        {
-          "count": 1,
-          "name": "Sold Out"
-        },
-        {
-          "count": 1,
-          "name": "Abandon Attachments"
-        },
-        {
-          "count": 1,
-          "name": "An Offer You Can't Refuse"
-        },
-        {
-          "count": 1,
-          "name": "Zuko's Conviction"
-        },
-        {
-          "count": 1,
-          "name": "Bolt Bend"
-        },
-        {
-          "count": 1,
-          "name": "Zuko's Exile"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Strike"
-        },
-        {
-          "count": 1,
-          "name": "Ozai's Cruelty"
-        },
-        {
-          "count": 1,
-          "name": "Iroh's Demonstration"
-        },
-        {
-          "count": 1,
-          "name": "Aang's Journey"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Jet's Brainwashing"
-        },
-        {
-          "count": 1,
-          "name": "Epic Downfall"
-        },
-        {
-          "count": 1,
-          "name": "Ruinous Waterbending"
-        },
-        {
-          "count": 1,
-          "name": "Price of Freedom"
-        },
-        {
-          "count": 1,
-          "name": "Lost in the Spirit World"
-        },
-        {
-          "count": 1,
-          "name": "Reanimate"
-        },
-        {
-          "count": 1,
-          "name": "Foggy Swamp Visions"
-        },
-        {
-          "count": 1,
-          "name": "Deadly Precision"
-        },
-        {
-          "count": 1,
-          "name": "The Rise of Sozin"
-        },
-        {
-          "count": 1,
-          "name": "Fire Nation's Conquest"
-        },
-        {
-          "count": 1,
-          "name": "Twin Blades"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Kyoshi Battle Fan"
-        },
-        {
-          "count": 1,
-          "name": "Bender's Waterskin"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Barrels of Blasting Jelly"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Commander's Sphere"
-        },
-        {
-          "count": 9,
-          "name": "Mountain"
-        },
-        {
-          "count": 5,
-          "name": "Island"
-        },
-        {
-          "count": 8,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Airship Engine Room"
-        },
-        {
-          "count": 1,
-          "name": "Thriving Isle"
-        },
-        {
-          "count": 1,
-          "name": "Thriving Bluff"
-        },
-        {
-          "count": 1,
-          "name": "Rumble Arena"
-        },
-        {
-          "count": 1,
-          "name": "Boiling Rock Prison"
-        },
-        {
-          "count": 1,
-          "name": "Serpent's Pass"
-        },
-        {
-          "count": 1,
-          "name": "Thriving Moor"
-        },
-        {
-          "count": 1,
-          "name": "Realm of Koh"
-        },
-        {
-          "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        }
-      ],
-      "sideboard": []
-    },
-    {
       "name": "Y'shtola, Night's Blessed",
       "author": "MTGGoldfish",
       "colors": [
@@ -1428,6 +1089,345 @@
         {
           "count": 1,
           "name": "Y'shtola, Night's Blessed"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Fire Lord Azula",
+      "author": "MTGGoldfish",
+      "colors": [
+        "R",
+        "U",
+        "B"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Fire Lord Azula"
+        },
+        {
+          "count": 1,
+          "name": "Mai, Jaded Edge"
+        },
+        {
+          "count": 1,
+          "name": "Professor Zei, Anthropologist"
+        },
+        {
+          "count": 1,
+          "name": "Fire Nation Archers"
+        },
+        {
+          "count": 1,
+          "name": "Fire Nation Cadets"
+        },
+        {
+          "count": 1,
+          "name": "Firebending Student"
+        },
+        {
+          "count": 1,
+          "name": "Bria, Riptide Rogue"
+        },
+        {
+          "count": 1,
+          "name": "Azula, Cunning Usurper"
+        },
+        {
+          "count": 1,
+          "name": "Dragonfly Swarm"
+        },
+        {
+          "count": 1,
+          "name": "Stormcatch Mentor"
+        },
+        {
+          "count": 1,
+          "name": "Pirate Peddlers"
+        },
+        {
+          "count": 1,
+          "name": "Rough Rhino Cavalry"
+        },
+        {
+          "count": 1,
+          "name": "Raven Eagle"
+        },
+        {
+          "count": 1,
+          "name": "Wartime Protestors"
+        },
+        {
+          "count": 1,
+          "name": "Fire Sages"
+        },
+        {
+          "count": 1,
+          "name": "The Mechanist, Aerial Artisan"
+        },
+        {
+          "count": 1,
+          "name": "Gogo, Mysterious Mime"
+        },
+        {
+          "count": 1,
+          "name": "The Terror of Serpent's Pass"
+        },
+        {
+          "count": 1,
+          "name": "Vindictive Warden"
+        },
+        {
+          "count": 1,
+          "name": "Zuko, Exiled Prince"
+        },
+        {
+          "count": 1,
+          "name": "Azula, On the Hunt"
+        },
+        {
+          "count": 1,
+          "name": "Fire Nation Raider"
+        },
+        {
+          "count": 1,
+          "name": "Gran-Gran"
+        },
+        {
+          "count": 1,
+          "name": "Corrupt Court Official"
+        },
+        {
+          "count": 1,
+          "name": "Merchant of Many Hats"
+        },
+        {
+          "count": 1,
+          "name": "Rowdy Snowballers"
+        },
+        {
+          "count": 1,
+          "name": "Accumulate Wisdom"
+        },
+        {
+          "count": 1,
+          "name": "Lost Days"
+        },
+        {
+          "count": 1,
+          "name": "It'll Quench Ya!"
+        },
+        {
+          "count": 1,
+          "name": "Fire Nation Attacks"
+        },
+        {
+          "count": 1,
+          "name": "Cunning Maneuver"
+        },
+        {
+          "count": 1,
+          "name": "Heartless Act"
+        },
+        {
+          "count": 1,
+          "name": "Roku's Mastery"
+        },
+        {
+          "count": 1,
+          "name": "Azula Always Lies"
+        },
+        {
+          "count": 1,
+          "name": "Run Amok"
+        },
+        {
+          "count": 1,
+          "name": "The Last Agni Kai"
+        },
+        {
+          "count": 1,
+          "name": "Big Score"
+        },
+        {
+          "count": 1,
+          "name": "Octopus Form"
+        },
+        {
+          "count": 1,
+          "name": "How to Start a Riot"
+        },
+        {
+          "count": 1,
+          "name": "Sold Out"
+        },
+        {
+          "count": 1,
+          "name": "Abandon Attachments"
+        },
+        {
+          "count": 1,
+          "name": "An Offer You Can't Refuse"
+        },
+        {
+          "count": 1,
+          "name": "Zuko's Conviction"
+        },
+        {
+          "count": 1,
+          "name": "Bolt Bend"
+        },
+        {
+          "count": 1,
+          "name": "Zuko's Exile"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Strike"
+        },
+        {
+          "count": 1,
+          "name": "Ozai's Cruelty"
+        },
+        {
+          "count": 1,
+          "name": "Iroh's Demonstration"
+        },
+        {
+          "count": 1,
+          "name": "Aang's Journey"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Jet's Brainwashing"
+        },
+        {
+          "count": 1,
+          "name": "Epic Downfall"
+        },
+        {
+          "count": 1,
+          "name": "Ruinous Waterbending"
+        },
+        {
+          "count": 1,
+          "name": "Price of Freedom"
+        },
+        {
+          "count": 1,
+          "name": "Lost in the Spirit World"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Foggy Swamp Visions"
+        },
+        {
+          "count": 1,
+          "name": "Deadly Precision"
+        },
+        {
+          "count": 1,
+          "name": "The Rise of Sozin"
+        },
+        {
+          "count": 1,
+          "name": "Fire Nation's Conquest"
+        },
+        {
+          "count": 1,
+          "name": "Twin Blades"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Kyoshi Battle Fan"
+        },
+        {
+          "count": 1,
+          "name": "Bender's Waterskin"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Barrels of Blasting Jelly"
+        },
+        {
+          "count": 1,
+          "name": "Swiftfoot Boots"
+        },
+        {
+          "count": 1,
+          "name": "Commander's Sphere"
+        },
+        {
+          "count": 9,
+          "name": "Mountain"
+        },
+        {
+          "count": 5,
+          "name": "Island"
+        },
+        {
+          "count": 8,
+          "name": "Swamp"
+        },
+        {
+          "count": 1,
+          "name": "Airship Engine Room"
+        },
+        {
+          "count": 1,
+          "name": "Thriving Isle"
+        },
+        {
+          "count": 1,
+          "name": "Thriving Bluff"
+        },
+        {
+          "count": 1,
+          "name": "Rumble Arena"
+        },
+        {
+          "count": 1,
+          "name": "Boiling Rock Prison"
+        },
+        {
+          "count": 1,
+          "name": "Serpent's Pass"
+        },
+        {
+          "count": 1,
+          "name": "Thriving Moor"
+        },
+        {
+          "count": 1,
+          "name": "Realm of Koh"
+        },
+        {
+          "count": 1,
+          "name": "Evolving Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
         }
       ],
       "sideboard": []
@@ -1794,6 +1794,291 @@
         {
           "count": 1,
           "name": "Valgavoth, Harrower of Souls"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "The Unbeatable Squirrel Girl",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Oakhollow Village"
+        },
+        {
+          "count": 1,
+          "name": "Myriad Landscape"
+        },
+        {
+          "count": 1,
+          "name": "Evolving Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Terramorphic Expanse"
+        },
+        {
+          "count": 33,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "The Unbeatable Squirrel Girl"
+        },
+        {
+          "count": 1,
+          "name": "Chitterspitter"
+        },
+        {
+          "count": 1,
+          "name": "Emerald Medallion"
+        },
+        {
+          "count": 1,
+          "name": "Skullclamp"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Altar of the Brood"
+        },
+        {
+          "count": 1,
+          "name": "Banner of Kinship"
+        },
+        {
+          "count": 1,
+          "name": "Idol of Oblivion"
+        },
+        {
+          "count": 1,
+          "name": "Eldrazi Monument"
+        },
+        {
+          "count": 1,
+          "name": "Vanquisher's Banner"
+        },
+        {
+          "count": 1,
+          "name": "Herald's Horn"
+        },
+        {
+          "count": 1,
+          "name": "Swarmyard"
+        },
+        {
+          "count": 1,
+          "name": "Beastmaster Ascension"
+        },
+        {
+          "count": 1,
+          "name": "Growing Rites of Itlimoc"
+        },
+        {
+          "count": 1,
+          "name": "Primal Vigor"
+        },
+        {
+          "count": 1,
+          "name": "Elven Chorus"
+        },
+        {
+          "count": 1,
+          "name": "Cryptolith Rite"
+        },
+        {
+          "count": 1,
+          "name": "Springleaf Parade"
+        },
+        {
+          "count": 1,
+          "name": "Squirrel Nest"
+        },
+        {
+          "count": 1,
+          "name": "Sylvan Anthem"
+        },
+        {
+          "count": 1,
+          "name": "Kenrith's Transformation"
+        },
+        {
+          "count": 1,
+          "name": "Song of the Dryads"
+        },
+        {
+          "count": 1,
+          "name": "Beast Within"
+        },
+        {
+          "count": 1,
+          "name": "Return of the Wildspeaker"
+        },
+        {
+          "count": 1,
+          "name": "Krosan Grip"
+        },
+        {
+          "count": 1,
+          "name": "Verdant Command"
+        },
+        {
+          "count": 1,
+          "name": "Wrap in Vigor"
+        },
+        {
+          "count": 1,
+          "name": "Naturalize"
+        },
+        {
+          "count": 1,
+          "name": "Second Harvest"
+        },
+        {
+          "count": 1,
+          "name": "Chatterstorm"
+        },
+        {
+          "count": 1,
+          "name": "Cultivate"
+        },
+        {
+          "count": 1,
+          "name": "Shamanic Revelation"
+        },
+        {
+          "count": 1,
+          "name": "For the Common Good"
+        },
+        {
+          "count": 1,
+          "name": "Rampant Growth"
+        },
+        {
+          "count": 1,
+          "name": "Rootcast Apprenticeship"
+        },
+        {
+          "count": 1,
+          "name": "Kodama's Reach"
+        },
+        {
+          "count": 1,
+          "name": "Harmonize"
+        },
+        {
+          "count": 1,
+          "name": "Collective Unconscious"
+        },
+        {
+          "count": 1,
+          "name": "Harvest Season"
+        },
+        {
+          "count": 1,
+          "name": "Heroic Intervention"
+        },
+        {
+          "count": 1,
+          "name": "Toski, Bearer of Secrets"
+        },
+        {
+          "count": 1,
+          "name": "Scurry of Squirrels"
+        },
+        {
+          "count": 1,
+          "name": "Honored Dreyleader"
+        },
+        {
+          "count": 1,
+          "name": "Squirrel Mob"
+        },
+        {
+          "count": 1,
+          "name": "Thornvault Forager"
+        },
+        {
+          "count": 1,
+          "name": "Squirrel Sovereign"
+        },
+        {
+          "count": 1,
+          "name": "Tippy-Toe, Terrific Partner"
+        },
+        {
+          "count": 1,
+          "name": "Bakersbane Duo"
+        },
+        {
+          "count": 1,
+          "name": "Realmwalker"
+        },
+        {
+          "count": 1,
+          "name": "Metallic Mimic"
+        },
+        {
+          "count": 1,
+          "name": "Spider-Ham, Peter Porker"
+        },
+        {
+          "count": 1,
+          "name": "Treetop Sentries"
+        },
+        {
+          "count": 1,
+          "name": "Scurrid Colony"
+        },
+        {
+          "count": 1,
+          "name": "Frog-Squirrels"
+        },
+        {
+          "count": 1,
+          "name": "Bushy Bodyguard"
+        },
+        {
+          "count": 1,
+          "name": "Nut Collector"
+        },
+        {
+          "count": 1,
+          "name": "Scurry Oak"
+        },
+        {
+          "count": 1,
+          "name": "Curious Forager"
+        },
+        {
+          "count": 1,
+          "name": "Bloodroot Apothecary"
+        },
+        {
+          "count": 1,
+          "name": "Adaptive Automaton"
+        },
+        {
+          "count": 1,
+          "name": "Bloodline Pretender"
+        },
+        {
+          "count": 1,
+          "name": "Explosive Vegetation"
         }
       ],
       "sideboard": []
@@ -2210,10 +2495,12 @@
       "sideboard": []
     },
     {
-      "name": "The Unbeatable Squirrel Girl",
+      "name": "Xyris, the Writhing Storm",
       "author": "MTGGoldfish",
       "colors": [
-        "G"
+        "G",
+        "U",
+        "R"
       ],
       "tags": [
         "metagame"
@@ -2221,43 +2508,15 @@
       "main": [
         {
           "count": 1,
-          "name": "Oakhollow Village"
+          "name": "Adrix and Nev, Twincasters"
         },
         {
           "count": 1,
-          "name": "Myriad Landscape"
+          "name": "An Offer You Can't Refuse"
         },
         {
           "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Terramorphic Expanse"
-        },
-        {
-          "count": 33,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "The Unbeatable Squirrel Girl"
-        },
-        {
-          "count": 1,
-          "name": "Chitterspitter"
-        },
-        {
-          "count": 1,
-          "name": "Emerald Medallion"
-        },
-        {
-          "count": 1,
-          "name": "Skullclamp"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
+          "name": "Arcane Denial"
         },
         {
           "count": 1,
@@ -2265,71 +2524,7 @@
         },
         {
           "count": 1,
-          "name": "Altar of the Brood"
-        },
-        {
-          "count": 1,
           "name": "Banner of Kinship"
-        },
-        {
-          "count": 1,
-          "name": "Idol of Oblivion"
-        },
-        {
-          "count": 1,
-          "name": "Eldrazi Monument"
-        },
-        {
-          "count": 1,
-          "name": "Vanquisher's Banner"
-        },
-        {
-          "count": 1,
-          "name": "Herald's Horn"
-        },
-        {
-          "count": 1,
-          "name": "Swarmyard"
-        },
-        {
-          "count": 1,
-          "name": "Beastmaster Ascension"
-        },
-        {
-          "count": 1,
-          "name": "Growing Rites of Itlimoc"
-        },
-        {
-          "count": 1,
-          "name": "Primal Vigor"
-        },
-        {
-          "count": 1,
-          "name": "Elven Chorus"
-        },
-        {
-          "count": 1,
-          "name": "Cryptolith Rite"
-        },
-        {
-          "count": 1,
-          "name": "Springleaf Parade"
-        },
-        {
-          "count": 1,
-          "name": "Squirrel Nest"
-        },
-        {
-          "count": 1,
-          "name": "Sylvan Anthem"
-        },
-        {
-          "count": 1,
-          "name": "Kenrith's Transformation"
-        },
-        {
-          "count": 1,
-          "name": "Song of the Dryads"
         },
         {
           "count": 1,
@@ -2337,31 +2532,27 @@
         },
         {
           "count": 1,
-          "name": "Return of the Wildspeaker"
+          "name": "Beastmaster Ascension"
         },
         {
           "count": 1,
-          "name": "Krosan Grip"
+          "name": "Chaos Warp"
         },
         {
           "count": 1,
-          "name": "Verdant Command"
+          "name": "Chromatic Lantern"
         },
         {
           "count": 1,
-          "name": "Wrap in Vigor"
+          "name": "Command Tower"
         },
         {
           "count": 1,
-          "name": "Naturalize"
+          "name": "Counterspell"
         },
         {
           "count": 1,
-          "name": "Second Harvest"
-        },
-        {
-          "count": 1,
-          "name": "Chatterstorm"
+          "name": "Cryptolith Rite"
         },
         {
           "count": 1,
@@ -2369,11 +2560,155 @@
         },
         {
           "count": 1,
-          "name": "Shamanic Revelation"
+          "name": "Dictate of Kruphix"
         },
         {
           "count": 1,
-          "name": "For the Common Good"
+          "name": "Doubling Season"
+        },
+        {
+          "count": 1,
+          "name": "Dream Fracture"
+        },
+        {
+          "count": 1,
+          "name": "Dreamroot Cascade"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Farseek"
+        },
+        {
+          "count": 1,
+          "name": "Fevered Visions"
+        },
+        {
+          "count": 1,
+          "name": "Folio of Fancies"
+        },
+        {
+          "count": 1,
+          "name": "Forced Fruition"
+        },
+        {
+          "count": 5,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Frontier Bivouac"
+        },
+        {
+          "count": 1,
+          "name": "Gamble"
+        },
+        {
+          "count": 1,
+          "name": "Geier Reach Sanitarium"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Bombardment"
+        },
+        {
+          "count": 1,
+          "name": "Growing Rites of Itlimoc"
+        },
+        {
+          "count": 1,
+          "name": "Growth Spiral"
+        },
+        {
+          "count": 1,
+          "name": "Hinterland Harbor"
+        },
+        {
+          "count": 1,
+          "name": "Horn of Greed"
+        },
+        {
+          "count": 1,
+          "name": "Howling Mine"
+        },
+        {
+          "count": 1,
+          "name": "Impact Tremors"
+        },
+        {
+          "count": 7,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Jace's Archivist"
+        },
+        {
+          "count": 1,
+          "name": "Kami of the Crescent Moon"
+        },
+        {
+          "count": 1,
+          "name": "Laboratory Maniac"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Greaves"
+        },
+        {
+          "count": 1,
+          "name": "Magus of the Wheel"
+        },
+        {
+          "count": 1,
+          "name": "Mikokoro, Center of the Sea"
+        },
+        {
+          "count": 1,
+          "name": "Mistrise Village"
+        },
+        {
+          "count": 1,
+          "name": "Molten Gatekeeper"
+        },
+        {
+          "count": 1,
+          "name": "Molten Psyche"
+        },
+        {
+          "count": 4,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Negate"
+        },
+        {
+          "count": 1,
+          "name": "Ominous Seas"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 1,
+          "name": "Pongify"
+        },
+        {
+          "count": 1,
+          "name": "Proft's Eidetic Memory"
+        },
+        {
+          "count": 1,
+          "name": "Prosperity"
+        },
+        {
+          "count": 1,
+          "name": "Psychosis Crawler"
         },
         {
           "count": 1,
@@ -2381,115 +2716,143 @@
         },
         {
           "count": 1,
-          "name": "Rootcast Apprenticeship"
+          "name": "Razorkin Needlehead"
         },
         {
           "count": 1,
-          "name": "Kodama's Reach"
+          "name": "Reflecting Pool"
         },
         {
           "count": 1,
-          "name": "Harmonize"
+          "name": "Reforge the Soul"
         },
         {
           "count": 1,
-          "name": "Collective Unconscious"
+          "name": "Rejuvenating Springs"
         },
         {
           "count": 1,
-          "name": "Harvest Season"
+          "name": "Reliquary Tower"
         },
         {
           "count": 1,
-          "name": "Heroic Intervention"
+          "name": "Rites of Flourishing"
         },
         {
           "count": 1,
-          "name": "Toski, Bearer of Secrets"
+          "name": "Rockfall Vale"
         },
         {
           "count": 1,
-          "name": "Scurry of Squirrels"
+          "name": "Rogue's Passage"
         },
         {
           "count": 1,
-          "name": "Honored Dreyleader"
+          "name": "Rootbound Crag"
         },
         {
           "count": 1,
-          "name": "Squirrel Mob"
+          "name": "Sakura-Tribe Elder"
         },
         {
           "count": 1,
-          "name": "Thornvault Forager"
+          "name": "Scrawling Crawler"
         },
         {
           "count": 1,
-          "name": "Squirrel Sovereign"
+          "name": "Seshiro the Anointed"
         },
         {
           "count": 1,
-          "name": "Tippy-Toe, Terrific Partner"
+          "name": "Shared Animosity"
         },
         {
           "count": 1,
-          "name": "Bakersbane Duo"
+          "name": "Skullclamp"
         },
         {
           "count": 1,
-          "name": "Realmwalker"
+          "name": "Snakeskin Veil"
         },
         {
           "count": 1,
-          "name": "Metallic Mimic"
+          "name": "Spire Garden"
         },
         {
           "count": 1,
-          "name": "Spider-Ham, Peter Porker"
+          "name": "Stormcarved Coast"
         },
         {
           "count": 1,
-          "name": "Treetop Sentries"
+          "name": "Sulfur Falls"
         },
         {
           "count": 1,
-          "name": "Scurrid Colony"
+          "name": "Swiftfoot Boots"
         },
         {
           "count": 1,
-          "name": "Frog-Squirrels"
+          "name": "Talisman of Creativity"
         },
         {
           "count": 1,
-          "name": "Bushy Bodyguard"
+          "name": "Talisman of Curiosity"
         },
         {
           "count": 1,
-          "name": "Nut Collector"
+          "name": "Tamiyo's Safekeeping"
         },
         {
           "count": 1,
-          "name": "Scurry Oak"
+          "name": "Teferi's Puzzle Box"
         },
         {
           "count": 1,
-          "name": "Curious Forager"
+          "name": "Temple of the False God"
         },
         {
           "count": 1,
-          "name": "Bloodroot Apothecary"
+          "name": "The Locust God"
         },
         {
           "count": 1,
-          "name": "Adaptive Automaton"
+          "name": "Thought Vessel"
         },
         {
           "count": 1,
-          "name": "Bloodline Pretender"
+          "name": "Training Center"
         },
         {
           "count": 1,
-          "name": "Explosive Vegetation"
+          "name": "Tyvar's Stand"
+        },
+        {
+          "count": 1,
+          "name": "Vision Skeins"
+        },
+        {
+          "count": 1,
+          "name": "Wheel and Deal"
+        },
+        {
+          "count": 1,
+          "name": "Windfall"
+        },
+        {
+          "count": 1,
+          "name": "Winds of Change"
+        },
+        {
+          "count": 1,
+          "name": "Wizard Class"
+        },
+        {
+          "count": 1,
+          "name": "Maze of Ith"
+        },
+        {
+          "count": 1,
+          "name": "Xyris, the Writhing Storm"
         }
       ],
       "sideboard": []
@@ -2963,11 +3326,11 @@
       ]
     },
     {
-      "name": "Xyris, the Writhing Storm",
+      "name": "Kaalia of the Vast",
       "author": "MTGGoldfish",
       "colors": [
-        "G",
-        "U",
+        "W",
+        "B",
         "R"
       ],
       "tags": [
@@ -2976,15 +3339,203 @@
       "main": [
         {
           "count": 1,
-          "name": "Adrix and Nev, Twincasters"
+          "name": "Adarkar Valkyrie"
         },
         {
           "count": 1,
-          "name": "An Offer You Can't Refuse"
+          "name": "Aegis Angel"
         },
         {
           "count": 1,
-          "name": "Arcane Denial"
+          "name": "Akroma, Angel of Fury"
+        },
+        {
+          "count": 1,
+          "name": "Akroma, Angel of Wrath"
+        },
+        {
+          "count": 1,
+          "name": "Angel of Despair"
+        },
+        {
+          "count": 1,
+          "name": "Angel of Serenity"
+        },
+        {
+          "count": 1,
+          "name": "Angelic Arbiter"
+        },
+        {
+          "count": 1,
+          "name": "Angelic Skirmisher"
+        },
+        {
+          "count": 1,
+          "name": "Angel of the Ruins"
+        },
+        {
+          "count": 1,
+          "name": "Archfiend of Depravity"
+        },
+        {
+          "count": 1,
+          "name": "Balor"
+        },
+        {
+          "count": 1,
+          "name": "Bladewing the Risen"
+        },
+        {
+          "count": 1,
+          "name": "Bloodgift Demon"
+        },
+        {
+          "count": 1,
+          "name": "Breathkeeper Seraph"
+        },
+        {
+          "count": 1,
+          "name": "Dawnbreak Reclaimer"
+        },
+        {
+          "count": 1,
+          "name": "Demon of Loathing"
+        },
+        {
+          "count": 1,
+          "name": "Drakuseth, Maw of Flames"
+        },
+        {
+          "count": 1,
+          "name": "Emeria Shepherd"
+        },
+        {
+          "count": 1,
+          "name": "Giada, Font of Hope"
+        },
+        {
+          "count": 1,
+          "name": "Harvester of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Indulgent Tormentor"
+        },
+        {
+          "count": 1,
+          "name": "Isshin, Two Heavens as One"
+        },
+        {
+          "count": 1,
+          "name": "Liesa, Forgotten Archangel"
+        },
+        {
+          "count": 1,
+          "name": "Overseer of the Damned"
+        },
+        {
+          "count": 1,
+          "name": "Piru, the Volatile"
+        },
+        {
+          "count": 1,
+          "name": "Resolute Archangel"
+        },
+        {
+          "count": 1,
+          "name": "Reya Dawnbringer"
+        },
+        {
+          "count": 1,
+          "name": "Sephara, Sky's Blade"
+        },
+        {
+          "count": 1,
+          "name": "Serra's Guardian"
+        },
+        {
+          "count": 1,
+          "name": "Steel Hellkite"
+        },
+        {
+          "count": 1,
+          "name": "Terror of Mount Velus"
+        },
+        {
+          "count": 1,
+          "name": "Twilight Shepherd"
+        },
+        {
+          "count": 1,
+          "name": "Victory's Herald"
+        },
+        {
+          "count": 1,
+          "name": "Ambition's Cost"
+        },
+        {
+          "count": 1,
+          "name": "Boros Charm"
+        },
+        {
+          "count": 1,
+          "name": "Crackling Doom"
+        },
+        {
+          "count": 1,
+          "name": "Despark"
+        },
+        {
+          "count": 1,
+          "name": "Fake Your Own Death"
+        },
+        {
+          "count": 1,
+          "name": "Fracture"
+        },
+        {
+          "count": 1,
+          "name": "Mortify"
+        },
+        {
+          "count": 1,
+          "name": "Return to Dust"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Terminate"
+        },
+        {
+          "count": 1,
+          "name": "Akroma's Vengeance"
+        },
+        {
+          "count": 1,
+          "name": "Diabolic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Earthquake"
+        },
+        {
+          "count": 1,
+          "name": "Painful Truths"
+        },
+        {
+          "count": 1,
+          "name": "Read the Bones"
+        },
+        {
+          "count": 1,
+          "name": "Sign in Blood"
+        },
+        {
+          "count": 1,
+          "name": "Unburial Rites"
         },
         {
           "count": 1,
@@ -2992,585 +3543,23 @@
         },
         {
           "count": 1,
-          "name": "Banner of Kinship"
+          "name": "Boros Signet"
         },
         {
           "count": 1,
-          "name": "Beast Within"
+          "name": "Commander's Sphere"
         },
         {
           "count": 1,
-          "name": "Beastmaster Ascension"
+          "name": "Orzhov Signet"
         },
         {
           "count": 1,
-          "name": "Chaos Warp"
+          "name": "Rakdos Signet"
         },
         {
           "count": 1,
-          "name": "Chromatic Lantern"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Counterspell"
-        },
-        {
-          "count": 1,
-          "name": "Cryptolith Rite"
-        },
-        {
-          "count": 1,
-          "name": "Cultivate"
-        },
-        {
-          "count": 1,
-          "name": "Dictate of Kruphix"
-        },
-        {
-          "count": 1,
-          "name": "Doubling Season"
-        },
-        {
-          "count": 1,
-          "name": "Dream Fracture"
-        },
-        {
-          "count": 1,
-          "name": "Dreamroot Cascade"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Farseek"
-        },
-        {
-          "count": 1,
-          "name": "Fevered Visions"
-        },
-        {
-          "count": 1,
-          "name": "Folio of Fancies"
-        },
-        {
-          "count": 1,
-          "name": "Forced Fruition"
-        },
-        {
-          "count": 5,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Frontier Bivouac"
-        },
-        {
-          "count": 1,
-          "name": "Gamble"
-        },
-        {
-          "count": 1,
-          "name": "Geier Reach Sanitarium"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Bombardment"
-        },
-        {
-          "count": 1,
-          "name": "Growing Rites of Itlimoc"
-        },
-        {
-          "count": 1,
-          "name": "Growth Spiral"
-        },
-        {
-          "count": 1,
-          "name": "Hinterland Harbor"
-        },
-        {
-          "count": 1,
-          "name": "Horn of Greed"
-        },
-        {
-          "count": 1,
-          "name": "Howling Mine"
-        },
-        {
-          "count": 1,
-          "name": "Impact Tremors"
-        },
-        {
-          "count": 7,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Jace's Archivist"
-        },
-        {
-          "count": 1,
-          "name": "Kami of the Crescent Moon"
-        },
-        {
-          "count": 1,
-          "name": "Laboratory Maniac"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Magus of the Wheel"
-        },
-        {
-          "count": 1,
-          "name": "Mikokoro, Center of the Sea"
-        },
-        {
-          "count": 1,
-          "name": "Mistrise Village"
-        },
-        {
-          "count": 1,
-          "name": "Molten Gatekeeper"
-        },
-        {
-          "count": 1,
-          "name": "Molten Psyche"
-        },
-        {
-          "count": 4,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Negate"
-        },
-        {
-          "count": 1,
-          "name": "Ominous Seas"
-        },
-        {
-          "count": 1,
-          "name": "Otawara, Soaring City"
-        },
-        {
-          "count": 1,
-          "name": "Pongify"
-        },
-        {
-          "count": 1,
-          "name": "Proft's Eidetic Memory"
-        },
-        {
-          "count": 1,
-          "name": "Prosperity"
-        },
-        {
-          "count": 1,
-          "name": "Psychosis Crawler"
-        },
-        {
-          "count": 1,
-          "name": "Rampant Growth"
-        },
-        {
-          "count": 1,
-          "name": "Razorkin Needlehead"
-        },
-        {
-          "count": 1,
-          "name": "Reflecting Pool"
-        },
-        {
-          "count": 1,
-          "name": "Reforge the Soul"
-        },
-        {
-          "count": 1,
-          "name": "Rejuvenating Springs"
-        },
-        {
-          "count": 1,
-          "name": "Reliquary Tower"
-        },
-        {
-          "count": 1,
-          "name": "Rites of Flourishing"
-        },
-        {
-          "count": 1,
-          "name": "Rockfall Vale"
-        },
-        {
-          "count": 1,
-          "name": "Rogue's Passage"
-        },
-        {
-          "count": 1,
-          "name": "Rootbound Crag"
-        },
-        {
-          "count": 1,
-          "name": "Sakura-Tribe Elder"
-        },
-        {
-          "count": 1,
-          "name": "Scrawling Crawler"
-        },
-        {
-          "count": 1,
-          "name": "Seshiro the Anointed"
-        },
-        {
-          "count": 1,
-          "name": "Shared Animosity"
-        },
-        {
-          "count": 1,
-          "name": "Skullclamp"
-        },
-        {
-          "count": 1,
-          "name": "Snakeskin Veil"
-        },
-        {
-          "count": 1,
-          "name": "Spire Garden"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 1,
-          "name": "Sulfur Falls"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Creativity"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Curiosity"
-        },
-        {
-          "count": 1,
-          "name": "Tamiyo's Safekeeping"
-        },
-        {
-          "count": 1,
-          "name": "Teferi's Puzzle Box"
-        },
-        {
-          "count": 1,
-          "name": "Temple of the False God"
-        },
-        {
-          "count": 1,
-          "name": "The Locust God"
-        },
-        {
-          "count": 1,
-          "name": "Thought Vessel"
-        },
-        {
-          "count": 1,
-          "name": "Training Center"
-        },
-        {
-          "count": 1,
-          "name": "Tyvar's Stand"
-        },
-        {
-          "count": 1,
-          "name": "Vision Skeins"
-        },
-        {
-          "count": 1,
-          "name": "Wheel and Deal"
-        },
-        {
-          "count": 1,
-          "name": "Windfall"
-        },
-        {
-          "count": 1,
-          "name": "Winds of Change"
-        },
-        {
-          "count": 1,
-          "name": "Wizard Class"
-        },
-        {
-          "count": 1,
-          "name": "Maze of Ith"
-        },
-        {
-          "count": 1,
-          "name": "Xyris, the Writhing Storm"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Vivi Ornitier",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "An Offer You Can't Refuse"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Archmage Emeritus"
-        },
-        {
-          "count": 1,
-          "name": "Baral, Chief of Compliance"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Bolt Bend"
-        },
-        {
-          "count": 1,
-          "name": "Brainstorm"
-        },
-        {
-          "count": 1,
-          "name": "Candy Trail"
-        },
-        {
-          "count": 1,
-          "name": "Chaos Warp"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Curate"
-        },
-        {
-          "count": 1,
-          "name": "Curfew"
-        },
-        {
-          "count": 1,
-          "name": "Desperate Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Dizzy Spell"
-        },
-        {
-          "count": 1,
-          "name": "Dramatic Reversal"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Fading Hope"
-        },
-        {
-          "count": 1,
-          "name": "Fellwar Stone"
-        },
-        {
-          "count": 1,
-          "name": "Fiery Islet"
-        },
-        {
-          "count": 1,
-          "name": "Fire Magic"
-        },
-        {
-          "count": 1,
-          "name": "Flashback"
-        },
-        {
-          "count": 1,
-          "name": "Frostboil Snarl"
-        },
-        {
-          "count": 1,
-          "name": "Gamble"
-        },
-        {
-          "count": 1,
-          "name": "Geosurge"
-        },
-        {
-          "count": 1,
-          "name": "Gifts Ungiven"
-        },
-        {
-          "count": 1,
-          "name": "Gitaxian Probe"
-        },
-        {
-          "count": 1,
-          "name": "Grafdigger's Cage"
-        },
-        {
-          "count": 1,
-          "name": "Grapeshot"
-        },
-        {
-          "count": 1,
-          "name": "Hexing Squelcher"
-        },
-        {
-          "count": 1,
-          "name": "Hullbreaker Horror"
-        },
-        {
-          "count": 1,
-          "name": "Infernal Plunge"
-        },
-        {
-          "count": 14,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Isochron Scepter"
-        },
-        {
-          "count": 1,
-          "name": "Izzet Signet"
-        },
-        {
-          "count": 1,
-          "name": "Kitsa, Otterball Elite"
-        },
-        {
-          "count": 1,
-          "name": "Lantern of the Lost"
-        },
-        {
-          "count": 1,
-          "name": "Last Chance"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Bolt"
-        },
-        {
-          "count": 1,
-          "name": "Magic Damper"
-        },
-        {
-          "count": 1,
-          "name": "Mind Stone"
-        },
-        {
-          "count": 1,
-          "name": "Miscast"
-        },
-        {
-          "count": 8,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Muddle the Mixture"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Remora"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Sanctuary"
-        },
-        {
-          "count": 1,
-          "name": "Narset, Parter of Veils"
-        },
-        {
-          "count": 1,
-          "name": "Negate"
-        },
-        {
-          "count": 1,
-          "name": "Pit of Offerings"
-        },
-        {
-          "count": 1,
-          "name": "Ponder"
-        },
-        {
-          "count": 1,
-          "name": "Pongify"
-        },
-        {
-          "count": 1,
-          "name": "Preordain"
-        },
-        {
-          "count": 1,
-          "name": "Rapid Hybridization"
-        },
-        {
-          "count": 1,
-          "name": "Red Elemental Blast"
-        },
-        {
-          "count": 1,
-          "name": "Reshape"
-        },
-        {
-          "count": 1,
-          "name": "Rite of Flame"
-        },
-        {
-          "count": 1,
-          "name": "Seething Song"
-        },
-        {
-          "count": 1,
-          "name": "Shivan Reef"
-        },
-        {
-          "count": 1,
-          "name": "Simian Spirit Guide"
-        },
-        {
-          "count": 1,
-          "name": "Snap"
+          "name": "Savai Crystal"
         },
         {
           "count": 1,
@@ -3578,83 +3567,111 @@
         },
         {
           "count": 1,
-          "name": "Solve the Equation"
-        },
-        {
-          "count": 1,
-          "name": "Spell Pierce"
-        },
-        {
-          "count": 1,
-          "name": "Springleaf Drum"
-        },
-        {
-          "count": 1,
-          "name": "Storm-Kiln Artist"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 1,
-          "name": "Strike It Rich"
-        },
-        {
-          "count": 1,
-          "name": "Stubborn Denial"
-        },
-        {
-          "count": 1,
-          "name": "Sulfur Falls"
-        },
-        {
-          "count": 1,
           "name": "Swiftfoot Boots"
         },
         {
           "count": 1,
-          "name": "Tale's End"
+          "name": "Talisman of Conviction"
         },
         {
           "count": 1,
-          "name": "Talisman of Creativity"
+          "name": "Talisman of Hierarchy"
         },
         {
           "count": 1,
-          "name": "Thorn of Amethyst"
+          "name": "Whispersilk Cloak"
         },
         {
           "count": 1,
-          "name": "Thought Vessel"
+          "name": "Firja's Retribution"
         },
         {
           "count": 1,
-          "name": "Tormod's Crypt"
+          "name": "Kaya's Ghostform"
         },
         {
           "count": 1,
-          "name": "Tribute Mage"
+          "name": "Liliana's Contract"
         },
         {
           "count": 1,
-          "name": "Vandalblast"
+          "name": "Rampage of the Valkyries"
         },
         {
           "count": 1,
-          "name": "Wild Ride"
+          "name": "Akoum Refuge"
         },
         {
           "count": 1,
-          "name": "Counterspell"
+          "name": "Bloodfell Caves"
         },
         {
           "count": 1,
-          "name": "Windfall"
+          "name": "Boros Garrison"
         },
         {
           "count": 1,
-          "name": "Vivi Ornitier"
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Evolving Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Nomad Outpost"
+        },
+        {
+          "count": 1,
+          "name": "Orzhov Basilica"
+        },
+        {
+          "count": 1,
+          "name": "Rakdos Carnarium"
+        },
+        {
+          "count": 1,
+          "name": "Rogue's Passage"
+        },
+        {
+          "count": 1,
+          "name": "Scoured Barrens"
+        },
+        {
+          "count": 1,
+          "name": "Temple of Silence"
+        },
+        {
+          "count": 1,
+          "name": "Temple of Triumph"
+        },
+        {
+          "count": 1,
+          "name": "Terramorphic Expanse"
+        },
+        {
+          "count": 1,
+          "name": "Wind-Scarred Crag"
+        },
+        {
+          "count": 8,
+          "name": "Plains"
+        },
+        {
+          "count": 7,
+          "name": "Swamp"
+        },
+        {
+          "count": 4,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Kaalia of the Vast"
         }
       ],
       "sideboard": []

--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "modern",
   "version": 1,
-  "updated": "2026-07-25T00:00:00Z",
+  "updated": "2026-07-26T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/modern",
   "decks": [
     {

--- a/client/public/feeds/mtggoldfish-pioneer.json
+++ b/client/public/feeds/mtggoldfish-pioneer.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "pioneer",
   "version": 1,
-  "updated": "2026-07-25T00:00:00Z",
+  "updated": "2026-07-26T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/pioneer",
   "decks": [
     {
@@ -719,15 +719,15 @@
       "name": "Orzhov Greasefang",
       "author": "MTGGoldfish",
       "colors": [
-        "B",
-        "W"
+        "W",
+        "B"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
-          "count": 2,
+          "count": 1,
           "name": "Bleachbone Verge"
         },
         {
@@ -735,12 +735,16 @@
           "name": "Brightclimb Pathway"
         },
         {
+          "count": 4,
+          "name": "Fatal Push"
+        },
+        {
           "count": 1,
           "name": "Eiganjo, Seat of the Empire"
         },
         {
-          "count": 4,
-          "name": "Monument to Endurance"
+          "count": 3,
+          "name": "Concealed Courtyard"
         },
         {
           "count": 4,
@@ -749,6 +753,10 @@
         {
           "count": 1,
           "name": "Geier Reach Sanitarium"
+        },
+        {
+          "count": 4,
+          "name": "Godless Shrine"
         },
         {
           "count": 4,
@@ -763,12 +771,12 @@
           "name": "Iron-Shield Elf"
         },
         {
-          "count": 1,
-          "name": "Lively Dirge"
+          "count": 2,
+          "name": "Sheltered by Ghosts"
         },
         {
           "count": 4,
-          "name": "The Mycosynth Gardens"
+          "name": "Monument to Endurance"
         },
         {
           "count": 4,
@@ -776,23 +784,19 @@
         },
         {
           "count": 1,
-          "name": "Swamp"
+          "name": "Plains"
         },
         {
-          "count": 1,
-          "name": "Plains"
+          "count": 2,
+          "name": "Shadowy Backstreet"
         },
         {
           "count": 1,
           "name": "Takenuma, Abandoned Mire"
         },
         {
-          "count": 4,
+          "count": 1,
           "name": "Concealed Courtyard"
-        },
-        {
-          "count": 2,
-          "name": "Duress"
         },
         {
           "count": 1,
@@ -800,61 +804,57 @@
         },
         {
           "count": 1,
-          "name": "Vanishing Verse"
+          "name": "Bleachbone Verge"
         },
         {
           "count": 4,
-          "name": "Godless Shrine"
+          "name": "The Mycosynth Gardens"
+        },
+        {
+          "count": 2,
+          "name": "Vanishing Verse"
+        },
+        {
+          "count": 1,
+          "name": "Swamp"
+        },
+        {
+          "count": 1,
+          "name": "Lively Dirge"
         },
         {
           "count": 4,
           "name": "Thoughtseize"
-        },
-        {
-          "count": 2,
-          "name": "Shadowy Backstreet"
-        },
-        {
-          "count": 4,
-          "name": "Fatal Push"
-        },
-        {
-          "count": 1,
-          "name": "Sheltered by Ghosts"
         }
       ],
       "sideboard": [
         {
           "count": 2,
+          "name": "Ral Zarek, Guest Lecturer"
+        },
+        {
+          "count": 2,
           "name": "Soul-Guide Lantern"
         },
         {
-          "count": 3,
-          "name": "Doorkeeper Thrull"
-        },
-        {
-          "count": 2,
-          "name": "Damping Sphere"
-        },
-        {
-          "count": 2,
+          "count": 1,
           "name": "Vanishing Verse"
         },
         {
           "count": 2,
-          "name": "Seam Rip"
+          "name": "Loran of the Third Path"
         },
         {
-          "count": 1,
-          "name": "Go Blank"
-        },
-        {
-          "count": 1,
-          "name": "Duress"
+          "count": 2,
+          "name": "Pest Control"
         },
         {
           "count": 2,
           "name": "Bitter Triumph"
+        },
+        {
+          "count": 4,
+          "name": "Doorkeeper Thrull"
         }
       ]
     },
@@ -1128,19 +1128,11 @@
       "sideboard": [
         {
           "count": 1,
-          "name": "Abrade"
+          "name": "Flowstone Infusion"
         },
         {
           "count": 1,
-          "name": "Brotherhood's End"
-        },
-        {
-          "count": 1,
-          "name": "Chandra's Defeat"
-        },
-        {
-          "count": 1,
-          "name": "Into the Flood Maw"
+          "name": "Thassa's Oracle"
         },
         {
           "count": 1,
@@ -1155,16 +1147,8 @@
           "name": "Annul"
         },
         {
-          "count": 1,
-          "name": "Rending Volley"
-        },
-        {
-          "count": 2,
+          "count": 3,
           "name": "Spell Pierce"
-        },
-        {
-          "count": 1,
-          "name": "Thassa's Oracle"
         },
         {
           "count": 1,
@@ -1172,7 +1156,15 @@
         },
         {
           "count": 1,
-          "name": "Fiery Impulse"
+          "name": "Into the Flood Maw"
+        },
+        {
+          "count": 2,
+          "name": "Chandra's Defeat"
+        },
+        {
+          "count": 1,
+          "name": "Negate"
         }
       ]
     },
@@ -1188,24 +1180,16 @@
       ],
       "main": [
         {
-          "count": 1,
-          "name": "Island"
+          "count": 2,
+          "name": "Shivan Reef"
+        },
+        {
+          "count": 2,
+          "name": "Riverpyre Verge"
         },
         {
           "count": 1,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 1,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Riverglide Pathway"
+          "name": "Ral, Crackling Wit"
         },
         {
           "count": 4,
@@ -1228,12 +1212,12 @@
           "name": "Stormchaser's Talent"
         },
         {
-          "count": 1,
-          "name": "Ral, Crackling Wit"
+          "count": 4,
+          "name": "Riverglide Pathway"
         },
         {
-          "count": 2,
-          "name": "Riverpyre Verge"
+          "count": 4,
+          "name": "Steam Vents"
         },
         {
           "count": 3,
@@ -1276,8 +1260,8 @@
           "name": "Island"
         },
         {
-          "count": 2,
-          "name": "Shivan Reef"
+          "count": 3,
+          "name": "Island"
         },
         {
           "count": 1,
@@ -1286,12 +1270,12 @@
       ],
       "sideboard": [
         {
-          "count": 3,
-          "name": "Abrade"
+          "count": 1,
+          "name": "Disdainful Stroke"
         },
         {
           "count": 1,
-          "name": "Disdainful Stroke"
+          "name": "Abrade"
         },
         {
           "count": 2,
@@ -1306,8 +1290,8 @@
           "name": "Soul-Guide Lantern"
         },
         {
-          "count": 1,
-          "name": "Ral, Crackling Wit"
+          "count": 2,
+          "name": "Abrade"
         },
         {
           "count": 1,
@@ -1328,6 +1312,10 @@
         {
           "count": 1,
           "name": "Price of Freedom"
+        },
+        {
+          "count": 1,
+          "name": "Ral, Crackling Wit"
         }
       ]
     },

--- a/client/public/feeds/mtggoldfish-standard.json
+++ b/client/public/feeds/mtggoldfish-standard.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "standard",
   "version": 1,
-  "updated": "2026-07-25T00:00:00Z",
+  "updated": "2026-07-26T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/standard",
   "decks": [
     {
@@ -403,207 +403,6 @@
       ]
     },
     {
-      "name": "4c Control",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "W",
-        "U",
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 2,
-          "name": "Abrade"
-        },
-        {
-          "count": 3,
-          "name": "Consult the Star Charts"
-        },
-        {
-          "count": 1,
-          "name": "Cori Mountain Monastery"
-        },
-        {
-          "count": 1,
-          "name": "Day of Judgment"
-        },
-        {
-          "count": 2,
-          "name": "Flashback"
-        },
-        {
-          "count": 1,
-          "name": "Floodfarm Verge"
-        },
-        {
-          "count": 3,
-          "name": "Great Hall of the Biblioplex"
-        },
-        {
-          "count": 3,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 3,
-          "name": "Inevitable Defeat"
-        },
-        {
-          "count": 1,
-          "name": "Mistrise Village"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Helix"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Multiversal Passage"
-        },
-        {
-          "count": 1,
-          "name": "Plains"
-        },
-        {
-          "count": 2,
-          "name": "No More Lies"
-        },
-        {
-          "count": 1,
-          "name": "North Wind Avatar"
-        },
-        {
-          "count": 1,
-          "name": "Mistrise Village"
-        },
-        {
-          "count": 2,
-          "name": "Riverpyre Verge"
-        },
-        {
-          "count": 4,
-          "name": "Jeskai Revelation"
-        },
-        {
-          "count": 2,
-          "name": "Sear"
-        },
-        {
-          "count": 2,
-          "name": "Hallowed Fountain"
-        },
-        {
-          "count": 1,
-          "name": "Slagstorm"
-        },
-        {
-          "count": 1,
-          "name": "Great Hall of the Biblioplex"
-        },
-        {
-          "count": 4,
-          "name": "Stock Up"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 4,
-          "name": "Tablet of Discovery"
-        },
-        {
-          "count": 1,
-          "name": "Three Steps Ahead"
-        },
-        {
-          "count": 1,
-          "name": "Thunder Magic"
-        },
-        {
-          "count": 1,
-          "name": "Day of Judgment"
-        },
-        {
-          "count": 3,
-          "name": "Shattered Sanctum"
-        },
-        {
-          "count": 2,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 2,
-          "name": "Watery Grave"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Ancient Vendetta"
-        },
-        {
-          "count": 1,
-          "name": "Get Lost"
-        },
-        {
-          "count": 1,
-          "name": "Disdainful Stroke"
-        },
-        {
-          "count": 2,
-          "name": "Emeritus of Ideation"
-        },
-        {
-          "count": 1,
-          "name": "Fire Magic"
-        },
-        {
-          "count": 1,
-          "name": "Flashfreeze"
-        },
-        {
-          "count": 1,
-          "name": "Flashfreeze"
-        },
-        {
-          "count": 1,
-          "name": "Negate"
-        },
-        {
-          "count": 1,
-          "name": "Outrageous Robbery"
-        },
-        {
-          "count": 1,
-          "name": "Petrified Hamlet"
-        },
-        {
-          "count": 1,
-          "name": "Day of Judgment"
-        },
-        {
-          "count": 2,
-          "name": "Strategic Betrayal"
-        },
-        {
-          "count": 1,
-          "name": "Slagstorm"
-        }
-      ]
-    },
-    {
       "name": "Izzet Spellementals",
       "author": "MTGGoldfish",
       "colors": [
@@ -727,104 +526,183 @@
       ]
     },
     {
-      "name": "Mono-Green Landfall",
+      "name": "4c Control",
       "author": "MTGGoldfish",
       "colors": [
-        "G"
+        "W",
+        "B",
+        "U",
+        "R"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
-          "count": 2,
-          "name": "Lumbering Worldwagon"
+          "count": 1,
+          "name": "North Wind Avatar"
         },
         {
           "count": 4,
-          "name": "Earthbender Ascension"
-        },
-        {
-          "count": 4,
-          "name": "Mightform Harmonizer"
-        },
-        {
-          "count": 4,
-          "name": "Esper Origins"
-        },
-        {
-          "count": 4,
-          "name": "Escape Tunnel"
-        },
-        {
-          "count": 3,
-          "name": "Meltstrider's Resolve"
+          "name": "Tablet of Discovery"
         },
         {
           "count": 1,
-          "name": "Royal Treatment"
+          "name": "Sundown Pass"
+        },
+        {
+          "count": 1,
+          "name": "Sunbillow Verge"
+        },
+        {
+          "count": 3,
+          "name": "Consult the Star Charts"
+        },
+        {
+          "count": 2,
+          "name": "Firebending Lesson"
+        },
+        {
+          "count": 2,
+          "name": "Flashback"
+        },
+        {
+          "count": 1,
+          "name": "Stormcarved Coast"
+        },
+        {
+          "count": 1,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Godless Shrine"
+        },
+        {
+          "count": 1,
+          "name": "Cori Mountain Monastery"
+        },
+        {
+          "count": 2,
+          "name": "Shattered Sanctum"
+        },
+        {
+          "count": 1,
+          "name": "Mistrise Village"
         },
         {
           "count": 4,
-          "name": "Sazh's Chocobo"
+          "name": "Great Hall of the Biblioplex"
+        },
+        {
+          "count": 2,
+          "name": "Hallowed Fountain"
+        },
+        {
+          "count": 2,
+          "name": "Gloomlake Verge"
+        },
+        {
+          "count": 3,
+          "name": "Sacred Foundry"
         },
         {
           "count": 4,
-          "name": "Ba Sing Se"
+          "name": "Steam Vents"
+        },
+        {
+          "count": 2,
+          "name": "Day of Judgment"
         },
         {
           "count": 4,
-          "name": "Llanowar Elves"
+          "name": "Stock Up"
+        },
+        {
+          "count": 1,
+          "name": "Negate"
+        },
+        {
+          "count": 2,
+          "name": "Sear"
+        },
+        {
+          "count": 1,
+          "name": "Meticulous Archive"
+        },
+        {
+          "count": 1,
+          "name": "Multiversal Passage"
+        },
+        {
+          "count": 2,
+          "name": "No More Lies"
+        },
+        {
+          "count": 2,
+          "name": "Lightning Helix"
         },
         {
           "count": 4,
-          "name": "Icetill Explorer"
+          "name": "Jeskai Revelation"
         },
         {
           "count": 4,
-          "name": "Badgermole Cub"
+          "name": "Inevitable Defeat"
         },
         {
-          "count": 4,
-          "name": "Fabled Passage"
-        },
-        {
-          "count": 14,
-          "name": "Forest"
+          "count": 1,
+          "name": "Island"
         }
       ],
       "sideboard": [
         {
-          "count": 1,
-          "name": "Meltstrider's Resolve"
+          "count": 2,
+          "name": "Emeritus of Ideation"
         },
         {
           "count": 1,
-          "name": "Surrak, Elusive Hunter"
+          "name": "Disdainful Stroke"
         },
         {
           "count": 1,
-          "name": "Royal Treatment"
-        },
-        {
-          "count": 1,
-          "name": "Glorious Decay"
-        },
-        {
-          "count": 3,
-          "name": "Soul-Guide Lantern"
-        },
-        {
-          "count": 4,
-          "name": "Mossborn Hydra"
+          "name": "Day of Judgment"
         },
         {
           "count": 2,
-          "name": "Sapling Nursery"
+          "name": "Strategic Betrayal"
+        },
+        {
+          "count": 1,
+          "name": "Outrageous Robbery"
+        },
+        {
+          "count": 1,
+          "name": "Petrified Hamlet"
+        },
+        {
+          "count": 1,
+          "name": "Pyroclasm"
+        },
+        {
+          "count": 1,
+          "name": "Riverchurn Monument"
+        },
+        {
+          "count": 1,
+          "name": "Spell Snare"
         },
         {
           "count": 2,
-          "name": "Eumidian Terrabotanist"
+          "name": "Flashfreeze"
+        },
+        {
+          "count": 1,
+          "name": "Pest Control"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Vendetta"
         }
       ]
     },
@@ -956,6 +834,108 @@
         {
           "count": 1,
           "name": "Petrified Hamlet"
+        }
+      ]
+    },
+    {
+      "name": "Mono-Green Landfall",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 2,
+          "name": "Lumbering Worldwagon"
+        },
+        {
+          "count": 4,
+          "name": "Earthbender Ascension"
+        },
+        {
+          "count": 4,
+          "name": "Mightform Harmonizer"
+        },
+        {
+          "count": 4,
+          "name": "Esper Origins"
+        },
+        {
+          "count": 4,
+          "name": "Escape Tunnel"
+        },
+        {
+          "count": 3,
+          "name": "Meltstrider's Resolve"
+        },
+        {
+          "count": 1,
+          "name": "Royal Treatment"
+        },
+        {
+          "count": 4,
+          "name": "Sazh's Chocobo"
+        },
+        {
+          "count": 4,
+          "name": "Ba Sing Se"
+        },
+        {
+          "count": 4,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 4,
+          "name": "Icetill Explorer"
+        },
+        {
+          "count": 4,
+          "name": "Badgermole Cub"
+        },
+        {
+          "count": 4,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 14,
+          "name": "Forest"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Meltstrider's Resolve"
+        },
+        {
+          "count": 1,
+          "name": "Surrak, Elusive Hunter"
+        },
+        {
+          "count": 1,
+          "name": "Royal Treatment"
+        },
+        {
+          "count": 1,
+          "name": "Glorious Decay"
+        },
+        {
+          "count": 3,
+          "name": "Soul-Guide Lantern"
+        },
+        {
+          "count": 4,
+          "name": "Mossborn Hydra"
+        },
+        {
+          "count": 2,
+          "name": "Sapling Nursery"
+        },
+        {
+          "count": 2,
+          "name": "Eumidian Terrabotanist"
         }
       ]
     },
@@ -1206,90 +1186,14 @@
       "name": "Mardu Discard",
       "author": "MTGGoldfish",
       "colors": [
-        "R",
+        "W",
         "B",
-        "W"
+        "R"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
-        {
-          "count": 2,
-          "name": "Erode"
-        },
-        {
-          "count": 1,
-          "name": "Concealed Courtyard"
-        },
-        {
-          "count": 4,
-          "name": "Iron-Shield Elf"
-        },
-        {
-          "count": 1,
-          "name": "Inspiring Vantage"
-        },
-        {
-          "count": 4,
-          "name": "Starting Town"
-        },
-        {
-          "count": 2,
-          "name": "Practiced Offense"
-        },
-        {
-          "count": 3,
-          "name": "Blazemire Verge"
-        },
-        {
-          "count": 2,
-          "name": "Get Lost"
-        },
-        {
-          "count": 4,
-          "name": "Marauding Mako"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 2,
-          "name": "Carnage, Crimson Chaos"
-        },
-        {
-          "count": 4,
-          "name": "Cool but Rude"
-        },
-        {
-          "count": 4,
-          "name": "Blood Crypt"
-        },
-        {
-          "count": 4,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 2,
-          "name": "Casey Jones, Vigilante"
-        },
-        {
-          "count": 3,
-          "name": "Bloodghast"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 2,
-          "name": "Cecil, Dark Knight"
-        },
-        {
-          "count": 1,
-          "name": "Tersa Lightshatter"
-        },
         {
           "count": 4,
           "name": "Godless Shrine"
@@ -1299,34 +1203,114 @@
           "name": "Hardened Academic"
         },
         {
+          "count": 2,
+          "name": "Practiced Offense"
+        },
+        {
+          "count": 1,
+          "name": "Erode"
+        },
+        {
           "count": 4,
           "name": "Moonshadow"
         },
         {
+          "count": 4,
+          "name": "Cool but Rude"
+        },
+        {
+          "count": 2,
+          "name": "Sacred Foundry"
+        },
+        {
+          "count": 2,
+          "name": "Requiting Hex"
+        },
+        {
+          "count": 4,
+          "name": "Iron-Shield Elf"
+        },
+        {
+          "count": 2,
+          "name": "Carnage, Crimson Chaos"
+        },
+        {
+          "count": 3,
+          "name": "Sunset Saboteur"
+        },
+        {
+          "count": 2,
+          "name": "Cecil, Dark Knight"
+        },
+        {
           "count": 1,
-          "name": "Get Lost"
+          "name": "Mountain"
+        },
+        {
+          "count": 4,
+          "name": "Blood Crypt"
+        },
+        {
+          "count": 2,
+          "name": "Bloodghast"
+        },
+        {
+          "count": 1,
+          "name": "Concealed Courtyard"
+        },
+        {
+          "count": 4,
+          "name": "Inspiring Vantage"
+        },
+        {
+          "count": 3,
+          "name": "Blazemire Verge"
+        },
+        {
+          "count": 4,
+          "name": "Marauding Mako"
+        },
+        {
+          "count": 1,
+          "name": "Tersa Lightshatter"
+        },
+        {
+          "count": 4,
+          "name": "Starting Town"
+        },
+        {
+          "count": 2,
+          "name": "Casey Jones, Vigilante"
         }
       ],
       "sideboard": [
+        {
+          "count": 1,
+          "name": "Sunset Saboteur"
+        },
+        {
+          "count": 1,
+          "name": "Get Lost"
+        },
         {
           "count": 1,
           "name": "Case of the Crimson Pulse"
         },
         {
           "count": 2,
-          "name": "Doorkeeper Thrull"
-        },
-        {
-          "count": 3,
-          "name": "Magebane Lizard"
+          "name": "Duress"
         },
         {
           "count": 2,
-          "name": "Nowhere to Run"
+          "name": "Magebane Lizard"
         },
         {
           "count": 3,
-          "name": "Duress"
+          "name": "Doorkeeper Thrull"
+        },
+        {
+          "count": 1,
+          "name": "Voice of Victory"
         },
         {
           "count": 2,
@@ -1334,7 +1318,7 @@
         },
         {
           "count": 2,
-          "name": "Voice of Victory"
+          "name": "Dawn's Truce"
         }
       ]
     }


### PR DESCRIPTION
Automated daily metagame feed refresh from MTGGoldfish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed MTGGoldfish feed data for Commander, Modern, Pioneer, and Standard.
  * Updated decklists across multiple formats, including new and revised deck entries, card compositions, and sideboards.
  * Added newly available decks such as *The Unbeatable Squirrel Girl*, *Izzet Spellementals*, and *Mono-Green Landfall*.
  * Updated feed timestamps to reflect the latest data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->