### PR TITLE
fix(draft): put suggested nonbasic lands on main_deck

### DIFF
--- a/client/src/components/draft/LimitedDeckBuilder.tsx
+++ b/client/src/components/draft/LimitedDeckBuilder.tsx
@@ -220,6 +220,8 @@ export function LimitedDeckBuilder({
 
   const [hoveredCard, setHoveredCard] = useState<CardHoverInfo | null>(null);
 
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const pool = useMemo(() => view?.pool ?? [], [view?.pool]);
 
   const remainingPool = useMemo(
@@ -361,7 +363,20 @@ export function LimitedDeckBuilder({
 
             <button
               type="button"
-              onClick={submitDeck}
+              onClick={async () => {
+                setSubmitError(null);
+                try {
+                  await submitDeck();
+                } catch (err) {
+                  const message =
+                    err instanceof Error
+                      ? err.message
+                      : typeof err === "string"
+                        ? err
+                        : String(err);
+                  setSubmitError(message);
+                }
+              }}
               disabled={!deckValid}
               className={menuButtonClass({
                 tone: "emerald",
@@ -372,6 +387,14 @@ export function LimitedDeckBuilder({
             >
               {t("limitedDeck.submitDeck")}
             </button>
+            {submitError ? (
+              <p
+                role="alert"
+                className="rounded-md border border-red-500/40 bg-red-950/40 px-2 py-1.5 text-xs text-red-200"
+              >
+                {submitError}
+              </p>
+            ) : null}
           </section>
         </div>
       </div>

--- a/crates/draft-core/src/types.rs
+++ b/crates/draft-core/src/types.rs
@@ -415,7 +415,14 @@ pub enum DraftError {
     CardNotInPack { card_instance_id: String },
     #[error("seat {seat} has no pending pack")]
     NoPendingPack { seat: u8 },
-    #[error("deck validation failed")]
+    #[error(
+        "deck validation failed: {}",
+        errors
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ")
+    )]
     ValidationFailed { errors: Vec<LimitedDeckError> },
     #[error("pairing not found: {match_id}")]
     PairingNotFound { match_id: String },
@@ -715,5 +722,30 @@ mod tests {
         }"#;
         let config: DraftConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.spectator_visibility, SpectatorVisibility::Public);
+    }
+
+    #[test]
+    fn validation_failed_display_includes_per_card_errors() {
+        let err = DraftError::ValidationFailed {
+            errors: vec![
+                LimitedDeckError::ExceedsPoolCount {
+                    name: "Hell's Kitchen".to_string(),
+                    requested: 2,
+                    available: 1,
+                },
+                LimitedDeckError::NotInPool {
+                    name: "Ghost Card".to_string(),
+                },
+            ],
+        };
+        let message = err.to_string();
+        assert!(
+            message.contains("Hell's Kitchen") && message.contains("Ghost Card"),
+            "Display must name offending cards, got {message}"
+        );
+        assert!(
+            message.contains("used 2 times") || message.contains("not in the drafted pool"),
+            "Display must include reasons, got {message}"
+        );
     }
 }

--- a/crates/draft-wasm/src/suggest.rs
+++ b/crates/draft-wasm/src/suggest.rs
@@ -88,10 +88,17 @@ pub fn suggest_deck(
         }
     }
 
-    // `main_deck` holds the non-land spells only; `lands` carries the land
-    // distribution separately. Consumers (the deckbuilder store, `get_bot_deck`)
-    // concatenate the two — appending lands here as well would double-count them
-    // (e.g. 23 spells + 17 lands in `main_deck`, then +17 lands again = 57).
+    // `main_deck` holds drafted cards (spells + nonbasic fixing lands); `lands`
+    // carries only the always-addable basic fill. Consumers (the deckbuilder
+    // store, `get_bot_deck`) concatenate the two — never put basics into
+    // `main_deck` or they'd double-count (e.g. 23 spells + 17 lands in
+    // `main_deck`, then +17 lands again = 57).
+    //
+    // Drafted nonbasics must live in `main_deck`, not `lands`: the limited
+    // deckbuilder UI only exposes `lands` for `addable_cards` (basics), and
+    // `computeRemainingPool` only subtracts `mainDeck`. Putting duals in
+    // `lands` left them visible in the pool so players could add them again,
+    // then submit expanded both maps → ExceedsPoolCount (#6562).
     let spell_names: Vec<String> = spells.iter().map(|c| c.name.clone()).collect();
     let land_total = min_deck_size.saturating_sub(spell_names.len()) as u8;
 
@@ -109,15 +116,16 @@ pub fn suggest_deck(
     };
     let nonbasic_count: u8 = nonbasic_lands.values().copied().sum();
     let basics_total = land_total.saturating_sub(nonbasic_count);
-    let mut lands = suggest_addable_cards(&spell_names, pool, basics_total, addable_cards);
+    let lands = suggest_addable_cards(&spell_names, pool, basics_total, addable_cards);
+
+    let mut main_deck = spell_names;
     for (name, count) in nonbasic_lands {
-        *lands.entry(name).or_insert(0) += count;
+        for _ in 0..count {
+            main_deck.push(name.clone());
+        }
     }
 
-    SuggestedDeck {
-        main_deck: spell_names,
-        lands,
-    }
+    SuggestedDeck { main_deck, lands }
 }
 
 /// On-color drafted nonbasic fixing lands as a `name -> copy-count` map, capped at
@@ -480,9 +488,19 @@ mod tests {
             &DeckAddableCards::standard_basics(),
         );
         assert!(
-            deck.lands.contains_key("On Color Dual"),
-            "on-color (W/U) fixing land should be admitted to the manabase, got {:?}",
+            deck.main_deck.iter().any(|n| n == "On Color Dual"),
+            "on-color (W/U) fixing land should be admitted onto main_deck, got {:?}",
+            deck.main_deck
+        );
+        assert!(
+            !deck.lands.contains_key("On Color Dual"),
+            "drafted nonbasics must not go in lands (basics-only map), got {:?}",
             deck.lands
+        );
+        assert!(
+            !deck.main_deck.iter().any(|n| n == "Off Color Dual"),
+            "off-color (B/R) fixing land must not be admitted, got {:?}",
+            deck.main_deck
         );
         assert!(
             !deck.lands.contains_key("Off Color Dual"),
@@ -506,7 +524,8 @@ mod tests {
         assert_eq!(
             deck.main_deck.len() as u32 + land_count,
             8,
-            "spells + lands must equal min_deck_size; lands = {:?}",
+            "main_deck + basics must equal min_deck_size; main={:?} lands={:?}",
+            deck.main_deck,
             deck.lands
         );
     }
@@ -522,6 +541,7 @@ mod tests {
             8,
             &DeckAddableCards::standard_basics(),
         );
+        assert!(!deck.main_deck.iter().any(|n| n == "On Color Dual"));
         assert!(!deck.lands.contains_key("On Color Dual"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes **#6562**: suggested drafted duals were placed in `lands`, but the limited deckbuilder only exposes `lands` for addable basics and `computeRemainingPool` only subtracts `mainDeck`. Duals stayed visible in the pool, players could add them again, and submit expanded both maps → `ExceedsPoolCount` (often as a silent “deck validation failed”). Drafted nonbasics now go on `main_deck`; `lands` stays basics-only. `ValidationFailed` Display includes per-card errors, and the submit button surfaces that message in-app.

## Files changed

- `crates/draft-wasm/src/suggest.rs` — admit fixing lands onto `main_deck`; update unit tests
- `crates/draft-core/src/types.rs` — include `LimitedDeckError`s in `ValidationFailed` Display + regression test
- `client/src/components/draft/LimitedDeckBuilder.tsx` — show submit validation errors in-app

## Track

Developer

## LLM

Model: Composer
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — draft-wasm / draft-core / limited deckbuilder UI, not `crates/engine/` game rules. No `/engine-implementer` path.

## CR references

None — Limited deck construction / tournament UI, not MTG Comprehensive Rules game logic.

## Verification

- [x] Gate A output below is for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.
- [ ] Local `cargo test` deferred — no Rust toolchain in this environment; CI will run `draft-wasm` / `draft-core` tests.
- `scripts/check-parser-combinators.sh origin/main` — **Gate A PASS** (no parser files touched).

## Gate A

Gate A PASS head=6f2f0093ab36e2330a21da7a701abf66fdda18f2 base=e9a268a4d5ef4db00dd903ed2e1c1f6ceebcd95a

## Anchored on

- `crates/draft-wasm/src/suggest.rs` — existing comment that consumers concatenate `main_deck` + `lands` (double-count hazard); nonbasics belong with drafted cards in `main_deck`
- `crates/draft-core/src/validation.rs` — `LimitedDeckError` already carries per-card Display text; `ValidationFailed` now forwards it the same way other `DraftError` variants surface detail

## Final review-impl

Final review-impl PASS head=6f2f0093ab36e2330a21da7a701abf66fdda18f2 — non-engine draft suggest/validation Display fix; tests updated for main_deck placement and Display content.

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited deck submission errors are now shown directly in the deck builder.
  * Validation messages provide detailed card-specific reasons for rejected decks.
  * Drafted nonbasic fixing lands are now correctly included in the main deck when eligible.
  * Deck suggestions continue to exclude off-color fixing lands and maintain valid deck-size totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->