### PR TITLE
refactor(parser): Plan 05b T5 — nine trigger recognizer sites through the TriggerNodeIr seam

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3981,7 +3981,17 @@ pub(crate) fn parse_oracle_ir(
             });
         }
         for trigger in triggers {
-            emitter.trigger_at(*level_line, trigger);
+            // The CR 711.2a/711.2b level graft above stays exactly where it is,
+            // operating on the LOWERED definition. That is deliberate: moving it
+            // pre-lowering would compose `And[gate, ..]` against an already-
+            // composed intervening-if and yield `And[And[gate, x], y]` where the
+            // post-lowering graft yields the flat `And[gate, x, y]`, and
+            // `trigger_condition_source_zones` would additionally start deriving
+            // `trigger_zones` from the level gate. Identity lowering keeps both.
+            emitter.trigger_ir_at(
+                *level_line,
+                TriggerNodeIr::from_definition(ability_text, trigger),
+            );
         }
     }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4872,7 +4872,7 @@ pub(crate) fn parse_oracle_ir(
                     .trigger_zones(vec![Zone::Battlefield])
                     .execute(effect_def)
                     .description(line.to_string());
-                emitter.trigger_at(item_line, trigger);
+                emitter.trigger_ir_at(item_line, TriggerNodeIr::from_definition(&line, trigger));
             }
             i += 1;
             continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4844,7 +4844,12 @@ pub(crate) fn parse_oracle_ir(
                     .trigger_zones(vec![Zone::Battlefield])
                     .execute(effect_def)
                     .description(line.to_string());
-                emitter.trigger_at(item_line, trigger);
+                // `&line` is the whole printed sentence, which is also what the
+                // recognizer stamped as `description` — the body was parsed
+                // from the suffix after ". When you do, ", but the CR 701.43d
+                // optional attack cost and its CR 607.2h linked reflexive
+                // trigger are one printed paragraph.
+                emitter.trigger_ir_at(item_line, TriggerNodeIr::from_definition(&line, trigger));
             }
             i += 1;
             continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4011,7 +4011,10 @@ pub(crate) fn parse_oracle_ir(
             emitter.static_ir_at(line, ir);
         }
         for (line, trigger) in sc_triggers {
-            emitter.trigger_at(line, trigger);
+            // CR 702.184a + CR 721.2 station gate, same shape as the leveler
+            // graft above: the condition is stamped inside the preprocessor on
+            // the lowered definition, so identity lowering is what keeps it.
+            emitter.trigger_ir_at(line, TriggerNodeIr::from_definition(lines[line], trigger));
         }
         // Post-processing runs here (pre-emit), exactly as before — the (B)
         // tuple-return design obviates moving it inside the preprocessor.

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4895,7 +4895,12 @@ pub(crate) fn parse_oracle_ir(
                     .trigger_zones(vec![Zone::Battlefield])
                     .execute(effect_def)
                     .description(line.to_string());
-                emitter.trigger_at(item_line, trigger);
+                // The leading if-gate this arm dispatches on is still DROPPED —
+                // no condition is stamped for "hasn't been exerted this turn".
+                // That gap is pre-existing and deliberately preserved here: the
+                // conversion is behavior-identical, and the fix belongs in a
+                // change that is allowed to move bytes.
+                emitter.trigger_ir_at(item_line, TriggerNodeIr::from_definition(&line, trigger));
             }
             i += 1;
             continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3862,7 +3862,15 @@ pub(crate) fn parse_oracle_ir(
         let (chapter_triggers, (etb_line, etb_replacement), consumed) =
             parse_saga_chapters(&lines, card_name);
         for (line, trigger) in chapter_triggers {
-            emitter.trigger_at(line, trigger);
+            // `lines[line]` is the printed chapter line the preprocessor
+            // consumed — provenance only. A multi-numeral line (CR 714.2c)
+            // yields several triggers that legitimately share it.
+            //
+            // The identity path is what preserves the CR 714 `description`:
+            // the preprocessor stamps `"Chapter {n}"`, NOT the printed line,
+            // and `lower_trigger_node_ir` never runs the `lower_trigger_ir`
+            // overwrite that would replace it with `source_text`.
+            emitter.trigger_ir_at(line, TriggerNodeIr::from_definition(lines[line], trigger));
         }
         emitter.replacement_ir_at(etb_line, etb_replacement);
         consumed

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -5025,7 +5025,12 @@ pub(crate) fn parse_oracle_ir(
 
         if let Some((option, trigger)) = parse_flash_cleanup_sacrifice_casting_option(&line) {
             emitter.casting_option_at(item_line, option);
-            emitter.trigger_at(item_line, trigger);
+            // The one trigger in this tranche whose `execute` is FULLY
+            // synthesized — `CreateDelayedTrigger{AtNextPhase(Cleanup)} ->
+            // Sacrifice{SelfRef}`, hand-assembled from three `tag()`s with no
+            // parsed source text. `&line` is therefore pure provenance: it is
+            // the sentence that licensed the synthesis, not its input.
+            emitter.trigger_ir_at(item_line, TriggerNodeIr::from_definition(&line, trigger));
             i += 1;
             continue;
         }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3883,7 +3883,12 @@ pub(crate) fn parse_oracle_ir(
     {
         let (visit_triggers, consumed) = parse_attraction_visit_triggers(&lines, card_name);
         for (line, trigger) in visit_triggers {
-            emitter.trigger_at(line, trigger);
+            // Mirror of the Saga emission above, and the reason both are
+            // identity-lowered: the CR 717 visit trigger leaves `description`
+            // at `None`, the exact opposite of Saga's `"Chapter {n}"` stamp.
+            // Routing either through `lower_trigger_ir` would overwrite one and
+            // invent the other from `source_text`.
+            emitter.trigger_ir_at(line, TriggerNodeIr::from_definition(lines[line], trigger));
         }
         preparsed_consumed.extend(consumed);
     }

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -20,6 +20,7 @@ use super::oracle_effect::parse_effect_chain;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::replacement::ReplacementIr;
 use super::oracle_ir::static_ir::StaticIr;
+use super::oracle_ir::trigger::TriggerNodeIr;
 use super::oracle_keyword::extract_granted_keyword_list;
 use super::oracle_modal::strip_ability_word;
 use super::oracle_nom::primitives as nom_primitives;
@@ -140,7 +141,16 @@ pub(crate) fn parse_class_oracle_text(
             // Check for "When this Class becomes level N" trigger pattern
             if is_class_level_trigger(&lower, card_name) {
                 if let Some(trigger) = parse_class_level_trigger(line, card_name, section.level) {
-                    items.push((line_index, OracleNodeIr::PreLoweredTrigger(trigger)));
+                    // The `ClassLevelGained` mode, the `AtClassLevel { level }`
+                    // constraint and the `"When ~ becomes level N"` description
+                    // are all stamped by the recognizer.
+                    // `lower_trigger_node_ir` is the identity on `Assembled`, so
+                    // none of them is re-derived — in particular the description
+                    // is not overwritten with `source_text`.
+                    items.push((
+                        line_index,
+                        OracleNodeIr::Trigger(TriggerNodeIr::from_definition(line, trigger)),
+                    ));
                     continue;
                 }
             }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -388,6 +388,33 @@ fn kabira_vindicator() {
     insta::assert_json_snapshot!("kabira_vindicator_lowered", &lowered);
 }
 
+/// Leveler *body* TRIGGER, with a printed intervening-if (Plan 05b, T5a witness).
+///
+/// The two levelers above print only P/T, keyword and static lines inside their
+/// LEVEL blocks, so neither reaches the trigger arm of the LEVEL re-parse loop
+/// (`oracle.rs`, "Triggered abilities within LEVEL blocks get a HasCounters
+/// condition"). Without this fixture T5a's conversion would be
+/// snapshot-invisible.
+///
+/// Lighthouse Chronologist is chosen over the other two pool levelers with a
+/// LEVEL-block trigger (Lord of Shatterskull Pass, The Fearsome Flock) because
+/// its trigger is the only one that prints its own CR 603.4 intervening-if
+/// ("if it's not your turn"). That makes it the witness for the composing arm
+/// of the CR 711.2a/711.2b level graft — `Some(existing) => And { .. }` — and
+/// not merely the `None` arm, which is the half the flat-vs-nested shape
+/// question actually turns on.
+#[test]
+fn lighthouse_chronologist() {
+    let (ir, lowered) = parse_two_layer(
+        "Level up {U} ({U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 4-6\n2/4\nLEVEL 7+\n3/5\nAt the beginning of each end step, if it's not your turn, take an extra turn after this one.",
+        "Lighthouse Chronologist",
+        &["Creature"],
+        &["Human", "Wizard"],
+    );
+    insta::assert_json_snapshot!("lighthouse_chronologist_ir", &ir);
+    insta::assert_json_snapshot!("lighthouse_chronologist_lowered", &lowered);
+}
+
 // ---------------------------------------------------------------------------
 // Spacecraft threshold lines (Plan 05b, T2 witness)
 // ---------------------------------------------------------------------------
@@ -410,6 +437,29 @@ fn lumen_class_frigate() {
     );
     insta::assert_json_snapshot!("lumen_class_frigate_ir", &ir);
     insta::assert_json_snapshot!("lumen_class_frigate_lowered", &lowered);
+}
+
+/// Spacecraft threshold TRIGGER line (Plan 05b, T5a witness).
+///
+/// `lumen_class_frigate` above prints two static threshold lines and reaches
+/// neither trigger arm. Entropic Battlecruiser prints `1+ | Whenever an
+/// opponent discards a card, …`, which is the threshold-trigger arm
+/// (`oracle_spacecraft.rs`), *and* an ordinary un-gated `Whenever this
+/// Spacecraft attacks` trigger below the threshold block. Carrying both on one
+/// card makes the fixture witness the CR 707.9a per-category trigger slot
+/// ordering across the preprocessor/dispatch-loop boundary as well as the
+/// threshold condition itself.
+#[test]
+fn entropic_battlecruiser() {
+    let (ir, lowered) = parse_two_layer_with_keywords(
+        "Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery. It's an artifact creature at 8+.)\n1+ | Whenever an opponent discards a card, they lose 3 life.\n8+ | Flying, deathtouch\nWhenever this Spacecraft attacks, each opponent discards a card. Each opponent who can't loses 3 life.",
+        "Entropic Battlecruiser",
+        &["station"],
+        &["Artifact"],
+        &["Spacecraft"],
+    );
+    insta::assert_json_snapshot!("entropic_battlecruiser_ir", &ir);
+    insta::assert_json_snapshot!("entropic_battlecruiser_lowered", &lowered);
 }
 
 // ---------------------------------------------------------------------------
@@ -1422,6 +1472,144 @@ fn wizard_class() {
     );
     insta::assert_json_snapshot!("wizard_class_two_layer_ir", &ir);
     insta::assert_json_snapshot!("wizard_class_two_layer_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
+// Preprocessor-assembled triggers (Plan 05b, T5b witnesses)
+// ---------------------------------------------------------------------------
+
+/// CR 714 Saga chapter triggers, including the CR 714.2c multi-numeral line.
+///
+/// The Saga preprocessor hand-builds one `TriggerDefinition` per numeral and
+/// stamps `description = "Chapter {n}"` — deliberately NOT the printed line, so
+/// this fixture is also the standing regression witness for that stamp. No
+/// other card in the two-layer corpus is a Saga, so without it T5b's Saga
+/// conversion is snapshot-invisible.
+///
+/// `I, II — …` shares one source line between two chapters; the emitted pair
+/// must keep ascending ordinals on that shared line key (CR 714.2c).
+#[test]
+fn history_of_benalia() {
+    let (ir, lowered) = parse_two_layer(
+        "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II — Create a 2/2 white Knight creature token with vigilance.\nIII — Knights you control get +2/+1 until end of turn.",
+        "History of Benalia",
+        &["Enchantment"],
+        &["Saga"],
+    );
+    insta::assert_json_snapshot!("history_of_benalia_ir", &ir);
+    insta::assert_json_snapshot!("history_of_benalia_lowered", &lowered);
+}
+
+/// CR 717 Attraction visit trigger.
+///
+/// The Attraction preprocessor hand-builds a `VisitAttraction` trigger and
+/// leaves `description` at `None` — the opposite of the Saga stamp, and the
+/// reason both belong in the corpus: a lowering path that overwrote
+/// `description` from the source line would corrupt Saga's value and invent one
+/// for Attraction, and only one fixture would catch each.
+///
+/// Bumper Cars is the plain `Visit — …` header form. The numbered form
+/// (`"1, 3 — …"`, which stamps `AttractionVisitRoll { min, max }`) has **no
+/// witness here because it has none in the pool**: zero Attractions in
+/// `data/card-data.json` print a numbered visit line.
+#[test]
+fn bumper_cars() {
+    let (ir, lowered) = parse_two_layer(
+        "Visit — Target creature must be blocked this turn if able.",
+        "Bumper Cars",
+        &["Artifact"],
+        &["Attraction"],
+    );
+    insta::assert_json_snapshot!("bumper_cars_ir", &ir);
+    insta::assert_json_snapshot!("bumper_cars_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
+// CR 701.43d exert-as-attacks, all three printed forms (Plan 05b, T5c witnesses)
+// ---------------------------------------------------------------------------
+//
+// Each of the three dispatch arms hand-builds an `Exerted` trigger whose
+// `description` is the WHOLE printed line while its `execute` is parsed from
+// the text SUFFIX after ". When you do, ". Nothing in the two-layer corpus
+// reached any of them before these fixtures, so all three T5c exert
+// conversions would have been snapshot-invisible.
+
+/// Bare-`~` form: `"You may exert this creature as it attacks."`
+#[test]
+fn ahn_crop_champion() {
+    let (ir, lowered) = parse_two_layer(
+        "You may exert this creature as it attacks. When you do, untap all other creatures you control. (An exerted creature won't untap during your next untap step.)",
+        "Ahn-Crop Champion",
+        &["Creature"],
+        &["Human", "Warrior"],
+    );
+    insta::assert_json_snapshot!("ahn_crop_champion_ir", &ir);
+    insta::assert_json_snapshot!("ahn_crop_champion_lowered", &lowered);
+}
+
+/// Card-name form with a gendered pronoun: `"You may exert Themberchaud as he
+/// attacks."` — the arm the bare-`~` tags above cannot match, because
+/// self-reference normalization rewrites the name but not `"as he attacks"`.
+///
+/// Themberchaud also prints an ordinary ETB trigger ABOVE the exert line, so
+/// this fixture additionally witnesses that converting the exert emission does
+/// not disturb the CR 707.9a printed-trigger slot of a preceding trigger.
+#[test]
+fn themberchaud() {
+    let (ir, lowered) = parse_two_layer_with_keywords(
+        "Trample\nWhen Themberchaud enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control.\nYou may exert Themberchaud as he attacks. When you do, he gains flying until end of turn. (An exerted creature won't untap during your next untap step.)",
+        "Themberchaud",
+        &["trample"],
+        &["Creature"],
+        &["Dragon"],
+    );
+    insta::assert_json_snapshot!("themberchaud_ir", &ir);
+    insta::assert_json_snapshot!("themberchaud_lowered", &lowered);
+}
+
+/// Conditional form: `"If this creature hasn't been exerted this turn, …"`.
+/// Combat Celebrant is the ONLY card in the pool that reaches this arm.
+///
+/// Baselines a known pre-existing gap rather than hiding it: the leading
+/// if-gate is parsed for dispatch and then **dropped** — the emitted trigger
+/// carries no condition for it. That is recorded as a census harvest item; this
+/// fixture pins the current (wrong) shape so the conversion is provably
+/// behavior-preserving and the gap stays visible for a separate fix.
+#[test]
+fn combat_celebrant() {
+    let (ir, lowered) = parse_two_layer(
+        "If this creature hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase. (An exerted creature won't untap during your next untap step.)",
+        "Combat Celebrant",
+        &["Creature"],
+        &["Human", "Warrior"],
+    );
+    insta::assert_json_snapshot!("combat_celebrant_ir", &ir);
+    insta::assert_json_snapshot!("combat_celebrant_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
+// Synthesized flash-cleanup-sacrifice trigger (Plan 05b, T5c witness)
+// ---------------------------------------------------------------------------
+
+/// The one recognizer in this tranche whose `execute` is **fully synthesized**:
+/// no part of the printed line is parsed into it. The line grants a casting
+/// option, and the paired trigger's body — `CreateDelayedTrigger { AtNextPhase
+/// (Cleanup) } → Sacrifice { SelfRef }` — is hand-assembled from three
+/// `tag()`s, so its shape is a pure function of the recognizer matching at all.
+///
+/// Armor of Thorns is the alphabetically-first of the pool cards printing this
+/// exact sentence; the other arms of the same class (Grave Servitude, Lightning
+/// Reflexes, Mystic Veil, …) differ only in the Aura body below it.
+#[test]
+fn armor_of_thorns() {
+    let (ir, lowered) = parse_two_layer(
+        "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nEnchant nonblack creature\nEnchanted creature gets +2/+2.",
+        "Armor of Thorns",
+        &["Enchantment"],
+        &["Aura"],
+    );
+    insta::assert_json_snapshot!("armor_of_thorns_ir", &ir);
+    insta::assert_json_snapshot!("armor_of_thorns_lowered", &lowered);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ahn_crop_champion_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ahn_crop_champion_ir.snap
@@ -22,59 +22,64 @@ expression: "&ir"
         "fragment": "You may exert ~ as it attacks. When you do, untap all other creatures you control. (An exerted creature won't untap during your next untap step.)"
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Exerted",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "SetTapState",
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": "You",
-                "properties": [
-                  {
-                    "type": "Another"
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "Exerted",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "SetTapState",
+                  "target": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  },
+                  "scope": {
+                    "type": "All"
+                  },
+                  "state": {
+                    "type": "Untap"
                   }
-                ]
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
               },
-              "scope": {
-                "type": "All"
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "state": {
-                "type": "Untap"
-              }
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "You may exert ~ as it attacks. When you do, untap all other creatures you control.",
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "You may exert ~ as it attacks. When you do, untap all other creatures you control.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "source_text": "You may exert ~ as it attacks. When you do, untap all other creatures you control."
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ahn_crop_champion_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ahn_crop_champion_ir.snap
@@ -1,0 +1,84 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 145,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "You may exert ~ as it attacks. When you do, untap all other creatures you control. (An exerted creature won't untap during your next untap step.)"
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Exerted",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "SetTapState",
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "Another"
+                  }
+                ]
+              },
+              "scope": {
+                "type": "All"
+              },
+              "state": {
+                "type": "Untap"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "You may exert ~ as it attacks. When you do, untap all other creatures you control.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "You may exert this creature as it attacks. When you do, untap all other creatures you control. (An exerted creature won't untap during your next untap step.)",
+  "card_name": "Ahn-Crop Champion"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ahn_crop_champion_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ahn_crop_champion_lowered.snap
@@ -1,0 +1,66 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "Exerted",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "SetTapState",
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": [
+              {
+                "type": "Another"
+              }
+            ]
+          },
+          "scope": {
+            "type": "All"
+          },
+          "state": {
+            "type": "Untap"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "You may exert ~ as it attacks. When you do, untap all other creatures you control.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__armor_of_thorns_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__armor_of_thorns_ir.snap
@@ -45,27 +45,41 @@ expression: "&ir"
         "fragment": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "CreateDelayedTrigger",
-              "condition": {
-                "type": "AtNextPhase",
-                "phase": "Cleanup"
-              },
-              "effect": {
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "ChangesZone",
+              "execute": {
                 "kind": "Spell",
                 "effect": {
-                  "type": "Sacrifice",
-                  "target": {
-                    "type": "SelfRef"
+                  "type": "CreateDelayedTrigger",
+                  "condition": {
+                    "type": "AtNextPhase",
+                    "phase": "Cleanup"
                   },
-                  "count": {
-                    "type": "Fixed",
-                    "value": 1
-                  }
+                  "effect": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "Sacrifice",
+                      "target": {
+                        "type": "SelfRef"
+                      },
+                      "count": {
+                        "type": "Fixed",
+                        "value": 1
+                      }
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": null,
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false
+                  },
+                  "uses_tracked_set": false
                 },
                 "cost": null,
                 "sub_ability": null,
@@ -77,37 +91,28 @@ expression: "&ir"
                 "optional": false,
                 "forward_result": false
               },
-              "uses_tracked_set": false
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.",
+              "constraint": null,
+              "condition": {
+                "type": "CastTimingPermission",
+                "permission": "AsThoughHadFlash"
+              },
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.",
-          "constraint": null,
-          "condition": {
-            "type": "CastTimingPermission",
-            "permission": "AsThoughHadFlash"
-          },
-          "batched": false
+            "source_text": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step."
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__armor_of_thorns_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__armor_of_thorns_ir.snap
@@ -1,0 +1,172 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 206,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step."
+      },
+      "node": {
+        "CastingOption": {
+          "kind": "AsThoughHadFlash"
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 206,
+          "precision": "Exact",
+          "ordinal_within_span": 1
+        },
+        "fragment": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "CreateDelayedTrigger",
+              "condition": {
+                "type": "AtNextPhase",
+                "phase": "Cleanup"
+              },
+              "effect": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Sacrifice",
+                  "target": {
+                    "type": "SelfRef"
+                  },
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "uses_tracked_set": false
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.",
+          "constraint": null,
+          "condition": {
+            "type": "CastTimingPermission",
+            "permission": "AsThoughHadFlash"
+          },
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 233,
+          "end_byte": 263,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Enchanted creature gets +2/+2."
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "EnchantedBy"
+                }
+              ]
+            },
+            "modifications": [
+              {
+                "type": "AddPower",
+                "value": 2
+              },
+              {
+                "type": "AddToughness",
+                "value": 2
+              }
+            ],
+            "condition": null,
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Enchanted creature gets +2/+2."
+          },
+          "source_text": "Enchanted creature gets +2/+2.",
+          "body_ir": null
+        }
+      }
+    }
+  ],
+  "source_text": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.\nEnchant nonblack creature\nEnchanted creature gets +2/+2.",
+  "card_name": "Armor of Thorns"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__armor_of_thorns_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__armor_of_thorns_lowered.snap
@@ -1,0 +1,113 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "ChangesZone",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "CreateDelayedTrigger",
+          "condition": {
+            "type": "AtNextPhase",
+            "phase": "Cleanup"
+          },
+          "effect": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Sacrifice",
+              "target": {
+                "type": "SelfRef"
+              },
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "uses_tracked_set": false
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": "Battlefield",
+      "trigger_zones": [],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "You may cast this spell as though it had flash. If you cast it any time a sorcery couldn't have been cast, the controller of the permanent it becomes sacrifices it at the beginning of the next cleanup step.",
+      "constraint": null,
+      "condition": {
+        "type": "CastTimingPermission",
+        "permission": "AsThoughHadFlash"
+      },
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Creature"
+        ],
+        "controller": null,
+        "properties": [
+          {
+            "type": "EnchantedBy"
+          }
+        ]
+      },
+      "modifications": [
+        {
+          "type": "AddPower",
+          "value": 2
+        },
+        {
+          "type": "AddToughness",
+          "value": 2
+        }
+      ],
+      "condition": null,
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Enchanted creature gets +2/+2."
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": [],
+  "castingOptions": [
+    {
+      "kind": "AsThoughHadFlash"
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bumper_cars_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bumper_cars_ir.snap
@@ -1,0 +1,101 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 60,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Visit — Target creature must be blocked this turn if able."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "VisitAttraction",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": {
+                    "MustBeBlocked": {
+                      "by": null
+                    }
+                  },
+                  "affected": {
+                    "type": "ParentTarget"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddStaticMode",
+                      "mode": {
+                        "MustBeBlocked": {
+                          "by": null
+                        }
+                      }
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": null
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": null,
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "Visit — Target creature must be blocked this turn if able.",
+  "card_name": "Bumper Cars"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bumper_cars_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bumper_cars_ir.snap
@@ -22,76 +22,81 @@ expression: "&ir"
         "fragment": "Visit — Target creature must be blocked this turn if able."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "VisitAttraction",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": {
-                    "MustBeBlocked": {
-                      "by": null
-                    }
-                  },
-                  "affected": {
-                    "type": "ParentTarget"
-                  },
-                  "modifications": [
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "VisitAttraction",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "GenericEffect",
+                  "static_abilities": [
                     {
-                      "type": "AddStaticMode",
                       "mode": {
                         "MustBeBlocked": {
                           "by": null
                         }
-                      }
+                      },
+                      "affected": {
+                        "type": "ParentTarget"
+                      },
+                      "modifications": [
+                        {
+                          "type": "AddStaticMode",
+                          "mode": {
+                            "MustBeBlocked": {
+                              "by": null
+                            }
+                          }
+                        }
+                      ],
+                      "condition": null,
+                      "affected_zone": null,
+                      "effect_zone": null,
+                      "active_zones": [],
+                      "characteristic_defining": false,
+                      "description": null
                     }
                   ],
-                  "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": null
-                }
-              ],
-              "duration": "UntilEndOfTurn",
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": null,
-                "properties": []
-              }
+                  "duration": "UntilEndOfTurn",
+                  "target": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": "UntilEndOfTurn",
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": null,
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "source_text": "Visit — Target creature must be blocked this turn if able."
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bumper_cars_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bumper_cars_lowered.snap
@@ -1,0 +1,83 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "VisitAttraction",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GenericEffect",
+          "static_abilities": [
+            {
+              "mode": {
+                "MustBeBlocked": {
+                  "by": null
+                }
+              },
+              "affected": {
+                "type": "ParentTarget"
+              },
+              "modifications": [
+                {
+                  "type": "AddStaticMode",
+                  "mode": {
+                    "MustBeBlocked": {
+                      "by": null
+                    }
+                  }
+                }
+              ],
+              "condition": null,
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": null
+            }
+          ],
+          "duration": "UntilEndOfTurn",
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": []
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": null,
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__combat_celebrant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__combat_celebrant_ir.snap
@@ -1,0 +1,128 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 240,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "If ~ hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase. (An exerted creature won't untap during your next untap step.)"
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Exerted",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "SetTapState",
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "Another"
+                  }
+                ]
+              },
+              "scope": {
+                "type": "All"
+              },
+              "state": {
+                "type": "Untap"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "AdditionalPhase",
+                "target": {
+                  "type": "Controller"
+                },
+                "phase": "BeginCombat",
+                "after": "EndCombat",
+                "followed_by": [],
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "attacker_restriction": null
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "If ~ hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "If this creature hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase. (An exerted creature won't untap during your next untap step.)",
+  "card_name": "Combat Celebrant",
+  "diagnostics": [
+    {
+      "type": "SwallowedClause",
+      "detector": "Duration_ThisTurn",
+      "description": "If this creature hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after",
+      "line_index": 0,
+      "unit_span": {
+        "first_line": 0,
+        "last_line": 0,
+        "start_byte": 0,
+        "end_byte": 252,
+        "precision": "Exact",
+        "ordinal_within_span": 0
+      },
+      "items": [
+        0
+      ]
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__combat_celebrant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__combat_celebrant_ir.snap
@@ -22,84 +22,89 @@ expression: "&ir"
         "fragment": "If ~ hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase. (An exerted creature won't untap during your next untap step.)"
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Exerted",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "SetTapState",
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": "You",
-                "properties": [
-                  {
-                    "type": "Another"
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "Exerted",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "SetTapState",
+                  "target": {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  },
+                  "scope": {
+                    "type": "All"
+                  },
+                  "state": {
+                    "type": "Untap"
                   }
-                ]
-              },
-              "scope": {
-                "type": "All"
-              },
-              "state": {
-                "type": "Untap"
-              }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "AdditionalPhase",
-                "target": {
-                  "type": "Controller"
                 },
-                "phase": "BeginCombat",
-                "after": "EndCombat",
-                "followed_by": [],
-                "count": {
-                  "type": "Fixed",
-                  "value": 1
+                "cost": null,
+                "sub_ability": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "AdditionalPhase",
+                    "target": {
+                      "type": "Controller"
+                    },
+                    "phase": "BeginCombat",
+                    "after": "EndCombat",
+                    "followed_by": [],
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "attacker_restriction": null
+                  },
+                  "cost": null,
+                  "sub_ability": null,
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": null,
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false
                 },
-                "attacker_restriction": null
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
               },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
               "optional": false,
-              "forward_result": false
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "If ~ hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase.",
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "If ~ hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "source_text": "If ~ hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase."
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__combat_celebrant_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__combat_celebrant_lowered.snap
@@ -1,0 +1,110 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "Exerted",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "SetTapState",
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": [
+              {
+                "type": "Another"
+              }
+            ]
+          },
+          "scope": {
+            "type": "All"
+          },
+          "state": {
+            "type": "Untap"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "AdditionalPhase",
+            "target": {
+              "type": "Controller"
+            },
+            "phase": "BeginCombat",
+            "after": "EndCombat",
+            "followed_by": [],
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "attacker_restriction": null
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "If ~ hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after this phase, there is an additional combat phase.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [],
+  "parseWarnings": [
+    {
+      "type": "SwallowedClause",
+      "detector": "Duration_ThisTurn",
+      "description": "If this creature hasn't been exerted this turn, you may exert it as it attacks. When you do, untap all other creatures you control and after",
+      "line_index": 0,
+      "unit_span": {
+        "first_line": 0,
+        "last_line": 0,
+        "start_byte": 0,
+        "end_byte": 252,
+        "precision": "Exact",
+        "ordinal_within_span": 0
+      },
+      "items": [
+        0
+      ]
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__entropic_battlecruiser_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__entropic_battlecruiser_ir.snap
@@ -22,65 +22,70 @@ expression: "&ir"
         "fragment": "1+ | Whenever an opponent discards a card, they lose 3 life."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Discarded",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "LoseLife",
-              "amount": {
-                "type": "Fixed",
-                "value": 3
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "Discarded",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "LoseLife",
+                  "amount": {
+                    "type": "Fixed",
+                    "value": 3
+                  },
+                  "target": {
+                    "type": "TriggeringPlayer"
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
               },
-              "target": {
-                "type": "TriggeringPlayer"
-              }
+              "valid_card": {
+                "type": "Typed",
+                "type_filters": [
+                  "Card"
+                ],
+                "controller": null,
+                "properties": []
+              },
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": {
+                "type": "Typed",
+                "type_filters": [],
+                "controller": "Opponent",
+                "properties": []
+              },
+              "valid_source": null,
+              "description": "Whenever an opponent discards a card, they lose 3 life.",
+              "constraint": null,
+              "condition": {
+                "type": "HasCounters",
+                "counters": {
+                  "type": "OfType",
+                  "data": "charge"
+                },
+                "minimum": 1
+              },
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              "Card"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": {
-            "type": "Typed",
-            "type_filters": [],
-            "controller": "Opponent",
-            "properties": []
-          },
-          "valid_source": null,
-          "description": "Whenever an opponent discards a card, they lose 3 life.",
-          "constraint": null,
-          "condition": {
-            "type": "HasCounters",
-            "counters": {
-              "type": "OfType",
-              "data": "charge"
-            },
-            "minimum": 1
-          },
-          "batched": false
+            "source_text": "1+ | Whenever an opponent discards a card, they lose 3 life."
+          }
         }
       }
     },
@@ -155,96 +160,101 @@ expression: "&ir"
         "fragment": "Whenever ~ attacks, each opponent discards a card. Each opponent who can't loses 3 life."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Attacks",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Discard",
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "target": {
-                "type": "Controller"
-              }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "LoseLife",
-                "amount": {
-                  "type": "Fixed",
-                  "value": 3
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "Attacks",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Discard",
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  },
+                  "target": {
+                    "type": "Controller"
+                  }
                 },
-                "target": {
-                  "type": "ScopedPlayer"
-                }
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": {
-                "type": "And",
-                "conditions": [
-                  {
-                    "type": "Not",
-                    "condition": {
-                      "type": "EffectOutcome",
-                      "signal": "CurrentScopeSucceeded"
+                "cost": null,
+                "sub_ability": {
+                  "kind": "Spell",
+                  "effect": {
+                    "type": "LoseLife",
+                    "amount": {
+                      "type": "Fixed",
+                      "value": 3
+                    },
+                    "target": {
+                      "type": "ScopedPlayer"
                     }
                   },
-                  {
-                    "type": "ScopedPlayerMatches",
-                    "filter": {
-                      "type": "Opponent"
-                    }
-                  }
-                ]
+                  "cost": null,
+                  "sub_ability": null,
+                  "duration": null,
+                  "description": null,
+                  "target_prompt": null,
+                  "condition": {
+                    "type": "And",
+                    "conditions": [
+                      {
+                        "type": "Not",
+                        "condition": {
+                          "type": "EffectOutcome",
+                          "signal": "CurrentScopeSucceeded"
+                        }
+                      },
+                      {
+                        "type": "ScopedPlayerMatches",
+                        "filter": {
+                          "type": "Opponent"
+                        }
+                      }
+                    ]
+                  },
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false
+                },
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false,
+                "player_scope": {
+                  "type": "Opponent"
+                }
               },
-              "optional_targeting": false,
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
               "optional": false,
-              "forward_result": false
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "Whenever ~ attacks, each opponent discards a card. Each opponent who can't loses 3 life.",
+              "constraint": null,
+              "condition": {
+                "type": "HasCounters",
+                "counters": {
+                  "type": "OfType",
+                  "data": "charge"
+                },
+                "minimum": 8
+              },
+              "batched": false
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "player_scope": {
-              "type": "Opponent"
-            }
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever ~ attacks, each opponent discards a card. Each opponent who can't loses 3 life.",
-          "constraint": null,
-          "condition": {
-            "type": "HasCounters",
-            "counters": {
-              "type": "OfType",
-              "data": "charge"
-            },
-            "minimum": 8
-          },
-          "batched": false
+            "source_text": "Whenever ~ attacks, each opponent discards a card. Each opponent who can't loses 3 life."
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__entropic_battlecruiser_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__entropic_battlecruiser_ir.snap
@@ -1,0 +1,254 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 149,
+          "end_byte": 209,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "1+ | Whenever an opponent discards a card, they lose 3 life."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Discarded",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "LoseLife",
+              "amount": {
+                "type": "Fixed",
+                "value": 3
+              },
+              "target": {
+                "type": "TriggeringPlayer"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "Typed",
+            "type_filters": [
+              "Card"
+            ],
+            "controller": null,
+            "properties": []
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": {
+            "type": "Typed",
+            "type_filters": [],
+            "controller": "Opponent",
+            "properties": []
+          },
+          "valid_source": null,
+          "description": "Whenever an opponent discards a card, they lose 3 life.",
+          "constraint": null,
+          "condition": {
+            "type": "HasCounters",
+            "counters": {
+              "type": "OfType",
+              "data": "charge"
+            },
+            "minimum": 1
+          },
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 210,
+          "end_byte": 233,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "8+ | Flying, deathtouch"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "AddKeyword",
+                "keyword": "Flying"
+              },
+              {
+                "type": "AddKeyword",
+                "keyword": "Deathtouch"
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "charge"
+              },
+              "minimum": 8
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "8+ | Flying, deathtouch"
+          },
+          "source_text": "Flying, deathtouch",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 234,
+          "end_byte": 322,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever ~ attacks, each opponent discards a card. Each opponent who can't loses 3 life."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Attacks",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Discard",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "LoseLife",
+                "amount": {
+                  "type": "Fixed",
+                  "value": 3
+                },
+                "target": {
+                  "type": "ScopedPlayer"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": {
+                "type": "And",
+                "conditions": [
+                  {
+                    "type": "Not",
+                    "condition": {
+                      "type": "EffectOutcome",
+                      "signal": "CurrentScopeSucceeded"
+                    }
+                  },
+                  {
+                    "type": "ScopedPlayerMatches",
+                    "filter": {
+                      "type": "Opponent"
+                    }
+                  }
+                ]
+              },
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "player_scope": {
+              "type": "Opponent"
+            }
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever ~ attacks, each opponent discards a card. Each opponent who can't loses 3 life.",
+          "constraint": null,
+          "condition": {
+            "type": "HasCounters",
+            "counters": {
+              "type": "OfType",
+              "data": "charge"
+            },
+            "minimum": 8
+          },
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "Station (Tap another creature you control: Put charge counters equal to its power on this Spacecraft. Station only as a sorcery. It's an artifact creature at 8+.)\n1+ | Whenever an opponent discards a card, they lose 3 life.\n8+ | Flying, deathtouch\nWhenever this Spacecraft attacks, each opponent discards a card. Each opponent who can't loses 3 life.",
+  "card_name": "Entropic Battlecruiser"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__entropic_battlecruiser_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__entropic_battlecruiser_lowered.snap
@@ -1,0 +1,193 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "Discarded",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "LoseLife",
+          "amount": {
+            "type": "Fixed",
+            "value": 3
+          },
+          "target": {
+            "type": "TriggeringPlayer"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "Typed",
+        "type_filters": [
+          "Card"
+        ],
+        "controller": null,
+        "properties": []
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": {
+        "type": "Typed",
+        "type_filters": [],
+        "controller": "Opponent",
+        "properties": []
+      },
+      "valid_source": null,
+      "description": "Whenever an opponent discards a card, they lose 3 life.",
+      "constraint": null,
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "charge"
+        },
+        "minimum": 1
+      },
+      "batched": false
+    },
+    {
+      "mode": "Attacks",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Discard",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "Controller"
+          }
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "LoseLife",
+            "amount": {
+              "type": "Fixed",
+              "value": 3
+            },
+            "target": {
+              "type": "ScopedPlayer"
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": {
+            "type": "And",
+            "conditions": [
+              {
+                "type": "Not",
+                "condition": {
+                  "type": "EffectOutcome",
+                  "signal": "CurrentScopeSucceeded"
+                }
+              },
+              {
+                "type": "ScopedPlayerMatches",
+                "filter": {
+                  "type": "Opponent"
+                }
+              }
+            ]
+          },
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false,
+        "player_scope": {
+          "type": "Opponent"
+        }
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "Whenever ~ attacks, each opponent discards a card. Each opponent who can't loses 3 life.",
+      "constraint": null,
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "charge"
+        },
+        "minimum": 8
+      },
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "AddKeyword",
+          "keyword": "Flying"
+        },
+        {
+          "type": "AddKeyword",
+          "keyword": "Deathtouch"
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "charge"
+        },
+        "minimum": 8
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "8+ | Flying, deathtouch"
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__history_of_benalia_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__history_of_benalia_ir.snap
@@ -1,0 +1,323 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 81,
+          "end_byte": 147,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "I, II — Create a 2/2 white Knight creature token with vigilance."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "CounterAdded",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Token",
+              "name": "Knight",
+              "power": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "toughness": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "types": [
+                "Creature",
+                "Knight"
+              ],
+              "colors": [
+                "White"
+              ],
+              "keywords": [
+                "Vigilance"
+              ],
+              "tapped": false,
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "owner": {
+                "type": "Controller"
+              },
+              "enters_attacking": false
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Chapter 1",
+          "constraint": null,
+          "condition": null,
+          "counter_filter": {
+            "counter_type": "lore",
+            "threshold": 1
+          },
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 81,
+          "end_byte": 147,
+          "precision": "Exact",
+          "ordinal_within_span": 1
+        },
+        "fragment": "I, II — Create a 2/2 white Knight creature token with vigilance."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "CounterAdded",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Token",
+              "name": "Knight",
+              "power": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "toughness": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "types": [
+                "Creature",
+                "Knight"
+              ],
+              "colors": [
+                "White"
+              ],
+              "keywords": [
+                "Vigilance"
+              ],
+              "tapped": false,
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "owner": {
+                "type": "Controller"
+              },
+              "enters_attacking": false
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Chapter 2",
+          "constraint": null,
+          "condition": null,
+          "counter_filter": {
+            "counter_type": "lore",
+            "threshold": 2
+          },
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 81,
+          "end_byte": 147,
+          "precision": "Exact",
+          "ordinal_within_span": 2
+        },
+        "fragment": "I, II — Create a 2/2 white Knight creature token with vigilance."
+      },
+      "node": {
+        "Replacement": {
+          "definition": {
+            "event": "Moved",
+            "execute": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "lore",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "target": {
+                  "type": "SelfRef"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "mode": {
+              "type": "Mandatory"
+            },
+            "valid_card": {
+              "type": "SelfRef"
+            },
+            "description": "Saga ETB lore counter",
+            "condition": null,
+            "destination_zone": "Battlefield"
+          },
+          "source_text": "Saga ETB lore counter",
+          "execute_ir": null
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 148,
+          "end_byte": 204,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "III — Knights you control get +2/+1 until end of turn."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "CounterAdded",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PumpAll",
+              "power": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "toughness": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  {
+                    "Subtype": "Knight"
+                  }
+                ],
+                "controller": "You",
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Chapter 3",
+          "constraint": null,
+          "condition": null,
+          "counter_filter": {
+            "counter_type": "lore",
+            "threshold": 3
+          },
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "(As this Saga enters and after your draw step, add a lore counter. Sacrifice after III.)\nI, II — Create a 2/2 white Knight creature token with vigilance.\nIII — Knights you control get +2/+1 until end of turn.",
+  "card_name": "History of Benalia"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__history_of_benalia_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__history_of_benalia_ir.snap
@@ -22,73 +22,78 @@ expression: "&ir"
         "fragment": "I, II — Create a 2/2 white Knight creature token with vigilance."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "CounterAdded",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Token",
-              "name": "Knight",
-              "power": {
-                "type": "Fixed",
-                "value": 2
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "CounterAdded",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Token",
+                  "name": "Knight",
+                  "power": {
+                    "type": "Fixed",
+                    "value": 2
+                  },
+                  "toughness": {
+                    "type": "Fixed",
+                    "value": 2
+                  },
+                  "types": [
+                    "Creature",
+                    "Knight"
+                  ],
+                  "colors": [
+                    "White"
+                  ],
+                  "keywords": [
+                    "Vigilance"
+                  ],
+                  "tapped": false,
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  },
+                  "owner": {
+                    "type": "Controller"
+                  },
+                  "enters_attacking": false
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
               },
-              "toughness": {
-                "type": "Fixed",
-                "value": 2
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "types": [
-                "Creature",
-                "Knight"
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "colors": [
-                "White"
-              ],
-              "keywords": [
-                "Vigilance"
-              ],
-              "tapped": false,
-              "count": {
-                "type": "Fixed",
-                "value": 1
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "Chapter 1",
+              "constraint": null,
+              "condition": null,
+              "counter_filter": {
+                "counter_type": "lore",
+                "threshold": 1
               },
-              "owner": {
-                "type": "Controller"
-              },
-              "enters_attacking": false
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Chapter 1",
-          "constraint": null,
-          "condition": null,
-          "counter_filter": {
-            "counter_type": "lore",
-            "threshold": 1
-          },
-          "batched": false
+            "source_text": "I, II — Create a 2/2 white Knight creature token with vigilance."
+          }
         }
       }
     },
@@ -110,73 +115,78 @@ expression: "&ir"
         "fragment": "I, II — Create a 2/2 white Knight creature token with vigilance."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "CounterAdded",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Token",
-              "name": "Knight",
-              "power": {
-                "type": "Fixed",
-                "value": 2
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "CounterAdded",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Token",
+                  "name": "Knight",
+                  "power": {
+                    "type": "Fixed",
+                    "value": 2
+                  },
+                  "toughness": {
+                    "type": "Fixed",
+                    "value": 2
+                  },
+                  "types": [
+                    "Creature",
+                    "Knight"
+                  ],
+                  "colors": [
+                    "White"
+                  ],
+                  "keywords": [
+                    "Vigilance"
+                  ],
+                  "tapped": false,
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  },
+                  "owner": {
+                    "type": "Controller"
+                  },
+                  "enters_attacking": false
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
               },
-              "toughness": {
-                "type": "Fixed",
-                "value": 2
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "types": [
-                "Creature",
-                "Knight"
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "colors": [
-                "White"
-              ],
-              "keywords": [
-                "Vigilance"
-              ],
-              "tapped": false,
-              "count": {
-                "type": "Fixed",
-                "value": 1
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "Chapter 2",
+              "constraint": null,
+              "condition": null,
+              "counter_filter": {
+                "counter_type": "lore",
+                "threshold": 2
               },
-              "owner": {
-                "type": "Controller"
-              },
-              "enters_attacking": false
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Chapter 2",
-          "constraint": null,
-          "condition": null,
-          "counter_filter": {
-            "counter_type": "lore",
-            "threshold": 2
-          },
-          "batched": false
+            "source_text": "I, II — Create a 2/2 white Knight creature token with vigilance."
+          }
         }
       }
     },
@@ -257,63 +267,68 @@ expression: "&ir"
         "fragment": "III — Knights you control get +2/+1 until end of turn."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "CounterAdded",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PumpAll",
-              "power": {
-                "type": "Fixed",
-                "value": 2
-              },
-              "toughness": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  {
-                    "Subtype": "Knight"
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "CounterAdded",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "PumpAll",
+                  "power": {
+                    "type": "Fixed",
+                    "value": 2
+                  },
+                  "toughness": {
+                    "type": "Fixed",
+                    "value": 1
+                  },
+                  "target": {
+                    "type": "Typed",
+                    "type_filters": [
+                      {
+                        "Subtype": "Knight"
+                      }
+                    ],
+                    "controller": "You",
+                    "properties": []
                   }
-                ],
-                "controller": "You",
-                "properties": []
-              }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": "UntilEndOfTurn",
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "Chapter 3",
+              "constraint": null,
+              "condition": null,
+              "counter_filter": {
+                "counter_type": "lore",
+                "threshold": 3
+              },
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Chapter 3",
-          "constraint": null,
-          "condition": null,
-          "counter_filter": {
-            "counter_type": "lore",
-            "threshold": 3
-          },
-          "batched": false
+            "source_text": "III — Knights you control get +2/+1 until end of turn."
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__history_of_benalia_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__history_of_benalia_lowered.snap
@@ -1,0 +1,242 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "CounterAdded",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Token",
+          "name": "Knight",
+          "power": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "toughness": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "types": [
+            "Creature",
+            "Knight"
+          ],
+          "colors": [
+            "White"
+          ],
+          "keywords": [
+            "Vigilance"
+          ],
+          "tapped": false,
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "owner": {
+            "type": "Controller"
+          },
+          "enters_attacking": false
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "Chapter 1",
+      "constraint": null,
+      "condition": null,
+      "counter_filter": {
+        "counter_type": "lore",
+        "threshold": 1
+      },
+      "batched": false
+    },
+    {
+      "mode": "CounterAdded",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Token",
+          "name": "Knight",
+          "power": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "toughness": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "types": [
+            "Creature",
+            "Knight"
+          ],
+          "colors": [
+            "White"
+          ],
+          "keywords": [
+            "Vigilance"
+          ],
+          "tapped": false,
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "owner": {
+            "type": "Controller"
+          },
+          "enters_attacking": false
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "Chapter 2",
+      "constraint": null,
+      "condition": null,
+      "counter_filter": {
+        "counter_type": "lore",
+        "threshold": 2
+      },
+      "batched": false
+    },
+    {
+      "mode": "CounterAdded",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "PumpAll",
+          "power": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "toughness": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              {
+                "Subtype": "Knight"
+              }
+            ],
+            "controller": "You",
+            "properties": []
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "Chapter 3",
+      "constraint": null,
+      "condition": null,
+      "counter_filter": {
+        "counter_type": "lore",
+        "threshold": 3
+      },
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [
+    {
+      "event": "Moved",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "PutCounter",
+          "counter_type": "lore",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "SelfRef"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "mode": {
+        "type": "Mandatory"
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "description": "Saga ETB lore counter",
+      "condition": null,
+      "destination_zone": "Battlefield"
+    }
+  ],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lighthouse_chronologist_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lighthouse_chronologist_ir.snap
@@ -158,63 +158,68 @@ expression: "&ir"
         "fragment": "At the beginning of each end step, if it's not your turn, take an extra turn after this one."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "ExtraTurn",
-              "target": {
-                "type": "Controller"
-              }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "End",
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of each end step, if it's not your turn, take an extra turn after this one.",
-          "constraint": null,
-          "condition": {
-            "type": "And",
-            "conditions": [
-              {
-                "type": "Not",
-                "condition": {
-                  "type": "DuringPlayersTurn",
-                  "player": {
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "Phase",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "ExtraTurn",
+                  "target": {
                     "type": "Controller"
                   }
-                }
-              },
-              {
-                "type": "HasCounters",
-                "counters": {
-                  "type": "OfType",
-                  "data": "level"
                 },
-                "minimum": 7
-              }
-            ]
-          },
-          "batched": false
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": "End",
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "At the beginning of each end step, if it's not your turn, take an extra turn after this one.",
+              "constraint": null,
+              "condition": {
+                "type": "And",
+                "conditions": [
+                  {
+                    "type": "Not",
+                    "condition": {
+                      "type": "DuringPlayersTurn",
+                      "player": {
+                        "type": "Controller"
+                      }
+                    }
+                  },
+                  {
+                    "type": "HasCounters",
+                    "counters": {
+                      "type": "OfType",
+                      "data": "level"
+                    },
+                    "minimum": 7
+                  }
+                ]
+              },
+              "batched": false
+            },
+            "source_text": "At the beginning of each end step, if it's not your turn, take an extra turn after this one."
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lighthouse_chronologist_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lighthouse_chronologist_ir.snap
@@ -1,0 +1,224 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 76,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Level up {U} ({U}: Put a level counter on this. Level up only as a sorcery.)"
+      },
+      "node": {
+        "Keyword": {
+          "LevelUp": {
+            "type": "Cost",
+            "shards": [
+              "Blue"
+            ],
+            "generic": 0
+          }
+        }
+      }
+    },
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 77,
+          "end_byte": 86,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 4-6"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "SetPower",
+                "value": 2
+              },
+              {
+                "type": "SetToughness",
+                "value": 4
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 4,
+              "maximum": 6
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "LEVEL 4-6 / 2/4"
+          },
+          "source_text": "LEVEL 4-6 / 2/4",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 91,
+          "end_byte": 99,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 7+"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "SetPower",
+                "value": 3
+              },
+              {
+                "type": "SetToughness",
+                "value": 5
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 7
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "LEVEL 7+ / 3/5"
+          },
+          "source_text": "LEVEL 7+ / 3/5",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 5,
+          "last_line": 5,
+          "start_byte": 104,
+          "end_byte": 196,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "At the beginning of each end step, if it's not your turn, take an extra turn after this one."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Phase",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ExtraTurn",
+              "target": {
+                "type": "Controller"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": null,
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": "End",
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "At the beginning of each end step, if it's not your turn, take an extra turn after this one.",
+          "constraint": null,
+          "condition": {
+            "type": "And",
+            "conditions": [
+              {
+                "type": "Not",
+                "condition": {
+                  "type": "DuringPlayersTurn",
+                  "player": {
+                    "type": "Controller"
+                  }
+                }
+              },
+              {
+                "type": "HasCounters",
+                "counters": {
+                  "type": "OfType",
+                  "data": "level"
+                },
+                "minimum": 7
+              }
+            ]
+          },
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "Level up {U} ({U}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 4-6\n2/4\nLEVEL 7+\n3/5\nAt the beginning of each end step, if it's not your turn, take an extra turn after this one.",
+  "card_name": "Lighthouse Chronologist"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lighthouse_chronologist_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lighthouse_chronologist_lowered.snap
@@ -1,0 +1,140 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "Phase",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "ExtraTurn",
+          "target": {
+            "type": "Controller"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": null,
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": "End",
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "At the beginning of each end step, if it's not your turn, take an extra turn after this one.",
+      "constraint": null,
+      "condition": {
+        "type": "And",
+        "conditions": [
+          {
+            "type": "Not",
+            "condition": {
+              "type": "DuringPlayersTurn",
+              "player": {
+                "type": "Controller"
+              }
+            }
+          },
+          {
+            "type": "HasCounters",
+            "counters": {
+              "type": "OfType",
+              "data": "level"
+            },
+            "minimum": 7
+          }
+        ]
+      },
+      "batched": false
+    }
+  ],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetPower",
+          "value": 2
+        },
+        {
+          "type": "SetToughness",
+          "value": 4
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 4,
+        "maximum": 6
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "LEVEL 4-6 / 2/4"
+    },
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetPower",
+          "value": 3
+        },
+        {
+          "type": "SetToughness",
+          "value": 5
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 7
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "LEVEL 7+ / 3/5"
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": [
+    {
+      "LevelUp": {
+        "type": "Cost",
+        "shards": [
+          "Blue"
+        ],
+        "generic": 0
+      }
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__themberchaud_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__themberchaud_ir.snap
@@ -113,63 +113,68 @@ expression: "&ir"
         "fragment": "You may exert ~ as he attacks. When you do, he gains flying until end of turn. (An exerted creature won't untap during your next untap step.)"
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Exerted",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "SelfRef"
-                  },
-                  "modifications": [
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "Exerted",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "GenericEffect",
+                  "static_abilities": [
                     {
-                      "type": "AddKeyword",
-                      "keyword": "Flying"
+                      "mode": "Continuous",
+                      "affected": {
+                        "type": "SelfRef"
+                      },
+                      "modifications": [
+                        {
+                          "type": "AddKeyword",
+                          "keyword": "Flying"
+                        }
+                      ],
+                      "condition": null,
+                      "affected_zone": null,
+                      "effect_zone": null,
+                      "active_zones": [],
+                      "characteristic_defining": false,
+                      "description": "gain flying"
                     }
                   ],
-                  "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain flying"
-                }
+                  "duration": "UntilEndOfTurn",
+                  "target": null
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": "UntilEndOfTurn",
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
+              },
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "duration": "UntilEndOfTurn",
-              "target": null
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "You may exert ~ as he attacks. When you do, he gains flying until end of turn.",
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "You may exert ~ as he attacks. When you do, he gains flying until end of turn.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "source_text": "You may exert ~ as he attacks. When you do, he gains flying until end of turn."
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__themberchaud_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__themberchaud_ir.snap
@@ -1,0 +1,179 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 8,
+          "end_byte": 143,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When ~ enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "DamageAll",
+              "amount": {
+                "type": "Ref",
+                "qty": {
+                  "type": "ObjectCount",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      {
+                        "Subtype": "Mountain"
+                      }
+                    ],
+                    "controller": "You",
+                    "properties": []
+                  }
+                }
+              },
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "Another"
+                  },
+                  {
+                    "type": "WithoutKeyword",
+                    "value": "Flying"
+                  }
+                ]
+              },
+              "player_filter": {
+                "type": "All"
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When ~ enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 144,
+          "end_byte": 285,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "You may exert ~ as he attacks. When you do, he gains flying until end of turn. (An exerted creature won't untap during your next untap step.)"
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "Exerted",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "SelfRef"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddKeyword",
+                      "keyword": "Flying"
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "gain flying"
+                }
+              ],
+              "duration": "UntilEndOfTurn",
+              "target": null
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": null,
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "You may exert ~ as he attacks. When you do, he gains flying until end of turn.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    }
+  ],
+  "source_text": "Trample\nWhen Themberchaud enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control.\nYou may exert Themberchaud as he attacks. When you do, he gains flying until end of turn. (An exerted creature won't untap during your next untap step.)",
+  "card_name": "Themberchaud"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__themberchaud_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__themberchaud_lowered.snap
@@ -1,0 +1,141 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [],
+  "triggers": [
+    {
+      "mode": "ChangesZone",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "DamageAll",
+          "amount": {
+            "type": "Ref",
+            "qty": {
+              "type": "ObjectCount",
+              "filter": {
+                "type": "Typed",
+                "type_filters": [
+                  {
+                    "Subtype": "Mountain"
+                  }
+                ],
+                "controller": "You",
+                "properties": []
+              }
+            }
+          },
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": [
+              {
+                "type": "Another"
+              },
+              {
+                "type": "WithoutKeyword",
+                "value": "Flying"
+              }
+            ]
+          },
+          "player_filter": {
+            "type": "All"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": "Battlefield",
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "When ~ enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    },
+    {
+      "mode": "Exerted",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GenericEffect",
+          "static_abilities": [
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "SelfRef"
+              },
+              "modifications": [
+                {
+                  "type": "AddKeyword",
+                  "keyword": "Flying"
+                }
+              ],
+              "condition": null,
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "gain flying"
+            }
+          ],
+          "duration": "UntilEndOfTurn",
+          "target": null
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": null,
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "You may exert ~ as he attacks. When you do, he gains flying until end of turn.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wizard_class_two_layer_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wizard_class_two_layer_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1348
 expression: "&ir"
 ---
 {
@@ -119,51 +118,56 @@ expression: "&ir"
         "fragment": "When ~ becomes level 2, draw two cards."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ClassLevelGained",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Draw",
-              "count": {
-                "type": "Fixed",
-                "value": 2
+        "Trigger": {
+          "Assembled": {
+            "definition": {
+              "mode": "ClassLevelGained",
+              "execute": {
+                "kind": "Spell",
+                "effect": {
+                  "type": "Draw",
+                  "count": {
+                    "type": "Fixed",
+                    "value": 2
+                  },
+                  "target": {
+                    "type": "Controller"
+                  }
+                },
+                "cost": null,
+                "sub_ability": null,
+                "duration": null,
+                "description": null,
+                "target_prompt": null,
+                "condition": null,
+                "optional_targeting": false,
+                "optional": false,
+                "forward_result": false
               },
-              "target": {
-                "type": "Controller"
-              }
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": "When ~ becomes level 2",
+              "constraint": {
+                "type": "AtClassLevel",
+                "level": 2
+              },
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ becomes level 2",
-          "constraint": {
-            "type": "AtClassLevel",
-            "level": 2
-          },
-          "condition": null,
-          "batched": false
+            "source_text": "When ~ becomes level 2, draw two cards."
+          }
         }
       }
     },

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -13,7 +13,7 @@
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
 crates/engine/src/parser/oracle.rs         16
-crates/engine/src/parser/oracle_class.rs    6
+crates/engine/src/parser/oracle_class.rs    5
 
 # --- infrastructure: NOT burn-down targets ----------------------------------
 # The variant declarations and their consumers. These legitimately survive


### PR DESCRIPTION
Plan 05b tranche **T5** — nine trigger recognizer sites converted from `PreLoweredTrigger` to the
`TriggerNodeIr` seam T4 opened. Follows #6703 (T4) and #6708 (T7).

One commit per row, plus a baseline fixture commit that lands **before** any conversion.

| commit | row | site |
|---|---|---|
| baseline | — | 8 new two-layer fixtures |
| `U0-08` | T5b | Saga chapter triggers (CR 714) |
| `U0-10` | T5b | Attraction visit triggers (CR 717) |
| `U0-13` | T5a | leveler LEVEL-block triggers (CR 711.2a/b) |
| `U0-15` | T5a | Spacecraft threshold triggers (CR 702.184a) |
| `U0-33` | T5c | compound exert, bare form (CR 701.43d) |
| `U0-34` | T5c | compound exert, card-name form |
| `U0-35` | T5c | conditional exert |
| `U0-36` | T5c | synthesized flash-cleanup-sacrifice |
| `U0-54` | T5d | `oracle_class.rs` level-gained triggers |

## CR-faithfulness — by construction, for all nine rows

Every conversion reduces to a **one-line emission change**:

```diff
- emitter.trigger_at(item_line, trigger);
+ emitter.trigger_ir_at(item_line, TriggerNodeIr::from_definition(&line, trigger));
```

`trigger` is the finished `TriggerDefinition` the recognizer already built. Nothing about how it was
built changes; it is merely wrapped for source-ordered emission, and `lower_trigger_node_ir` returns
it untouched. **No property of any card's text participates in the argument**, so a future MTGJSON
card reaching any of these sites is covered too.

Three consequences worth stating explicitly, because the plan anticipated each as a hazard requiring
mitigation and the identity path removes all three:

**The `ChainLoweringMode` hazard (§7.1) is structurally out of scope in T5c.** The recensus flags the
exert trio as the tranche's most dangerous rows — `parse_effect_chain_ir`/`lower_effect_chain_ir`
alone runs neither the bypasses nor `finalize_effect_chain`, silently dropping finalize + anchor on
~113 cards. No chain parsing was moved, re-invoked or re-moded here: `grep` for
`ChainLoweringMode|parse_effect_chain|WithContext` across all four T5c commits returns **zero** changed
lines. The mode was never in scope to change.

**T5b's `description` overwrite cannot fire.** `lower_trigger_ir` does
`def.description = Some(ir.source_text)` unconditionally, which would corrupt Saga (stamps
`"Chapter {n}"`, not the line) and Attraction (stamps nothing). `lower_trigger_node_ir` never calls it.
Verified in the committed `_lowered` snapshots rather than argued:

```
history_of_benalia_lowered:  "description": "Chapter 1" / "Chapter 2" / "Chapter 3"
bumper_cars_lowered:         "description": null
```

`I, II —` correctly yields **both** Chapter 1 and Chapter 2 from one shared source line (CR 714.2c).

**T5a/T5d are by construction, NOT by corpus — a correction to the recensus §5.2 classification.**
That document labels these rows correct-by-corpus, relying on "all four Class `And` conditions in
today's pool are exactly two-element", and names the future card that would break it: one whose
printed condition is *already* an `And`, yielding `And[And[gate,x],y]` instead of the flat
`And[gate,x,y]` that #6021 deliberately introduced.

That hazard exists only if the CR 711.2a/711.2b graft moves **pre**-lowering. It does not. The graft
stays exactly where it is, operating on the lowered definition, so the identical code produces the
identical flat shape. `grep` for `extra_conditions|partial_def.condition` across the tranche returns
**zero** — no graft was relocated. Consequently `trigger_condition_source_zones`
(`oracle_trigger.rs:1836`) also does not start deriving `trigger_zones` from the level/station gate,
which was the second half of the plan's concern. There is no corpus dependency to state, and the
future-card shape the plan names cannot arise.

## Empirical gate

**Snapshot discipline (§5.1.5) — the load-bearing result:**

```
_lowered.snap  MODIFIED after baseline:  0     <- the STOP condition, not triggered
_ir.snap       modified after baseline:  9     <- one per converted row
whole branch:  16 A (8 fixtures x _ir/_lowered), 1 M (wizard_class_two_layer_ir.snap)
```

The IR representation re-nested on every fixture while **every lowered output stayed bit-identical**.
The single pre-existing snapshot modified is an `_ir` file, which is permitted. No churn in
`oracle_static/snapshots/*`, `oracle_replacement.rs` parity tests, `oracle_trigger_snapshot_tests.rs`,
`client/public/card-data.json` or `data/card-data.json`.

Hunks read (§5.1.6), not merely counted. The diff shape is pure re-nesting:

```diff
-  "PreLoweredTrigger": { "mode": "CounterAdded", "execute": {...
+  "Trigger": { "Assembled": { "definition": { "mode": "CounterAdded", "execute": {...
```

Same fields, one level deeper, `mode` and `execute` preserved. No `active_zones` drift, no rebound
`CountersOn.scope` — the charter's STOP conditions.

Other gates: `Gate P PASS` (ratchet), `✓ oracle-parser skill references valid`,
`cargo fmt --all --check` clean, cherry-picks onto current `main` with zero conflicts.

## Non-vacuity (§5.3) — eight of nine rows had NO witness

This is why the baseline commit exists and why it lands first. Eight of the nine rows had **no** card
in the two-layer snapshot corpus reaching their site, so a "byte-identical" claim on them would have
been a broken probe rather than a pass. The baseline adds one fixture per uncovered row:

```
lighthouse_chronologist  1 node   U0-13    entropic_battlecruiser  2 nodes  U0-15
history_of_benalia       3 nodes  U0-08    bumper_cars             1 node   U0-10
ahn_crop_champion        1 node   U0-33    themberchaud            2 nodes  U0-34
combat_celebrant         1 node   U0-35    armor_of_thorns         1 node   U0-36
```

**Probe verified live, not assumed:** each new `_ir.snap` was confirmed to contain at least one
`PreLoweredTrigger` node *before* conversion, so each fixture provably reaches the site its row
converts. The node counts above are measured. U0-54 needed no fixture — `wizard_class` already
witnessed it (2 nodes), verified rather than assumed.

Witness selection was driven by arm predicates, not convenience. Lighthouse Chronologist was chosen
over the pool's other LEVEL-block-trigger levelers because it is the only one printing its own
CR 603.4 intervening-if, making it the witness for the **composing** arm of the level graft
(`Some(existing) => And { .. }`) rather than only the `None` arm — which is the half the flat-vs-nested
question actually turns on. Entropic Battlecruiser carries both a threshold trigger and an ungated
one, so it also witnesses CR 707.9a per-category slot ordering across the preprocessor/dispatch-loop
boundary.

Every card's Oracle text is copied verbatim from the engine-authoritative pool
(`data/card-data.json`, regenerated 2026-07-27 11:20), never from memory.

## Additional verification beyond snapshot diffing

**Definition value-identity was machine-proved, not eyeballed.** §5.1.6 asks that every regenerated
hunk be read to confirm the definition fields are unchanged modulo indentation. A script that unwraps
`Trigger.Assembled.definition` back to `PreLoweredTrigger` reproduces each prior snapshot exactly
across all 12 converted trigger nodes on 9 cards:

```
PASS ahn_crop_champion 1 · armor_of_thorns 1 · bumper_cars 1 · combat_celebrant 1
PASS entropic_battlecruiser 2 · history_of_benalia 3 · lighthouse_chronologist 1
PASS themberchaud 1 · wizard_class_two_layer 1
ALL DEFINITIONS VALUE-IDENTICAL: True
```

**Two rows convert only ONE of two triggers on the card** (U0-34 Themberchaud, U0-54 `wizard_class`),
leaving the sibling `PreLowered`. That checks — rather than assumes — that an unconverted sibling's
CR 707.9a printed slot is undisturbed, which is exactly the failure mode a shared `trigger_slot`
counter would produce.

**Full parser suite green by execution**, not merely unchanged on disk:

```
two-layer suite:     98 passed; 0 failed
full parser suite: 8623 passed; 0 failed; 3 ignored
```

That run covers `oracle_trigger_snapshot_tests`, the `oracle_replacement` parity tests and the
`oracle_static` snapshots.

**One prediction failed and was chased rather than rounded off:** `entropic_battlecruiser` was expected
to convert 1 node and converted 2. The second is the *unprefixed* `"Whenever this Spacecraft attacks…"`
line, which the preprocessor attaches to the preceding `8+` section. Minima checked individually —
prefixed line `min=1`, continuation `min=8` — matching the physical card's station-bar layout. Correct
behavior, and it makes that fixture cover both arms of U0-15.

## Harvest (§5.4)

**1. The ratchet cannot see 8 of this tranche's 9 conversions.** It converted **eight** producers in
`oracle.rs` and that file's count did not move (20 → 20); #6708 converted **zero** producers and moved
it 20 → 16. The marker text lives in emitter method *bodies* (`trigger_at`) and consumer *match arms*,
never at producer call sites.

Crucially, `oracle.rs` staying at 20 is **correct, not a miss**: `trigger_at` must survive while
`drain_result_vectors` and the three T10-blocked `__item` sites still call it. `oracle_class.rs` moved
6 → 5 only because that site pushes the variant *literally* into a vector rather than through a helper.
**The metric tracks helper deletion, not producer conversion.** Do not read the flat 20 as "T5 did
nothing".

So §6.1's premise — *"Every tranche that converts a producer must lower its number in the same commit,
which is what makes the burn-down visible in `git log`"* — does not hold for `oracle.rs`. The gate is
sound as a **ceiling** (it would still catch a new producer), but the per-tranche burn-down it was
designed to expose is invisible there, and §6 closing criterion 4 becomes reachable only when the
emitter family is deleted at T9. Flagged; no gate was edited.

**2. `oracle_spacecraft.rs` clobbers where its sibling composes.**
`trig.condition = Some(self.trigger_cond.clone())` unconditionally discards any printed CR 603.4
intervening-if, while the CR 711.2a leveler graft ~130 lines away composes with `And` and carries a
comment explaining why. Two counter-threshold gates on printed triggers, opposite policies, one
silently lossy. Latent — no pool card currently prints an intervening-if on a threshold line.

**3. A mis-cited CR already in the tree.** `oracle_class.rs:123` reads
`// CR 602.5d + CR 716.4: Level N+1 can only activate at sorcery speed…`. **CR 716.4 is the
leveler-disambiguation rule** ("Some older creature cards, called leveler cards … are *not* the same as
class level abilities"). The rule that actually says this is **CR 716.2a**. Independently re-verified
against `docs/MagicCompRules.txt`. Not fixed here — §7.3 says report, don't fix inside a byte-identity
tranche.

**4. Silent line-drop in exert arms 2 and 3.** If `split_once_on_lower(.., ". when you do, ")` returns
`None`, the arm still runs `i += 1; continue` — the line is consumed with nothing emitted and no
diagnostic. The exert cost vanishes silently.

**5. `scan_contains` dispatch in U0-34's arm** (`"as "` + `"attacks"`) is exactly the `contains()`-style
parsing dispatch the nom mandate prohibits.

**6. Sibling-cluster smell in the exert trio** — the same 5-call builder chain (`TriggerMode::Exerted` /
`SelfRef` / `[Battlefield]` / `execute` / `description`) repeated verbatim three times, differing only
in recognition and split.

**7. `AttractionVisitRoll{min,max}` has no pool witness.** Zero Attractions in `data/card-data.json`
print a numbered visit line. The arm is converted and correct by construction but exercised by no test;
recorded in its commit body so it is not mistaken for covered.

**8. Unverified observation, flagged as such.** The leveler *activated* branch resets
`ctx.subject`/`ctx.actor`; the *trigger* branch does not and reuses the outer `ctx` across LEVEL lines,
where `oracle_spacecraft.rs` passes a fresh `ParseContext::default()` per trigger. Possible
subject/actor leakage; not proven to change any card's parse.

**9. T5a/T5d's by-corpus classification in the recensus is wrong** (see above) — a correction to the
plan, not the code.

## Scope discipline

The IR-native `TriggerNodeIr::Parsed` design was considered and **rejected** for T5a, for two
independent reasons: it is only correct-by-corpus (the `And` flattening question above), and it would
require a new arm in the `finish()` match in `oracle_ir/doc.rs` — the region #6708 was concurrently
editing. If the IR-native decomposition is wanted for its own sake it is a separate chartered change
with a real behavioral delta, and should not ride inside a byte-identity tranche.

## Not claimed

**Full-pool `card-data.json` byte-identity was not run from the executor worktree**, deliberately: per
§5.0 that rung is batched and Tilt regenerates it automatically from *its* checkout, so a run from a
worktree would measure a different population (§5.1.3's void-evidence trap). The snapshot-layer
evidence here is strictly stronger per-card — zero `_lowered` churn plus machine-proved definition
identity across 12 nodes — but the full-pool `cmp` is a separate read and is not being claimed.

The ratchet was lowered once, in the U0-54 commit, rather than in each of nine, to keep the conflict
surface a single hunk. Every earlier commit sits *below* its ceiling, which the gate treats as a pass,
so no intermediate commit is red.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trigger processing for Saga chapter triggers, Attraction visit triggers, LEVEL internal triggered abilities, Spacecraft threshold triggers, exerted abilities, and Flashback cleanup sacrifice effects.
  * Preserved trigger identity and description fidelity when parsing class-level “becomes level N” abilities.

* **Tests**
  * Expanded two-layer parsing and lowering snapshot coverage for additional Oracle trigger patterns and ordering.

* **Chores**
  * Updated the prelowering ratchet threshold used for build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->