### PR TITLE
docs(manabrew-compat): correct the capability-registry counts

### DIFF
--- a/crates/manabrew-compat/CLAUDE.md
+++ b/crates/manabrew-compat/CLAUDE.md
@@ -57,7 +57,7 @@ rg -o '"(local|upstream)\.[a-z0-9-]+"' crates/manabrew-compat/src/lib.rs | sort 
 
 Compare emitted codes against declared entries. Divergence is a defect, not a backlog item.
 
-The registry is now **exhaustive** over emitted codes (78 declared; 65 emitted at live call sites, plus 13 documentary entries that describe a gap without a code path). `no_emitted_capability_code_is_undeclared` scans the production half of `lib.rs` and fails on any new undeclared code, so this no longer needs a manual audit — but re-run the command above if you doubt the test.
+The registry is now **exhaustive** over emitted codes (82 declared; 69 emitted at live call sites, plus 13 documentary entries that describe a gap without a code path). `no_emitted_capability_code_is_undeclared` scans the production half of `lib.rs` and fails on any new undeclared code, so this no longer needs a manual audit — but re-run the command above if you doubt the test.
 
 ### 4. A mapping claim must be exhibited by a test, not asserted in prose.
 


### PR DESCRIPTION
The guide claimed 78 declared / 65 emitted. Four codes were added when the
generic interaction path shipped (#6700) — simultaneous-decisions,
schema-response, and aggregate-bound refusals, plus a narrowed
prompt-unsupported — so the live figures are 82 and 69. The 13 documentary-only
entries are unchanged, as is the invariant that matters: zero emitted codes are
undeclared.

Recomputed against this tree rather than carried over from the earlier count:

    declared 82 · emitted 69 · documentary-only 13 · undeclared emitted 0

which also agrees with the array's own type, `[UnsupportedCapability; 82]`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated capability registry documentation with revised declared and emitted capability-code counts.
  - Clarified that registry exhaustiveness is enforced through verification checks.
  - Added guidance to rerun the verification command when results are uncertain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->