### PR TITLE
fix(engine): bind interaction authority so viewer interaction is not inert

### DIFF
--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -2986,7 +2986,7 @@ function projectedManaChoiceLabel(t: TFunction<"game">, surfaces: InteractionPre
   };
 }
 
-function projectedManaChoices(
+export function projectedManaChoices(
   interaction: ViewerInteraction | null,
   objectId: ObjectId,
 ): Map<string, InteractionPresentationSurface[]> {

--- a/client/src/pages/__tests__/GamePage.projectedManaChoices.test.ts
+++ b/client/src/pages/__tests__/GamePage.projectedManaChoices.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import { projectedManaChoices } from "../GamePage";
+import type {
+  InteractionActionId,
+  InteractionChoice,
+  InteractionChoiceId,
+  InteractionId,
+  InteractionPresentationSurface,
+  ViewerInteraction,
+} from "../../adapter/generated/interaction";
+import type { ObjectId } from "../../adapter/types";
+
+const FOREST: ObjectId = 42;
+const MOUNTAIN: ObjectId = 43;
+
+function tapChoice(actionId: string, source: ObjectId, symbol: string): InteractionChoice {
+  const surfaces: InteractionPresentationSurface[] = [
+    {
+      type: "action",
+      data: { code: "tapLandForMana", actionId: actionId as InteractionActionId },
+    },
+    {
+      type: "object",
+      data: {
+        role: "source",
+        index: null,
+        reference: String(source),
+        name: null,
+        zone: "battlefield",
+        controller: 0,
+        power: null,
+        tapped: false,
+      },
+    },
+    {
+      type: "mana",
+      data: { role: "producedMana", index: null, symbols: [symbol], restrictions: [] },
+    },
+  ];
+  return {
+    id: `${actionId}-choice` as InteractionChoiceId,
+    surfaces,
+    status: { type: "available" },
+  };
+}
+
+function interactionWith(choices: InteractionChoice[]): ViewerInteraction {
+  return {
+    waitingForKind: { simultaneous: null, terminal: false, code: "choose" },
+    authorizedSubmitters: [0],
+    canSubmit: true,
+    autoPassRecommended: false,
+    opportunities: [
+      {
+        interactionId: "session.0.1" as InteractionId,
+        response: { type: "exactChoices", data: { choices } },
+        surfaces: [],
+        progress: {
+          selected: 0,
+          minimum: 1,
+          maximum: 1,
+          aggregate: null,
+          confirmable: false,
+        },
+      },
+    ],
+    availability: { type: "inputRequired" },
+  };
+}
+
+describe("projectedManaChoices", () => {
+  it("keys each tapLandForMana choice by its action id", () => {
+    const choices = projectedManaChoices(
+      interactionWith([tapChoice("act-green", FOREST, "G")]),
+      FOREST,
+    );
+
+    expect([...choices.keys()]).toEqual(["act-green"]);
+    expect(choices.get("act-green")).toContainEqual({
+      type: "mana",
+      data: { role: "producedMana", index: null, symbols: ["G"], restrictions: [] },
+    });
+  });
+
+  it("returns only the choices whose source surface is the requested object", () => {
+    const interaction = interactionWith([
+      tapChoice("act-green", FOREST, "G"),
+      tapChoice("act-red", MOUNTAIN, "R"),
+    ]);
+
+    expect([...projectedManaChoices(interaction, FOREST).keys()]).toEqual(["act-green"]);
+    expect([...projectedManaChoices(interaction, MOUNTAIN).keys()]).toEqual(["act-red"]);
+  });
+
+  // An engine whose interaction authority is unbound reports
+  // `availability: unsupported { authorityUnbound }` and — critically — an empty
+  // `opportunities` list, which is what the mana choice modal received for as
+  // long as no production code path called `bind_interaction_authority`. This
+  // pins the resulting behaviour so a future regression is visible as a silently
+  // unlabelled modal rather than an error.
+  it("yields nothing when the engine reports no opportunities", () => {
+    const unbound: ViewerInteraction = {
+      ...interactionWith([]),
+      opportunities: [],
+      availability: { type: "unsupported", data: { reason: "authorityUnbound" } },
+    };
+
+    expect(projectedManaChoices(unbound, FOREST).size).toBe(0);
+    expect(projectedManaChoices(null, FOREST).size).toBe(0);
+  });
+});

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -16,6 +16,7 @@ use engine::game::engine::{
     apply, apply_for_simulation, resolve_all_fast_forward, ResolveAllCallbackDecision,
     ResolveAllFastForwardResult as BatchResolveResult,
 };
+use engine::game::interaction::bind_interaction_authority;
 use engine::game::preview::{compute_preview_diff, preview_auto_payment_sources};
 use engine::game::{
     can_pair_commanders, companion_candidates, deck_copy_limit_for, estimate_bracket,
@@ -29,6 +30,7 @@ use engine::game::{
 use engine::types::format::{DeckCopyLimit, FormatConfig, GameFormat};
 use engine::types::game_state::{PersistedGameState, TrustedGameStateEnvelope, WaitingFor};
 use engine::types::identifiers::ObjectId;
+use engine::types::interaction::InteractionSessionId;
 use engine::types::mana::ManaCost;
 use engine::types::match_config::MatchConfig;
 use engine::types::{GameAction, GameState, PlayerId, ReplayHeader, ReplayLog};
@@ -42,6 +44,34 @@ fn decode_restored_game_state(json_str: &str) -> Result<GameState, JsValue> {
     serde_json::from_str::<PersistedGameState>(json_str)
         .map(PersistedGameState::into_game_state)
         .map_err(|e| JsValue::from_str(&format!("Failed to deserialize GameState: {e}")))
+}
+
+/// Bind the engine's interaction authority for the one game this module hosts.
+///
+/// Both `GameState::new` and the persisted decode leave `interaction_session_id`
+/// as `None`, and while it is unset `derive_viewer_interaction` reports
+/// `AuthorityUnbound` and returns no opportunities at all — so every interaction
+/// surface goes dark. `ensure_interaction_authority` cannot repair this: it only
+/// *maintains* an already-bound session, and clears the slots when there is none.
+///
+/// Always a fresh random id, never the one carried in a restored blob. The id is
+/// the namespace of every minted `InteractionId` (`"{session}.{generation}.{serial}"`),
+/// and re-binding the *same* session deliberately preserves the counters — so
+/// reusing a snapshot's id after an undo would re-issue ids already handed out on
+/// the abandoned branch. A new namespace makes that collision impossible, and
+/// matches server-core's rule that a persisted blob must not drive live authority.
+///
+/// Failure needs no log here (unlike server-core, which has `tracing`): the only
+/// way to get one is decimal-serial exhaustion, so this uses the same
+/// `debug_assert` discipline as `ensure_interaction_authority` itself rather than
+/// pulling `web_sys` into a size-optimized WASM artifact for an unreachable arm.
+fn bind_interaction_session(state: &mut GameState) {
+    let session = InteractionSessionId(format!("wasm-{:016x}", rand::rng().random::<u64>()));
+    let bound = bind_interaction_authority(state, session);
+    debug_assert!(
+        bound.is_ok(),
+        "interaction authority bind failed: {bound:?}"
+    );
 }
 
 /// Result of `get_legal_actions_js` — bundles actions with the engine's auto-pass
@@ -914,6 +944,11 @@ pub fn initialize_game(
     };
     REPLAY_LOG.with(|cell| cell.set(Some(ReplayLog::new(replay_header))));
 
+    // After `start_game`, so the slots bound here match the pause the caller is
+    // about to be handed — `bind_all_current_slots` binds for the *current*
+    // `waiting_for`, and nothing re-derives it until the first action boundary.
+    bind_interaction_session(&mut state);
+
     GAME_STATE.with(|cell| cell.set(Some(state)));
     clear_ai_session_cache();
 
@@ -1549,6 +1584,7 @@ pub fn restore_game_state(json_str: &str) -> Result<(), JsValue> {
         }
     });
     finalize_public_state(&mut state);
+    bind_interaction_session(&mut state);
     GAME_STATE.with(|cell| cell.set(Some(state)));
     // Restoring (undo, or resuming a save from a fresh worker that never saw
     // `initialize_game`) invalidates any in-progress recording — the restored
@@ -1617,6 +1653,7 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<(), JsValue> {
         }
     });
     finalize_public_state(&mut state);
+    bind_interaction_session(&mut state);
 
     GAME_STATE.with(|cell| cell.set(Some(state)));
     MULTIPLAYER_MODE.with(|cell| cell.set(true));

--- a/crates/engine/src/game/match_flow.rs
+++ b/crates/engine/src/game/match_flow.rs
@@ -451,6 +451,17 @@ fn restart_between_games_with_starting_player(
     next_state.debug_mode = state.debug_mode;
     next_state.debug_permitted = state.debug_permitted.clone();
 
+    // Interaction authority is likewise a property of the match, not of a single
+    // game, and has the identical failure shape: `GameState::new` leaves
+    // `interaction_session_id` as `None`, and while it is unset
+    // `derive_viewer_interaction` yields no opportunities at all — so without this
+    // carry every interaction surface silently goes dark from game 2 onward.
+    //
+    // Captured before the rebuild overwrites `state`, and re-applied after
+    // `waiting_for` is final (below) rather than copied field-by-field, so the
+    // slots the engine binds match the new game's pause.
+    let interaction_session = state.interaction_session_id.clone();
+
     load_deck_into_state(&mut next_state, &payload);
     let start = super::engine::start_game_with_starting_player(&mut next_state, starting_player);
     events.extend(start.events);
@@ -458,6 +469,12 @@ fn restart_between_games_with_starting_player(
     let waiting_for = start.waiting_for.clone();
     *state = next_state;
     state.waiting_for = waiting_for.clone();
+    if let Some(session) = interaction_session {
+        // Same `debug_assert` discipline as `ensure_interaction_authority`: the only
+        // failure is decimal-serial exhaustion, which must not fail a live match.
+        let bound = super::interaction::bind_interaction_authority(state, session);
+        debug_assert!(bound.is_ok(), "between-games interaction rebind failed");
+    }
     Ok(waiting_for)
 }
 
@@ -1220,5 +1237,78 @@ mod tests {
             CommanderBracketTier::Cedh,
             "AI seat bracket_tier (Cedh) must be propagated — not silently dropped"
         );
+    }
+
+    /// Game 2 of a Bo3 is a fresh `GameState::new`, which defaults
+    /// `interaction_session_id` to `None`. Without an explicit carry, every
+    /// interaction surface reports `AuthorityUnbound` from game 2 onward — the
+    /// same silent-from-game-2 failure the `debug_mode` carry above exists to
+    /// prevent.
+    #[test]
+    fn between_games_restart_carries_interaction_authority() {
+        use crate::game::interaction::bind_interaction_authority;
+        use crate::types::game_state::PlayerDeckPool;
+        use crate::types::interaction::InteractionSessionId;
+
+        let mut state = GameState::new_two_player(21);
+        state.match_config.match_type = MatchType::Bo3;
+        state.match_phase = MatchPhase::BetweenGames;
+        state.next_game_chooser = Some(PlayerId(0));
+        state.deck_pools = vec![
+            PlayerDeckPool {
+                player: PlayerId(0),
+                current_main: std::sync::Arc::new(vec![entry("P0", 40)]),
+                ..Default::default()
+            },
+            PlayerDeckPool {
+                player: PlayerId(1),
+                current_main: std::sync::Arc::new(vec![entry("P1", 40)]),
+                ..Default::default()
+            },
+        ];
+
+        let session = InteractionSessionId("match-authority-carry".to_string());
+        bind_interaction_authority(&mut state, session.clone())
+            .expect("game 1 binds authority the way its creator does");
+
+        let mut events = Vec::new();
+        handle_choose_play_draw(&mut state, PlayerId(0), true, &mut events)
+            .expect("game 2 of the Bo3 must start");
+
+        // The rebuild replaces `state` wholesale with a `GameState::new`, so if
+        // that constructor ever started binding authority itself the assertion
+        // below would pass without the carry existing at all.
+        assert_eq!(
+            GameState::new(state.format_config.clone(), 2, 1).interaction_session_id,
+            None,
+            "probe is vacuous: a freshly constructed state is already bound, so \
+             the carry is no longer what makes the next assertion hold"
+        );
+
+        assert_eq!(
+            state.interaction_session_id.as_ref(),
+            Some(&session),
+            "the rebuilt game must keep the match's session; `GameState::new` \
+             leaves it None, so this is None without the carry"
+        );
+
+        // The carry re-binds rather than copying the old slots, so the slots must
+        // describe game 2's pause — stale game-1 slots would authorize decisions
+        // that no longer exist.
+        let acting = state.waiting_for.acting_players();
+        assert!(
+            !acting.is_empty(),
+            "fixture must land on a pause with an acting player, or the slot \
+             assertions below prove nothing"
+        );
+        for owner in acting {
+            assert!(
+                state
+                    .active_interaction_slots
+                    .iter()
+                    .any(|slot| slot.semantic_owner == owner.0),
+                "no slot bound for {owner:?}, who is acting in game 2"
+            );
+        }
     }
 }

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -8,6 +8,7 @@ use engine::database::CardDatabase;
 use engine::game::deck_loading::{DeckPayload, PlayerDeckPayload};
 use engine::game::engine::{apply, start_game};
 use engine::game::finalize_public_state;
+use engine::game::interaction::bind_interaction_authority;
 use engine::game::preview::preview_auto_payment_sources;
 use engine::game::{load_and_hydrate_decks, rehydrate_game_from_card_db};
 use engine::types::actions::GameAction;
@@ -15,6 +16,7 @@ use engine::types::events::GameEvent;
 use engine::types::format::FormatConfig;
 use engine::types::game_state::{GameState, PersistedGameState};
 use engine::types::identifiers::ObjectId;
+use engine::types::interaction::InteractionSessionId;
 use engine::types::log::GameLogEntry;
 use engine::types::mana::ManaCost;
 use engine::types::match_config::MatchConfig;
@@ -30,6 +32,37 @@ use crate::persist::{PersistedLobbyMeta, PersistedSession};
 use crate::protocol::PlayerSlotInfo;
 use crate::reconnect::ReconnectManager;
 use crate::takeback::PendingTakeback;
+
+/// Bind the engine's interaction authority to a freshly created or restored state.
+///
+/// Every server-side `GameState` must pass through here. `GameState::new` leaves
+/// `interaction_session_id` as `None`, and while it is unset
+/// `derive_viewer_interaction` short-circuits to `AuthorityUnbound` with zero
+/// opportunities — so every interaction-driven client surface silently goes dark.
+/// `ensure_interaction_authority` cannot repair this: it only *maintains* slots for
+/// an already-bound session, and clears them when the session is absent.
+///
+/// The game code is a sound session id: non-empty and far under the 128-byte limit.
+/// Uniqueness only has to hold *within* a state — the id namespaces that state's
+/// interaction ids and detects stale ones — so `generate_game_code`'s lack of a
+/// collision check (6 random chars) is not a concern here. Nor is guessability:
+/// `slot_for_submission` authorizes against the authenticated actor, never this id.
+///
+/// Always re-bind on restore rather than trusting an id carried in a persisted blob,
+/// matching how this module re-stamps `hosting` and revokes unentitled debug capability.
+fn bind_interaction_session(state: &mut GameState, game_code: &str) {
+    if let Err(error) =
+        bind_interaction_authority(state, InteractionSessionId(game_code.to_string()))
+    {
+        // Reachable only on decimal-serial exhaustion, so failing the game would be
+        // disproportionate — but degrading silently is the very defect this fixes.
+        warn!(
+            game = %game_code,
+            code = ?error.code,
+            "failed to bind interaction authority; interaction surfaces unavailable for this session"
+        );
+    }
+}
 
 /// Result of handling a game action: raw state snapshot, events, legal actions, log entries,
 /// auto-pass flag, spell costs, and per-object action grouping.
@@ -361,6 +394,9 @@ impl GameSession {
         };
         self.state.set_match_config(match_config);
         self.seed_debug_capability();
+        // `GameState::new` above reset the authority to `None`, exactly as it reset
+        // the debug capability that `seed_debug_capability` restores.
+        bind_interaction_session(&mut self.state, &self.game_code);
     }
 
     /// Seeds `debug_mode` / `debug_permitted` for the state just built by
@@ -784,6 +820,10 @@ impl GameSession {
         state.rng_seed = fresh_seed;
         state.rng = rand_chacha::ChaCha20Rng::seed_from_u64(fresh_seed);
         finalize_public_state(&mut state);
+        // Re-bind rather than trusting any id the blob carries, on the same
+        // principle that `restore_session` re-stamps `hosting` and revokes an
+        // unentitled debug capability: a persisted blob never drives authority.
+        bind_interaction_session(&mut state, &ps.game_code);
 
         let ai_seats: HashSet<PlayerId> = ps.ai_seats.iter().map(|&s| PlayerId(s)).collect();
 
@@ -942,6 +982,8 @@ impl SessionManager {
                 state.debug_permitted.insert(PlayerId(i));
             }
         }
+
+        bind_interaction_session(&mut state, &game_code);
 
         let session = GameSession {
             game_code: game_code.clone(),
@@ -1440,6 +1482,7 @@ mod tests {
     use engine::database::card_db::CardDatabase;
     use engine::game::deck_loading::DeckEntry;
     use engine::game::engine::apply;
+    use engine::game::interaction::derive_viewer_interaction;
     use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
     use engine::game::scenario_db::GameScenarioDbExt;
     use engine::types::ability::TargetRef;
@@ -1447,6 +1490,7 @@ mod tests {
     use engine::types::card::CardFace;
     use engine::types::card_type::CardType;
     use engine::types::game_state::{CastPaymentMode, PersistedGameState, WaitingFor};
+    use engine::types::interaction::{InteractionAvailability, InteractionReasonCode};
     use engine::types::mana::ManaCost;
     use engine::types::phase::{Phase, PhaseStop, PhaseStopScope};
     use engine::types::zones::Zone;
@@ -1518,6 +1562,98 @@ mod tests {
         assert!(result.is_ok());
         let (token2, _state) = result.unwrap();
         assert_eq!(token2.len(), 32);
+    }
+
+    /// `GameState::new` leaves `interaction_session_id` as `None`, and while it is
+    /// unset every `derive_viewer_interaction` call returns `AuthorityUnbound` with
+    /// zero opportunities. Nothing self-heals it: `ensure_interaction_authority`
+    /// only maintains slots for an already-bound session.
+    #[test]
+    fn created_session_binds_interaction_authority() {
+        let mut mgr = SessionManager::new();
+        let (code, _token) = mgr.create_game(make_deck());
+
+        assert_eq!(
+            mgr.sessions
+                .get(&code)
+                .unwrap()
+                .state
+                .interaction_session_id,
+            Some(InteractionSessionId(code.clone())),
+            "a created session must carry interaction authority"
+        );
+    }
+
+    /// The behavioural half: authority actually reaches `derive_viewer_interaction`.
+    ///
+    /// Guarded against vacuity in-test. `derive_viewer_interaction` checks terminal
+    /// and `can_submit` *before* the authority check, so a state that never reaches
+    /// the third guard would pass this trivially. Clearing the binding on a copy and
+    /// asserting the unbound verdict *does* appear proves the assertion discriminates.
+    #[test]
+    fn bound_session_does_not_report_authority_unbound() {
+        let mut mgr = SessionManager::new();
+        let (code, _token) = mgr.create_game(make_deck());
+        mgr.join_game(&code, make_deck())
+            .expect("second seat joins");
+
+        let state = mgr.sessions.get(&code).unwrap().state.clone();
+        let filtered = filter_state_for_player(&state, PlayerId(0));
+
+        let unbound_reason = InteractionAvailability::Unsupported {
+            reason: InteractionReasonCode::AuthorityUnbound,
+        };
+
+        let bound = derive_viewer_interaction(&state, &filtered, PlayerId(0));
+        assert_ne!(
+            bound.availability, unbound_reason,
+            "a bound session must not report AuthorityUnbound"
+        );
+
+        // Clearing the slots alongside the session is not cosmetic: the engine
+        // asserts that an unbound state holds no slots
+        // (`debug_assert_interaction_consistency`), and clearing them is exactly
+        // what the unbound production path did before this fix
+        // (`ensure_interaction_authority`). Dropping only the session id builds a
+        // state the engine considers impossible.
+        let mut stripped = state.clone();
+        stripped.interaction_session_id = None;
+        stripped.active_interaction_slots.clear();
+        let unbound = derive_viewer_interaction(&stripped, &filtered, PlayerId(0));
+        assert_eq!(
+            unbound.availability, unbound_reason,
+            "probe is vacuous: this state does not reach the authority check at all, \
+             so the assertion above proves nothing"
+        );
+    }
+
+    /// A restored blob must be re-bound, not trusted. Mirrors how `restore_session`
+    /// re-stamps `hosting` and revokes an unentitled debug capability.
+    ///
+    /// The blob is deliberately poisoned with a foreign session id first. Without
+    /// that step the test would be vacuous: `interaction_session_id` is an ordinary
+    /// serialized field, so a snapshot of an already-bound session round-trips its
+    /// id and the assertion would hold whether or not `from_persisted` re-binds.
+    #[test]
+    fn restored_session_rebinds_interaction_authority() {
+        let mut mgr = SessionManager::new();
+        let (code, _token) = mgr.create_game(make_deck());
+        mgr.sessions
+            .get_mut(&code)
+            .unwrap()
+            .state
+            .interaction_session_id = Some(InteractionSessionId("some-other-game".to_string()));
+        let persisted = mgr.sessions.get(&code).unwrap().to_persisted();
+
+        let db = CardDatabase::default();
+        let restored = GameSession::from_persisted(persisted, &db);
+
+        assert_eq!(
+            restored.state.interaction_session_id,
+            Some(InteractionSessionId(code)),
+            "the restored session's authority must come from the game code, not \
+             from whatever id the persisted blob happened to carry"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`bind_interaction_authority` had zero production callers — every call site
was in `tests/integration/interaction_contract.rs`. `GameState::new` leaves
`interaction_session_id` as `None`, and while it is unset
`derive_viewer_interaction` short-circuits past the terminal and `can_submit`
guards to `opportunities: []` + `Unsupported { AuthorityUnbound }`. That fired
at all 11 production call sites (phase-server x8, engine-wasm x3): the
subsystem was plumbed end-to-end and permanently dark.

`ensure_interaction_authority` cannot repair it. It only *maintains* slots for
an already-bound session, and with no session it clears them and returns —
which is exactly why nothing self-healed.

Bind at every site that constructs or restores a state:

  server-core   create_game_n_players (covers create_game,
                _with_settings, _with_ai), rebuild_pregame_state,
                from_persisted
  engine        the Bo3 between-games rebuild, next to the `debug_mode`
                carry whose comment records the identical failure shape:
                "without an explicit carry the sandbox panel silently
                stops working from game 2 onward"
  engine-wasm   initialize_game, restore_game_state,
                resume_multiplayer_host_state

Restores re-bind rather than trusting an id carried in a persisted blob,
following this module's established rule — `restore_session` already
re-stamps `hosting` and revokes an unentitled debug capability on the
principle that a blob must not drive live authority.

engine-wasm mints a fresh random id per bind instead of reusing the game
code. The session id is the namespace of every minted `InteractionId`
("{session}.{generation}.{serial}"), and re-binding the *same* session
deliberately preserves the generation/serial counters — so reusing a
snapshot's id after an undo would re-issue ids already handed out on the
abandoned branch, whose serial is higher. A fresh namespace makes that
collision impossible.

Reusing the game code server-side is sound: uniqueness only has to hold
*within* a state, and guessability is irrelevant because `slot_for_submission`
authorizes on the authenticated actor, never on the session id.

Bind failure is logged, not swallowed — it is reachable only on decimal-serial
exhaustion, so failing a live game would be disproportionate, but degrading
silently is the very defect this fixes. engine-wasm uses `debug_assert`
instead, matching `ensure_interaction_authority`'s own discipline rather than
pulling `web_sys` into a size-optimized artifact for an unreachable arm.

This is user-visible, not a dormant-code cleanup: `projectedManaChoices` feeds
`AbilityChoiceModal` from `interaction.opportunities` and returned an empty
`Map` every time, so the modal rendered without engine-provided mana labels
and restrictions.

Each test was watched failing first. Two needed a non-vacuity guard, because
both would otherwise have passed against the unfixed code:

  * the restore test poisons the blob with a foreign session id first —
    `interaction_session_id` is `#[serde(default, skip_serializing_if)]`,
    not `skip`, so an already-bound snapshot round-trips its own id and the
    assertion would have been testing serde.
  * the server-core probe asserts the unbound verdict *does* appear on a
    stripped copy, since `derive_viewer_interaction` checks terminal and
    `can_submit` before authority — a state that never reaches the third
    guard would pass trivially. Stripping must clear the slots too:
    `debug_assert_interaction_consistency` holds that an unbound state has
    none, so dropping only the id builds a state the engine calls impossible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored and resumed games now correctly regain interactive controls.
  * Starting a new game after a match restart preserves player interaction availability.
  * Recreated sessions now reliably support player actions instead of appearing unavailable.
  * Improved recovery of interactive game state across persistence and multiplayer hosting flows.

* **Tests**
  * Added coverage for interaction availability during new, restored, resumed, and between-game sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->