### PR TITLE
refactor(parser): Plan 05b T8-A0 — the ability shell widening (infrastructure only)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -58,9 +58,9 @@ use super::oracle_cost::{parse_oracle_cost, parse_single_cost, try_parse_cost_re
 use super::oracle_dispatch::dispatch_line_nom;
 use super::oracle_effect::sequence::try_parse_same_is_true_continuation;
 use super::oracle_effect::{
-    lower_effect_chain_ir, parse_additional_cost_instead_condition_fragment, parse_effect_chain,
-    parse_effect_chain_ir, parse_effect_chain_with_context, rewrite_condition_keyword,
-    try_parse_temporal_delayed_trigger_ability,
+    lower_ability_ir, lower_effect_chain_ir, parse_additional_cost_instead_condition_fragment,
+    parse_effect_chain, parse_effect_chain_ir, parse_effect_chain_with_context,
+    rewrite_condition_keyword, try_parse_temporal_delayed_trigger_ability,
 };
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
@@ -68,6 +68,7 @@ use super::oracle_ir::doc::{
     OracleDocBuilder, OracleDocIr, OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan,
     OracleUnitSource, PrintedAbilityIndex, PrintedTriggerIndex,
 };
+use super::oracle_ir::effect_chain::AbilityIr;
 use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
@@ -3597,6 +3598,48 @@ impl<'a> DocEmitter<'a> {
         // `spells_emitted` stack (see `last_ability_node`).
         self.emit_at(line, OracleNodeIr::PreLoweredSpell(def));
     }
+
+    /// The IR seam for spell/activated bodies — Plan 05b Unit 3b, **phase A**.
+    ///
+    /// Phase A lowers **eagerly and still emits the pre-lowered node**, which is
+    /// what lets every producer convert one tranche at a time with the node
+    /// payload, `finish()`, `item_ability`, `mutate_last_spell`, `reemit_spell`
+    /// and the cross-line instead-fold all untouched — and therefore with zero
+    /// snapshot churn and a diff a reviewer can actually read. Phase B (T9)
+    /// changes this body to `self.emit_at(line, OracleNodeIr::Spell(ir))` and
+    /// every producer is already correct.
+    ///
+    /// Written as delegation to `ability_at` rather than as a second emission of
+    /// its own for two reasons. It states the phase-A identity
+    /// `ability_ir_at(l, ir) == ability_at(l, lower_ability_ir(&ir))` literally
+    /// instead of restating it as a separately-maintained copy. And it keeps the
+    /// Plan 05b burn-down ratchet (`scripts/check-prelowered-ratchet.sh`)
+    /// monotone: that gate counts a bare token textually, `oracle.rs` sits
+    /// exactly at its ceiling, and one more occurrence of that token here — in
+    /// code OR in prose — would raise the count and fail a gate whose ceiling may
+    /// only ever decrease.
+    ///
+    /// # CR 707.9a is NOT gapped by this seam
+    ///
+    /// Printed-slot stamping happens only in `OracleDocBuilder::finish`, which
+    /// runs *before* lowering, so a copy-except clause inside an IR-native
+    /// `OracleNodeIr::Spell` body can never be stamped — there is no definition
+    /// to stamp until lowering builds one (`doc.rs`, the `Spell(_)` arm advances
+    /// `ability_slot` without stamping, on purpose). That gap cannot open in
+    /// phase A: this method emits the pre-lowered spell variant, so every
+    /// phase-A-converted producer lands in the corresponding `finish()` arm and
+    /// is stamped by `stamp_retained_printed_slot`, which recurses the whole
+    /// definition (effect, `sub_ability`, `else_ability`, `mode_abilities`). The
+    /// gap becomes reachable exactly when this body switches to
+    /// `OracleNodeIr::Spell(ir)`, so moving the stamp into `lower_oracle_ir`
+    /// belongs to T9 — where it is also the only place it can be done without a
+    /// byte delta on the one pre-existing `Spell` producer, which is deliberately
+    /// not stamped today.
+    // Producer arrives in T8-A1; the allow is deleted, not moved, by that tranche.
+    #[allow(dead_code)]
+    fn ability_ir_at(&mut self, line: usize, ir: AbilityIr) {
+        self.ability_at(line, lower_ability_ir(&ir));
+    }
     fn trigger_at(&mut self, line: usize, def: TriggerDefinition) {
         self.last_trigger = Some(def.clone());
         self.emit_at(line, OracleNodeIr::PreLoweredTrigger(def));
@@ -6885,7 +6928,7 @@ fn strip_cost_reduction_node(
 /// as a `ManaSpellGrant::TriggerOnSpend` (Lapis Orb of Dragonkind, Scaled
 /// Nurturer, Gilanra). Only applies to mana abilities; otherwise the clause
 /// drops to an `Effect:when` gap.
-fn extract_mana_spend_trigger_from_chain(def: &mut AbilityDefinition) {
+pub(crate) fn extract_mana_spend_trigger_from_chain(def: &mut AbilityDefinition) {
     if !matches!(&*def.effect, Effect::Mana { .. }) {
         return;
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -157,7 +157,7 @@ pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
     EffectChainIr, OtherwiseKind, PlayerScopeRewrite, PriorModifier, ReplaceMeaningKind,
-    ReplicateKind,
+    ReplicateKind, ShellStage,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -26578,6 +26578,17 @@ pub(crate) enum ChainLoweringMode {
 /// `finalize_effect_chain` and the owner-library anchor belong here and not in
 /// `lower_effect_chain_ir`: pushing them down would newly apply them at the
 /// production callers that lower a *chain* without being a whole ability body.
+///
+/// # The order is pinned and behavior-load-bearing
+///
+/// **chain → finalize → anchor → `sub_link` → envelope stamps → stages.**
+///
+/// It is not an aesthetic choice: it reproduces what the whole-body recognizers
+/// in `oracle.rs` do by hand. Every one of them stamps its root fields *after*
+/// `parse_effect_chain_with_context` returns (which is itself this function) and
+/// runs the `extract_*` folds last. Reordering — in particular running a stage
+/// before the stamps — changes output, because both stages write root fields
+/// that a stamp may also write. Do not reorder for elegance.
 pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     let mut def = lower_effect_chain_ir(&ir.body);
     finalize_effect_chain(&mut def);
@@ -26586,10 +26597,74 @@ pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     if let Some(sub_link) = ir.shell.sub_link {
         def.sub_link = sub_link;
     }
+    apply_ability_shell_envelope(&mut def, &ir.shell);
+    for stage in &ir.shell.stages {
+        match stage {
+            ShellStage::ExtractCostReduction => {
+                crate::parser::oracle::extract_cost_reduction_from_chain(&mut def);
+            }
+            ShellStage::ExtractManaSpendTrigger => {
+                crate::parser::oracle::extract_mana_spend_trigger_from_chain(&mut def);
+            }
+        }
+    }
     def
 }
 
-fn parse_ability_ir(
+/// Apply the CR 602.1 activation envelope onto an already-lowered root.
+///
+/// Every field is **defer-on-default**, so a `default()` shell is a no-op and the
+/// widening is byte-identical by construction: `AbilityShellIr::default()` is the
+/// only shell any producer builds until T8-A1 converts the first recognizer.
+///
+/// Split out of `lower_ability_ir` so the pinned step order above reads as six
+/// named steps rather than one field-stamp wall.
+fn apply_ability_shell_envelope(def: &mut AbilityDefinition, shell: &AbilityShellIr) {
+    // CR 602.1a: the activation cost (everything before the colon).
+    if let Some(cost) = &shell.cost {
+        def.cost = Some(cost.clone());
+    }
+    // CR 601.2f: an explicitly stamped reduction. A site that sets this must not
+    // also list `ShellStage::ExtractCostReduction`, which derives the same field.
+    if let Some(cost_reduction) = &shell.cost_reduction {
+        def.cost_reduction = Some(cost_reduction.clone());
+    }
+    // CR 602.1b: activation instructions. `extend`, never `=` — see the field doc
+    // on `AbilityShellIr::activation_restrictions` for the exhaustive verification
+    // that nothing inside this function writes the root's restrictions.
+    def.activation_restrictions
+        .extend(shell.activation_restrictions.iter().cloned());
+    if let Some(restriction) = shell.activation_mana_payment_restriction {
+        def.activation_mana_payment_restriction = Some(restriction);
+    }
+    if let Some(activator_filter) = &shell.activator_filter {
+        def.activator_filter = Some(activator_filter.clone());
+    }
+    // CR 113.6m: the zone the ability functions in.
+    if let Some(activation_zone) = shell.activation_zone {
+        def.activation_zone = Some(activation_zone);
+    }
+    if let Some(ability_tag) = shell.ability_tag {
+        def.ability_tag = Some(ability_tag);
+    }
+    // CR 601.2b: `max`, so the `0` default can never lower an established floor.
+    def.min_x_value = def.min_x_value.max(shell.min_x_value);
+    // CR 707.10: monotone OR, so a `false` default can never clear the flag.
+    def.cant_be_copied |= shell.cant_be_copied;
+    if let Some(description) = &shell.description {
+        def.description = Some(description.clone());
+    }
+}
+
+/// Parse a whole ability body into its `AbilityIr` decomposition.
+///
+/// Prefer the mode-pinned wrappers [`parse_ability_ir_with_context`] and
+/// [`parse_ability_ir_standalone`] over naming a [`ChainLoweringMode`] at a call
+/// site: they exist so a recognizer converted to the IR seam inherits its
+/// original entry point's recognizer set **mechanically** rather than by a
+/// reviewer's judgment. See the `ChainLoweringMode` doc block for why the two
+/// sets must never be unified.
+pub(crate) fn parse_ability_ir(
     text: &str,
     kind: AbilityKind,
     mode: ChainLoweringMode,
@@ -26638,6 +26713,7 @@ fn parse_ability_ir(
             // no preceding ClauseBoundary can stamp its link.
             shell: AbilityShellIr {
                 sub_link: Some(SubAbilityLink::SequentialSibling),
+                ..AbilityShellIr::default()
             },
         };
     }
@@ -26648,29 +26724,61 @@ fn parse_ability_ir(
     }
 }
 
-pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
-    lower_ability_ir(&parse_ability_ir(
+/// Parse an ability body in `Standalone` mode — the mode-pinned wrapper for
+/// every site whose original body called [`parse_effect_chain`].
+///
+/// Takes no `ParseContext` **on purpose**, mirroring `parse_effect_chain`'s own
+/// signature: the standalone entry point has always parsed against a fresh
+/// `default()` context that is discarded. A converted site therefore inherits its
+/// original mode by swapping one function name, with the argument list unchanged
+/// — there is no context argument for a reviewer to get wrong.
+pub(crate) fn parse_ability_ir_standalone(text: &str, kind: AbilityKind) -> AbilityIr {
+    parse_ability_ir(
         text,
         kind,
         ChainLoweringMode::Standalone,
         &mut ParseContext::default(),
-    ))
+    )
+}
+
+/// Parse an ability body in `WithContext` mode — the mode-pinned wrapper for
+/// every site whose original body called [`parse_effect_chain_with_context`].
+///
+/// Same argument list as the function it replaces, for the same reason as
+/// [`parse_ability_ir_standalone`]. **Never** substitute one wrapper for the
+/// other while converting a site: the two modes run different whole-body
+/// recognizer sets, and crossing them silently moves ~113 die-roll cards.
+pub(crate) fn parse_ability_ir_with_context(
+    text: &str,
+    kind: AbilityKind,
+    ctx: &mut ParseContext,
+) -> AbilityIr {
+    parse_ability_ir(text, kind, ChainLoweringMode::WithContext, ctx)
+}
+
+/// The algebraic identity T8 rests on, written literally:
+/// `parse_effect_chain(t, k)` **is** `lower_ability_ir(&parse_ability_ir_standalone(t, k))`.
+pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
+    lower_ability_ir(&parse_ability_ir_standalone(text, kind))
 }
 
 /// Parse a compound effect chain with subject context for pronoun resolution.
 /// CR 608.2k: Used by the trigger parser to thread the trigger subject so that
 /// bare pronouns ("it") resolve to TriggeringSource instead of SelfRef.
+///
+/// The `WithContext` half of the same identity:
+/// `parse_effect_chain_with_context(t, k, cx)` **is**
+/// `lower_ability_ir(&parse_ability_ir_with_context(t, k, cx))`. A T8 producer
+/// conversion replaces this single call with the two halves and inserts its root
+/// stamps into the `AbilityShellIr` between them, which is why the conversion is
+/// byte-identical for the whole *class* of text the recognizer handles rather
+/// than merely for today's corpus.
 pub(crate) fn parse_effect_chain_with_context(
     text: &str,
     kind: AbilityKind,
     ctx: &mut ParseContext,
 ) -> AbilityDefinition {
-    lower_ability_ir(&parse_ability_ir(
-        text,
-        kind,
-        ChainLoweringMode::WithContext,
-        ctx,
-    ))
+    lower_ability_ir(&parse_ability_ir_with_context(text, kind, ctx))
 }
 
 /// CR 701.24a + CR 701.58a/e + CR 608.2c: Expose the Culprit mode 2 — "Exile any

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -11,12 +11,14 @@ use serde::Serialize;
 use super::ast::{ClauseBoundary, ContinuationAst, ParsedEffectClause};
 use super::doc::{OracleDocBuilder, OracleSourceSpan, OracleUnitSource};
 use crate::types::ability::{
-    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ControllerRef,
+    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag,
+    ActivationManaPaymentRestriction, ActivationRestriction, ControllerRef, CostReduction,
     DelayedTriggerCondition, MultiTargetSpec, OpponentMayScope, PlayerFilter, QuantityExpr,
     RoundingMode, SubAbilityLink, TargetFilter, TargetSelectionMode, UnlessPayModifier,
 };
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaExpiry;
+use crate::types::zones::Zone;
 
 /// Chain-level IR: the complete parsed representation of an effect chain before assembly.
 ///
@@ -121,12 +123,37 @@ impl EffectChainIr {
 /// a whole-body recognizer that must stamp a root field returns an `AbilityIr`
 /// carrying that field here, rather than a hand-built definition.
 ///
-/// **Scope is measured, not guessed.** Auditing the `return` expressions of the
-/// nine effect-side bypasses (not a field-name grep — a field set on a *nested*
-/// sub-ability reads identically to one set on the returned root) shows they set
-/// exactly `kind`, `effect`, `sub_ability`, `duration`, `player_scope`, and
-/// `sub_link`. The first five are already `ParsedEffectClause`/`ClauseIr` fields.
-/// `sub_link` is the sole residue, so it is the sole shell field.
+/// # The partition is the rules' own, not an engineering convenience
+///
+/// CR 602.1 (`MagicCompRules.txt:2514`) — *"Activated abilities have a cost and
+/// an effect. They are written as `[Cost]: [Effect.] [Activation instructions
+/// (if any).]`"* — draws exactly the seam this type sits on, and CR 113.3b
+/// (:761) repeats the tripartite form for abilities generally. So:
+///
+/// | shell field group | CR |
+/// |---|---|
+/// | `cost`, `cost_reduction` | CR 602.1a — everything before the colon (:2516) |
+/// | `activation_restrictions`, `activation_mana_payment_restriction`, `activator_filter`, `activation_zone` | CR 602.1b — activation instructions, *"not part of the ability's effect"* (:2519) |
+/// | `min_x_value` | CR 601.2b — the announced value of a variable cost (:2459) |
+/// | `ability_tag`, `cant_be_copied`, `description` | ability-level identity/provenance, not resolution steps |
+///
+/// while `EffectChainIr` holds the CR 608.2 (:2785) resolution instructions.
+/// Because the root-vs-clause axis follows a seam CR 602.1 already draws, the
+/// widening satisfies the categorical-boundary rule rather than straddling rule
+/// sections.
+///
+/// **This is 10 of `AbilityDefinition`'s 38 root fields, deliberately not a
+/// mirror of the root.** Fields excluded on purpose — `effect`, `sub_ability`,
+/// `else_ability`, `condition` — are all CR 608.2 resolution tree and are
+/// already expressible as `ClauseIr`/`ClauseDisposition`. A shell that mirrored
+/// the root would re-open the escape hatch this type exists to close.
+///
+/// # Applier semantics (see `lower_ability_ir`)
+///
+/// Every field is **defer-on-default**: an unset field leaves whatever lowering
+/// produced, so a `default()` shell is exactly today's behavior. That is what
+/// makes the widening byte-identical by construction — see the per-field docs
+/// for the one-line rule each obeys.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub(crate) struct AbilityShellIr {
     /// CR 608.2c: how the lowered root attaches to its parent — a resolution step
@@ -144,6 +171,151 @@ pub(crate) struct AbilityShellIr {
     /// `Default` is `ContinuationStep`, so a defaulted shell would silently
     /// *overwrite* the lowered stamp instead of deferring to it.
     pub(crate) sub_link: Option<SubAbilityLink>,
+
+    /// CR 602.1a: the activation cost — everything before the colon.
+    /// `Some(_)` overrides; `None` defers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cost: Option<AbilityCost>,
+
+    /// CR 601.2f: a cost reduction determined while computing total cost.
+    ///
+    /// Distinct from [`ShellStage::ExtractCostReduction`], which *derives* this
+    /// field by folding a node out of the chain. A site that stamps it
+    /// explicitly must NOT also run that stage — see the `ShellStage` docs.
+    /// `Some(_)` overrides; `None` defers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) cost_reduction: Option<CostReduction>,
+
+    /// CR 602.1b: activation instructions restricting *when* the ability may be
+    /// activated.
+    ///
+    /// **Applied with `extend`, never `=`.** The shell is applied after lowering,
+    /// and no path inside `lower_ability_ir` writes the root's
+    /// `activation_restrictions` — verified exhaustively: `rg
+    /// activation_restrictions crates/engine/src/parser/oracle_effect/` returns
+    /// zero hits, and that directory holds the whole of `lower_ability_ir`
+    /// (`lower_effect_chain_ir`, `finalize_effect_chain`, the owner-library
+    /// anchor, and all five whole-body bypasses `parse_ability_ir` dispatches
+    /// to). The only writes reachable from there land on *nested* granted/static
+    /// definitions boxed inside an `Effect` payload, never on the root the shell
+    /// stamps. So `extend` reproduces a site that wrote `=` while additionally
+    /// being correct if lowering ever does contribute one.
+    ///
+    /// Order is the site's: the vec is applied verbatim, so a site that pushed an
+    /// implicit restriction before extending with parsed ones builds its vec in
+    /// that order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) activation_restrictions: Vec<ActivationRestriction>,
+
+    /// CR 602.1b: a restriction on which mana may pay the activation cost.
+    /// `Some(_)` overrides; `None` defers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) activation_mana_payment_restriction: Option<ActivationManaPaymentRestriction>,
+
+    /// CR 602.1b: which players may activate the ability ("Any player may
+    /// activate this ability"). `Some(_)` overrides; `None` defers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) activator_filter: Option<PlayerFilter>,
+
+    /// CR 113.6m: the zone the ability functions in. `Some(_)` overrides;
+    /// `None` defers.
+    ///
+    /// Note for later tranches: the generic activated-ability recognizer derives
+    /// this field by *reading the lowered def*
+    /// (`activation_zone_from_self_cost` / `activation_zone_from_self_effect`),
+    /// which a shell stamped before lowering cannot express. That is one of the
+    /// reasons `parse_activated_ability_definition` is scoped to its own unit
+    /// rather than to T8 — this field is here for the recognizers that know
+    /// their zone from the printed keyword (Channel, Forecast), not for that one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) activation_zone: Option<Zone>,
+
+    /// The keyword/ability-word class this ability was printed under (Boast,
+    /// Exhaust, Power-up …), so meta-referencing effects can name the class.
+    /// `Some(_)` overrides; `None` defers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) ability_tag: Option<AbilityTag>,
+
+    /// CR 601.2b: the floor on an announced variable cost ("X can't be 0").
+    ///
+    /// `u32`, not `Option<u32>`, because the root field is `u32` with a `0`
+    /// default that already means "no floor". Applied with `max`, not `=`: `0`
+    /// (the shell default) can then never lower a floor lowering established,
+    /// and a site stamping `N` over a lowered `0` still yields `N`. `max` is also
+    /// exactly the semantic `raise_last_spell_min_x` will need in T9.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub(crate) min_x_value: u32,
+
+    /// CR 707.10: the stack-copy restriction printed as "This ability can't be
+    /// copied" — CR 707.10 is the rule that defines copying an activated or
+    /// triggered ability onto the stack, which is what the printed line forbids.
+    /// (Not CR 707.9a, which is the unrelated rule for copy effects that cause a
+    /// copy to *gain* an ability.)
+    ///
+    /// Applied as a monotone OR, never an assignment, so a `false` shell (the
+    /// default) cannot clear a flag lowering set. Mirrors the root field's own
+    /// `bool` rather than inventing a parallel encoding for a two-state fact the
+    /// definition already stores as a `bool`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) cant_be_copied: bool,
+
+    /// The verbatim printed text this ability was rendered from, for coverage
+    /// and UI provenance. `Some(_)` overrides; `None` defers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) description: Option<String>,
+
+    /// Chain-**structure** folds to run after the field stamps, in list order.
+    ///
+    /// Ordered `Vec`, not a set of flags: see [`ShellStage`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) stages: Vec<ShellStage>,
+}
+
+/// `serde` predicate: a `min_x_value` of `0` is the "no floor" default and is
+/// skipped, so an unset shell serializes exactly as it did before the widening.
+#[allow(clippy::trivially_copy_pass_by_ref)] // serde requires the `&T` predicate shape.
+fn is_zero(v: &u32) -> bool {
+    *v == 0
+}
+
+/// A chain-**structure** transform `lower_ability_ir` runs after the shell's
+/// field stamps, in list order.
+///
+/// # Why an ordered `Vec` and not a set of booleans
+///
+/// Both stages are folds that rewrite the `sub_ability` chain *and* write a root
+/// field, so their position relative to the field stamps is behavior-load-bearing
+/// — a plain field bag cannot express "run these two, in this order, after the
+/// stamps":
+///
+/// * [`ShellStage::ExtractCostReduction`] strips a node out of the `sub_ability`
+///   chain **and writes** `def.cost_reduction`. It must therefore not run at a
+///   site that stamped `cost_reduction` explicitly — the Power-up recognizer
+///   (`oracle.rs`, CR 702.193b) does exactly that, and running the stage there
+///   would let a chain node silently overwrite the keyword-defined reduction.
+/// * [`ShellStage::ExtractManaSpendTrigger`] early-returns unless `def.effect` is
+///   already `Effect::Mana`, so it is meaningful only *post*-lowering — it cannot
+///   be hoisted into clause assembly.
+///
+/// Variants are named for the transform, not for a call site, so the list stays
+/// a description of *what runs* rather than of *who asked*.
+// A0 builds the mechanism and converts no producers, so both variants are
+// constructed for the first time by T8-A2 (the R1 sites that run both folds).
+// The allow is DELETED by that tranche, not moved: unlike `TriggerNodeIr::Parsed`
+// there is no second home for it, because a stage with no producer is exactly
+// the state A2 ends.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) enum ShellStage {
+    /// CR 601.2f: fold a trailing self-referential "this ability costs {X} less
+    /// to activate" node out of the `sub_ability` chain into `cost_reduction`.
+    /// Runs `oracle::extract_cost_reduction_from_chain`.
+    ExtractCostReduction,
+    /// CR 106.6 + CR 603.3: fold a trailing "when you spend this mana …"
+    /// sub-ability into the parent mana effect's `grants`. Runs
+    /// `oracle::extract_mana_spend_trigger_from_chain`, which is a no-op unless
+    /// the lowered root effect is already `Effect::Mana`.
+    ExtractManaSpendTrigger,
 }
 
 /// An effect chain plus the root-level metadata applied around it.


### PR DESCRIPTION
Plan 05b tranche **T8-A0** — the ability shell widening. **Infrastructure only: zero producers
converted, zero call sites changed.**

Follows #6709 (T5). This is the foundation the rest of T8 stands on: it builds the mechanism that
makes A1–A4's recognizer conversions mechanical rather than a per-site judgment call.

## What landed

1. `AbilityShellIr` widened from `{ sub_link }` to the **CR 602.1 activation envelope** — 10 of
   `AbilityDefinition`'s 38 root fields, deliberately *not* a mirror of the root.
2. An ordered `stages: Vec<ShellStage>`, because two of the transforms the call sites run are chain
   **structure** folds that write root fields, and their order relative to the field stamps is
   load-bearing. A field bag cannot express "run these two, in this order, after the stamps."
3. `lower_ability_ir` extended to apply the envelope and the stages in the pinned order
   **chain → finalize → anchor → `sub_link` → envelope → stages**.
4. `parse_ability_ir` published as `pub(crate)`, plus the two mode-pinned wrappers
   `parse_ability_ir_with_context` / `parse_ability_ir_standalone`. These exist so a converted site
   inherits its original `ChainLoweringMode` **by name** rather than by a reviewer re-deriving it at
   nine call sites.
5. The `ability_ir_at` emitter, which still emits the pre-lowered node.

## Byte-identity is by construction, and the property has a name

**Defer-on-default**: every shell field's applier is a no-op at its default, so
`AbilityShellIr::default()` — the only shell any producer builds until A1 — leaves the lowered
definition bit-for-bit unchanged. In `apply_ability_shell_envelope`: `Option` fields write only under
`if let Some`; `activation_restrictions` extends from an empty vec; `min_x_value` uses `max` against
`0`; `cant_be_copied` ORs with `false`; the stage loop iterates an empty `Vec`.

No property of any card's text participates, so a future MTGJSON card reaching one of these sites is
covered by the same argument.

The identity is now also **literal in the tree** rather than merely argued: `parse_effect_chain` is
exactly `lower_ability_ir(&parse_ability_ir_standalone(t, k))`, and `parse_effect_chain_with_context`
its `WithContext` twin.

## H3 — the verification the plan explicitly deferred to the implementer: PASSED, no site excluded

The live sites split between `activation_restrictions = constraints` (U0-23 Channel, U0-12 leveler)
and `.extend(constraints)` (U0-24/25/27). `extend` is the only correct shell semantic, but that is
only sound if nothing in `lower_ability_ir`'s closure writes the root field first.

`parse_ability_ir` can dispatch to exactly **five** whole-body paths, plus three post-parse steps.
Every one lives in `crates/engine/src/parser/oracle_effect/`, and that entire directory contains
**zero** occurrences of `activation_restrictions` at the base commit. That is the whole closure, so
no bypass writes the root's restrictions.

The check did not stop at the file grep, because `oracle_effect/` *does* call into modules that write
the field. All six such calls go to `oracle_static`, and every result is boxed into a
`GrantStaticAbility` / `StaticDefinition` / `CreateEmblem` **inside an `Effect` payload** — those land
on *nested* definitions, never the root the shell stamps, and `StaticDefinition` has no
`activation_restrictions` field at all.

**Verdict: `extend` ≡ `=` for the root at every T8 R1 site; both `=` sites provably start from empty;
nothing is excluded from T8.** The invariant is maintainable — any future violation has to write the
field inside `oracle_effect/`, which the same one-line grep catches.

## One thing A1–A4 must not "tidy"

Restriction **order** is site-specific. The Solved recognizer pushes `IsSolved` *before* extending
with parsed constraints; Boast/Exhaust/Forecast/Power-up extend parsed constraints *first*, then push
their implicit ones. A shell with separate "implicit"/"parsed" fields would silently normalize that
away. Hence one ordered `Vec` composed by the site, applied by a single `extend`.

## CR 707.9a is not gapped by this seam

`ability_ir_at` emits the pre-lowered spell variant, so every phase-A-converted producer lands in
`finish()`'s pre-lowered arm and is stamped by `stamp_retained_printed_slot` — which recurses the
whole definition (effect, `sub_ability`, `else_ability`, `mode_abilities`). A copy-except clause
inside a converted body *is* stamped, at the same slot it got before. A0 adds zero new reachable
instances.

Moving the stamp to `lower_oracle_ir` (the recensus's T9 recommendation) would be **actively unsafe
here**: it would newly stamp U0-39's `Spell` node, which #6708 deliberately leaves unstamped. That
changes output for any card pairing a prevention spell with a copy-except clause — an intentional byte
delta, which this tranche is chartered not to land. T9 is the right home, because that is where the
emitter switches payloads *and* where U0-39's delta is already being adjudicated.

## Gates

```
cargo fmt --all                                      clean
cargo clippy -p engine --lib -- -D warnings          zero warnings
cargo nextest run -p engine --lib                    17844 tests run: 17844 passed, 6 skipped
./scripts/check-prelowered-ratchet.sh                Gate P PASS
./scripts/check-skill-doc.sh                         ✓ oracle-parser skill references valid
./scripts/check-parser-combinators.sh                Gate G PASS / Gate A PASS
```

**Snapshot churn: ZERO**, as an infrastructure-only tranche requires. `find . -name '*.snap.new'` → 0
files after the full 17844-test run; the complete branch delta is three parser files, no `*_ir.snap`,
no `*_lowered.snap`, no card-data. Gate P per-file counts are identical to baseline with **no ledger
edit** — every file sits exactly at its ceiling, so nothing was silently loosened.

**Gate P caught a real defect in the first draft, which is worth recording.** It raised `oracle.rs`
16 → 21, and not one of the five came from code — all five were the token appearing in a new doc
comment. The gate is textual; your own prose counts. The prose was rewritten to carry the meaning
without the token.

That is also why `ability_ir_at` is written as `self.ability_at(line, lower_ability_ir(&ir))` rather
than spelling out the `emit_at(.., PreLoweredSpell(..))` form: `ability_at` **is** exactly that
`emit_at`, so the two are behaviorally identical, but the spelled-out form would push `oracle.rs` to
17 against a ceiling of 16. Delegation adds zero tokens and states the phase-A identity once instead
of maintaining a second copy of it. T9's one-line body swap is unaffected. No ceiling was raised.

## Deliberate `#[allow(dead_code)]`, both with a named owner

`ShellStage` (first producer arrives in **A2**, the R1 sites running both folds) and `ability_ir_at`
(first producer in **A1**). Unlike `TriggerNodeIr::Parsed`, neither allow *moves* — both are
**deleted** by the tranche that adds the first producer, and the code comments say so.

## Not run, and why

Full-pool `card-data.json` byte-identity. For a tranche that converts no producers it is *vacuously*
green and therefore supplies no signal; manufacturing a green that cannot be interpreted was declined
in favour of saying so. The non-vacuity probe belongs to A1, which is the first tranche with a
converted site to mis-mode.

CR numbers grep-verified against `docs/MagicCompRules.txt` before entering code: 602.1, 602.1a,
602.1b, 113.3b, 601.2b, 608.2, 601.2f, 113.6m, 707.9a, 702.142a, 702.193b, 106.6, 603.3, 707.10.

One was corrected in draft: `cant_be_copied` was annotated CR 707.9a, which is the unrelated rule for
copy effects that cause a copy to *gain* an ability. The printed line "This ability can't be copied"
restricts putting a copy on the stack — **CR 707.10**. Both the field doc and the applier now cite
707.10 and say why it is not 707.9a.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved ability and effect-chain parsing for more consistent handling of activation costs, restrictions, copying rules, and minimum values.
  * Improved detection of mana-spend triggers and cost-reduction effects during ability processing.
  * Refined serialization so default or empty values are omitted from generated output.

* **Bug Fixes**
  * Improved preservation of ability properties when combining and lowering effect-chain information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->