### PR TITLE
refactor(engine): extract the CR 603.3d uncommitted-trigger removal authority

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8562,13 +8562,7 @@ fn apply_retarget(
 /// CR 603.3c + CR 608.2c: Drop a mid-construction optional triggered modal that
 /// was declined before mode choice.
 pub(super) fn drop_mid_construction_pending_trigger(state: &mut GameState) {
-    if let Some(entry_id) = state.pending_trigger_entry.take() {
-        if state.stack.back().map(|e| e.id) == Some(entry_id) {
-            state.stack.pop_back();
-            state.stack_paid_facts.remove(&entry_id);
-            state.stack_trigger_event_batches.remove(&entry_id);
-        }
-    }
+    super::stack::pop_uncommitted_pending_trigger_entry(state);
     state.pending_trigger = None;
 }
 
@@ -8663,13 +8657,7 @@ pub(super) fn begin_pending_trigger_target_selection(
                 &mode_abilities,
                 &unavailable_modes,
             ) else {
-                if let Some(entry_id) = state.pending_trigger_entry.take() {
-                    if state.stack.back().map(|e| e.id) == Some(entry_id) {
-                        state.stack.pop_back();
-                        state.stack_paid_facts.remove(&entry_id);
-                        state.stack_trigger_event_batches.remove(&entry_id);
-                    }
-                }
+                super::stack::pop_uncommitted_pending_trigger_entry(state);
                 state.pending_trigger = None;
                 return Ok(None);
             };
@@ -8688,13 +8676,7 @@ pub(super) fn begin_pending_trigger_target_selection(
                  dispatch_pending_trigger_context must resolve it inline",
             );
             if modal.selection.is_random() {
-                if let Some(entry_id) = state.pending_trigger_entry.take() {
-                    if state.stack.back().map(|e| e.id) == Some(entry_id) {
-                        state.stack.pop_back();
-                        state.stack_paid_facts.remove(&entry_id);
-                        state.stack_trigger_event_batches.remove(&entry_id);
-                    }
-                }
+                super::stack::pop_uncommitted_pending_trigger_entry(state);
                 state.pending_trigger = None;
                 return Ok(None);
             }
@@ -8708,13 +8690,7 @@ pub(super) fn begin_pending_trigger_target_selection(
             // dead branch — kept as a defensive cleanup for any
             // delayed-revalidation paths.
             if unavailable_modes.len() >= modal.mode_count {
-                if let Some(entry_id) = state.pending_trigger_entry.take() {
-                    if state.stack.back().map(|e| e.id) == Some(entry_id) {
-                        state.stack.pop_back();
-                        state.stack_paid_facts.remove(&entry_id);
-                        state.stack_trigger_event_batches.remove(&entry_id);
-                    }
-                }
+                super::stack::pop_uncommitted_pending_trigger_entry(state);
                 state.pending_trigger = None;
                 return Ok(None);
             }
@@ -8829,13 +8805,7 @@ pub(super) fn begin_pending_trigger_target_selection(
         // branch above: if the "push first" dispatcher already pushed an
         // in-construction entry for this trigger, pop it before clearing the
         // cursor.
-        if let Some(entry_id) = state.pending_trigger_entry.take() {
-            if state.stack.back().map(|e| e.id) == Some(entry_id) {
-                state.stack.pop_back();
-                state.stack_paid_facts.remove(&entry_id);
-                state.stack_trigger_event_batches.remove(&entry_id);
-            }
-        }
+        super::stack::pop_uncommitted_pending_trigger_entry(state);
         state.pending_trigger = None;
         return Ok(None);
     };

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -346,13 +346,7 @@ pub(super) fn resolve_random_modal_trigger(
         // CR 603.3c: No legal mode — drop the trigger. The interactive branches
         // already removed the in-flight stack entry before this point, so just
         // clear the cursor here.
-        if let Some(entry_id) = state.pending_trigger_entry.take() {
-            if state.stack.back().map(|e| e.id) == Some(entry_id) {
-                state.stack.pop_back();
-                state.stack_paid_facts.remove(&entry_id);
-                state.stack_trigger_event_batches.remove(&entry_id);
-            }
-        }
+        super::stack::pop_uncommitted_pending_trigger_entry(state);
         state.pending_trigger = None;
         return Ok(None);
     };

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -267,6 +267,40 @@ pub fn apply_resolved_stack_entry_finalize(
     Ok(())
 }
 
+/// CR 603.3d: removes an uncommitted triggered ability from the stack.
+///
+/// The "push first, choose second" invariant (see
+/// [`GameState::pending_trigger_entry`]) puts a triggered ability on the stack
+/// BEFORE its choices are gathered, so the entry is live while a `WaitingFor`
+/// fills its slots. CR 603.3d: "If a choice is required when the triggered
+/// ability goes on the stack but no legal choices can be made for it, or if a
+/// rule or a continuous effect otherwise makes the ability illegal, the ability
+/// is simply removed from the stack." This is the single authority for that
+/// removal.
+///
+/// The two side tables are cleared here rather than by the callers because they
+/// are keyed on the entry and settle WITH the pop — a removal that dropped the
+/// entry but left `stack_paid_facts` or `stack_trigger_event_batches` behind
+/// would strand rows against an id no longer on the stack.
+///
+/// Guarded on the entry still being topmost: the cursor can outlive the entry
+/// when another path already removed it, and popping unconditionally would then
+/// discard an unrelated stack object.
+///
+/// Note this deliberately does NOT clear `pending_trigger`; that is a separate
+/// piece of construction state owned by
+/// `engine::drop_mid_construction_pending_trigger`, which calls this and then
+/// clears it.
+pub(crate) fn pop_uncommitted_pending_trigger_entry(state: &mut GameState) {
+    if let Some(entry_id) = state.pending_trigger_entry.take() {
+        if state.stack.back().map(|e| e.id) == Some(entry_id) {
+            state.stack.pop_back();
+            state.stack_paid_facts.remove(&entry_id);
+            state.stack_trigger_event_batches.remove(&entry_id);
+        }
+    }
+}
+
 /// The ability currently represented by a stack entry for presentation.
 ///
 /// A spell is placed on the stack before its cast is finalized (CR 601.2a-b),


### PR DESCRIPTION
The "push first, choose second" invariant puts a triggered ability on the stack
before its choices are gathered (see `GameState::pending_trigger_entry`), so the
entry is live while a `WaitingFor` fills its slots. When those choices cannot be
completed, CR 603.3d says the ability is simply removed from the stack.

That removal was written raw at SIX sites as a byte-identical seven-line block
(verified by whole-block comparison, not a sampled window): the pop, plus the two
per-entry side tables that settle with it.

    if let Some(entry_id) = state.pending_trigger_entry.take() {
        if state.stack.back().map(|e| e.id) == Some(entry_id) {
            state.stack.pop_back();
            state.stack_paid_facts.remove(&entry_id);
            state.stack_trigger_event_batches.remove(&entry_id);
        }
    }

One of the six was already inside `drop_mid_construction_pending_trigger`, so
this is one existing authority plus five sites bypassing it — not six orphans.
The five are in `begin_pending_trigger_target_selection` (x4) and
`resolve_random_modal_trigger`.

Routing the five INTO `drop_mid_construction_pending_trigger` would have been
wrong: that function additionally clears `pending_trigger`, which the five
deliberately do not, so it would have been a silent behaviour change at five call
sites. Instead the shared seven lines become
`stack::pop_uncommitted_pending_trigger_entry`, the existing authority calls it
and then clears `pending_trigger`, and the five call it directly. One authority
for the mutation, no semantic change anywhere.

The two side tables are cleared inside the authority rather than by callers
because they are keyed on the entry and settle WITH the pop — a removal that
dropped the entry but left `stack_paid_facts` or `stack_trigger_event_batches`
behind would strand rows against an id no longer on the stack.

Deliberately NOT folded in: `triggers.rs`'s recovery path clears both side tables
with no pop, because its entry has already vanished from the stack. Same two
lines, different operation.

Prerequisite for journaling the CR733 stack-pop family, which requires exactly
one authority per family — the same shape #6647 used for the CR 707.10 copy push.
No journaling here; this is the extraction only.

CR 603.3d grep-verified against docs/MagicCompRules.txt: "If a choice is required
when the triggered ability goes on the stack but no legal choices can be made for
it, or if a rule or a continuous effect otherwise makes the ability illegal, the
ability is simply removed from the stack."

Behaviour-preserving: engine integration suite 4057 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of triggered abilities that are declined, cannot select a legal mode, or do not require a target.
  * Prevented incomplete trigger entries from remaining in the game state after defensive cleanup.
  * Preserved related stack information while clearing invalid pending triggers consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->