### PR TITLE
feat(engine): journal the CR 603.3d uncommitted-trigger removal

### DIFF
--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -17,6 +17,8 @@ use crate::types::player::PlayerId;
 use crate::types::resolved_commands::{
     ResolvedStackEntryFinalizeCommand, ResolvedStackEntryFinalizeReplayInvariantError,
     ResolvedStackPushCommand, ResolvedStackPushOrigin, ResolvedStackPushReplayInvariantError,
+    ResolvedUncommittedTriggerRemovalCommand,
+    ResolvedUncommittedTriggerRemovalReplayInvariantError,
 };
 use crate::types::zones::Zone;
 
@@ -292,13 +294,105 @@ pub fn apply_resolved_stack_entry_finalize(
 /// `engine::drop_mid_construction_pending_trigger`, which calls this and then
 /// clears it.
 pub(crate) fn pop_uncommitted_pending_trigger_entry(state: &mut GameState) {
-    if let Some(entry_id) = state.pending_trigger_entry.take() {
-        if state.stack.back().map(|e| e.id) == Some(entry_id) {
-            state.stack.pop_back();
+    let Some(entry_id) = state.pending_trigger_entry.take() else {
+        // No cursor: nothing was consumed and nothing settled, so there is no
+        // mutation to journal.
+        return;
+    };
+    let removed = (state.stack.back().map(|e| e.id) == Some(entry_id))
+        .then(|| {
+            let entry = state.stack.pop_back().expect("the entry was just observed");
             state.stack_paid_facts.remove(&entry_id);
             state.stack_trigger_event_batches.remove(&entry_id);
+            entry
+        })
+        .map(Box::new);
+
+    // CR 733: journal AFTER the removal settles, and journal BOTH outcomes. The
+    // `.take()` above is unconditional, so a guard that declines to pop still
+    // consumed the cursor — recording only the popping case would leave a replay
+    // of the other holding a `pending_trigger_entry` the real execution cleared.
+    let cause = state.current_or_begin_rules_execution_node();
+    let command = ResolvedUncommittedTriggerRemovalCommand {
+        consumed_entry_id: entry_id,
+        removed,
+        resulting_depth: state.stack.len(),
+        cause,
+    };
+    state
+        .resolved_rules_journal
+        .record_uncommitted_trigger_removal(command)
+        .expect("resolved uncommitted trigger removal must have a live journal cause");
+}
+
+/// Installs one already-resolved CR 603.3d removal verbatim.
+///
+/// Nothing is re-derived: the entry is compared WHOLE against the recorded one
+/// rather than matched by id, so a replay whose stack top merely shares an id
+/// fails closed instead of discarding a different object. The two side tables are
+/// dropped by the recorded entry's own id.
+///
+/// Both recorded outcomes are honoured. `removed: None` means the original
+/// execution consumed the cursor without popping, so this refuses to pop — and
+/// asserts the predecessor agrees, because a replay whose top IS that entry would
+/// otherwise silently diverge from the execution being replayed.
+pub fn apply_resolved_uncommitted_trigger_removal(
+    state: &mut GameState,
+    command: &ResolvedUncommittedTriggerRemovalCommand,
+) -> Result<(), ResolvedUncommittedTriggerRemovalReplayInvariantError> {
+    if state.pending_trigger_entry != Some(command.consumed_entry_id) {
+        return Err(
+            ResolvedUncommittedTriggerRemovalReplayInvariantError::CursorMismatch {
+                expected: command.consumed_entry_id,
+                found: state.pending_trigger_entry,
+            },
+        );
+    }
+    let top_id = state.stack.back().map(|e| e.id);
+    match command.removed.as_deref() {
+        Some(recorded) => {
+            if state.stack.len() != command.resulting_depth + 1 {
+                return Err(
+                    ResolvedUncommittedTriggerRemovalReplayInvariantError::DepthMismatch {
+                        expected: command.resulting_depth + 1,
+                        found: state.stack.len(),
+                    },
+                );
+            }
+            if state.stack.back() != Some(recorded) {
+                return Err(
+                    ResolvedUncommittedTriggerRemovalReplayInvariantError::RemovedEntryMismatch,
+                );
+            }
+        }
+        None => {
+            if state.stack.len() != command.resulting_depth {
+                return Err(
+                    ResolvedUncommittedTriggerRemovalReplayInvariantError::DepthMismatch {
+                        expected: command.resulting_depth,
+                        found: state.stack.len(),
+                    },
+                );
+            }
+            if top_id == Some(command.consumed_entry_id) {
+                return Err(
+                    ResolvedUncommittedTriggerRemovalReplayInvariantError::UnexpectedRemovableEntry(
+                        command.consumed_entry_id,
+                    ),
+                );
+            }
         }
     }
+
+    state.pending_trigger_entry = None;
+    if command.removed.is_some() {
+        state.stack.pop_back();
+        state.stack_paid_facts.remove(&command.consumed_entry_id);
+        state
+            .stack_trigger_event_batches
+            .remove(&command.consumed_entry_id);
+    }
+    Ok(())
 }
 
 /// The ability currently represented by a stack entry for presentation.

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -95,8 +95,9 @@ pub use resolved_commands::{
     ResolvedStackEntryFinalizeReplayInvariantError, ResolvedStackPushCommand,
     ResolvedStackPushOrigin, ResolvedStackPushReplayInvariantError, ResolvedTriggerCollection,
     ResolvedTriggerCollectionCommand, ResolvedTriggerCollectionReplayInvariantError,
-    ResolvedTriggerLedgerEdit, RulesExecutionNodeKind, RulesExecutionNodeRef, SettlementNode,
-    SettlementNodeOrdinal, SpentManaUnit,
+    ResolvedTriggerLedgerEdit, ResolvedUncommittedTriggerRemovalCommand,
+    ResolvedUncommittedTriggerRemovalReplayInvariantError, RulesExecutionNodeKind,
+    RulesExecutionNodeRef, SettlementNode, SettlementNodeOrdinal, SpentManaUnit,
 };
 pub use statics::StaticMode;
 pub use stickers::{AppliedSticker, StickerKind, StickerLocator};

--- a/crates/engine/src/types/resolved_commands.rs
+++ b/crates/engine/src/types/resolved_commands.rs
@@ -1092,6 +1092,65 @@ pub enum ResolvedStackEntryFinalizeReplayInvariantError {
     PaidFactsMismatch(ObjectId),
 }
 
+/// One exact CR 603.3d removal of an uncommitted triggered ability.
+///
+/// The "push first, choose second" invariant puts a triggered ability on the
+/// stack BEFORE its choices are gathered, so the entry is live while a
+/// `WaitingFor` fills its slots. CR 603.3d: if no legal choices can be made for
+/// it, "the ability is simply removed from the stack."
+///
+/// TWO OUTCOMES, both mutating, which is why `removed` is an `Option` rather
+/// than a plain entry. `stack::pop_uncommitted_pending_trigger_entry` consumes
+/// `pending_trigger_entry` UNCONDITIONALLY and only then decides whether to pop:
+///
+/// * guard holds — the cursor is consumed AND the entry leaves the stack with
+///   both per-entry side tables.
+/// * guard fails — the cursor is consumed and NOTHING else, because the cursor
+///   outlived its entry (another path already removed it).
+///
+/// A command that modelled only the first would leave a replay of the second
+/// holding `pending_trigger_entry == Some(id)` while the real execution cleared
+/// it — a divergence needing no forged journal, only an honest replay.
+///
+/// The removed side-table VALUES are deliberately not recorded. Contrast
+/// [`ResolvedStackEntryFinalizeCommand`], which records `expected_old_paid_facts`
+/// because it INSTALLS a value and must verify the predecessor it overwrites.
+/// This command only removes rows keyed on the recorded entry's own id — nothing
+/// is installed and nothing is re-derived, so there is no invariant a recorded
+/// value would pin, and carrying `Vec<GameEvent>` batches would widen every
+/// journal entry for nothing.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedUncommittedTriggerRemovalCommand {
+    /// The cursor value consumed by the `.take()`. Always present, because the
+    /// take is unconditional.
+    pub consumed_entry_id: ObjectId,
+    /// The entry actually removed, recorded verbatim so replay verifies the
+    /// whole object rather than trusting the id. `None` when the guard declined
+    /// to pop.
+    pub removed: Option<Box<StackEntry>>,
+    /// Stack depth AFTER the operation (CR 405.2).
+    pub resulting_depth: usize,
+    pub cause: RulesExecutionNodeRef,
+}
+
+/// Typed failure while applying one already-resolved CR 603.3d removal.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ResolvedUncommittedTriggerRemovalReplayInvariantError {
+    #[error("uncommitted-trigger removal expected pending cursor {expected:?}, found {found:?}")]
+    CursorMismatch {
+        expected: ObjectId,
+        found: Option<ObjectId>,
+    },
+    #[error("uncommitted-trigger removal targets depth {expected}, found {found}")]
+    DepthMismatch { expected: usize, found: usize },
+    #[error("uncommitted-trigger removal expected a different entry on top of the stack")]
+    RemovedEntryMismatch,
+    #[error(
+        "uncommitted-trigger removal recorded no pop, but {0:?} is on top and would have been popped"
+    )]
+    UnexpectedRemovableEntry(ObjectId),
+}
+
 /// Semantic command payload currently carried by a resolved-rules journal entry.
 ///
 /// Additional command families are intentionally added by their owning P2
@@ -1121,6 +1180,7 @@ pub enum ResolvedRulesCommand {
     TriggerCollection(ResolvedTriggerCollectionCommand),
     StackPush(Box<ResolvedStackPushCommand>),
     StackEntryFinalize(Box<ResolvedStackEntryFinalizeCommand>),
+    UncommittedTriggerRemoval(Box<ResolvedUncommittedTriggerRemovalCommand>),
 }
 
 /// An append-only trigger collection command has no replay-time precondition.
@@ -2187,6 +2247,17 @@ impl ResolvedRulesJournal {
         )
     }
 
+    /// Records one exact CR 603.3d uncommitted-trigger removal under its cause.
+    pub fn record_uncommitted_trigger_removal(
+        &mut self,
+        command: ResolvedUncommittedTriggerRemovalCommand,
+    ) -> Result<ResolvedCommandOrdinal, ResolvedRulesJournalError> {
+        self.append_command(
+            command.cause,
+            ResolvedRulesCommand::UncommittedTriggerRemoval(Box::new(command)),
+        )
+    }
+
     fn begin_settlement(
         &mut self,
         identity_for: impl FnOnce(SettlementNodeOrdinal) -> RulesExecutionNodeRef,
@@ -2402,7 +2473,8 @@ impl ResolvedRulesJournal {
                 | ResolvedRulesCommand::FrameTransition(_)
                 | ResolvedRulesCommand::TriggerCollection(_)
                 | ResolvedRulesCommand::StackPush(_)
-                | ResolvedRulesCommand::StackEntryFinalize(_) => {}
+                | ResolvedRulesCommand::StackEntryFinalize(_)
+                | ResolvedRulesCommand::UncommittedTriggerRemoval(_) => {}
             }
         }
         for node in &self.nodes {
@@ -2843,6 +2915,27 @@ impl ResolvedRulesJournal {
                     return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
                         "stack-entry finalize command has an unrelated cause".to_string(),
                     ));
+                }
+            }
+            ResolvedRulesCommand::UncommittedTriggerRemoval(command) => {
+                // Cause-only, plus the one invariant checkable without state: a
+                // recorded pop must name the entry it removed. Everything else
+                // (the live cursor, the CR 405.2 depth, the exact entry on top)
+                // is state-dependent and is enforced by
+                // `stack::apply_resolved_uncommitted_trigger_removal`. There is
+                // no allocator receipt — a removal draws nothing.
+                if entry.node != command.cause {
+                    return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                        "uncommitted-trigger removal command has an unrelated cause".to_string(),
+                    ));
+                }
+                if let Some(removed) = command.removed.as_ref() {
+                    if removed.id != command.consumed_entry_id {
+                        return Err(ResolvedRulesJournalError::InvalidSerializedAuthority(
+                            "uncommitted-trigger removal popped an entry other than its cursor"
+                                .to_string(),
+                        ));
+                    }
                 }
             }
         }

--- a/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
+++ b/crates/engine/tests/integration/cr733_resolved_commands_p2.rs
@@ -137,6 +137,13 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
             engine::game::stack::apply_resolved_stack_entry_finalize(state, command.as_ref())
                 .unwrap();
         }
+        ResolvedRulesCommand::UncommittedTriggerRemoval(command) => {
+            engine::game::stack::apply_resolved_uncommitted_trigger_removal(
+                state,
+                command.as_ref(),
+            )
+            .unwrap();
+        }
     }
 }
 
@@ -239,7 +246,8 @@ fn exact_mana_spend_rejects_a_second_removal() {
             | ResolvedRulesCommand::FrameTransition(_)
             | ResolvedRulesCommand::TriggerCollection(_)
             | ResolvedRulesCommand::StackPush(_)
-            | ResolvedRulesCommand::StackEntryFinalize(_) => {
+            | ResolvedRulesCommand::StackEntryFinalize(_)
+            | ResolvedRulesCommand::UncommittedTriggerRemoval(_) => {
                 apply_semantic_command(&mut replay, command)
             }
         }

--- a/crates/engine/tests/integration/cr733_resolved_draw.rs
+++ b/crates/engine/tests/integration/cr733_resolved_draw.rs
@@ -102,6 +102,13 @@ fn apply_semantic_command(state: &mut GameState, command: &ResolvedRulesCommand)
             engine::game::stack::apply_resolved_stack_entry_finalize(state, command.as_ref())
                 .unwrap();
         }
+        ResolvedRulesCommand::UncommittedTriggerRemoval(command) => {
+            engine::game::stack::apply_resolved_uncommitted_trigger_removal(
+                state,
+                command.as_ref(),
+            )
+            .unwrap();
+        }
     }
 }
 

--- a/crates/engine/tests/integration/cr733_resolved_trigger_removal.rs
+++ b/crates/engine/tests/integration/cr733_resolved_trigger_removal.rs
@@ -1,0 +1,286 @@
+//! CR733 P2 coverage for the CR 603.3d uncommitted-trigger removal.
+//!
+//! CR 603.3d: "If a choice is required when the triggered ability goes on the
+//! stack but no legal choices can be made for it, or if a rule or a continuous
+//! effect otherwise makes the ability illegal, the ability is simply removed
+//! from the stack."
+//!
+//! The engine reaches that removal through the "push first, choose second"
+//! invariant: a triggered ability is PUT on the stack and only then are its
+//! choices gathered, with `pending_trigger_entry` marking the entry whose slots
+//! are still unfilled. Declining an optional "you may" trigger is the production
+//! path that abandons one, and both call sites funnel through the single
+//! authority `stack::pop_uncommitted_pending_trigger_entry`.
+//!
+//! FIXTURE NOTE — the trigger must be optional AND MODAL, and both halves were
+//! established by measuring which shapes actually reach the authority:
+//!
+//! * `you may choose one — ...` (this card) — reaches it; the entry is popped.
+//! * `choose one — ...` (modal, NOT optional) — reaches the mid-construction
+//!   state but is never removed, because there is no may-offer to decline. This
+//!   is the control: it proves the removal is driven by the DECLINE, not merely
+//!   by a trigger being modal.
+//! * `you may destroy target creature` — never reaches the authority at all. A
+//!   "you may" attached to an effect is resolved under CR 608.2d when the
+//!   ability RESOLVES; the ability is fully constructed when pushed, so
+//!   declining it makes it do nothing rather than removing it from the stack.
+//!
+//! So the may-offer must precede the MODE choice, which is what makes
+//! construction genuinely unable to complete (CR 603.3c). Do not drop the
+//! "you may", and do not swap the modal for a targeted effect — either change
+//! makes every assertion in this file vacuous.
+//!
+//! The authority has TWO outcomes and both mutate state, which is why the
+//! command carries `removed: Option<_>` rather than a bare entry: the cursor is
+//! consumed UNCONDITIONALLY, and only then is the pop guarded on the entry still
+//! being topmost. A command modelling only the popping case would leave a replay
+//! of the other outcome still holding a cursor the real execution cleared.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::stack::apply_resolved_uncommitted_trigger_removal;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::resolved_commands::{
+    ResolvedRulesCommand, ResolvedUncommittedTriggerRemovalCommand,
+    ResolvedUncommittedTriggerRemovalReplayInvariantError,
+};
+
+const MAY_MODAL_ORACLE: &str =
+    "When this creature enters, you may choose one — Draw a card; or you gain 3 life.";
+
+/// Every removal journaled in `state`, in journal order.
+fn removals(state: &GameState) -> Vec<ResolvedUncommittedTriggerRemovalCommand> {
+    state
+        .resolved_rules_journal
+        .entries()
+        .iter()
+        .filter_map(|entry| entry.command.as_ref())
+        .filter_map(|command| match command {
+            ResolvedRulesCommand::UncommittedTriggerRemoval(command) => {
+                Some(command.as_ref().clone())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Casts a creature whose ETB is an optional targeted trigger and DECLINES it,
+/// which is what drives the CR 603.3d removal through production.
+fn declined_optional_trigger_state() -> GameState {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let creature = scenario
+        .add_creature_to_hand_from_oracle(P0, "Journal Optional", 2, 2, MAY_MODAL_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    // A legal target must exist, or the trigger is dropped for want of targets
+    // before it can reach the optional offer — a different code path.
+    for name in ["Alpha", "Beta"] {
+        scenario.add_card_to_library_top(P0, name);
+    }
+
+    let mut runner = scenario.build();
+    runner.cast(creature).decline_optional().resolve();
+    runner.state().clone()
+}
+
+/// Rebuilds the pre-removal predecessor from what the command says it removed.
+///
+/// The predecessor is mid-construction — after the trigger was pushed, before
+/// the decline — so no fixture can capture it directly. Reconstructing it from
+/// the recorded values is what makes the replay assertion meaningful: if the
+/// applier touched anything the command did not record, the round trip would not
+/// land back on the observed post-state.
+fn pre_removal_state(
+    state: &GameState,
+    command: &ResolvedUncommittedTriggerRemovalCommand,
+) -> GameState {
+    let mut predecessor = state.clone();
+    predecessor.pending_trigger_entry = Some(command.consumed_entry_id);
+    if let Some(removed) = command.removed.as_deref() {
+        predecessor.stack.push_back(removed.clone());
+    }
+    predecessor
+}
+
+#[test]
+fn declining_an_optional_trigger_journals_an_exact_removal() {
+    let state = declined_optional_trigger_state();
+
+    // The discriminating assertion: the removal is journaled. A raw pop records
+    // nothing here. This doubles as the reach guard — it fails if the fixture
+    // never reached the mid-construction state at all.
+    let commands = removals(&state);
+    assert_eq!(
+        commands.len(),
+        1,
+        "declining the optional trigger must journal exactly one CR 603.3d removal"
+    );
+    let command = &commands[0];
+    let removed = command
+        .removed
+        .as_ref()
+        .expect("the declined entry was on top, so the guard held and it was popped");
+    assert_eq!(
+        removed.id, command.consumed_entry_id,
+        "the recorded entry is the one the cursor named"
+    );
+
+    // CR 603.3d post-state: the ability is gone and the cursor is consumed.
+    assert!(
+        !state
+            .stack
+            .iter()
+            .any(|e| e.id == command.consumed_entry_id),
+        "the declined trigger must be removed from the stack"
+    );
+    assert_eq!(
+        state.pending_trigger_entry, None,
+        "the cursor is consumed by the removal"
+    );
+    assert_eq!(
+        command.resulting_depth,
+        state.stack.len(),
+        "CR 405.2: the recorded depth is the depth after the removal"
+    );
+
+    // Replay-exactness: from the reconstructed predecessor, applying the record
+    // reproduces the removal with nothing re-derived.
+    let mut replay = pre_removal_state(&state, command);
+    apply_resolved_uncommitted_trigger_removal(&mut replay, command)
+        .expect("the recorded removal must replay against its predecessor");
+    assert!(
+        !replay
+            .stack
+            .iter()
+            .any(|e| e.id == command.consumed_entry_id),
+        "replay removes the recorded entry"
+    );
+    assert_eq!(
+        replay.pending_trigger_entry, None,
+        "replay clears the cursor"
+    );
+    assert!(
+        !replay
+            .stack_paid_facts
+            .contains_key(&command.consumed_entry_id),
+        "replay drops the paid-facts row keyed on the removed entry"
+    );
+    assert!(
+        !replay
+            .stack_trigger_event_batches
+            .contains_key(&command.consumed_entry_id),
+        "replay drops the trigger-batch row keyed on the removed entry"
+    );
+    assert_eq!(
+        replay.stack.len(),
+        command.resulting_depth,
+        "replay lands on the recorded depth"
+    );
+
+    // Re-applying is not idempotent: the cursor is gone, so it fails closed
+    // rather than popping an unrelated entry.
+    assert!(
+        matches!(
+            apply_resolved_uncommitted_trigger_removal(&mut replay, command),
+            Err(ResolvedUncommittedTriggerRemovalReplayInvariantError::CursorMismatch { .. })
+        ),
+        "a second application must fail closed on the cursor precondition"
+    );
+}
+
+/// Each probe diverges exactly one axis, so a rejection can only come from the
+/// precondition being probed.
+#[test]
+fn removal_rejects_a_divergent_predecessor() {
+    let state = declined_optional_trigger_state();
+    let commands = removals(&state);
+    let command = &commands[0];
+
+    // Cursor names a different entry.
+    let mut wrong_cursor = pre_removal_state(&state, command);
+    wrong_cursor.pending_trigger_entry = Some(ObjectId(9999));
+    assert!(matches!(
+        apply_resolved_uncommitted_trigger_removal(&mut wrong_cursor, command),
+        Err(ResolvedUncommittedTriggerRemovalReplayInvariantError::CursorMismatch { .. })
+    ));
+
+    // Cursor correct, but the entry on top is not the recorded one. Comparing
+    // the entry WHOLE rather than by id is what catches this — an applier that
+    // matched on `id` alone would happily discard a divergent object.
+    let mut wrong_top = pre_removal_state(&state, command);
+    wrong_top
+        .stack
+        .back_mut()
+        .expect("the reconstructed predecessor has the entry on top")
+        .source_id = ObjectId(4242);
+    assert!(matches!(
+        apply_resolved_uncommitted_trigger_removal(&mut wrong_top, command),
+        Err(ResolvedUncommittedTriggerRemovalReplayInvariantError::RemovedEntryMismatch)
+    ));
+    assert_eq!(
+        wrong_top.pending_trigger_entry,
+        Some(command.consumed_entry_id),
+        "the rejected replay must not have consumed the cursor"
+    );
+}
+
+/// The `removed: None` outcome — cursor consumed, nothing popped.
+///
+/// This arm exists because `.take()` runs unconditionally while the pop is
+/// guarded. A command recording no pop must ALSO refuse a predecessor where the
+/// entry is still on top: replaying it there would clear the cursor and strand
+/// the entry, a state the original execution never produced and which nothing
+/// would otherwise report.
+#[test]
+fn a_removal_that_popped_nothing_still_clears_the_cursor() {
+    let state = declined_optional_trigger_state();
+    let commands = removals(&state);
+    let popping = &commands[0];
+
+    let no_pop = ResolvedUncommittedTriggerRemovalCommand {
+        consumed_entry_id: popping.consumed_entry_id,
+        removed: None,
+        resulting_depth: state.stack.len(),
+        cause: popping.cause,
+    };
+
+    // Predecessor whose top IS that entry: a no-pop record is a divergence.
+    let mut still_present = pre_removal_state(&state, popping);
+    assert!(
+        matches!(
+            apply_resolved_uncommitted_trigger_removal(&mut still_present, &no_pop),
+            Err(ResolvedUncommittedTriggerRemovalReplayInvariantError::DepthMismatch { .. })
+                | Err(
+                    ResolvedUncommittedTriggerRemovalReplayInvariantError::UnexpectedRemovableEntry(
+                        _
+                    )
+                )
+        ),
+        "a no-pop record must not apply where the entry is still removable"
+    );
+    assert_eq!(
+        still_present.pending_trigger_entry,
+        Some(popping.consumed_entry_id),
+        "the rejected replay must not have consumed the cursor"
+    );
+
+    // Predecessor where the entry has already gone: the same record applies and
+    // clears the cursor without touching the stack.
+    let mut already_gone = state.clone();
+    already_gone.pending_trigger_entry = Some(popping.consumed_entry_id);
+    let depth_before = already_gone.stack.len();
+    apply_resolved_uncommitted_trigger_removal(&mut already_gone, &no_pop)
+        .expect("a no-pop removal replays where the entry is already gone");
+    assert_eq!(
+        already_gone.pending_trigger_entry, None,
+        "the cursor is consumed even when nothing was popped"
+    );
+    assert_eq!(
+        already_gone.stack.len(),
+        depth_before,
+        "a no-pop removal must not touch the stack"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -109,6 +109,7 @@ mod cr733_resolved_stack_push;
 mod cr733_resolved_token_creation;
 mod cr733_resolved_transform;
 mod cr733_resolved_trigger_collection;
+mod cr733_resolved_trigger_removal;
 mod cr733_resolved_zone_change;
 mod cr_annotations;
 mod craft_tithing_blade_transform;


### PR DESCRIPTION
CR 603.3d: "If a choice is required when the triggered ability goes on the stack
but no legal choices can be made for it, or if a rule or a continuous effect
otherwise makes the ability illegal, the ability is simply removed from the
stack."

The engine reaches that removal through the "push first, choose second"
invariant: a triggered ability is PUT on the stack and only then are its choices
gathered, with `pending_trigger_entry` marking the entry whose slots are still
unfilled. Declining an optional MODAL trigger before its mode choice abandons
one, and #6664 funnelled all six sites through a single authority. This journals
that authority.

TWO OUTCOMES, both mutating, which is why `removed` is an `Option` rather than a
bare entry. The authority consumes `pending_trigger_entry` UNCONDITIONALLY and
only then decides whether to pop:

  * guard holds — cursor consumed AND the entry leaves with both side tables
  * guard fails — cursor consumed and nothing else, because the cursor outlived
    its entry (another path already removed it)

A command modelling only the first would leave a replay of the second holding a
`pending_trigger_entry` the real execution had cleared — a divergence needing no
forged journal, only an honest replay. The applier therefore also REFUSES a
`removed: None` record whose predecessor still has the entry on top: replaying
there would clear the cursor and strand the entry, a state no execution produces.

The removed side-table VALUES are deliberately not recorded. Contrast
`ResolvedStackEntryFinalizeCommand`, which records `expected_old_paid_facts`
because it INSTALLS a value and must verify what it overwrites. This command only
removes rows keyed on the recorded entry's own id — nothing is installed and
nothing re-derived, so there is no invariant a recorded value would pin, and
carrying `Vec<GameEvent>` batches would widen every journal entry for nothing.

The applier compares the popped entry WHOLE rather than by id. `ObjectId` is
reused across a replay, so an id-only match would discard a divergent entry that
merely shares an id and report success.

Fixture note, because three plausible cards do NOT reach this authority and each
failure is silent. Measured:
  * `you may choose one — ...`  reaches it; entry popped.
  * `choose one — ...`          reaches mid-construction, never removed (no
                                may-offer to decline). Control.
  * `you may destroy target creature`  never reaches it at all — a "you may" on
                                an effect is resolved under CR 608.2d when the
                                ability RESOLVES, so the ability is fully
                                constructed when pushed and declining it makes it
                                do nothing rather than removing it.

Revert probes, each watched go red and restored:
  1. journal call removed -> 0 passed / 3 failed, `left: 0, right: 1`. Proves
     every test reaches the production journal path.
  2. applier matches by id instead of whole entry -> 2 passed / 1 failed, only
     `removal_rejects_a_divergent_predecessor`. Proves that test is
     discriminating rather than incidentally coupled.

CR 603.3d and CR 603.3c grep-verified against docs/MagicCompRules.txt.
Engine integration suite 4064 passed, 0 failed. `clippy -p engine --lib` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added journaled tracking for removal of uncommitted triggered abilities.
  - Recorded outcomes now distinguish between entries removed from the stack and cursor-only consumption.
  - Added replay safeguards to detect inconsistent or invalid game states.

- **Bug Fixes**
  - Related trigger data is now cleared when an uncommitted ability is removed.
  - Replay reliably restores the correct stack depth and pending-trigger state.

- **Tests**
  - Added coverage for removal, replay, cursor handling, and invalid predecessor states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->