### PR TITLE
Add Orzhov Advokist

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -3746,13 +3746,22 @@ fn attack_passes_temporary_prohibition(
         let crate::types::ability::GameRestriction::ProhibitActivity {
             source,
             affected_players,
-            activity: crate::types::ability::ProhibitedActivity::Attack { defended },
+            activity:
+                crate::types::ability::ProhibitedActivity::Attack {
+                    defended,
+                    protected_player,
+                },
             ..
         } = restriction
         else {
             continue;
         };
-        let Some(protected) = state.objects.get(source).map(|o| o.controller) else {
+        // New restrictions snapshot the protected player on resolution. Legacy
+        // serialized restrictions have no snapshot and retain their historic
+        // source-controller lookup.
+        let Some(protected) = (*protected_player)
+            .or_else(|| state.objects.get(source).map(|object| object.controller))
+        else {
             continue;
         };
         let attacker_is_affected = match affected_players {

--- a/crates/engine/src/game/effects/add_restriction.rs
+++ b/crates/engine/src/game/effects/add_restriction.rs
@@ -581,7 +581,7 @@ mod tests {
         ));
     }
 
-    /// CR 109.5 + CR 514.2: an Advokist-style per-player restriction preserves
+    /// CR 109.5: an Advokist-style per-player restriction preserves
     /// the trigger controller for both "you" and "your next turn", while its
     /// affected player remains the accepting scoped player.
     #[test]

--- a/crates/engine/src/game/effects/add_restriction.rs
+++ b/crates/engine/src/game/effects/add_restriction.rs
@@ -1,5 +1,6 @@
 use crate::types::ability::{
-    Effect, EffectError, EffectKind, GameRestriction, ResolvedAbility, RestrictionExpiry,
+    Effect, EffectError, EffectKind, GameRestriction, ProhibitedActivity, ResolvedAbility,
+    RestrictionExpiry,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
@@ -93,6 +94,10 @@ fn fill_runtime_fields(
     restriction: &mut GameRestriction,
     ability: &ResolvedAbility,
 ) {
+    // CR 109.5: "you" in a triggered ability remains the controller when it
+    // triggered, even if the source later changes controller or leaves play.
+    let original_controller = ability.original_controller.unwrap_or(ability.controller);
+
     match restriction {
         GameRestriction::DamagePreventionDisabled { source, .. }
         | GameRestriction::ProhibitActivity { source, .. }
@@ -167,6 +172,18 @@ fn fill_runtime_fields(
         | GameRestriction::CantEnterBattlefieldFrom { .. } => {}
     }
 
+    if let GameRestriction::ProhibitActivity {
+        activity: ProhibitedActivity::Attack {
+            protected_player, ..
+        },
+        ..
+    } = restriction
+    {
+        // CR 109.5: snapshot the resolving ability's controller for the
+        // controller-relative "you" in the attack restriction.
+        *protected_player = Some(original_controller);
+    }
+
     match restriction {
         GameRestriction::ProhibitActivity {
             expiry,
@@ -191,7 +208,7 @@ fn fill_runtime_fields(
                     player: PlayerScope::Controller,
                 }) => {
                     *expiry = RestrictionExpiry::UntilPlayerNextTurn {
-                        player: ability.controller,
+                        player: original_controller,
                     };
                 }
                 // CR 514.2 + CR 500.7: "during [the controller's] next turn …"
@@ -208,7 +225,7 @@ fn fill_runtime_fields(
                         // ("during their next turn") anchors on the restricted
                         // player; fall back to the controller for grants with no
                         // resolved specific player (Kang's self-controller form).
-                        player: restricted_player.unwrap_or(ability.controller),
+                        player: restricted_player.unwrap_or(original_controller),
                     };
                 }
                 _ => {}
@@ -492,6 +509,7 @@ mod tests {
                     expiry: RestrictionExpiry::EndOfTurn,
                     activity: ProhibitedActivity::Attack {
                         defended: AttackTargetFilter::PlayerOrPermanents,
+                        protected_player: None,
                     },
                 },
             },
@@ -520,6 +538,7 @@ mod tests {
                 },
                 activity: ProhibitedActivity::Attack {
                     defended: AttackTargetFilter::PlayerOrPermanents,
+                    protected_player: Some(PlayerId(0)),
                 },
             }
         ));
@@ -541,6 +560,7 @@ mod tests {
                     expiry: RestrictionExpiry::EndOfTurn,
                     activity: ProhibitedActivity::Attack {
                         defended: AttackTargetFilter::Player,
+                        protected_player: None,
                     },
                 },
             },
@@ -557,6 +577,55 @@ mod tests {
             GameRestriction::ProhibitActivity {
                 affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(0)),
                 ..
+            }
+        ));
+    }
+
+    /// CR 109.5 + CR 514.2: an Advokist-style per-player restriction preserves
+    /// the trigger controller for both "you" and "your next turn", while its
+    /// affected player remains the accepting scoped player.
+    #[test]
+    fn attack_restriction_snapshots_original_controller_without_rebinding_scoped_player() {
+        use crate::types::triggers::AttackTargetFilter;
+
+        let mut state = GameState::new(crate::types::format::FormatConfig::standard(), 3, 42);
+        let mut ability = ResolvedAbility::new(
+            Effect::AddRestriction {
+                restriction: GameRestriction::ProhibitActivity {
+                    source: ObjectId(0),
+                    affected_players: RestrictionPlayerScope::ScopedPlayer,
+                    expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::Attack {
+                        defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                        protected_player: None,
+                    },
+                },
+            },
+            vec![],
+            ObjectId(7),
+            PlayerId(1), // rebound current player for this each-player iteration
+        )
+        .duration(Duration::UntilNextTurnOf {
+            player: crate::types::ability::PlayerScope::Controller,
+        });
+        ability.original_controller = Some(PlayerId(0));
+        ability.scoped_player = Some(PlayerId(1));
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).expect("restriction resolves");
+
+        assert!(matches!(
+            &state.restrictions[0],
+            GameRestriction::ProhibitActivity {
+                source: ObjectId(7),
+                affected_players: RestrictionPlayerScope::SpecificPlayer(PlayerId(1)),
+                expiry: RestrictionExpiry::UntilPlayerNextTurn {
+                    player: PlayerId(0)
+                },
+                activity: ProhibitedActivity::Attack {
+                    defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                    protected_player: Some(PlayerId(0)),
+                },
             }
         ));
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -4240,20 +4240,64 @@ fn try_parse_during_that_turn_powerup_prohibition(tp: TextPair<'_>) -> Option<Pa
     })
 }
 
-/// CR 508.1c + CR 514.2 + CR 500.7: "that player can't attack you [or your
-/// permanents/planeswalkers] during their next turn" (Willie Lumpkin) — a
-/// player-scoped, next-turn-expiring attack prohibition. The "that player"
-/// anaphor reuses the parent draw-trigger's targeted player (CR 608.2c), so the
-/// restriction's `affected_players` is `ParentTargetedPlayer`, resolved to a
-/// `SpecificPlayer` at resolution by `add_restriction`. The defended scope rides
-/// the shared `AttackTargetFilter` via `parse_cant_attack_defended_scope_nom`
-/// (the single scope authority), so the declare-attackers gate reuses the same
-/// matcher as static `CantAttack`. The `UntilEndOfNextTurnOf` duration anchors on
-/// the RESTRICTED player (the resolved `SpecificPlayer`), not the controller —
-/// see `add_restriction::fill_runtime_fields`.
+/// CR 508.1c + CR 514.2 + CR 500.7: player-scoped temporary attack
+/// prohibitions. The scoped Advokist form keeps the accepting player as
+/// `ScopedPlayer` and the controller-relative "you" / "your next turn" data for
+/// `add_restriction` to snapshot. The legacy "that player" / "they" form
+/// reuses the parent draw-trigger's targeted player (CR 608.2c), so its
+/// `affected_players` is `ParentTargetedPlayer`, resolved to a `SpecificPlayer`
+/// at resolution. Both forms use `parse_cant_attack_defended_scope_nom` as the
+/// single `AttackTargetFilter` authority, shared with static `CantAttack`.
 fn try_parse_that_player_cant_attack_prohibition(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
     use crate::parser::oracle_static::parse_cant_attack_defended_scope_nom;
     use crate::types::triggers::AttackTargetFilter;
+
+    // Orzhov Advokist: this bounded form must precede the legacy anaphor branch.
+    // Unlike the latter, its "creatures that player controls" subject carries
+    // `ScopedPlayer`, and both the explicit defended scope and "until your next
+    // turn" duration are required discriminators. Do not let an incomplete
+    // prefix become a broad blanket attack ban.
+    if let Some((defended, remaining)) = nom_on_lower(tp.original, tp.lower, |input| {
+        let (input, _) = tag("creatures that player controls ").parse(input)?;
+        let (input, _) =
+            preceded(alt((tag("can't"), tag("cannot"))), tag(" attack")).parse(input)?;
+        let (input, defended) = parse_cant_attack_defended_scope_nom(input)?;
+        let Some(defended) = defended else {
+            return Err(oracle_err(input));
+        };
+        let (input, _) = tag(" until your next turn").parse(input)?;
+        Ok((input, defended))
+    }) {
+        if !remaining
+            .chars()
+            .all(|character| character == '.' || character.is_whitespace())
+        {
+            return None;
+        }
+
+        return Some(ParsedEffectClause {
+            effect: Effect::AddRestriction {
+                restriction: GameRestriction::ProhibitActivity {
+                    source: ObjectId(0),
+                    affected_players: RestrictionPlayerScope::ScopedPlayer,
+                    expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::Attack {
+                        defended,
+                        protected_player: None,
+                    },
+                },
+            },
+            duration: Some(Duration::UntilNextTurnOf {
+                player: PlayerScope::Controller,
+            }),
+            sub_ability: None,
+            distribute: None,
+            multi_target: None,
+            condition: None,
+            optional: false,
+            unless_pay: None,
+        });
+    }
 
     // Subject: "that player" / "they" (the parent draw-trigger's targeted
     // opponent). Both anaphors bind to `ParentTargetedPlayer` (CR 608.2c). The
@@ -4319,7 +4363,10 @@ fn try_parse_that_player_cant_attack_prohibition(tp: TextPair<'_>) -> Option<Par
                 // below re-anchors the expiry to the restricted player's next turn
                 // in `add_restriction`.
                 expiry: RestrictionExpiry::EndOfTurn,
-                activity: ProhibitedActivity::Attack { defended },
+                activity: ProhibitedActivity::Attack {
+                    defended,
+                    protected_player: None,
+                },
             },
         },
         duration,
@@ -6539,6 +6586,22 @@ pub(crate) fn parse_effect_clause(text: &str, ctx: &mut ParseContext) -> ParsedE
         }
     };
     let text = text.as_str();
+
+    // This shared temporary-attack-prohibition recognizer owns the duration,
+    // so dispatch before the clause shell peels it. Normalize the same leading
+    // sequence connector and terminal punctuation that the inner parser does.
+    let prohibition_probe = strip_leading_sequence_connector(text)
+        .trim()
+        .trim_end_matches('.')
+        .trim();
+    let prohibition_probe_lower = prohibition_probe.to_lowercase();
+    if let Some(clause) = try_parse_that_player_cant_attack_prohibition(TextPair::new(
+        prohibition_probe,
+        &prohibition_probe_lower,
+    )) {
+        return attach_unless_slots(clause, unless_condition, unless_pay_deferred);
+    }
+
     // Phase 2: peel structural slots off the head of the clause before
     // body parsing. The recursive shell strips slot-bearing prefixes/suffixes
     // (optional, opponent-may, condition, duration, for-each, player-scope)
@@ -8430,14 +8493,6 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
     // activated" (Kang). Tag-scoped prohibition for the granted extra turn — try
     // before the generic non-mana-ability prohibition.
     if let Some(clause) = try_parse_during_that_turn_powerup_prohibition(tp) {
-        return clause;
-    }
-
-    // CR 508.1c + CR 514.2: "that player can't attack you [or your permanents]
-    // during their next turn" (Willie Lumpkin) — player-scoped, next-turn-expiring
-    // attack prohibition. Run before the generic restriction-mode path, which
-    // would otherwise drop the defended scope / duration as Unimplemented.
-    if let Some(clause) = try_parse_that_player_cant_attack_prohibition(tp) {
         return clause;
     }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -28336,7 +28336,8 @@ fn second_doctor_subject_only_who_does_lowers_cross_scope_restriction() {
             assert_eq!(
                 *activity,
                 ProhibitedActivity::Attack {
-                    defended: AttackTargetFilter::PlayerOrPermanents
+                    defended: AttackTargetFilter::PlayerOrPermanents,
+                    protected_player: None,
                 },
                 "\"you or permanents you control\" defends player + permanents"
             );
@@ -28396,7 +28397,8 @@ fn city_hall_subject_only_who_does_lowers_same_scope_restriction() {
             assert_eq!(
                 *activity,
                 ProhibitedActivity::Attack {
-                    defended: AttackTargetFilter::Player
+                    defended: AttackTargetFilter::Player,
+                    protected_player: None,
                 },
                 "bare \"you\" defends the player only"
             );
@@ -30561,6 +30563,7 @@ fn that_player_cant_attack_branches_on_duration_phrase() {
                     expiry: RestrictionExpiry::EndOfTurn,
                     activity: ProhibitedActivity::Attack {
                         defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                        protected_player: None,
                     },
                     ..
                 }
@@ -30585,6 +30588,116 @@ fn that_player_cant_attack_branches_on_duration_phrase() {
         "the 'next turn' branch must carry UntilEndOfNextTurnOf (got {:?})",
         next_turn.duration
     );
+}
+
+#[test]
+fn public_attack_prohibition_parser_preserves_legacy_anaphora_and_connector() {
+    for text in [
+        "that player can't attack you during their next turn.",
+        "they cannot attack you during their next turn.",
+    ] {
+        let parsed = parse_effect_chain(text, AbilityKind::Spell);
+        assert!(matches!(
+            parsed.effect.as_ref(),
+            Effect::AddRestriction {
+                restriction: GameRestriction::ProhibitActivity {
+                    affected_players: RestrictionPlayerScope::ParentTargetedPlayer,
+                    expiry: RestrictionExpiry::EndOfTurn,
+                    activity: ProhibitedActivity::Attack {
+                        defended: crate::types::triggers::AttackTargetFilter::Player,
+                        protected_player: None,
+                    },
+                    ..
+                }
+            }
+        ));
+        assert!(matches!(
+            parsed.duration,
+            Some(Duration::UntilEndOfNextTurnOf {
+                player: PlayerScope::Controller,
+            })
+        ));
+    }
+
+    let connector =
+        parse_effect_chain("Then, they can't attack you this turn.", AbilityKind::Spell);
+    assert!(matches!(
+        connector.effect.as_ref(),
+        Effect::AddRestriction {
+            restriction: GameRestriction::ProhibitActivity {
+                affected_players: RestrictionPlayerScope::ParentTargetedPlayer,
+                expiry: RestrictionExpiry::EndOfTurn,
+                activity: ProhibitedActivity::Attack {
+                    defended: crate::types::triggers::AttackTargetFilter::Player,
+                    protected_player: None,
+                },
+                ..
+            }
+        }
+    ));
+    assert!(connector.duration.is_none());
+}
+
+#[test]
+fn scoped_cant_attack_prohibition_supports_both_verbs_and_all_defended_scopes() {
+    use crate::types::triggers::AttackTargetFilter;
+
+    for verb in ["can't", "cannot"] {
+        for (scope, expected_defended) in [
+            ("you", AttackTargetFilter::Player),
+            (
+                "you or planeswalkers you control",
+                AttackTargetFilter::PlayerOrPlaneswalker,
+            ),
+            (
+                "you or permanents you control",
+                AttackTargetFilter::PlayerOrPermanents,
+            ),
+        ] {
+            let text = format!(
+                "creatures that player controls {verb} attack {scope} until your next turn."
+            );
+            let parsed = parse_effect_chain(&text, AbilityKind::Spell);
+            assert!(
+                matches!(
+                    parsed.effect.as_ref(),
+                    Effect::AddRestriction {
+                        restriction: GameRestriction::ProhibitActivity {
+                            affected_players: RestrictionPlayerScope::ScopedPlayer,
+                            expiry: RestrictionExpiry::EndOfTurn,
+                            activity: ProhibitedActivity::Attack {
+                                defended,
+                                protected_player: None,
+                            },
+                            ..
+                        }
+                    } if *defended == expected_defended
+                ),
+                "expected scoped restriction for {text:?}, got {parsed:?}"
+            );
+            assert_eq!(
+                parsed.duration,
+                Some(Duration::UntilNextTurnOf {
+                    player: PlayerScope::Controller,
+                }),
+                "expected controller-next-turn expiry for {text:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn scoped_cant_attack_prohibition_fails_closed_without_its_complete_grammar() {
+    for text in [
+        "creatures that player controls can't attack you",
+        "creatures that player controls can't attack until your next turn",
+        "creatures that player controls can't attack you until your next turn or draw a card",
+    ] {
+        assert!(
+            try_parse_that_player_cant_attack_prohibition(TextPair::new(text, text)).is_none(),
+            "the bounded scoped form must reject {text:?}"
+        );
+    }
 }
 
 #[test]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -2606,6 +2606,12 @@ pub enum ProhibitedActivity {
     /// static `CantAttack` restrictions.
     Attack {
         defended: crate::types::triggers::AttackTargetFilter,
+        /// The player protected by this resolved restriction. New restrictions
+        /// snapshot this at resolution so they retain the trigger controller's
+        /// meaning of "you" after their source changes controller or leaves the
+        /// battlefield. `None` preserves the legacy source-controller lookup.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        protected_player: Option<PlayerId>,
     },
     /// CR 116.2a + CR 305.1 + CR 601.2a: Prohibit *playing* (casting a spell OR
     /// playing a land) cards located in `zone` for the affected players.

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -759,6 +759,7 @@ mod omniscience_free_cast_chalice_x;
 mod omniscience_free_cast_vexing_bauble;
 mod omo_queen_of_vesuva;
 mod oracle_parser;
+mod orzhov_advokist;
 mod overload_no_legal_target;
 mod oversimplify_per_player_fractal;
 mod ozolith_leaves_battlefield_counters;

--- a/crates/engine/tests/integration/orzhov_advokist.rs
+++ b/crates/engine/tests/integration/orzhov_advokist.rs
@@ -1,0 +1,330 @@
+//! Orzhov Advokist: each player may accept two counters, and only an accepting
+//! player's creatures are barred from attacking the trigger controller and that
+//! controller's planeswalkers until the controller's next turn.
+
+use engine::game::combat::{declare_attackers, AttackTarget};
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::game::triggers::process_triggers;
+use engine::game::turns::execute_untap;
+use engine::game::zones::{create_object, move_to_zone};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, ControllerRef, Duration, Effect, GameRestriction, PlayerFilter, PlayerScope,
+    ProhibitedActivity, RestrictionExpiry, RestrictionPlayerScope, TargetFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::triggers::AttackTargetFilter;
+use engine::types::zones::Zone;
+
+const ORZHOV_ADVOKIST_ORACLE: &str = "At the beginning of your upkeep, each player may put two +1/+1 counters on a creature they control. If a player does, creatures that player controls can't attack you or planeswalkers you control until your next turn.";
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+const P2: PlayerId = PlayerId(2);
+
+fn find_attack_restriction(definition: &AbilityDefinition) -> Option<&AbilityDefinition> {
+    if matches!(
+        definition.effect.as_ref(),
+        Effect::AddRestriction {
+            restriction: GameRestriction::ProhibitActivity {
+                activity: ProhibitedActivity::Attack { .. },
+                ..
+            },
+        }
+    ) {
+        return Some(definition);
+    }
+    definition
+        .sub_ability
+        .as_deref()
+        .and_then(find_attack_restriction)
+}
+
+#[test]
+fn orzhov_advokist_parser_keeps_scoped_player_and_trigger_controller_distinct() {
+    let parsed = parse_oracle_text(
+        ORZHOV_ADVOKIST_ORACLE,
+        "Orzhov Advokist",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Advisor".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find_map(|trigger| trigger.execute.as_deref())
+        .expect("Orzhov Advokist has an upkeep trigger");
+
+    assert!(trigger.optional, "each player may choose independently");
+    assert_eq!(trigger.player_scope, Some(PlayerFilter::All));
+    assert!(matches!(
+        trigger.effect.as_ref(),
+        Effect::PutCounter {
+            counter_type: CounterType::Plus1Plus1,
+            target: TargetFilter::Typed(TypedFilter {
+                controller: Some(ControllerRef::ScopedPlayer),
+                ..
+            }),
+            ..
+        }
+    ));
+
+    let restriction = find_attack_restriction(trigger)
+        .expect("the accepting-player rider must lower to an attack restriction");
+    assert_eq!(
+        restriction.duration,
+        Some(Duration::UntilNextTurnOf {
+            player: PlayerScope::Controller,
+        })
+    );
+    assert!(matches!(
+        restriction.effect.as_ref(),
+        Effect::AddRestriction {
+            restriction: GameRestriction::ProhibitActivity {
+                source: ObjectId(0),
+                affected_players: RestrictionPlayerScope::ScopedPlayer,
+                expiry: RestrictionExpiry::EndOfTurn,
+                activity: ProhibitedActivity::Attack {
+                    defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                    protected_player: None,
+                },
+            },
+        }
+    ));
+}
+
+fn plus_counters(runner: &GameRunner, object: ObjectId) -> u32 {
+    runner.state().objects[&object]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn add_creature(state: &mut GameState, controller: PlayerId, name: &str) -> ObjectId {
+    let card = CardId(state.next_object_id);
+    let object = create_object(state, card, controller, name.to_string(), Zone::Battlefield);
+    let creature = state.objects.get_mut(&object).expect("created object");
+    creature.card_types.core_types = vec![CoreType::Creature];
+    creature.base_card_types = creature.card_types.clone();
+    creature.power = Some(2);
+    creature.toughness = Some(2);
+    creature.base_power = Some(2);
+    creature.base_toughness = Some(2);
+    creature.summoning_sick = false;
+    object
+}
+
+fn attack_is_legal(
+    state: &GameState,
+    controller: PlayerId,
+    attacker: ObjectId,
+    target: AttackTarget,
+) -> bool {
+    let mut state = state.clone();
+    state.active_player = controller;
+    let mut events = Vec::new();
+    declare_attackers(&mut state, &[(attacker, target)], &mut events).is_ok()
+}
+
+/// Drive the real phase-trigger and optional-effect pipeline. P0 and P2 decline;
+/// P1 accepts and selects their first creature for the two counters.
+fn resolve_advokist_upkeep(
+    runner: &mut GameRunner,
+    source: ObjectId,
+    p1_creature_a: ObjectId,
+    p1_creature_b: ObjectId,
+) {
+    process_triggers(
+        runner.state_mut(),
+        &[GameEvent::PhaseChanged {
+            phase: Phase::Upkeep,
+        }],
+    );
+
+    let mut optional_players = Vec::new();
+    for _ in 0..96 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice {
+                player, source_id, ..
+            } => {
+                assert_eq!(source_id, source, "each offer comes from Advokist");
+                optional_players.push(player);
+                runner
+                    .act(GameAction::DecideOptionalEffect {
+                        accept: player == P1,
+                    })
+                    .expect("answering an Advokist optional offer succeeds");
+            }
+            WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+                assert_eq!(player, P1, "the accepting player chooses their creature");
+                assert!(cards.contains(&p1_creature_a) && cards.contains(&p1_creature_b));
+                runner
+                    .act(GameAction::SelectCards {
+                        cards: vec![p1_creature_a],
+                    })
+                    .expect("P1 can select their creature for the counters");
+            }
+            WaitingFor::TargetSelection { .. } | WaitingFor::TriggerTargetSelection { .. } => {
+                runner
+                    .act(GameAction::ChooseTarget {
+                        target: Some(engine::types::ability::TargetRef::Object(p1_creature_a)),
+                    })
+                    .expect("P1 can target their creature for the counters");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => {
+                assert_eq!(optional_players, vec![P0, P1, P2]);
+                return;
+            }
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("priority progresses the upkeep trigger");
+            }
+            other => panic!("unexpected Advokist resolution state: {other:?}"),
+        }
+    }
+    panic!("Advokist trigger did not finish within the resolution budget");
+}
+
+#[test]
+fn orzhov_advokist_restriction_tracks_acceptance_controller_changes_and_expiry() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::Upkeep);
+    let advokist = scenario
+        .add_creature_from_oracle(P0, "Orzhov Advokist", 1, 4, ORZHOV_ADVOKIST_ORACLE)
+        .id();
+    let _p0_creature = scenario.add_creature(P0, "P0 Bear", 2, 2).id();
+    let p1_creature_a = scenario.add_creature(P1, "P1 Bear A", 2, 2).id();
+    let p1_creature_b = scenario.add_creature(P1, "P1 Bear B", 2, 2).id();
+    let p2_creature = scenario.add_creature(P2, "P2 Bear", 2, 2).id();
+    let p0_planeswalker = scenario
+        .add_creature(P0, "P0 Walker", 0, 0)
+        .as_planeswalker_with_loyalty("Test", 4)
+        .id();
+
+    let mut runner = scenario.build();
+    for object in [p1_creature_a, p1_creature_b, p2_creature] {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&object)
+            .unwrap()
+            .summoning_sick = false;
+    }
+    resolve_advokist_upkeep(&mut runner, advokist, p1_creature_a, p1_creature_b);
+
+    assert_eq!(plus_counters(&runner, p1_creature_a), 2);
+    assert_eq!(plus_counters(&runner, p1_creature_b), 0);
+    assert_eq!(runner.state().restrictions.len(), 1);
+    assert!(matches!(
+        &runner.state().restrictions[0],
+        GameRestriction::ProhibitActivity {
+            source,
+            affected_players: RestrictionPlayerScope::SpecificPlayer(P1),
+            expiry: RestrictionExpiry::UntilPlayerNextTurn { player: P0 },
+            activity: ProhibitedActivity::Attack {
+                defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                protected_player: Some(P0),
+            },
+        } if *source == advokist
+    ));
+
+    // CR 508.1c / CR 508.1d: P1 alone is barred from attacking P0 and P0's
+    // planeswalker; attacking P2 remains legal, as does P2 attacking P0.
+    assert!(!attack_is_legal(
+        runner.state(),
+        P1,
+        p1_creature_a,
+        AttackTarget::Player(P0)
+    ));
+    assert!(!attack_is_legal(
+        runner.state(),
+        P1,
+        p1_creature_a,
+        AttackTarget::Planeswalker(p0_planeswalker)
+    ));
+    assert!(attack_is_legal(
+        runner.state(),
+        P1,
+        p1_creature_a,
+        AttackTarget::Player(P2)
+    ));
+    assert!(attack_is_legal(
+        runner.state(),
+        P2,
+        p2_creature,
+        AttackTarget::Player(P0)
+    ));
+
+    // CR 611.2c: later P1 creatures and a creature P2 gives to P1 are both
+    // affected while the rule-modifying restriction lasts.
+    let later_p1_creature = add_creature(runner.state_mut(), P1, "Later P1 Bear");
+    assert!(!attack_is_legal(
+        runner.state(),
+        P1,
+        later_p1_creature,
+        AttackTarget::Player(P0)
+    ));
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&p2_creature)
+        .unwrap()
+        .controller = P1;
+    assert!(!attack_is_legal(
+        runner.state(),
+        P1,
+        p2_creature,
+        AttackTarget::Player(P0)
+    ));
+
+    // The source changing controller and leaving cannot rewrite the trigger's
+    // "you": the resolved restriction still protects P0.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&advokist)
+        .unwrap()
+        .controller = P2;
+    let mut leave_events = Vec::new();
+    move_to_zone(
+        runner.state_mut(),
+        advokist,
+        Zone::Graveyard,
+        &mut leave_events,
+    );
+    assert_eq!(runner.state().objects[&advokist].zone, Zone::Graveyard);
+    assert!(!attack_is_legal(
+        runner.state(),
+        P1,
+        p1_creature_a,
+        AttackTarget::Player(P0)
+    ));
+    assert!(attack_is_legal(
+        runner.state(),
+        P1,
+        p1_creature_a,
+        AttackTarget::Player(P2)
+    ));
+
+    // CR 514.2: expiry occurs at P0's next turn, not P1's next turn.
+    runner.state_mut().active_player = P0;
+    runner.state_mut().turn_number += 3;
+    let mut untap_events = Vec::new();
+    execute_untap(runner.state_mut(), &mut untap_events);
+    assert!(runner.state().restrictions.is_empty());
+    assert!(attack_is_legal(
+        runner.state(),
+        P1,
+        p1_creature_a,
+        AttackTarget::Player(P0)
+    ));
+}

--- a/crates/engine/tests/integration/rules/combat.rs
+++ b/crates/engine/tests/integration/rules/combat.rs
@@ -2461,6 +2461,7 @@ fn temporary_attack_prohibition_bars_only_the_protected_player() {
                 expiry: RestrictionExpiry::EndOfTurn,
                 activity: ProhibitedActivity::Attack {
                     defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                    protected_player: None,
                 },
             });
         park_3p_declare(&mut runner, &[attacker]);

--- a/crates/engine/tests/integration/sandswirl_wanderglyph_attacked_you_cant_cast.rs
+++ b/crates/engine/tests/integration/sandswirl_wanderglyph_attacked_you_cant_cast.rs
@@ -186,6 +186,7 @@ fn full_card_parses_both_clauses_no_unimplemented() {
                 restriction: GameRestriction::ProhibitActivity {
                     activity: ProhibitedActivity::Attack {
                         defended: AttackTargetFilter::PlayerOrPlaneswalker,
+                        protected_player: None,
                     },
                     // CR 514.2: "… this turn" expires at the CURRENT turn's cleanup
                     // (`RestrictionExpiry::EndOfTurn`), NOT a permanent restriction and

--- a/crates/engine/tests/integration/willie_lumpkin_cant_attack.rs
+++ b/crates/engine/tests/integration/willie_lumpkin_cant_attack.rs
@@ -72,7 +72,7 @@ fn willie_cant_attack_clause_parses_to_player_scoped_prohibition() {
             restriction:
                 GameRestriction::ProhibitActivity {
                     affected_players,
-                    activity: ProhibitedActivity::Attack { defended },
+                    activity: ProhibitedActivity::Attack { defended, .. },
                     ..
                 },
         } => {
@@ -145,6 +145,7 @@ fn board_with_restriction() -> (GameState, ObjectId, ObjectId, ObjectId, ObjectI
                 expiry: RestrictionExpiry::EndOfTurn,
                 activity: ProhibitedActivity::Attack {
                     defended: AttackTargetFilter::PlayerOrPermanents,
+                    protected_player: None,
                 },
             },
         },


### PR DESCRIPTION
## Summary

Adds full engine support for Orzhov Advokist's upkeep choice and its accepting-player combat restriction. The resolved restriction snapshots the trigger controller while retaining the accepting player, so it remains correct through control changes and source departure.

## Files changed

- `crates/engine/src/types/ability.rs` — persist the protected player on temporary attack restrictions.
- `crates/engine/src/game/effects/add_restriction.rs` — bind scoped player, protected controller, and next-turn expiry at resolution.
- `crates/engine/src/game/combat.rs` — enforce the snapshot-backed prohibition with legacy fallback.
- `crates/engine/src/parser/oracle_effect/mod.rs` — extend the shared temporary attack-prohibition parser.
- `crates/engine/src/parser/oracle_effect/tests.rs` — cover scoped grammar, verb/scope matrix, legacy forms, and rejection boundaries.
- `crates/engine/tests/integration/orzhov_advokist.rs` — exercise the real multiplayer trigger, choice, combat, source-change, and expiry flow.
- `crates/engine/tests/integration/main.rs` — register the integration test.
- `crates/engine/tests/integration/rules/combat.rs` — update the attack-prohibition constructor.
- `crates/engine/tests/integration/sandswirl_wanderglyph_attacked_you_cant_cast.rs` — update the attack-prohibition constructor.
- `crates/engine/tests/integration/willie_lumpkin_cant_attack.rs` — update the attack-prohibition constructor.

## Track

Developer

## LLM

Model: gpt-5.6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 109.5, CR 508.1c, CR 608.2c, CR 611.2c, CR 514.2, CR 500.7.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — exit 0.
- `cargo clippy-strict` — exit 0.
- `cargo test -p engine` — 4,076 passed; 0 failed; 2 ignored.
- `./scripts/gen-card-data.sh` — exit 0.
- `cargo coverage` — exit 0; Orzhov Advokist is supported with `gap_count: 0`.
- `cargo semantic-audit` — exit 0.
- `./scripts/check-parser-combinators.sh` — `Gate A PASS head=37cf80b4343cb96f7ea04684b19fff5e366c496f base=6895ca39a2b1017ceec96c25fb8141d0ee6847a7`.

## Gate A

Gate A PASS head=37cf80b4343cb96f7ea04684b19fff5e366c496f base=6895ca39a2b1017ceec96c25fb8141d0ee6847a7

## Anchored on

- `crates/engine/src/parser/oracle_static/shared.rs:5821` — shared `parse_cant_attack_defended_scope_nom` authority reused for every defended-target form.
- `crates/engine/src/parser/oracle_effect/mod.rs:4200` — existing bounded nom parser that lowers a temporary prohibition with a controller-relative duration.

## Final review-impl

Final review-impl PASS head=37cf80b4343cb96f7ea04684b19fff5e366c496f

## Claimed parse impact

Orzhov Advokist.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Temporary “can’t/cannot attack” restrictions now preserve the correct “you” player context, including when control changes or the source leaves play.
  - Expiration tied to “until/at your next turn” now ends at the correct time.
  - Improved handling of temporary attack prohibitions for player-scoped and defended-scope cases.

- **Tests**
  - Added new integration coverage for Orzhov Advokist-style each-player behavior and trigger/controller changes.
  - Updated existing tests and assertions to match the enhanced restriction structure and parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->