### PR TITLE
refactor(parser): Plan 05b Class-B bring-up, tranches T0-T3

### DIFF
--- a/.claude/skills/oracle-parser/SKILL.md
+++ b/.claude/skills/oracle-parser/SKILL.md
@@ -453,7 +453,6 @@ Unlabeled handlers interleaved between labeled slots are shown as `—` rows.
 | `13b` | Kicker/Multikicker leftovers | skip (handled by keywords) | — |
 | `13c` | Vehicle tier lines "N+ \| keyword(s)" | skip | `oracle_classifier.rs` |
 | `13d` | "Activate only…" constraint line | skip | — |
-| `13e` | "X can't be 0." annotation → `min_x_value` on previous ability | defensive fallback | `oracle.rs` |
 | `14` | Ability word prefix ("Landfall —") — strip, map known words to typed conditions, re-classify the body | `strip_ability_word_with_name()` + `ability_word_to_condition()` | `oracle.rs` |
 | `14a` | Nom fallback dispatch — try effect, trigger, static, and replacement sub-parsers | `dispatch_line_nom()` | `oracle_dispatch.rs` |
 | `15` | Final fallback | `Effect::Unimplemented` with diagnostic trace | — |

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,4 +6,7 @@ echo "Running pre-commit checks..."
 echo "  [rust] parser combinator gate"
 ./scripts/check-parser-combinators.sh
 
+echo "  [rust] PreLowered ratchet"
+./scripts/check-prelowered-ratchet.sh
+
 echo "All pre-commit checks passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,14 @@ jobs:
           fi
           ./scripts/check-parser-combinators.sh "$BASE"
 
+      - name: PreLowered ratchet (Plan 05b burn-down)
+        # Ceiling check on `OracleNodeIr::PreLowered*` occurrences per parser
+        # file. Counts may only decrease, and a parser file carrying PreLowered
+        # with no ledger entry fails, so a new producer cannot be added in a
+        # third file and escape the burn-down. Ledger:
+        # scripts/prelowered-ratchet.txt
+        run: ./scripts/check-prelowered-ratchet.sh
+
       - name: Skill doc gate (oracle-parser SKILL.md)
         # Asserts .claude/skills/oracle-parser/SKILL.md still matches the
         # parser source tree: documented paths/symbols exist and the §3

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3829,8 +3829,11 @@ pub(crate) fn parse_oracle_ir(
     // header..=max(mod_lines) via `emit_span`).
     let (level_statics, level_consumed, level_ability_lines) =
         parse_level_blocks(&lines, card_name);
-    for (sd, first_line, last_line) in level_statics {
-        emitter.emit_span(first_line, last_line, OracleNodeIr::PreLoweredStatic(sd));
+    // Keeps `emit_span` rather than routing through `static_ir_at`: the
+    // `first..=last` range is load-bearing, and `static_ir_at` would also write
+    // the `last_static` peek mirror, which the leveler deliberately does not.
+    for (ir, first_line, last_line) in level_statics {
+        emitter.emit_span(first_line, last_line, OracleNodeIr::Static(ir));
     }
     // CR 711.2a + CR 711.2b: Re-parse ability lines found within LEVEL blocks through
     // the normal trigger/activated/static pipeline, then attach the level counter condition.
@@ -3925,8 +3928,8 @@ pub(crate) fn parse_oracle_ir(
         // resolves to the correct printed-trigger slot.
         let (sc_statics, sc_triggers, sc_abilities, consumed) =
             parse_spacecraft_threshold_lines(&lines, card_name, PrintedTriggerIndex::placeholder());
-        for (line, sd) in sc_statics {
-            emitter.static_at(line, sd);
+        for (line, ir) in sc_statics {
+            emitter.static_ir_at(line, ir);
         }
         for (line, trigger) in sc_triggers {
             emitter.trigger_at(line, trigger);

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3808,7 +3808,7 @@ pub(crate) fn parse_oracle_ir(
         for (line, trigger) in chapter_triggers {
             emitter.trigger_at(line, trigger);
         }
-        emitter.replacement_at(etb_line, etb_replacement);
+        emitter.replacement_ir_at(etb_line, etb_replacement);
         consumed
     } else {
         std::collections::HashSet::new()
@@ -5343,8 +5343,14 @@ pub(crate) fn parse_oracle_ir(
             // one definition and cannot emit the dual pair. The tight
             // PutCounter-SelfRef guard makes it fall through on any non-counter
             // as-enters line, so the choose/becomes/enters-with siblings are safe.
-            if lower_as_enters_or_face_up_counters(&line, &mut result) {
-                emitter.drain_result_vectors(item_line, &mut result);
+            // Emits directly rather than draining the shared scratch: this is
+            // the only vector this recognizer ever wrote, and every other
+            // `&mut result` handoff in the loop is drain-followed, so the
+            // scratch is provably empty here.
+            if let Some(replacement_irs) = lower_as_enters_or_face_up_counters(&line) {
+                for replacement_ir in replacement_irs {
+                    emitter.replacement_ir_at(item_line, replacement_ir);
+                }
                 i += 1;
                 continue;
             }
@@ -5990,17 +5996,13 @@ pub(crate) fn parse_oracle_ir(
             continue;
         }
 
-        // Priority 13e: "X can't be 0." — casting constraint annotation, not an ability.
-        // These appear as standalone lines on X-cost spells. Earlier empty-line
-        // handling stamps the previous ability's `min_x_value`; this guard is a
-        // defensive fallback for already-normalized forms.
-        if lower.trim_end_matches('.') == "x can't be 0" {
-            emitter.mutate_last_spell(|previous| {
-                previous.min_x_value = previous.min_x_value.max(1);
-            });
-            i += 1;
-            continue;
-        }
+        // Priority 13e ("X can't be 0.") was deleted as structurally unreachable:
+        // `strip_x_cant_be_zero_suffix` returns `""` for exactly that input, and
+        // `lower` is bound once from the post-strip line and never rebound, so
+        // the empty-line guard above always claims it first. Its own comment
+        // called it a "defensive fallback"; it was dead, and it was one of the
+        // two `mutate_last_spell` callers whose destructure asserts a single node
+        // shape.
 
         // Priority 14: Ability word — strip prefix and re-classify effect.
         // B7: Known ability words (Threshold, Metalcraft, Delirium, Spell mastery, Revolt)

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5996,7 +5996,13 @@ pub(crate) fn parse_oracle_ir(
             continue;
         }
 
-        // Priority 13e ("X can't be 0.") was deleted as structurally unreachable:
+        // The former priority slot 13e ("X can't be 0.") was deleted as
+        // structurally unreachable. This gravestone deliberately avoids the
+        // labeled-slot comment shape that `check-skill-doc.sh` harvests: in
+        // that shape it reads as a live declaration and demands a §3 row for a
+        // slot that no longer exists. A retired slot is documented by its
+        // absence from the table, not by a row saying it is gone.
+        //
         // `strip_x_cant_be_zero_suffix` returns `""` for exactly that input, and
         // `lower` is bound once from the post-strip line and never rebound, so
         // the empty-line guard above always claims it first. Its own comment

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -18,6 +18,8 @@ use super::oracle_classifier::{
 use super::oracle_cost::parse_oracle_cost;
 use super::oracle_effect::parse_effect_chain;
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::replacement::ReplacementIr;
+use super::oracle_ir::static_ir::StaticIr;
 use super::oracle_keyword::extract_granted_keyword_list;
 use super::oracle_modal::strip_ability_word;
 use super::oracle_nom::primitives as nom_primitives;
@@ -190,7 +192,10 @@ pub(crate) fn parse_class_oracle_text(
                     if section.level > 1 {
                         static_def = wrap_static_with_class_level(static_def, section.level);
                     }
-                    items.push((line_index, OracleNodeIr::PreLoweredStatic(static_def)));
+                    items.push((
+                        line_index,
+                        OracleNodeIr::Static(StaticIr::from_definition(&static_line, static_def)),
+                    ));
                     continue;
                 }
             }
@@ -201,7 +206,10 @@ pub(crate) fn parse_class_oracle_text(
                     if section.level > 1 {
                         static_def = wrap_static_with_class_level(static_def, section.level);
                     }
-                    items.push((line_index, OracleNodeIr::PreLoweredStatic(static_def)));
+                    items.push((
+                        line_index,
+                        OracleNodeIr::Static(StaticIr::from_definition(&static_line, static_def)),
+                    ));
                     continue;
                 }
             }
@@ -218,7 +226,10 @@ pub(crate) fn parse_class_oracle_text(
                     if section.level > 1 {
                         rep_def = wrap_replacement_with_class_level(rep_def, section.level);
                     }
-                    items.push((line_index, OracleNodeIr::PreLoweredReplacement(rep_def)));
+                    items.push((
+                        line_index,
+                        OracleNodeIr::Replacement(ReplacementIr::from_definition(line, rep_def)),
+                    ));
                     continue;
                 }
             }
@@ -257,7 +268,13 @@ pub(crate) fn parse_class_oracle_text(
                         if section.level > 1 {
                             static_def = wrap_static_with_class_level(static_def, section.level);
                         }
-                        items.push((line_index, OracleNodeIr::PreLoweredStatic(static_def)));
+                        items.push((
+                            line_index,
+                            OracleNodeIr::Static(StaticIr::from_definition(
+                                &effect_static,
+                                static_def,
+                            )),
+                        ));
                         continue;
                     }
                 }

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -317,8 +317,6 @@ pub(crate) enum OracleNodeIr {
     #[allow(dead_code)]
     Trigger(TriggerIr),
     /// Static ability.
-    // PLAN-05 DEBT (2026-07-17, post-U2): constructed only by the Class-B bring-up (unit 3); retire this allow there.
-    #[allow(dead_code)]
     Static(StaticIr),
     /// Replacement effect.
     Replacement(ReplacementIr),

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -366,6 +366,52 @@ fn student_of_warfare() {
     insta::assert_json_snapshot!("student_of_warfare_lowered", &lowered);
 }
 
+/// Leveler *body* static (Plan 05b, T2 witness).
+///
+/// `student_of_warfare` above reaches only the block-SUMMARY static
+/// (`oracle_level.rs:194`), synthesized from P/T and keyword lines. Kabira
+/// Vindicator prints a full sentence inside each LEVEL block, so it is the
+/// witness for the body arm (`oracle_level.rs:154`, via `parse_static_line`)
+/// — twice, once per block — while still carrying two block summaries.
+///
+/// The sibling multi arm (`:146`, `parse_static_line_multi`) has no pool
+/// witness: no printed LEVEL body line lowers to more than one static.
+#[test]
+fn kabira_vindicator() {
+    let (ir, lowered) = parse_two_layer(
+        "Level up {2}{W} ({2}{W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-4\n3/6\nOther creatures you control get +1/+1.\nLEVEL 5+\n4/8\nOther creatures you control get +2/+2.",
+        "Kabira Vindicator",
+        &["Creature"],
+        &["Human", "Knight"],
+    );
+    insta::assert_json_snapshot!("kabira_vindicator_ir", &ir);
+    insta::assert_json_snapshot!("kabira_vindicator_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
+// Spacecraft threshold lines (Plan 05b, T2 witness)
+// ---------------------------------------------------------------------------
+
+/// Both Spacecraft static arms on one card (CR 702.184a / CR 721.2).
+///
+/// `2+ | Other creatures you control get +1/+1.` takes the
+/// `parse_static_line` arm (`oracle_spacecraft.rs:256`); `12+ | Flying,
+/// lifelink` takes the keyword-only arm (`:178`). Nothing else in the two-layer
+/// corpus reaches either — Chalice of the Void carries `charge` counters but
+/// prints no threshold line — so without this fixture T2's Spacecraft
+/// conversion would be snapshot-invisible.
+#[test]
+fn lumen_class_frigate() {
+    let (ir, lowered) = parse_two_layer(
+        "Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery. It's an artifact creature at 12+.)\n2+ | Other creatures you control get +1/+1.\n12+ | Flying, lifelink",
+        "Lumen-Class Frigate",
+        &["Artifact"],
+        &["Spacecraft"],
+    );
+    insta::assert_json_snapshot!("lumen_class_frigate_ir", &ir);
+    insta::assert_json_snapshot!("lumen_class_frigate_lowered", &lowered);
+}
+
 // ---------------------------------------------------------------------------
 // Adventure
 // ---------------------------------------------------------------------------

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -1242,6 +1242,114 @@ fn aerial_formation() {
 }
 
 // ---------------------------------------------------------------------------
+// Class level sections (Plan 05b, T1 witness corpus)
+//
+// No Class card was in the two-layer corpus, which made T1's byte-identity gate
+// vacuous: the `oracle_class.rs` level-section arms could be converted from
+// `PreLowered*` to IR nodes with zero snapshot churn and zero proof the conversion
+// was reached. All five cards below are pool-verified (Oracle text and `card_type`
+// read from `data/card-data.json`, never written from memory).
+//
+// The arm each line actually reaches was read off the generated baseline
+// (node variant + source fragment per item), not predicted — an earlier version of
+// this comment guessed three of them wrong. Arm attribution follows from the
+// dispatch order in `parse_class_sections` and the predicates in
+// `oracle_classifier.rs`; `is_granted_static_line` is checked first and requires a
+// prefix from `GRANTED_STATIC_PREFIXES` *and* a verb from `GRANTED_STATIC_VERBS`
+// (`has "` / `have "` / `gains "` / `gain "` — the quote is part of the match), so
+// only a granted *quoted ability* reaches it. An unquoted grant falls through to
+// `is_static_pattern`.
+//
+//   arm                          unwrapped (level 1)   wrapped (level > 1)
+//   ---------------------------  --------------------  ----------------------------
+//   granted quoted static (193)  (none)                Sorcerer Class L2
+//   plain static (204)           Wizard Class L1       Barbarian L3, Innkeeper L2,
+//                                                      Bard L2
+//   replacement (221)            Bard Class L1         Innkeeper's Talent L3
+//   ability-word static (260)    (none)                (none)
+//
+// Two coverage gaps are recorded rather than papered over:
+//
+//   * Row 260 has NO witness in the pool. All three ability-word-prefixed Class
+//     level bodies (Druid Class, A-Druid Class, Advanced Floral Invocations) are
+//     `Landfall — Whenever ...` and take the trigger arm instead. Its conversion
+//     rests on the class argument alone, not on corpus evidence.
+//   * Row 193 is witnessed only in its wrapped form. The wrap is applied to
+//     `static_def` *before* the push in both branches, so the conversion site is
+//     identical either way; the unwrapped half is covered by row 204's Wizard L1.
+//
+// Non-witness worth knowing about: Barbarian Class L1 ("If you would roll one or
+// more dice, instead roll that many dice plus one and ignore the lowest roll")
+// does NOT reach the replacement arm — it falls through to the generic path and
+// lands as `PreLoweredSpell` with an `Unimplemented` effect. That is a pre-existing
+// parser gap, not something T1 introduces; it is baselined here so that if T1
+// changes it, the churn is visible and must be explained.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sorcerer_class() {
+    let (ir, lowered) = parse_two_layer(
+        "(Gain the next level as a sorcery to add its ability.)\nWhen this Class enters, draw two cards, then discard two cards.\n{U}{R}: Level 2\nCreatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\"\n{3}{U}{R}: Level 3\nWhenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn.",
+        "Sorcerer Class",
+        &["Enchantment"],
+        &["Class"],
+    );
+    insta::assert_json_snapshot!("sorcerer_class_ir", &ir);
+    insta::assert_json_snapshot!("sorcerer_class_lowered", &lowered);
+}
+
+#[test]
+fn barbarian_class() {
+    let (ir, lowered) = parse_two_layer(
+        "(Gain the next level as a sorcery to add its ability.)\nIf you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.\n{1}{R}: Level 2\nWhenever you roll one or more dice, target creature you control gets +2/+0 and gains menace until end of turn.\n{2}{R}: Level 3\nCreatures you control have haste.",
+        "Barbarian Class",
+        &["Enchantment"],
+        &["Class"],
+    );
+    insta::assert_json_snapshot!("barbarian_class_ir", &ir);
+    insta::assert_json_snapshot!("barbarian_class_lowered", &lowered);
+}
+
+#[test]
+fn innkeepers_talent() {
+    let (ir, lowered) = parse_two_layer(
+        "(Gain the next level as a sorcery to add its ability.)\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\n{G}: Level 2\nPermanents you control with counters on them have ward {1}.\n{3}{G}: Level 3\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
+        "Innkeeper's Talent",
+        &["Enchantment"],
+        &["Class"],
+    );
+    insta::assert_json_snapshot!("innkeepers_talent_ir", &ir);
+    insta::assert_json_snapshot!("innkeepers_talent_lowered", &lowered);
+}
+
+#[test]
+fn bard_class() {
+    let (ir, lowered) = parse_two_layer(
+        "(Gain the next level as a sorcery to add its ability.)\nLegendary creatures you control enter with an additional +1/+1 counter on them.\n{R}{G}: Level 2\nLegendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\n{3}{R}{G}: Level 3\nWhenever you cast a legendary spell, exile the top two cards of your library. You may play them this turn.",
+        "Bard Class",
+        &["Enchantment"],
+        &["Class"],
+    );
+    insta::assert_json_snapshot!("bard_class_ir", &ir);
+    insta::assert_json_snapshot!("bard_class_lowered", &lowered);
+}
+
+/// Level-1 plain static — the unwrapped half of the `is_static_pattern` arm.
+/// `"You have no maximum hand size."` matches `GRANTED_STATIC_PREFIXES` on `"you "`
+/// but carries no quoted ability, so it falls past `is_granted_static_line`.
+#[test]
+fn wizard_class() {
+    let (ir, lowered) = parse_two_layer(
+        "(Gain the next level as a sorcery to add its ability.)\nYou have no maximum hand size.\n{2}{U}: Level 2\nWhen this Class becomes level 2, draw two cards.\n{4}{U}: Level 3\nWhenever you draw a card, put a +1/+1 counter on target creature you control.",
+        "Wizard Class",
+        &["Enchantment"],
+        &["Class"],
+    );
+    insta::assert_json_snapshot!("wizard_class_two_layer_ir", &ir);
+    insta::assert_json_snapshot!("wizard_class_two_layer_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Diagnostic snapshot tests (Phase 51, D-10)
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
@@ -1,0 +1,302 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1300
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 55,
+          "end_byte": 155,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll."
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 156,
+          "end_byte": 171,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{1}{R}: Level 2"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 2
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Red"
+              ],
+              "generic": 1
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{1}{R}: Level 2",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 1
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 172,
+          "end_byte": 282,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever you roll one or more dice, target creature you control gets +2/+0 and gains menace until end of turn."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "RolledDie",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "ParentTarget"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddPower",
+                      "value": 2
+                    },
+                    {
+                      "type": "AddToughness",
+                      "value": 0
+                    },
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Menace"
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "get +2/+0 and gains menace"
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": {
+            "type": "Controller"
+          },
+          "valid_source": null,
+          "description": "Whenever you roll one or more dice, target creature you control gets +2/+0 and gains menace until end of turn.",
+          "constraint": null,
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 2
+          },
+          "batched": true
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 283,
+          "end_byte": 298,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{2}{R}: Level 3"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 3
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Red"
+              ],
+              "generic": 2
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{2}{R}: Level 3",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 2
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 4,
+      "source": {
+        "id": {
+          "item": 4,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 5,
+          "last_line": 5,
+          "start_byte": 299,
+          "end_byte": 332,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Creatures you control have haste."
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": []
+          },
+          "modifications": [
+            {
+              "type": "AddKeyword",
+              "keyword": "Haste"
+            }
+          ],
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 3
+          },
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Creatures you control have haste."
+        }
+      }
+    }
+  ],
+  "source_text": "(Gain the next level as a sorcery to add its ability.)\nIf you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.\n{1}{R}: Level 2\nWhenever you roll one or more dice, target creature you control gets +2/+0 and gains menace until end of turn.\n{2}{R}: Level 3\nCreatures you control have haste.",
+  "card_name": "Barbarian Class"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1300
+assertion_line: 1309
 expression: "&ir"
 ---
 {
@@ -268,31 +268,35 @@ expression: "&ir"
         "fragment": "Creatures you control have haste."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": []
+            },
+            "modifications": [
+              {
+                "type": "AddKeyword",
+                "keyword": "Haste"
+              }
             ],
-            "controller": "You",
-            "properties": []
+            "condition": {
+              "type": "ClassLevelGE",
+              "level": 3
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Creatures you control have haste."
           },
-          "modifications": [
-            {
-              "type": "AddKeyword",
-              "keyword": "Haste"
-            }
-          ],
-          "condition": {
-            "type": "ClassLevelGE",
-            "level": 3
-          },
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Creatures you control have haste."
+          "source_text": "Creatures you control have haste.",
+          "body_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_lowered.snap
@@ -1,0 +1,206 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1310
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "Unimplemented",
+        "name": "unknown",
+        "description": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll."
+      },
+      "cost": null,
+      "sub_ability": null,
+      "duration": null,
+      "description": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 2
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Red"
+          ],
+          "generic": 1
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{1}{R}: Level 2",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 1
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 3
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Red"
+          ],
+          "generic": 2
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{2}{R}: Level 3",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 2
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [
+    {
+      "mode": "RolledDie",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GenericEffect",
+          "static_abilities": [
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "ParentTarget"
+              },
+              "modifications": [
+                {
+                  "type": "AddPower",
+                  "value": 2
+                },
+                {
+                  "type": "AddToughness",
+                  "value": 0
+                },
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Menace"
+                }
+              ],
+              "condition": null,
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "get +2/+0 and gains menace"
+            }
+          ],
+          "duration": "UntilEndOfTurn",
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": []
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": {
+        "type": "Controller"
+      },
+      "valid_source": null,
+      "description": "Whenever you roll one or more dice, target creature you control gets +2/+0 and gains menace until end of turn.",
+      "constraint": null,
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 2
+      },
+      "batched": true
+    }
+  ],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Creature"
+        ],
+        "controller": "You",
+        "properties": []
+      },
+      "modifications": [
+        {
+          "type": "AddKeyword",
+          "keyword": "Haste"
+        }
+      ],
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 3
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Creatures you control have haste."
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
@@ -1,0 +1,348 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1324
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 55,
+          "end_byte": 134,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Legendary creatures you control enter with an additional +1/+1 counter on them."
+      },
+      "node": {
+        "PreLoweredReplacement": {
+          "event": "Moved",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "P1P1",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "SelfRef"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "mode": {
+            "type": "Mandatory"
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "description": "Legendary creatures you control enter with an additional +1/+1 counter on them.",
+          "condition": null,
+          "destination_zone": "Battlefield"
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 135,
+          "end_byte": 150,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{R}{G}: Level 2"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 2
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Red",
+                "Green"
+              ],
+              "generic": 0
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{R}{G}: Level 2",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 1
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 151,
+          "end_byte": 263,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Legendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay."
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": {
+            "ModifyCost": {
+              "mode": "Reduce",
+              "amount": {
+                "type": "Cost",
+                "shards": [
+                  "Red",
+                  "Green"
+                ],
+                "generic": 0
+              },
+              "spell_filter": {
+                "type": "Typed",
+                "type_filters": [
+                  "Card"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "HasSupertype",
+                    "value": "Legendary"
+                  }
+                ]
+              }
+            }
+          },
+          "affected": {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": "You",
+            "properties": []
+          },
+          "modifications": [],
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 2
+          },
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Legendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay."
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 264,
+          "end_byte": 282,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{3}{R}{G}: Level 3"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 3
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Red",
+                "Green"
+              ],
+              "generic": 3
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{3}{R}{G}: Level 3",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 2
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 4,
+      "source": {
+        "id": {
+          "item": 4,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 5,
+          "last_line": 5,
+          "start_byte": 283,
+          "end_byte": 389,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever you cast a legendary spell, exile the top two cards of your library. You may play them this turn."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "SpellCast",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ExileTop",
+              "player": {
+                "type": "Controller"
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "position": {
+                "type": "Top"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "CastFromZone",
+                "target": {
+                  "type": "ParentTarget"
+                },
+                "without_paying_mana_cost": false,
+                "mode": "Play",
+                "duration": "UntilEndOfTurn"
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": "UntilEndOfTurn",
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "HasSupertype",
+                "value": "Legendary"
+              }
+            ]
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": {
+            "type": "Controller"
+          },
+          "valid_source": null,
+          "description": "Whenever you cast a legendary spell, exile the top two cards of your library. You may play them this turn.",
+          "constraint": null,
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 3
+          },
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "(Gain the next level as a sorcery to add its ability.)\nLegendary creatures you control enter with an additional +1/+1 counter on them.\n{R}{G}: Level 2\nLegendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay.\n{3}{R}{G}: Level 3\nWhenever you cast a legendary spell, exile the top two cards of your library. You may play them this turn.",
+  "card_name": "Bard Class"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1324
+assertion_line: 1333
 expression: "&ir"
 ---
 {
@@ -23,40 +23,44 @@ expression: "&ir"
         "fragment": "Legendary creatures you control enter with an additional +1/+1 counter on them."
       },
       "node": {
-        "PreLoweredReplacement": {
-          "event": "Moved",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "P1P1",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Replacement": {
+          "definition": {
+            "event": "Moved",
+            "execute": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "P1P1",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "target": {
+                  "type": "SelfRef"
+                }
               },
-              "target": {
-                "type": "SelfRef"
-              }
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
+            "mode": {
+              "type": "Mandatory"
+            },
+            "valid_card": {
+              "type": "SelfRef"
+            },
+            "description": "Legendary creatures you control enter with an additional +1/+1 counter on them.",
             "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            "destination_zone": "Battlefield"
           },
-          "mode": {
-            "type": "Mandatory"
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "description": "Legendary creatures you control enter with an additional +1/+1 counter on them.",
-          "condition": null,
-          "destination_zone": "Battlefield"
+          "source_text": "Legendary creatures you control enter with an additional +1/+1 counter on them.",
+          "execute_ir": null
         }
       }
     },
@@ -135,51 +139,55 @@ expression: "&ir"
         "fragment": "Legendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": {
-            "ModifyCost": {
-              "mode": "Reduce",
-              "amount": {
-                "type": "Cost",
-                "shards": [
-                  "Red",
-                  "Green"
-                ],
-                "generic": 0
-              },
-              "spell_filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Card"
-                ],
-                "controller": null,
-                "properties": [
-                  {
-                    "type": "HasSupertype",
-                    "value": "Legendary"
-                  }
-                ]
+        "Static": {
+          "definition": {
+            "mode": {
+              "ModifyCost": {
+                "mode": "Reduce",
+                "amount": {
+                  "type": "Cost",
+                  "shards": [
+                    "Red",
+                    "Green"
+                  ],
+                  "generic": 0
+                },
+                "spell_filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Card"
+                  ],
+                  "controller": null,
+                  "properties": [
+                    {
+                      "type": "HasSupertype",
+                      "value": "Legendary"
+                    }
+                  ]
+                }
               }
-            }
+            },
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Card"
+              ],
+              "controller": "You",
+              "properties": []
+            },
+            "modifications": [],
+            "condition": {
+              "type": "ClassLevelGE",
+              "level": 2
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Legendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay."
           },
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Card"
-            ],
-            "controller": "You",
-            "properties": []
-          },
-          "modifications": [],
-          "condition": {
-            "type": "ClassLevelGE",
-            "level": 2
-          },
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Legendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay."
+          "source_text": "Legendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay.",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_lowered.snap
@@ -1,0 +1,253 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1334
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 2
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Red",
+            "Green"
+          ],
+          "generic": 0
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{R}{G}: Level 2",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 1
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 3
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Red",
+            "Green"
+          ],
+          "generic": 3
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{3}{R}{G}: Level 3",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 2
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [
+    {
+      "mode": "SpellCast",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "ExileTop",
+          "player": {
+            "type": "Controller"
+          },
+          "count": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "position": {
+            "type": "Top"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "CastFromZone",
+            "target": {
+              "type": "ParentTarget"
+            },
+            "without_paying_mana_cost": false,
+            "mode": "Play",
+            "duration": "UntilEndOfTurn"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "sub_link": "SequentialSibling"
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "Typed",
+        "type_filters": [
+          "Card"
+        ],
+        "controller": null,
+        "properties": [
+          {
+            "type": "HasSupertype",
+            "value": "Legendary"
+          }
+        ]
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": {
+        "type": "Controller"
+      },
+      "valid_source": null,
+      "description": "Whenever you cast a legendary spell, exile the top two cards of your library. You may play them this turn.",
+      "constraint": null,
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 3
+      },
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": {
+        "ModifyCost": {
+          "mode": "Reduce",
+          "amount": {
+            "type": "Cost",
+            "shards": [
+              "Red",
+              "Green"
+            ],
+            "generic": 0
+          },
+          "spell_filter": {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "HasSupertype",
+                "value": "Legendary"
+              }
+            ]
+          }
+        }
+      },
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Card"
+        ],
+        "controller": "You",
+        "properties": []
+      },
+      "modifications": [],
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 2
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Legendary spells you cast cost {R}{G} less to cast. This effect reduces only the amount of colored mana you pay."
+    }
+  ],
+  "replacements": [
+    {
+      "event": "Moved",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "PutCounter",
+          "counter_type": "P1P1",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "SelfRef"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "mode": {
+        "type": "Mandatory"
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "description": "Legendary creatures you control enter with an additional +1/+1 counter on them.",
+      "condition": null,
+      "destination_zone": "Battlefield"
+    }
+  ],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__innkeepers_talent_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__innkeepers_talent_ir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1312
+assertion_line: 1321
 expression: "&ir"
 ---
 {
@@ -148,52 +148,56 @@ expression: "&ir"
         "fragment": "Permanents you control with counters on them have ward {1}."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Permanent"
-            ],
-            "controller": "You",
-            "properties": [
-              {
-                "type": "Counters",
-                "counters": {
-                  "type": "Any"
-                },
-                "comparator": "GE",
-                "count": {
-                  "type": "Fixed",
-                  "value": 1
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Permanent"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "Counters",
+                  "counters": {
+                    "type": "Any"
+                  },
+                  "comparator": "GE",
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  }
                 }
-              }
-            ]
-          },
-          "modifications": [
-            {
-              "type": "AddKeyword",
-              "keyword": {
-                "Ward": {
-                  "type": "Mana",
-                  "data": {
-                    "type": "Cost",
-                    "shards": [],
-                    "generic": 1
+              ]
+            },
+            "modifications": [
+              {
+                "type": "AddKeyword",
+                "keyword": {
+                  "Ward": {
+                    "type": "Mana",
+                    "data": {
+                      "type": "Cost",
+                      "shards": [],
+                      "generic": 1
+                    }
                   }
                 }
               }
-            }
-          ],
-          "condition": {
-            "type": "ClassLevelGE",
-            "level": 2
+            ],
+            "condition": {
+              "type": "ClassLevelGE",
+              "level": 2
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Permanents you control with counters on them have ward {1}."
           },
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Permanents you control with counters on them have ward {1}."
+          "source_text": "Permanents you control with counters on them have ward {1}.",
+          "body_ir": null
         }
       }
     },
@@ -271,24 +275,28 @@ expression: "&ir"
         "fragment": "If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead."
       },
       "node": {
-        "PreLoweredReplacement": {
-          "event": "AddCounter",
-          "execute": null,
-          "mode": {
-            "type": "Mandatory"
+        "Replacement": {
+          "definition": {
+            "event": "AddCounter",
+            "execute": null,
+            "mode": {
+              "type": "Mandatory"
+            },
+            "valid_card": null,
+            "description": "If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
+            "condition": {
+              "type": "ClassLevelGE",
+              "level": 3
+            },
+            "quantity_modification": {
+              "type": "Times",
+              "factor": 2
+            },
+            "valid_player": "You",
+            "counter_replacement_subject": "Actor"
           },
-          "valid_card": null,
-          "description": "If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
-          "condition": {
-            "type": "ClassLevelGE",
-            "level": 3
-          },
-          "quantity_modification": {
-            "type": "Times",
-            "factor": 2
-          },
-          "valid_player": "You",
-          "counter_replacement_subject": "Actor"
+          "source_text": "If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
+          "execute_ir": null
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__innkeepers_talent_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__innkeepers_talent_ir.snap
@@ -1,0 +1,298 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1312
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 55,
+          "end_byte": 147,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "P1P1",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "BeginCombat",
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
+          "constraint": {
+            "type": "OnlyDuringYourTurn"
+          },
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 148,
+          "end_byte": 160,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{G}: Level 2"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 2
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Green"
+              ],
+              "generic": 0
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{G}: Level 2",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 1
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 161,
+          "end_byte": 220,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Permanents you control with counters on them have ward {1}."
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "Typed",
+            "type_filters": [
+              "Permanent"
+            ],
+            "controller": "You",
+            "properties": [
+              {
+                "type": "Counters",
+                "counters": {
+                  "type": "Any"
+                },
+                "comparator": "GE",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                }
+              }
+            ]
+          },
+          "modifications": [
+            {
+              "type": "AddKeyword",
+              "keyword": {
+                "Ward": {
+                  "type": "Mana",
+                  "data": {
+                    "type": "Cost",
+                    "shards": [],
+                    "generic": 1
+                  }
+                }
+              }
+            }
+          ],
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 2
+          },
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Permanents you control with counters on them have ward {1}."
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 221,
+          "end_byte": 236,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{3}{G}: Level 3"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 3
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Green"
+              ],
+              "generic": 3
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{3}{G}: Level 3",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 2
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 4,
+      "source": {
+        "id": {
+          "item": 4,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 5,
+          "last_line": 5,
+          "start_byte": 237,
+          "end_byte": 392,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead."
+      },
+      "node": {
+        "PreLoweredReplacement": {
+          "event": "AddCounter",
+          "execute": null,
+          "mode": {
+            "type": "Mandatory"
+          },
+          "valid_card": null,
+          "description": "If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 3
+          },
+          "quantity_modification": {
+            "type": "Times",
+            "factor": 2
+          },
+          "valid_player": "You",
+          "counter_replacement_subject": "Actor"
+        }
+      }
+    }
+  ],
+  "source_text": "(Gain the next level as a sorcery to add its ability.)\nAt the beginning of combat on your turn, put a +1/+1 counter on target creature you control.\n{G}: Level 2\nPermanents you control with counters on them have ward {1}.\n{3}{G}: Level 3\nIf you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
+  "card_name": "Innkeeper's Talent"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__innkeepers_talent_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__innkeepers_talent_lowered.snap
@@ -1,0 +1,203 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1322
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 2
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Green"
+          ],
+          "generic": 0
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{G}: Level 2",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 1
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 3
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Green"
+          ],
+          "generic": 3
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{3}{G}: Level 3",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 2
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [
+    {
+      "mode": "Phase",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "PutCounter",
+          "counter_type": "P1P1",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": []
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": "BeginCombat",
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
+      "constraint": {
+        "type": "OnlyDuringYourTurn"
+      },
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Permanent"
+        ],
+        "controller": "You",
+        "properties": [
+          {
+            "type": "Counters",
+            "counters": {
+              "type": "Any"
+            },
+            "comparator": "GE",
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            }
+          }
+        ]
+      },
+      "modifications": [
+        {
+          "type": "AddKeyword",
+          "keyword": {
+            "Ward": {
+              "type": "Mana",
+              "data": {
+                "type": "Cost",
+                "shards": [],
+                "generic": 1
+              }
+            }
+          }
+        }
+      ],
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 2
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Permanents you control with counters on them have ward {1}."
+    }
+  ],
+  "replacements": [
+    {
+      "event": "AddCounter",
+      "execute": null,
+      "mode": {
+        "type": "Mandatory"
+      },
+      "valid_card": null,
+      "description": "If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.",
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 3
+      },
+      "quantity_modification": {
+        "type": "Times",
+        "factor": 2
+      },
+      "valid_player": "You",
+      "counter_replacement_subject": "Actor"
+    }
+  ],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kabira_vindicator_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kabira_vindicator_ir.snap
@@ -1,0 +1,272 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 387
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 4,
+      "source": {
+        "id": {
+          "item": 4,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 82,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Level up {2}{W} ({2}{W}: Put a level counter on this. Level up only as a sorcery.)"
+      },
+      "node": {
+        "Keyword": {
+          "LevelUp": {
+            "type": "Cost",
+            "shards": [
+              "White"
+            ],
+            "generic": 2
+          }
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 83,
+          "end_byte": 92,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 2-4"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "SetPower",
+                "value": 3
+              },
+              {
+                "type": "SetToughness",
+                "value": 6
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 2,
+              "maximum": 4
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "LEVEL 2-4 / 3/6"
+          },
+          "source_text": "LEVEL 2-4 / 3/6",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 97,
+          "end_byte": 135,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Other creatures you control get +1/+1."
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "Another"
+                }
+              ]
+            },
+            "modifications": [
+              {
+                "type": "AddPower",
+                "value": 1
+              },
+              {
+                "type": "AddToughness",
+                "value": 1
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 2,
+              "maximum": 4
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Other creatures you control get +1/+1."
+          },
+          "source_text": "Other creatures you control get +1/+1.",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 136,
+          "end_byte": 144,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 5+"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "SetPower",
+                "value": 4
+              },
+              {
+                "type": "SetToughness",
+                "value": 8
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 5
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "LEVEL 5+ / 4/8"
+          },
+          "source_text": "LEVEL 5+ / 4/8",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 6,
+          "last_line": 6,
+          "start_byte": 149,
+          "end_byte": 187,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Other creatures you control get +2/+2."
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "Another"
+                }
+              ]
+            },
+            "modifications": [
+              {
+                "type": "AddPower",
+                "value": 2
+              },
+              {
+                "type": "AddToughness",
+                "value": 2
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 5
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Other creatures you control get +2/+2."
+          },
+          "source_text": "Other creatures you control get +2/+2.",
+          "body_ir": null
+        }
+      }
+    }
+  ],
+  "source_text": "Level up {2}{W} ({2}{W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-4\n3/6\nOther creatures you control get +1/+1.\nLEVEL 5+\n4/8\nOther creatures you control get +2/+2.",
+  "card_name": "Kabira Vindicator"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kabira_vindicator_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kabira_vindicator_lowered.snap
@@ -1,0 +1,159 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 388
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetPower",
+          "value": 3
+        },
+        {
+          "type": "SetToughness",
+          "value": 6
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 2,
+        "maximum": 4
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "LEVEL 2-4 / 3/6"
+    },
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Creature"
+        ],
+        "controller": "You",
+        "properties": [
+          {
+            "type": "Another"
+          }
+        ]
+      },
+      "modifications": [
+        {
+          "type": "AddPower",
+          "value": 1
+        },
+        {
+          "type": "AddToughness",
+          "value": 1
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 2,
+        "maximum": 4
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Other creatures you control get +1/+1."
+    },
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetPower",
+          "value": 4
+        },
+        {
+          "type": "SetToughness",
+          "value": 8
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 5
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "LEVEL 5+ / 4/8"
+    },
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Creature"
+        ],
+        "controller": "You",
+        "properties": [
+          {
+            "type": "Another"
+          }
+        ]
+      },
+      "modifications": [
+        {
+          "type": "AddPower",
+          "value": 2
+        },
+        {
+          "type": "AddToughness",
+          "value": 2
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 5
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Other creatures you control get +2/+2."
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": [
+    {
+      "LevelUp": {
+        "type": "Cost",
+        "shards": [
+          "White"
+        ],
+        "generic": 2
+      }
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lumen_class_frigate_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lumen_class_frigate_ir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 365
+assertion_line: 411
 expression: "&ir"
 ---
 {
@@ -16,21 +16,29 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 76,
+          "end_byte": 149,
           "precision": "Exact",
           "ordinal_within_span": 0
         },
-        "fragment": "Level up {W} ({W}: Put a level counter on this. Level up only as a sorcery.)"
+        "fragment": "Station (Tap another creature you control: Put charge counters equal to its power on ~. Station only as a sorcery. It's an artifact creature at 12+.)"
       },
       "node": {
-        "Keyword": {
-          "LevelUp": {
-            "type": "Cost",
-            "shards": [
-              "White"
-            ],
-            "generic": 0
-          }
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Station"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Station",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
         }
       }
     },
@@ -44,50 +52,54 @@ expression: "&ir"
         "span": {
           "first_line": 1,
           "last_line": 1,
-          "start_byte": 77,
-          "end_byte": 86,
+          "start_byte": 150,
+          "end_byte": 193,
           "precision": "Exact",
           "ordinal_within_span": 0
         },
-        "fragment": "LEVEL 2-6"
+        "fragment": "2+ | Other creatures you control get +1/+1."
       },
       "node": {
         "Static": {
           "definition": {
             "mode": "Continuous",
             "affected": {
-              "type": "SelfRef"
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "Another"
+                }
+              ]
             },
             "modifications": [
               {
-                "type": "SetPower",
-                "value": 3
+                "type": "AddPower",
+                "value": 1
               },
               {
-                "type": "SetToughness",
-                "value": 3
-              },
-              {
-                "type": "AddKeyword",
-                "keyword": "FirstStrike"
+                "type": "AddToughness",
+                "value": 1
               }
             ],
             "condition": {
               "type": "HasCounters",
               "counters": {
                 "type": "OfType",
-                "data": "level"
+                "data": "charge"
               },
-              "minimum": 2,
-              "maximum": 6
+              "minimum": 2
             },
             "affected_zone": null,
             "effect_zone": null,
             "active_zones": [],
             "characteristic_defining": false,
-            "description": "LEVEL 2-6 / 3/3 / First strike"
+            "description": "Other creatures you control get +1/+1."
           },
-          "source_text": "LEVEL 2-6 / 3/3 / First strike",
+          "source_text": "Other creatures you control get +1/+1.",
           "body_ir": null
         }
       }
@@ -100,14 +112,14 @@ expression: "&ir"
           "ordinal": 0
         },
         "span": {
-          "first_line": 4,
-          "last_line": 4,
-          "start_byte": 104,
-          "end_byte": 112,
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 194,
+          "end_byte": 216,
           "precision": "Exact",
           "ordinal_within_span": 0
         },
-        "fragment": "LEVEL 7+"
+        "fragment": "12+ | Flying, lifelink"
       },
       "node": {
         "Static": {
@@ -118,38 +130,34 @@ expression: "&ir"
             },
             "modifications": [
               {
-                "type": "SetPower",
-                "value": 4
-              },
-              {
-                "type": "SetToughness",
-                "value": 4
+                "type": "AddKeyword",
+                "keyword": "Flying"
               },
               {
                 "type": "AddKeyword",
-                "keyword": "DoubleStrike"
+                "keyword": "Lifelink"
               }
             ],
             "condition": {
               "type": "HasCounters",
               "counters": {
                 "type": "OfType",
-                "data": "level"
+                "data": "charge"
               },
-              "minimum": 7
+              "minimum": 12
             },
             "affected_zone": null,
             "effect_zone": null,
             "active_zones": [],
             "characteristic_defining": false,
-            "description": "LEVEL 7+ / 4/4 / Double strike"
+            "description": "12+ | Flying, lifelink"
           },
-          "source_text": "LEVEL 7+ / 4/4 / Double strike",
+          "source_text": "Flying, lifelink",
           "body_ir": null
         }
       }
     }
   ],
-  "source_text": "Level up {W} ({W}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-6\n3/3\nFirst strike\nLEVEL 7+\n4/4\nDouble strike",
-  "card_name": "Student of Warfare"
+  "source_text": "Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery. It's an artifact creature at 12+.)\n2+ | Other creatures you control get +1/+1.\n12+ | Flying, lifelink",
+  "card_name": "Lumen-Class Frigate"
 }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lumen_class_frigate_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lumen_class_frigate_lowered.snap
@@ -1,0 +1,98 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 412
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "Unimplemented",
+        "name": "unknown",
+        "description": "Station"
+      },
+      "cost": null,
+      "sub_ability": null,
+      "duration": null,
+      "description": "Station",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Creature"
+        ],
+        "controller": "You",
+        "properties": [
+          {
+            "type": "Another"
+          }
+        ]
+      },
+      "modifications": [
+        {
+          "type": "AddPower",
+          "value": 1
+        },
+        {
+          "type": "AddToughness",
+          "value": 1
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "charge"
+        },
+        "minimum": 2
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Other creatures you control get +1/+1."
+    },
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "AddKeyword",
+          "keyword": "Flying"
+        },
+        {
+          "type": "AddKeyword",
+          "keyword": "Lifelink"
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "charge"
+        },
+        "minimum": 12
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "12+ | Flying, lifelink"
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sorcerer_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sorcerer_class_ir.snap
@@ -1,0 +1,410 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1288
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 55,
+          "end_byte": 109,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When ~ enters, draw two cards, then discard two cards."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Draw",
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Discard",
+                "count": {
+                  "type": "Fixed",
+                  "value": 2
+                },
+                "target": {
+                  "type": "Controller"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ enters, draw two cards, then discard two cards.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 110,
+          "end_byte": 125,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{U}{R}: Level 2"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 2
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Blue",
+                "Red"
+              ],
+              "generic": 0
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{U}{R}: Level 2",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 1
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 126,
+          "end_byte": 258,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Creatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\""
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "Continuous",
+          "affected": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": []
+          },
+          "modifications": [
+            {
+              "type": "GrantAbility",
+              "definition": {
+                "kind": "Activated",
+                "effect": {
+                  "type": "Mana",
+                  "produced": {
+                    "type": "AnyOneColor",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "color_options": [
+                      "Blue",
+                      "Red"
+                    ]
+                  }
+                },
+                "cost": {
+                  "type": "Tap"
+                },
+                "sub_ability": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "spend",
+                    "description": "Spend this mana only to cast an instant or sorcery spell or to gain a Class level"
+                  },
+                  "cost": null,
+                  "sub_ability": null,
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": null,
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false,
+                  "sub_link": "SequentialSibling"
+                },
+                "duration": null,
+                "description": "{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.",
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "is_mana_ability": true
+              }
+            }
+          ],
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 2
+          },
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "Creatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\""
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 259,
+          "end_byte": 277,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{3}{U}{R}: Level 3"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 3
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Blue",
+                "Red"
+              ],
+              "generic": 3
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{3}{U}{R}: Level 3",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 2
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 4,
+      "source": {
+        "id": {
+          "item": 4,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 5,
+          "last_line": 5,
+          "start_byte": 278,
+          "end_byte": 438,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "SpellCast",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "DamageEachPlayer",
+              "amount": {
+                "type": "Ref",
+                "qty": {
+                  "type": "SpellsCastThisTurn",
+                  "scope": "Controller",
+                  "filter": {
+                    "type": "Or",
+                    "filters": [
+                      {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Instant"
+                        ],
+                        "controller": null,
+                        "properties": []
+                      },
+                      {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Sorcery"
+                        ],
+                        "controller": null,
+                        "properties": []
+                      }
+                    ]
+                  }
+                }
+              },
+              "player_filter": {
+                "type": "Opponent"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "Or",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Instant"
+                ],
+                "controller": null,
+                "properties": []
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Sorcery"
+                ],
+                "controller": null,
+                "properties": []
+              }
+            ]
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": {
+            "type": "Controller"
+          },
+          "valid_source": null,
+          "description": "Whenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn.",
+          "constraint": null,
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 3
+          },
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "(Gain the next level as a sorcery to add its ability.)\nWhen this Class enters, draw two cards, then discard two cards.\n{U}{R}: Level 2\nCreatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\"\n{3}{U}{R}: Level 3\nWhenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn.",
+  "card_name": "Sorcerer Class"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sorcerer_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sorcerer_class_ir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1288
+assertion_line: 1297
 expression: "&ir"
 ---
 {
@@ -164,76 +164,80 @@ expression: "&ir"
         "fragment": "Creatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\""
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "Continuous",
-          "affected": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": "You",
-            "properties": []
-          },
-          "modifications": [
-            {
-              "type": "GrantAbility",
-              "definition": {
-                "kind": "Activated",
-                "effect": {
-                  "type": "Mana",
-                  "produced": {
-                    "type": "AnyOneColor",
-                    "count": {
-                      "type": "Fixed",
-                      "value": 1
-                    },
-                    "color_options": [
-                      "Blue",
-                      "Red"
-                    ]
-                  }
-                },
-                "cost": {
-                  "type": "Tap"
-                },
-                "sub_ability": {
-                  "kind": "Spell",
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": []
+            },
+            "modifications": [
+              {
+                "type": "GrantAbility",
+                "definition": {
+                  "kind": "Activated",
                   "effect": {
-                    "type": "Unimplemented",
-                    "name": "spend",
-                    "description": "Spend this mana only to cast an instant or sorcery spell or to gain a Class level"
+                    "type": "Mana",
+                    "produced": {
+                      "type": "AnyOneColor",
+                      "count": {
+                        "type": "Fixed",
+                        "value": 1
+                      },
+                      "color_options": [
+                        "Blue",
+                        "Red"
+                      ]
+                    }
                   },
-                  "cost": null,
-                  "sub_ability": null,
+                  "cost": {
+                    "type": "Tap"
+                  },
+                  "sub_ability": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "Unimplemented",
+                      "name": "spend",
+                      "description": "Spend this mana only to cast an instant or sorcery spell or to gain a Class level"
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": null,
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false,
+                    "sub_link": "SequentialSibling"
+                  },
                   "duration": null,
-                  "description": null,
+                  "description": "{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.",
                   "target_prompt": null,
                   "condition": null,
                   "optional_targeting": false,
                   "optional": false,
                   "forward_result": false,
-                  "sub_link": "SequentialSibling"
-                },
-                "duration": null,
-                "description": "{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.",
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false,
-                "is_mana_ability": true
+                  "is_mana_ability": true
+                }
               }
-            }
-          ],
-          "condition": {
-            "type": "ClassLevelGE",
-            "level": 2
+            ],
+            "condition": {
+              "type": "ClassLevelGE",
+              "level": 2
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Creatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\""
           },
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "Creatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\""
+          "source_text": "Creatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\"",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sorcerer_class_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sorcerer_class_lowered.snap
@@ -1,0 +1,314 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1298
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 2
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Blue",
+            "Red"
+          ],
+          "generic": 0
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{U}{R}: Level 2",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 1
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 3
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Blue",
+            "Red"
+          ],
+          "generic": 3
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{3}{U}{R}: Level 3",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 2
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [
+    {
+      "mode": "ChangesZone",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Draw",
+          "count": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "target": {
+            "type": "Controller"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Discard",
+            "count": {
+              "type": "Fixed",
+              "value": 2
+            },
+            "target": {
+              "type": "Controller"
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": "Battlefield",
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "When ~ enters, draw two cards, then discard two cards.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    },
+    {
+      "mode": "SpellCast",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "DamageEachPlayer",
+          "amount": {
+            "type": "Ref",
+            "qty": {
+              "type": "SpellsCastThisTurn",
+              "scope": "Controller",
+              "filter": {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Instant"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Sorcery"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                ]
+              }
+            }
+          },
+          "player_filter": {
+            "type": "Opponent"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "Or",
+        "filters": [
+          {
+            "type": "Typed",
+            "type_filters": [
+              "Instant"
+            ],
+            "controller": null,
+            "properties": []
+          },
+          {
+            "type": "Typed",
+            "type_filters": [
+              "Sorcery"
+            ],
+            "controller": null,
+            "properties": []
+          }
+        ]
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": {
+        "type": "Controller"
+      },
+      "valid_source": null,
+      "description": "Whenever you cast an instant or sorcery spell, that spell deals damage to each opponent equal to the number of instant and sorcery spells you've cast this turn.",
+      "constraint": null,
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 3
+      },
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Creature"
+        ],
+        "controller": "You",
+        "properties": []
+      },
+      "modifications": [
+        {
+          "type": "GrantAbility",
+          "definition": {
+            "kind": "Activated",
+            "effect": {
+              "type": "Mana",
+              "produced": {
+                "type": "AnyOneColor",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "color_options": [
+                  "Blue",
+                  "Red"
+                ]
+              }
+            },
+            "cost": {
+              "type": "Tap"
+            },
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Unimplemented",
+                "name": "spend",
+                "description": "Spend this mana only to cast an instant or sorcery spell or to gain a Class level"
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false,
+              "sub_link": "SequentialSibling"
+            },
+            "duration": null,
+            "description": "{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.",
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "is_mana_ability": true
+          }
+        }
+      ],
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 2
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Creatures you control have \"{T}: Add {U} or {R}. Spend this mana only to cast an instant or sorcery spell or to gain a Class level.\""
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wizard_class_two_layer_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wizard_class_two_layer_ir.snap
@@ -23,21 +23,25 @@ expression: "&ir"
         "fragment": "You have no maximum hand size."
       },
       "node": {
-        "PreLoweredStatic": {
-          "mode": "NoMaximumHandSize",
-          "affected": {
-            "type": "Typed",
-            "type_filters": [],
-            "controller": "You",
-            "properties": []
+        "Static": {
+          "definition": {
+            "mode": "NoMaximumHandSize",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [],
+              "controller": "You",
+              "properties": []
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "You have no maximum hand size."
           },
-          "modifications": [],
-          "condition": null,
-          "affected_zone": null,
-          "effect_zone": null,
-          "active_zones": [],
-          "characteristic_defining": false,
-          "description": "You have no maximum hand size."
+          "source_text": "You have no maximum hand size.",
+          "body_ir": null
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wizard_class_two_layer_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wizard_class_two_layer_ir.snap
@@ -1,0 +1,297 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1348
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 55,
+          "end_byte": 85,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "You have no maximum hand size."
+      },
+      "node": {
+        "PreLoweredStatic": {
+          "mode": "NoMaximumHandSize",
+          "affected": {
+            "type": "Typed",
+            "type_filters": [],
+            "controller": "You",
+            "properties": []
+          },
+          "modifications": [],
+          "condition": null,
+          "affected_zone": null,
+          "effect_zone": null,
+          "active_zones": [],
+          "characteristic_defining": false,
+          "description": "You have no maximum hand size."
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 86,
+          "end_byte": 101,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{2}{U}: Level 2"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 2
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Blue"
+              ],
+              "generic": 2
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{2}{U}: Level 2",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 1
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 102,
+          "end_byte": 141,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When ~ becomes level 2, draw two cards."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ClassLevelGained",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Draw",
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ becomes level 2",
+          "constraint": {
+            "type": "AtClassLevel",
+            "level": 2
+          },
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 142,
+          "end_byte": 157,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{4}{U}: Level 3"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SetClassLevel",
+            "level": 3
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Blue"
+              ],
+              "generic": 4
+            }
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{4}{U}: Level 3",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "ClassLevelIs",
+              "data": {
+                "level": 2
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 4,
+      "source": {
+        "id": {
+          "item": 4,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 5,
+          "last_line": 5,
+          "start_byte": 158,
+          "end_byte": 235,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever you draw a card, put a +1/+1 counter on target creature you control."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Drawn",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "P1P1",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": {
+            "type": "Controller"
+          },
+          "valid_source": null,
+          "description": "Whenever you draw a card, put a +1/+1 counter on target creature you control.",
+          "constraint": null,
+          "condition": {
+            "type": "ClassLevelGE",
+            "level": 3
+          },
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "(Gain the next level as a sorcery to add its ability.)\nYou have no maximum hand size.\n{2}{U}: Level 2\nWhen this Class becomes level 2, draw two cards.\n{4}{U}: Level 3\nWhenever you draw a card, put a +1/+1 counter on target creature you control.",
+  "card_name": "Wizard Class"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wizard_class_two_layer_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wizard_class_two_layer_lowered.snap
@@ -1,0 +1,201 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1349
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 2
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Blue"
+          ],
+          "generic": 2
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{2}{U}: Level 2",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 1
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SetClassLevel",
+        "level": 3
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Blue"
+          ],
+          "generic": 4
+        }
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{4}{U}: Level 3",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "ClassLevelIs",
+          "data": {
+            "level": 2
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [
+    {
+      "mode": "ClassLevelGained",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Draw",
+          "count": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "target": {
+            "type": "Controller"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "When ~ becomes level 2",
+      "constraint": {
+        "type": "AtClassLevel",
+        "level": 2
+      },
+      "condition": null,
+      "batched": false
+    },
+    {
+      "mode": "Drawn",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "PutCounter",
+          "counter_type": "P1P1",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": []
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": {
+        "type": "Controller"
+      },
+      "valid_source": null,
+      "description": "Whenever you draw a card, put a +1/+1 counter on target creature you control.",
+      "constraint": null,
+      "condition": {
+        "type": "ClassLevelGE",
+        "level": 3
+      },
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": "NoMaximumHandSize",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [],
+        "controller": "You",
+        "properties": []
+      },
+      "modifications": [],
+      "condition": null,
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "You have no maximum hand size."
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_level.rs
+++ b/crates/engine/src/parser/oracle_level.rs
@@ -7,6 +7,7 @@ use crate::types::ability::{
 use crate::types::counter::{CounterMatch, CounterType};
 
 use super::oracle::find_activated_colon;
+use super::oracle_ir::static_ir::StaticIr;
 use super::oracle_keyword::parse_granted_keyword_fragment;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_special::normalize_self_refs_for_static;
@@ -28,8 +29,14 @@ use super::oracle_util::strip_reminder_text;
 /// Return shape of [`parse_level_blocks`]: level-gated statics with their
 /// `(first_line, last_line)` spans, consumed line indices, and body ability
 /// lines paired with the level condition that gates them.
+///
+/// The statics are [`StaticIr`], not bare definitions, so this preprocessor is
+/// the single authority for its own provenance: only it knows that a body
+/// static's recognizer input is the self-ref-normalized sub-line rather than
+/// the printed line, and that the block summary is synthesized from the joined
+/// modification lines with no single printed line behind it.
 type LevelBlocksParse = (
-    Vec<(StaticDefinition, usize, usize)>,
+    Vec<(StaticIr, usize, usize)>,
     Vec<usize>,
     Vec<(String, StaticCondition, usize)>,
 );
@@ -54,7 +61,7 @@ pub(crate) fn parse_level_blocks(lines: &[&str], card_name: &str) -> LevelBlocks
     // yet cannot byte-overlap a body static printed between the header and a later
     // P/T/keyword line (which would trip `OverlappingSiblingSpans`).
     // `ability_lines` likewise carry their line.
-    let mut statics: Vec<(StaticDefinition, usize, usize)> = Vec::new();
+    let mut statics: Vec<(StaticIr, usize, usize)> = Vec::new();
     let mut consumed_indices = Vec::new();
     let mut ability_lines = Vec::new();
 
@@ -143,7 +150,7 @@ pub(crate) fn parse_level_blocks(lines: &[&str], card_name: &str) -> LevelBlocks
                     for mut sd in multi {
                         sd.condition = Some(condition.clone());
                         // Body static: emitted at its OWN line (single-line span).
-                        statics.push((sd, i, i));
+                        statics.push((StaticIr::from_definition(&static_text, sd), i, i));
                     }
                     i += 1;
                     continue;
@@ -151,7 +158,7 @@ pub(crate) fn parse_level_blocks(lines: &[&str], card_name: &str) -> LevelBlocks
                 if let Some(mut sd) = parse_static_line(&static_text) {
                     consumed_indices.push(i);
                     sd.condition = Some(condition.clone());
-                    statics.push((sd, i, i));
+                    statics.push((StaticIr::from_definition(&static_text, sd), i, i));
                     i += 1;
                     continue;
                 }
@@ -191,12 +198,21 @@ pub(crate) fn parse_level_blocks(lines: &[&str], card_name: &str) -> LevelBlocks
                 // P/T/keyword line (which would trip `OverlappingSiblingSpans` and
                 // panic `emit`). Body statics carry their own single line; the
                 // summary sorts first within the block by its header line.
+                // The summary has no single printed line behind it: it is
+                // synthesized from the block's modification lines, so those
+                // joined lines ARE its recognizer input. Anything else — the
+                // `LEVEL N-M` header the span anchors to, say — would claim
+                // provenance the definition does not derive from.
+                let summary_text = description_parts.join(" / ");
                 statics.push((
-                    StaticDefinition::continuous()
-                        .affected(TargetFilter::SelfRef)
-                        .condition(condition)
-                        .modifications(modifications)
-                        .description(description_parts.join(" / ")),
+                    StaticIr::from_definition(
+                        &summary_text,
+                        StaticDefinition::continuous()
+                            .affected(TargetFilter::SelfRef)
+                            .condition(condition)
+                            .modifications(modifications)
+                            .description(summary_text.clone()),
+                    ),
                     header,
                     header,
                 ));
@@ -260,7 +276,10 @@ mod tests {
     ) {
         let (statics, consumed, ability_lines) = parse_level_blocks(lines, name);
         (
-            statics.into_iter().map(|(s, _, _)| s).collect(),
+            // `.definition` — not `lower_static_ir` — keeps these preprocessor
+            // unit tests asserting exactly what they asserted before the IR
+            // wrap; the document-level second lowering is argued separately.
+            statics.into_iter().map(|(s, _, _)| s.definition).collect(),
             consumed,
             ability_lines
                 .into_iter()

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -2876,9 +2876,7 @@ pub(crate) fn lower_as_enters_or_face_up_counters(text: &str) -> Option<Vec<Repl
 
     // Recover the ORIGINAL-case effect slice via byte offset (mirrors
     // `split_once_on_lower`) so `parse_effect_chain` sees the printed casing.
-    let Some(effect_start) = text.len().checked_sub(tail_lower.len()) else {
-        return None;
-    };
+    let effect_start = text.len().checked_sub(tail_lower.len())?;
     let effect_text = text[effect_start..].trim().trim_end_matches('.').trim();
     if effect_text.is_empty() {
         return None;

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -2855,16 +2855,13 @@ fn subject_lower_has_face_up(after_subject: &str) -> bool {
 /// CR 708.11: an "As … is turned face up" ability applies while the permanent is
 /// being turned face up (the face-up arm).
 /// CR 122.1a: the placed +1/+1 counters add to the creature's power and toughness.
-pub(crate) fn lower_as_enters_or_face_up_counters(
-    text: &str,
-    result: &mut super::oracle::ParsedAbilities,
-) -> bool {
+pub(crate) fn lower_as_enters_or_face_up_counters(text: &str) -> Option<Vec<ReplacementIr>> {
     type VE<'a> = OracleError<'a>;
     let lower = text.to_lowercase();
 
     // nom-frame: "as ~ enters[ the battlefield][ or is turned face up], ".
     let Ok((rest, _)) = tag::<_, _, VE>("as ~ enters").parse(lower.as_str()) else {
-        return false;
+        return None;
     };
     let (rest, _the_battlefield) = opt(tag::<_, _, VE>(" the battlefield"))
         .parse(rest)
@@ -2874,17 +2871,17 @@ pub(crate) fn lower_as_enters_or_face_up_counters(
         .unwrap_or((rest, None));
     let has_face_up = face_up.is_some();
     let Ok((tail_lower, _)) = tag::<_, _, VE>(", ").parse(rest) else {
-        return false;
+        return None;
     };
 
     // Recover the ORIGINAL-case effect slice via byte offset (mirrors
     // `split_once_on_lower`) so `parse_effect_chain` sees the printed casing.
     let Some(effect_start) = text.len().checked_sub(tail_lower.len()) else {
-        return false;
+        return None;
     };
     let effect_text = text[effect_start..].trim().trim_end_matches('.').trim();
     if effect_text.is_empty() {
-        return false;
+        return None;
     }
 
     // Reuse the counter + quantity effect stack (where-X → ObjectCount / Another).
@@ -2895,32 +2892,39 @@ pub(crate) fn lower_as_enters_or_face_up_counters(
     // Unimplemented or externally targeted). Rewrites the "it" placeholder to
     // `SelfRef` so the runtime event-modifier fold recognizes it.
     if !normalize_self_put_counter_chain(&mut execute) {
-        return false;
+        return None;
     }
+
+    // Both arms derive from the same printed sentence, so both carry `text` as
+    // their provenance — the sentence never splits, which is why this recognizer
+    // exists at all.
+    let mut irs = Vec::new();
 
     // CR 614.1c: ETB arm — a battlefield-entry-scoped `Moved` replacement whose
     // `PutCounter { SelfRef }` execute is folded into the entering object's
     // enter-with-counters by the runtime event-modifier path.
-    result.replacements.push(
+    irs.push(ReplacementIr::from_definition(
+        text,
         ReplacementDefinition::new(ReplacementEvent::Moved)
             .execute(execute.clone())
             .valid_card(TargetFilter::SelfRef)
             .destination_zone(Zone::Battlefield)
             .description(text.to_string()),
-    );
+    ));
 
     // CR 708.11: face-up arm — the same effect applies as the permanent is turned
     // face up (Disguise/megamorph turn-up), bound to that permanent via SelfRef.
     if has_face_up {
-        result.replacements.push(
+        irs.push(ReplacementIr::from_definition(
+            text,
             ReplacementDefinition::new(ReplacementEvent::TurnFaceUp)
                 .valid_card(TargetFilter::SelfRef)
                 .execute(execute)
                 .description(text.to_string()),
-        );
+        ));
     }
 
-    true
+    Some(irs)
 }
 
 /// Validate + normalize the execute chain of an as-enters / turned-face-up

--- a/crates/engine/src/parser/oracle_saga.rs
+++ b/crates/engine/src/parser/oracle_saga.rs
@@ -15,6 +15,7 @@ use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 
 use super::oracle_effect::parse_effect_chain;
+use super::oracle_ir::replacement::ReplacementIr;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_util::strip_reminder_text;
 
@@ -121,7 +122,7 @@ fn is_chapter_body_continuation(line: &str) -> bool {
 /// the `(line, ETB replacement)` pair, and the set of consumed line indices.
 type SagaChaptersParse = (
     Vec<(usize, TriggerDefinition)>,
-    (usize, ReplacementDefinition),
+    (usize, ReplacementIr),
     HashSet<usize>,
 );
 
@@ -203,6 +204,15 @@ pub(crate) fn parse_saga_chapters(lines: &[&str], _card_name: &str) -> SagaChapt
     }
 
     // CR 714.3a: As a Saga enters the battlefield, its controller puts a lore counter on it.
+    //
+    // Provenance convention for a SYNTHESIZED rule item: the source text is the
+    // definition's own description. CR 714.3a prints no line — the rule applies
+    // from the subtype alone — so there is no Oracle slice to cite. Naming the
+    // first chapter's line instead would be a lie the anchor already tempts us
+    // into: `etb_line` points there for ordering, but the chapter-I trigger owns
+    // that text. A synthetic label cannot be located in the Oracle text, which is
+    // the honest answer for an item that was never printed.
+    const ETB_SYNTHETIC_SOURCE: &str = "Saga ETB lore counter";
     let etb_replacement = ReplacementDefinition::new(ReplacementEvent::Moved)
         .execute(AbilityDefinition::new(
             AbilityKind::Spell,
@@ -214,7 +224,8 @@ pub(crate) fn parse_saga_chapters(lines: &[&str], _card_name: &str) -> SagaChapt
         ))
         .valid_card(TargetFilter::SelfRef)
         .destination_zone(Zone::Battlefield)
-        .description("Saga ETB lore counter".to_string());
+        .description(ETB_SYNTHETIC_SOURCE.to_string());
+    let etb_replacement = ReplacementIr::from_definition(ETB_SYNTHETIC_SOURCE, etb_replacement);
 
     // CR 714.3a: the ETB lore-counter replacement has no printed line of its own;
     // anchor it at the FIRST chapter's line so it emits at/near the front of the
@@ -318,7 +329,7 @@ mod tests {
         let (triggers, (_, etb), consumed) = parse_saga_chapters(lines, name);
         (
             triggers.into_iter().map(|(_, t)| t).collect(),
-            etb,
+            etb.definition,
             consumed,
         )
     }

--- a/crates/engine/src/parser/oracle_spacecraft.rs
+++ b/crates/engine/src/parser/oracle_spacecraft.rs
@@ -30,6 +30,7 @@ use super::oracle_cost::parse_oracle_cost;
 use super::oracle_effect::parse_effect_chain;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::doc::PrintedTriggerIndex;
+use super::oracle_ir::static_ir::StaticIr;
 use super::oracle_keyword::parse_granted_keyword_fragment;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_special::normalize_self_refs_for_static;
@@ -61,8 +62,12 @@ pub fn max_spacecraft_threshold(lines: &[&str]) -> Option<u32> {
 /// Return shape of [`parse_spacecraft_threshold_lines`]: source-line-tagged
 /// statics, triggers, and activated abilities, plus the set of consumed line
 /// indices (so the main oracle dispatcher can skip them).
+///
+/// The statics are [`StaticIr`] so this preprocessor owns its own provenance:
+/// the recognizer input is the post-`|` threshold body, never the printed
+/// `N+ | …` line the span anchors to.
 type SpacecraftThresholdParse = (
-    Vec<(usize, StaticDefinition)>,
+    Vec<(usize, StaticIr)>,
     Vec<(usize, TriggerDefinition)>,
     Vec<(usize, AbilityDefinition)>,
     Vec<usize>,
@@ -159,7 +164,7 @@ struct ThresholdParser<'a> {
 }
 
 struct ThresholdOutput<'a> {
-    statics: &'a mut Vec<(usize, StaticDefinition)>,
+    statics: &'a mut Vec<(usize, StaticIr)>,
     triggers: &'a mut Vec<(usize, TriggerDefinition)>,
     abilities: &'a mut Vec<(usize, AbilityDefinition)>,
 }
@@ -177,11 +182,14 @@ impl ThresholdParser<'_> {
         if let Some(keyword_mods) = parse_keyword_only_body(body) {
             output.statics.push((
                 line_idx,
-                StaticDefinition::continuous()
-                    .affected(TargetFilter::SelfRef)
-                    .condition(self.static_cond.clone())
-                    .modifications(keyword_mods)
-                    .description(description.to_string()),
+                StaticIr::from_definition(
+                    body,
+                    StaticDefinition::continuous()
+                        .affected(TargetFilter::SelfRef)
+                        .condition(self.static_cond.clone())
+                        .modifications(keyword_mods)
+                        .description(description.to_string()),
+                ),
             ));
             return true;
         }
@@ -247,13 +255,17 @@ impl ThresholdParser<'_> {
         if !multi.is_empty() {
             for mut sd in multi {
                 sd.condition = Some(self.static_cond.clone());
-                output.statics.push((line_idx, sd));
+                output
+                    .statics
+                    .push((line_idx, StaticIr::from_definition(&static_text, sd)));
             }
             return true;
         }
         if let Some(mut sd) = parse_static_line(&static_text) {
             sd.condition = Some(self.static_cond.clone());
-            output.statics.push((line_idx, sd));
+            output
+                .statics
+                .push((line_idx, StaticIr::from_definition(&static_text, sd)));
             return true;
         }
 
@@ -342,7 +354,7 @@ mod tests {
         let (statics, triggers, abilities, consumed) =
             parse_spacecraft_threshold_lines(lines, name, base_trigger_index);
         (
-            statics.into_iter().map(|(_, s)| s).collect(),
+            statics.into_iter().map(|(_, s)| s.definition).collect(),
             triggers.into_iter().map(|(_, t)| t).collect(),
             abilities.into_iter().map(|(_, a)| a).collect(),
             consumed,

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -218,6 +218,20 @@ pub(crate) fn parse_static_line_ir(text: &str) -> Option<StaticIr> {
 }
 
 /// Lowering: apply post-parse transforms to produce the final `StaticDefinition`.
+///
+/// **Every transform added here must be idempotent.** Recognizers that already
+/// call `parse_static_line` (which lowers internally, above) and then hand the
+/// result to `StaticIr::from_definition` cause this function to run a second
+/// time over an already-lowered definition — the Class level-section arms in
+/// `oracle_class.rs` are the current example, and they interpose
+/// `wrap_static_with_class_level` between the two passes, so a transform must
+/// also be stable under a condition it did not see on the first pass. Both
+/// transforms below satisfy this today: `populate_active_zones_from_condition`
+/// self-guards on `active_zones.is_empty()` and its collector ignores
+/// `ClassLevelGE`, and `bind_counter_anaphor_to_recipient` rewrites only
+/// `ObjectScope::Anaphoric`, of which none survive the first pass. A
+/// non-idempotent transform added here would silently double-apply across every
+/// such site.
 pub(crate) fn lower_static_ir(ir: &StaticIr) -> crate::types::ability::StaticDefinition {
     let mut def = ir.definition.clone();
     shared::populate_active_zones_from_condition(&mut def);

--- a/scripts/check-prelowered-ratchet.sh
+++ b/scripts/check-prelowered-ratchet.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Plan 05b ratchet: the `OracleNodeIr::PreLowered*` producer count may only go
+# down.
+#
+# Why this is a grep and not a type-level check: the point is to catch a
+# producer being *written*, not a variant being *reachable*. A type-level check
+# would go green the moment the last variant is deleted — that is the end
+# state, not the tracking mechanism. Before this gate existed, "is Plan 05b
+# done?" was answerable only by archaeology, which is how the `#[allow(dead_code)]`
+# on `OracleNodeIr::Static` stayed in the tree for nine days after the work that
+# was supposed to retire it had already landed.
+#
+# Contract (per plan §6.1):
+#   * ceiling, not equality — reducing a count passes, raising it fails
+#   * a parser file carrying `PreLowered` with no ledger entry fails, so a new
+#     producer cannot be added in a third file and escape the ratchet
+#   * slack (count below ceiling) passes, but prints the exact edit to tighten
+#     it, because the burn-down is only visible in `git log` if each tranche
+#     lowers its own number
+#
+# Generated snapshots under `parser/**/snapshots/` are excluded: they are
+# output, not source, and their counts move for reasons unrelated to producers.
+#
+# Usage: scripts/check-prelowered-ratchet.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LEDGER="$SCRIPT_DIR/prelowered-ratchet.txt"
+SCOPE="crates/engine/src/parser"
+NEEDLE="PreLowered"
+
+cd "$REPO_ROOT"
+
+if [[ ! -f "$LEDGER" ]]; then
+  echo "prelowered-ratchet: ledger not found at $LEDGER" >&2
+  exit 1
+fi
+
+# --- ledger -> associative array ------------------------------------------
+declare -A ceiling=()
+while read -r path limit _rest; do
+  [[ -z "${path:-}" || "$path" == \#* ]] && continue
+  if ! [[ "$limit" =~ ^[0-9]+$ ]]; then
+    echo "prelowered-ratchet: malformed ledger line for '$path' (ceiling '$limit')" >&2
+    exit 1
+  fi
+  ceiling["$path"]="$limit"
+done < "$LEDGER"
+
+# --- measured counts -------------------------------------------------------
+declare -A actual=()
+while IFS=: read -r path count; do
+  [[ -z "${path:-}" ]] && continue
+  actual["$path"]="$count"
+done < <(
+  rg --count-matches --glob '*.rs' --glob '!**/snapshots/**' "$NEEDLE" "$SCOPE" 2>/dev/null || true
+)
+
+status=0
+slack=()
+
+# Over ceiling, or present with no ledger entry.
+for path in "${!actual[@]}"; do
+  count="${actual[$path]}"
+  if [[ -z "${ceiling[$path]+set}" ]]; then
+    echo "prelowered-ratchet: FAIL — $path has $count '$NEEDLE' occurrence(s) but no ledger entry." >&2
+    echo "    A new PreLowered producer in a new file is exactly what this gate exists to catch." >&2
+    echo "    If this is intentional, add it to scripts/prelowered-ratchet.txt with a reason." >&2
+    status=1
+  elif (( count > ceiling[$path] )); then
+    echo "prelowered-ratchet: FAIL — $path has $count '$NEEDLE' occurrence(s), ceiling is ${ceiling[$path]}." >&2
+    echo "    Plan 05b converts PreLowered producers to IR nodes; the count may only decrease." >&2
+    status=1
+  elif (( count < ceiling[$path] )); then
+    slack+=("$path ${ceiling[$path]} -> $count")
+  fi
+done
+
+# A ledger entry that has reached zero should be removed, not left at 0.
+for path in "${!ceiling[@]}"; do
+  if [[ -z "${actual[$path]+set}" && "${ceiling[$path]}" != "0" ]]; then
+    slack+=("$path ${ceiling[$path]} -> 0  (entry can be deleted)")
+  fi
+done
+
+if (( ${#slack[@]} > 0 )); then
+  echo "prelowered-ratchet: ${#slack[@]} entry(ies) below ceiling — tighten scripts/prelowered-ratchet.txt in this commit:"
+  printf '    %s\n' "${slack[@]}"
+fi
+
+if (( status != 0 )); then
+  exit 1
+fi
+
+echo "Gate P PASS (PreLowered ratchet: no producer count increased)"

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -1,0 +1,26 @@
+# Plan 05b burn-down ledger: textual `PreLowered` occurrences per file.
+#
+# Enforced by scripts/check-prelowered-ratchet.sh. Each number is a CEILING:
+# a change that lowers it passes, a change that raises it fails, and a file
+# that appears here with no entry fails outright (so a new PreLowered producer
+# cannot be smuggled into a third file).
+#
+# Format: <repo-relative path><whitespace><ceiling>
+#
+# --- burn-down: Class-B producers, target is 0 ------------------------------
+# These are the `OracleNodeIr::PreLowered*` emissions that Plan 05b converts to
+# real IR nodes. Every tranche that converts a producer must lower its number
+# in the same commit, which is what makes the burn-down visible in `git log`
+# on this one file.
+crates/engine/src/parser/oracle.rs         21
+crates/engine/src/parser/oracle_class.rs   10
+
+# --- infrastructure: NOT burn-down targets ----------------------------------
+# The variant declarations and their consumers. These legitimately survive
+# until the last producer is gone and the variants themselves are deleted, so
+# they are ceilings only — they are not expected to reach 0 before then.
+crates/engine/src/parser/oracle_ir/doc.rs      16
+crates/engine/src/parser/oracle_ir/feature.rs   9
+
+# Prose references in the T1 witness-corpus comment.
+crates/engine/src/parser/oracle_ir/snapshot_tests.rs   2

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -12,7 +12,7 @@
 # real IR nodes. Every tranche that converts a producer must lower its number
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
-crates/engine/src/parser/oracle.rs         21
+crates/engine/src/parser/oracle.rs         20
 crates/engine/src/parser/oracle_class.rs    6
 
 # --- infrastructure: NOT burn-down targets ----------------------------------

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -13,7 +13,7 @@
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
 crates/engine/src/parser/oracle.rs         21
-crates/engine/src/parser/oracle_class.rs   10
+crates/engine/src/parser/oracle_class.rs    6
 
 # --- infrastructure: NOT burn-down targets ----------------------------------
 # The variant declarations and their consumers. These legitimately survive


### PR DESCRIPTION
Plan 05b Class-B bring-up, tranches T0–T3 (`.planning/architecture-remediation/05b-class-b-bringup.md`,
row table in `05b-U0-recensus-2026-07-26.md`). Six commits, four tranches, seven converted producer sites.

| commit | tranche | what |
|---|---|---|
| `2b230ba0fa` | T0 | retire the stale `dead_code` allow on `OracleNodeIr::Static` |
| `8c224078ed` | — | land the `PreLowered` ratchet early (§6.1), seeded as a ceiling |
| `2e1973d48a` | T1 | baseline the Class level-section two-layer corpus |
| `22a58386c7` | T1 | 4 `class-section-prelowered` rows → `StaticIr` / `ReplacementIr` |
| `163a47bee5` | T2 | leveler + Spacecraft preprocessors own their source text |
| `ddf26b32a9` | T3 | dual as-enters (CR 614.1c + CR 708.11) + Saga ETB (CR 714.3a) → IR |

## Gate half one — empirical

**Byte-identity: PASS, by attribution rather than by `cmp`.**

The pinned baseline was voided mid-tranche by exactly the hazard the charter names
("MTGJSON refresh rolls Monday — a mid-tranche refresh voids the baseline"): `3cf2930a39` bumped
`crates/engine/data/mtgjson-vintage`. A raw `cmp` therefore shows red for reasons that are not this PR.

Full-pool regeneration (card-data build 2427) diffed per card key against the pinned baseline:

- 35,516 entries both sides; **0 added, 0 removed**.
- **13 entries changed — all 13 are Licids**, attributable to `6b29e0d720`
  *"fix(engine): Licids attach themselves, not their enchant target (#6668)"*, which landed between the
  baseline pin and the regeneration.
- **0 changed entries in any class these conversions touch**, and the negative is non-vacuous:

  | class | in pool | changed |
  |---|---|---|
  | leveler (`LEVEL` block) | 27 | 0 |
  | Spacecraft (`N+ \| body`) | 68 | 0 |
  | Saga (chapters) | 243 | 0 |
  | as-enters / turn-face-up counters | 35 | 0 |

**Snapshots.** `student_of_warfare_ir` is the only genuinely pre-conversion baseline among the churned
fixtures; its churn was verified to be pure re-nesting by normalizing `Static{definition,..}` back to
`PreLoweredStatic{..}` and comparing `==` — not by reading the re-indented diff. `active_zones` stayed
`[]` and no `CountersOn.scope` rebound, which is the charter's STOP condition for the double-lowering.
`student_of_warfare_lowered.snap` **did not change at all**.

Two fixtures were added because the corpus could not witness T2's rows at all
(`lumen_class_frigate` reaches both Spacecraft static arms; `kabira_vindicator` reaches the leveler
body arm twice). Six `Static` nodes, zero `PreLoweredStatic`, every `source_text` the real recognizer
input rather than `lines[line]`.

`test-engine` green at build 2420 — observed red first at 2413 on exactly these two fixtures, then
green after accepting, per the seen-red rule. `cargo fmt --all` clean. Ratchet gate PASS.

## Gate half two — CR-faithfulness for the class

- **T1/T2 statics.** `lower_static_ir` applies two transforms and both are idempotent and blind to the
  interposed condition: `collect_source_in_zones` reads only `SourceInZone` and
  `populate_active_zones_from_condition` self-guards on `active_zones.is_empty()`;
  `bind_anaphoric_counters` rewrites only `ObjectScope::Anaphoric` and derives its bound value from
  `def.affected`, which neither the `ClassLevelGE` wrap nor CR 711.2a / CR 702.184a `HasCounters`
  touches. So the double-lowering is a no-op **for the class**, not merely for today's corpus.
- **T1/T3 replacements.** `lower_replacement_ir` is `ir.definition.clone()` — identity by construction.
- **T3 provenance convention.** A *synthesized* rule item's source text is its own description. The Saga
  ETB replacement (CR 714.3a) prints no line — the rule applies from the subtype alone — and the anchor
  tempts a lie, since `etb_line` points at chapter I's line, which the chapter-I trigger owns.

**Standing obligation created:** `lower_static_ir`'s doc comment now records that any future transform
added there must be idempotent, or all 29 sites silently double-apply it.

## Harvest (§5.4)

1. **Dead branch deleted.** Priority 13e (`"X can't be 0."`) was structurally unreachable:
   `strip_x_cant_be_zero_suffix` returns `""` for exactly that input and `lower` is bound once from the
   post-strip line, so the empty-line guard always claims it first. Its own comment called it a
   "defensive fallback". Removing it also drops `mutate_last_spell` from two callers to one, halving the
   surface of item 2.
2. **Verified detonation path for T8.** `doc.rs:804` pushes **both** `Spell(_)` and `PreLoweredSpell(_)`
   onto `spells_emitted`, and `take_last_spell` pops that stack with no variant filter — while
   `oracle.rs:3683` and `:5827` destructure with `unreachable!("… returns only PreLoweredSpell items")`.
   The first native `Spell` producer makes both reachable: a panic during card parsing, not a silent
   skip. This is a hard prerequisite for T8, confirming §7.4.
3. **Description is not a provenance carrier.** Lumen-Class Frigate's keyword-only Spacecraft static has
   `description: "12+ | Flying, lifelink"` but `source_text: "Flying, lifelink"`. Left as-is (the
   description feeds card data), and it is incidental evidence for why the preprocessor had to own
   `source_text` explicitly.
4. **Two rows have no pool witness**, recorded rather than papered over: the leveler multi arm
   (`oracle_level.rs:146`, `parse_static_line_multi` — no printed LEVEL body lowers to more than one
   static) and T1's row U0-60 (ability-word static — all three ability-word-prefixed Class level bodies
   are `Landfall — Whenever …` and take the trigger arm). Their conversions rest on the class argument.
5. **Ratchet is a ceiling, not a progress meter.** T2 converted two producers but the ledger moves only
   21 → 20, because the Spacecraft site emitted through the `static_at` helper and never had a textual
   `PreLowered` hit of its own. Helper-mediated producers stay invisible until the helper dies.
6. **Process.** `insta` writes `.snap.new` into the Tilt-watched source tree, so a failing snapshot test
   self-perpetuates a rebuild loop that starves every other resource on the cargo lock — `card-data` sat
   `pending` for ~7h behind it. Same failure class `gen-card-data.sh`'s `.tmp.` infix already guards
   against for `known-tokens.toml`.

## Scoped out, deliberately

U0-05 / U0-06 (the `drain_result_vectors` static and replacement arms). Converting them needs
`ParsedAbilities.statics` / `.replacements` to carry IR — 93 call sites on a `pub` type — and the
modal-block feeder passes only the block HEADER line, so every drained per-mode static would have to
source its own text from inside `lower_oracle_block`. Until that lands, `static_at` and `replacement_at`
each retain exactly one caller, so T3's headline payoff of deleting both emitter methods is still pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved parsing and lowering of Saga chapters, LEVEL blocks, Spacecraft threshold lines, and Class static/replacement text.
  * Refined counter/ETB-related replacement handling for more consistent IR generation.
* **Quality**
  * Expanded snapshot coverage for Level sections, Class cards, and threshold-based behavior to improve regression detection.
* **Developer Tools**
  * Added an extra CI lint gate and a pre-commit validation to enforce “pre-lowered” migration progress using a burn-down ledger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->