### PR TITLE
refactor(parser): Plan 05b T8-A1 — the first two producer conversions (U0-22, U0-26)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -58,9 +58,10 @@ use super::oracle_cost::{parse_oracle_cost, parse_single_cost, try_parse_cost_re
 use super::oracle_dispatch::dispatch_line_nom;
 use super::oracle_effect::sequence::try_parse_same_is_true_continuation;
 use super::oracle_effect::{
-    lower_ability_ir, lower_effect_chain_ir, parse_additional_cost_instead_condition_fragment,
-    parse_effect_chain, parse_effect_chain_ir, parse_effect_chain_with_context,
-    rewrite_condition_keyword, try_parse_temporal_delayed_trigger_ability,
+    lower_ability_ir, lower_effect_chain_ir, parse_ability_ir_with_context,
+    parse_additional_cost_instead_condition_fragment, parse_effect_chain, parse_effect_chain_ir,
+    parse_effect_chain_with_context, rewrite_condition_keyword,
+    try_parse_temporal_delayed_trigger_ability,
 };
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
@@ -3635,8 +3636,6 @@ impl<'a> DocEmitter<'a> {
     /// belongs to T9 — where it is also the only place it can be done without a
     /// byte delta on the one pre-existing `Spell` producer, which is deliberately
     /// not stamped today.
-    // Producer arrives in T8-A1; the allow is deleted, not moved, by that tranche.
-    #[allow(dead_code)]
     fn ability_ir_at(&mut self, line: usize, ir: AbilityIr) {
         self.ability_at(line, lower_ability_ir(&ir));
     }
@@ -4475,22 +4474,31 @@ pub(crate) fn parse_oracle_ir(
                 let (effect_text, constraints) = strip_activated_constraints(effect_text);
                 let cost = parse_oracle_cost(cost_text);
 
+                // The `ParseContext` reset is a parser side effect, not part of
+                // the CR 602.1 envelope: it must keep firing here, before the
+                // parse, and so stays at the call site rather than moving into
+                // the shell.
                 ctx.subject = None;
                 ctx.actor = None;
-                let mut def =
-                    parse_effect_chain_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
-                def.cost = Some(cost);
-                def.description = Some(line.to_string());
+                let mut ir =
+                    parse_ability_ir_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
+                // CR 602.1a: the activation cost, everything before the colon.
+                ir.shell.cost = Some(cost);
+                ir.shell.description = Some(line.to_string());
+                // CR 602.1b: the activation instructions, composed in the order
+                // this recognizer applies them — the implicit restriction LEADS
+                // and the parsed ones follow. The shell applies the vec verbatim,
+                // so this order is preserved rather than normalized against the
+                // Power-up recognizer below, which is deliberately the reverse.
+                //
                 // CR 719.3c: Solved abilities only activate while Case is solved.
-                def.activation_restrictions
-                    .push(ActivationRestriction::IsSolved);
+                let mut activation_restrictions = vec![ActivationRestriction::IsSolved];
                 // CR 602.5d: `constraints.restrictions` already contains
                 // `AsSorcery` when the source text said "Activate only as a
-                // sorcery"; extend preserves it so the legality gate fires.
-                if !constraints.restrictions.is_empty() {
-                    def.activation_restrictions.extend(constraints.restrictions);
-                }
-                emitter.ability_at(item_line, def);
+                // sorcery"; extending preserves it so the legality gate fires.
+                activation_restrictions.extend(constraints.restrictions);
+                ir.shell.activation_restrictions = activation_restrictions;
+                emitter.ability_ir_at(item_line, ir);
                 i += 1;
                 continue;
             }
@@ -4609,18 +4617,31 @@ pub(crate) fn parse_oracle_ir(
                 let cost = parse_oracle_cost(cost_text);
                 ctx.subject = None;
                 ctx.actor = None;
-                let mut def =
-                    parse_effect_chain_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
-                def.cost = Some(cost);
-                def.description = Some(line.to_string());
-                def.activation_restrictions.extend(constraints.restrictions);
+                let mut ir =
+                    parse_ability_ir_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
+                // CR 602.1a: the activation cost, everything before the colon.
+                ir.shell.cost = Some(cost);
+                ir.shell.description = Some(line.to_string());
+                // CR 602.1b: the activation instructions, composed in this
+                // recognizer's own order — the parsed constraints LEAD and the
+                // implicit restriction trails, the reverse of the Solved
+                // recognizer above. The shell applies the vec verbatim, so the
+                // two orders are preserved rather than unified.
+                //
                 // CR 702.193a: power-up may be activated only once.
-                def.activation_restrictions
-                    .push(ActivationRestriction::OnlyOnce);
-                def.ability_tag = Some(AbilityTag::PowerUp);
+                let mut activation_restrictions = constraints.restrictions;
+                activation_restrictions.push(ActivationRestriction::OnlyOnce);
+                ir.shell.activation_restrictions = activation_restrictions;
+                ir.shell.ability_tag = Some(AbilityTag::PowerUp);
                 // CR 702.193b + CR 602.2b + CR 601.2f + CR 302.6: the activation cost's
                 // generic mana is reduced by the source's mana value if it entered this turn.
-                def.cost_reduction = Some(CostReduction {
+                //
+                // Stamped explicitly from the keyword definition, which is why
+                // `shell.stages` stays EMPTY here: this is the one site in the
+                // family that does not derive the reduction from the chain, and
+                // `ShellStage::ExtractCostReduction` would both overwrite this
+                // value and strip a node out of the `sub_ability` chain.
+                ir.shell.cost_reduction = Some(CostReduction {
                     mode: crate::types::statics::CostModifyMode::Reduce,
                     amount_per: 1,
                     count: QuantityExpr::Ref {
@@ -4628,7 +4649,7 @@ pub(crate) fn parse_oracle_ir(
                     },
                     condition: Some(ParsedCondition::SourceEnteredThisTurn),
                 });
-                emitter.ability_at(item_line, def);
+                emitter.ability_ir_at(item_line, ir);
                 i += 1;
                 continue;
             }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -1354,6 +1354,37 @@ fn case_of_the_crimson_pulse() {
     insta::assert_json_snapshot!("case_of_the_crimson_pulse_lowered", &lowered);
 }
 
+/// CR 719.3c: the **activated** `"Solved — {cost}: {effect}"` shape, which the
+/// sibling `case_of_the_crimson_pulse` fixture above does NOT reach — its Solved
+/// clause is a triggered ability, so it never passes `find_activated_colon`.
+///
+/// Landed with T8-A1 because the §5.3 non-vacuity probe measured the gap rather
+/// than assuming it: with a `panic!` at the recognizer, **zero** of the 17844
+/// `--lib` tests fired, and the only two tests that reach it at all
+/// (`case_solve_condition`) assert on `is_solved` and use `"Solved — {T}: Add
+/// {R}."` — a fixture with **empty** parsed constraints, so it cannot observe the
+/// activation-restriction vector at all. Dropping the implicit
+/// `ActivationRestriction::IsSolved` stayed green across every one of them.
+///
+/// Case of the Stashed Skeleton is chosen because its trailing "Activate only as
+/// a sorcery." makes `strip_activated_constraints` yield a **non-empty**
+/// `constraints.restrictions`. The snapshot therefore pins both halves of the
+/// vector *and their order* — implicit `IsSolved` first (CR 719.3c), parsed
+/// `AsSorcery` second (CR 602.5d) — which is the one property of this recognizer
+/// that T8's shell conversion could silently normalize away, since the Power-up
+/// recognizer composes the same vector in the opposite order.
+#[test]
+fn case_of_the_stashed_skeleton() {
+    let (ir, lowered) = parse_two_layer(
+        "When this Case enters, create a 2/1 black Skeleton creature token and suspect it. (It has menace and can't block.)\nTo solve — You control no suspected Skeletons. (If unsolved, solve at the beginning of your end step.)\nSolved — {1}{B}, Sacrifice this Case: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
+        "Case of the Stashed Skeleton",
+        &["Enchantment"],
+        &["Case"],
+    );
+    insta::assert_json_snapshot!("case_of_the_stashed_skeleton_ir", &ir);
+    insta::assert_json_snapshot!("case_of_the_stashed_skeleton_lowered", &lowered);
+}
+
 #[test]
 fn aerial_formation() {
     let (ir, lowered) = parse_two_layer(

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
@@ -1,0 +1,249 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 111,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "When this ~ enters, create a 2/1 black Skeleton creature token and suspect it. (It has menace and can't block.)"
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Token",
+              "name": "Skeleton",
+              "power": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "toughness": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "types": [
+                "Creature",
+                "Skeleton"
+              ],
+              "colors": [
+                "Black"
+              ],
+              "keywords": [],
+              "tapped": false,
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "owner": {
+                "type": "Controller"
+              },
+              "enters_attacking": false
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "SelfRef"
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "When this ~ enters, create a 2/1 black Skeleton creature token and suspect it.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 112,
+          "end_byte": 216,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "To solve — You control no suspected Skeletons. (If unsolved, solve at the beginning of your end step.)"
+      },
+      "node": {
+        "SolveCondition": {
+          "type": "ObjectCount",
+          "filter": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature",
+              {
+                "Subtype": "Skeleton"
+              }
+            ],
+            "controller": "You",
+            "properties": [
+              {
+                "type": "Suspected"
+              }
+            ]
+          },
+          "comparator": "EQ",
+          "threshold": 0
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 2,
+          "last_line": 2,
+          "start_byte": 217,
+          "end_byte": 350,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Solved — {1}{B}, Sacrifice this ~: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "SearchLibrary",
+            "filter": {
+              "type": "Typed",
+              "type_filters": [
+                "Card"
+              ],
+              "controller": null,
+              "properties": []
+            },
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "reveal": false
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Black"
+                  ],
+                  "generic": 1
+                }
+              },
+              {
+                "type": "Sacrifice",
+                "target": {
+                  "type": "SelfRef"
+                },
+                "count": 1
+              }
+            ]
+          },
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "ChangeZone",
+              "origin": "Library",
+              "destination": "Hand",
+              "target": {
+                "type": "Any"
+              },
+              "owner_library": false,
+              "enter_transformed": false,
+              "enter_tapped": false,
+              "enters_attacking": false
+            },
+            "cost": null,
+            "sub_ability": {
+              "kind": "Spell",
+              "effect": {
+                "type": "Shuffle",
+                "target": {
+                  "type": "Controller"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            },
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": null,
+          "description": "Solved — {1}{B}, Sacrifice this ~: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "IsSolved"
+            },
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "When this Case enters, create a 2/1 black Skeleton creature token and suspect it. (It has menace and can't block.)\nTo solve — You control no suspected Skeletons. (If unsolved, solve at the beginning of your end step.)\nSolved — {1}{B}, Sacrifice this Case: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
+  "card_name": "Case of the Stashed Skeleton"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_lowered.snap
@@ -1,0 +1,192 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "SearchLibrary",
+        "filter": {
+          "type": "Typed",
+          "type_filters": [
+            "Card"
+          ],
+          "controller": null,
+          "properties": []
+        },
+        "count": {
+          "type": "Fixed",
+          "value": 1
+        },
+        "reveal": false
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Black"
+              ],
+              "generic": 1
+            }
+          },
+          {
+            "type": "Sacrifice",
+            "target": {
+              "type": "SelfRef"
+            },
+            "count": 1
+          }
+        ]
+      },
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "ChangeZone",
+          "origin": "Library",
+          "destination": "Hand",
+          "target": {
+            "type": "Any"
+          },
+          "owner_library": false,
+          "enter_transformed": false,
+          "enter_tapped": false,
+          "enters_attacking": false
+        },
+        "cost": null,
+        "sub_ability": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Shuffle",
+            "target": {
+              "type": "Controller"
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        },
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": null,
+      "description": "Solved — {1}{B}, Sacrifice this ~: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "IsSolved"
+        },
+        {
+          "type": "AsSorcery"
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [
+    {
+      "mode": "ChangesZone",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Token",
+          "name": "Skeleton",
+          "power": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "toughness": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "types": [
+            "Creature",
+            "Skeleton"
+          ],
+          "colors": [
+            "Black"
+          ],
+          "keywords": [],
+          "tapped": false,
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "owner": {
+            "type": "Controller"
+          },
+          "enters_attacking": false
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "SelfRef"
+      },
+      "origin": null,
+      "destination": "Battlefield",
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "When this ~ enters, create a 2/1 black Skeleton creature token and suspect it.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": [],
+  "solveCondition": {
+    "type": "ObjectCount",
+    "filter": {
+      "type": "Typed",
+      "type_filters": [
+        "Creature",
+        {
+          "Subtype": "Skeleton"
+        }
+      ],
+      "controller": "You",
+      "properties": [
+        {
+          "type": "Suspected"
+        }
+      ]
+    },
+    "comparator": "EQ",
+    "threshold": 0
+  }
+}


### PR DESCRIPTION
Plan 05b tranche **T8-A1** — the first two producer conversions through A0's ability shell.
Follows #6714 (A0), which built the mechanism this consumes.

Two sites, both recipe **R1**, both with no stages: **U0-22** (CR 719.3c, activated `Solved`) and
**U0-26** (CR 702.193a-b, Power-up).

Two commits, deliberately separable: the conversion touches only `oracle.rs` (+47/−26); the §5.3
remediation guard is purely additive.

## The conversion

The identity is already in the tree, so this is a rewrite rather than a redesign:

```
parse_effect_chain_with_context(t,k,cx)  ==  lower_ability_ir(&parse_ability_ir_with_context(t,k,cx))
phase-A  ability_ir_at(l, ir)            ==  ability_at(l, lower_ability_ir(&ir))
```

Both sites' original entry point was `parse_effect_chain_with_context(&effect_text,
AbilityKind::Activated, &mut ctx)`, so both take `parse_ability_ir_with_context` — chosen **by name**
per §7.1, not by re-deriving the mode at the call site. That is the entire point of A0's mode-pinned
wrappers.

`ability_ir_at`'s `#[allow(dead_code)]` is **deleted**, not moved — A0 assigned it to whichever
tranche added the first producer, and this is that tranche. `ShellStage`'s own allow stays; A2 owns it.

## Restriction order is preserved, and the two sites disagree on purpose

```rust
// U0-22 — implicit LEADS
let mut activation_restrictions = vec![ActivationRestriction::IsSolved];
activation_restrictions.extend(constraints.restrictions);

// U0-26 — parsed LEADS
let mut activation_restrictions = constraints.restrictions;
activation_restrictions.push(ActivationRestriction::OnlyOnce);
```

These are exact reverses of one another, and both reproduce their original `push`/`extend` sequence.
This is why A0 carries **one ordered `Vec` composed by the site** rather than separate
"implicit"/"parsed" fields — a split shell would silently normalize the asymmetry away. Each site now
carries a comment pointing at the other, so a future tidying refactor has to read the asymmetry before
unifying it.

U0-22's `ParseContext` reset stays at the call site, before the parse, untouched: it is a parser side
effect with different timing, not part of the CR 602.1 envelope.

U0-26 stamps `cost_reduction` explicitly from the keyword definition and leaves `stages` **empty**.
Listing `ShellStage::ExtractCostReduction` there would both overwrite the keyword-defined value and
strip a node out of the `sub_ability` chain. Commented in place.

## §5.3 non-vacuity: two null results reported as findings, one of them remediated

A reachability probe ran first, because a green perturbation is ambiguous between "identical" and
"never executed".

**Reachability** (temporary `panic!` at both sites): U0-22 fires in **zero** of 17,844 `--lib` tests
but **is** reached by 2 integration tests; U0-26 by 1 `--lib` and 10 integration tests. The `--lib`
zero initially read as "wholly untested" and that reading was **falsified** by the integration run —
recorded here because the narrower true statement is the useful one.

**Null result 1 — wrong `ChainLoweringMode` at both sites: no divergence.** The two modes differ only
by `parse_face_down_pile_ir` / `try_parse_exile_pile_shuffle_cloak`, and no Solved or Power-up fixture
reaches either. The mode axis is **extensionally inert at these two sites**, so mode preservation here
rests entirely on the by-construction argument and §7.1's name-matching rule — not on any test. §5.3's
suggested probe ("watch full-pool regeneration go red on die-result cards") does not apply here; the
~113 die-roll cards §7.1 warns about are unreachable from these recognizers. A2/A3 should not expect a
red from it either, and should re-run the probe per-tranche rather than inheriting this null.

**Null result 2 — deleting U0-22's implicit `IsSolved`: no divergence.** That is a genuine semantic
change (a Solved ability becomes activatable while unsolved) and nothing caught it. Root cause,
measured: the only fixture reaching U0-22 is `"Solved — {T}: Add {R}."` — no trailing activation
instruction, so `constraints.restrictions` is **empty**, making the fixture degenerate on exactly the
axis this conversion touches. Its assertions target `is_solved`, not the activation envelope. The
sibling `case_of_the_crimson_pulse` fixture is a decoy: its Solved clause is *triggered*, so it never
passes `find_activated_colon`.

**Perturbation that did go red** — U0-26's `cost_reduction` blanked:
```
FAIL power_up_keyword::power_up_cost_reduced_by_source_mana_value_when_entered_this_turn
ActivateAbility must be accepted by the engine: ActionNotAllowed("Cannot pay mana cost")
```

## The remediation (second commit)

A two-layer snapshot for **Case of the Stashed Skeleton**, whose Oracle text was taken verbatim from
the card pool:

> Solved — {1}{B}, Sacrifice this Case: Search your library for a card, put it into your hand, then
> shuffle. **Activate only as a sorcery.**

Chosen for being **non-degenerate**: the trailing activation instruction makes
`constraints.restrictions` non-empty, so the fixture reaches the two-element arm and pins both halves
*and their order*:

```json
"activation_restrictions": [ { "type": "IsSolved" }, { "type": "AsSorcery" } ]
```

A card with only one restriction would witness that the field is populated while saying nothing about
sequencing — and sequencing is the property at risk. Watched go red on a pure order swap:

```
229  232 │   "type": "IsSolved"
230      │-  },
231      │-  { "type": "AsSorcery"
FAIL engine parser::oracle_ir::snapshot_tests::case_of_the_stashed_skeleton
```

It lives in `oracle_ir/snapshot_tests.rs` rather than `tests/integration/` on purpose: as an inline
`#[cfg(test)]` src module it runs under `--lib`, which is what closes the measured reachability hole,
and it reuses the existing `parse_two_layer` harness next to its near-miss sibling. No new test binary
is created. 4 pool cards reach this recognizer (Case of the Burning Masks / Filched Falcon / Stashed
Skeleton / Uneaten Feast); 37 reach Power-up.

## Gates

```
cargo fmt --all                                      clean
cargo clippy -p engine --lib -- -D warnings          zero warnings
cargo nextest run -p engine --lib                    17845 tests run: 17845 passed, 6 skipped
./scripts/check-prelowered-ratchet.sh                Gate P PASS
./scripts/check-skill-doc.sh                         ✓ oracle-parser skill references valid
./scripts/check-parser-combinators.sh                Gate G PASS / Gate A PASS
```

**Snapshot churn: ZERO existing snapshots changed.** `git diff --name-status <base>..HEAD` is **2 A /
2 M**, both modified files are source; every snapshot in the diff is an add, for a card that had no
prior fixture. `find . -name '*.snap.new'` → empty.

`oracle.rs` stayed at **16** on the ratchet, which is correct and worth restating: all 16 occurrences
are consumer match arms, emitter method bodies and prose — none at producer call sites. **The metric
tracks helper deletion, not producer conversion**, so a tranche that converts producers can and does
leave it unmoved. Ledger not edited; no count rose.

## Harvest (§5.4)

1. **§5.3's own suggested probe does not work at these sites** — see null result 1. Recommend the plan
   qualify it as applicable only to sites whose effect text can reach the two `WithContext`-only
   recognizers.
2. **`case_of_the_crimson_pulse` is a decoy fixture** — its name and Case/Solved shape imply coverage
   of the Solved family, but it exercises only the *triggered* branch. Worth a note so nobody else
   counts it as coverage for U0-22.
3. **Pre-existing CR-fidelity gap at U0-26, not fixed.** CR 702.193a reduces the cost by the
   permanent's **mana cost**, and 702.193b splits colored/colorless from generic. The implementation
   reduces **generic** by `QuantityRef::SelfManaValue` — the total mana *value*. For a `{2}{R}{R}`
   source that is 4 generic rather than 2 generic + 2 red. Pre-existing and unchanged here; fixing it
   inside a byte-identity tranche would contaminate the gate.
4. **Pre-existing questionable citation at U0-26**: `// CR 702.193b + CR 602.2b + CR 601.2f + CR 302.6`
   — CR 302.6 is the summoning-sickness rule and does not describe a cost reduction. The number exists;
   the text does not support the use. Left verbatim to keep the diff surgical.
5. **Dead guard removed**: U0-22's `if !constraints.restrictions.is_empty()` wrapped an `extend`, which
   is already a no-op on an empty vec — provably behavior-identical.
6. **Census rows 142 and 146 are accurate**, and their `needs-design` label was pessimistic. Both were
   mechanical under A0's shell; recipe R1 worked exactly as specified.

## Known limitation

Full-pool `card-data` regeneration was not run locally — Tilt owns it and §5.0 says read it, don't run
it. Byte-identity here rests on the by-construction argument, zero snapshot churn, and 17,845 green
lib tests plus the integration binary. CI's card-data job is the empirical check.

CR numbers grep-verified against `docs/MagicCompRules.txt` before entering code, text checked rather
than existence alone: 602.1, 602.1a, 602.1b, 602.5d, 719.3c added; 702.193a, 702.193b, 602.2b, 601.2f,
302.6 verified as preserved context lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of “Solved” and “Power-up” activated abilities.
  * Ensured activation costs, restrictions, descriptions, ability tags, and cost reductions are applied consistently.

* **Tests**
  * Added coverage for a “Solved — {cost}: {effect}” ability pattern.
  * Expanded snapshots to verify both intermediate parsing and final ability output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->