### PR TITLE
refactor(parser): Plan 05b T8-A3 — the R1 remainder (U0-50, U0-12)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6288,9 +6288,22 @@ pub(crate) fn parse_oracle_ir(
             // Try as effect
             ctx.subject = None;
             ctx.actor = None;
-            let def = parse_effect_chain_with_context(&effect_text, AbilityKind::Spell, &mut ctx);
-            if !has_unimplemented(&def) {
-                emitter.ability_at(item_line, def);
+            // The one site in the family whose shell stays `default()`: it stamps
+            // no root field at all, not even `description`, so the conversion is
+            // the bare entry-point swap with nothing to carry.
+            let ir = parse_ability_ir_with_context(&effect_text, AbilityKind::Spell, &mut ctx);
+            // Whether to emit *at all* is control flow, not a property of the
+            // definition, so the guard stays here rather than becoming a shell
+            // field. `has_unimplemented` reads a lowered root, and an
+            // `AbilityDefinition` cannot be un-lowered into an `AbilityIr`, so the
+            // predicate runs on `lower_ability_ir(&ir)` while the *retained*
+            // artifact stays the IR — same shape the prevention-text site above
+            // already uses. `lower_ability_ir` is a pure `&AbilityIr ->
+            // AbilityDefinition` (no `ctx`, no interior mutability anywhere under
+            // `oracle_effect/`), so lowering here and again in `ability_ir_at` is
+            // a repeat of the same computation, never a different one.
+            if !has_unimplemented(&lower_ability_ir(&ir)) {
+                emitter.ability_ir_at(item_line, ir);
                 i += 1;
                 continue;
             }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3966,29 +3966,79 @@ pub(crate) fn parse_oracle_ir(
 
             ctx.subject = None;
             ctx.actor = None;
-            let mut def =
-                parse_effect_chain_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
-            if has_unimplemented(&def) {
+            // The self-ref-normalized retry, and the one place in this tranche
+            // where the *decision* is made on a LOWERED definition while the
+            // *retained artifact* must stay an IR.
+            //
+            // It cannot be expressed by lowering, mutating and re-wrapping:
+            // `AbilityIr` has no `from_definition` and an `AbilityDefinition`
+            // cannot be un-lowered into an `EffectChainIr`. So both candidates
+            // are parsed as IR and each is lowered purely to *ask* the question,
+            // while whichever IR won is what gets emitted.
+            //
+            // Three properties make this the same computation as the original:
+            //
+            // 1. `parse_effect_chain_with_context(t,k,cx)` IS
+            //    `lower_ability_ir(&parse_ability_ir_with_context(t,k,cx))`, so
+            //    each `has_unimplemented` argument is bit-for-bit the definition
+            //    the original tested.
+            // 2. The `ctx` sequencing is preserved exactly. The retry's parse
+            //    receives the SAME, already-mutated `ctx` as the first parse —
+            //    not a fresh one — and interposing the lowering between the two
+            //    parses cannot perturb that, because `lower_ability_ir` takes no
+            //    `ParseContext` and nothing under `oracle_effect/` carries
+            //    interior mutability.
+            // 3. The predicate is invariant under the envelope:
+            //    `has_unimplemented` reads only `effect` and `sub_ability`, both
+            //    CR 608.2 resolution-tree fields, and the shell stamps neither.
+            //
+            // Cost: one extra lowering per LEVEL-block activated line (two or
+            // three rather than one or two). It is intrinsic, not laziness — the
+            // predicate's lowered value is *pre*-shell and the emitted one is
+            // *post*-shell, so they are different values and neither can be
+            // reused as the other. The path runs only on LEVEL blocks.
+            let mut ir =
+                parse_ability_ir_with_context(&effect_text, AbilityKind::Activated, &mut ctx);
+            if has_unimplemented(&lower_ability_ir(&ir)) {
                 let normalized_effect = normalize_self_refs_for_static(&effect_text, card_name);
                 if normalized_effect != effect_text {
-                    let alt = parse_effect_chain_with_context(
+                    let alt = parse_ability_ir_with_context(
                         &normalized_effect,
                         AbilityKind::Activated,
                         &mut ctx,
                     );
-                    if !has_unimplemented(&alt) {
-                        def = alt;
+                    if !has_unimplemented(&lower_ability_ir(&alt)) {
+                        ir = alt;
                     }
                 }
             }
-            def.cost = Some(cost);
-            def.description = Some(ability_text.to_string());
-            let mut restrictions = constraints.restrictions;
-            restrictions.push(ActivationRestriction::LevelCounterRange { minimum, maximum });
-            def.activation_restrictions = restrictions;
-            extract_cost_reduction_from_chain(&mut def);
-            extract_mana_spend_trigger_from_chain(&mut def);
-            emitter.ability_at(*level_line, def);
+            // CR 602.1a: the activation cost, everything before the colon. The
+            // self-ref normalization it is parsed from happens before the colon
+            // split and stays there.
+            ir.shell.cost = Some(cost);
+            // The full printed ability line, not the post-colon effect text.
+            ir.shell.description = Some(ability_text.to_string());
+            // CR 602.1b: the activation instructions, composed in this site's own
+            // order — the parsed constraints LEAD and the implicit level gate
+            // trails. The original wrote `=` rather than `extend`, and the two
+            // agree here: `rg activation_restrictions
+            // crates/engine/src/parser/oracle_effect/` hits only
+            // `apply_ability_shell_envelope` itself, so nothing reachable from
+            // `lower_ability_ir` writes the root's restrictions and the field is
+            // empty when the shell runs.
+            let mut activation_restrictions = constraints.restrictions;
+            // CR 711.2a + CR 711.2b: the abilities printed in a level striation
+            // function only while the creature's level counters are in that
+            // striation's range.
+            activation_restrictions
+                .push(ActivationRestriction::LevelCounterRange { minimum, maximum });
+            ir.shell.activation_restrictions = activation_restrictions;
+            // CR 601.2f then CR 106.6 + CR 603.3, in this order — see `ShellStage`.
+            ir.shell.stages = vec![
+                ShellStage::ExtractCostReduction,
+                ShellStage::ExtractManaSpendTrigger,
+            ];
+            emitter.ability_ir_at(*level_line, ir);
             continue;
         }
 

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -463,6 +463,70 @@ fn entropic_battlecruiser() {
 }
 
 // ---------------------------------------------------------------------------
+// Plan 05b T8-A3 (§5.3 remediation): U0-12 had no fixture that witnessed the
+// envelope it stamps.
+// ---------------------------------------------------------------------------
+
+/// U0-12 — the CR 711.2a/711.2b LEVEL-block activated line (T8-A3 witness).
+///
+/// **What was unwitnessed.** The only pre-existing test over this site
+/// (`oracle_tests::leveler_activated_abilities_get_level_counter_range`) asserts
+/// `LevelCounterRange` presence with `.contains(…)`, which is order-insensitive,
+/// and asserts nothing about the `cost` or `description` the site also stamps.
+/// Dropping `LevelCounterRange` was witnessed; every other axis was not.
+///
+/// Guul Draz Assassin is the richest fixture in the nine-card leveler
+/// population: two striations, a two-component `{B}, {T}` cost (so the CR 602.1a
+/// stamp is pinned to something more than a bare `{T}`), a targeted effect, and
+/// two *different* level ranges — a bounded `2-3` and an unbounded `4+` — so a
+/// range that collapsed to a constant would show.
+///
+/// Fixture is pool-verified, not synthetic: Oracle text, `Creature` type and
+/// `Vampire`/`Assassin` subtypes are verbatim from `data/card-data.json`.
+#[test]
+fn guul_draz_assassin_level_activated() {
+    let (ir, lowered) = parse_two_layer_with_keywords(
+        "Level up {1}{B} ({1}{B}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-3\n2/2\n{B}, {T}: Target creature gets -2/-2 until end of turn.\nLEVEL 4+\n4/4\n{B}, {T}: Target creature gets -4/-4 until end of turn.",
+        "Guul Draz Assassin",
+        &["level up"],
+        &["Creature"],
+        &["Vampire", "Assassin"],
+    );
+    insta::assert_json_snapshot!("guul_draz_assassin_ir", &ir);
+    insta::assert_json_snapshot!("guul_draz_assassin_lowered", &lowered);
+}
+
+/// U0-12 — the first site in phase A where `ExtractManaSpendTrigger`'s guard is
+/// LIVE (T8-A3 witness).
+///
+/// A2 established that its four keyword sites can never run that fold: no pool
+/// card with those keywords lowers to a root `Effect::Mana`, so the stage
+/// early-returns every time. **U0-12 is different.** Joraga Treespeaker's
+/// `LEVEL 1-4` body is `{T}: Add {G}{G}.`, which lowers to a root `Effect::Mana`,
+/// so the guard passes here for the first time in the tranche.
+///
+/// The fold's *body* still does nothing — it additionally needs a trailing "when
+/// you spend this mana …" sub-ability, and no leveler card prints one — so
+/// dropping the stage is still extensionally inert. Pinning the mana root is
+/// what makes that distinction visible: this fixture is the one that would start
+/// discriminating the moment a level striation prints a spend trigger.
+///
+/// Fixture is pool-verified, not synthetic: Oracle text, `Creature` type and
+/// `Elf`/`Druid` subtypes are verbatim from `data/card-data.json`.
+#[test]
+fn joraga_treespeaker_level_mana_ability() {
+    let (ir, lowered) = parse_two_layer_with_keywords(
+        "Level up {1}{G} ({1}{G}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n1/2\n{T}: Add {G}{G}.\nLEVEL 5+\n1/4\nElves you control have \"{T}: Add {G}{G}.\"",
+        "Joraga Treespeaker",
+        &["level up"],
+        &["Creature"],
+        &["Elf", "Druid"],
+    );
+    insta::assert_json_snapshot!("joraga_treespeaker_ir", &ir);
+    insta::assert_json_snapshot!("joraga_treespeaker_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // CR 603.12 deferred rider on a top-of-library play permission
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_ir.snap
@@ -1,0 +1,300 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 524
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 4,
+      "source": {
+        "id": {
+          "item": 4,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 82,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Level up {1}{B} ({1}{B}: Put a level counter on this. Level up only as a sorcery.)"
+      },
+      "node": {
+        "Keyword": {
+          "LevelUp": {
+            "type": "Cost",
+            "shards": [
+              "Black"
+            ],
+            "generic": 1
+          }
+        }
+      }
+    },
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 83,
+          "end_byte": 92,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 2-3"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "SetPower",
+                "value": 2
+              },
+              {
+                "type": "SetToughness",
+                "value": 2
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 2,
+              "maximum": 3
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "LEVEL 2-3 / 2/2"
+          },
+          "source_text": "LEVEL 2-3 / 2/2",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 97,
+          "end_byte": 152,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{B}, {T}: Target creature gets -2/-2 until end of turn."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Pump",
+            "power": {
+              "type": "Fixed",
+              "value": -2
+            },
+            "toughness": {
+              "type": "Fixed",
+              "value": -2
+            },
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            }
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Black"
+                  ],
+                  "generic": 0
+                }
+              },
+              {
+                "type": "Tap"
+              }
+            ]
+          },
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "{B}, {T}: Target creature gets -2/-2 until end of turn.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "LevelCounterRange",
+              "data": {
+                "minimum": 2,
+                "maximum": 3
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 153,
+          "end_byte": 161,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 4+"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "SetPower",
+                "value": 4
+              },
+              {
+                "type": "SetToughness",
+                "value": 4
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 4
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "LEVEL 4+ / 4/4"
+          },
+          "source_text": "LEVEL 4+ / 4/4",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 6,
+          "last_line": 6,
+          "start_byte": 166,
+          "end_byte": 221,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{B}, {T}: Target creature gets -4/-4 until end of turn."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Pump",
+            "power": {
+              "type": "Fixed",
+              "value": -4
+            },
+            "toughness": {
+              "type": "Fixed",
+              "value": -4
+            },
+            "target": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            }
+          },
+          "cost": {
+            "type": "Composite",
+            "costs": [
+              {
+                "type": "Mana",
+                "cost": {
+                  "type": "Cost",
+                  "shards": [
+                    "Black"
+                  ],
+                  "generic": 0
+                }
+              },
+              {
+                "type": "Tap"
+              }
+            ]
+          },
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": "{B}, {T}: Target creature gets -4/-4 until end of turn.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "LevelCounterRange",
+              "data": {
+                "minimum": 4
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Level up {1}{B} ({1}{B}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 2-3\n2/2\n{B}, {T}: Target creature gets -2/-2 until end of turn.\nLEVEL 4+\n4/4\n{B}, {T}: Target creature gets -4/-4 until end of turn.",
+  "card_name": "Guul Draz Assassin"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_lowered.snap
@@ -1,0 +1,196 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 525
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Pump",
+        "power": {
+          "type": "Fixed",
+          "value": -2
+        },
+        "toughness": {
+          "type": "Fixed",
+          "value": -2
+        },
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Creature"
+          ],
+          "controller": null,
+          "properties": []
+        }
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Black"
+              ],
+              "generic": 0
+            }
+          },
+          {
+            "type": "Tap"
+          }
+        ]
+      },
+      "sub_ability": null,
+      "duration": "UntilEndOfTurn",
+      "description": "{B}, {T}: Target creature gets -2/-2 until end of turn.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "LevelCounterRange",
+          "data": {
+            "minimum": 2,
+            "maximum": 3
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Pump",
+        "power": {
+          "type": "Fixed",
+          "value": -4
+        },
+        "toughness": {
+          "type": "Fixed",
+          "value": -4
+        },
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Creature"
+          ],
+          "controller": null,
+          "properties": []
+        }
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Black"
+              ],
+              "generic": 0
+            }
+          },
+          {
+            "type": "Tap"
+          }
+        ]
+      },
+      "sub_ability": null,
+      "duration": "UntilEndOfTurn",
+      "description": "{B}, {T}: Target creature gets -4/-4 until end of turn.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "LevelCounterRange",
+          "data": {
+            "minimum": 4
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetPower",
+          "value": 2
+        },
+        {
+          "type": "SetToughness",
+          "value": 2
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 2,
+        "maximum": 3
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "LEVEL 2-3 / 2/2"
+    },
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetPower",
+          "value": 4
+        },
+        {
+          "type": "SetToughness",
+          "value": 4
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 4
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "LEVEL 4+ / 4/4"
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": [
+    {
+      "LevelUp": {
+        "type": "Cost",
+        "shards": [
+          "Black"
+        ],
+        "generic": 1
+      }
+    }
+  ]
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_ir.snap
@@ -1,0 +1,282 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 554
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 4,
+      "source": {
+        "id": {
+          "item": 4,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 82,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Level up {1}{G} ({1}{G}: Put a level counter on this. Level up only as a sorcery.)"
+      },
+      "node": {
+        "Keyword": {
+          "LevelUp": {
+            "type": "Cost",
+            "shards": [
+              "Green"
+            ],
+            "generic": 1
+          }
+        }
+      }
+    },
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 83,
+          "end_byte": 92,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 1-4"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "SetPower",
+                "value": 1
+              },
+              {
+                "type": "SetToughness",
+                "value": 2
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 1,
+              "maximum": 4
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "LEVEL 1-4 / 1/2"
+          },
+          "source_text": "LEVEL 1-4 / 1/2",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 3,
+      "source": {
+        "id": {
+          "item": 3,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 3,
+          "last_line": 3,
+          "start_byte": 97,
+          "end_byte": 113,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{T}: Add {G}{G}."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Activated",
+          "effect": {
+            "type": "Mana",
+            "produced": {
+              "type": "Fixed",
+              "colors": [
+                "Green",
+                "Green"
+              ]
+            }
+          },
+          "cost": {
+            "type": "Tap"
+          },
+          "sub_ability": null,
+          "duration": null,
+          "description": "{T}: Add {G}{G}.",
+          "target_prompt": null,
+          "activation_restrictions": [
+            {
+              "type": "LevelCounterRange",
+              "data": {
+                "minimum": 1,
+                "maximum": 4
+              }
+            }
+          ],
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false,
+          "is_mana_ability": true
+        }
+      }
+    },
+    {
+      "id": 2,
+      "source": {
+        "id": {
+          "item": 2,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 4,
+          "last_line": 4,
+          "start_byte": 114,
+          "end_byte": 122,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "LEVEL 5+"
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "SelfRef"
+            },
+            "modifications": [
+              {
+                "type": "SetPower",
+                "value": 1
+              },
+              {
+                "type": "SetToughness",
+                "value": 4
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 5
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "LEVEL 5+ / 1/4"
+          },
+          "source_text": "LEVEL 5+ / 1/4",
+          "body_ir": null
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 6,
+          "last_line": 6,
+          "start_byte": 127,
+          "end_byte": 168,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Elves you control have \"{T}: Add {G}{G}.\""
+      },
+      "node": {
+        "Static": {
+          "definition": {
+            "mode": "Continuous",
+            "affected": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature",
+                {
+                  "Subtype": "Elf"
+                }
+              ],
+              "controller": "You",
+              "properties": []
+            },
+            "modifications": [
+              {
+                "type": "GrantAbility",
+                "definition": {
+                  "kind": "Activated",
+                  "effect": {
+                    "type": "Mana",
+                    "produced": {
+                      "type": "Fixed",
+                      "colors": [
+                        "Green",
+                        "Green"
+                      ]
+                    }
+                  },
+                  "cost": {
+                    "type": "Tap"
+                  },
+                  "sub_ability": null,
+                  "duration": null,
+                  "description": "{T}: Add {G}{G}.",
+                  "target_prompt": null,
+                  "condition": null,
+                  "optional_targeting": false,
+                  "optional": false,
+                  "forward_result": false,
+                  "is_mana_ability": true
+                }
+              }
+            ],
+            "condition": {
+              "type": "HasCounters",
+              "counters": {
+                "type": "OfType",
+                "data": "level"
+              },
+              "minimum": 5
+            },
+            "affected_zone": null,
+            "effect_zone": null,
+            "active_zones": [],
+            "characteristic_defining": false,
+            "description": "Elves you control have \"{T}: Add {G}{G}.\""
+          },
+          "source_text": "Elves you control have \"{T}: Add {G}{G}.\"",
+          "body_ir": null
+        }
+      }
+    }
+  ],
+  "source_text": "Level up {1}{G} ({1}{G}: Put a level counter on this. Level up only as a sorcery.)\nLEVEL 1-4\n1/2\n{T}: Add {G}{G}.\nLEVEL 5+\n1/4\nElves you control have \"{T}: Add {G}{G}.\"",
+  "card_name": "Joraga Treespeaker"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_lowered.snap
@@ -1,0 +1,174 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 555
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Mana",
+        "produced": {
+          "type": "Fixed",
+          "colors": [
+            "Green",
+            "Green"
+          ]
+        }
+      },
+      "cost": {
+        "type": "Tap"
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{T}: Add {G}{G}.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "LevelCounterRange",
+          "data": {
+            "minimum": 1,
+            "maximum": 4
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false,
+      "is_mana_ability": true
+    }
+  ],
+  "triggers": [],
+  "statics": [
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetPower",
+          "value": 1
+        },
+        {
+          "type": "SetToughness",
+          "value": 2
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 1,
+        "maximum": 4
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "LEVEL 1-4 / 1/2"
+    },
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "SelfRef"
+      },
+      "modifications": [
+        {
+          "type": "SetPower",
+          "value": 1
+        },
+        {
+          "type": "SetToughness",
+          "value": 4
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 5
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "LEVEL 5+ / 1/4"
+    },
+    {
+      "mode": "Continuous",
+      "affected": {
+        "type": "Typed",
+        "type_filters": [
+          "Creature",
+          {
+            "Subtype": "Elf"
+          }
+        ],
+        "controller": "You",
+        "properties": []
+      },
+      "modifications": [
+        {
+          "type": "GrantAbility",
+          "definition": {
+            "kind": "Activated",
+            "effect": {
+              "type": "Mana",
+              "produced": {
+                "type": "Fixed",
+                "colors": [
+                  "Green",
+                  "Green"
+                ]
+              }
+            },
+            "cost": {
+              "type": "Tap"
+            },
+            "sub_ability": null,
+            "duration": null,
+            "description": "{T}: Add {G}{G}.",
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "is_mana_ability": true
+          }
+        }
+      ],
+      "condition": {
+        "type": "HasCounters",
+        "counters": {
+          "type": "OfType",
+          "data": "level"
+        },
+        "minimum": 5
+      },
+      "affected_zone": null,
+      "effect_zone": null,
+      "active_zones": [],
+      "characteristic_defining": false,
+      "description": "Elves you control have \"{T}: Add {G}{G}.\""
+    }
+  ],
+  "replacements": [],
+  "extractedKeywords": [
+    {
+      "LevelUp": {
+        "type": "Cost",
+        "shards": [
+          "Green"
+        ],
+        "generic": 1
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Plan 05b tranche **T8-A3** — the R1 remainder: **U0-50** (Priority 14 ability-word "try as effect")
and **U0-12** (CR 711.2a/711.2b LEVEL-block activated line). Follows #6716 (A2).

Three commits, one concern each. The two sites are asymmetric to an unusual degree: U0-50 stamps
nothing at all, and U0-12 has the only retry in phase A whose predicate runs on the **lowered**
definition.

## U0-50 — the site whose shell stays `default()`

Entry point `parse_effect_chain_with_context(&effect_text, AbilityKind::Spell, &mut ctx)` — note
`Spell`, the one A3 site that is not `Activated` — so it takes `parse_ability_ir_with_context`, chosen
by name.

`ir.shell` stays `AbilityShellIr::default()`; no fields were invented for it. The **conditional emit
guard stays at the call site**: "should this be emitted at all" is control flow over the dispatch
loop, not a property of a definition, and folding it into the shell would make `AbilityShellIr` a
place where a recognizer can decline.

## U0-12 — the retry whose predicate runs on the lowered def

The site parses, tests `has_unimplemented(&def)`, and on failure re-parses a self-ref-normalized
variant **through the same already-mutated `ctx`**, keeping the alternative only if it comes back
clean. A0's H4 forbids an `AbilityIr::from_definition`, so this cannot lower-mutate-rewrap.

The shipped shape lowers purely to *ask* the predicate, while whichever IR won is what reaches
`ability_ir_at`. **No IR-level `has_unimplemented` was invented** — a second predicate over
`EffectChainIr` would be a rival authority free to diverge from the real one.

Three properties make it the same computation, each verified rather than assumed:

1. `parse_effect_chain_with_context(t,k,cx)` **is** `lower_ability_ir(&parse_ability_ir_with_context(t,k,cx))`,
   so every `has_unimplemented` argument is bit-for-bit the definition the original tested.
2. **`ctx` sequencing preserved.** The retry's second parse receives the same already-mutated `ctx`,
   not a fresh one, and the reset above it is not reordered. Interposing the lowering cannot perturb
   this: `lower_ability_ir` takes no `ParseContext`, and a sweep for `thread_local!`/`static mut`/
   `AtomicU`/`RefCell<`/`Cell<` across `parser/oracle_effect/` returns zero hits, so nothing on the
   lowering path carries interior mutability. H4's non-idempotence concerns `def → IR → def`
   round-trips, which do not exist here; applying a pure function twice is safe.
3. **The predicate is invariant under the envelope** — a property the plan did not state.
   `has_unimplemented` reads only `effect` and `sub_ability`, both CR 608.2 resolution-tree fields, and
   the shell stamps neither. So keeping the predicate pre-stamp is provably safe rather than merely
   faithful.

Cost is one extra lowering per LEVEL-block activated line. That is intrinsic rather than laziness: the
predicate's lowered value is *pre*-shell and the emitted one is *post*-shell, so they are genuinely
different values and neither can be cached as the other. The path runs on nine cards.

The shape is also already precedented in the tree — the instant/sorcery prevention-text site does
`has_unimplemented(&lower_effect_chain_ir(&effect_ir))` around a retained `OracleNodeIr::Spell`.

Restrictions: parsed `constraints.restrictions` **lead**, then `LevelCounterRange{minimum,maximum}` —
same polarity as A2. Stages `[ExtractCostReduction, ExtractManaSpendTrigger]`. The triggered branch
below, whose `And` graft is deliberately post-lowering, is **untouched**.

## §5.3 — reachability first, and the silences are distinguished

Reachability probes attributed by **message, never by name** — which mattered, since neither U0-50
reacher's name mentions the recognizer:

| site | `--lib` | integration |
|---|---|---|
| U0-50 | `swallow_check::tests::duration_until_eot_drop_tower` | `printed_ability_order::memory_test_triggers_are_in_printed_order` |
| U0-12 | `oracle::tests::leveler_activated_abilities_get_level_counter_range` | `printed_ability_order::under_construction_skyscraper_abilities_are_in_printed_order` |

Exactly one test per binary per site. Because a `panic!` at block entry fails every test that enters,
that enumeration is **complete**, which licenses scoping perturbations to those tests by argument
rather than by hope.

Perturbations ran through a harness carrying a **mandatory-red liveness arm**, so a dead harness could
not read as "all silent". Liveness → red, control → green, in both binaries.

| perturbation | result |
|---|---|
| drop `LevelCounterRange` | **RED** — the only witnessed axis |
| swap parsed-vs-implicit order | silent |
| drop `ExtractCostReduction` / drop `ExtractManaSpendTrigger` / reorder stages | silent |
| retry never fires | silent |
| `ChainLoweringMode` → `Standalone` | silent (**null reported as null**) |
| U0-50 emit guard inverted | silent across both full suites |

**The silences were then diagnosed rather than lumped together**, over the full nine-card leveler
population:

- **Restriction order is UNREACHABLE, not merely untested.** `constraints.restrictions` is empty for
  *every* leveler card, so the composed vec is always one element and a reversal is a no-op. There is
  no non-degenerate pool card, so the A1/A2 remediation recipe is **impossible** here rather than
  skipped.
- **The retry is dead on the pool, and disjointly so.** Its gate opens for exactly one card —
  Under-Construction Skyscraper, whose `Add {W}, {B}, {G}, or {C}` lowers to `Unimplemented` — but that
  text has no self-reference, so `normalized_effect != effect_text` is false and the alt parse never
  runs. Every card that *does* self-reference parses cleanly and never opens the gate. The most
  intricate logic in the tranche is unwitnessed and currently unreachable.
- **`ExtractManaSpendTrigger`'s guard is LIVE here — the first time in phase A.** A2 proved zero pool
  cards at its four sites lower to a root `Effect::Mana`; Joraga Treespeaker's `{T}: Add {G}{G}` does.
  The fold *body* remains inert (it additionally needs a trailing "when you spend this mana" node, and
  no leveler prints one), so dropping the fold is correctly silent. Stated as **guard-live /
  body-dead** rather than as a blanket "first live witness".

## Remediation

Additive two-layer snapshots for **Guul Draz Assassin** (two striations, two-component `{B}, {T}`
cost, bounded `2-3` plus unbounded `4+`) and **Joraga Treespeaker** (pins the live mana root), Oracle
text verbatim from the card pool. Both watched go **red** under a dropped `LevelCounterRange`, then
restored.

## Gates

```
cargo fmt --all                                      clean
cargo clippy -p engine --lib -- -D warnings          zero warnings
cargo nextest run -p engine --lib                    17851 passed, 6 skipped   (17849 + 2 new)
cargo nextest run -p engine --test integration       4123 passed, 2 skipped
./scripts/check-prelowered-ratchet.sh                Gate P PASS
./scripts/check-skill-doc.sh                         ✓ oracle-parser skill references valid
./scripts/check-parser-combinators.sh                Gate G PASS / Gate A PASS
```

**Zero existing snapshots changed**: `git diff --name-status` is **4 A / 2 M**, both modified files
source. `.snap.new` count 0. `oracle.rs` unmoved at 16 on the ratchet; ledger unedited.

Parser string-dispatch diff gate clean, including the `rfind`/`split`/`split_once`/`rsplit`
blind-spot arms. CR diff gate: 8 numbers, **0 unverified**, text read for each — 106.6, 601.2f, 602.1a,
602.1b, 603.3, 608.2, 711.2a, 711.2b.

## Harvest (§5.4)

1. **Kargan Dragonlord's LEVEL 8+ firebreathing is silently swallowed — pre-existing, and a class
   bug.** `parse_level_blocks` (`oracle_level.rs`) attempts **static** classification *before*
   activated-colon detection, and `{R}: this creature gets +1/+0 until end of turn.` matches a static
   line, which consumes it with a `continue`. The card yields **zero** abilities where all eight
   sibling levelers yield gated ones — and an *unconsumed* line would instead fall through and yield
   an ungated ability, so the observed zero pins the static branch as the consumer. Net effect: a
   repeatable `{R}`-per-activation pump becomes a permanent static bonus (CR 711.2 + CR 602.1). Any
   level-block activated ability whose post-colon text parses as a static is affected.
2. **Under-Construction Skyscraper's `Add {W}, {B}, {G}, or {C}` is `Unimplemented`** at both
   striations — a real parser gap for "add one of N colors" mana abilities.
3. **`duration_until_eot_drop_tower` is a vacuous negative.** Its only assertion is
   `!has_swallowed_detector(…)`, which holds when the ability is never emitted at all — which is
   precisely why inverting U0-50's emit guard is silent.
4. Restriction-order at U0-12 is unreachable by construction on the current pool.
5. The retry is dead on the current pool by disjointness of its two conditions.

## One limitation stated rather than papered over

**U0-50's emit guard polarity is unwitnessed.** A Drop Tower fixture was built, measured, and
**discarded**: modelling the card correctly — `Artifact` plus its verbatim `Attraction` subtype —
routes the Visit line to the CR 717 preprocessor, and a re-inserted probe confirmed the site is never
reached. The two in-suite reachers hit U0-50 only because they supply no subtype, i.e. only because
they model the card wrongly. Shipping that fixture would have "closed" the gap with a test that passes
for the wrong reason.

For the record, this does **not** put the site's production reachability in doubt: U0-50 is the general
ability-word handler (its own comment cites "Void Shields —"), not an Attraction path, and **1,027
cards in the pool carry an ability-word prefix line**. The unwitnessed axis is the guard's polarity,
not the site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of level-based and ability-word effects, including activation costs, descriptions, and level restrictions.
  * Better handling of self-referential ability text and previously unsupported content.

* **Tests**
  * Added coverage for level-based activated abilities and level-based mana abilities.
  * Added snapshots validating activation restrictions and mana ability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->