### PR TITLE
fix(client): split the multiplayer predicate so desktop solo regains sandbox, checkpoints and reconnect

### DIFF
--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -643,6 +643,66 @@ describe("WebSocketAdapter", () => {
       });
     });
 
+    // A refused takeback answers a fire-and-forget request, so no promise owns
+    // the rejection. Before this branch the whole `if (this.pendingReject)`
+    // body was skipped and the refusal was dropped on the floor — which is why
+    // the server had been reaching for `ServerMessage::error` instead, the
+    // event `handleNativeEvent` treats as terminal.
+    it("emits requestRejected when an ActionRejected has no in-flight action", () => {
+      const listener = vi.fn();
+      adapter.onEvent(listener);
+
+      adapter.sendRequestTakeback();
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "ActionRejected",
+          data: { reason: "There is no previous action of yours to take back" },
+        }),
+      );
+
+      expect(listener).toHaveBeenCalledWith({
+        type: "requestRejected",
+        reason: "There is no previous action of yours to take back",
+      });
+      // The survivability property: no terminal `error` event, which is what
+      // tears down a native session.
+      expect(listener).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error" }),
+      );
+    });
+
+    // Guards the new `else` against swallowing the normal path.
+    //
+    // Delivered through `onmessage` directly rather than `dispatchSynthetic`,
+    // and that distinction is load-bearing here. `dispatchSynthetic` calls
+    // `onmessage` AND `dispatchEvent`, and happy-dom routes `dispatchEvent`
+    // back through the `onmessage` IDL attribute — so it hands the adapter
+    // each frame TWICE. On the second delivery `pendingReject` has already
+    // been cleared by the first, so the `else` fires and this negative could
+    // never pass. A real browser WebSocket delivers a frame once, and the
+    // adapter registers no `addEventListener("message")` listener, so a single
+    // `onmessage` call is the faithful reproduction of production.
+    it("does not emit requestRejected when an action IS in flight", async () => {
+      const listener = vi.fn();
+      adapter.onEvent(listener);
+
+      const pending = adapter.submitAction({ type: "PassPriority" }, 0);
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "ActionRejected",
+          data: { reason: "Engine error: Something genuinely wrong" },
+        }),
+      });
+
+      // Reach-guard: the frame really was delivered and handled — without this
+      // the negative below would pass for a message that never arrived.
+      await expect(pending).rejects.toMatchObject({ code: "ACTION_REJECTED" });
+      expect(listener).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "requestRejected" }),
+      );
+    });
+
     it("sends the action frame and keeps the promise pending on a healthy socket", () => {
       ws.send.mockClear();
       void adapter.submitAction({ type: "PassPriority" }, 0);

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -203,6 +203,118 @@ describe("WebSocketAdapter", () => {
       await initPromise;
     });
 
+    // A dropped socket used to be instantly fatal for desktop solo:
+    // `maxReconnectAttempts` was 0, and `attemptReconnect` compares
+    // `reconnectAttempt >= maxReconnectAttempts`, so 0 >= 0 short-circuits to
+    // `reconnectFailed` before the `reconnecting` emit at all. The sidecar
+    // runs `--single-user`, so its reconnect window is effectively unbounded
+    // and the session is still there to reconnect to.
+    it("retries a dropped native-ai socket instead of failing on first drop", async () => {
+      MockWebSocket.last = null;
+      const nativeAdapter = new WebSocketAdapter(
+        "native-engine",
+        "host",
+        { main_deck: [], sideboard: [] },
+        undefined,
+        undefined,
+        undefined,
+        "Player",
+        nativeAiOptions(
+          () => new MockWebSocket("native-engine") as unknown as PhaseSocketTransport,
+        ),
+      );
+
+      const initPromise = nativeAdapter.initialize();
+      await Promise.resolve();
+      const nativeSocket = MockWebSocket.last!;
+      nativeSocket.dispatchSynthetic("message", SERVER_HELLO);
+      await Promise.resolve();
+      await Promise.resolve();
+      // A live session is the first branch `attemptReconnect` reaches: with no
+      // game code / player token it short-circuits to `reconnectFailed`
+      // regardless of the cap, so the fixture must establish one or the test
+      // measures the wrong branch.
+      nativeSocket.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "GameCreated",
+          data: { game_code: "ABCD", player_token: "tok" },
+        }),
+      );
+      nativeSocket.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "GameStarted",
+          data: { state: createMockState(), your_player: 0 },
+        }),
+      );
+      await initPromise;
+
+      const listener = vi.fn();
+      nativeAdapter.onEvent(listener);
+      nativeSocket.dispatchSynthetic("close");
+
+      // Presently unsatisfiable on the old code: `attemptReconnect` returned
+      // before the `reconnecting` emit, so this event was NEVER produced for
+      // a native-ai adapter.
+      expect(listener).toHaveBeenCalledWith({
+        type: "reconnecting",
+        attempt: 1,
+        maxAttempts: 8,
+      });
+      expect(listener).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "reconnectFailed" }),
+      );
+
+      nativeAdapter.dispose();
+    });
+
+    // Scope guard: this asserts a property of the DIFF (the change was scoped
+    // to `nativeAi` and did not widen to both options), not that 0 is the
+    // right answer for pregame — that path is explicitly not analysed.
+    it("leaves the native pregame transport failing on first drop", async () => {
+      MockWebSocket.last = null;
+      const pregameAdapter = new WebSocketAdapter(
+        "native-engine",
+        "host",
+        { main_deck: [], sideboard: [] },
+        undefined,
+        undefined,
+        undefined,
+        "Host",
+        {
+          nativePregame: {
+            kind: "host",
+            socketFactory: () => new MockWebSocket("native-engine") as unknown as PhaseSocketTransport,
+            playerCount: 2,
+            aiSeats: [],
+          },
+        },
+      );
+
+      const attached = pregameAdapter.initializePregame();
+      const nativeSocket = await completeHandshake(pregameAdapter);
+      nativeSocket.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "SessionAttached",
+          data: { game_code: "WXYZ", player_id: 0, player_token: "tok" },
+        }),
+      );
+      await attached;
+
+      const listener = vi.fn();
+      pregameAdapter.onEvent(listener);
+      nativeSocket.dispatchSynthetic("close");
+
+      expect(listener).toHaveBeenCalledWith({ type: "reconnectFailed" });
+      expect(listener).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "reconnecting" }),
+      );
+
+      pregameAdapter.dispose();
+    });
+
     it("rejects a release version mismatch before creating a game", async () => {
       MockWebSocket.last = null;
       const nativeAdapter = new WebSocketAdapter(

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -27,13 +27,28 @@ class MockWebSocket extends EventTarget {
     super();
     MockWebSocket.last = this;
   }
-  // `openPhaseSocket` calls `addEventListener("close", ...)` / ("message", ...)
-  // in addition to the legacy `onXxx` assignments. Route both channels:
-  // legacy `onXxx` fires first, EventTarget listeners fire after.
+  // Deliver a frame the way production does — which is asymmetric between
+  // the two event types, so this routes them differently.
+  //
+  // `"message"`: `onmessage` ONLY. Both `openPhaseSocket`
+  // (`openPhaseSocket.ts:190`) and the adapter (`ws-adapter.ts:528`) assign
+  // the `onmessage` IDL attribute, and neither registers an
+  // `addEventListener("message", ...)` — `PhaseSocketTransport` types
+  // `addEventListener` for `"close"` alone (`openPhaseSocket.ts:20-25`), so
+  // a message listener is not even expressible through the interface. This
+  // previously also called `dispatchEvent(new MessageEvent(...))` under a
+  // comment claiming `openPhaseSocket` registered a message listener; it
+  // does not, and happy-dom routes `dispatchEvent` back through the
+  // `onmessage` attribute, so every frame in this file was handled TWICE.
+  // Harmless for idempotent handlers, but it silently defeats any negative
+  // that depends on state the first delivery consumes.
+  //
+  // `"close"`: both channels, because production genuinely uses both —
+  // `openPhaseSocket.ts:366` registers `addEventListener("close", ...)`
+  // alongside the `onclose` assignment.
   dispatchSynthetic(type: "message" | "close", data?: string) {
     if (type === "message" && data !== undefined) {
       this.onmessage?.({ data });
-      this.dispatchEvent(new MessageEvent("message", { data }));
     } else if (type === "close") {
       this.onclose?.();
       this.dispatchEvent(new Event("close"));
@@ -786,26 +801,24 @@ describe("WebSocketAdapter", () => {
 
     // Guards the new `else` against swallowing the normal path.
     //
-    // Delivered through `onmessage` directly rather than `dispatchSynthetic`,
-    // and that distinction is load-bearing here. `dispatchSynthetic` calls
-    // `onmessage` AND `dispatchEvent`, and happy-dom routes `dispatchEvent`
-    // back through the `onmessage` IDL attribute — so it hands the adapter
-    // each frame TWICE. On the second delivery `pendingReject` has already
-    // been cleared by the first, so the `else` fires and this negative could
-    // never pass. A real browser WebSocket delivers a frame once, and the
-    // adapter registers no `addEventListener("message")` listener, so a single
-    // `onmessage` call is the faithful reproduction of production.
+    // This test is why the double delivery in `dispatchSynthetic` had to be
+    // fixed rather than worked around: a second delivery of the same frame
+    // finds `pendingReject` already cleared by the first, takes the `else`,
+    // and makes the negative below unpassable no matter what the adapter
+    // does. It now goes through `dispatchSynthetic` like every other frame
+    // in this file.
     it("does not emit requestRejected when an action IS in flight", async () => {
       const listener = vi.fn();
       adapter.onEvent(listener);
 
       const pending = adapter.submitAction({ type: "PassPriority" }, 0);
-      ws.onmessage?.({
-        data: JSON.stringify({
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({
           type: "ActionRejected",
           data: { reason: "Engine error: Something genuinely wrong" },
         }),
-      });
+      );
 
       // Reach-guard: the frame really was delivered and handled — without this
       // the negative below would pass for a message that never arrived.

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -275,7 +275,28 @@ export class WebSocketAdapter implements EngineAdapter {
     private readonly displayName = "Player",
     private readonly options: WebSocketAdapterOptions = {},
   ) {
-    this.maxReconnectAttempts = options.nativeAi || options.nativePregame ? 0 : 8;
+    // 0 is terminal, not "retry once": `attemptReconnect` compares
+    // `reconnectAttempt >= maxReconnectAttempts`, so 0 >= 0 is true on the
+    // very first attempt — it emits `reconnectFailed` and returns without
+    // ever emitting `reconnecting`, incrementing, or scheduling a timer. Any
+    // socket drop is instantly fatal.
+    //
+    // `nativeAi` no longer takes that. The sidecar runs `--single-user`, so
+    // its reconnect grace period is effectively unbounded and sessions are
+    // never stale-purged; a transient drop against a live sidecar is exactly
+    // the recoverable case, and 8 attempts is the same budget `online` gets.
+    //
+    // Not purely additive: a genuinely DEAD sidecar now spends ~27s of
+    // `reconnecting` UI (capped exponential backoff, 1+2+4+5+5+5+5+5) before
+    // `reconnectFailed`, where today it fails instantly. That is the right
+    // trade — the common case goes from fatal to recovered — but it is a
+    // user-visible latency regression on the most likely desktop failure.
+    //
+    // `nativePregame` keeps 0, and that is out of scope rather than endorsed:
+    // a pregame drop is recoverable by re-entering the lobby (no game has
+    // been invested yet), and that path has adapter-level special-casing of
+    // `options.nativePregame` that has NOT been analysed here.
+    this.maxReconnectAttempts = options.nativePregame ? 0 : 8;
   }
 
   get gameCode(): string | null {

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -174,7 +174,11 @@ export type WsAdapterEvent =
   | { type: "conceded"; player: PlayerId }
   | { type: "timerUpdate"; player: PlayerId; remainingSeconds: number }
   | { type: "takebackRequested"; requester: PlayerId; requesterName: string }
-  | { type: "takebackResolved"; approved: boolean; resolvedBy: PlayerId | null };
+  | { type: "takebackResolved"; approved: boolean; resolvedBy: PlayerId | null }
+  /** The server refused a fire-and-forget request (e.g. `RequestTakeback`).
+   *  Distinct from `error`, which the native session treats as terminal:
+   *  this one is survivable and carries a server-authored reason to show. */
+  | { type: "requestRejected"; reason: string };
 
 type WsAdapterEventListener = (event: WsAdapterEvent) => void;
 
@@ -1195,6 +1199,19 @@ export class WebSocketAdapter implements EngineAdapter {
           );
           this.pendingResolve = null;
           this.pendingReject = null;
+        } else {
+          // No in-flight action owns this rejection, so it answers a
+          // fire-and-forget request — `sendRequestTakeback` is the only one
+          // today. Surface it instead of dropping it on the floor.
+          //
+          // These two branches cannot race: `handle_client_message` is
+          // awaited to completion before the socket reads the next frame, so
+          // a takeback refusal is not even parsed until any preceding action
+          // has been fully answered. That is what rules out the sharper
+          // hazard here — rejecting an in-flight ACTION's promise with a
+          // TAKEBACK's reason string, which would be a misattribution rather
+          // than merely a stale spinner.
+          this.emit({ type: "requestRejected", reason: data.reason });
         }
         break;
       }

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -286,11 +286,25 @@ export class WebSocketAdapter implements EngineAdapter {
     // never stale-purged; a transient drop against a live sidecar is exactly
     // the recoverable case, and 8 attempts is the same budget `online` gets.
     //
-    // Not purely additive: a genuinely DEAD sidecar now spends ~27s of
-    // `reconnecting` UI (capped exponential backoff, 1+2+4+5+5+5+5+5) before
-    // `reconnectFailed`, where today it fails instantly. That is the right
-    // trade — the common case goes from fatal to recovered — but it is a
-    // user-visible latency regression on the most likely desktop failure.
+    // Not purely additive: a genuinely DEAD sidecar now spends **32s** of
+    // `reconnecting` UI before `reconnectFailed`, where today it fails
+    // instantly. `attemptReconnect`'s
+    // `Math.min(Math.pow(2, attempt - 1) * 1000, 5000)` over attempts 1-8 is
+    // 1+2+4+5+5+5+5+5 = 32, not the 27 first claimed here — the series was
+    // right and the sum was wrong.
+    //
+    // That is a floor, not a ceiling. It assumes each connect is *refused*
+    // immediately. If they hang instead, `attachSocket` calls
+    // `openPhaseSocket` without a `timeoutMs`, taking its 5000ms default, so
+    // the worst case is 32 + 8x5 = 72s.
+    //
+    // Still the right trade — the common case goes from fatal to recovered —
+    // but it is a user-visible latency regression on the most likely desktop
+    // failure, and for a LOOPBACK socket that failure is a crash or a
+    // sleep/resume rather than a spurious drop. 8 attempts buys little over
+    // 3-4 there, and nothing respawns the sidecar: `ensureNativeEngine` is
+    // never called from a close or error handler. Worth revisiting; the
+    // budget is deliberately left matching `online` rather than tuned here.
     //
     // `nativePregame` keeps 0, and that is out of scope rather than endorsed:
     // a pregame drop is recoverable by re-entering the lobby (no game has

--- a/client/src/components/board/UndoButton.tsx
+++ b/client/src/components/board/UndoButton.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 
-import { isMultiplayerMode, useGameStore } from "../../stores/gameStore.ts";
+import { isAuthorityRemote, useGameStore } from "../../stores/gameStore.ts";
 
 /**
  * Undo button for the local player, rendered attached to the player HUD beside
@@ -10,7 +10,7 @@ import { isMultiplayerMode, useGameStore } from "../../stores/gameStore.ts";
 export function UndoButton() {
   const { t } = useTranslation("game");
   const canUndo = useGameStore(
-    (s) => s.stateHistory.length > 0 && !isMultiplayerMode(s.gameMode),
+    (s) => s.stateHistory.length > 0 && !isAuthorityRemote(s.gameMode),
   );
   const undo = useGameStore((s) => s.undo);
 

--- a/client/src/components/chrome/DebugCreateActions.tsx
+++ b/client/src/components/chrome/DebugCreateActions.tsx
@@ -33,6 +33,8 @@ import {
   TextInput,
   useAccordion,
 } from "./debugFields";
+import { WebSocketAdapter } from "../../adapter/ws-adapter.ts";
+import { useGameStore } from "../../stores/gameStore";
 
 const ZONES: readonly Zone[] = [
   "Battlefield",
@@ -791,11 +793,42 @@ function CopyPermanentForm({ onDispatch }: Props) {
 
 export function DebugCreateActions({ onDispatch }: Props) {
   const { expanded, toggle } = useAccordion();
+  // `Debug::CreateCard` resolves a card NAME, which needs a `CardDatabase` at
+  // action-handling time. Only the WASM layer holds one: `engine-wasm/src/lib.rs`
+  // intercepts the action before `apply()` ever sees it, and `apply()` itself
+  // returns `InvalidAction("Debug::CreateCard must be handled at the WASM
+  // layer")` (`engine/src/game/engine_debug.rs`). `server-core`'s
+  // `handle_action` takes no `&CardDatabase` and has no interception — the
+  // wire path's only CreateCard handling is a string-length guard that
+  // ADMITS the action — so on a server-backed transport this form dispatches
+  // an action that always fails, surfacing as a generic "CreateCard failed".
+  //
+  // Transport capability, not a mode policy — the same seam as the takeback
+  // gate, and for the same reason: the mode does not determine which engine
+  // is behind the adapter, and P2P runs the WASM engine at the host.
+  //
+  // The three sibling forms below are unaffected: `CreateToken` and
+  // `CreateTokenCopy` are handled in `engine_debug.rs` and carry their own
+  // characteristics rather than a name to look up, so they work everywhere.
+  const adapter = useGameStore((s) => s.adapter);
+  const canCreateCardByName = !(adapter instanceof WebSocketAdapter);
 
   return (
     <div>
       <AccordionItem label="Create Card" expanded={expanded === "card"} onToggle={() => toggle("card")}>
-        <CreateCardForm onDispatch={onDispatch} />
+        {canCreateCardByName ? (
+          <CreateCardForm onDispatch={onDispatch} />
+        ) : (
+          /* Named rather than hidden, matching the checkpoint-restore notice:
+             the capability is genuinely absent here and a silently missing
+             accordion body reads as a bug. Hardcoded rather than `t()`-wrapped
+             — `client/src/i18n/README.md` lists dev/debug strings under
+             "Never wrap with t()". */
+          <p className="px-2 py-3 text-xs text-gray-600">
+            Spawning a card by name needs the in-browser engine. The token forms
+            below work on this connection.
+          </p>
+        )}
       </AccordionItem>
       <AccordionItem label="Create Token (Catalog)" expanded={expanded === "token-catalog"} onToggle={() => toggle("token-catalog")}>
         <CatalogTokenForm onDispatch={onDispatch} />

--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -87,6 +87,12 @@ export function DebugPanel() {
   // can open the panel straight to "actions" via `openSandboxTools()`.
   const activeTab = useUiStore((s) => s.debugPanelTab);
   const setActiveTab = useUiStore((s) => s.setDebugPanelTab);
+  // Deliberately NOT `!hasRemoteHumans(gameMode)`, despite reading like a
+  // company question. This is the set of modes whose adapter implements
+  // `restoreState`: `WasmAdapter` does; `WebSocketAdapter.restoreState`
+  // throws, as does the P2P adapter. Widening it to `native-ai` would light
+  // up a button that throws. Server-authoritative restore for
+  // wire-authoritative sessions is a separate piece of work.
   const canRestoreCheckpoints = gameMode === "ai" || gameMode === "local";
 
   const handleRestore = useCallback(async (state: GameState) => {
@@ -349,7 +355,15 @@ export function DebugPanel() {
             Turn Checkpoints
           </h3>
           {!canRestoreCheckpoints ? (
-            <p className="text-xs text-gray-600">Restore disabled in multiplayer</p>
+            /* Misleading twice over before: desktop solo-vs-AI is not
+               multiplayer, and the real reason is a transport limit rather
+               than a mode policy. Names the actual cause and points at the
+               affordance that does work. Hardcoded rather than `t()`-wrapped:
+               `client/src/i18n/README.md` lists dev/debug strings under
+               "Never wrap with t()". */
+            <p className="text-xs text-gray-600">
+              Restore needs the in-browser engine. Use Takeback to undo your last action.
+            </p>
           ) : turnCheckpoints.length === 0 ? (
             <p className="text-xs text-gray-600">No checkpoints yet (saved at turn start)</p>
           ) : (

--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -218,7 +218,10 @@ export function GameMenu({
               }}
             />
           )}
-          {isOnlineMode && onRequestTakeback && (
+          {/* The prop's presence is the authority, matching `showSandboxTools`
+              two blocks above. A menu should not re-derive when an action is
+              legal — GamePage decides, from the transport that implements it. */}
+          {onRequestTakeback && (
             <MenuButton
               label={t("gameMenu.requestTakeback")}
               onClick={() => {

--- a/client/src/components/chrome/__tests__/DebugPanel.sandboxCapability.test.tsx
+++ b/client/src/components/chrome/__tests__/DebugPanel.sandboxCapability.test.tsx
@@ -7,16 +7,22 @@
  * must NOT alter on the client: checkpoint restore stays off (a transport
  * limit, not a mode policy), and the host grant/revoke console stays hidden.
  */
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DebugPanel } from "../DebugPanel";
+import { WebSocketAdapter } from "../../../adapter/ws-adapter.ts";
 import type { GameMode } from "../../../stores/gameStore";
 
 const storeState = {
   gameMode: "native-ai" as GameMode | null,
   turnCheckpoints: [] as unknown[],
   gameState: null as unknown,
+  // The desktop sidecar is reached through a `WebSocketAdapter`, same as
+  // online play. `DebugCreateActions` gates card spawning on the adapter
+  // type, so this has to be a real instance — an `instanceof` check cannot
+  // be satisfied by a duck-typed object.
+  adapter: null as unknown,
 };
 
 vi.mock("../../../stores/gameStore", () => ({
@@ -41,13 +47,25 @@ vi.mock("../../../stores/uiStore", () => ({
   ),
 }));
 
-vi.mock("../../../hooks/usePlayerId", () => ({ usePlayerId: () => 0 }));
+// `usePerspectivePlayerId` is only needed once `CreateCardForm` actually
+// renders — its `PlayerSelect`/`ObjectSelect` reach for it. The gated branch
+// never does, which is itself evidence the two branches render different
+// subtrees rather than the same one with different copy.
+vi.mock("../../../hooks/usePlayerId", () => ({
+  usePlayerId: () => 0,
+  usePerspectivePlayerId: () => 0,
+}));
 vi.mock("../../../hooks/useGameDispatch", () => ({ useGameDispatch: () => vi.fn() }));
 vi.mock("../../../game/dispatch", () => ({ restoreGameState: vi.fn() }));
 vi.mock("../../../audio/AudioManager", () => ({
   audioManager: { play: vi.fn(), diagnostics: () => "" },
 }));
 vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+// `CardNameAutocomplete` fetches the full name list on mount via a build-time
+// define that vitest does not provide. Only the ungated branch mounts it, and
+// the suggestion list is not what these tests measure — the input's presence
+// is.
+vi.mock("../../../services/cardNames", () => ({ getCardNames: async () => [] }));
 
 /**
  * The m8 fixture. After the server change a `native-ai` game has a POPULATED
@@ -124,5 +142,67 @@ describe("DebugPanel — desktop solo capability", () => {
     // `allow_debug_actions` to true makes `hasRevocation` true (1 < 2) and
     // this console appears for the first time.
     expect(screen.queryByText(/grant/i)).toBeNull();
+  });
+
+  /**
+   * `Debug::CreateCard` is the sandbox panel's headline capability and it
+   * cannot work on the sidecar: only `engine-wasm` intercepts it, `apply()`
+   * returns `InvalidAction`, and `server-core`'s `handle_action` has no
+   * `CardDatabase` to resolve a name against. Granting desktop solo the panel
+   * without gating this form would ship a control whose only possible outcome
+   * is "CreateCard failed". Pre-existing for shared-server sandbox, newly
+   * surfaced here.
+   */
+  class SidecarAdapter extends WebSocketAdapter {
+    // Real superclass construction — the `instanceof` check the component uses
+    // cannot be satisfied by a duck-typed object. The constructor only assigns
+    // fields; it opens no socket, so no transport is stubbed here.
+    constructor() {
+      super("ws://test/ws", "host", { main_deck: [], sideboard: [] });
+    }
+  }
+
+  /** Create tab, then the "Create Card" accordion — both start collapsed. */
+  function openCreateCardAccordion() {
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    fireEvent.click(screen.getByRole("button", { name: /Create Card/ }));
+  }
+
+  it("explains why card spawning is unavailable on the sidecar transport", () => {
+    uiState.debugPanelTab = "actions";
+    storeState.adapter = new SidecarAdapter();
+
+    render(<DebugPanel />);
+    openCreateCardAccordion();
+
+    // Reach guard: the Create tab really rendered its body, so the missing
+    // form below is the transport gate and not an unrendered subtree. The
+    // token accordions are the siblings that DO work on this transport.
+    expect(screen.getByText("Create Token (Catalog)")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Spawning a card by name needs the in-browser engine/),
+    ).toBeInTheDocument();
+    // The revert-failing assertion: the card-name input's placeholder is
+    // unique to `CreateCardForm`. Remove the gate and the form renders and
+    // this is found. (Its submit button is NOT usable here — it shares the
+    // accordion header's accessible name.)
+    expect(screen.queryByPlaceholderText("Lightning Bolt")).toBeNull();
+  });
+
+  it("still offers card spawning when the in-browser engine is behind the adapter", () => {
+    // Paired positive, and the proof the gate is a transport check rather
+    // than "always off": `null` stands for any non-WebSocket adapter, i.e.
+    // browser solo's `WasmAdapter`, where `CreateCard` is intercepted and
+    // genuinely works.
+    uiState.debugPanelTab = "actions";
+    storeState.adapter = null;
+
+    render(<DebugPanel />);
+    openCreateCardAccordion();
+
+    expect(screen.getByPlaceholderText("Lightning Bolt")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Spawning a card by name needs the in-browser engine/),
+    ).toBeNull();
   });
 });

--- a/client/src/components/chrome/__tests__/DebugPanel.sandboxCapability.test.tsx
+++ b/client/src/components/chrome/__tests__/DebugPanel.sandboxCapability.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * DebugPanel under desktop solo-vs-AI (`native-ai`).
+ *
+ * Unlike GamePage — whose `mode` is URL-derived and can never be `native-ai` —
+ * DebugPanel subscribes to the store's `gameMode`, so it genuinely observes
+ * the value. These tests pin the two things the server-side capability change
+ * must NOT alter on the client: checkpoint restore stays off (a transport
+ * limit, not a mode policy), and the host grant/revoke console stays hidden.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DebugPanel } from "../DebugPanel";
+import type { GameMode } from "../../../stores/gameStore";
+
+const storeState = {
+  gameMode: "native-ai" as GameMode | null,
+  turnCheckpoints: [] as unknown[],
+  gameState: null as unknown,
+};
+
+vi.mock("../../../stores/gameStore", () => ({
+  useGameStore: Object.assign(
+    vi.fn((selector: (s: typeof storeState) => unknown) => selector(storeState)),
+    { getState: () => storeState, setState: vi.fn() },
+  ),
+}));
+
+// `console` shows Turn Checkpoints / Import State; `actions` shows
+// DebugActions. Both are exercised below, so the tab is mutable.
+const uiState = {
+  debugPanelOpen: true,
+  debugPanelTab: "console" as "console" | "actions",
+  setDebugPanelTab: vi.fn(),
+};
+
+vi.mock("../../../stores/uiStore", () => ({
+  useUiStore: Object.assign(
+    vi.fn((selector: (s: typeof uiState) => unknown) => selector(uiState)),
+    { getState: () => uiState, setState: vi.fn() },
+  ),
+}));
+
+vi.mock("../../../hooks/usePlayerId", () => ({ usePlayerId: () => 0 }));
+vi.mock("../../../hooks/useGameDispatch", () => ({ useGameDispatch: () => vi.fn() }));
+vi.mock("../../../game/dispatch", () => ({ restoreGameState: vi.fn() }));
+vi.mock("../../../audio/AudioManager", () => ({
+  audioManager: { play: vi.fn(), diagnostics: () => "" },
+}));
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+
+/**
+ * The m8 fixture. After the server change a `native-ai` game has a POPULATED
+ * `debug_permitted` (`[0]`) and `player_count` 2, so
+ * `debugPermitted.length > 0 && debugPermitted.length < playerCount` is TRUE.
+ * That leaves `allow_debug_actions === false` as the ONLY thing keeping the
+ * grant/revoke console hidden — which is exactly the property under test.
+ * A fixture with an empty set would pass for the wrong reason and would stop
+ * guarding the decision to leave the sandbox format flag off.
+ */
+function nativeAiSandboxState() {
+  return {
+    debug_permitted: [0],
+    players: [{}, {}],
+    format_config: { allow_debug_actions: false },
+  };
+}
+
+beforeEach(() => {
+  storeState.gameMode = "native-ai";
+  storeState.turnCheckpoints = [];
+  storeState.gameState = nativeAiSandboxState();
+  uiState.debugPanelTab = "console";
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("DebugPanel — desktop solo capability", () => {
+  it("says why checkpoint restore is unavailable instead of blaming multiplayer", () => {
+    render(<DebugPanel />);
+
+    expect(
+      screen.getByText(
+        "Restore needs the in-browser engine. Use Takeback to undo your last action.",
+      ),
+    ).toBeInTheDocument();
+    // The assertion that fails on revert: the old copy called a solo game
+    // multiplayer. Asserting only the new string's presence would pass if
+    // both rendered.
+    expect(screen.queryByText(/multiplayer/i)).toBeNull();
+  });
+
+  it("still shows the checkpoint notice for browser solo, where restore works", () => {
+    // Reach guard for the negative above: with a mode whose adapter DOES
+    // implement `restoreState`, the notice is replaced by the empty-state,
+    // proving the branch is mode-sensitive rather than always rendering.
+    storeState.gameMode = "ai";
+
+    render(<DebugPanel />);
+
+    expect(screen.getByText("No checkpoints yet (saved at turn start)")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Restore needs the in-browser engine. Use Takeback to undo your last action.",
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps the host grant/revoke console hidden on a native-ai game", () => {
+    uiState.debugPanelTab = "actions";
+
+    render(<DebugPanel />);
+
+    // Reach guard: the debug actions panel itself rendered and the seat is
+    // permitted, so the console's absence is `allow_debug_actions === false`
+    // and not an unrendered subtree or a "disabled for this seat" bailout.
+    expect(screen.getByText("Debug Actions")).toBeInTheDocument();
+    expect(screen.queryByText(/disabled for this seat/i)).toBeNull();
+    // This is the test that fails if an implementer takes the rejected
+    // `FormatConfig::with_sandbox()` shortcut on the server: flipping
+    // `allow_debug_actions` to true makes `hasRevocation` true (1 < 2) and
+    // this console appears for the first time.
+    expect(screen.queryByText(/grant/i)).toBeNull();
+  });
+});

--- a/client/src/components/chrome/__tests__/GameMenu.test.tsx
+++ b/client/src/components/chrome/__tests__/GameMenu.test.tsx
@@ -112,4 +112,35 @@ describe("GameMenu", () => {
       "true",
     );
   });
+
+  // The takeback item's gate used to be `isOnlineMode && onRequestTakeback`,
+  // which hid it for desktop solo-vs-AI (`native-ai` reaches GamePage as
+  // `mode=ai`, so `isOnlineMode` is false) even though that game has a real
+  // server-authoritative takeback and no client-side undo. GamePage is now the
+  // single authority and gates on the transport; the menu only asks whether it
+  // was given a handler.
+  it("offers takeback whenever a handler is supplied, even outside online mode", () => {
+    const onRequestTakeback = vi.fn();
+    // `isOnlineMode: false` is the whole point — this is the desktop-solo
+    // shape, and it is what fails if the `isOnlineMode &&` gate comes back.
+    renderGameMenu({ isOnlineMode: false, onRequestTakeback });
+
+    fireEvent.click(screen.getByRole("button", { name: "Game menu" }));
+    fireEvent.click(screen.getByRole("button", { name: "Request Takeback" }));
+
+    expect(onRequestTakeback).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides takeback when no handler is supplied", () => {
+    // Paired negative: without it, "render always" would pass the test above.
+    renderGameMenu({ isOnlineMode: true, onRequestTakeback: undefined });
+
+    fireEvent.click(screen.getByRole("button", { name: "Game menu" }));
+
+    // Reach guard: the menu really did open, so the absence below is the gate
+    // rather than an unrendered menu.
+    expect(screen.getByRole("button", { name: "Concede" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request Takeback" })).toBeNull();
+  });
+
 });

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -13,7 +13,7 @@ import i18n from "../i18n";
 import { useAnimationStore } from "../stores/animationStore";
 import { useAppNotificationStore } from "../stores/appToastStore";
 import {
-  isMultiplayerMode,
+  isAuthorityRemote,
   useGameStore,
   saveAuthoritativeGame,
   saveCheckpoints,
@@ -291,7 +291,7 @@ async function processAction(
   const { gameMode } = useGameStore.getState();
   const shouldSaveHistory =
     UNDOABLE_ACTIONS.has(action.type) &&
-    !isMultiplayerMode(gameMode) &&
+    !isAuthorityRemote(gameMode) &&
     gameState.stack.length === 0;
 
   // 3. Call WASM — get events without updating state yet.

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { isMultiplayerMode, useGameStore } from "../stores/gameStore";
+import { isAuthorityRemote, useGameStore } from "../stores/gameStore";
 import { useUiStore } from "../stores/uiStore";
 import { dispatchAction } from "../game/dispatch";
 import { getPlayerId } from "./usePlayerId";
@@ -141,7 +141,7 @@ export function useKeyboardShortcuts(): void {
           // Suppressed in multiplayer — the store's undo() already returns
           // early in that mode, but gating the shortcut here also avoids
           // swallowing the keystroke.
-          if (!e.ctrlKey && !e.metaKey && !isMultiplayerMode(gameMode)) {
+          if (!e.ctrlKey && !e.metaKey && !isAuthorityRemote(gameMode)) {
             e.preventDefault();
             if (stateHistory.length > 0) {
               undo();

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -506,6 +506,15 @@ export function GamePage() {
           setReconnectState({ status: "failed" });
         }
         break;
+      case "requestRejected":
+        // The server refused a request; the session is intact. Deliberately
+        // does NOT touch `reconnectState` — that is the whole point of this
+        // case existing beside `error` rather than being folded into it.
+        // `event.reason` is server-authored and so passes through raw, per
+        // `client/src/i18n/README.md` ("a string gets `t()` if and only if the
+        // frontend authored it").
+        useMultiplayerStore.getState().showToast(event.reason);
+        break;
       case "deckRejected":
         navigate("/multiplayer", {
           state: {

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1545,7 +1545,27 @@ function GamePageContent({
         onSettingsClick={() => setPreferencesOpen({})}
         onHelpClick={() => setHelpSheetOpen(true)}
         onConcede={onShowConcedeDialog}
-        onRequestTakeback={isOnlineMode ? handleRequestTakeback : undefined}
+        // Takeback is a TRANSPORT capability, not a mode policy: only
+        // `WebSocketAdapter` implements `sendRequestTakeback`, which is why
+        // `handleRequestTakeback` already guards on the adapter type. Gating
+        // the prop the same way makes the button's presence agree with the
+        // handler instead of duplicating a different rule.
+        //
+        // `isOnlineMode` was wrong twice over. It is URL-derived and can never
+        // see `native-ai` (desktop solo arrives as `mode=ai`), so desktop solo
+        // — which has a real server-authoritative takeback and no client-side
+        // undo — never got the button. And it showed the button to spectators,
+        // whom `request_takeback` rejects server-side.
+        //
+        // A mode-based replacement would be wrong in the other direction:
+        // `p2p-host`/`p2p-join`/`draft-match` are also wire-authoritative but
+        // do not necessarily carry a `WebSocketAdapter`, so they would get a
+        // dead button that silently no-ops inside the handler's own guard.
+        onRequestTakeback={
+          adapter instanceof WebSocketAdapter && mode !== "spectate"
+            ? handleRequestTakeback
+            : undefined
+        }
         showSandboxTools={mode === "ai" || mode === "local" || isSandboxGame}
         onSandboxToolsClick={() => useUiStore.getState().openSandboxTools()}
         debugClickModeButtonVisible={debugClickModeButtonVisible}

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -441,3 +441,112 @@ describe("GamePage — toast surface", () => {
     expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
   });
 });
+
+/**
+ * A refused takeback must not destroy a desktop-solo session.
+ *
+ * Desktop solo-vs-AI is served by the `phase-server` sidecar over a
+ * WebSocket and arrives here as `mode=ai`, so `isOnlineMode` is false and
+ * `case "error"` sets a TERMINAL `reconnectState`. The server used to answer
+ * every refused takeback with `ServerMessage::error`, so a second takeback
+ * click — reachable because an approved takeback clears the history — tore
+ * down the adapter and stranded the game behind a "Connection lost" banner.
+ * The refusal now travels `ServerMessage::ActionRejected`, which the adapter
+ * surfaces as `requestRejected`.
+ */
+describe("GamePage — a refused request is survivable", () => {
+  it("toasts a refused takeback without entering the terminal reconnect state", () => {
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    act(() => {
+      capturedOnWsEvent?.({
+        type: "requestRejected",
+        reason: "There is no previous action of yours to take back",
+      });
+    });
+
+    // Delivery witness. Without this the two negatives below would be
+    // satisfied by an event that was never delivered at all.
+    expect(mockMultiplayerState.showToast).toHaveBeenCalledWith(
+      "There is no previous action of yours to take back",
+    );
+    // The session is intact: no terminal banner, no Return-to-Menu escape
+    // hatch. These are the assertions that fail if the server reverts to
+    // `ServerMessage::error`, or if GameProvider forwards this event into
+    // the teardown branch instead of its own.
+    expect(screen.queryByText("Connection lost")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Return to Menu" })).toBeNull();
+  });
+
+  it("still tears down on a genuine transport error from the same fixture", () => {
+    // Reach guard for the negatives above: the SAME fixture and the SAME
+    // event channel can and does produce the terminal state, so their
+    // absence in the test above is the classification change and not an
+    // inert harness.
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    act(() => {
+      capturedOnWsEvent?.({ type: "error", message: "WebSocket connection failed" });
+    });
+
+    expect(screen.getByText("Connection lost")).toBeInTheDocument();
+  });
+
+  it("survives a second refusal, the click that used to be reachable", () => {
+    // An approved takeback clears `takeback_history`, so takeback-twice
+    // lands on "there is no previous action of yours to take back". This is
+    // the exact reachability that made the destructive path a routine
+    // second click rather than an edge case.
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    act(() => {
+      capturedOnWsEvent?.({ type: "requestRejected", reason: "first refusal" });
+      capturedOnWsEvent?.({
+        type: "requestRejected",
+        reason: "There is no previous action of yours to take back",
+      });
+    });
+
+    expect(mockMultiplayerState.showToast).toHaveBeenCalledTimes(2);
+    expect(screen.queryByText("Connection lost")).toBeNull();
+  });
+
+  it("routes an adjacent refusal reason down the same non-terminal path", () => {
+    // The fix is per-CHANNEL, not per-message: "only human players may
+    // request a takeback" and "a takeback request is already pending" travel
+    // the same wire message and must behave identically.
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    act(() => {
+      capturedOnWsEvent?.({
+        type: "requestRejected",
+        reason: "Only human players may request a takeback",
+      });
+    });
+
+    expect(mockMultiplayerState.showToast).toHaveBeenCalledWith(
+      "Only human players may request a takeback",
+    );
+    expect(screen.queryByText("Connection lost")).toBeNull();
+  });
+
+  it("does not set the terminal state for an online refusal either", () => {
+    // Behaviour-preserving for `online`: it toasted before (via `case
+    // "error"`, where `isOnlineMode` suppressed the terminal branch) and
+    // toasts now via `case "requestRejected"`.
+    //
+    // `?mode=host` — the URL spelling. `?mode=online` is NOT an inhabitant of
+    // the raw-mode set and falls through to `local`, for which GamePage passes
+    // no `onWsEvent` at all, so the whole test would go silently inert.
+    renderGamePage("/game/test-game-123?mode=host");
+
+    act(() => {
+      capturedOnWsEvent?.({ type: "requestRejected", reason: "refused" });
+    });
+
+    // Reach guard: `capturedOnWsEvent` must actually exist for this mode.
+    expect(capturedOnWsEvent).toBeDefined();
+    expect(mockMultiplayerState.showToast).toHaveBeenCalledWith("refused");
+    expect(screen.queryByText("Connection lost")).toBeNull();
+  });
+});

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -19,6 +19,7 @@ import { GamePage } from "../GamePage";
 import type { FormatConfig } from "../../adapter/types";
 import type { WsAdapterEvent } from "../../adapter/ws-adapter";
 import type { P2PAdapterEvent } from "../../adapter/p2p-adapter";
+import { WebSocketAdapter } from "../../adapter/ws-adapter";
 
 // ── Hoisted variables (must be declared before vi.mock hoisting) ─────────────
 
@@ -28,10 +29,18 @@ let capturedFormatConfig: FormatConfig | undefined;
 let capturedOnWsEvent: ((event: WsAdapterEvent) => void) | undefined;
 let capturedOnP2PEvent: ((event: P2PAdapterEvent) => void) | undefined;
 
-const { mockClearPromptOverlayState, mockSetGameState } = vi.hoisted(() => ({
+const { mockClearPromptOverlayState, mockSetGameState, storeOverrides } = vi.hoisted(() => ({
   mockClearPromptOverlayState: vi.fn(),
   mockSetGameState: vi.fn(),
+  // Mutable slice of the mocked game store. Defaults match the previous
+  // hardcoded values, so every pre-existing test is unaffected; tests that
+  // need a live adapter assign here and `beforeEach` resets.
+  storeOverrides: { adapter: null as unknown },
 }));
+
+// Captures the props GameMenu was rendered with, so tests can assert which
+// affordances GamePage decided to offer without rendering the real menu.
+let capturedGameMenuProps: Record<string, unknown> | undefined;
 
 const { mockMultiplayerState, mockUseMultiplayerStore } = vi.hoisted(() => {
   const mockMultiplayerState = {
@@ -126,7 +135,7 @@ vi.mock("../../stores/gameStore", () => ({
         events: [],
         eventHistory: [],
         logHistory: [],
-        adapter: null,
+        adapter: storeOverrides.adapter,
         lobbyProgress: null,
       }),
     ),
@@ -228,7 +237,10 @@ vi.mock("../../adapter/draft-adapter", () => ({
 }));
 
 vi.mock("../../components/chrome/GameMenu", () => ({
-  GameMenu: () => null,
+  GameMenu: (props: Record<string, unknown>) => {
+    capturedGameMenuProps = props;
+    return null;
+  },
 }));
 
 vi.mock("../../hooks/useCardDataMeta", () => ({
@@ -257,6 +269,8 @@ beforeEach(() => {
   capturedFormatConfig = undefined;
   capturedOnWsEvent = undefined;
   capturedOnP2PEvent = undefined;
+  capturedGameMenuProps = undefined;
+  storeOverrides.adapter = null;
   vi.clearAllMocks();
 });
 
@@ -548,5 +562,72 @@ describe("GamePage — a refused request is survivable", () => {
     expect(capturedOnWsEvent).toBeDefined();
     expect(mockMultiplayerState.showToast).toHaveBeenCalledWith("refused");
     expect(screen.queryByText("Connection lost")).toBeNull();
+  });
+});
+
+/**
+ * Takeback is offered by TRANSPORT, not by mode.
+ *
+ * `onRequestTakeback` used to be gated on `isOnlineMode`, which is URL-derived
+ * and can never see `native-ai` — desktop solo arrives as `mode=ai`. So the one
+ * mode with a server-authoritative takeback and no client-side undo was the one
+ * mode that never got the button, while spectators (whom `request_takeback`
+ * rejects server-side) did.
+ */
+describe("GamePage — takeback is a transport capability", () => {
+  class FakeWebSocketAdapter extends WebSocketAdapter {
+    // Bypass the real constructor: this fixture only needs `instanceof` to
+    // hold, which is the exact predicate GamePage and `handleRequestTakeback`
+    // both use.
+    constructor() {
+      super("ws://test/ws", "host", { main_deck: [], sideboard: [] });
+    }
+  }
+
+  it("offers takeback for a WebSocketAdapter in desktop-solo mode", () => {
+    storeOverrides.adapter = new FakeWebSocketAdapter();
+
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    // `mode=ai` is exactly how desktop solo-vs-AI reaches this page, and it is
+    // the case the old `isOnlineMode` gate got wrong.
+    expect(capturedGameMenuProps?.isOnlineMode).toBe(false);
+    expect(capturedGameMenuProps?.onRequestTakeback).toBeTypeOf("function");
+  });
+
+  it("withholds takeback when the adapter cannot send it", () => {
+    // Paired negative: `null` stands for any non-WebSocket adapter (the WASM
+    // engine of browser solo, which has real local undo instead). Proves the
+    // gate is a transport check and not "always on".
+    storeOverrides.adapter = null;
+
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    // Reach guard: GameMenu really was rendered, so the undefined prop is the
+    // gate rather than an unmounted menu.
+    expect(capturedGameMenuProps).toBeDefined();
+    expect(capturedGameMenuProps?.onRequestTakeback).toBeUndefined();
+  });
+
+  it("withholds takeback from spectators even on a WebSocketAdapter", () => {
+    // This removes a currently-VISIBLE control from a live mode, so it gets
+    // its own case rather than riding on the justification that
+    // `request_takeback` rejects spectators server-side anyway.
+    storeOverrides.adapter = new FakeWebSocketAdapter();
+
+    renderGamePage("/game/test-game-123?mode=spectate");
+
+    // Reach guard: the transport half of the gate is satisfied, so the
+    // undefined prop can only come from the spectate half.
+    expect(capturedGameMenuProps?.isOnlineMode).toBe(true);
+    expect(capturedGameMenuProps?.onRequestTakeback).toBeUndefined();
+  });
+
+  it("keeps offering takeback to online play", () => {
+    storeOverrides.adapter = new FakeWebSocketAdapter();
+
+    renderGamePage("/game/test-game-123?mode=host");
+
+    expect(capturedGameMenuProps?.onRequestTakeback).toBeTypeOf("function");
   });
 });

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -576,9 +576,12 @@ describe("GamePage — a refused request is survivable", () => {
  */
 describe("GamePage — takeback is a transport capability", () => {
   class FakeWebSocketAdapter extends WebSocketAdapter {
-    // Bypass the real constructor: this fixture only needs `instanceof` to
-    // hold, which is the exact predicate GamePage and `handleRequestTakeback`
-    // both use.
+    // Real superclass construction, not a stub — `super(...)` runs. It is safe
+    // to call here because the constructor only assigns fields and
+    // `maxReconnectAttempts`; it opens no socket. The subclass exists solely
+    // to supply throwaway arguments, since all this fixture needs is
+    // `instanceof` to hold — the exact predicate GamePage and
+    // `handleRequestTakeback` both use.
     constructor() {
       super("ws://test/ws", "host", { main_deck: [], sideboard: [] });
     }

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -1580,6 +1580,20 @@ export function GameProvider({
                 waitingFor: { type: "GameOver", data: { winner: event.winner } },
               });
             }
+            if (event.type === "requestRejected") {
+              // A NEW forwarding branch, not an addition to an existing group:
+              // `stateChanged` and `gameOver` above are handled inline and are
+              // never forwarded, so the only pre-existing `onWsEventRef` call
+              // in this handler is the terminal one below. This event must
+              // reach GamePage (which toasts it) while touching nothing else —
+              // it must not null `nativeAdapter`, dispose the controller, or
+              // clear the store adapter. `nativeSessionLive` is the existing
+              // guard against firing into a torn-down page.
+              //
+              // The online path needs no counterpart: its listener forwards
+              // every event unconditionally.
+              if (nativeSessionLive) onWsEventRef.current?.(event);
+            }
             if (event.type === "reconnectFailed" || event.type === "error") {
               const adapter = nativeAdapter;
               nativeAdapter = null;

--- a/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
+++ b/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
@@ -5,7 +5,11 @@ import { useMultiplayerStore } from "../../stores/multiplayerStore";
 
 type NativeAdapterEvent =
   | { type: "reconnectFailed" }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string }
+  // Non-terminal: the server refused a fire-and-forget request. Listed here
+  // alongside the two terminal events precisely because `handleNativeEvent`
+  // must treat it differently from both.
+  | { type: "requestRejected"; reason: string };
 
 const {
   NativeEngineVersionMismatchError,

--- a/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
+++ b/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
@@ -615,6 +615,44 @@ describe("GameProvider native AI routing", () => {
     await expectNativeTerminalEvent({ type: "reconnectFailed" });
   });
 
+  // `requestRejected` needs its OWN forwarding branch, not a place in an
+  // existing group: `stateChanged` and `gameOver` are handled inline and are
+  // never forwarded, so before this change the only `onWsEvent` call in
+  // `handleNativeEvent` was the terminal one. Adding the event to that branch
+  // would have forwarded it AND destroyed the session — the opposite of the
+  // point.
+  it("forwards a refused request without disposing the native session", async () => {
+    const onWsEvent = vi.fn();
+    render(
+      <GameProvider gameId="native-request-rejected" mode="ai" onWsEvent={onWsEvent}>
+        <div />
+      </GameProvider>,
+    );
+
+    await waitFor(() => {
+      expect(gameStoreState.setGameMode).toHaveBeenCalledWith("native-ai");
+      expect(nativeAdapters).toHaveLength(1);
+    });
+
+    const nativeAdapter = nativeAdapters[0]!;
+    const event = {
+      type: "requestRejected" as const,
+      reason: "There is no previous action of yours to take back",
+    };
+    nativeAdapter.emit(event);
+
+    // Forwarded, so GamePage can toast it. This is the assertion that fails
+    // if the new branch is omitted, and it is what the GamePage-level test
+    // (which mocks GameProvider) cannot cover.
+    expect(onWsEvent).toHaveBeenCalledWith(event);
+    // …and the session survives. `expectNativeTerminalEvent` above asserts
+    // the exact opposite of these two for `error`/`reconnectFailed` against
+    // the same fixture, which is what makes them a real discrimination
+    // rather than a property the harness has anyway.
+    expect(nativeAdapter.dispose).not.toHaveBeenCalled();
+    expect(gameStoreState.adapter).not.toBeNull();
+  });
+
   it("disposes a native game and surfaces bridge errors as terminal", async () => {
     await expectNativeTerminalEvent({ type: "error", message: "WebSocket connection failed" });
   });

--- a/client/src/pwa/multiplayerGuard.ts
+++ b/client/src/pwa/multiplayerGuard.ts
@@ -1,4 +1,4 @@
-import { isMultiplayerMode, useGameStore } from "../stores/gameStore";
+import { isAuthorityRemote, useGameStore } from "../stores/gameStore";
 
 /**
  * True when a multiplayer game is live in this tab and reloading would
@@ -14,7 +14,7 @@ import { isMultiplayerMode, useGameStore } from "../stores/gameStore";
  */
 export function isMultiplayerGameLive(): boolean {
   const { gameMode, gameState, adapter } = useGameStore.getState();
-  if (!isMultiplayerMode(gameMode)) return false;
+  if (!isAuthorityRemote(gameMode)) return false;
   if (!adapter) return false;
   if (gameState?.waiting_for?.type === "GameOver") return false;
   return true;
@@ -43,7 +43,7 @@ export function whenMultiplayerGameEnds(callback: () => void): () => void {
   };
   const unsub = useGameStore.subscribe(
     (s) => {
-      if (!isMultiplayerMode(s.gameMode)) return false;
+      if (!isAuthorityRemote(s.gameMode)) return false;
       if (!s.adapter) return false;
       if (s.gameState?.waiting_for?.type === "GameOver") return false;
       return true;

--- a/client/src/stores/__tests__/gameStore.test.ts
+++ b/client/src/stores/__tests__/gameStore.test.ts
@@ -7,7 +7,56 @@ import {
   buildGameState,
   buildStackEntry,
 } from "../../test/factories/gameStateFactory";
-import { useGameStore } from "../gameStore";
+import type { GameMode } from "../gameStore";
+import { hasRemoteHumans, isAuthorityRemote, useGameStore } from "../gameStore";
+
+describe("game mode classification", () => {
+  // The two questions the old `isMultiplayerMode` answered with one bit:
+  //   authority — does the authoritative engine state live off this client?
+  //   company   — do humans on OTHER clients share this game?
+  // `native-ai` (desktop solo vs the phase-server sidecar) is the mode where
+  // they disagree, which is exactly what the merged predicate could not say.
+  const EXPECTED: Record<GameMode, { authority: boolean; company: boolean }> = {
+    "ai": { authority: false, company: false },
+    "local": { authority: false, company: false },
+    "native-ai": { authority: true, company: false },
+    "online": { authority: true, company: true },
+    "p2p-host": { authority: true, company: true },
+    "p2p-join": { authority: true, company: true },
+    "draft-match": { authority: true, company: true },
+    "spectate": { authority: true, company: true },
+  };
+
+  it.each(Object.keys(EXPECTED) as GameMode[])(
+    "classifies %s on both axes",
+    (mode) => {
+      expect(isAuthorityRemote(mode)).toBe(EXPECTED[mode].authority);
+      expect(hasRemoteHumans(mode)).toBe(EXPECTED[mode].company);
+    },
+  );
+
+  it("answers the two questions differently for native-ai", () => {
+    // Non-vacuity: these two assertions are contradictory for ANY single
+    // merged predicate. `isMultiplayerMode` — and equally the rejected
+    // `isMultiplayerMode(mode) || mode === "native-ai"` shape — returns one
+    // value for this input and therefore fails one of them whichever way it
+    // answers. Only a genuine split can satisfy both.
+    expect(isAuthorityRemote("native-ai")).toBe(true);
+    expect(hasRemoteHumans("native-ai")).toBe(false);
+  });
+
+  it("treats hot-seat local as solo despite having two humans", () => {
+    // The row a careless "solo means one human" reading gets wrong: two
+    // humans share one client and one state, so there is no peer to desync.
+    expect(hasRemoteHumans("local")).toBe(false);
+    expect(isAuthorityRemote("local")).toBe(false);
+  });
+
+  it("answers false to both for the pre-game null mode", () => {
+    expect(isAuthorityRemote(null)).toBe(false);
+    expect(hasRemoteHumans(null)).toBe(false);
+  });
+});
 
 describe("gameStore", () => {
   beforeEach(() => {
@@ -251,6 +300,25 @@ describe("gameStore", () => {
     await act(() => useGameStore.getState().undo());
 
     // History untouched; restoreState never invoked.
+    expect(useGameStore.getState().stateHistory).toHaveLength(1);
+    expect(adapter.restoreState).not.toHaveBeenCalled();
+  });
+
+  it("undo is a no-op for native-ai, whose authority is the sidecar", async () => {
+    // Regression guard for the predicate split: `native-ai` is solo but
+    // wire-authoritative, so the rename must NOT have leaked client-side
+    // rewind into it. `WebSocketAdapter.restoreState` throws on this
+    // transport, so a leak here would surface as a thrown adapter call.
+    const state1 = buildGameState({ turn_number: 1 });
+    const adapter = buildEngineAdapterMock(state1);
+
+    await act(() => useGameStore.getState().initGame("test-id", adapter));
+    act(() => {
+      useGameStore.setState({ stateHistory: [state1], gameMode: "native-ai" });
+    });
+
+    await act(() => useGameStore.getState().undo());
+
     expect(useGameStore.getState().stateHistory).toHaveLength(1);
     expect(adapter.restoreState).not.toHaveBeenCalled();
   });

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -65,18 +65,76 @@ export type GameMode =
   | "draft-match"
   | "spectate";
 
-/** True for modes where the engine state is shared across the wire —
- * undo/rewind would desync from the authoritative game, so the client
- * must not build a stateHistory or expose an Undo affordance. */
-export function isMultiplayerMode(mode: GameMode | null): boolean {
-  return (
-    mode === "native-ai"
-    || mode === "online"
-    || mode === "p2p-host"
-    || mode === "p2p-join"
-    || mode === "draft-match"
-    || mode === "spectate"
-  );
+/** Where the authoritative engine state lives. `"wire"` means some process
+ *  other than this client owns it, so this client must never rewind: a local
+ *  rewind desyncs from the authority on the next exchange. */
+export type EngineAuthority = "client" | "wire";
+
+/** Whether humans on OTHER clients share this game. `"solo"` covers hot-seat
+ *  `local` too: two humans at one screen share one client and one state, so
+ *  nothing they do can desync a peer or leak hidden info across a wire. */
+export type TableCompany = "solo" | "remote-humans";
+
+interface GameModeTraits {
+  readonly authority: EngineAuthority;
+  readonly company: TableCompany;
+}
+
+/**
+ * The two questions the old `isMultiplayerMode` answered with one bit, split
+ * and answered separately for every mode. Exhaustive by construction: a new
+ * `GameMode` fails to compile until it declares both axes.
+ *
+ * This table is the census. Never widen a predicate with an `|| mode === "..."`
+ * at a call site — that is how the conflation this file exists to undo comes
+ * back, one call site at a time.
+ *
+ * `spectate` is `remote-humans` by the *game* it observes, not by the observer.
+ */
+const GAME_MODE_TRAITS: Record<GameMode, GameModeTraits> = {
+  "ai": { authority: "client", company: "solo" },
+  "local": { authority: "client", company: "solo" },
+  "native-ai": { authority: "wire", company: "solo" },
+  "online": { authority: "wire", company: "remote-humans" },
+  "p2p-host": { authority: "wire", company: "remote-humans" },
+  "p2p-join": { authority: "wire", company: "remote-humans" },
+  "draft-match": { authority: "wire", company: "remote-humans" },
+  "spectate": { authority: "wire", company: "remote-humans" },
+};
+
+/** True when the authoritative engine state lives off this client — i.e. the
+ *  authority is REMOTE. Such a client must not rewind its own view
+ *  (`stateHistory`/`undo`); see `WebSocketAdapter.restoreState`, which rejects
+ *  it at the transport. This is deliberately NOT "is this multiplayer":
+ *  desktop solo-vs-AI (`native-ai`) is a wire-authoritative game with no other
+ *  humans in it, and every one of this predicate's seven call sites wants the
+ *  authority question, not the company one. */
+export function isAuthorityRemote(mode: GameMode | null): boolean {
+  return mode !== null && GAME_MODE_TRAITS[mode].authority === "wire";
+}
+
+/**
+ * True when humans on other clients share this game. Local-only affordances
+ * are safe when false — there is nobody else's game to disturb and no hidden
+ * info to leak across a wire.
+ *
+ * **This predicate has no production caller today, deliberately.** Every gate
+ * that reads `gameMode` asks the authority question above; the company
+ * question is what the merged predicate silently got *wrong* for `native-ai`,
+ * and naming it is the fix. It is exported rather than left implicit so that
+ * the next gate needing "are other humans watching?" has an answer to call
+ * instead of an `||` to append — and so the classification is observable, which
+ * is what lets a test prove the two axes actually disagree for `native-ai`.
+ * No lint flags unused exports here (`client/eslint.config.js` configures only
+ * `@typescript-eslint/no-unused-vars`, and there is no knip), so this comment,
+ * not a suppression, is the honest handling.
+ *
+ * Do not repurpose it for transport questions: `canRestoreCheckpoints`
+ * (`DebugPanel.tsx`) looks like a company gate but is really "does this
+ * adapter implement `restoreState`", and `native-ai`'s does not.
+ */
+export function hasRemoteHumans(mode: GameMode | null): boolean {
+  return mode !== null && GAME_MODE_TRAITS[mode].company === "remote-humans";
 }
 
 interface GameStoreState {
@@ -536,7 +594,7 @@ export const useGameStore = create<GameStore>()(
       //    activation/trigger sequence, never mid-resolution.
       const shouldSaveHistory =
         UNDOABLE_ACTIONS.has(submittedAction.type) &&
-        !isMultiplayerMode(gameMode) &&
+        !isAuthorityRemote(gameMode) &&
         gameState.stack.length === 0;
 
       // `getPlayerId()` returns the local human's authenticated seat ID.
@@ -564,7 +622,7 @@ export const useGameStore = create<GameStore>()(
 
     undo: async () => {
       const { stateHistory, adapter, gameMode } = get();
-      if (isMultiplayerMode(gameMode)) return;
+      if (isAuthorityRemote(gameMode)) return;
       if (stateHistory.length === 0 || !adapter) return;
 
       const previous = stateHistory[stateHistory.length - 1];

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -125,6 +125,10 @@ export function isAuthorityRemote(mode: GameMode | null): boolean {
  * the next gate needing "are other humans watching?" has an answer to call
  * instead of an `||` to append — and so the classification is observable, which
  * is what lets a test prove the two axes actually disagree for `native-ai`.
+ * Without it a test could still tabulate `isAuthorityRemote` across all eight
+ * modes and go red on any classification change; that test would not be
+ * vacuous, it would just be a no-op restatement of the behaviour before the
+ * split, unable to say anything about the axis this change exists to name.
  * No lint flags unused exports here (`client/eslint.config.js` configures only
  * `@typescript-eslint/no-unused-vars`, and there is no knip), so this comment,
  * not a suppression, is the honest handling.

--- a/crates/engine/src/game/match_flow.rs
+++ b/crates/engine/src/game/match_flow.rs
@@ -431,6 +431,25 @@ fn restart_between_games_with_starting_player(
     // If the game is drawn, this chooser gets to choose again. Archenemy fixes
     // the chooser/starter to the archenemy per CR 904.6.
     next_state.next_game_chooser = Some(chooser);
+    // Debug capability is a property of the match, not of a single game: it is
+    // derived once (from the sandbox format flag, or from a single-user server
+    // instance) and must survive this rebuild exactly as `match_config` does.
+    // `GameState::new` defaults these to false/empty, so without an explicit
+    // carry the sandbox panel silently stops working from game 2 onward.
+    // Revocations are preserved because this is a continuation of the same
+    // match — unlike `GameSession::rebuild_pregame_state`, which resets them
+    // because it builds a fresh pregame context.
+    //
+    // A verbatim carry, not a re-derivation: this is engine state continuity
+    // and must stay ignorant of the server's deployment shape. Re-seeding from
+    // `format_config.allow_debug_actions` here would work for sandbox games and
+    // would silently break desktop solo, whose flag is false.
+    //
+    // No CR annotation: debug capability implements no game rule (see
+    // `visibility.rs` — "CR is silent; this is an out-of-game capability").
+    // In particular this is NOT covered by the CR 732.2a note above.
+    next_state.debug_mode = state.debug_mode;
+    next_state.debug_permitted = state.debug_permitted.clone();
 
     load_deck_into_state(&mut next_state, &payload);
     let start = super::engine::start_game_with_starting_player(&mut next_state, starting_player);
@@ -943,6 +962,118 @@ mod tests {
             "detector opt-in must persist across the engine between-games rebuild"
         );
         assert_eq!(state.match_config.loop_detection, LoopDetectionMode::On);
+    }
+
+    /// Debug capability must survive the ENGINE between-games rebuild, exactly
+    /// as the `loop_detection` opt-in above does. Without the carry, a sandbox
+    /// or desktop-solo match gets a working debug panel for game 1 and a
+    /// silently dead one from game 2 onward: `GameState::new` defaults
+    /// `debug_mode` to false and `debug_permitted` to empty, and this rebuild
+    /// never touches `GameSession`, so no server-side seeding authority can
+    /// reach it.
+    ///
+    /// Mode-agnostic by construction (it drives the engine directly), which is
+    /// why the two-line carry repairs desktop solo, browser solo, and sandbox
+    /// multiplayer at once.
+    ///
+    /// REVERT-FAIL: remove either carry ⇒ that field reverts to its
+    /// `GameState::new` default and its assertion below fails.
+    #[test]
+    fn bo3_restart_preserves_debug_capability() {
+        let mut state = GameState::new_two_player(19);
+        state.match_config.match_type = MatchType::Bo3;
+
+        // Seat 0 only — the desktop-solo shape. Seat 1 must stay absent, which
+        // is what proves the carry is a copy and not a re-seed of all seats.
+        state.debug_mode = true;
+        state.debug_permitted.insert(PlayerId(0));
+        // The capability did NOT come from the sandbox format flag: this is
+        // the desktop-solo case, where the flag is false and only a verbatim
+        // carry can preserve it.
+        assert!(!state.format_config.allow_debug_actions);
+
+        let payload = DeckPayload {
+            player: PlayerDeckPayload {
+                main_deck: vec![entry("P0", 7)],
+                sideboard: vec![entry("P0SB", 1)],
+                commander: vec![],
+                ..Default::default()
+            },
+            opponent: PlayerDeckPayload {
+                main_deck: vec![entry("P1", 7)],
+                sideboard: vec![entry("P1SB", 1)],
+                commander: vec![],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        load_deck_into_state(&mut state, &payload);
+        let _ = start_game(&mut state);
+
+        state.match_phase = MatchPhase::BetweenGames;
+        state.match_score = crate::types::match_config::MatchScore {
+            p0_wins: 1,
+            p1_wins: 0,
+            draws: 0,
+        };
+        state.game_number = 2;
+        state.next_game_chooser = Some(PlayerId(1));
+        state.sideboard_submitted.clear();
+        state.waiting_for = WaitingFor::BetweenGamesSideboard {
+            player: PlayerId(0),
+            game_number: 2,
+            score: state.match_score,
+            min_main_deck_size: 0,
+            max_sideboard_size: None,
+        };
+
+        apply_as_current(
+            &mut state,
+            GameAction::SubmitSideboard {
+                main: vec![DeckCardCount {
+                    name: "P0".to_string(),
+                    count: 7,
+                }],
+                sideboard: vec![DeckCardCount {
+                    name: "P0SB".to_string(),
+                    count: 1,
+                }],
+            },
+        )
+        .unwrap();
+        apply_as_current(
+            &mut state,
+            GameAction::SubmitSideboard {
+                main: vec![DeckCardCount {
+                    name: "P1".to_string(),
+                    count: 7,
+                }],
+                sideboard: vec![DeckCardCount {
+                    name: "P1SB".to_string(),
+                    count: 1,
+                }],
+            },
+        )
+        .unwrap();
+        apply_as_current(&mut state, GameAction::ChoosePlayDraw { play_first: true }).unwrap();
+
+        // Sibling probe: if these fail, the test drove the wrong path and the
+        // capability assertions below would be meaningless.
+        assert_eq!(state.match_phase, MatchPhase::InGame);
+        assert_eq!(state.game_number, 2);
+        assert_eq!(state.match_score.p0_wins, 1);
+
+        // Asserted AFTER `*state = next_state`, against a state this test did
+        // not construct.
+        assert!(
+            state.debug_mode,
+            "debug_mode must survive the between-games rebuild"
+        );
+        assert!(state.debug_permitted.contains(&PlayerId(0)));
+        assert!(
+            !state.debug_permitted.contains(&PlayerId(1)),
+            "the carry is a copy, not a re-seed of every seat"
+        );
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1002,10 +1002,12 @@ async fn main() {
 
     // A single-user instance has no other players whose seats a grace period
     // would free, so reconnects never expire — a game suspended for any length
-    // of time stays resumable. `with_grace_period` sets the reconnect window;
+    // of time stays resumable. `single_user` sets the reconnect window;
     // ten years is effectively unbounded without risking overflow in `now + grace`.
+    // It also stamps `HostingMode::SingleUser` on every session this manager
+    // owns, which is what grants the desktop sidecar its debug capability.
     let state: SharedState = Arc::new(Mutex::new(if cli.single_user {
-        SessionManager::with_grace_period(Duration::from_secs(10 * 365 * 24 * 60 * 60))
+        SessionManager::single_user(Duration::from_secs(10 * 365 * 24 * 60 * 60))
     } else {
         SessionManager::new()
     }));

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -5517,7 +5517,15 @@ async fn handle_client_message(
 
             match result {
                 Err(reason) => {
-                    let msg = ServerMessage::error(reason);
+                    // The third member of the same class as the two arms
+                    // above: `cancel_takeback`'s only failures are benign
+                    // refusals ("only the player who requested the takeback
+                    // may cancel it", "there is no pending takeback
+                    // request"). Answer on the rejection channel, not the
+                    // terminal error channel — `handleNativeEvent` disposes
+                    // the adapter on ANY `error` event, so a mis-clicked
+                    // cancel would end the desktop session.
+                    let msg = ServerMessage::ActionRejected { reason };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -5364,7 +5364,21 @@ async fn handle_client_message(
 
             match outcome {
                 Err(reason) => {
-                    let msg = ServerMessage::error(reason);
+                    // A refused takeback is a benign rejection, not a
+                    // transport error: "there is no previous action of yours
+                    // to take back", "a takeback request is already pending",
+                    // "only human players may request a takeback". Answer on
+                    // the same channel the sibling `ClientMessage::Action`
+                    // handler uses for a rejected action.
+                    //
+                    // `ServerMessage::error` is read by the native client as a
+                    // terminal socket failure: `handleNativeEvent` disposes the
+                    // adapter on ANY `error` event and GamePage then sets
+                    // `reconnectState: "failed"`, leaving the desktop session
+                    // unrecoverable. Reaching for the error channel here was
+                    // this handler's inconsistency with its own sibling ~2,400
+                    // lines above, not a deliberate signal.
+                    let msg = ServerMessage::ActionRejected { reason };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }
@@ -5436,7 +5450,13 @@ async fn handle_client_message(
 
             match outcome {
                 Err(reason) => {
-                    let msg = ServerMessage::error(reason);
+                    // Same classification as the `RequestTakeback` arm above:
+                    // "there is no pending takeback request" and "only human
+                    // players may respond" are refusals, not socket failures.
+                    // Fixed here too so the pair stays consistent — a benign
+                    // refusal must never travel the channel the native client
+                    // treats as terminal.
+                    let msg = ServerMessage::ActionRejected { reason };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -144,9 +144,16 @@ pub struct GameSession {
     pub timer_seconds: Option<u32>,
     /// Deployment shape of the process hosting this session, copied from the
     /// owning `SessionManager` at creation and **re-stamped, never
-    /// deserialized**, at `SessionManager::restore_session` — a session saved
-    /// by a single-user desktop instance must not carry its capability into a
-    /// shared server. Deliberately absent from `PersistedSession`.
+    /// deserialized**, at `SessionManager::restore_session`. Deliberately
+    /// absent from `PersistedSession`.
+    ///
+    /// The stamp blocks re-*derivation* only: it stops a restored blob from
+    /// claiming this process is a sidecar when it is not. The capability the
+    /// derivation produces (`GameState::debug_mode` / `debug_permitted`) is
+    /// a plain `#[serde(default)]` pair that rides inside the blob, so the
+    /// stamp alone does not keep a sidecar's capability out of a shared
+    /// server — `GameSession::revoke_unentitled_debug_capability`, called
+    /// immediately after the stamp, is what does that.
     ///
     /// **Read fence.** This field is read by exactly one function,
     /// `seed_debug_capability`, which is reachable only via
@@ -353,7 +360,7 @@ impl GameSession {
             }
         };
         self.state.set_match_config(match_config);
-        self.seed_debug_capability(player_count);
+        self.seed_debug_capability();
     }
 
     /// Seeds `debug_mode` / `debug_permitted` for the state just built by
@@ -375,9 +382,18 @@ impl GameSession {
     /// Note `GameState::debug_mode`'s own doc comment still reads "Always
     /// false for multiplayer games" — stale as of this commit, since the
     /// client classifies `native-ai` as multiplayer. A rider is filed against
-    /// `crates/engine/src/types/game_state.rs` to correct it; the file is
-    /// owned by concurrent work and is deliberately not edited here.
-    fn seed_debug_capability(&mut self, player_count: u8) {
+    /// `crates/engine/src/types/game_state.rs` to correct it. That file is
+    /// clean in the working tree; it is out of this change's scope because it
+    /// belongs to the sibling Item 1 workstream, not because another agent
+    /// holds it. (The earlier wording here claimed the latter and was wrong —
+    /// an unverified ownership claim is the same failure mode as the stale
+    /// comment it defers.)
+    ///
+    /// Both branches below read `self.player_count` as the single seat-count
+    /// authority: `human_seats()` derives from it, and `apply_seat_delta`
+    /// assigns it before rebuilding, so a parameter would only reintroduce
+    /// the chance of the two disagreeing.
+    fn seed_debug_capability(&mut self) {
         if self.state.format_config.allow_debug_actions {
             // Sandbox is a shared playground, not an admin console: every seat
             // is permitted by default. Explicit revocations from a previous
@@ -386,7 +402,7 @@ impl GameSession {
             // "through rematch" — it does not: a Bo3 rematch rebuilds in the
             // engine, never through this function.)
             self.state.debug_mode = true;
-            for i in 0..player_count {
+            for i in 0..self.player_count {
                 self.state.debug_permitted.insert(PlayerId(i));
             }
         } else if self.hosting == HostingMode::SingleUser {
@@ -409,6 +425,41 @@ impl GameSession {
                 self.state.debug_permitted.insert(seat);
             }
         }
+    }
+
+    /// Drop debug capability this process is not entitled to grant.
+    ///
+    /// The inverse of `seed_debug_capability`, applied on the restore path.
+    /// `debug_mode` / `debug_permitted` are plain `#[serde(default)]` fields
+    /// on `GameState` and `to_persisted` captures the whole state, so both
+    /// ride inside `PersistedGameState`; `rebuild_pregame_state` never runs
+    /// on a restore, so nothing else re-examines them. Two things can entitle
+    /// a session to the capability, and they belong to different owners:
+    ///
+    /// - `format_config.allow_debug_actions` — a property of the GAME, which
+    ///   legitimately travels with the blob. A sandbox game is a sandbox game
+    ///   wherever it is resumed.
+    /// - `HostingMode::SingleUser` — a property of THIS PROCESS, which does
+    ///   not travel. This is the one the restore stamp establishes.
+    ///
+    /// If neither holds, `seed_debug_capability` would take neither branch,
+    /// so the capability is one this process would never have granted: a blob
+    /// written by a `--single-user` sidecar (`debug_mode: true`,
+    /// `debug_permitted: {0}`) must not arrive on a shared server with seat 0
+    /// still past the `handle_action` debug gate. Only deployment
+    /// configuration (the sidecar's separate `PHASE_GAMES_DB`) keeps that
+    /// unreachable today, which is not a mechanism.
+    ///
+    /// An entitled session keeps its persisted values **verbatim** rather
+    /// than being re-seeded. An explicit `RevokeDebugPermission` taken before
+    /// the save is game state, and re-deriving would silently reinstate the
+    /// revoked seat.
+    fn revoke_unentitled_debug_capability(&mut self) {
+        if self.state.format_config.allow_debug_actions || self.hosting == HostingMode::SingleUser {
+            return;
+        }
+        self.state.debug_mode = false;
+        self.state.debug_permitted.clear();
     }
 
     pub fn apply_seat_delta(&mut self, new_state: SeatState, delta: &SeatDelta, db: &CardDatabase) {
@@ -1157,18 +1208,19 @@ impl SessionManager {
             );
         }
 
-        // Sandbox capability gate. A `Debug(_)` is accepted only when the
-        // session was created in sandbox mode AND the submitting player is in
-        // the `debug_permitted` set. The set is host-managed via
-        // `GrantDebugPermission` / `RevokeDebugPermission` and is initialized
-        // to `{host}` when the game is sandbox-flagged.
+        // Debug capability gate. `debug_permitted` is the single authority:
+        // a `Debug(_)` is accepted iff the submitting player is in the set.
+        // `seed_debug_capability` fills it from one of two sources — every
+        // seat when the game is sandbox-flagged, or the human seats when this
+        // process is a `HostingMode::SingleUser` desktop instance — and the
+        // host adjusts it afterwards via `GrantDebugPermission` /
+        // `RevokeDebugPermission` (sandbox games only). Naming a mode in the
+        // refusal would be wrong for the single-user source, so the message
+        // stays on the seat, which is what was actually checked.
         if matches!(action, GameAction::Debug(_))
             && !session.state.debug_permitted.contains(&player)
         {
-            return Err(
-                "Debug actions are not permitted (Sandbox mode disabled or no permission)"
-                    .to_string(),
-            );
+            return Err("Debug actions are not permitted for this seat".to_string());
         }
 
         // Grant/Revoke debug permission: host-only, and only meaningful in a
@@ -1339,11 +1391,16 @@ impl SessionManager {
     /// Registers all player tokens in the token-to-game index.
     pub fn restore_session(&mut self, mut session: GameSession) {
         // Deployment shape is a property of THIS process, never of the
-        // persisted blob — a session saved by a single-user desktop instance
-        // must not carry its capability into a shared server. Re-derived here,
-        // never deserialized. This is the sole entry for a restored session
-        // into a manager.
+        // persisted blob. Re-stamped here, never deserialized. This is the
+        // sole entry for a restored session into a manager (`sessions.insert`
+        // has exactly two call sites: create, and this one).
         session.hosting = self.hosting;
+        // The stamp above only stops the blob from driving a future
+        // *derivation*. `debug_mode` / `debug_permitted` are serialized state
+        // and arrive already set, so a sidecar's capability would otherwise
+        // walk straight into a shared server. Order matters: this reads the
+        // `hosting` just stamped.
+        session.revoke_unentitled_debug_capability();
         let game_code = session.game_code.clone();
         for token in &session.player_tokens {
             if !token.is_empty() {
@@ -2879,6 +2936,108 @@ mod tests {
         session.state.debug_mode = false;
         session.state.debug_permitted.clear();
         session.rebuild_pregame_state(pc);
+        assert!(session.state.debug_mode);
+        assert_eq!(session.state.debug_permitted, BTreeSet::from([PlayerId(0)]));
+    }
+
+    /// Serialize through JSON exactly as `persist.rs` writes to disk, so the
+    /// "the capability rides in the blob" premise is measured rather than
+    /// asserted from the `#[serde(default)]` attributes.
+    fn round_trip_through_disk(session: &GameSession, db: &CardDatabase) -> GameSession {
+        let json = serde_json::to_string(&session.to_persisted()).unwrap();
+        let persisted: crate::persist::PersistedSession = serde_json::from_str(&json).unwrap();
+        GameSession::from_persisted(persisted, db)
+    }
+
+    #[test]
+    fn restore_drops_a_sidecar_blobs_debug_capability_on_a_shared_server() {
+        // The `hosting` re-stamp blocks re-DERIVATION only. `debug_mode` and
+        // `debug_permitted` are `#[serde(default)]` (not `skip`) and
+        // `to_persisted` captures the whole `GameState`, so they arrive
+        // already set and `rebuild_pregame_state` never runs on the restore
+        // path to re-examine them.
+        let db = engine::database::CardDatabase::default();
+        let mut sidecar = SessionManager::single_user(Duration::from_secs(60));
+        let code = single_ai_opponent_game(&mut sidecar);
+
+        let origin = sidecar.sessions.get(&code).unwrap();
+        // Premise 1: the sidecar really granted it, so a cleared result below
+        // cannot come from the blob never having had the capability.
+        assert!(origin.state.debug_mode);
+        assert_eq!(origin.state.debug_permitted, BTreeSet::from([PlayerId(0)]));
+        // Premise 2: the grant came from the hosting mode, not the sandbox
+        // format flag — the flag is what legitimately travels with the blob,
+        // and if it were set here the session would stay entitled.
+        assert!(!origin.state.format_config.allow_debug_actions);
+
+        let restored = round_trip_through_disk(origin, &db);
+        // Premise 3: both fields genuinely survive a disk round trip. If this
+        // ever goes false the assertions below become vacuous.
+        assert!(restored.state.debug_mode);
+        assert_eq!(
+            restored.state.debug_permitted,
+            BTreeSet::from([PlayerId(0)])
+        );
+
+        let mut shared = SessionManager::new();
+        shared.restore_session(restored);
+        let session = shared.sessions.get(&code).unwrap();
+        assert_eq!(session.hosting, HostingMode::Shared);
+        assert!(
+            !session.state.debug_mode,
+            "a --single-user sidecar's capability must not survive into a shared server"
+        );
+        assert!(
+            session.state.debug_permitted.is_empty(),
+            "seat 0 would otherwise stay past the handle_action debug gate"
+        );
+    }
+
+    #[test]
+    fn restore_keeps_a_sandbox_games_capability_including_its_revocations() {
+        // The paired positive, and the guard against clearing unconditionally:
+        // `allow_debug_actions` is a property of the GAME and travels with the
+        // blob, so a sandbox game is still a sandbox game after a restart.
+        // Values are kept VERBATIM rather than re-seeded — an explicit
+        // `RevokeDebugPermission` is game state, and re-deriving would
+        // silently reinstate the revoked seat.
+        let db = engine::database::CardDatabase::default();
+        let mut origin_mgr = SessionManager::new();
+        let (code, _token) = create_sandbox_game(&mut origin_mgr);
+        let origin = origin_mgr.sessions.get_mut(&code).unwrap();
+        assert_eq!(
+            origin.state.debug_permitted,
+            BTreeSet::from([PlayerId(0), PlayerId(1)]),
+            "premise: sandbox seeds every seat"
+        );
+        origin.state.debug_permitted.remove(&PlayerId(1));
+
+        let restored = round_trip_through_disk(origin, &db);
+        let mut shared = SessionManager::new();
+        shared.restore_session(restored);
+        let session = shared.sessions.get(&code).unwrap();
+        assert!(session.state.debug_mode);
+        assert_eq!(
+            session.state.debug_permitted,
+            BTreeSet::from([PlayerId(0)]),
+            "seat 0 keeps its grant and seat 1 stays revoked"
+        );
+    }
+
+    #[test]
+    fn restore_keeps_the_sidecars_capability_when_it_resumes_its_own_game() {
+        // The production restore direction: the desktop sidecar resuming a
+        // suspended game. `HostingMode::SingleUser` is the second entitlement,
+        // so nothing is dropped here. Fails against a restore that clears
+        // whenever `allow_debug_actions` is false.
+        let db = engine::database::CardDatabase::default();
+        let mut origin_mgr = SessionManager::single_user(Duration::from_secs(60));
+        let code = single_ai_opponent_game(&mut origin_mgr);
+        let restored = round_trip_through_disk(origin_mgr.sessions.get(&code).unwrap(), &db);
+
+        let mut sidecar = SessionManager::single_user(Duration::from_secs(60));
+        sidecar.restore_session(restored);
+        let session = sidecar.sessions.get(&code).unwrap();
         assert!(session.state.debug_mode);
         assert_eq!(session.state.debug_permitted, BTreeSet::from([PlayerId(0)]));
     }

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -103,6 +103,28 @@ pub fn is_acting(state: &GameState, player: PlayerId) -> bool {
     engine::game::turn_control::is_authorized_submitter(state, player)
 }
 
+/// Deployment shape of this `phase-server` instance. Selected once at startup
+/// from `--single-user`; never per-session, because a session cannot prove it
+/// is unobserved — `SpectatorJoin` admits any started game by code, with no
+/// `public` / password / `ai_seats` check. Deriving capability from the seat
+/// mix would therefore open sandbox on a *shared* server to any client that
+/// created an all-AI game.
+///
+/// Shape precedent: `phase_server::persistence::SessionRetention`, which is
+/// likewise a two-variant `Copy` enum selected from the same CLI flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostingMode {
+    /// A shared instance: other humans may join or spectate any session.
+    Shared,
+    /// The desktop shell's sidecar. `SingleUser` asserts that no other client
+    /// can reach this instance at all, and that assertion rests on the spawn
+    /// arguments — `--bind 127.0.0.1` plus `--allowed-origin`
+    /// (`client/src-tauri/src/native_engine.rs`), NOT on the seat mix. If the
+    /// sidecar is ever bound beyond loopback, this variant stops being true
+    /// and the capability it grants must be re-derived.
+    SingleUser,
+}
+
 pub struct GameSession {
     pub game_code: String,
     /// Monotonic server-authored revision of the current authoritative state.
@@ -120,6 +142,20 @@ pub struct GameSession {
     /// reservations are released by socket cleanup.
     pub reservations: HashMap<String, SeatReservation>,
     pub timer_seconds: Option<u32>,
+    /// Deployment shape of the process hosting this session, copied from the
+    /// owning `SessionManager` at creation and **re-stamped, never
+    /// deserialized**, at `SessionManager::restore_session` — a session saved
+    /// by a single-user desktop instance must not carry its capability into a
+    /// shared server. Deliberately absent from `PersistedSession`.
+    ///
+    /// **Read fence.** This field is read by exactly one function,
+    /// `seed_debug_capability`, which is reachable only via
+    /// `rebuild_pregame_state`, which is called only from `start_game` and
+    /// from `apply_seat_delta`. Neither runs during the lobby re-registration
+    /// window in which a restored session still holds the `from_persisted`
+    /// placeholder. **Any new read must either sit behind
+    /// `rebuild_pregame_state` or be added after the restore stamp.**
+    pub hosting: HostingMode,
     /// Number of human player seats in this game.
     pub player_count: u8,
     /// Seats controlled by AI (not occupied by a human player).
@@ -317,15 +353,60 @@ impl GameSession {
             }
         };
         self.state.set_match_config(match_config);
-        // Preserve sandbox seeding through rematch — the format flag is
-        // immutable, so debug capability survives the new game. Every seat
-        // is permitted by default (see initial create site for rationale);
-        // explicit revocations from the previous game are dropped at rematch
-        // since the new game is a fresh debug context.
+        self.seed_debug_capability(player_count);
+    }
+
+    /// Seeds `debug_mode` / `debug_permitted` for the state just built by
+    /// `rebuild_pregame_state`.
+    ///
+    /// That function is the only SESSION-LAYER seeding site whose result
+    /// survives `start_game`: it replaces `self.state` wholesale, discarding
+    /// anything seeded during construction (`create_game_n_players` seeds
+    /// before `start_game` runs, so its seeding is unobservable to a client —
+    /// `create_game_with_ai` starts the game before returning the game code).
+    ///
+    /// It is *not* the only seeding site in the codebase. The engine's
+    /// between-games rebuild (`engine::game::match_flow`'s
+    /// `restart_between_games_with_starting_player`) builds a fresh
+    /// `GameState` that never touches `GameSession`, so it carries these two
+    /// fields forward itself. A `session.rs` authority structurally cannot
+    /// reach it.
+    ///
+    /// Note `GameState::debug_mode`'s own doc comment still reads "Always
+    /// false for multiplayer games" — stale as of this commit, since the
+    /// client classifies `native-ai` as multiplayer. A rider is filed against
+    /// `crates/engine/src/types/game_state.rs` to correct it; the file is
+    /// owned by concurrent work and is deliberately not edited here.
+    fn seed_debug_capability(&mut self, player_count: u8) {
         if self.state.format_config.allow_debug_actions {
+            // Sandbox is a shared playground, not an admin console: every seat
+            // is permitted by default. Explicit revocations from a previous
+            // game are dropped, since a rebuilt pregame state is a fresh debug
+            // context. (The old comment here claimed this preserved seeding
+            // "through rematch" — it does not: a Bo3 rematch rebuilds in the
+            // engine, never through this function.)
             self.state.debug_mode = true;
             for i in 0..player_count {
                 self.state.debug_permitted.insert(PlayerId(i));
+            }
+        } else if self.hosting == HostingMode::SingleUser {
+            // Desktop-solo parity with the browser engine, which enables
+            // `debug_mode` unconditionally for single-player. The sandbox
+            // *format* flag stays false, so own-library name exposure
+            // (`engine::game::visibility`) and the host grant/revoke flow
+            // (rejected above with "Sandbox mode is not enabled") remain
+            // closed — this grants the debug panel, not a shared sandbox.
+            //
+            // Human seats only. An AI seat has no client and never submits a
+            // Debug action; excluding it keeps the strict wire gate in
+            // `handle_action` a meaningful per-seat check rather than a global
+            // on-switch. `human_seats()` is correct here and only here: both
+            // callers of `rebuild_pregame_state` have already populated
+            // `ai_seats` (`start_game` <- `create_game_with_ai`;
+            // `apply_seat_delta` <- its own rebuild).
+            self.state.debug_mode = true;
+            for seat in self.human_seats() {
+                self.state.debug_permitted.insert(seat);
             }
         }
     }
@@ -686,6 +767,11 @@ impl GameSession {
             display_names: ps.display_names,
             reservations: HashMap::new(),
             timer_seconds: ps.timer_seconds,
+            // Least-privilege placeholder. `hosting` is a property of THIS
+            // process, not of the persisted blob, and is re-stamped by
+            // `SessionManager::restore_session`. Between here and that stamp
+            // the value can only *under*-grant, never over-grant.
+            hosting: HostingMode::Shared,
             player_count: ps.player_count,
             ai_seats,
             ai_configs,
@@ -704,23 +790,32 @@ impl GameSession {
 pub struct SessionManager {
     pub sessions: HashMap<String, GameSession>,
     pub reconnect: ReconnectManager,
+    /// Deployment shape of this process, stamped onto every session this
+    /// manager creates or restores. See `HostingMode`.
+    pub hosting: HostingMode,
     /// Maps player_token -> game_code for token-based lookups.
     token_to_game: HashMap<String, String>,
 }
 
 impl SessionManager {
+    /// A shared instance: other humans may join or spectate.
     pub fn new() -> Self {
         Self {
             sessions: HashMap::new(),
             reconnect: ReconnectManager::default(),
+            hosting: HostingMode::Shared,
             token_to_game: HashMap::new(),
         }
     }
 
-    pub fn with_grace_period(grace_period: Duration) -> Self {
+    /// The desktop shell's sidecar: one user, loopback-bound, no other client
+    /// can reach it. `grace_period` sets the reconnect window, which a
+    /// single-user instance makes effectively unbounded.
+    pub fn single_user(grace_period: Duration) -> Self {
         Self {
             sessions: HashMap::new(),
             reconnect: ReconnectManager::new(grace_period),
+            hosting: HostingMode::SingleUser,
             token_to_game: HashMap::new(),
         }
     }
@@ -807,6 +902,7 @@ impl SessionManager {
             display_names,
             reservations: HashMap::new(),
             timer_seconds,
+            hosting: self.hosting,
             player_count,
             ai_seats: HashSet::new(),
             ai_configs: HashMap::new(),
@@ -1241,7 +1337,13 @@ impl SessionManager {
 
     /// Restore a pre-built session (e.g., from disk persistence).
     /// Registers all player tokens in the token-to-game index.
-    pub fn restore_session(&mut self, session: GameSession) {
+    pub fn restore_session(&mut self, mut session: GameSession) {
+        // Deployment shape is a property of THIS process, never of the
+        // persisted blob — a session saved by a single-user desktop instance
+        // must not carry its capability into a shared server. Re-derived here,
+        // never deserialized. This is the sole entry for a restored session
+        // into a manager.
+        session.hosting = self.hosting;
         let game_code = session.game_code.clone();
         for token in &session.player_tokens {
             if !token.is_empty() {
@@ -1276,6 +1378,8 @@ pub fn generate_player_token() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
+
     use engine::database::card_db::CardDatabase;
     use engine::game::deck_loading::DeckEntry;
     use engine::game::engine::apply;
@@ -2538,6 +2642,247 @@ mod tests {
         );
     }
 
+    /// Fixture shape for the `HostingMode` tests below, matching the existing
+    /// `takeback_auto_approves_for_sole_human_seat` precedent: a default
+    /// `CardDatabase` and `format_config: None` are enough to run
+    /// `create_game_with_ai` all the way through `start_game`. (The
+    /// "can't fully start the game without a database" comment elsewhere in
+    /// this module does not apply to this path.) `format_config: None`
+    /// yields `FormatConfig::standard`, so `allow_debug_actions` is false —
+    /// which is what makes the capability assertions load-bearing rather
+    /// than a restatement of the sandbox flag.
+    fn single_ai_opponent_game(mgr: &mut SessionManager) -> String {
+        let db = engine::database::CardDatabase::default();
+        let (code, _token) = mgr.create_game_with_ai(
+            make_deck(),
+            "Host".to_string(),
+            None,
+            MatchConfig::default(),
+            vec![(1, AiDifficulty::Easy, make_deck())],
+            Vec::new(),
+            None,
+            &db,
+        );
+        code
+    }
+
+    #[test]
+    fn single_user_instance_seeds_human_seats_through_start_game() {
+        // The surviving-seam probe. `create_game_with_ai` calls `start_game`,
+        // which calls `rebuild_pregame_state`, which replaces `self.state`
+        // wholesale. Seeding placed anywhere earlier — `create_game_n_players`,
+        // or the tail of `create_game_with_ai` — is wiped, and this test fails.
+        // A test built on `create_game_n_players` alone (the shape both
+        // pre-existing debug tests use) would pass against the wrong seam.
+        let mut mgr = SessionManager::single_user(Duration::from_secs(60));
+        let code = single_ai_opponent_game(&mut mgr);
+        let session = mgr.sessions.get(&code).unwrap();
+
+        // The capability came from the hosting mode, NOT from a sandbox
+        // format flag: this assertion fails if someone reaches for
+        // `FormatConfig::with_sandbox()` instead.
+        assert!(
+            !session.state.format_config.allow_debug_actions,
+            "sandbox format flag must stay off — it changes hidden-info exposure"
+        );
+        assert!(session.state.debug_mode);
+        assert_eq!(
+            session.state.debug_permitted,
+            BTreeSet::from([PlayerId(0)]),
+            "human seats only: the AI seat has no client and never submits Debug"
+        );
+    }
+
+    #[test]
+    fn shared_instance_does_not_seed_debug_capability() {
+        // Discriminates "seeded from the hosting mode" from "seeded always".
+        // Without this, the test above passes for an implementation that
+        // seeds unconditionally — which would open the debug panel on the
+        // online server.
+        let mut mgr = SessionManager::new();
+        let code = single_ai_opponent_game(&mut mgr);
+        let session = mgr.sessions.get(&code).unwrap();
+
+        assert!(!session.state.debug_mode);
+        assert!(session.state.debug_permitted.is_empty());
+    }
+
+    #[test]
+    fn single_user_human_seat_may_submit_debug_action_but_ai_seat_may_not() {
+        // Two authorities in one fixture, positive then negative, against the
+        // SAME `session.state`.
+        let mut mgr = SessionManager::single_user(Duration::from_secs(60));
+        let db = engine::database::CardDatabase::default();
+        let (code, host_token) = mgr.create_game_with_ai(
+            make_deck(),
+            "Host".to_string(),
+            None,
+            MatchConfig::default(),
+            vec![(1, AiDifficulty::Easy, make_deck())],
+            Vec::new(),
+            None,
+            &db,
+        );
+
+        // POSITIVE, through the real wire gate. `ShuffleLibrary` (not
+        // `CreateCard`) is the reach-guard: `CreateCard` is resolved at the
+        // WASM layer and the engine returns `InvalidAction` if it reaches
+        // `apply()`, so a positive built on it passes identically against a
+        // totally broken gate. `ShuffleLibrary` is state-only and actually
+        // applied, so `Ok` is reachable only past the strict wire gate in
+        // `handle_action` AND both engine gates.
+        let ok = mgr.handle_action(
+            &code,
+            &host_token,
+            GameAction::Debug(engine::types::actions::DebugAction::ShuffleLibrary {
+                player_id: PlayerId(0),
+            }),
+        );
+        assert!(ok.is_ok(), "seat 0 must be permitted: {:?}", ok.err());
+
+        // NEGATIVE — and it deliberately does NOT go through `handle_action`.
+        // That function authenticates by TOKEN, never by `PlayerId`:
+        // `player_for_token` scans `player_tokens`, `create_game_n_players`
+        // builds `vec![String::new(); pc]` and assigns only index 0, and
+        // `create_game_with_ai` never assigns a token to an AI seat. So any
+        // AI-seat attempt returns `Err("Invalid player token")`, satisfying a
+        // bare `assert!(result.is_err())` IDENTICALLY against a totally broken
+        // debug gate. Drive the per-seat gate where an AI seat is addressable:
+        // the engine.
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        assert_eq!(
+            session.state.debug_permitted,
+            BTreeSet::from([PlayerId(0)]),
+            "fixture premise: only the human seat is permitted. An empty set \
+             would make the engine's lenient gate ALLOW, flipping this test red"
+        );
+        let err = engine::game::apply(
+            &mut session.state,
+            PlayerId(1),
+            GameAction::Debug(engine::types::actions::DebugAction::ShuffleLibrary {
+                player_id: PlayerId(1),
+            }),
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:?}").contains("Debug actions require debug permission"),
+            "must fail the per-seat gate specifically, not the debug_mode gate \
+             ('Debug actions require debug_mode to be enabled') and not a token \
+             check: {err:?}"
+        );
+    }
+
+    #[test]
+    fn seat_delta_rebuild_rederives_debug_capability() {
+        // The SECOND caller of `rebuild_pregame_state`. `start_game` is the
+        // first (covered above); `apply_seat_delta` reaches the same seam,
+        // gated on `old_player_count != new_player_count`. A seeding
+        // implementation wired only into `start_game` passes every test above
+        // and fails this one.
+        struct UnusedResolver;
+        impl seat_reducer::types::DeckResolver for UnusedResolver {
+            fn resolve(
+                &self,
+                _choice: &DeckChoice,
+            ) -> Result<engine::game::deck_loading::PlayerDeckList, String> {
+                panic!("human seat removal must not resolve a deck")
+            }
+        }
+
+        let db = engine::database::CardDatabase::default();
+        let mut mgr = SessionManager::single_user(Duration::from_secs(60));
+        let (code, _host) = mgr.create_game_n_players(
+            make_deck(),
+            "Host".to_string(),
+            None,
+            3,
+            MatchConfig::default(),
+            None,
+        );
+        // Seat 1 joins; seat 2 is left waiting, because the reducer rejects
+        // removing a claimed seat (`SeatClaimed`).
+        mgr.join_game(&code, make_deck()).unwrap();
+
+        // Premise: nothing is seeded before the rebuild, so the assertion
+        // below cannot be satisfied by leftovers from game creation.
+        assert!(
+            mgr.sessions
+                .get(&code)
+                .unwrap()
+                .state
+                .debug_permitted
+                .is_empty(),
+            "fixture premise: pregame state carries no capability yet"
+        );
+
+        let resolver = UnusedResolver;
+        let ctx = seat_reducer::types::ReducerCtx {
+            platform: Platform::Native,
+            deck_resolver: &resolver,
+        };
+        let mut seat_state = mgr.sessions.get(&code).unwrap().seat_state();
+        let delta = seat_reducer::apply(
+            &mut seat_state,
+            SeatMutation::Remove { seat_index: 2 },
+            &ctx,
+        )
+        .unwrap();
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.apply_seat_delta(seat_state, &delta, &db);
+
+        // Re-derived at the NEW seat count, not carried stale from 3 seats.
+        assert_eq!(session.player_count, 2);
+        assert!(session.state.debug_mode);
+        assert_eq!(
+            session.state.debug_permitted,
+            BTreeSet::from([PlayerId(0), PlayerId(1)]),
+            "both remaining seats are human, and seat 2 must not survive"
+        );
+    }
+
+    #[test]
+    fn restore_session_stamps_this_instances_hosting() {
+        // Direction matters, and only this one discriminates. `hosting` is
+        // deliberately absent from `PersistedSession`, so `from_persisted`
+        // ALWAYS yields the least-privilege `Shared` placeholder. Restoring
+        // into a `Shared` manager therefore has the placeholder and the
+        // manager agreeing, and would pass with the stamp deleted — verified,
+        // not assumed. Restoring into a `SingleUser` manager makes the two
+        // sources disagree, so only the manager's value winning can produce
+        // `SingleUser` here.
+        //
+        // It is also the production direction: the desktop sidecar restores
+        // its own suspended game and must regain the capability.
+        let db = engine::database::CardDatabase::default();
+        let mut origin = SessionManager::new();
+        let code = single_ai_opponent_game(&mut origin);
+        let persisted = origin.sessions.get(&code).unwrap().to_persisted();
+        let restored = GameSession::from_persisted(persisted, &db);
+        assert_eq!(
+            restored.hosting,
+            HostingMode::Shared,
+            "premise: the un-stamped placeholder is Shared, so a SingleUser \
+             result below can only have come from the manager"
+        );
+
+        let mut sidecar = SessionManager::single_user(Duration::from_secs(60));
+        sidecar.restore_session(restored);
+        let session = sidecar.sessions.get_mut(&code).unwrap();
+        assert_eq!(session.hosting, HostingMode::SingleUser);
+
+        // And the stamp is load-bearing, not decorative: a rebuild on the
+        // sidecar manager re-derives the capability the placeholder would
+        // have denied. Cleared first so the assertion cannot be satisfied by
+        // values riding along inside `PersistedGameState` (both fields are
+        // `#[serde(default)]`, not `skip`).
+        let pc = session.player_count;
+        session.state.debug_mode = false;
+        session.state.debug_permitted.clear();
+        session.rebuild_pregame_state(pc);
+        assert!(session.state.debug_mode);
+        assert_eq!(session.state.debug_permitted, BTreeSet::from([PlayerId(0)]));
+    }
+
     // CR 107.1c: "remove any number of counters" — a human's intermediate submit
     // ("remove 2 of 3") is not one of the coarse AI candidates (remove-none /
     // remove-all), but the engine validates the full legal space directly.
@@ -2829,6 +3174,8 @@ mod tests {
             display_names: vec!["Host".to_string(), "AI (CEDH)".to_string()],
             reservations: HashMap::new(),
             timer_seconds: None,
+            // This test asserts cEDH bracket validation, not capability.
+            hosting: HostingMode::Shared,
             player_count: pc as u8,
             ai_seats: [ai_pid].into_iter().collect(),
             ai_configs: [(ai_pid, cedh_config)].into_iter().collect(),


### PR DESCRIPTION
Desktop solo-vs-AI (`native-ai`) was being treated as multiplayer, which cost it
sandbox tools, checkpoints and reconnect — and any refused action destroyed the
session outright.

## The actual defect

`isMultiplayerMode` conflated two unrelated questions:

- **"Is this client the sole authority?"** — governs undo/rewind. Genuinely
  false for `native-ai`, because the engine lives in the sidecar.
- **"Are other humans watching?"** — governs sandbox tools, checkpoints and
  reconnect. **False for `native-ai`** — nobody else is at the table.

One predicate answered both, so disabling undo (correct) also disabled the
sandbox panel and checkpoints (wrong).

Appending `|| mode === "native-ai"` at each call site would have papered over
this while leaving the conflation in place for the next mode added. Instead the
two axes are named and made a compiler-enforced census:

```ts
export type EngineAuthority = "client" | "wire";
export type TableCompany   = "solo" | "remote-humans";

const GAME_MODE_TRAITS: Record<GameMode, GameModeTraits> = {
  "ai":        { authority: "client", company: "solo" },
  "local":     { authority: "client", company: "solo" },
  "native-ai": { authority: "wire",   company: "solo" },   // the entire bug, stated positively
  "online":    { authority: "wire",   company: "remote-humans" },
  ...
```

A new `GameMode` **fails to compile** until it declares both axes. No boolean
flags, no `|| mode === …` in production, zero remaining `isMultiplayerMode` call
sites, no suppressions.

## Three unreported defects found and fixed along the way

A refused action on the native transport went out on `ServerMessage::error`,
which `ws-adapter.ts` emits as `{type:"error"}`, which `handleNativeEvent`
handles by **disposing the controller and adapter** → `reconnectState: "failed"`.
So a benign refusal killed the session.

- **Takeback** — reachable on the second click, since `takeback_history` is
  cleared after an approved rollback.
- **`RespondTakeback`** — byte-identical shape.
- **`CancelTakeback`** — same again.

All three now answer on `ServerMessage::ActionRejected { reason }`.

Also removed a comment in `session.rs` asserting a security property the
mechanism did not actually provide.

## Deferred, with evidence

**Three benign-refusal sites remain on the error channel**, same mechanism as
above:

| Site | What | Live today? |
|---|---|---|
| `main.rs:5691` | emote | **Path is live.** `EmoteOverlay` renders under `{!isSpectatorMode}`, not a mode gate. Saved only by guard narrowness (empty / over-length / control-char) against a frozen 5-element ASCII emote set. **Adding a rate limit or profanity filter to `guard_emote` turns this into a live session-killer with nothing in the way.** |
| `main.rs:5753` | seat mutation | gated |
| `main.rs:5795` | seat mutation | gated |

**Two sites deliberately not swapped:**

- `main.rs:3701` — the snapshot broadcast guard fires on a **successful** action,
  so `ActionRejected` would be a lie. It needs a distinct non-terminal "succeeded
  but could not broadcast" path. Latent rather than live: the guards are
  count-based (≤10,000 objects) versus a realistic board of a few hundred — but
  note this PR hands desktop solo the sandbox panel, so spawning thousands
  becomes possible one click at a time.
- `main.rs:5874` — bracket violation, deliberately terminal, with UI built
  against it.

**`Debug(CreateCard)` still cannot work on the sidecar.** It resolves a card
*name*, which needs a `CardDatabase` at action-handling time; only the WASM layer
holds one, and `server-core`'s `handle_action` takes no `&CardDatabase`. This PR
**gates the form on the transport** rather than implementing server-side
interception, and names the limit in the UI instead of hiding the accordion.
Desktop solo therefore gains the panel and every debug action *except* spawning a
card by name — the token forms and Copy Permanent do work, since those carry
characteristics rather than a name to look up. Threading `&CardDatabase` into
`handle_action` is a real change to the session API and its own scoped work.

**`ws-adapter.ts` sends `StartGame` and `ReadyToggle`**, neither of which exists
in the protocol enum. They deserialize-fail straight onto the error channel —
i.e. two client messages have been silently failing. Flagged, not fixed.

## Verification

`clippy`, `test-engine`, `check-frontend`, `test-frontend` green.

Caveat worth stating: **no Tilt resource runs `server-core` or `phase-server`
tests**, so for the Rust half of this PR a green board is compile+lint evidence
only. The `server-core` changes were executed directly in an isolated
`CARGO_TARGET_DIR`; the wire-level behaviour is covered by frontend adapter tests
that feed the adapter the exact frame.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear notifications when takeback or other requests are declined, without ending the game session.
  * Native AI games now attempt to reconnect after a dropped connection.
  * Takeback availability now reflects supported game transports and modes.

* **Bug Fixes**
  * Improved undo and checkpoint behavior across solo, AI, and remote-authority games.
  * Debug permissions now persist correctly between games and are enforced according to hosting mode.
  * Card creation controls are hidden when the selected engine does not support them.
  * Updated checkpoint and debug-action messaging to explain availability more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->