### PR TITLE
fix(parser): Plan 05b T7 — Unit 3b prerequisites (printed slot, item_ability, unsound destructures)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while};
@@ -1158,9 +1160,33 @@ fn item_replacement(item: &OracleItemIr) -> Option<&ReplacementDefinition> {
     }
 }
 
-fn item_ability(item: &OracleItemIr) -> Option<&AbilityDefinition> {
+/// CR 607.2d: the ability side of document-relation discovery.
+///
+/// Returns `Cow` because the two spell-bearing node shapes own their definition
+/// at different times. A pre-lowered item already holds an `AbilityDefinition`
+/// and lends it out; an IR-native item holds only an `EffectChainIr` and owns no
+/// definition at all until lowering builds one, so it must lower and hand back
+/// the result owned. A plain `&AbilityDefinition` cannot express the second case
+/// — there is nothing to borrow from — and a plain `AbilityDefinition` would
+/// clone the first case at all seven call sites, most of which scan every item
+/// on the card.
+///
+/// This is where the trigger side's reasoning stops applying.
+/// `item_trigger` keeps a borrow and pushes exhaustiveness down onto
+/// `TriggerNodeIr::definition()`, because both of its shapes own a
+/// `TriggerDefinition` — `TriggerNodeIr::Assembled` carries one directly. There
+/// is no equivalent layer to push this obligation onto: a spell node's IR
+/// payload is an `EffectChainIr`, not an enum of definition-owning
+/// representations, so both shapes are named here. `_ => None` is safe for the
+/// same reason it is safe there: every remaining variant is genuinely `None`.
+///
+/// Lowering is the identity conversion `lower_oracle_ir` (the `Spell` arm) will
+/// perform for the same item, so a relation predicate sees exactly the
+/// definition the relation will later be applied to.
+fn item_ability(item: &OracleItemIr) -> Option<Cow<'_, AbilityDefinition>> {
     match &item.node {
-        OracleNodeIr::PreLoweredSpell(def) => Some(def),
+        OracleNodeIr::PreLoweredSpell(def) => Some(Cow::Borrowed(def)),
+        OracleNodeIr::Spell(effect_ir) => Some(Cow::Owned(lower_effect_chain_ir(effect_ir))),
         _ => None,
     }
 }
@@ -1421,7 +1447,7 @@ fn detect_linked_choice_type_statics(
                     }
                 )
             });
-            let is_dig = item_ability(item).is_some_and(ability_chain_has_dig)
+            let is_dig = item_ability(item).is_some_and(|def| ability_chain_has_dig(&def))
                 || item_trigger(item)
                     .and_then(|trigger| trigger.execute.as_deref())
                     .is_some_and(ability_chain_has_dig);
@@ -1542,7 +1568,7 @@ fn chosen_subtype_kind_from_persisted_choice_items(
             items
                 .iter()
                 .filter_map(item_ability)
-                .find_map(chosen_subtype_kind_from_ability)
+                .find_map(|def| chosen_subtype_kind_from_ability(&def))
         })
         .or_else(|| {
             items
@@ -1643,7 +1669,7 @@ fn detect_linked_choice_persisted_player(
 ) {
     let has_durable_reader = items.iter().any(|item| {
         item_static(item).is_some_and(static_references_source_chosen_player)
-            || item_ability(item).is_some_and(ability_references_source_chosen_player)
+            || item_ability(item).is_some_and(|def| ability_references_source_chosen_player(&def))
             || item_trigger(item).is_some_and(trigger_references_source_chosen_player)
     });
     if !has_durable_reader {
@@ -1652,7 +1678,7 @@ fn detect_linked_choice_persisted_player(
     let choosers: Vec<OracleItemId> = items
         .iter()
         .filter(|item| {
-            item_ability(item).is_some_and(ability_chain_has_player_choice)
+            item_ability(item).is_some_and(|def| ability_chain_has_player_choice(&def))
                 || item_trigger(item)
                     .and_then(|trigger| trigger.execute.as_deref())
                     .is_some_and(ability_chain_has_player_choice)
@@ -1703,9 +1729,9 @@ fn detect_linked_choice_copy_chosen_host(
     items: &[OracleItemIr],
     relations: &mut Vec<DocumentRelationIr>,
 ) {
-    let chooser = items
-        .iter()
-        .find(|item| item_ability(item).is_some_and(ability_is_as_enters_choose_permanent_gap));
+    let chooser = items.iter().find(|item| {
+        item_ability(item).is_some_and(|def| ability_is_as_enters_choose_permanent_gap(&def))
+    });
     let copy_static = items.iter().find(|item| {
         item_static(item).is_some_and(|s| {
             s.modifications
@@ -3075,12 +3101,12 @@ fn ability_is_active_player_punisher(def: &AbilityDefinition) -> bool {
 fn detect_active_player_punisher(items: &[OracleItemIr], relations: &mut Vec<DocumentRelationIr>) {
     let Some(coerce) = items
         .iter()
-        .find(|item| item_ability(item).is_some_and(ability_is_active_player_coerce))
+        .find(|item| item_ability(item).is_some_and(|def| ability_is_active_player_coerce(&def)))
     else {
         return;
     };
     for item in items {
-        if item_ability(item).is_some_and(ability_is_active_player_punisher) {
+        if item_ability(item).is_some_and(|def| ability_is_active_player_punisher(&def)) {
             relations.push(DocumentRelationIr::ActivePlayerPunisher {
                 coerce: coerce.id,
                 punisher: item.id,
@@ -3699,13 +3725,19 @@ impl<'a> DocEmitter<'a> {
     ///
     /// `take_last_spell` pops the emission-ordered spell stack, which equals
     /// `abilities.last_mut()` regardless of triggers/statics emitted in between.
+    ///
+    /// Reads the popped item through `lower_spell_node`, which accepts BOTH
+    /// spell node shapes. It must: `emit` pushes either shape onto
+    /// `spells_emitted` and `take_last_spell` pops it with no variant filter, so
+    /// a destructure that names one shape panics the parser the first time an
+    /// IR-native spell precedes a mutating line.
     fn mutate_last_spell(&mut self, f: impl FnOnce(&mut AbilityDefinition)) {
         let Some(item) = self.builder.take_last_spell() else {
             return;
         };
         let OracleItemIr { source, node, .. } = item;
-        let OracleNodeIr::PreLoweredSpell(mut def) = node else {
-            unreachable!("take_last_spell returns only PreLoweredSpell items");
+        let Some(mut def) = lower_spell_node(&node) else {
+            unreachable!("`spells_emitted` holds only spell nodes, and both spell shapes lower");
         };
         f(&mut def);
         self.reemit_spell(&source, def);
@@ -5852,8 +5884,13 @@ pub(crate) fn parse_oracle_ir(
                             node: base_node,
                             ..
                         } = base_item;
-                        let OracleNodeIr::PreLoweredSpell(mut base) = base_node else {
-                            unreachable!("pop_last_spell returns only PreLoweredSpell items");
+                        // Both spell node shapes, via the shared reader:
+                        // `pop_last_spell` pops `spells_emitted`, which `emit`
+                        // fills from either shape with no variant filter.
+                        let Some(mut base) = lower_spell_node(&base_node) else {
+                            unreachable!(
+                                "`spells_emitted` holds only spell nodes, and both spell shapes lower"
+                            );
                         };
                         // Save the base ability's continuation chain in else_ability
                         // so the engine can run it when the condition is NOT met.

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -914,14 +914,13 @@ impl OracleDocBuilder {
         // dispatch loop baked in.
         //
         // Match is EXHAUSTIVE over `OracleNodeIr` (no `_`), mirroring `emit`'s
-        // printed-slot match above: a future node variant — or the still
-        // never-constructed `Spell` IR variant once a later commit emits it —
-        // must fail to compile here until its slot behavior is decided, rather
-        // than being silently skipped (which would mis-index every later
-        // trigger/ability). `Trigger` is destructured to its one payload variant
-        // for the same reason: adding an IR-native trigger payload must break
-        // this match, because the stamp targets `execute`, which a decomposition
-        // does not have until lowering builds it.
+        // printed-slot match above: a future node variant must fail to compile
+        // here until its slot behavior is decided, rather than being silently
+        // skipped (which would mis-index every later trigger/ability).
+        // `Trigger` is destructured to its one payload variant for the same
+        // reason: adding an IR-native trigger payload must break this match,
+        // because the stamp targets `execute`, which a decomposition does not
+        // have until lowering builds it.
         let mut trigger_slot = 0usize;
         let mut ability_slot = 0usize;
         for item in self.items.values_mut() {
@@ -938,12 +937,29 @@ impl OracleDocBuilder {
                     stamp_retained_printed_slot(def, ability_slot, PrintedItemKind::Ability);
                     ability_slot += 1;
                 }
-                // No retain modification can reach these today: the `*` IR variants
-                // are never constructed in unit 3a, and the remaining categories do
-                // not carry a copy-except body. Left explicit (not `_`) so a new
-                // slot-bearing node is a compile error, per the note above.
-                OracleNodeIr::Spell(_)
-                | OracleNodeIr::Static(_)
+                // CR 707.9a printed slots count PRINTED abilities. The set of
+                // variants that advance `ability_slot` here must equal the set
+                // `lower_oracle_ir` (`oracle.rs`) pushes into `result.abilities`,
+                // which is in turn the set `emit` pushes onto `spells_emitted`
+                // above: both spell shapes. Three matches over one set.
+                //
+                // Advances WITHOUT stamping, on purpose — do not try to make this
+                // arm symmetric with the arm above. An IR-native spell body has no
+                // `AbilityDefinition` until lowering builds one, and
+                // `stamp_retained_printed_slot` takes `&mut AbilityDefinition`, so
+                // there is nothing here to stamp. The printed slot is consumed all
+                // the same: skipping the advance stamps every LATER ability one
+                // slot low, silently binding a copy's "except it has this ability"
+                // to the wrong ability.
+                OracleNodeIr::Spell(_) => {
+                    ability_slot += 1;
+                }
+                // Neither stamps nor counts: `RetainPrinted*FromSource` exists only
+                // for the trigger and ability categories (CR 707.9a), so these
+                // carry no slot to rewrite and consume neither counter this walk
+                // maintains. Left explicit (not `_`) so a new slot-bearing node is
+                // a compile error, per the note above.
+                OracleNodeIr::Static(_)
                 | OracleNodeIr::PreLoweredStatic(_)
                 | OracleNodeIr::Replacement(_)
                 | OracleNodeIr::PreLoweredReplacement(_)

--- a/crates/engine/tests/integration/ir_spell_node_readers.rs
+++ b/crates/engine/tests/integration/ir_spell_node_readers.rs
@@ -1,0 +1,111 @@
+//! Readers of an IR-native spell item (`OracleNodeIr::Spell`) — Plan 05b T7.
+//!
+//! That node shape has a live producer today (the instant/sorcery
+//! prevent-damage recognizer in `parser/oracle.rs`), but several of its readers
+//! were written when it had none, and each assumed the pre-lowered shape. The
+//! defects they carried are silent by construction: a mis-stamped printed slot
+//! and a missed document relation both produce a card that parses successfully
+//! into the wrong thing, so full-pool byte-identity cannot see them.
+//!
+//! These tests drive the real `parse_oracle_text` pipeline and assert on the
+//! parsed AST, which is the layer the defects live in.
+
+use engine::parser::oracle::ParsedAbilities;
+use engine::parser::parse_oracle_text;
+use engine::types::ability::{AbilityDefinition, ContinuousModification, Effect};
+
+/// Every CR 707.9a printed-ability slot a card's copy-except clauses resolve to.
+fn retained_ability_slots(parsed: &ParsedAbilities) -> Vec<usize> {
+    fn from_mods(mods: &[ContinuousModification], out: &mut Vec<usize>) {
+        for m in mods {
+            if let ContinuousModification::RetainPrintedAbilityFromSource {
+                source_ability_index,
+            } = m
+            {
+                out.push(*source_ability_index);
+            }
+        }
+    }
+    fn walk(def: &AbilityDefinition, out: &mut Vec<usize>) {
+        match def.effect.as_ref() {
+            Effect::CopySpell {
+                additional_modifications,
+                ..
+            }
+            | Effect::CopyTokenOf {
+                additional_modifications,
+                ..
+            }
+            | Effect::BecomeCopy {
+                additional_modifications,
+                ..
+            } => from_mods(additional_modifications, out),
+            Effect::AddPendingEntersModifications { modifications } => {
+                from_mods(modifications, out)
+            }
+            _ => {}
+        }
+        if let Some(sub) = def.sub_ability.as_deref() {
+            walk(sub, out);
+        }
+    }
+    let mut out = Vec::new();
+    for ability in &parsed.abilities {
+        walk(ability, &mut out);
+    }
+    out
+}
+
+/// CR 707.9a: a printed slot is consumed by the printed ability that occupies
+/// it, whether or not that ability has a definition yet to stamp.
+///
+/// `OracleDocBuilder::finish()` resolves every "…except it has this ability"
+/// clause by walking items in source order and counting each category
+/// separately. An IR-native spell node holds only an effect chain, so there is
+/// nothing to stamp into — but it still occupies an ability slot, because
+/// `lower_oracle_ir` pushes it into `result.abilities` exactly like a
+/// pre-lowered one does.
+///
+/// DISCRIMINATING: with the `Spell` arm parked in `finish()`'s no-op list this
+/// reads `0`, and the copy grafts the FIRST printed ability — the prevention
+/// spell — instead of itself.
+///
+/// Line 1 is the shape the only live `OracleNodeIr::Spell` producer emits: an
+/// instant/sorcery prevention line. Line 2 is a synthetic activated ability,
+/// which is the sole source of `RetainPrintedAbilityFromSource`. No printing
+/// pairs the two today — which is exactly why this defect had no corpus witness
+/// and why the full-pool byte gate is silent on it.
+#[test]
+fn an_ir_native_spell_consumes_the_printed_ability_slot_it_occupies() {
+    let parsed = parse_oracle_text(
+        "Prevent all damage that would be dealt to you this turn.\n{2}: Create a token that's a copy of target creature, except it has this ability.",
+        "Probe",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+
+    // Reach-guard: both printed abilities must be present, or the slot
+    // assertion below is vacuous.
+    assert_eq!(
+        parsed.abilities.len(),
+        2,
+        "expected the prevention spell and the copy ability, got {:?}",
+        parsed.abilities
+    );
+    assert!(
+        matches!(
+            parsed.abilities[0].effect.as_ref(),
+            Effect::PreventDamage { .. }
+        ),
+        "the first printed ability must be the IR-native prevention spell, got {:?}",
+        parsed.abilities[0].effect
+    );
+
+    assert_eq!(
+        retained_ability_slots(&parsed),
+        vec![1],
+        "the copy-except clause must resolve to printed slot 1 — the IR-native \
+         prevention spell consumed slot 0 despite carrying no definition to stamp"
+    );
+}

--- a/crates/engine/tests/integration/ir_spell_node_readers.rs
+++ b/crates/engine/tests/integration/ir_spell_node_readers.rs
@@ -12,7 +12,9 @@
 
 use engine::parser::oracle::ParsedAbilities;
 use engine::parser::parse_oracle_text;
-use engine::types::ability::{AbilityDefinition, ContinuousModification, Effect};
+use engine::types::ability::{
+    AbilityDefinition, ContinuousModification, ControllerRef, Effect, FilterProp, TargetFilter,
+};
 
 /// Every CR 707.9a printed-ability slot a card's copy-except clauses resolve to.
 fn retained_ability_slots(parsed: &ParsedAbilities) -> Vec<usize> {
@@ -107,5 +109,147 @@ fn an_ir_native_spell_consumes_the_printed_ability_slot_it_occupies() {
         vec![1],
         "the copy-except clause must resolve to printed slot 1 — the IR-native \
          prevention spell consumed slot 0 despite carrying no definition to stamp"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CR 607.2d document relations and the `item_ability` reader.
+//
+// `item_ability` is the ability side of cross-item relation discovery. It used
+// to return `Option<&AbilityDefinition>` and recognize exactly one spell node
+// shape; it now returns `Option<Cow<'_, AbilityDefinition>>` and recognizes
+// both, lowering the IR-native shape on demand because that shape owns no
+// definition to borrow.
+//
+// A relation that stops being discovered fails SILENTLY — no error, no panic,
+// just a card that parses to its unrelated line-local shape, with the symptom
+// surfacing on a different card from the one that was edited. The borrowed path
+// therefore needs an explicit non-regression witness across the signature
+// change.
+//
+// SCOPE, stated honestly: this witnesses the BORROWED arm. The new IR-native
+// arm has no witness, because no text can currently reach it — the single live
+// `Spell` producer is a prevent-damage spell line, and no relation predicate
+// matches a prevention chain. Verified by construction (removing the new arm
+// leaves these tests green) and by attempting to synthesize a card that pairs
+// the two, which the line splitter refuses to produce. The arm is forward
+// hardening for T8, when `Spell` producers rise from 1 to ~14.
+// ---------------------------------------------------------------------------
+
+/// Verified against Scryfall 2026-07-27 (`cards/named?exact=Siren's Call`).
+const SIRENS_CALL: &str = "Cast this spell only during an opponent's turn, before attackers are declared.\nCreatures the active player controls attack this turn if able.\nAt the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn. Ignore this effect for each creature the player didn't control continuously since the beginning of the turn.";
+
+/// The delayed punisher's destroyed set, plus whether its exemption sibling is
+/// still hanging off the delayed ability.
+fn punisher_destroy_target(parsed: &ParsedAbilities) -> (TargetFilter, bool) {
+    for ability in &parsed.abilities {
+        if let Effect::CreateDelayedTrigger { effect, .. } = ability.effect.as_ref() {
+            if let Effect::DestroyAll { target, .. } = effect.effect.as_ref() {
+                return (target.clone(), effect.sub_ability.is_some());
+            }
+        }
+    }
+    panic!("expected a delayed DestroyAll punisher ability, got {parsed:?}");
+}
+
+fn typed_controllers(filter: &TargetFilter, out: &mut Vec<Option<ControllerRef>>) {
+    match filter {
+        TargetFilter::Typed(tf) => out.push(tf.controller.clone()),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().for_each(|f| typed_controllers(f, out))
+        }
+        TargetFilter::Not { filter } => typed_controllers(filter, out),
+        _ => {}
+    }
+}
+
+fn typed_props(filter: &TargetFilter, out: &mut Vec<FilterProp>) {
+    match filter {
+        TargetFilter::Typed(tf) => out.extend(tf.properties.iter().cloned()),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().for_each(|f| typed_props(f, out))
+        }
+        TargetFilter::Not { filter } => typed_props(filter, out),
+        _ => {}
+    }
+}
+
+/// CR 102.1 + CR 603.7c + CR 608.2c: the `ActivePlayerPunisher` relation pairs
+/// the mass-attack coerce clause with its sibling delayed punisher, then
+/// rebinds the punisher's "that player controls" anaphor from the line-local
+/// `You` default to `ActivePlayer`.
+///
+/// Siren's Call is the witness because BOTH sides of the relation are ability
+/// items — two printed abilities on one instant — so a single card drives
+/// `item_ability` twice, once per predicate.
+///
+/// DISCRIMINATING: the rebind is reachable ONLY through the relation, and the
+/// relation is discovered only if `item_ability` returns a definition for both
+/// participating items. Blind the reader on either side and this sees the
+/// line-local `You` — the wrong player, which destroys the caster's own
+/// creatures.
+#[test]
+fn active_player_punisher_relation_survives_the_item_ability_reader() {
+    let parsed = parse_oracle_text(
+        SIRENS_CALL,
+        "Siren's Call",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let (target, exemption_sibling_present) = punisher_destroy_target(&parsed);
+
+    let mut controllers = Vec::new();
+    typed_controllers(&target, &mut controllers);
+    assert!(
+        !controllers.is_empty(),
+        "reach-guard: the destroyed set must carry at least one typed node to rebind, got {target:?}"
+    );
+    assert!(
+        controllers
+            .iter()
+            .all(|c| *c == Some(ControllerRef::ActivePlayer)),
+        "the punisher's destroyed set must be rebound to ActivePlayer by the CR 607.2d relation; \
+         a `You` here means the relation was not discovered, got {controllers:?}"
+    );
+
+    // CR 302.6 + CR 508.1a: the same relation folds the continuous-control
+    // exemption into the destroyed set and CONSUMES the redundant sibling. Both
+    // halves are asserted so a partial application cannot pass.
+    let mut props = Vec::new();
+    typed_props(&target, &mut props);
+    assert!(
+        props.contains(&FilterProp::ControlledContinuouslySinceTurnBegan),
+        "the exemption must be folded into the destroyed set as a filter prop, got {props:?}"
+    );
+    assert!(
+        !exemption_sibling_present,
+        "the redundant exemption sibling must be consumed once folded"
+    );
+}
+
+/// Reach-guard for the assertion above: `ActivePlayer` must not be something
+/// the punisher line parses to on its own. With no sibling coerce clause there
+/// is no relation to discover, so the anaphor keeps its line-local `You`.
+///
+/// Without this, the test above would still pass against an `item_ability` that
+/// returned `Some` for every item, or against a parser that hardcoded
+/// `ActivePlayer` into the punisher line.
+#[test]
+fn the_punisher_line_alone_keeps_its_line_local_controller() {
+    let parsed = parse_oracle_text(
+        "At the beginning of the next end step, destroy all non-Wall creatures that player controls that didn't attack this turn.",
+        "Probe",
+        &[],
+        &["Instant".to_string()],
+        &[],
+    );
+    let (target, _) = punisher_destroy_target(&parsed);
+    let mut controllers = Vec::new();
+    typed_controllers(&target, &mut controllers);
+    assert!(
+        !controllers.contains(&Some(ControllerRef::ActivePlayer)),
+        "with no coerce sibling there is no relation, so the anaphor must NOT be \
+         rebound to ActivePlayer, got {controllers:?}"
     );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -241,6 +241,7 @@ mod integration_bending;
 mod integration_landfall;
 mod interaction_contract;
 mod invoke_calamity_free_cast;
+mod ir_spell_node_readers;
 mod issue_1005_suffer_the_past;
 mod issue_1007_fractal_harness_attach;
 mod issue_1008_korvold_sacrifice_triggers;

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -12,7 +12,7 @@
 # real IR nodes. Every tranche that converts a producer must lower its number
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
-crates/engine/src/parser/oracle.rs         20
+crates/engine/src/parser/oracle.rs         16
 crates/engine/src/parser/oracle_class.rs    6
 
 # --- infrastructure: NOT burn-down targets ----------------------------------


### PR DESCRIPTION
Plan 05b tranche **T7** — the Unit 3b prerequisites. Three defect fixes, **zero conversions**.

Follows #6703 (T4). All three defects are on the **already-live** `Spell(EffectChainIr)` variant, so
all three are live today; they escalate from 1 producer to ~14 the moment T8 lands.

## P1 — `finish()` did not consume a printed slot for `OracleNodeIr::Spell(_)`

The invariant this restores is worth stating as a class, because nothing in the type system enforces
it: the set of variants that advance `ability_slot` in `finish()` must equal the set
`lower_oracle_ir` pushes into `result.abilities`, which must equal the set `emit` pushes onto
`spells_emitted`. **Three matches over one set**, coupled only by convention — which is exactly how
they drifted. `Spell(_)` was in the first match's no-op list and in the other two's live lists.

Consequence: every ability printed *after* a `Spell` item was stamped one CR 707.9a slot low, so a
copy-except clause grafted the wrong ability.

The arm advances **without stamping**, deliberately and un-symmetrically with its `PreLoweredSpell`
sibling: `stamp_retained_printed_slot` takes `&mut AbilityDefinition`, and an IR-native spell body has
no definition until lowering builds one. There is nothing to stamp; the printed slot is consumed all
the same. The comment says so inline so the next reader does not "fix" the asymmetry.

## P2 — `item_ability` was blind to `Spell(_)`

The CR 607.2d ability side of relation discovery had a bare `_ => None`, so every relation pairing an
ability item went blind on an IR-native spell — silently, with no compiler help.

Now returns `Cow<'_, AbilityDefinition>`. **This is where `item_trigger`'s reasoning stops applying**,
and the asymmetry is structural rather than stylistic: `item_trigger` keeps a borrow and pushes
exhaustiveness down onto `TriggerNodeIr::definition()`, which works because *both* of its shapes own a
`TriggerDefinition`. A spell node's payload is an `EffectChainIr` — not an enum of definition-owning
representations — so there is no lower layer to carry the obligation, and both shapes are named in the
accessor.

`Cow` rather than a borrow because the second case has nothing to borrow from; rather than an owned
value because that would clone the first case at all seven call sites, most of which scan every item
on the card.

**Cost, verified rather than asserted:** seven call sites, **zero** regressed into a per-item clone.
The pre-lowered arm returns `Cow::Borrowed` (a clone is not representable there); every consumer takes
`&def`, which deref-coerces at the argument position; and `into_owned` / `to_mut()` — the only two ways
to force a `Cow` to clone — appear **nowhere** in `oracle.rs`. On the pre-lowered path the cost is
byte-identical to the old `Option<&AbilityDefinition>`.

## P3 — two `unreachable!` destructures were unsound

`emit` pushes **both** spell shapes onto `spells_emitted` and `take_last_spell` pops with no variant
filter, so `unreachable!("... returns only PreLowered... items")` was simply false. The first
IR-native spell preceding a min-X annotation or an "instead" fold line panics the parser mid-card —
and `oracle_gen` has no `catch_unwind`, so it aborts full-pool generation rather than degrading one
card.

The fix turned out to be **reuse, not new code**: `lower_spell_node` (`oracle.rs:631`) is exactly the
node-shape-agnostic reader both sites needed, and was already consumed by `last_ability_definition`
~3,000 lines above. A building-block search miss, not a design gap. The surviving `unreachable!` now
states an invariant that is actually true (`spells_emitted` holds only spell nodes).

## Empirical gate

- **Full engine suite: `21953 tests run: 21953 passed (11 slow), 8 skipped`.** Caveat stated plainly:
  that run predates a test-file rename; the production sources were confirmed byte-identical
  (`diff -q`) to what passed it, and only test-file naming changed after.
- **Scoped run on the committed tree: `3 tests run: 3 passed`.**
- **Seen-red probe (§5.3)** — both fixes reverted in place, then restored:
  ```
  FAIL an_ir_native_spell_consumes_the_printed_ability_slot_it_occupies
    left: [0]   right: [1]
  ```
  A gate that has never been watched go red is not a gate.
- Snapshot discipline (§5.1.5): **zero** churn — no `*_ir.snap`, no `*_lowered.snap`, no
  `oracle_static/snapshots/*`, no card-data.
- `Gate P PASS` (ratchet, `oracle.rs` 20 → 16); `✓ oracle-parser skill references valid`;
  `cargo fmt --all` clean.

## P1's byte delta: MEASURED ZERO — no bug report

The plan predicts zero and says nonzero means a live mis-indexed card exists. Measured by direct
corpus probe rather than full-pool regen, which is sharper for this defect: across all 35,516 cards in
`data/card-data.json`, **173** are `Spell`-node candidates (Instant/Sorcery whose text contains
"prevent" and "damage" — deliberately a **superset** of the real producer). Of those 173, **zero**
carry a `RetainPrintedAbilityFromSource` anywhere in their parse.

P1 can only move a stamp on a card having *both* a `Spell` node and a copy-except clause. No such card
exists in the pool, and because the probe ran over a superset of producers the conclusion holds
*a fortiori*.

**Full-pool regeneration was NOT run**, and that is deliberate: the executor worktree carries only
`data/mtgjson/test_fixture.json` (the real `AtomicCards.json` is gitignored and exists only in the
main checkout), so generating there would have measured a fixture population — the §5.1.3
void-evidence trap. A manufactured green was declined in favour of saying so. Pre-edit baseline for
whoever runs it on the main checkout: `a717afe7328faad9d074cf517abc598120b0a7fcf5bdcca38400d32bb42185db`,
99,201,816 bytes, 2026-07-27T11:20:54-0700. Side-observation: Tilt regenerated card-data at 13:39 and
the hash was **unchanged**, so concurrent agents' game-layer edits are not moving card-data and that
baseline is sound.

## Harvest (§5.4)

- **The recensus is stale on P3's blast radius.** It names two `mutate_last_spell` callers; the base
  commit had already deleted the second. There is exactly **one** today. (Independently re-verified.)
- **A second false comment the brief did not name**: `doc.rs:916-924` also claimed the `Spell` IR
  variant is "still never-constructed". Both it and the `941-944` comment were false at base; both
  fixed.
- **A second-order gap T8 must decide before converting producers.** Stamping happens *only* in
  `finish()`, which runs **before** lowering, and `lower_oracle_ir` does no stamping. So a copy-except
  clause **inside** an IR-native `Spell` body keeps `placeholder()` (= 0) permanently. P1 fixes every
  *later* ability; the IR-native item's own clause is never stamped. Unreachable today, reachable at
  T8. This is the same question the recensus flags for T9 ("move the stamp to `lower_oracle_ir`").
- **`ability_index()` / `trigger_index()` are dead in production** — zero callers outside `doc.rs`
  (grep-verified); the only readers are `doc.rs`'s own tests, while `finish()` is the live authority
  and says so. Both still carry `PLAN-05 DEBT` allows.
- **The ratchet makes some in-scope tests unwritable.** `doc.rs` sits *at* its ceiling (16/16), and any
  `#[cfg(test)]` helper constructing a stamp carrier must name the marker word. The ceiling was **not**
  raised; the test moved to `crates/engine/tests/integration/` (outside the gate's scope), which also
  upgraded it to driving the real `parse_oracle_text` pipeline.

## Known limitation, stated rather than papered over

**P2's new IR-native arm has no test witness — it is vacuously covered.** Removing the arm leaves all
three tests green. No relation predicate matches a prevention chain, and an attempt to synthesize a
card pairing the two failed because the line splitter emits the choice as its own item, so the chooser
is never the `Spell` node. The arm is forward hardening for T8. The Siren's Call test *is* a genuine
non-regression witness for the **borrowed** arm, which is the change class §5.1.8 actually asks for.

## Deliberate allocations introduced, flagged for review

`lower_spell_node(&node)` clones the definition on the pre-lowered arm at `mutate_last_spell` and at
the "instead" fold, where the old code moved it — one clone per occurrence on two rare
once-per-card-line parse paths. Chosen over duplicating the match inline twice (DRY); the alternative
is minting a by-value sibling of `lower_spell_node` for two callers.

CR numbers grep-verified against `docs/MagicCompRules.txt` before entering code or commit messages:
707.9a, 607.2d, 102.1, 603.7c, 608.2c, 302.6, 508.1a.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of spell abilities in document relation processing.
  * Corrected printed ability-slot tracking when spell effects are represented in their native form.
  * Fixed controller rebinding and exemption handling for delayed effects.

* **Tests**
  * Added integration coverage for spell-slot alignment, controller reassignment, and line-local targeting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->