### PR TITLE
Add Felisa, Fang of Silverquill

### DIFF
--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -4825,13 +4825,15 @@ fn event_context_counter_count_from_lki(
     };
     let count = match crate::types::game_state::battlefield_departure_trigger_source_context(&event)
     {
-        Ok(Some(context)) => counter_count_from_map(&context.lki.counters, Some(counter_type)),
-        Ok(None) => state
+        crate::types::game_state::BattlefieldDepartureSourceContext::Present(context) => {
+            counter_count_from_map(&context.lki.counters, Some(counter_type))
+        }
+        crate::types::game_state::BattlefieldDepartureSourceContext::Absent => state
             .lki_cache
             .get(&object_id)
             .map(|lki| counter_count_from_map(&lki.counters, Some(counter_type)))?,
         // A malformed record must not consume a newer incarnation's cache.
-        Err(()) => return None,
+        crate::types::game_state::BattlefieldDepartureSourceContext::Malformed => return None,
     };
     (count > 0).then_some(count)
 }
@@ -4902,15 +4904,15 @@ fn resolve_counters_on_scope(
                 {
                     return match crate::types::game_state::battlefield_departure_trigger_source_context(event)
                     {
-                        Ok(Some(context)) => {
+                        crate::types::game_state::BattlefieldDepartureSourceContext::Present(context) => {
                             counter_count_from_map(&context.lki.counters, counter_type)
                         }
-                        Ok(None) => state
+                        crate::types::game_state::BattlefieldDepartureSourceContext::Absent => state
                             .lki_cache
                             .get(object_id)
                             .map(|lki| counter_count_from_map(&lki.counters, counter_type))
                             .unwrap_or(0),
-                        Err(()) => 0,
+                        crate::types::game_state::BattlefieldDepartureSourceContext::Malformed => 0,
                     };
                 }
             }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -23,8 +23,10 @@ use crate::types::ability::{
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::{positive_counter_types, CounterType};
+use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    DamageRecord, GameState, LinkedExileSnapshot, TriggerSourceContext,
+    BattlefieldDepartureSourceContext, DamageRecord, GameState, LinkedExileSnapshot,
+    TriggerSourceContext,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{ManaColor, ManaCost};
@@ -4783,6 +4785,53 @@ pub(crate) fn distinct_counter_kinds_among(
     kinds
 }
 
+/// The counter-value authority for a battlefield departure event.
+enum BattlefieldDepartureCounterContext<'a> {
+    NotBattlefieldDeparture,
+    Present { context: &'a TriggerSourceContext },
+    Absent { object_id: ObjectId },
+    Malformed,
+}
+
+/// Returns the event that currently supplies triggered-ability provenance.
+fn current_or_detection_trigger_event(state: &GameState) -> Option<GameEvent> {
+    state
+        .current_trigger_event
+        .as_ref()
+        .cloned()
+        .or_else(detection_trigger_event)
+}
+
+/// CR 400.7 + CR 603.10a: Classify a battlefield departure's counter authority.
+///
+/// The record-owned context is authoritative for a coherent departure; an
+/// absent context preserves the legacy ObjectId-keyed cache fallback, while a
+/// malformed one must never rebind to that cache.
+fn battlefield_departure_counter_context(
+    event: &GameEvent,
+) -> BattlefieldDepartureCounterContext<'_> {
+    let GameEvent::ZoneChanged {
+        object_id,
+        from: Some(Zone::Battlefield),
+        ..
+    } = event
+    else {
+        return BattlefieldDepartureCounterContext::NotBattlefieldDeparture;
+    };
+
+    match crate::types::game_state::battlefield_departure_trigger_source_context(event) {
+        BattlefieldDepartureSourceContext::Present(context) => {
+            BattlefieldDepartureCounterContext::Present { context }
+        }
+        BattlefieldDepartureSourceContext::Absent => BattlefieldDepartureCounterContext::Absent {
+            object_id: *object_id,
+        },
+        BattlefieldDepartureSourceContext::Malformed => {
+            BattlefieldDepartureCounterContext::Malformed
+        }
+    }
+}
+
 /// CR 603.10 + CR 608.2h + CR 122.2: For a battlefield-departure look-back
 /// counter effect ("Whenever a creature you control dies/leaves the battlefield,
 /// if it had one or more <X> counters on it, put that many <X> counters on …" —
@@ -4811,29 +4860,18 @@ fn event_context_counter_count_from_lki(
         ) => counter_type,
         _ => return None,
     };
-    let event @ crate::types::events::GameEvent::ZoneChanged {
-        object_id,
-        from: Some(crate::types::zones::Zone::Battlefield),
-        ..
-    } = state
-        .current_trigger_event
-        .as_ref()
-        .cloned()
-        .or_else(detection_trigger_event)?
-    else {
-        return None;
-    };
-    let count = match crate::types::game_state::battlefield_departure_trigger_source_context(&event)
-    {
-        crate::types::game_state::BattlefieldDepartureSourceContext::Present(context) => {
+    let event = current_or_detection_trigger_event(state)?;
+    let count = match battlefield_departure_counter_context(&event) {
+        BattlefieldDepartureCounterContext::Present { context } => {
             counter_count_from_map(&context.lki.counters, Some(counter_type))
         }
-        crate::types::game_state::BattlefieldDepartureSourceContext::Absent => state
+        BattlefieldDepartureCounterContext::Absent { object_id } => state
             .lki_cache
             .get(&object_id)
             .map(|lki| counter_count_from_map(&lki.counters, Some(counter_type)))?,
         // A malformed record must not consume a newer incarnation's cache.
-        crate::types::game_state::BattlefieldDepartureSourceContext::Malformed => return None,
+        BattlefieldDepartureCounterContext::Malformed
+        | BattlefieldDepartureCounterContext::NotBattlefieldDeparture => return None,
     };
     (count > 0).then_some(count)
 }
@@ -4848,6 +4886,49 @@ pub(crate) fn counter_count_from_map(
     }
 }
 
+/// Resolve an ordinary object scope through its live object or its LKI snapshot.
+///
+/// CR 122.2 + CR 400.7 + CR 603.10a: When a source has changed zones, its
+/// live counter map has been cleared, so its departure snapshot provides the
+/// pre-exit values. A live battlefield object remains authoritative over a
+/// stale ObjectId-keyed cache entry from an earlier incarnation.
+fn resolve_counters_on_live_or_lki_scope(
+    state: &GameState,
+    scope: ObjectScope,
+    ctx: QuantityContext,
+    targets: &[TargetRef],
+    counter_type: Option<&CounterType>,
+) -> i32 {
+    // CR 608.2k: An `Anaphoric` counter read that reached runtime found no
+    // clause subject and no per-recipient static to bind it, so the pronoun
+    // names the ability's own object — "+1/+1 counters on him" on Red Hulk's
+    // Enrage reflex.
+    if matches!(scope, ObjectScope::Source | ObjectScope::Anaphoric) && ctx.trigger_source.is_some()
+    {
+        return source_lki_for_context(state, &ctx)
+            .map(|lki| counter_count_from_map(&lki.counters, counter_type))
+            .unwrap_or(0);
+    }
+    // An unbound anaphor resolves through the `Source` lookup — the generic
+    // scope helpers have no referent for `Anaphoric` itself.
+    let lookup_scope = match scope {
+        ObjectScope::Anaphoric => ObjectScope::Source,
+        other => other,
+    };
+    let Some(object_id) = object_id_for_scope(state, lookup_scope, ctx, targets) else {
+        return 0;
+    };
+    let live = state.objects.get(&object_id);
+    let on_battlefield = live.is_some_and(|obj| obj.zone == Zone::Battlefield);
+    if !on_battlefield {
+        if let Some(lki) = state.lki_cache.get(&object_id) {
+            return counter_count_from_map(&lki.counters, counter_type);
+        }
+    }
+    live.map(|obj| counter_count_from_map(&obj.counters, counter_type))
+        .unwrap_or(0)
+}
+
 fn resolve_counters_on_scope(
     state: &GameState,
     scope: ObjectScope,
@@ -4857,91 +4938,32 @@ fn resolve_counters_on_scope(
     counter_type: Option<&CounterType>,
 ) -> i32 {
     match scope {
-        // CR 122.2 + CR 400.7 + CR 603.10a: When the source or triggering
-        // event source has changed zones (e.g., a dies-trigger reading
-        // "counters on ~"), `obj.counters` has been cleared by
-        // `apply_zone_exit_cleanup`. The LKI snapshot captured there
-        // preserves the pre-exit counter map per CR 400.7's "new object"
-        // semantics.
-        //
-        // The fallback must be zone-keyed, not presence-keyed: an object that
-        // died and was returned earlier this turn keeps both a stale LKI entry
-        // (from the death) and a live counter map (post-return). A live
-        // battlefield object's `obj.counters` is authoritative; only when the
-        // source has changed zones (so it isn't on the battlefield as the
-        // "same" object) does CR 603.10a's look-back apply.
-        //
-        // Mirrors `resolve_object_pt`'s LKI fallback for power/toughness
-        // (where the cleared field becomes `None`); the counter analogue must
-        // be zone-keyed because an empty `HashMap<CounterType, u32>` is
-        // `Some({})`, not `None`.
-        // CR 608.2k: An `Anaphoric` counter read that reached runtime found no
-        // clause subject and no per-recipient static to bind it, so the pronoun
-        // names the ability's own object — "+1/+1 counters on him" on Red Hulk's
-        // Enrage reflex. Grouped with `Source` so the unbound anaphor keeps
-        // exactly the referent it had before the scope carried provenance.
-        ObjectScope::Source | ObjectScope::EventSource | ObjectScope::Anaphoric => {
-            // CR 400.7 + CR 603.10a: `EventSource` on a battlefield departure
-            // names the object in the event, not a same-id incarnation that
-            // might have returned before this trigger resolves. The complete
-            // event record is authoritative; a context-free legacy record may
-            // use the historic cache fallback, but malformed provenance fails
-            // closed. Other event kinds and Source/Anaphoric retain their
-            // existing resolution paths below.
-            if scope == ObjectScope::EventSource {
-                let event = state
-                    .current_trigger_event
-                    .as_ref()
-                    .cloned()
-                    .or_else(detection_trigger_event);
-                if let Some(
-                    event @ crate::types::events::GameEvent::ZoneChanged {
-                        object_id,
-                        from: Some(crate::types::zones::Zone::Battlefield),
-                        ..
-                    },
-                ) = event.as_ref()
-                {
-                    return match crate::types::game_state::battlefield_departure_trigger_source_context(event)
-                    {
-                        crate::types::game_state::BattlefieldDepartureSourceContext::Present(context) => {
-                            counter_count_from_map(&context.lki.counters, counter_type)
-                        }
-                        crate::types::game_state::BattlefieldDepartureSourceContext::Absent => state
-                            .lki_cache
-                            .get(object_id)
-                            .map(|lki| counter_count_from_map(&lki.counters, counter_type))
-                            .unwrap_or(0),
-                        crate::types::game_state::BattlefieldDepartureSourceContext::Malformed => 0,
-                    };
-                }
-            }
-            if matches!(scope, ObjectScope::Source | ObjectScope::Anaphoric)
-                && ctx.trigger_source.is_some()
+        // CR 400.7 + CR 603.10a: On a battlefield departure, EventSource is
+        // the event's prior incarnation, not a same-id object that has since
+        // returned. Other event kinds retain the ordinary scope lookup below.
+        ObjectScope::EventSource => {
+            let event = current_or_detection_trigger_event(state);
+            match event
+                .as_ref()
+                .map(battlefield_departure_counter_context)
+                .unwrap_or(BattlefieldDepartureCounterContext::NotBattlefieldDeparture)
             {
-                return source_lki_for_context(state, &ctx)
+                BattlefieldDepartureCounterContext::Present { context } => {
+                    counter_count_from_map(&context.lki.counters, counter_type)
+                }
+                BattlefieldDepartureCounterContext::Absent { object_id } => state
+                    .lki_cache
+                    .get(&object_id)
                     .map(|lki| counter_count_from_map(&lki.counters, counter_type))
-                    .unwrap_or(0);
-            }
-            // An unbound anaphor resolves through the `Source` lookup — the
-            // generic scope helpers have no referent for `Anaphoric` itself.
-            let lookup_scope = match scope {
-                ObjectScope::Anaphoric => ObjectScope::Source,
-                other => other,
-            };
-            let Some(object_id) = object_id_for_scope(state, lookup_scope, ctx, targets) else {
-                return 0;
-            };
-            let live = state.objects.get(&object_id);
-            let on_battlefield =
-                live.is_some_and(|obj| obj.zone == crate::types::zones::Zone::Battlefield);
-            if !on_battlefield {
-                if let Some(lki) = state.lki_cache.get(&object_id) {
-                    return counter_count_from_map(&lki.counters, counter_type);
+                    .unwrap_or(0),
+                BattlefieldDepartureCounterContext::Malformed => 0,
+                BattlefieldDepartureCounterContext::NotBattlefieldDeparture => {
+                    resolve_counters_on_live_or_lki_scope(state, scope, ctx, targets, counter_type)
                 }
             }
-            live.map(|obj| counter_count_from_map(&obj.counters, counter_type))
-                .unwrap_or(0)
+        }
+        ObjectScope::Source | ObjectScope::Anaphoric => {
+            resolve_counters_on_live_or_lki_scope(state, scope, ctx, targets, counter_type)
         }
         ObjectScope::CostPaidObject => ability
             .and_then(|ability| ability.cost_paid_object.as_ref())
@@ -12273,6 +12295,79 @@ mod tests {
             resolve_quantity_with_targets(&state, &expr, &ability),
             3,
             "only an absent legacy context may use the ObjectId-keyed cache"
+        );
+    }
+
+    #[test]
+    fn resolve_quantity_counters_on_event_source_fails_closed_for_malformed_context() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Runecarved Obelisk".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .counters
+            .insert(CounterType::Generic("charge".to_string()), 3);
+
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, source, Zone::Graveyard, &mut events);
+        assert_eq!(
+            state
+                .lki_cache
+                .get(&source)
+                .map(|lki| {
+                    counter_count_from_map(
+                        &lki.counters,
+                        Some(&CounterType::Generic("charge".to_string())),
+                    )
+                }),
+            Some(3),
+            "the legacy cache reach-guard proves malformed provenance, rather than an empty cache, causes the zero"
+        );
+
+        let mut event = events
+            .into_iter()
+            .find(|event| {
+                matches!(event, crate::types::events::GameEvent::ZoneChanged { object_id, .. } if *object_id == source)
+            })
+            .expect("move_to_zone must emit a ZoneChanged event");
+        let crate::types::events::GameEvent::ZoneChanged { record, .. } = &mut event else {
+            unreachable!("selected ZoneChanged event")
+        };
+        record
+            .trigger_source_context
+            .as_mut()
+            .expect("production record has owned context")
+            .identity
+            .expected_zone = Zone::Graveyard;
+        state.current_trigger_event = Some(event);
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::CountersOn {
+                scope: ObjectScope::EventSource,
+                counter_type: Some(CounterType::Generic("charge".to_string())),
+            },
+        };
+        let ability = crate::types::ability::ResolvedAbility::new(
+            Effect::Draw {
+                count: expr.clone(),
+                target: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(99),
+            PlayerId(0),
+        );
+
+        assert_eq!(
+            resolve_quantity_with_targets(&state, &expr, &ability),
+            0,
+            "a malformed record must not silently downgrade to the legacy cache"
         );
     }
 

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -4811,16 +4811,28 @@ fn event_context_counter_count_from_lki(
         ) => counter_type,
         _ => return None,
     };
-    let crate::types::events::GameEvent::ZoneChanged {
+    let event @ crate::types::events::GameEvent::ZoneChanged {
         object_id,
         from: Some(crate::types::zones::Zone::Battlefield),
         ..
-    } = state.current_trigger_event.as_ref()?
+    } = state
+        .current_trigger_event
+        .as_ref()
+        .cloned()
+        .or_else(detection_trigger_event)?
     else {
         return None;
     };
-    let lki = state.lki_cache.get(object_id)?;
-    let count = counter_count_from_map(&lki.counters, Some(counter_type));
+    let count = match crate::types::game_state::battlefield_departure_trigger_source_context(&event)
+    {
+        Ok(Some(context)) => counter_count_from_map(&context.lki.counters, Some(counter_type)),
+        Ok(None) => state
+            .lki_cache
+            .get(&object_id)
+            .map(|lki| counter_count_from_map(&lki.counters, Some(counter_type)))?,
+        // A malformed record must not consume a newer incarnation's cache.
+        Err(()) => return None,
+    };
     (count > 0).then_some(count)
 }
 
@@ -4867,6 +4879,41 @@ fn resolve_counters_on_scope(
         // Enrage reflex. Grouped with `Source` so the unbound anaphor keeps
         // exactly the referent it had before the scope carried provenance.
         ObjectScope::Source | ObjectScope::EventSource | ObjectScope::Anaphoric => {
+            // CR 400.7 + CR 603.10a: `EventSource` on a battlefield departure
+            // names the object in the event, not a same-id incarnation that
+            // might have returned before this trigger resolves. The complete
+            // event record is authoritative; a context-free legacy record may
+            // use the historic cache fallback, but malformed provenance fails
+            // closed. Other event kinds and Source/Anaphoric retain their
+            // existing resolution paths below.
+            if scope == ObjectScope::EventSource {
+                let event = state
+                    .current_trigger_event
+                    .as_ref()
+                    .cloned()
+                    .or_else(detection_trigger_event);
+                if let Some(
+                    event @ crate::types::events::GameEvent::ZoneChanged {
+                        object_id,
+                        from: Some(crate::types::zones::Zone::Battlefield),
+                        ..
+                    },
+                ) = event.as_ref()
+                {
+                    return match crate::types::game_state::battlefield_departure_trigger_source_context(event)
+                    {
+                        Ok(Some(context)) => {
+                            counter_count_from_map(&context.lki.counters, counter_type)
+                        }
+                        Ok(None) => state
+                            .lki_cache
+                            .get(object_id)
+                            .map(|lki| counter_count_from_map(&lki.counters, counter_type))
+                            .unwrap_or(0),
+                        Err(()) => 0,
+                    };
+                }
+            }
             if matches!(scope, ObjectScope::Source | ObjectScope::Anaphoric)
                 && ctx.trigger_source.is_some()
             {
@@ -12159,7 +12206,72 @@ mod tests {
             PlayerId(0),
         );
 
-        assert_eq!(resolve_quantity_with_targets(&state, &expr, &ability), 3);
+        // The live object is now in the graveyard with no counters. Poison the
+        // mutable cache with that post-departure state too: EventSource must
+        // still use the record-owned departure context, not either fallback.
+        state
+            .lki_cache
+            .insert(source, state.objects[&source].snapshot_for_mana_spent());
+
+        assert_eq!(
+            resolve_quantity_with_targets(&state, &expr, &ability),
+            3,
+            "the zone-change record's LKI outranks a later cache incarnation"
+        );
+    }
+
+    #[test]
+    fn resolve_quantity_counters_on_event_source_uses_legacy_cache_only_when_context_absent() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Runecarved Obelisk".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .counters
+            .insert(CounterType::Generic("charge".to_string()), 3);
+
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, source, Zone::Graveyard, &mut events);
+        let mut event = events
+            .into_iter()
+            .find(|event| {
+                matches!(event, crate::types::events::GameEvent::ZoneChanged { object_id, .. } if *object_id == source)
+            })
+            .expect("move_to_zone must emit a ZoneChanged event");
+        let crate::types::events::GameEvent::ZoneChanged { record, .. } = &mut event else {
+            unreachable!("selected ZoneChanged event")
+        };
+        record.trigger_source_context = None;
+        state.current_trigger_event = Some(event);
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::CountersOn {
+                scope: ObjectScope::EventSource,
+                counter_type: Some(CounterType::Generic("charge".to_string())),
+            },
+        };
+        let ability = crate::types::ability::ResolvedAbility::new(
+            Effect::Draw {
+                count: expr.clone(),
+                target: TargetFilter::Controller,
+            },
+            Vec::new(),
+            ObjectId(99),
+            PlayerId(0),
+        );
+
+        assert_eq!(
+            resolve_quantity_with_targets(&state, &expr, &ability),
+            3,
+            "only an absent legacy context may use the ObjectId-keyed cache"
+        );
     }
 
     /// CR 122.1: `AnyCountersOnSelf` sums every counter type on the source

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3292,28 +3292,30 @@ fn collect_pending_triggers_with_collection(
             ..
         } = event
         {
-            let matched_triggers = if let Ok(Some(source_context)) =
-                crate::types::game_state::battlefield_departure_trigger_source_context(event)
-            {
-                collect_matching_triggers_from_context(
-                    state,
-                    event,
-                    events,
+            let matched_triggers =
+                if let crate::types::game_state::BattlefieldDepartureSourceContext::Present(
                     source_context,
-                    Some(Zone::Battlefield),
-                    &mut batched_this_pass,
-                    &mut registered_this_event,
-                    &active_suppress_triggers,
-                    collection,
-                    TriggerSourceVisit::EventSubject,
-                )
-            } else {
-                // A record without its owned pre-event context cannot prove that
-                // a current same-id object is the object that left the battlefield.
-                // Fail closed rather than rebinding an LTB trigger to a later
-                // incarnation.
-                Vec::new()
-            };
+                ) = crate::types::game_state::battlefield_departure_trigger_source_context(event)
+                {
+                    collect_matching_triggers_from_context(
+                        state,
+                        event,
+                        events,
+                        source_context,
+                        Some(Zone::Battlefield),
+                        &mut batched_this_pass,
+                        &mut registered_this_event,
+                        &active_suppress_triggers,
+                        collection,
+                        TriggerSourceVisit::EventSubject,
+                    )
+                } else {
+                    // A record without its owned pre-event context cannot prove that
+                    // a current same-id object is the object that left the battlefield.
+                    // Fail closed rather than rebinding an LTB trigger to a later
+                    // incarnation.
+                    Vec::new()
+                };
             if !matched_triggers.is_empty() {
                 for matched in matched_triggers {
                     record_trigger_fired_with_ref(
@@ -9148,12 +9150,18 @@ fn evaluate_trigger_condition_with_source(
                     match crate::types::game_state::battlefield_departure_trigger_source_context(
                         event,
                     ) {
-                        Ok(Some(context)) => matches_counter(&context.lki),
+                        crate::types::game_state::BattlefieldDepartureSourceContext::Present(
+                            context,
+                        ) => matches_counter(&context.lki),
                         // Compatibility for legacy/defaulted records only. A
                         // present incoherent context is not absent and must
                         // never be rebound through the ObjectId-keyed cache.
-                        Ok(None) => state.lki_cache.get(object_id).is_some_and(matches_counter),
-                        Err(()) => false,
+                        crate::types::game_state::BattlefieldDepartureSourceContext::Absent => {
+                            state.lki_cache.get(object_id).is_some_and(matches_counter)
+                        }
+                        crate::types::game_state::BattlefieldDepartureSourceContext::Malformed => {
+                            false
+                        }
                     }
                 }
                 // Non-departure ZoneChanged events never had an owned
@@ -10506,7 +10514,7 @@ pub mod tests {
         };
         assert!(matches!(
             crate::types::game_state::battlefield_departure_trigger_source_context(&event),
-            Ok(Some(_))
+            crate::types::game_state::BattlefieldDepartureSourceContext::Present(_)
         ));
 
         let mismatched_event = GameEvent::ZoneChanged {
@@ -10519,7 +10527,7 @@ pub mod tests {
             crate::types::game_state::battlefield_departure_trigger_source_context(
                 &mismatched_event
             ),
-            Err(())
+            crate::types::game_state::BattlefieldDepartureSourceContext::Malformed
         ));
 
         let mut post_change_context = record.clone();
@@ -10539,7 +10547,7 @@ pub mod tests {
             crate::types::game_state::battlefield_departure_trigger_source_context(
                 &malformed_context_event
             ),
-            Err(())
+            crate::types::game_state::BattlefieldDepartureSourceContext::Malformed
         ));
 
         let missing_context =
@@ -10552,7 +10560,7 @@ pub mod tests {
         };
         assert!(matches!(
             crate::types::game_state::battlefield_departure_trigger_source_context(&legacy_event),
-            Ok(None)
+            crate::types::game_state::BattlefieldDepartureSourceContext::Absent
         ));
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -1061,22 +1061,6 @@ impl LogicalZoneTriggerCollection<'_> {
     }
 }
 
-/// Returns the record-owned source for a battlefield departure. An absent or
-/// mismatched context is not recoverable from the current object map: that map
-/// may already hold a different incarnation at the same storage id.
-fn ltb_trigger_source_context(
-    record: &crate::types::game_state::ZoneChangeRecord,
-    moved_id: ObjectId,
-) -> Option<&TriggerSourceContext> {
-    (record.object_id == moved_id && record.from_zone == Some(Zone::Battlefield))
-        .then(|| record.trigger_source_context())
-        .flatten()
-        .filter(|context| {
-            context.identity.reference.object_id == moved_id
-                && context.identity.expected_zone == Zone::Battlefield
-        })
-}
-
 fn batched_zone_change_batch(events: &[GameEvent]) -> bool {
     !events.is_empty()
         && events
@@ -3305,31 +3289,31 @@ fn collect_pending_triggers_with_collection(
         if let GameEvent::ZoneChanged {
             object_id: moved_id,
             from: Some(Zone::Battlefield),
-            record,
             ..
         } = event
         {
-            let matched_triggers =
-                if let Some(source_context) = ltb_trigger_source_context(record, *moved_id) {
-                    collect_matching_triggers_from_context(
-                        state,
-                        event,
-                        events,
-                        source_context,
-                        Some(Zone::Battlefield),
-                        &mut batched_this_pass,
-                        &mut registered_this_event,
-                        &active_suppress_triggers,
-                        collection,
-                        TriggerSourceVisit::EventSubject,
-                    )
-                } else {
-                    // A record without its owned pre-event context cannot prove that
-                    // a current same-id object is the object that left the battlefield.
-                    // Fail closed rather than rebinding an LTB trigger to a later
-                    // incarnation.
-                    Vec::new()
-                };
+            let matched_triggers = if let Ok(Some(source_context)) =
+                crate::types::game_state::battlefield_departure_trigger_source_context(event)
+            {
+                collect_matching_triggers_from_context(
+                    state,
+                    event,
+                    events,
+                    source_context,
+                    Some(Zone::Battlefield),
+                    &mut batched_this_pass,
+                    &mut registered_this_event,
+                    &active_suppress_triggers,
+                    collection,
+                    TriggerSourceVisit::EventSubject,
+                )
+            } else {
+                // A record without its owned pre-event context cannot prove that
+                // a current same-id object is the object that left the battlefield.
+                // Fail closed rather than rebinding an LTB trigger to a later
+                // incarnation.
+                Vec::new()
+            };
             if !matched_triggers.is_empty() {
                 for matched in matched_triggers {
                     record_trigger_fired_with_ref(
@@ -9154,12 +9138,31 @@ fn evaluate_trigger_condition_with_source(
                 None => lki.counters.values().any(|&count| count > 0),
             };
             match trigger_event {
-                Some(GameEvent::ZoneChanged {
-                    object_id, record, ..
-                }) => match record.trigger_source_context() {
-                    Some(context) => matches_counter(&context.lki),
-                    None => state.lki_cache.get(object_id).is_some_and(matches_counter),
-                },
+                Some(
+                    event @ GameEvent::ZoneChanged {
+                        object_id,
+                        from: Some(Zone::Battlefield),
+                        ..
+                    },
+                ) => {
+                    match crate::types::game_state::battlefield_departure_trigger_source_context(
+                        event,
+                    ) {
+                        Ok(Some(context)) => matches_counter(&context.lki),
+                        // Compatibility for legacy/defaulted records only. A
+                        // present incoherent context is not absent and must
+                        // never be rebound through the ObjectId-keyed cache.
+                        Ok(None) => state.lki_cache.get(object_id).is_some_and(matches_counter),
+                        Err(()) => false,
+                    }
+                }
+                // Non-departure ZoneChanged events never had an owned
+                // battlefield LKI requirement. Preserve their established
+                // event-subject cache lookup rather than classifying them as
+                // malformed departures.
+                Some(GameEvent::ZoneChanged { object_id, .. }) => {
+                    state.lki_cache.get(object_id).is_some_and(matches_counter)
+                }
                 Some(event) => {
                     if let Some(event_object_id) =
                         crate::game::targeting::extract_source_from_event(event)
@@ -10485,7 +10488,7 @@ pub mod tests {
     }
 
     #[test]
-    fn ltb_source_requires_the_record_owned_context_for_the_moved_object() {
+    fn ltb_source_requires_a_coherent_record_owned_context() {
         let object = GameObject::new(
             ObjectId(9),
             CardId(12),
@@ -10495,8 +10498,29 @@ pub mod tests {
         );
         let record =
             object.snapshot_for_zone_change(object.id, Some(Zone::Battlefield), Zone::Graveyard);
-        assert!(ltb_trigger_source_context(&record, object.id).is_some());
-        assert!(ltb_trigger_source_context(&record, ObjectId(10)).is_none());
+        let event = GameEvent::ZoneChanged {
+            object_id: object.id,
+            from: Some(Zone::Battlefield),
+            to: Zone::Graveyard,
+            record: Box::new(record.clone()),
+        };
+        assert!(matches!(
+            crate::types::game_state::battlefield_departure_trigger_source_context(&event),
+            Ok(Some(_))
+        ));
+
+        let mismatched_event = GameEvent::ZoneChanged {
+            object_id: ObjectId(10),
+            from: Some(Zone::Battlefield),
+            to: Zone::Graveyard,
+            record: Box::new(record.clone()),
+        };
+        assert!(matches!(
+            crate::types::game_state::battlefield_departure_trigger_source_context(
+                &mismatched_event
+            ),
+            Err(())
+        ));
 
         let mut post_change_context = record.clone();
         post_change_context
@@ -10505,11 +10529,31 @@ pub mod tests {
             .expect("snapshot context")
             .identity
             .expected_zone = Zone::Graveyard;
-        assert!(ltb_trigger_source_context(&post_change_context, object.id).is_none());
+        let malformed_context_event = GameEvent::ZoneChanged {
+            object_id: object.id,
+            from: Some(Zone::Battlefield),
+            to: Zone::Graveyard,
+            record: Box::new(post_change_context),
+        };
+        assert!(matches!(
+            crate::types::game_state::battlefield_departure_trigger_source_context(
+                &malformed_context_event
+            ),
+            Err(())
+        ));
 
         let missing_context =
             ZoneChangeRecord::test_minimal(object.id, Some(Zone::Battlefield), Zone::Graveyard);
-        assert!(ltb_trigger_source_context(&missing_context, object.id).is_none());
+        let legacy_event = GameEvent::ZoneChanged {
+            object_id: object.id,
+            from: Some(Zone::Battlefield),
+            to: Zone::Graveyard,
+            record: Box::new(missing_context),
+        };
+        assert!(matches!(
+            crate::types::game_state::battlefield_departure_trigger_source_context(&legacy_event),
+            Ok(None)
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -8534,6 +8534,13 @@ pub(crate) fn parse_where_x_quantity_expression(where_x_expression: &str) -> Opt
     if let Some(expr) = parse_cda_quantity(where_x_expression) {
         return Some(expr);
     }
+    // Keep the compositional nom quantity grammar available to where-X
+    // bindings after the more-specific CDA interpreter has declined them.
+    // This covers past-tense event-subject forms such as "the number of
+    // counters it had" without adding a card-name-specific token parser.
+    if let Ok((_, qty)) = nom_quantity::parse_quantity_ref_complete(expression_lower.as_str()) {
+        return Some(QuantityExpr::Ref { qty });
+    }
     // CR 107.3i + CR 115.1: Some where-X definitions spell the count as
     // "the number of <for-each clause>" where the clause itself may need a
     // target player ("Islands target opponent controls"). Keep that grammar in

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -8534,10 +8534,11 @@ pub(crate) fn parse_where_x_quantity_expression(where_x_expression: &str) -> Opt
     if let Some(expr) = parse_cda_quantity(where_x_expression) {
         return Some(expr);
     }
-    // Keep the compositional nom quantity grammar available to where-X
-    // bindings after the more-specific CDA interpreter has declined them.
-    // This covers past-tense event-subject forms such as "the number of
-    // counters it had" without adding a card-name-specific token parser.
+    // CR 107.3i: Keep the compositional nom quantity grammar available to
+    // where-X bindings after the more-specific CDA interpreter has declined
+    // them. This supplies a single X value for past-tense event-subject forms
+    // such as "the number of counters it had" without a card-name-specific
+    // token parser.
     if let Ok((_, qty)) = nom_quantity::parse_quantity_ref_complete(expression_lower.as_str()) {
         return Some(QuantityExpr::Ref { qty });
     }

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1244,6 +1244,33 @@ fn parse_number_of_counters_on_object(input: &str) -> OracleResult<'_, QuantityR
     ))
 }
 
+/// CR 603.10a + CR 122.2: Parse the past-tense event-subject counter count
+/// after "the number of". Unlike "counters on it", "counters it had" names
+/// the creature that just left, so it resolves through the trigger event's
+/// departure snapshot rather than the ability source.
+///
+/// The untyped arm intentionally comes first: the open generic counter parser
+/// otherwise accepts `counters` as a counter type and commits before the
+/// past-tense grammar can recognize it.
+fn parse_number_of_counters_it_had(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (rest, counter_type) = alt((
+        value(None, tag("counters it had")),
+        map(
+            terminated(parse_counter_type_typed, tag(" counters it had")),
+            Some,
+        ),
+    ))
+    .parse(input)?;
+    let (rest, _) = opt(tag(" on it")).parse(rest)?;
+    Ok((
+        rest,
+        QuantityRef::CountersOn {
+            scope: ObjectScope::EventSource,
+            counter_type,
+        },
+    ))
+}
+
 /// Parse the object scope for counter references: "it", "that creature", "that permanent", etc.
 ///
 /// CR 122.1 + CR 608.2k: A creature's ability that counts "+1/+1 counters on
@@ -1548,10 +1575,17 @@ fn parse_number_of_inner(input: &str) -> OracleResult<'_, QuantityRef> {
         // "[typeword] you control" misread (no `TypeFilter` for counter kinds).
         parse_player_counter_ref_tail,
         parse_lost_game_player_count,
-        // CR 122.1: "[kind] counters on [object]" — counter count on an object.
-        // Must precede generic type-filter arm. Used for patterns like
-        // "equal to the number of charge counters on it".
-        parse_number_of_counters_on_object,
+        // Past-tense event-subject counters must precede the present-tense
+        // parser: its open generic counter-type arm would otherwise consume
+        // the leading `counters` token. Keep the pair nested to remain within
+        // nom's supported top-level `alt` tuple arity.
+        alt((
+            parse_number_of_counters_it_had,
+            // CR 122.1: "[kind] counters on [object]" — counter count on an object.
+            // Must precede generic type-filter arm. Used for patterns like
+            // "equal to the number of charge counters on it".
+            parse_number_of_counters_on_object,
+        )),
         // CR 700.8: "creatures in your party" must precede the generic
         // "<type> you control" arm — the trailing "in your party" is what
         // distinguishes party-size from a controlled-creature count.
@@ -10348,6 +10382,55 @@ mod tests {
             }
             _ => panic!("expected CountersOn"),
         }
+    }
+
+    /// CR 603.10a + CR 122.2: Past-tense "it had" names the zone-change
+    /// event subject rather than the triggered ability's source. Keep both
+    /// optional surface forms and a typed count pinned to the exact AST.
+    #[test]
+    fn parse_quantity_ref_past_tense_counters_it_had_uses_event_source() {
+        for phrase in [
+            "the number of counters it had",
+            "the number of counters it had on it",
+        ] {
+            let (_, qty) = parse_quantity_ref_complete(phrase)
+                .unwrap_or_else(|_| panic!("{phrase:?} should parse completely"));
+            assert_eq!(
+                qty,
+                QuantityRef::CountersOn {
+                    scope: ObjectScope::EventSource,
+                    counter_type: None,
+                },
+                "{phrase:?}"
+            );
+        }
+
+        let (_, typed) = parse_quantity_ref_complete("the number of +1/+1 counters it had on it")
+            .expect("typed past-tense counter count should parse completely");
+        assert_eq!(
+            typed,
+            QuantityRef::CountersOn {
+                scope: ObjectScope::EventSource,
+                counter_type: Some(crate::types::counter::CounterType::Plus1Plus1),
+            }
+        );
+    }
+
+    /// Present-tense quantities remain source-relative; past-tense support
+    /// must not steal the long-standing "counters on it" grammar.
+    #[test]
+    fn parse_quantity_ref_present_tense_counters_on_it_stays_source() {
+        let (_, qty) = parse_quantity_ref_complete("the number of charge counters on it")
+            .expect("present-tense counter count should parse completely");
+        assert_eq!(
+            qty,
+            QuantityRef::CountersOn {
+                scope: ObjectScope::Source,
+                counter_type: Some(crate::types::counter::CounterType::Generic(
+                    "charge".to_string(),
+                )),
+            }
+        );
     }
 
     /// Test parse_equal_to_sum for two-way sum expressions.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1544,7 +1544,8 @@ pub(crate) enum BattlefieldDepartureSourceContext<'a> {
     Malformed,
 }
 
-/// Returns the authority state for a battlefield departure's record-owned source context.
+/// CR 400.7 + CR 603.10a: Returns the authority state for a battlefield
+/// departure's record-owned source context.
 ///
 /// A `ZoneChanged` event and its record are one unit of event-time authority. A
 /// later incarnation at the same `ObjectId` (or an overwritten ObjectId-keyed

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1534,6 +1534,48 @@ impl ZoneChangeRecord {
     }
 }
 
+/// Returns the record-owned source context for a coherent battlefield departure.
+///
+/// A `ZoneChanged` event and its record are one unit of event-time authority. A
+/// later incarnation at the same `ObjectId` (or an overwritten ObjectId-keyed
+/// LKI cache entry) may not answer a question about the object that left the
+/// battlefield. Older saved/test records can lack a source context entirely,
+/// which is distinguishable from a present but malformed context: callers that
+/// retain a documented legacy cache fallback receive `Ok(None)`, while
+/// malformed provenance receives `Err(())` and must fail closed.
+pub fn battlefield_departure_trigger_source_context(
+    event: &GameEvent,
+) -> Result<Option<&TriggerSourceContext>, ()> {
+    let GameEvent::ZoneChanged {
+        object_id,
+        from,
+        to,
+        record,
+    } = event
+    else {
+        return Err(());
+    };
+
+    if *object_id != record.object_id
+        || *from != record.from_zone
+        || *to != record.to_zone
+        || *from != Some(Zone::Battlefield)
+    {
+        return Err(());
+    }
+
+    match record.trigger_source_context() {
+        None => Ok(None),
+        Some(context)
+            if context.identity.reference.object_id == *object_id
+                && context.identity.expected_zone == Zone::Battlefield =>
+        {
+            Ok(Some(context))
+        }
+        Some(_) => Err(()),
+    }
+}
+
 /// CR 506.4 / CR 508.1k / CR 509.1g / CR 509.1h: Combat role snapshot for an
 /// object leaving its current zone.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -1534,18 +1534,28 @@ impl ZoneChangeRecord {
     }
 }
 
-/// Returns the record-owned source context for a coherent battlefield departure.
+/// The authority state of a record-owned battlefield-departure source context.
+///
+/// `Absent` preserves compatibility with context-free saved/test records;
+/// `Malformed` is a present but incoherent record and must fail closed.
+pub(crate) enum BattlefieldDepartureSourceContext<'a> {
+    Present(&'a TriggerSourceContext),
+    Absent,
+    Malformed,
+}
+
+/// Returns the authority state for a battlefield departure's record-owned source context.
 ///
 /// A `ZoneChanged` event and its record are one unit of event-time authority. A
 /// later incarnation at the same `ObjectId` (or an overwritten ObjectId-keyed
 /// LKI cache entry) may not answer a question about the object that left the
 /// battlefield. Older saved/test records can lack a source context entirely,
 /// which is distinguishable from a present but malformed context: callers that
-/// retain a documented legacy cache fallback receive `Ok(None)`, while
-/// malformed provenance receives `Err(())` and must fail closed.
-pub fn battlefield_departure_trigger_source_context(
+/// retain a documented legacy cache fallback receive `Absent`, while
+/// malformed provenance receives `Malformed` and must fail closed.
+pub(crate) fn battlefield_departure_trigger_source_context(
     event: &GameEvent,
-) -> Result<Option<&TriggerSourceContext>, ()> {
+) -> BattlefieldDepartureSourceContext<'_> {
     let GameEvent::ZoneChanged {
         object_id,
         from,
@@ -1553,7 +1563,7 @@ pub fn battlefield_departure_trigger_source_context(
         record,
     } = event
     else {
-        return Err(());
+        return BattlefieldDepartureSourceContext::Malformed;
     };
 
     if *object_id != record.object_id
@@ -1561,18 +1571,18 @@ pub fn battlefield_departure_trigger_source_context(
         || *to != record.to_zone
         || *from != Some(Zone::Battlefield)
     {
-        return Err(());
+        return BattlefieldDepartureSourceContext::Malformed;
     }
 
     match record.trigger_source_context() {
-        None => Ok(None),
+        None => BattlefieldDepartureSourceContext::Absent,
         Some(context)
             if context.identity.reference.object_id == *object_id
                 && context.identity.expected_zone == Zone::Battlefield =>
         {
-            Ok(Some(context))
+            BattlefieldDepartureSourceContext::Present(context)
         }
-        Some(_) => Err(()),
+        Some(_) => BattlefieldDepartureSourceContext::Malformed,
     }
 }
 

--- a/crates/engine/tests/integration/felisa_fang_of_silverquill.rs
+++ b/crates/engine/tests/integration/felisa_fang_of_silverquill.rs
@@ -60,6 +60,20 @@ fn stack_entries_from(runner: &GameRunner, source: ObjectId) -> usize {
         .count()
 }
 
+fn felisa_with_counter_victim() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+    let felisa = scenario
+        .add_creature(P0, "Felisa, Fang of Silverquill", 3, 2)
+        .from_oracle_text_with_keywords(&["Flying", "Mentor"], FELISA_ORACLE)
+        .id();
+    let victim = scenario
+        .add_creature(P0, "Counter Victim", 1, 1)
+        .with_plus_counters(3)
+        .id();
+    (scenario.build(), felisa, victim)
+}
+
 /// CR 603.4 + CR 603.10a + CR 122.2: Felisa's intervening-if and X both read
 /// the dying creature's exact departure snapshot. Reanimating that creature
 /// before the trigger resolves must not turn three counters into zero.
@@ -245,17 +259,24 @@ fn felisa_counts_departure_counters_after_goryos_reanimates_the_victim() {
 /// fail closed at trigger detection instead of consulting the mutable LKI cache.
 #[test]
 fn felisa_does_not_trigger_from_a_malformed_departure_record() {
-    let mut scenario = GameScenario::new();
-    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
-    let felisa = scenario
-        .add_creature(P0, "Felisa, Fang of Silverquill", 3, 2)
-        .from_oracle_text_with_keywords(&["Flying", "Mentor"], FELISA_ORACLE)
-        .id();
-    let victim = scenario
-        .add_creature(P0, "Counter Victim", 1, 1)
-        .with_plus_counters(3)
-        .id();
-    let mut runner = scenario.build();
+    let (mut unmodified_runner, unmodified_felisa, unmodified_victim) =
+        felisa_with_counter_victim();
+    let mut unmodified_death_events = Vec::new();
+    move_to_zone(
+        unmodified_runner.state_mut(),
+        unmodified_victim,
+        Zone::Graveyard,
+        &mut unmodified_death_events,
+    );
+    process_triggers(unmodified_runner.state_mut(), &unmodified_death_events);
+    drain_order_triggers_with_identity(unmodified_runner.state_mut());
+    assert_eq!(
+        stack_entries_from(&unmodified_runner, unmodified_felisa),
+        1,
+        "the unmodified production death event reach-guards Felisa's trigger path"
+    );
+
+    let (mut runner, felisa, victim) = felisa_with_counter_victim();
 
     let mut death_events = Vec::new();
     move_to_zone(

--- a/crates/engine/tests/integration/felisa_fang_of_silverquill.rs
+++ b/crates/engine/tests/integration/felisa_fang_of_silverquill.rs
@@ -1,0 +1,290 @@
+//! Felisa, Fang of Silverquill — departure-counter LKI regression.
+//!
+//! Felisa counts counters on the creature that died, not on a later
+//! incarnation of that card. Goryo's Vengeance makes that distinction visible:
+//! it returns the card before Felisa resolves, so a live-object/cache lookup
+//! would see the counterless returned creature instead of the departure record.
+
+use engine::game::game_object::GameObject;
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::triggers::{drain_order_triggers_with_identity, process_triggers};
+use engine::game::zones::move_to_zone;
+use engine::types::ability::{
+    AbilityDefinition, Effect, ObjectScope, PtValue, QuantityExpr, QuantityRef,
+};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::zones::Zone;
+
+const FELISA_ORACLE: &str = "Flying\nMentor (Whenever this creature attacks, put a +1/+1 counter on target attacking creature with lesser power.)\nWhenever a nontoken creature you control dies, if it had counters on it, create X tapped 2/1 white and black Inkling creature tokens with flying, where X is the number of counters it had on it.";
+
+const GORYOS_VENGEANCE_ORACLE: &str = "Return target legendary creature card from your graveyard to the battlefield. That creature gains haste. Exile it at the beginning of the next end step.\nSplice onto Arcane {2}{B} (As you cast an Arcane spell, you may reveal this card from your hand and pay its splice cost. If you do, add this card's effects to that spell.)";
+
+fn has_unimplemented(definition: &AbilityDefinition) -> bool {
+    matches!(*definition.effect, Effect::Unimplemented { .. })
+        || matches!(
+            definition.effect.as_ref(),
+            Effect::CreateDelayedTrigger { effect, .. } if has_unimplemented(effect)
+        )
+        || definition
+            .sub_ability
+            .as_deref()
+            .is_some_and(has_unimplemented)
+        || definition
+            .else_ability
+            .as_deref()
+            .is_some_and(has_unimplemented)
+        || definition.mode_abilities.iter().any(has_unimplemented)
+}
+
+fn object_has_unimplemented(object: &GameObject) -> bool {
+    object.abilities.iter().any(has_unimplemented)
+        || object.trigger_definitions.as_slice().iter().any(|entry| {
+            entry
+                .definition
+                .execute
+                .as_deref()
+                .is_some_and(has_unimplemented)
+        })
+}
+
+fn stack_entries_from(runner: &GameRunner, source: ObjectId) -> usize {
+    runner
+        .state()
+        .stack
+        .iter()
+        .filter(|entry| entry.source_id == source)
+        .count()
+}
+
+/// CR 603.4 + CR 603.10a + CR 122.2: Felisa's intervening-if and X both read
+/// the dying creature's exact departure snapshot. Reanimating that creature
+/// before the trigger resolves must not turn three counters into zero.
+#[test]
+fn felisa_counts_departure_counters_after_goryos_reanimates_the_victim() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+
+    let felisa = {
+        let mut card = scenario.add_creature(P0, "Felisa, Fang of Silverquill", 3, 2);
+        card.as_legendary()
+            .with_subtypes(vec!["Vampire", "Wizard"])
+            .from_oracle_text_with_keywords(&["Flying", "Mentor"], FELISA_ORACLE);
+        card.id()
+    };
+    let victim = scenario
+        .add_creature(P0, "Legendary Counter Victim", 1, 1)
+        .as_legendary()
+        .with_plus_counters(3)
+        .id();
+    let goryos = {
+        let mut card = scenario.add_spell_to_hand_from_oracle(
+            P0,
+            "Goryo's Vengeance",
+            true,
+            GORYOS_VENGEANCE_ORACLE,
+        );
+        card.with_subtypes(vec!["Arcane"])
+            .with_mana_cost(ManaCost::Cost {
+                generic: 1,
+                shards: vec![ManaCostShard::Black],
+            })
+            .from_oracle_text_with_keywords(&["Splice"], GORYOS_VENGEANCE_ORACLE);
+        card.id()
+    };
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+
+    assert!(
+        !object_has_unimplemented(&runner.state().objects[&felisa]),
+        "Felisa's complete Oracle text must parse without an Unimplemented effect"
+    );
+    assert!(
+        !object_has_unimplemented(&runner.state().objects[&goryos]),
+        "Goryo's complete Oracle text, including Splice, must parse without an Unimplemented effect"
+    );
+
+    let dies_trigger = runner.state().objects[&felisa]
+        .trigger_definitions
+        .as_slice()
+        .iter()
+        .find(|entry| entry.definition.origin == Some(Zone::Battlefield))
+        .expect("Felisa must have a battlefield-departure trigger");
+    let execute = dies_trigger
+        .definition
+        .execute
+        .as_deref()
+        .expect("Felisa dies trigger must have an effect");
+    let Effect::Token {
+        name,
+        power,
+        toughness,
+        types,
+        colors,
+        keywords,
+        tapped,
+        count,
+        ..
+    } = execute.effect.as_ref()
+    else {
+        panic!(
+            "Felisa must create a typed token effect, got {:?}",
+            execute.effect
+        );
+    };
+    assert_eq!(name, "Inkling");
+    assert_eq!(power, &PtValue::Fixed(2));
+    assert_eq!(toughness, &PtValue::Fixed(1));
+    assert!(types.iter().any(|ty| ty == "Creature"));
+    assert!(types.iter().any(|ty| ty == "Inkling"));
+    assert_eq!(colors.len(), 2);
+    assert!(keywords.contains(&Keyword::Flying));
+    assert!(*tapped);
+    assert_eq!(
+        count,
+        &QuantityExpr::Ref {
+            qty: QuantityRef::CountersOn {
+                scope: ObjectScope::EventSource,
+                counter_type: None,
+            },
+        },
+        "Felisa's X must name the creature that died"
+    );
+
+    let mut death_events = Vec::new();
+    move_to_zone(
+        runner.state_mut(),
+        victim,
+        Zone::Graveyard,
+        &mut death_events,
+    );
+    process_triggers(runner.state_mut(), &death_events);
+    drain_order_triggers_with_identity(runner.state_mut());
+    assert_eq!(runner.state().objects[&victim].zone, Zone::Graveyard);
+    assert_eq!(
+        stack_entries_from(&runner, felisa),
+        1,
+        "Felisa must be pending before the reanimation response"
+    );
+
+    {
+        let committed = runner.cast(goryos).target_object(victim).commit();
+        assert_eq!(
+            committed.state().stack.len(),
+            2,
+            "Goryo's must be committed above Felisa before either resolves"
+        );
+    }
+    runner.resolve_top();
+
+    let returned = &runner.state().objects[&victim];
+    assert_eq!(returned.zone, Zone::Battlefield);
+    assert!(
+        returned.counters.is_empty(),
+        "the re-entered creature is a new, counterless incarnation"
+    );
+    assert_eq!(
+        stack_entries_from(&runner, felisa),
+        1,
+        "resolving Goryo's must leave Felisa pending"
+    );
+
+    runner.resolve_top();
+
+    let inklings: Vec<_> = runner
+        .state()
+        .objects
+        .values()
+        .filter(|object| {
+            object.is_token
+                && object.controller == P0
+                && object.owner == P0
+                && object.name == "Inkling"
+        })
+        .collect();
+    assert_eq!(
+        inklings.len(),
+        3,
+        "Felisa creates one token per departed counter"
+    );
+    for inkling in inklings {
+        assert!(inkling.tapped);
+        assert_eq!(inkling.power, Some(2));
+        assert_eq!(inkling.toughness, Some(1));
+        assert!(inkling.card_types.core_types.contains(&CoreType::Creature));
+        assert!(inkling.card_types.subtypes.iter().any(|ty| ty == "Inkling"));
+        assert!(inkling
+            .color
+            .contains(&engine::types::mana::ManaColor::White));
+        assert!(inkling
+            .color
+            .contains(&engine::types::mana::ManaColor::Black));
+        assert!(inkling.keywords.contains(&Keyword::Flying));
+    }
+
+    assert_eq!(
+        runner.state().objects[&victim]
+            .counters
+            .get(&CounterType::Plus1Plus1),
+        None,
+        "the token count came from the departure record, not the returned object"
+    );
+}
+
+/// A present but incoherent departure context is not a legacy record. It must
+/// fail closed at trigger detection instead of consulting the mutable LKI cache.
+#[test]
+fn felisa_does_not_trigger_from_a_malformed_departure_record() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+    let felisa = scenario
+        .add_creature(P0, "Felisa, Fang of Silverquill", 3, 2)
+        .from_oracle_text_with_keywords(&["Flying", "Mentor"], FELISA_ORACLE)
+        .id();
+    let victim = scenario
+        .add_creature(P0, "Counter Victim", 1, 1)
+        .with_plus_counters(3)
+        .id();
+    let mut runner = scenario.build();
+
+    let mut death_events = Vec::new();
+    move_to_zone(
+        runner.state_mut(),
+        victim,
+        Zone::Graveyard,
+        &mut death_events,
+    );
+    let record = death_events
+        .iter_mut()
+        .find_map(|event| match event {
+            engine::types::events::GameEvent::ZoneChanged {
+                object_id, record, ..
+            } if *object_id == victim => Some(record),
+            _ => None,
+        })
+        .expect("production death must emit a ZoneChanged record");
+    record
+        .trigger_source_context
+        .as_mut()
+        .expect("production record has owned context")
+        .identity
+        .expected_zone = Zone::Graveyard;
+
+    process_triggers(runner.state_mut(), &death_events);
+    drain_order_triggers_with_identity(runner.state_mut());
+    assert_eq!(
+        stack_entries_from(&runner, felisa),
+        0,
+        "a malformed context must not be silently downgraded to cache fallback"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -179,6 +179,7 @@ mod exquisite_blood_routing;
 mod eyetwitch_learn_decline_lesson;
 mod fact_or_fiction_pile_separation;
 mod fateful_handoff_target_mana_value_draw;
+mod felisa_fang_of_silverquill;
 mod festival_of_embers_graveyard_additional_cost;
 mod fevered_visions;
 mod fewer_than_existential_threshold;


### PR DESCRIPTION
## Summary

Adds engine support for **Felisa, Fang of Silverquill**, including past-tense departure-counter quantities and record-owned LKI authority so reanimation cannot change the token count.

## Files changed

- `crates/engine/src/game/quantity.rs`
- `crates/engine/src/game/triggers.rs`
- `crates/engine/src/parser/oracle_effect/lower.rs`
- `crates/engine/src/parser/oracle_nom/quantity.rs`
- `crates/engine/src/types/game_state.rs`
- `crates/engine/tests/integration/felisa_fang_of_silverquill.rs`
- `crates/engine/tests/integration/main.rs`

## Track

Developer

## LLM

Model: gpt-5.6-terra
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 122.2, CR 400.7, CR 603.10a.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — `EXIT_STATUS=0`.
- `cargo clippy-strict` — `EXIT_STATUS=0`.
- `cargo test -p engine` — 17,827 library tests and 4,118 integration tests passed; both Felisa integration tests passed.
- `./scripts/gen-card-data.sh` — `EXIT_STATUS=0`; Felisa is supported with `gap_count: 0`.
- `cargo coverage` — `EXIT_STATUS=0`.
- `cargo semantic-audit` — `EXIT_STATUS=0`.
- `./scripts/check-parser-combinators.sh` — `Gate A PASS head=e991d10db2c10563ce46219ff6b19006824e83aa base=6b29e0d72025be07c609cb6f992d2524267519b1`.

## Gate A

Gate A PASS head=e991d10db2c10563ce46219ff6b19006824e83aa base=6b29e0d72025be07c609cb6f992d2524267519b1

## Anchored on

- `crates/engine/src/parser/oracle_nom/quantity.rs:1234` — existing compositional counter-quantity parser using the same `QuantityRef::CountersOn` representation.
- `crates/engine/src/game/triggers.rs:8183` — existing record-owned trigger-context provenance check that rejects incoherent zone-change identity.

## Final review-impl

Final review-impl PASS head=e991d10db2c10563ce46219ff6b19006824e83aa

## Claimed parse impact

Felisa, Fang of Silverquill.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected counter-count sourcing for battlefield departures to use the departure snapshot (not a later incarnation), including strict provenance handling.
  * Fail-closed behavior: malformed or incoherent departure information no longer causes incorrect trigger/effect resolution.
  * Preserved legacy fallback only when departure context is genuinely absent.
* **New Features**
  * Added parsing for past-tense counter-count phrases like “the number of counters it had” (scoped to the event source).
  * Expanded support for additional where-X quantity expressions and compositional quantity-reference forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->