### PR TITLE
fix(deckbuilder): gate copy-limit affordances on engine canonical counts

### DIFF
--- a/client/src/components/deck-builder/CardGrid.tsx
+++ b/client/src/components/deck-builder/CardGrid.tsx
@@ -12,6 +12,8 @@ interface CardGridProps {
   onCardHover?: (cardName: string | null) => void;
   cardCounts?: Map<string, number>;
   legalityFormat?: BrowserLegalityFilter;
+  /** When false, the add affordance is disabled (copy ceiling reached). */
+  canAddCard?: (name: string) => boolean;
 }
 
 function getArtCropUrl(card: ScryfallCard): string {
@@ -35,6 +37,7 @@ export function CardGrid({
   onCardHover,
   cardCounts,
   legalityFormat = "all",
+  canAddCard,
 }: CardGridProps) {
   return (
     <div className="grid auto-rows-min grid-cols-[repeat(auto-fill,minmax(110px,1fr))] gap-2 overflow-y-auto p-2 sm:grid-cols-[repeat(auto-fill,minmax(130px,1fr))]">
@@ -44,6 +47,7 @@ export function CardGrid({
             key={card.id ?? card.name}
             card={card}
             legal={isFormatLegal(card, legalityFormat)}
+            canAdd={canAddCard?.(card.name) ?? true}
             count={cardCounts?.get(card.name)}
             legalityFormat={legalityFormat}
             onAddCard={onAddCard}
@@ -58,6 +62,7 @@ export function CardGrid({
 interface CardGridTileProps {
   card: ScryfallCard;
   legal: boolean;
+  canAdd: boolean;
   count: number | undefined;
   legalityFormat: BrowserLegalityFilter;
   onAddCard: (card: ScryfallCard) => void;
@@ -67,6 +72,7 @@ interface CardGridTileProps {
 function CardGridTile({
   card,
   legal,
+  canAdd,
   count,
   legalityFormat,
   onAddCard,
@@ -77,6 +83,7 @@ function CardGridTile({
   const formatLabel = legalityFormat === "all"
     ? t("grid.allFormats")
     : legalityFormat.charAt(0).toUpperCase() + legalityFormat.slice(1);
+  const addEnabled = legal && canAdd;
 
   // Touch model (mirrors MobileHandDrawer's DrawerCard): tap adds the card,
   // long-press opens the preview. firedRef suppresses the click that follows a
@@ -89,8 +96,14 @@ function CardGridTile({
       firedRef.current = false;
       return;
     }
-    if (legal) onAddCard(card);
+    if (addEnabled) onAddCard(card);
   };
+
+  const title = !legal
+    ? t("grid.notLegal", { name: card.name, format: formatLabel })
+    : !canAdd
+      ? t("grid.copyLimitReached", { name: card.name })
+      : t("grid.addCard", { name: card.name });
 
   return (
     <motion.button
@@ -103,10 +116,10 @@ function CardGridTile({
       onClick={handleClick}
       {...mouseHoverPreview(onCardHover, card.name)}
       {...handlers}
-      disabled={!legal}
-      title={legal ? t("grid.addCard", { name: card.name }) : t("grid.notLegal", { name: card.name, format: formatLabel })}
+      disabled={!addEnabled}
+      title={title}
       className={`group relative cursor-pointer overflow-hidden rounded-lg transition-transform hover:scale-105 ${
-        legal
+        addEnabled
           ? "ring-2 ring-transparent hover:ring-green-500"
           : "cursor-not-allowed opacity-60 ring-2 ring-red-600"
       }`}
@@ -128,6 +141,14 @@ function CardGridTile({
         <div className="absolute inset-0 flex items-center justify-center bg-black/50">
           <span className="rounded bg-red-700 px-2 py-0.5 text-[10px] font-bold text-white">
             {t("grid.notFormat", { format: formatLabel })}
+          </span>
+        </div>
+      )}
+
+      {legal && !canAdd && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/50">
+          <span className="rounded bg-red-700 px-2 py-0.5 text-[10px] font-bold text-white">
+            {t("grid.atCopyLimit")}
           </span>
         </div>
       )}

--- a/client/src/components/deck-builder/DeckBuilder.tsx
+++ b/client/src/components/deck-builder/DeckBuilder.tsx
@@ -398,6 +398,7 @@ export function DeckBuilder({
                   onCardHover={onCardHover}
                   cardCounts={cardCounts}
                   legalityFormat={searchFilters.browseFormat}
+                  canAddCard={canIncrement}
                 />
               </div>
             ) : (

--- a/client/src/components/deck-builder/__tests__/CardGrid.test.tsx
+++ b/client/src/components/deck-builder/__tests__/CardGrid.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CardGrid } from "../CardGrid";
+import type { ScryfallCard } from "../../../services/scryfall";
+
+afterEach(cleanup);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, string>) => {
+      if (key === "grid.copyLimitReached") return `${opts?.name} - at copy limit`;
+      if (key === "grid.atCopyLimit") return "At limit";
+      if (key === "grid.addCard") return `Add ${opts?.name}`;
+      if (key === "grid.notLegal") return `${opts?.name} - not legal`;
+      if (key === "grid.notFormat") return `Not ${opts?.format}`;
+      if (key === "grid.allFormats") return "all formats";
+      return key;
+    },
+  }),
+}));
+
+vi.mock("../../../hooks/useLongPress", () => ({
+  useLongPress: () => ({ handlers: {}, firedRef: { current: false } }),
+}));
+
+function makeCard(name: string): ScryfallCard {
+  return {
+    id: name.toLowerCase(),
+    name,
+    mana_cost: "",
+    cmc: 0,
+    type_line: "Artifact",
+    color_identity: [],
+    legalities: { modern: "legal" },
+  };
+}
+
+describe("CardGrid copy-limit affordance", () => {
+  it("disables add when canAddCard returns false", () => {
+    const onAddCard = vi.fn();
+    render(
+      <CardGrid
+        cards={[makeCard("Sol Ring")]}
+        onAddCard={onAddCard}
+        canAddCard={() => false}
+        legalityFormat="Modern"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /Sol Ring/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "Sol Ring - at copy limit");
+    fireEvent.click(button);
+    expect(onAddCard).not.toHaveBeenCalled();
+  });
+
+  it("adds when canAddCard allows it", () => {
+    const onAddCard = vi.fn();
+    render(
+      <CardGrid
+        cards={[makeCard("Sol Ring")]}
+        onAddCard={onAddCard}
+        canAddCard={() => true}
+        legalityFormat="Modern"
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /Sol Ring/i });
+    expect(button).not.toBeDisabled();
+    fireEvent.click(button);
+    expect(onAddCard).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/deck-builder/useDeckBuilder.ts
+++ b/client/src/components/deck-builder/useDeckBuilder.ts
@@ -31,6 +31,7 @@ import { getSharedAdapter } from "../../adapter/wasm-adapter";
 import { useBracketEstimate } from "../../hooks/useBracketEstimate";
 import { projectSignatureSpellForFormat } from "../../services/savedDeckProjection";
 import {
+  canonicalDeckCountKey,
   commanderPartnerCandidates,
   companionCandidates,
   isCardCommanderEligibleForFormat,
@@ -338,30 +339,41 @@ export function useDeckBuilder({
 
   // CR 100.4a: the copy limit applies to the main deck, sideboard, and command
   // zone combined, so the increment gate counts every slot a card can occupy.
+  // Counts are keyed by the engine's canonical name so alias spellings share a
+  // bucket (#6659) — never fold accents/case/DFC forms in the display layer.
+  const [canonicalKeys, setCanonicalKeys] = useState<Map<string, string>>(
+    () => new Map(),
+  );
+
   const combinedCopyCounts = useMemo(() => {
     const counts = new Map<string, number>();
-    const add = (name: string, n: number) =>
-      counts.set(name, (counts.get(name) ?? 0) + n);
+    const add = (name: string, n: number) => {
+      const key = canonicalKeys.get(name) ?? name;
+      counts.set(key, (counts.get(key) ?? 0) + n);
+    };
     for (const entry of deck.main) add(entry.name, entry.count);
     for (const entry of deck.sideboard) add(entry.name, entry.count);
     for (const name of commanders) add(name, 1);
     for (const name of deck.signature_spell ?? []) add(name, 1);
     if (deck.companion) add(deck.companion, 1);
     return counts;
-  }, [deck, commanders]);
+  }, [deck, commanders, canonicalKeys]);
 
   // Distinct names currently in the partition, as a stable key — the ceiling
   // for a (name, format) pair never changes, so this only refetches when the
   // set of names or the format actually changes, not on every count edit.
-  const copyLimitKey = useMemo(
-    () =>
-      [
-        ...new Set([...deck.main, ...deck.sideboard].map((entry) => entry.name)),
-      ]
-        .sort()
-        .join("|"),
-    [deck.main, deck.sideboard],
-  );
+  const copyLimitKey = useMemo(() => {
+    const names = new Set<string>();
+    for (const entry of deck.main) names.add(entry.name);
+    for (const entry of deck.sideboard) names.add(entry.name);
+    for (const name of commanders) names.add(name);
+    for (const name of deck.signature_spell ?? []) names.add(name);
+    if (deck.companion) names.add(deck.companion);
+    // Search results need ceilings too so CardGrid can disable adds at the
+    // limit — including when the result's spelling differs from a deck entry.
+    for (const card of searchResults) names.add(card.name);
+    return [...names].sort().join("|");
+  }, [deck, commanders, searchResults]);
 
   // CR 100.2a / CR 903.5b: the ceiling is engine-resolved per card and format
   // (basic-land exemption, printed overrides like Relentless Rats or Seven
@@ -373,19 +385,33 @@ export function useDeckBuilder({
     const names = copyLimitKey ? copyLimitKey.split("|") : [];
     if (names.length === 0) {
       setCopyLimits(new Map());
+      setCanonicalKeys(new Map());
       return;
     }
     let cancelled = false;
     Promise.all(
-      names.map(async (name) => [name, await maxDeckCopies(name, format)] as const),
+      names.map(async (name) => {
+        const [limit, canonical] = await Promise.all([
+          maxDeckCopies(name, format),
+          canonicalDeckCountKey(name),
+        ]);
+        return [name, limit, canonical] as const;
+      }),
     )
       .then((results) => {
-        if (!cancelled) setCopyLimits(new Map(results));
+        if (cancelled) return;
+        setCopyLimits(new Map(results.map(([name, limit]) => [name, limit])));
+        setCanonicalKeys(
+          new Map(results.map(([name, , canonical]) => [name, canonical])),
+        );
       })
       .catch(() => {
         // WASM may not be loaded yet; an empty map leaves increments open and
         // the engine's compatibility warnings still flag any real violation.
-        if (!cancelled) setCopyLimits(new Map());
+        if (!cancelled) {
+          setCopyLimits(new Map());
+          setCanonicalKeys(new Map());
+        }
       });
     return () => {
       cancelled = true;
@@ -396,9 +422,10 @@ export function useDeckBuilder({
     (name: string) => {
       const limit = copyLimits.get(name);
       if (!limit || limit.type === "Unlimited") return true;
-      return (combinedCopyCounts.get(name) ?? 0) < limit.data;
+      const key = canonicalKeys.get(name) ?? name;
+      return (combinedCopyCounts.get(key) ?? 0) < limit.data;
     },
-    [copyLimits, combinedCopyCounts],
+    [copyLimits, combinedCopyCounts, canonicalKeys],
   );
 
   const handleIncrementCard = useCallback(

--- a/client/src/i18n/locales/de/deck-builder.json
+++ b/client/src/i18n/locales/de/deck-builder.json
@@ -87,7 +87,9 @@
     "allFormats": "Alle",
     "addCard": "{{name}} hinzufügen",
     "notLegal": "{{name}} – nicht legal in {{format}}",
-    "notFormat": "Nicht {{format}}"
+    "notFormat": "Nicht {{format}}",
+    "copyLimitReached": "{{name}} – Kopielimit erreicht",
+    "atCopyLimit": "Limit erreicht"
   },
   "deckList": {
     "currentList": "Aktuelle Liste",

--- a/client/src/i18n/locales/en/deck-builder.json
+++ b/client/src/i18n/locales/en/deck-builder.json
@@ -87,7 +87,9 @@
     "allFormats": "All",
     "addCard": "Add {{name}}",
     "notLegal": "{{name}} - Not {{format}} legal",
-    "notFormat": "Not {{format}}"
+    "notFormat": "Not {{format}}",
+    "copyLimitReached": "{{name}} - at copy limit",
+    "atCopyLimit": "At limit"
   },
   "deckList": {
     "currentList": "Current List",

--- a/client/src/i18n/locales/es/deck-builder.json
+++ b/client/src/i18n/locales/es/deck-builder.json
@@ -87,7 +87,9 @@
     "allFormats": "Todos",
     "addCard": "Añadir {{name}}",
     "notLegal": "{{name}} - No es legal en {{format}}",
-    "notFormat": "No es {{format}}"
+    "notFormat": "No es {{format}}",
+    "copyLimitReached": "{{name}} - límite de copias alcanzado",
+    "atCopyLimit": "En el límite"
   },
   "deckList": {
     "currentList": "Lista actual",

--- a/client/src/i18n/locales/fr/deck-builder.json
+++ b/client/src/i18n/locales/fr/deck-builder.json
@@ -87,7 +87,9 @@
     "allFormats": "Tous",
     "addCard": "Ajouter {{name}}",
     "notLegal": "{{name}} - Non légal en {{format}}",
-    "notFormat": "Non {{format}}"
+    "notFormat": "Non {{format}}",
+    "copyLimitReached": "{{name}} - limite de copies atteinte",
+    "atCopyLimit": "Limite atteinte"
   },
   "deckList": {
     "currentList": "Liste actuelle",

--- a/client/src/i18n/locales/it/deck-builder.json
+++ b/client/src/i18n/locales/it/deck-builder.json
@@ -87,7 +87,9 @@
     "allFormats": "Tutti",
     "addCard": "Aggiungi {{name}}",
     "notLegal": "{{name}} - Non legale in {{format}}",
-    "notFormat": "Non {{format}}"
+    "notFormat": "Non {{format}}",
+    "copyLimitReached": "{{name}} - limite copie raggiunto",
+    "atCopyLimit": "Al limite"
   },
   "deckList": {
     "currentList": "Lista corrente",

--- a/client/src/i18n/locales/pl/deck-builder.json
+++ b/client/src/i18n/locales/pl/deck-builder.json
@@ -87,7 +87,9 @@
     "allFormats": "Wszystkie",
     "addCard": "Dodaj {{name}}",
     "notLegal": "{{name}} - Niedozwolona w formacie {{format}}",
-    "notFormat": "Nie {{format}}"
+    "notFormat": "Nie {{format}}",
+    "copyLimitReached": "{{name}} - osiągnięto limit kopii",
+    "atCopyLimit": "Limit"
   },
   "deckList": {
     "currentList": "Bieżąca lista",

--- a/client/src/i18n/locales/pt/deck-builder.json
+++ b/client/src/i18n/locales/pt/deck-builder.json
@@ -87,7 +87,9 @@
     "allFormats": "Todos",
     "addCard": "Adicionar {{name}}",
     "notLegal": "{{name}} - Não válido em {{format}}",
-    "notFormat": "Não {{format}}"
+    "notFormat": "Não {{format}}",
+    "copyLimitReached": "{{name}} - limite de cópias atingido",
+    "atCopyLimit": "No limite"
   },
   "deckList": {
     "currentList": "Lista Atual",

--- a/client/src/services/engineRuntime.ts
+++ b/client/src/services/engineRuntime.ts
@@ -297,6 +297,17 @@ export async function maxDeckCopies(
 }
 
 /**
+ * CR 201.3 + CR 100.2a: Engine canonical key for aggregating deck copy counts.
+ * Alias spellings, case variants, and DFC combined/front-face names share one
+ * bucket — the deck builder must key affordance counts on this value.
+ */
+export async function canonicalDeckCountKey(name: string): Promise<string> {
+  await ensureCardDatabase();
+  const engine = await loadEngineModule();
+  return engine.canonicalDeckCountKey(name) as string;
+}
+
+/**
  * CR 100.4a: Per-format sideboard policy as a discriminated union.
  *
  * `Forbidden` and `Unlimited` are unit variants and do not carry a `data`

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -294,6 +294,13 @@ export function load_replay_for_playback(json_str: string): number;
 export function maxDeckCopies(name: string, format: any): any;
 
 /**
+ * CR 201.3 + CR 100.2a: Canonical key for aggregating deck copy counts so
+ * alias spellings share one bucket. Returns the lowercased input when the
+ * card database isn't loaded.
+ */
+export function canonicalDeckCountKey(name: string): string;
+
+/**
  * Verify WASM integration works.
  */
 export function ping(): string;
@@ -493,6 +500,7 @@ export interface InitOutput {
     readonly load_card_database: (a: number, b: number) => [number, number, number];
     readonly load_replay_for_playback: (a: number, b: number) => [number, number, number];
     readonly maxDeckCopies: (a: number, b: number, c: any) => any;
+    readonly canonicalDeckCountKey: (a: number, b: number) => [number, number];
     readonly ping: () => [number, number];
     readonly preview_action_js: (a: number, b: any) => any;
     readonly preview_mana_payment_js: (a: number, b: any) => any;

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -19,8 +19,8 @@ use engine::game::engine::{
 use engine::game::interaction::bind_interaction_authority;
 use engine::game::preview::{compute_preview_diff, preview_auto_payment_sources};
 use engine::game::{
-    can_pair_commanders, companion_candidates, deck_copy_limit_for, estimate_bracket,
-    evaluate_deck_compatibility, filter_state_for_viewer, finalize_public_state,
+    can_pair_commanders, canonical_deck_count_key, companion_candidates, deck_copy_limit_for,
+    estimate_bracket, evaluate_deck_compatibility, filter_state_for_viewer, finalize_public_state,
     is_brawl_commander_eligible, is_commander_eligible, is_tiny_leader_eligible,
     load_and_hydrate_decks, max_deck_copies, rehydrate_game_from_card_db, resolve_deck_list,
     signature_spell_selection_policy, start_game, start_game_with_starting_player,
@@ -448,6 +448,24 @@ pub fn max_deck_copies_for_format(name: &str, format: JsValue) -> JsValue {
             return to_js(&DeckCopyLimit::Unlimited);
         };
         to_js(&max_deck_copies(db, name, format))
+    })
+}
+
+/// CR 201.3 + CR 100.2a: Canonical key for aggregating deck copy counts so
+/// alias spellings (`Nazgul`/`Nazgûl`), case variants, and DFC combined vs
+/// front-face names share one bucket. The deck builder must key affordance
+/// counts on this — never fold names in JS.
+///
+/// Returns the input lowercased when the card database isn't loaded, matching
+/// `maxDeckCopies`'s fail-open posture for a not-yet-hydrated frontend.
+#[wasm_bindgen(js_name = canonicalDeckCountKey)]
+pub fn canonical_deck_count_key_for_name(name: &str) -> String {
+    CARD_DB.with(|cell| {
+        let db = cell.borrow();
+        let Some(db) = db.as_ref() else {
+            return name.to_lowercase();
+        };
+        canonical_deck_count_key(db, name)
     })
 }
 

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -2619,7 +2619,10 @@ fn card_is_known(db: &CardDatabase, name: &str) -> bool {
 /// CR 201.3 + CR 100.2a: Canonical key for aggregating deck copy counts.
 /// Uses the indexed face name when the card resolves so alias spellings
 /// ("Nazgul" vs "Nazgûl") merge into one bucket for copy-limit checks.
-fn canonical_deck_count_key(db: &CardDatabase, name: &str) -> String {
+///
+/// Public so the deck-builder WASM surface can share the same authority the
+/// legality checker uses (affordance gating must not re-derive folding in JS).
+pub fn canonical_deck_count_key(db: &CardDatabase, name: &str) -> String {
     let resolved = resolve_card_name(db, name);
     db.get_face_by_name(resolved)
         .map(|face| face.name.to_lowercase())
@@ -3991,6 +3994,21 @@ mod tests {
         assert_eq!(
             max_deck_copies(&db, "Nazgul", GameFormat::Modern),
             DeckCopyLimit::UpTo(9)
+        );
+    }
+
+    #[test]
+    fn canonical_deck_count_key_merges_alias_spellings() {
+        // Public surface for the deck-builder affordance (#6659): alias
+        // spellings must share one key so client-side counts match validation.
+        let db = CardDatabase::from_json_str(&test_db_json()).unwrap();
+        assert_eq!(
+            canonical_deck_count_key(&db, "Nazgul"),
+            canonical_deck_count_key(&db, "Nazgûl")
+        );
+        assert_eq!(
+            canonical_deck_count_key(&db, "Nazgul"),
+            canonical_deck_count_key(&db, "nazgûl")
         );
     }
 

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -201,11 +201,12 @@ pub use deck_loading::{
     resolve_deck_list, resolve_player_deck_list, DeckEntry, DeckList, DeckPayload, PlayerDeckList,
 };
 pub use deck_validation::{
-    can_pair_commanders, companion_candidates, deck_copy_limit_for, evaluate_deck_compatibility,
-    is_brawl_commander_eligible, is_commander_eligible, is_tiny_leader_eligible, max_deck_copies,
-    signature_spell_selection_policy, validate_deck_for_format, validate_name_deck_for_format,
-    validate_name_deck_for_format_full, CompatibilityCheck, DeckCompatibilityRequest,
-    DeckCompatibilityResult, DeckCoverage, SignatureSpellSelectionPolicy, UnsupportedCard,
+    can_pair_commanders, canonical_deck_count_key, companion_candidates, deck_copy_limit_for,
+    evaluate_deck_compatibility, is_brawl_commander_eligible, is_commander_eligible,
+    is_tiny_leader_eligible, max_deck_copies, signature_spell_selection_policy,
+    validate_deck_for_format, validate_name_deck_for_format, validate_name_deck_for_format_full,
+    CompatibilityCheck, DeckCompatibilityRequest, DeckCompatibilityResult, DeckCoverage,
+    SignatureSpellSelectionPolicy, UnsupportedCard,
 };
 pub use engine::{
     apply, apply_as_current, new_game, start_game, start_game_skip_mulligan,


### PR DESCRIPTION
## Summary

Fixes **#6659**: two copy-limit affordance gaps. (1) Client `combinedCopyCounts` keyed on raw entry names, so alias spellings (`Nazgul`/`Nazgûl`, case, DFC forms) each got their own ceiling. Expose the engine’s existing `canonical_deck_count_key` via WASM and aggregate on that key. (2) Search `CardGrid` had no `canAddCard` gate (unlike `DeckStack`); wire `canIncrement` so at-ceiling search results disable visibly.

Neither gap can produce an illegal playable deck — `copy_limit_violations` already canonicalizes — these are stale-affordance fixes.

Supersedes closed #6712 (same change plus CardGrid test typing that failed CI type-check).

## Files changed

- `crates/engine/src/game/deck_validation.rs` — `pub fn canonical_deck_count_key` + unit test
- `crates/engine/src/game/mod.rs` — re-export
- `crates/engine-wasm/src/lib.rs` — `canonicalDeckCountKey` WASM binding
- `client/src/services/engineRuntime.ts` / `client/src/wasm/engine_wasm.d.ts` — TS surface
- `client/src/components/deck-builder/useDeckBuilder.ts` — canonical aggregation; include search names in limit fetch
- `client/src/components/deck-builder/CardGrid.tsx` + `DeckBuilder.tsx` — `canAddCard` affordance
- `client/src/components/deck-builder/__tests__/CardGrid.test.tsx` — disabled/enabled coverage (full `ScryfallCard` + `Modern` filter)
- `client/src/i18n/locales/*/deck-builder.json` — copy-limit strings

## Track

Developer

## LLM

Model: Composer
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — exposes the existing `deck_validation::canonical_deck_count_key` authority for deck-builder affordance gating; no rules/resolver/parser behavior change. Legality still enforced solely by `copy_limit_violations`.

## CR references

- CR 100.2a / CR 100.4a — copy limit across construction zones (existing annotations on `max_deck_copies` / `combined_copy_counts`)
- CR 201.3 — name identity / canonical face name (existing annotation on `canonical_deck_count_key`)

## Verification

- [x] Gate A output below is for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.
- [x] Local `pnpm run type-check` — pass
- [x] Local `vitest run src/components/deck-builder/__tests__/CardGrid.test.tsx` — 2 passed
- `scripts/check-parser-combinators.sh origin/main` — **Gate A PASS** (no parser files touched).

## Gate A

Gate A PASS head=fb30c845c8ff826f0c9fa853fffb2fd61f8fde1d base=e9a268a4d5ef4db00dd903ed2e1c1f6ceebcd95a

## Anchored on

- `crates/engine/src/game/deck_validation.rs` — `combined_copy_counts` / `max_deck_copies` already use `canonical_deck_count_key`; WASM now exposes that same key
- `client/src/components/deck-builder/DeckStack.tsx` — existing `canAddCard={canIncrement}` pattern mirrored onto `CardGrid`

## Final review-impl

Final review-impl PASS head=fb30c845c8ff826f0c9fa853fffb2fd61f8fde1d — no name folding in the client; ceilings and keys come from the engine; search grid uses the same `canIncrement` gate as deck rows; CardGrid test fixtures match `ScryfallCard` / `BrowserLegalityFilter`.

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deck Builder now enforces card copy limits consistently, including alternate spellings and card names that refer to the same card.
  * Cards at their copy limit are clearly marked, with disabled add buttons and explanatory tooltips.
  * Copy-limit messaging is now available in English, German, Spanish, French, Italian, Polish, and Portuguese.

* **Tests**
  * Added coverage for enabled and disabled card-add behavior at copy limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->