### PR TITLE
refactor(parser): Plan 05b T8-A2 — the four R1 sites that run both extract_* stages

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -69,7 +69,7 @@ use super::oracle_ir::doc::{
     OracleDocBuilder, OracleDocIr, OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan,
     OracleUnitSource, PrintedAbilityIndex, PrintedTriggerIndex,
 };
-use super::oracle_ir::effect_chain::AbilityIr;
+use super::oracle_ir::effect_chain::{AbilityIr, ShellStage};
 use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
@@ -4515,20 +4515,35 @@ pub(crate) fn parse_oracle_ir(
                 let cost = parse_oracle_cost(cost_text);
                 ctx.subject = None;
                 ctx.actor = None;
-                let mut def =
-                    parse_effect_chain_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
-                def.cost = Some(cost);
+                let mut ir =
+                    parse_ability_ir_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
+                // CR 602.1a: the activation cost, everything before the colon.
+                ir.shell.cost = Some(cost);
                 // CR 207.2c: Channel is an ability word; the underlying ability activates from hand.
-                def.activation_zone = Some(Zone::Hand);
-                def.description = Some(line.to_string());
-                if !constraints.restrictions.is_empty() {
-                    def.activation_restrictions = constraints.restrictions;
-                }
-                // CR 601.2f: Extract self-referential cost reduction from the terminal
-                // sub_ability in the chain (it may be several levels deep).
-                extract_cost_reduction_from_chain(&mut def);
-                extract_mana_spend_trigger_from_chain(&mut def);
-                emitter.ability_at(item_line, def);
+                ir.shell.activation_zone = Some(Zone::Hand);
+                ir.shell.description = Some(line.to_string());
+                // CR 602.1b: the activation instructions. This site is the one in
+                // the family whose original wrote `=` (guarded by an is-empty
+                // check) rather than `extend`, and the two are equivalent here:
+                // nothing reachable from `lower_ability_ir` writes the root's
+                // `activation_restrictions` (`rg activation_restrictions
+                // crates/engine/src/parser/oracle_effect/` hits only the shell
+                // applier itself), so the field is empty when the shell runs and
+                // `extend` onto empty reproduces the assignment exactly. The
+                // guard was therefore already redundant: assigning an empty vec
+                // and skipping the assignment are the same state.
+                ir.shell.activation_restrictions = constraints.restrictions;
+                // CR 601.2f: fold a self-referential cost reduction out of the
+                // terminal `sub_ability` in the chain (it may be several levels
+                // deep), then CR 106.6 + CR 603.3 fold a trailing "when you spend
+                // this mana" sub-ability into the mana effect. Both are chain
+                // *structure* folds that run after the field stamps, in this
+                // order — see `ShellStage`.
+                ir.shell.stages = vec![
+                    ShellStage::ExtractCostReduction,
+                    ShellStage::ExtractManaSpendTrigger,
+                ];
+                emitter.ability_ir_at(item_line, ir);
                 i += 1;
                 continue;
             }
@@ -4548,25 +4563,35 @@ pub(crate) fn parse_oracle_ir(
                 let cost = parse_oracle_cost(cost_text);
                 ctx.subject = None;
                 ctx.actor = None;
-                let mut def =
-                    parse_effect_chain_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
-                def.cost = Some(cost);
-                def.description = Some(line.to_string());
-                def.activation_restrictions.extend(constraints.restrictions);
+                let mut ir =
+                    parse_ability_ir_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
+                // CR 602.1a: the activation cost, everything before the colon.
+                ir.shell.cost = Some(cost);
+                ir.shell.description = Some(line.to_string());
+                // CR 602.1b: the activation instructions, composed in this
+                // recognizer's own order — the parsed constraints LEAD and the
+                // two implicit restrictions trail. The relative order of the two
+                // implicit ones is preserved as printed here as well; it is the
+                // reverse of the order CR 702.142a states them in, which is a
+                // pre-existing property of this site and not something the
+                // conversion may quietly normalize.
+                let mut activation_restrictions = constraints.restrictions;
                 // CR 702.142a: "Activate only if this creature attacked this turn
                 // and only once each turn."
-                def.activation_restrictions
-                    .push(ActivationRestriction::OnlyOnceEachTurn);
-                def.activation_restrictions
-                    .push(ActivationRestriction::RequiresCondition {
-                        condition: Some(ParsedCondition::SourceAttackedThisTurn),
-                    });
+                activation_restrictions.push(ActivationRestriction::OnlyOnceEachTurn);
+                activation_restrictions.push(ActivationRestriction::RequiresCondition {
+                    condition: Some(ParsedCondition::SourceAttackedThisTurn),
+                });
+                ir.shell.activation_restrictions = activation_restrictions;
                 // CR 702.142b: Tag this ability as originating from Boast so
                 // effects can reference "boast abilities" as a class.
-                def.ability_tag = Some(AbilityTag::Boast);
-                extract_cost_reduction_from_chain(&mut def);
-                extract_mana_spend_trigger_from_chain(&mut def);
-                emitter.ability_at(item_line, def);
+                ir.shell.ability_tag = Some(AbilityTag::Boast);
+                // CR 601.2f then CR 106.6 + CR 603.3, in this order — see `ShellStage`.
+                ir.shell.stages = vec![
+                    ShellStage::ExtractCostReduction,
+                    ShellStage::ExtractManaSpendTrigger,
+                ];
+                emitter.ability_ir_at(item_line, ir);
                 i += 1;
                 continue;
             }
@@ -4585,17 +4610,23 @@ pub(crate) fn parse_oracle_ir(
                 let cost = parse_oracle_cost(cost_text);
                 ctx.subject = None;
                 ctx.actor = None;
-                let mut def =
-                    parse_effect_chain_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
-                def.cost = Some(cost);
-                def.description = Some(line.to_string());
-                def.activation_restrictions.extend(constraints.restrictions);
-                def.activation_restrictions
-                    .push(ActivationRestriction::OnlyOnce);
-                def.ability_tag = Some(AbilityTag::Exhaust);
-                extract_cost_reduction_from_chain(&mut def);
-                extract_mana_spend_trigger_from_chain(&mut def);
-                emitter.ability_at(item_line, def);
+                let mut ir =
+                    parse_ability_ir_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
+                // CR 602.1a: the activation cost, everything before the colon.
+                ir.shell.cost = Some(cost);
+                ir.shell.description = Some(line.to_string());
+                // CR 602.1b: parsed constraints LEAD, the implicit restriction trails.
+                let mut activation_restrictions = constraints.restrictions;
+                // CR 702.177a: "Activate only once."
+                activation_restrictions.push(ActivationRestriction::OnlyOnce);
+                ir.shell.activation_restrictions = activation_restrictions;
+                ir.shell.ability_tag = Some(AbilityTag::Exhaust);
+                // CR 601.2f then CR 106.6 + CR 603.3, in this order — see `ShellStage`.
+                ir.shell.stages = vec![
+                    ShellStage::ExtractCostReduction,
+                    ShellStage::ExtractManaSpendTrigger,
+                ];
+                emitter.ability_ir_at(item_line, ir);
                 i += 1;
                 continue;
             }
@@ -4673,21 +4704,26 @@ pub(crate) fn parse_oracle_ir(
                 let cost = parse_oracle_cost(cost_text);
                 ctx.subject = None;
                 ctx.actor = None;
-                let mut def =
-                    parse_effect_chain_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
-                def.cost = Some(cost);
-                def.description = Some(line.to_string());
+                let mut ir =
+                    parse_ability_ir_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
+                // CR 602.1a: the activation cost, everything before the colon.
+                ir.shell.cost = Some(cost);
+                ir.shell.description = Some(line.to_string());
                 // CR 702.57a: a forecast ability is activated only from hand.
-                def.activation_zone = Some(Zone::Hand);
-                def.activation_restrictions.extend(constraints.restrictions);
+                ir.shell.activation_zone = Some(Zone::Hand);
+                // CR 602.1b: parsed constraints LEAD, the two implicit
+                // restrictions trail in the order CR 702.57b states them.
+                let mut activation_restrictions = constraints.restrictions;
                 // CR 702.57b: only during the owner's upkeep, only once each turn.
-                def.activation_restrictions
-                    .push(ActivationRestriction::DuringYourUpkeep);
-                def.activation_restrictions
-                    .push(ActivationRestriction::OnlyOnceEachTurn);
-                extract_cost_reduction_from_chain(&mut def);
-                extract_mana_spend_trigger_from_chain(&mut def);
-                emitter.ability_at(item_line, def);
+                activation_restrictions.push(ActivationRestriction::DuringYourUpkeep);
+                activation_restrictions.push(ActivationRestriction::OnlyOnceEachTurn);
+                ir.shell.activation_restrictions = activation_restrictions;
+                // CR 601.2f then CR 106.6 + CR 603.3, in this order — see `ShellStage`.
+                ir.shell.stages = vec![
+                    ShellStage::ExtractCostReduction,
+                    ShellStage::ExtractManaSpendTrigger,
+                ];
+                emitter.ability_ir_at(item_line, ir);
                 i += 1;
                 continue;
             }

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -299,12 +299,8 @@ fn is_zero(v: &u32) -> bool {
 ///
 /// Variants are named for the transform, not for a call site, so the list stays
 /// a description of *what runs* rather than of *who asked*.
-// A0 builds the mechanism and converts no producers, so both variants are
-// constructed for the first time by T8-A2 (the R1 sites that run both folds).
-// The allow is DELETED by that tranche, not moved: unlike `TriggerNodeIr::Parsed`
-// there is no second home for it, because a stage with no producer is exactly
-// the state A2 ends.
-#[allow(dead_code)]
+// Both variants are constructed by the T8-A2 recognizers (Channel, Boast,
+// Exhaust, Forecast), each of which lists them in this order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub(crate) enum ShellStage {
     /// CR 601.2f: fold a trailing self-referential "this ability costs {X} less

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -1385,6 +1385,127 @@ fn case_of_the_stashed_skeleton() {
     insta::assert_json_snapshot!("case_of_the_stashed_skeleton_lowered", &lowered);
 }
 
+// ---------------------------------------------------------------------------
+// T8-A2 §5.3 remediation: the activation-restriction ORDER at the four
+// keyword-labelled activated recognizers (Channel, Boast, Exhaust, Forecast).
+//
+// The non-vacuity probe measured these sites as REACHED but their restriction
+// *order* as UNWITNESSED. With the conversion in place, swapping the parsed
+// constraints against the implicit ones — and swapping the two implicit ones
+// against each other — left all 34 reaching tests green, because every existing
+// fixture is degenerate on this axis: the reminder text that states the
+// restrictions is stripped before `strip_activated_constraints` runs, so
+// `constraints.restrictions` is empty and the existing assertions use
+// order-insensitive `.contains(..)`.
+//
+// The four fixtures below are real pool cards (verbatim Oracle text from
+// `data/card-data.json`) chosen so each pins an order the conversion could
+// otherwise normalize away. Each was watched go RED under the corresponding
+// perturbation before being committed.
+// ---------------------------------------------------------------------------
+
+/// CR 207.2c Channel, with a NON-degenerate parsed constraint.
+///
+/// Channel is the one site of the four whose restriction vector is the parsed
+/// constraints *alone* — it pushes no implicit restriction — and whose original
+/// wrote `=` under an is-empty guard rather than `extend`. The existing Channel
+/// fixtures (`boseiju_who_endures` and the two `channel_*` parser tests) all
+/// have an EMPTY `constraints.restrictions`, so none of them can observe that
+/// vector reaching the lowered definition at all.
+///
+/// Ghost-Lit Stalker's trailing "Activate only as a sorcery." (CR 602.5d) makes
+/// it non-empty on BOTH its lines, so the snapshot pins the parsed constraint
+/// surviving the shell's `extend`. Watched red by deleting the
+/// `ir.shell.activation_restrictions` assignment: `AsSorcery` disappears from
+/// the Channel ability.
+#[test]
+fn ghost_lit_stalker() {
+    let (ir, lowered) = parse_two_layer(
+        "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery.\nChannel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
+        "Ghost-Lit Stalker",
+        &["Creature"],
+        &["Spirit"],
+    );
+    insta::assert_json_snapshot!("ghost_lit_stalker_ir", &ir);
+    insta::assert_json_snapshot!("ghost_lit_stalker_lowered", &lowered);
+}
+
+/// CR 702.177a Exhaust, with a NON-degenerate parsed constraint.
+///
+/// The only Exhaust card in the pool whose "Activate only as a sorcery."
+/// (CR 602.5d) sits OUTSIDE the reminder parentheses, so it is the only one that
+/// makes `constraints.restrictions` non-empty. That is what lets this snapshot
+/// pin the site's parsed-then-implicit order: parsed `AsSorcery` first, implicit
+/// `OnlyOnce` (CR 702.177a) second.
+///
+/// Watched red by composing the vector implicit-first instead: `OnlyOnce`
+/// relocates ahead of `AsSorcery`. `exhaust_mana_cost_parses_as_activated_with_once_per_game_restriction`
+/// and the `exhaust_keyword_once_per_permanent` integration tests all stay green
+/// under that swap, which is why this fixture is needed.
+#[test]
+fn liliana_the_repentant() {
+    let (ir, lowered) = parse_two_layer(
+        "Whenever another creature or planeswalker you control enters, mill two cards.\nExhaust — {5}{B}: Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana. Activate only as a sorcery. (Activate each exhaust ability only once.)",
+        "Liliana the Repentant",
+        &["Creature"],
+        &["Human", "Warlock"],
+    );
+    insta::assert_json_snapshot!("liliana_the_repentant_ir", &ir);
+    insta::assert_json_snapshot!("liliana_the_repentant_lowered", &lowered);
+}
+
+/// CR 702.142a Boast: pins the order of the two IMPLICIT restrictions.
+///
+/// No Boast card in the pool states its activation instruction outside reminder
+/// text, so the parsed-vs-implicit axis is unwitnessable here by any real card
+/// (reported as a finding rather than papered over with an invented card). What
+/// IS witnessable, and was previously unwitnessed, is the order of the two
+/// implicit restrictions relative to each other: this site pushes
+/// `OnlyOnceEachTurn` before `RequiresCondition{SourceAttackedThisTurn}`, which
+/// is the REVERSE of the order CR 702.142a states them in ("Activate only if
+/// this creature attacked this turn and only once each turn"). That inversion is
+/// pre-existing, is preserved by the conversion, and is now pinned so a later
+/// tranche cannot silently "tidy" it.
+///
+/// Watched red by swapping the two pushes.
+#[test]
+fn arni_brokenbrow() {
+    let (ir, lowered) = parse_two_layer(
+        "Haste\nBoast — {1}: You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn. (Activate only if this creature attacked this turn and only once each turn.)",
+        "Arni Brokenbrow",
+        &["Creature"],
+        &["Human", "Berserker"],
+    );
+    insta::assert_json_snapshot!("arni_brokenbrow_ir", &ir);
+    insta::assert_json_snapshot!("arni_brokenbrow_lowered", &lowered);
+}
+
+/// CR 702.57a-b Forecast: pins the order of the two IMPLICIT restrictions.
+///
+/// As with Boast, no Forecast card states its activation instruction outside
+/// reminder text, so only the implicit-vs-implicit axis is witnessable. This
+/// site pushes `DuringYourUpkeep` before `OnlyOnceEachTurn`, matching the order
+/// CR 702.57b states them in. Before this fixture the two `forecast_*` parser
+/// tests asserted both restrictions with order-insensitive `.contains(..)`, so a
+/// swap was silent.
+///
+/// Also the only two-layer snapshot coverage Forecast has had; its two parser
+/// tests were the entire reaching set, and neither reaches the integration
+/// binary.
+///
+/// Watched red by swapping the two pushes.
+#[test]
+fn govern_the_guildless() {
+    let (ir, lowered) = parse_two_layer(
+        "Gain control of target monocolored creature.\nForecast — {1}{U}, Reveal this card from your hand: Target creature becomes the color or colors of your choice until end of turn. (Activate only during your upkeep and only once each turn.)",
+        "Govern the Guildless",
+        &["Sorcery"],
+        &[],
+    );
+    insta::assert_json_snapshot!("govern_the_guildless_ir", &ir);
+    insta::assert_json_snapshot!("govern_the_guildless_lowered", &lowered);
+}
+
 #[test]
 fn aerial_formation() {
     let (ir, lowered) = parse_two_layer(

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
@@ -1,0 +1,107 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 5,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Haste"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "unknown",
+            "description": "Haste"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Haste",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 6,
+          "end_byte": 200,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Boast — {1}: You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn. (Activate only if ~ attacked this turn and only once each turn.)"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Unimplemented",
+            "name": "change",
+            "description": "change Arni's base power to 1 plus the greatest power among other creatures you control"
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 1
+            }
+          },
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "Boast — {1}: You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "OnlyOnceEachTurn"
+            },
+            {
+              "type": "RequiresCondition",
+              "data": {
+                "condition": {
+                  "type": "SourceAttackedThisTurn"
+                }
+              }
+            }
+          ],
+          "ability_tag": {
+            "type": "Boast"
+          },
+          "condition": null,
+          "optional_targeting": false,
+          "optional": true,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Haste\nBoast — {1}: You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn. (Activate only if this creature attacked this turn and only once each turn.)",
+  "card_name": "Arni Brokenbrow"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_lowered.snap
@@ -1,0 +1,69 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "Unimplemented",
+        "name": "unknown",
+        "description": "Haste"
+      },
+      "cost": null,
+      "sub_ability": null,
+      "duration": null,
+      "description": "Haste",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Unimplemented",
+        "name": "change",
+        "description": "change Arni's base power to 1 plus the greatest power among other creatures you control"
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [],
+          "generic": 1
+        }
+      },
+      "sub_ability": null,
+      "duration": "UntilEndOfTurn",
+      "description": "Boast — {1}: You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "OnlyOnceEachTurn"
+        },
+        {
+          "type": "RequiresCondition",
+          "data": {
+            "condition": {
+              "type": "SourceAttackedThisTurn"
+            }
+          }
+        }
+      ],
+      "ability_tag": {
+        "type": "Boast"
+      },
+      "condition": null,
+      "optional_targeting": false,
+      "optional": true,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_ir.snap
@@ -1,0 +1,148 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 74,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Discard",
+            "count": {
+              "type": "Fixed",
+              "value": 2
+            },
+            "target": {
+              "type": "Player"
+            }
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Black"
+                  ],
+                  "generic": 4
+                }
+              },
+              {
+                "type": "Tap"
+              }
+            ]
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 75,
+          "end_byte": 179,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Discard",
+            "count": {
+              "type": "Fixed",
+              "value": 4
+            },
+            "target": {
+              "type": "Player"
+            }
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Black",
+                    "Black"
+                  ],
+                  "generic": 5
+                }
+              },
+              {
+                "type": "Discard",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "filter": null,
+                "random": false,
+                "self_ref": true
+              }
+            ]
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            }
+          ],
+          "activation_zone": "Hand",
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "consumes_source": true
+        }
+      }
+    }
+  ],
+  "source_text": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery.\nChannel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
+  "card_name": "Ghost-Lit Stalker"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_lowered.snap
@@ -1,0 +1,110 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Discard",
+        "count": {
+          "type": "Fixed",
+          "value": 2
+        },
+        "target": {
+          "type": "Player"
+        }
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Black"
+              ],
+              "generic": 4
+            }
+          },
+          {
+            "type": "Tap"
+          }
+        ]
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Discard",
+        "count": {
+          "type": "Fixed",
+          "value": 4
+        },
+        "target": {
+          "type": "Player"
+        }
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Black",
+                "Black"
+              ],
+              "generic": 5
+            }
+          },
+          {
+            "type": "Discard",
+            "count": {
+              "type": "Fixed",
+              "value": 1
+            },
+            "filter": null,
+            "random": false,
+            "self_ref": true
+          }
+        ]
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        }
+      ],
+      "activation_zone": "Hand",
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false,
+      "consumes_source": true
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_ir.snap
@@ -1,0 +1,166 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 44,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Gain control of target monocolored creature."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "GainControl",
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": [
+                {
+                  "type": "ColorCount",
+                  "comparator": "EQ",
+                  "count": 1
+                }
+              ]
+            }
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": null,
+          "description": "Gain control of target monocolored creature.",
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 45,
+          "end_byte": 236,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Forecast — {1}{U}, Reveal this card from your hand: Target creature becomes the color or colors of your choice until end of turn. (Activate only during your upkeep and only once each turn.)"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Choose",
+            "choice_type": "Color",
+            "persist": false
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Blue"
+                  ],
+                  "generic": 1
+                }
+              },
+              {
+                "type": "Reveal",
+                "count": 1
+              }
+            ]
+          },
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "GenericEffect",
+              "static_abilities": [
+                {
+                  "mode": "Continuous",
+                  "affected": {
+                    "type": "ParentTarget"
+                  },
+                  "modifications": [
+                    {
+                      "type": "AddChosenColor",
+                      "mode": "Set"
+                    }
+                  ],
+                  "condition": null,
+                  "affected_zone": null,
+                  "effect_zone": null,
+                  "active_zones": [],
+                  "characteristic_defining": false,
+                  "description": "the color or colors of your choice"
+                }
+              ],
+              "duration": "Permanent",
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "duration": "UntilEndOfTurn",
+          "description": "Forecast — {1}{U}, Reveal this card from your hand: Target creature becomes the color or colors of your choice until end of turn.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "DuringYourUpkeep"
+            },
+            {
+              "type": "OnlyOnceEachTurn"
+            }
+          ],
+          "activation_zone": "Hand",
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Gain control of target monocolored creature.\nForecast — {1}{U}, Reveal this card from your hand: Target creature becomes the color or colors of your choice until end of turn. (Activate only during your upkeep and only once each turn.)",
+  "card_name": "Govern the Guildless"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_lowered.snap
@@ -1,0 +1,128 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "GainControl",
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Creature"
+          ],
+          "controller": null,
+          "properties": [
+            {
+              "type": "ColorCount",
+              "comparator": "EQ",
+              "count": 1
+            }
+          ]
+        }
+      },
+      "cost": null,
+      "sub_ability": null,
+      "duration": null,
+      "description": "Gain control of target monocolored creature.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Choose",
+        "choice_type": "Color",
+        "persist": false
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Blue"
+              ],
+              "generic": 1
+            }
+          },
+          {
+            "type": "Reveal",
+            "count": 1
+          }
+        ]
+      },
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "GenericEffect",
+          "static_abilities": [
+            {
+              "mode": "Continuous",
+              "affected": {
+                "type": "ParentTarget"
+              },
+              "modifications": [
+                {
+                  "type": "AddChosenColor",
+                  "mode": "Set"
+                }
+              ],
+              "condition": null,
+              "affected_zone": null,
+              "effect_zone": null,
+              "active_zones": [],
+              "characteristic_defining": false,
+              "description": "the color or colors of your choice"
+            }
+          ],
+          "duration": "Permanent",
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": null,
+            "properties": []
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "duration": "UntilEndOfTurn",
+      "description": "Forecast — {1}{U}, Reveal this card from your hand: Target creature becomes the color or colors of your choice until end of turn.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "DuringYourUpkeep"
+        },
+        {
+          "type": "OnlyOnceEachTurn"
+        }
+      ],
+      "activation_zone": "Hand",
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
@@ -1,0 +1,223 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 77,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Whenever another creature or planeswalker you control enters, mill two cards."
+      },
+      "node": {
+        "PreLoweredTrigger": {
+          "mode": "ChangesZone",
+          "execute": {
+            "kind": "Spell",
+            "effect": {
+              "type": "Mill",
+              "count": {
+                "type": "Fixed",
+                "value": 2
+              },
+              "target": {
+                "type": "Controller"
+              },
+              "destination": "Graveyard"
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false
+          },
+          "valid_card": {
+            "type": "Or",
+            "filters": [
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "Another"
+                  }
+                ]
+              },
+              {
+                "type": "Typed",
+                "type_filters": [
+                  "Planeswalker"
+                ],
+                "controller": "You",
+                "properties": [
+                  {
+                    "type": "Another"
+                  }
+                ]
+              }
+            ]
+          },
+          "origin": null,
+          "destination": "Battlefield",
+          "trigger_zones": [
+            "Battlefield"
+          ],
+          "phase": null,
+          "optional": false,
+          "damage_kind": "Any",
+          "secondary": false,
+          "valid_target": null,
+          "valid_source": null,
+          "description": "Whenever another creature or planeswalker you control enters, mill two cards.",
+          "constraint": null,
+          "condition": null,
+          "batched": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 78,
+          "end_byte": 284,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Exhaust — {5}{B}: Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana. Activate only as a sorcery. (Activate each exhaust ability only once.)"
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "ChangeZone",
+            "origin": "Graveyard",
+            "destination": "Battlefield",
+            "target": {
+              "type": "Or",
+              "filters": [
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "InZone",
+                      "zone": "Graveyard"
+                    }
+                  ]
+                },
+                {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Planeswalker"
+                  ],
+                  "controller": "You",
+                  "properties": [
+                    {
+                      "type": "InZone",
+                      "zone": "Graveyard"
+                    }
+                  ]
+                }
+              ]
+            },
+            "owner_library": false,
+            "enter_transformed": false,
+            "enter_tapped": false,
+            "enters_attacking": false
+          },
+          "cost": {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Black"
+              ],
+              "generic": 5
+            }
+          },
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PutCounter",
+              "counter_type": "P1P1",
+              "count": {
+                "type": "Fixed",
+                "value": 1
+              },
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  {
+                    "Subtype": "Liliana"
+                  }
+                ],
+                "controller": null,
+                "properties": []
+              }
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": null,
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "target_choice_timing": "Resolution",
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
+          "duration": null,
+          "description": "Exhaust — {5}{B}: Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana. Activate only as a sorcery.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "AsSorcery"
+            },
+            {
+              "type": "OnlyOnce"
+            }
+          ],
+          "ability_tag": {
+            "type": "Exhaust"
+          },
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Whenever another creature or planeswalker you control enters, mill two cards.\nExhaust — {5}{B}: Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana. Activate only as a sorcery. (Activate each exhaust ability only once.)",
+  "card_name": "Liliana the Repentant"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_lowered.snap
@@ -1,0 +1,186 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "ChangeZone",
+        "origin": "Graveyard",
+        "destination": "Battlefield",
+        "target": {
+          "type": "Or",
+          "filters": [
+            {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "InZone",
+                  "zone": "Graveyard"
+                }
+              ]
+            },
+            {
+              "type": "Typed",
+              "type_filters": [
+                "Planeswalker"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "InZone",
+                  "zone": "Graveyard"
+                }
+              ]
+            }
+          ]
+        },
+        "owner_library": false,
+        "enter_transformed": false,
+        "enter_tapped": false,
+        "enters_attacking": false
+      },
+      "cost": {
+        "type": "Mana",
+        "cost": {
+          "type": "Cost",
+          "shards": [
+            "Black"
+          ],
+          "generic": 5
+        }
+      },
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "PutCounter",
+          "counter_type": "P1P1",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "Typed",
+            "type_filters": [
+              {
+                "Subtype": "Liliana"
+              }
+            ],
+            "controller": null,
+            "properties": []
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "target_choice_timing": "Resolution",
+        "forward_result": false,
+        "sub_link": "SequentialSibling"
+      },
+      "duration": null,
+      "description": "Exhaust — {5}{B}: Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana. Activate only as a sorcery.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        },
+        {
+          "type": "OnlyOnce"
+        }
+      ],
+      "ability_tag": {
+        "type": "Exhaust"
+      },
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [
+    {
+      "mode": "ChangesZone",
+      "execute": {
+        "kind": "Spell",
+        "effect": {
+          "type": "Mill",
+          "count": {
+            "type": "Fixed",
+            "value": 2
+          },
+          "target": {
+            "type": "Controller"
+          },
+          "destination": "Graveyard"
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false
+      },
+      "valid_card": {
+        "type": "Or",
+        "filters": [
+          {
+            "type": "Typed",
+            "type_filters": [
+              "Creature"
+            ],
+            "controller": "You",
+            "properties": [
+              {
+                "type": "Another"
+              }
+            ]
+          },
+          {
+            "type": "Typed",
+            "type_filters": [
+              "Planeswalker"
+            ],
+            "controller": "You",
+            "properties": [
+              {
+                "type": "Another"
+              }
+            ]
+          }
+        ]
+      },
+      "origin": null,
+      "destination": "Battlefield",
+      "trigger_zones": [
+        "Battlefield"
+      ],
+      "phase": null,
+      "optional": false,
+      "damage_kind": "Any",
+      "secondary": false,
+      "valid_target": null,
+      "valid_source": null,
+      "description": "Whenever another creature or planeswalker you control enters, mill two cards.",
+      "constraint": null,
+      "condition": null,
+      "batched": false
+    }
+  ],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}


### PR DESCRIPTION
Plan 05b tranche **T8-A2** — the four R1 sites that run **both** `extract_*` chain-structure folds:
**U0-23** Channel · **U0-24** Boast · **U0-25** Exhaust · **U0-27** Forecast.

Follows #6715 (A1). This is the first tranche to consume `ShellStage`, so it deletes that type's
`#[allow(dead_code)]` — A0 assigned the allow to whichever tranche added the first producer.

Two commits: the conversion, and a §5.3 remediation that pins restriction order at all four sites.

## The conversion

All four originals were read individually rather than assumed uniform, and all four turned out
verbatim identical in entry point — `parse_effect_chain_with_context(&effect_text,
AbilityKind::Activated, &mut ctx)` — so all four take `parse_ability_ir_with_context`, chosen **by
name** per §7.1.

| site | envelope | composed restriction order | stages |
|---|---|---|---|
| U0-23 Channel | `activation_zone = Hand` | `[parsed]` — no implicit at all | `[ExtractCostReduction, ExtractManaSpendTrigger]` |
| U0-24 Boast | `ability_tag = Boast` | `[parsed…, OnlyOnceEachTurn, RequiresCondition{SourceAttackedThisTurn}]` | same |
| U0-25 Exhaust | `ability_tag = Exhaust` | `[parsed…, OnlyOnce]` | same |
| U0-27 Forecast | `activation_zone = Hand` | `[parsed…, DuringYourUpkeep, OnlyOnceEachTurn]` | same |

Each order was read from that site's current code. The four are **not** unified behind a shared
builder: they differ in zone, tag, restriction set and restriction order, and a shared builder would
normalize away exactly the asymmetry A0's ordered-`Vec` design exists to protect.

**U0-23's `=`-not-`extend` was verified, not assumed.** `activation_restrictions` appears in
`crates/engine/src/parser/oracle_effect/` exactly three times, all inside
`apply_ability_shell_envelope` itself, so the root field is provably empty when the shell runs and
`extend`-onto-empty reproduces the assignment.

## §5.3: reachability first, then perturbation

A reachability probe ran before any perturbation, because a green perturbation is otherwise ambiguous
between "identical" and "never executed" — the ambiguity that misled A1's first reading.

| site | `--lib` | integration |
|---|---|---|
| U0-23 Channel | 4 | 0 |
| U0-24 Boast | 4 | 11 |
| U0-25 Exhaust | 3 | 4 |
| U0-27 Forecast | 2 | 0 |

No `--lib` zeroes this time. A **decoy** was caught by probe message rather than by name:
`power_up_keyword::wonder_man_does_not_raise_non_power_up_once_limit` reaches the **Exhaust** site.

| perturbation | result |
|---|---|
| reorder the two stages, all 4 sites | **green — finding** |
| drop `ExtractCostReduction`, all 4 | **red** (via `boseiju_who_endures`) |
| drop `ExtractManaSpendTrigger`, all 4 | **green — finding** |
| drop an implicit restriction / envelope stamp, all 4 | **red** — 10 lib + 6 integration |
| swap parsed vs implicit order (U0-24/25/27) | **green — finding** |
| swap the two implicit restrictions (U0-24/27) | **green — finding** |
| flip mode wrapper to `Standalone` | **green — null**, matching A1 |

The `ExtractCostReduction` red is behavioral rather than serialization — phase A emits
`PreLoweredSpell(lower_ability_ir(&ir))`, so `stages` never reaches a snapshot:

```
< "sub_ability": null,        < "cost_reduction": { amount_per: 1, … }
> "sub_ability": { "effect": { "type": "Unimplemented",
>   "description": "This ability costs {1} less to activate for each legendary creature you control" } }
```

That red is also what makes the stage-reorder green a real inertness measurement rather than an
untested path.

**Why the order perturbations were silent:** every pre-existing fixture at all four sites is degenerate
on the restriction-order axis. The reminder text stating the restrictions is stripped before
`strip_activated_constraints`, so `constraints.restrictions` is empty, and the `boast_*`/`exhaust_*`/
`forecast_*` assertions use order-insensitive `.contains(..)`. Same defect class A1 found at U0-22 —
and it now looks general across the whole keyword-labelled activated family.

## Remediation (second commit)

Four real pool cards, Oracle text verbatim from the card pool, each watched go red with the other
three staying green so every red is attributable to its own site:

| fixture | closes | red on |
|---|---|---|
| **Ghost-Lit Stalker** (Channel) | parsed vec reaching the lowered def at all | deleting the `AsSorcery` block |
| **Liliana the Repentant** (Exhaust) | parsed-vs-implicit order | `OnlyOnce` relocating ahead of `AsSorcery` |
| **Arni Brokenbrow** (Boast) | implicit-vs-implicit order | `OnlyOnceEachTurn` transposing past `RequiresCondition` |
| **Govern the Guildless** (Forecast) | implicit-vs-implicit order | `DuringYourUpkeep`/`OnlyOnceEachTurn` transposing |

Ghost-Lit Stalker and Liliana are the genuinely non-degenerate pair: their "Activate only as a
sorcery." sits **outside** the reminder parens, yielding `[AsSorcery]` and `[AsSorcery, OnlyOnce]` in
the lowered snapshots. Arni and Govern state everything inside reminder text, so they pin
implicit-vs-implicit order only — which is stated plainly rather than papered over.

## Gates

```
cargo fmt --all                                      clean
cargo clippy -p engine --lib -- -D warnings          zero warnings
cargo nextest run -p engine --lib                    17849 passed, 6 skipped   (17845 → +4, exactly the new fixtures)
cargo nextest run -p engine --test integration       4123 passed, 2 skipped
./scripts/check-prelowered-ratchet.sh                Gate P PASS
./scripts/check-skill-doc.sh                         ✓ oracle-parser skill references valid
./scripts/check-parser-combinators.sh                Gate G PASS / Gate A PASS
```

**Zero existing snapshots changed.** `git diff --name-status` is **8 A / 3 M**; the three modified
files are all source. `find . -name '*.snap.new'` → 0. `oracle.rs` unmoved at 16 on the ratchet;
`scripts/prelowered-ratchet.txt` unedited.

Parser string-dispatch diff gate: clean — zero `.contains`/`starts_with`/`find`/`rfind`/`split*` in
added non-comment lines under `parser/`.

CR-annotation diff gate: 11 numbers added, **zero unverified**, each grep-checked against
`docs/MagicCompRules.txt` with the rule *text* read rather than existence alone — 106.6, 207.2c,
601.2f, 602.1a, 602.1b, 602.5d, 603.3, 702.57a, 702.57b, 702.142a, 702.177a. Confirms `channel` **is**
in CR 207.2c's ability-word list while boast/exhaust/forecast are **not**, consistent with those three
being keywords.

## Harvest (§5.4)

1. **`ShellStage::ExtractManaSpendTrigger` is dead at all four sites on today's pool.** Dropping it is
   silent across all 34 reaching tests, and a scan of all 35,516 cards finds **zero** A2-site lines
   whose root effect is `Effect::Mana` (Careful Cultivation's "Add {G}" is inside a *token's granted*
   ability, not the root). **Retained anyway** — it reproduces the pre-conversion call sequence, and a
   conversion must not quietly drop a fold. This is also *why* the stage reorder is inert: only one
   stage ever fires.
2. **`ExtractCostReduction` fires only at Channel** — the Kamigawa legendary land cycle (Boseiju,
   Eiganjo, Otawara, Sokenzan, Takenuma). Boast/Exhaust/Forecast run a fold that cannot fire for them.
3. **U0-24 Boast pushes its two implicit restrictions in the reverse of CR 702.142a's stated order.**
   The rule reads "Activate only if this creature attacked this turn and only once each turn"; the code
   pushes `OnlyOnceEachTurn` first. Semantically harmless — the restrictions are a conjunction — but
   pre-existing and now pinned by `arni_brokenbrow`. Preserved, not fixed.
4. **U0-23's `if !…is_empty()` guard was already redundant** — assigning an empty vec ≡ skipping it.
5. **Every pre-existing fixture at all four sites is degenerate on the restriction-order axis.** Same
   class as A1's U0-22 finding; it generalizes across the keyword-labelled activated family.
6. **Forecast had no two-layer snapshot and no integration coverage at all** — its entire reaching set
   was 2 parser tests.
7. **`ChainLoweringMode` is extensionally inert at all four sites**, matching A1's null.

## Two axes left honestly unwitnessed

Reported rather than designed around:

1. **No Boast or Forecast card in the pool states its activation instruction outside reminder text**,
   so parsed-vs-implicit order at U0-24/U0-27 cannot be witnessed by any real card. Inventing one would
   violate the verbatim-Oracle-text rule. Documented in the test file and commit message.
2. **`ExtractManaSpendTrigger` cannot be witnessed at any A2 site** (harvest #1), so its ordering
   relative to `ExtractCostReduction` is unwitnessed. The stage-order property is preserved by
   construction but not test-guarded: if a later tranche reorders `stages`, nothing goes red today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Channel, Boast, Exhaust, and Forecast activated abilities.
  - Correctly preserves activation costs, restrictions, descriptions, zones, and related mana triggers during parsing.
  - Ensures activation restrictions are applied in the correct order for more accurate ability behavior.

- **Tests**
  - Added coverage for representative cards using these mechanics to verify parsing and ability generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->