### PR TITLE
refactor(parser): open the trigger IR seam and convert the CR 603.12 rider gap

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -70,6 +70,7 @@ use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
 use super::oracle_ir::static_ir::StaticIr;
+use super::oracle_ir::trigger::TriggerNodeIr;
 pub use super::oracle_keyword::keyword_display_name;
 use super::oracle_keyword::{
     is_keyword_cost_line, is_kicker_family_line, parse_kicker_additional_cost_line,
@@ -101,7 +102,7 @@ use super::oracle_static::{
     try_parse_graveyard_keyword_grant_static, try_parse_top_of_library_cast_permission,
     GrantedCastKeywordKind,
 };
-use super::oracle_trigger::{lower_trigger_ir, parse_trigger_lines_at_index};
+use super::oracle_trigger::{lower_trigger_node_ir, parse_trigger_lines_at_index};
 use super::oracle_util::{
     normalize_card_name_refs, parse_mana_symbols, parse_number, split_same_is_true_static_tail,
     strip_reminder_text, TextPair, GRANTING_SELF_PLACEHOLDER,
@@ -1164,8 +1165,23 @@ fn item_ability(item: &OracleItemIr) -> Option<&AbilityDefinition> {
     }
 }
 
+/// CR 607.2d: the trigger side of document-relation discovery.
+///
+/// Both trigger-bearing node shapes are handled, which is what makes the
+/// `_ => None` safe here. Seven readers drive four document relations off this
+/// and five of them read `trigger.execute`, so a trigger node this failed to
+/// recognize would not fail loudly — it would silently drop the relation, and
+/// the regression would surface on a DIFFERENT card from the converted one,
+/// where per-card byte-identity cannot catch it.
+///
+/// The exhaustiveness obligation lives on `TriggerNodeIr::definition()`, not on
+/// this match, and that is the correct layer: a new trigger representation is a
+/// new `TriggerNodeIr` variant, so it breaks that match at compile time before
+/// it can reach here. Enumerating `OracleNodeIr` instead would add nothing —
+/// every other variant is genuinely `None`.
 fn item_trigger(item: &OracleItemIr) -> Option<&TriggerDefinition> {
     match &item.node {
+        OracleNodeIr::Trigger(node) => node.definition(),
         OracleNodeIr::PreLoweredTrigger(def) => Some(def),
         _ => None,
     }
@@ -2873,8 +2889,8 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
                 result.abilities.push(lower_effect_chain_ir(effect_ir));
                 ability_ids.push(item.id);
             }
-            OracleNodeIr::Trigger(trigger_ir) => {
-                result.triggers.push(lower_trigger_ir(trigger_ir));
+            OracleNodeIr::Trigger(trigger_node) => {
+                result.triggers.push(lower_trigger_node_ir(trigger_node));
                 trigger_ids.push(item.id);
             }
             OracleNodeIr::Static(static_ir) => {
@@ -3558,6 +3574,14 @@ impl<'a> DocEmitter<'a> {
     fn trigger_at(&mut self, line: usize, def: TriggerDefinition) {
         self.last_trigger = Some(def.clone());
         self.emit_at(line, OracleNodeIr::PreLoweredTrigger(def));
+    }
+    /// Mirrors `static_ir_at`: the peek mirror stores the LOWERED definition, so
+    /// the peek reader is unchanged and no `source_text` is invented for a slot
+    /// nothing reads it from. Lowering here is a clone (`lower_trigger_node_ir`
+    /// passes an assembled definition through), exactly what `trigger_at` paid.
+    fn trigger_ir_at(&mut self, line: usize, ir: TriggerNodeIr) {
+        self.last_trigger = Some(lower_trigger_node_ir(&ir));
+        self.emit_at(line, OracleNodeIr::Trigger(ir));
     }
     fn static_at(&mut self, line: usize, def: StaticDefinition) {
         self.last_static = Some(def.clone());
@@ -5015,7 +5039,11 @@ pub(crate) fn parse_oracle_ir(
                         item_line,
                         StaticIr::from_definition(&line, static_def.description(line.to_string())),
                     );
-                    emitter.trigger_at(item_line, rider_gap);
+                    // Same `&line` the sibling static above passes: both halves
+                    // of this sentence were recognized from the whole printed
+                    // line, before the `". when you do, "` split.
+                    emitter
+                        .trigger_ir_at(item_line, TriggerNodeIr::from_definition(&line, rider_gap));
                     i += 1;
                     continue;
                 }

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -28,7 +28,7 @@ use super::effect_chain::EffectChainIr;
 use super::relation::DocumentRelationIr;
 use super::replacement::ReplacementIr;
 use super::static_ir::StaticIr;
-use super::trigger::TriggerIr;
+use super::trigger::TriggerNodeIr;
 use crate::types::ability::{
     AbilityDefinition, AdditionalCost, CastingPermission, CastingRestriction,
     ContinuousModification, Effect, ModalChoice, ReplacementDefinition, SolveCondition,
@@ -313,9 +313,7 @@ pub(crate) enum OracleNodeIr {
     /// becomes typed IR rather than a pre-lowered `AbilityDefinition`.
     Spell(EffectChainIr),
     /// Triggered ability.
-    // PLAN-05 DEBT (2026-07-17, post-U2): constructed only by the Class-B bring-up (unit 3); retire this allow there.
-    #[allow(dead_code)]
-    Trigger(TriggerIr),
+    Trigger(TriggerNodeIr),
     /// Static ability.
     Static(StaticIr),
     /// Replacement effect.
@@ -916,17 +914,24 @@ impl OracleDocBuilder {
         // dispatch loop baked in.
         //
         // Match is EXHAUSTIVE over `OracleNodeIr` (no `_`), mirroring `emit`'s
-        // printed-slot match above: a future node variant — or the currently
-        // never-constructed `Trigger`/`Spell` IR variants once a later commit emits
-        // them — must fail to compile here until its slot behavior is decided,
-        // rather than being silently skipped (which would mis-index every later
-        // trigger/ability).
+        // printed-slot match above: a future node variant — or the still
+        // never-constructed `Spell` IR variant once a later commit emits it —
+        // must fail to compile here until its slot behavior is decided, rather
+        // than being silently skipped (which would mis-index every later
+        // trigger/ability). `Trigger` is destructured to its one payload variant
+        // for the same reason: adding an IR-native trigger payload must break
+        // this match, because the stamp targets `execute`, which a decomposition
+        // does not have until lowering builds it.
         let mut trigger_slot = 0usize;
         let mut ability_slot = 0usize;
         for item in self.items.values_mut() {
             match &mut item.node {
                 OracleNodeIr::PreLoweredTrigger(trigger) => {
                     stamp_trigger_printed_slot(trigger, trigger_slot, PrintedItemKind::Trigger);
+                    trigger_slot += 1;
+                }
+                OracleNodeIr::Trigger(TriggerNodeIr::Assembled { definition, .. }) => {
+                    stamp_trigger_printed_slot(definition, trigger_slot, PrintedItemKind::Trigger);
                     trigger_slot += 1;
                 }
                 OracleNodeIr::PreLoweredSpell(def) => {
@@ -937,8 +942,7 @@ impl OracleDocBuilder {
                 // are never constructed in unit 3a, and the remaining categories do
                 // not carry a copy-except body. Left explicit (not `_`) so a new
                 // slot-bearing node is a compile error, per the note above.
-                OracleNodeIr::Trigger(_)
-                | OracleNodeIr::Spell(_)
+                OracleNodeIr::Spell(_)
                 | OracleNodeIr::Static(_)
                 | OracleNodeIr::PreLoweredStatic(_)
                 | OracleNodeIr::Replacement(_)

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -413,6 +413,35 @@ fn lumen_class_frigate() {
 }
 
 // ---------------------------------------------------------------------------
+// CR 603.12 deferred rider on a top-of-library play permission
+// ---------------------------------------------------------------------------
+
+/// The `". When you do, …"` rider gap (Plan 05b, T4 witness).
+///
+/// The converted site emits BOTH halves of the second line: a static for the
+/// top-of-library play permission and, beside it, a deliberately-honest gap
+/// marker for the rider — `TriggerMode::Unknown("when you do")` with
+/// `execute: None`, so coverage shows the gap instead of an approximated and
+/// rules-incorrect `PlayCard` trigger.
+///
+/// This fixture exists because T4's churn is otherwise ZERO: none of the 28
+/// corpus cards carrying a trigger reaches this site, which would make the
+/// tranche's byte gate vacuous. It is the non-vacuity proof — the `_ir`
+/// snapshot must show a `Trigger` node rather than the pre-lowered variant on
+/// line 1, and `_lowered` must match what the old path produced.
+#[test]
+fn the_fourth_doctor() {
+    let (ir, lowered) = parse_two_layer(
+        "You may look at the top card of your library any time.\nWould You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token. (Artifacts, legendaries, and Sagas are historic.)",
+        "The Fourth Doctor",
+        &["Creature"],
+        &["Time Lord", "Doctor"],
+    );
+    insta::assert_json_snapshot!("the_fourth_doctor_ir", &ir);
+    insta::assert_json_snapshot!("the_fourth_doctor_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Adventure
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__the_fourth_doctor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__the_fourth_doctor_ir.snap
@@ -1,0 +1,165 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 440
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 54,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "You may look at the top card of your library any time."
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "MayLookAtTopOfLibrary",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [],
+              "controller": "You",
+              "properties": []
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "You may look at the top card of your library any time."
+          },
+          "source_text": "You may look at the top card of your library any time.",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 55,
+          "end_byte": 263,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Would You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token. (Artifacts, legendaries, and Sagas are historic.)"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": {
+              "TopOfLibraryCastPermission": {
+                "play_mode": "Play",
+                "frequency": "OncePerTurn",
+                "alt_cost": null
+              }
+            },
+            "affected": {
+              "type": "Or",
+              "filters": [
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Land"
+                  ],
+                  "controller": null,
+                  "properties": [
+                    {
+                      "type": "Historic"
+                    }
+                  ]
+                },
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Card"
+                  ],
+                  "controller": null,
+                  "properties": [
+                    {
+                      "type": "Historic"
+                    }
+                  ]
+                }
+              ]
+            },
+            "modifications": [],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Would You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token."
+          },
+          "source_text": "Would You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token.",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 55,
+          "end_byte": 263,
+          "precision": "Exact",
+          "ordinal_within_span": 1
+        },
+        "fragment": "Would You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token. (Artifacts, legendaries, and Sagas are historic.)"
+      },
+      "node": {
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": {
+                "Unknown": "when you do"
+              },
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "Would You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token.",
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "source_text": "Would You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token."
+          }
+        }
+      }
+    }
+  ],
+  "source_text": "You may look at the top card of your library any time.\nWould You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token. (Artifacts, legendaries, and Sagas are historic.)",
+  "card_name": "The Fourth Doctor"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__the_fourth_doctor_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__the_fourth_doctor_lowered.snap
@@ -1,0 +1,94 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": {
+        "Unknown": "when you do"
+      },
+      "execute": null,
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "Would You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": "MayLookAtTopOfLibrary",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [],
+        "controller": "You",
+        "properties": []
+      },
+      "modifications": [],
+      "condition": null,
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "You may look at the top card of your library any time."
+    },
+    {
+      "mode": {
+        "TopOfLibraryCastPermission": {
+          "play_mode": "Play",
+          "frequency": "OncePerTurn",
+          "alt_cost": null
+        }
+      },
+      "affected": {
+        "type": "Or",
+        "filters": [
+          {
+            "type": "Typed",
+            "type_filters": [
+              "Land"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "Historic"
+              }
+            ]
+          },
+          {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "Historic"
+              }
+            ]
+          }
+        ]
+      },
+      "modifications": [],
+      "condition": null,
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Would You Like A...? — Once each turn, you may play a historic land or cast a historic spell from the top of your library. When you do, create a Food token."
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -16,6 +16,69 @@ use crate::types::ability::{
 };
 use crate::types::triggers::TriggerMode;
 
+/// The document-node payload for a trigger: either a decomposition the parser
+/// produced, or a definition a recognizer already assembled.
+///
+/// The escape hatch lives HERE and not on `TriggerIr`, because
+/// `TriggerDefinition -> TriggerIr` has no inverse. Two fields of the
+/// decomposition are pure parse-time inputs with no representation in the
+/// output — `TriggerModifiers::trigger_subject` (CR 608.2k pronoun subject) and
+/// `TriggerModifiers::effect_lower`, the latter load-bearing at three sites in
+/// `lower_trigger_ir` — and `TriggerBody` has no variant carrying an
+/// already-lowered ability (unit 3b-5 deliberately deleted the one that did).
+/// Lowering then unconditionally overwrites nine `TriggerDefinition` fields, so
+/// a `partial_def = definition` round-trip does not survive contact with it.
+///
+/// This is the `QuantityExpr`/`QuantityRef` split CLAUDE.md mandates: a
+/// finished definition is a *constant*, not a decomposition, so it wraps the IR
+/// rather than becoming a variant of it.
+///
+/// The variant is `Assembled` rather than reusing the `OracleNodeIr` debt
+/// marker's name, on purpose: that name is what
+/// `scripts/check-prelowered-ratchet.sh` greps for, and this type is the
+/// mechanism that RETIRES that debt. Reusing it would make the burn-down metric
+/// count the fix as debt, so the number would rise as the debt fell.
+///
+/// One variant today, deliberately. The IR-native sibling (`Parsed`, boxing a
+/// `TriggerIr`) is added by the tranche that lands its first producer, not
+/// before: adding it now would need a `#[allow(dead_code)]` and a CR 707.9a
+/// slot-stamp arm that cannot be written until lowering runs (the stamp targets
+/// `execute`, which does not exist pre-lowering), leaving a latent panic behind.
+/// Adding the variant later instead turns every match site into a compile
+/// error, which is the stronger forcing function.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum TriggerNodeIr {
+    /// Already-assembled definition from a recognizer that builds its own.
+    /// `lower_trigger_node_ir` returns it untouched.
+    Assembled {
+        definition: TriggerDefinition,
+        /// The recognizer's own input text — provenance only. Document lowering
+        /// derives spans and fragments from the emitting line, never from here.
+        source_text: String,
+    },
+}
+
+impl TriggerNodeIr {
+    /// Wrap a recognizer-produced trigger definition for source-ordered emission.
+    pub(crate) fn from_definition(source_text: &str, definition: TriggerDefinition) -> Self {
+        Self::Assembled {
+            definition,
+            source_text: source_text.to_string(),
+        }
+    }
+
+    /// The assembled definition, when one exists.
+    ///
+    /// Returns `Option` rather than `&TriggerDefinition` because a future
+    /// IR-native variant has no definition before lowering — CR 607.2d relation
+    /// discovery must see `None` there, not a fabricated definition.
+    pub(crate) fn definition(&self) -> Option<&TriggerDefinition> {
+        match self {
+            Self::Assembled { definition, .. } => Some(definition),
+        }
+    }
+}
+
 /// Trigger-level IR: the complete parsed representation of a trigger line
 /// before final assembly into `TriggerDefinition`.
 ///

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -17,7 +17,7 @@ use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::doc::PrintedTriggerIndex;
 use super::oracle_ir::effect_chain::EffectChainIr;
 use super::oracle_ir::trigger::{
-    FirstTimeLimit, ReflexivePaymentIr, TriggerBody, TriggerIr, TriggerModifiers,
+    FirstTimeLimit, ReflexivePaymentIr, TriggerBody, TriggerIr, TriggerModifiers, TriggerNodeIr,
 };
 use super::oracle_modal::try_parse_inline_modal_ir;
 use super::oracle_nom::condition::parse_elided_subject_state_condition;
@@ -1563,6 +1563,27 @@ fn lower_trigger_effect_chain(
         ability.optional = true;
     }
     ability
+}
+
+/// Lower a document trigger node.
+///
+/// Deliberately does NOT route through `lower_trigger_ir`: an `Assembled`
+/// definition arrives complete, and `lower_trigger_ir` unconditionally
+/// overwrites nine of its fields (`execute`, `description`, `optional`,
+/// `unless_pay`, `condition`, `constraint`, `trigger_zones`, `valid_target`,
+/// `batched`) before re-running ~12 execute-mutating passes over an
+/// already-lowered execute — one of which can replace `execute.effect` with
+/// `Effect::unimplemented`. Passing through is therefore not an optimization,
+/// it is the only correct behavior.
+///
+/// Note this is a stronger byte-identity argument than the statics' one:
+/// statics rely on two transforms being idempotent, a property a future third
+/// transform could silently break; this relies on lowering not running at all,
+/// which nothing added to `lower_trigger_ir` can invalidate.
+pub(crate) fn lower_trigger_node_ir(ir: &TriggerNodeIr) -> TriggerDefinition {
+    match ir {
+        TriggerNodeIr::Assembled { definition, .. } => definition.clone(),
+    }
 }
 
 pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {


### PR DESCRIPTION
Plan 05b tranche **T4**. Opens the document-node seam every later trigger row needs, lands both
cross-cutting prerequisites, and converts the one trigger row that is mechanical today — U0-37, the
deferred `". When you do, …"` rider on a top-of-library play permission (The Fourth Doctor).

Follows #6699 (T0–T3).

## Why the escape hatch wraps `TriggerIr` instead of extending it

The statics tranches were mechanical because `StaticIr`/`ReplacementIr` carry a `definition` field, so
`from_definition` can wrap an already-built definition and let lowering re-run idempotently.
`TriggerIr` is **structural** and has no such field, and `TriggerDefinition -> TriggerIr` has no
inverse:

- two decomposition fields are pure parse-time inputs with no representation in the output
  (`TriggerModifiers::trigger_subject`, CR 608.2k pronoun subject; and `effect_lower`, which is
  load-bearing at three sites in `lower_trigger_ir`);
- `TriggerBody` has no variant carrying an already-lowered ability — unit 3b-5 deliberately deleted
  the one that did;
- lowering then unconditionally overwrites **nine** `TriggerDefinition` fields.

So a `partial_def = definition` round-trip does not survive contact with lowering. `TriggerNodeIr`
therefore goes one level **up**. This is the `QuantityExpr`/`QuantityRef` split CLAUDE.md mandates: a
finished definition is a *constant*, not a decomposition, so it wraps the IR rather than becoming a
variant of it.

## CR-faithfulness — by construction, and stronger than the statics' argument

`lower_trigger_node_ir` is pure identity and deliberately does **not** route through
`lower_trigger_ir`. An `Assembled` definition arrives complete; `lower_trigger_ir` would overwrite
nine fields and re-run ~12 execute-mutating passes over an already-lowered execute — one of which can
replace `execute.effect` with `Effect::unimplemented`. Passing through is not an optimization, it is
the only correct behavior.

This is a **stronger** byte-identity argument than T1–T3's: statics rely on two transforms being
idempotent, a property a future third transform could silently break at 29 sites. This relies on
lowering **not running at all**, which nothing added to `lower_trigger_ir` can invalidate.

Concretely for U0-37, CR 603.12's deliberately-honest gap marker (`TriggerMode::Unknown("when you do")`,
`execute: None`) is preserved bit-for-bit rather than approximated by a rules-incorrect `PlayCard`
trigger. The committed `_lowered` snapshot shows exactly that.

## Both prerequisites, which blocked every trigger row

- **`item_trigger` recognizes the new node**, so CR 607.2d relation discovery does not silently lose
  it. Seven readers drive four document relations off that function and five read `trigger.execute`;
  an unrecognized node would not fail loudly — it would drop the relation and regress a **different**
  card from the converted one, where per-card byte-identity cannot catch it.
- **`finish()` stamps CR 707.9a printed slots** on the new node and increments `trigger_slot` for it.
  Without this, converting one site mis-indexes every later trigger on the same card.

Retires the second of the two `#[allow(dead_code)]` this plan owes: `OracleNodeIr::Trigger` now has a
producer.

## Three deliberate deviations from the recensus §4.1 sketch

- **No `Parsed` variant yet.** §4.1 adds it now with the dead-code allow relocating to it. It has no
  producer until T5a, so it would need both an allow and a CR 707.9a stamp arm that cannot be written
  yet — the stamp targets `execute`, which a decomposition does not have until lowering builds it,
  i.e. a `todo!()`. §7.4 of that same document catalogues two `unreachable!` arms a later tranche will
  detonate; adding a third while cataloguing them would be perverse. Omitting the variant makes T5a's
  addition a **compile error at every match site**, which is the stronger forcing function, and leaves
  no new allow to retire at §6 criterion 3.
- **The variant is `Assembled`, not `PreLowered`.** That name is what `check-prelowered-ratchet.sh`
  greps, and this type is the mechanism that *retires* that debt; reusing the name made the burn-down
  metric count the fix as debt and failed the gate in four files. Two of the plan's own artifacts in
  direct conflict — renaming is the low-risk resolution.
- **`item_trigger` keeps its `_ => None`.** Enumerating `OracleNodeIr` there cost four debt-marker
  hits and would have required raising a ceiling the gate says may only fall — i.e. editing the gate
  so this change passes. The exhaustiveness obligation belongs on `TriggerNodeIr::definition()`,
  which has it: a new trigger representation is a new `TriggerNodeIr` variant, so it breaks that match
  at compile time before it can reach `item_trigger`.

## Empirical gate

- **Full engine suite: `21967 tests run: 21966 passed, 1 failed`** — the single failure was the
  deliberately-new fixture before its snapshots were accepted. Zero churn across all 28 existing
  trigger-carrying corpus cards, and across every other snapshot in the tree.
- The pre-existing `oracle_static::tests::the_fourth_doctor_full_card_parse` still passes untouched.
- No `*_lowered.snap` changed; the only `_lowered` file here is the new fixture's.
- Gates: `check-prelowered-ratchet.sh` → `Gate P PASS`; `check-skill-doc.sh` → `✓`; `cargo fmt --all`
  clean.

## Non-vacuity (§5.3) — why the fixture is mandatory, not decorative

T4's churn is otherwise **zero**: none of the 28 corpus cards carrying a trigger reaches this site,
which would make the byte gate vacuous. `the_fourth_doctor` is the probe. Its `_ir` snapshot must show
a `Trigger` node rather than the pre-lowered variant, alongside the sibling static this site emits on
the same line; its `_lowered` snapshot records what the old path produced. A gate that cannot go red
is not a gate.

Oracle text verified against the card pool, not recalled.

## Harvest (§5.4)

- The `finish()` comment claiming "the `*` IR variants are never constructed in unit 3a" **is already
  false** for `Spell`, which has a live producer. Corrected here for `Trigger`; the `Spell` half is
  T7-P1's defect and is left for that tranche rather than fixed inside a byte-identity commit.
- The peek mirror stores the **lowered** definition (mirroring `static_ir_at`) rather than §4.1's
  lower-on-demand slot. That design exists to avoid paying `lower_trigger_ir`'s ~20 passes for a
  `Parsed` node; with no `Parsed` producer the lowering is a clone — exactly what `trigger_at` already
  paid — and it avoids inventing a `source_text` for a slot nothing reads one from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of triggered abilities during document parsing and lowering.
  - Preserved assembled trigger definitions to ensure accurate “when you do” rider behavior.
  - Maintained correct source order and document-relation discovery for triggers.

- **Tests**
  - Added regression coverage validating trigger parsing and lowering for “when you do” riders.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->