### PR TITLE
fix(engine): cap max_deck_copies at one for format-restricted cards

### DIFF
--- a/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
+++ b/client/src/components/deck-builder/__tests__/DeckStack.test.tsx
@@ -238,6 +238,35 @@ describe("DeckStack", () => {
     expect(screen.getByTitle("Add one Sol Ring")).toBeEnabled();
   });
 
+  it("disables the add button when the engine says the card is at its copy limit", () => {
+    // The counterpart to the three cases above: those prove the stack never
+    // derives a ceiling of its own, this proves it does honour the one the
+    // engine hands it. Without this case every test here supplies a predicate
+    // that returns true, so they would all still pass if DeckStack dropped the
+    // engine's answer on the floor.
+    const canAddCard = vi.fn(() => false);
+    render(
+      <DeckStack
+        deck={{ main: [{ name: "Sol Ring", count: 1 }], sideboard: [] }}
+        commanders={[]}
+        cardDataCache={new Map([["Sol Ring", makeCard("Sol Ring", "Artifact", 1)]])}
+        format="Commander"
+        onAddCard={vi.fn()}
+        canAddCard={canAddCard}
+        onRemoveCard={vi.fn()}
+        onMoveCard={vi.fn()}
+        onRemoveCommander={vi.fn()}
+        groupMode="type"
+      />,
+    );
+
+    // At the limit the control stays on screen but goes inert, and its title
+    // explains why rather than still offering the add.
+    expect(screen.queryByTitle("Add one Sol Ring")).not.toBeInTheDocument();
+    expect(screen.getByTitle("Sol Ring is at the copy limit")).toBeDisabled();
+    expect(canAddCard).toHaveBeenCalledWith("Sol Ring");
+  });
+
   it("moves a second-section card back to the main deck via its move button", () => {
     // The recovery path for the Commander 'maybeboard trap': a card parked in
     // the second section must be returnable to the main deck from the stack.

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -2731,16 +2731,35 @@ fn effective_copy_limit(
     deck_copy_limit_for(db, canonical_name).unwrap_or(format_default)
 }
 
-/// CR 100.2a / CR 903.5b: How many copies of `name` a `format` deck may legally
-/// contain, counting main deck, sideboard, and command zone together
-/// (CR 100.4a: "The four-card limit applies to the combined deck and
+/// CR 100.2a / CR 100.2b / CR 903.5b: How many copies of `name` a `format` deck
+/// may legally contain, counting main deck, sideboard, and command zone
+/// together (CR 100.4a: "The four-card limit applies to the combined deck and
 /// sideboard"). `Unlimited` means no ceiling.
 ///
 /// This is the query-shaped counterpart to `copy_limit_violations` and the
 /// single authority consumers outside the engine must use — the deck builder
 /// disables its increment control from this, and must never re-derive the
 /// limit from Oracle text, card type, or a hardcoded four.
+///
+/// Being query-shaped is why the restricted list is applied here rather than in
+/// [`effective_copy_limit`]: validation reports a restricted overrun as its own
+/// distinct violation (`restricted_copy_violations`), so the shared helper must
+/// keep the two failures separable. A caller asking "how many may I have?"
+/// wants the one ceiling that actually binds.
 pub fn max_deck_copies(db: &CardDatabase, name: &str, format: GameFormat) -> DeckCopyLimit {
+    // CR 100.2b: a card the format's legality table marks Restricted is legal
+    // at no more than one copy, whichever way the format default or the card's
+    // printed override would otherwise point. Vintage is the canonical user,
+    // but the lookup is format-general.
+    if format
+        .legality_format()
+        .and_then(|legality_format| {
+            db.legality_status(resolve_card_name(db, name), legality_format)
+        })
+        .is_some_and(|status| status == LegalityStatus::Restricted)
+    {
+        return DeckCopyLimit::UpTo(1);
+    }
     effective_copy_limit(
         db,
         &canonical_deck_count_key(db, name),
@@ -3972,6 +3991,48 @@ mod tests {
         assert_eq!(
             max_deck_copies(&db, "Nazgul", GameFormat::Modern),
             DeckCopyLimit::UpTo(9)
+        );
+    }
+
+    /// CR 100.2b: the restricted list is a copy ceiling, so the query the deck
+    /// builder gates its increment control on has to honour it — otherwise the
+    /// `+` stays live through four Black Lotuses and the deck only fails later,
+    /// at validation. The restriction is format-scoped: the same card is a
+    /// plain four-of wherever its legality table doesn't restrict it.
+    #[test]
+    fn max_deck_copies_honours_the_format_restricted_list() {
+        let db = CardDatabase::from_json_str(&vintage_test_db()).unwrap();
+
+        // Reach guard: the ceiling below is only meaningful if the fixture
+        // really does mark this card Restricted in Vintage.
+        assert_eq!(
+            db.legality_status(
+                "Black Lotus",
+                GameFormat::Vintage.legality_format().unwrap()
+            ),
+            Some(LegalityStatus::Restricted),
+            "fixture must present Black Lotus as Vintage-restricted"
+        );
+
+        assert_eq!(
+            max_deck_copies(&db, "Black Lotus", GameFormat::Vintage),
+            DeckCopyLimit::UpTo(1),
+            "a Vintage-restricted card is capped at one copy, not the four-of default"
+        );
+
+        // Format-scoped: Legacy's legality table says nothing about this card,
+        // so it falls through to the CR 100.2a default rather than inheriting
+        // Vintage's restriction.
+        assert_eq!(
+            max_deck_copies(&db, "Black Lotus", GameFormat::Legacy),
+            DeckCopyLimit::UpTo(4)
+        );
+
+        // CR 205.4c still wins for basics — a restricted lookup must not
+        // shadow the exemption for cards the list doesn't name.
+        assert_eq!(
+            max_deck_copies(&db, "Island", GameFormat::Vintage),
+            DeckCopyLimit::Unlimited
         );
     }
 


### PR DESCRIPTION
Follow-up to #6654, addressing a CodeRabbit finding that landed after the PR
had already entered the merge queue.

`max_deck_copies` — the query the deck builder gates its `+` control on —
layered the basic-land exemption (CR 205.4c), the card's printed override, and
the format default (CR 100.2a / CR 903.5b), but never consulted the format's
restricted list. It therefore reported four for Black Lotus in Vintage, so the
`+` stayed live through four copies of a card CR 100.2b allows exactly once,
and the deck only failed later at validation — which enforces the restriction
on its own separate path.

The lookup goes in `max_deck_copies` rather than the shared
`effective_copy_limit` on purpose. Validation reports a restricted overrun as
its own distinct violation (`restricted_copy_violations`, "More than 1 copy of
a restricted card"), so the shared helper has to keep the two failures
separable; a caller asking "how many may I have?" wants the single ceiling that
actually binds.

## Tests

- `max_deck_copies_honours_the_format_restricted_list` — one copy in Vintage,
  with a reach guard asserting the fixture really presents the card as
  `Restricted`; four in Legacy, proving the restriction is format-scoped rather
  than global; and `Unlimited` for a basic, proving the new lookup doesn't
  shadow the CR 205.4c exemption.
- `DeckStack` gains the case that supplies a `false` predicate. Every existing
  case passed `() => true`, so all of them would have stayed green if the
  component ignored the engine's answer entirely. This one was watched failing
  before it passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced one-copy limits for cards listed as restricted in supported formats.
  * Preserved unlimited copies for basic lands where applicable.
  * Improved deck builder feedback when a card has reached its copy limit, including a disabled control with a clear explanation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->