### PR TITLE
refactor(parser): Plan 05b T8-A4 — U0-53, the one R2 row under the cap

### DIFF
--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -4,9 +4,9 @@ use nom::bytes::complete::tag;
 use nom::Parser;
 
 use crate::types::ability::{
-    AbilityDefinition, AbilityKind, ActivationRestriction, Effect, ReplacementCondition,
-    ReplacementDefinition, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition,
-    TriggerConstraint, TriggerDefinition,
+    AbilityKind, ActivationRestriction, Effect, ReplacementCondition, ReplacementDefinition,
+    StaticCondition, StaticDefinition, TargetFilter, TriggerCondition, TriggerConstraint,
+    TriggerDefinition,
 };
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
@@ -16,8 +16,12 @@ use super::oracle_classifier::{
     is_effect_sentence_candidate, is_granted_static_line, is_replacement_pattern, is_static_pattern,
 };
 use super::oracle_cost::parse_oracle_cost;
-use super::oracle_effect::parse_effect_chain;
+use super::oracle_effect::{lower_ability_ir, parse_effect_chain};
+use super::oracle_ir::ast::parsed_clause;
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::effect_chain::{
+    AbilityIr, AbilityShellIr, EffectChainIr, PlayerScopeRewrite,
+};
 use super::oracle_ir::replacement::ReplacementIr;
 use super::oracle_ir::static_ir::StaticIr;
 use super::oracle_ir::trigger::TriggerNodeIr;
@@ -112,24 +116,59 @@ pub(crate) fn parse_class_oracle_text(
     for section in &sections {
         // Generate the "{cost}: Level N" activated ability
         if let Some((level_line, cost_text, description)) = &section.level_up {
-            let cost = parse_oracle_cost(cost_text);
-            let mut def = AbilityDefinition::new(
+            // Plan 05b T8-A4, recipe R2: the hand-built definition becomes a
+            // one-clause `EffectChainIr` body plus a CR 602.1 activation shell,
+            // lowered through the single authority `lower_ability_ir`. Phase A
+            // still emits the pre-lowered node, so this is the same value the
+            // hand-built path produced; T9 swaps the payload for the IR itself.
+            //
+            // `source_text` is the whole printed level line, which is also the
+            // chain text and therefore the single clause's fragment: the clause
+            // IS the whole ability body here, so its span is the line's own
+            // `0..len` and nothing about the provenance is invented.
+            let mut body = EffectChainIr::single_clause(
+                description,
                 AbilityKind::Activated,
-                Effect::SetClassLevel {
+                parsed_clause(Effect::SetClassLevel {
                     level: section.level,
-                },
+                }),
+                None,
+                None,
+                false,
             );
-            def.cost = Some(cost);
-            def.description = Some(description.clone());
-            // CR 602.5d + CR 716.4: Level N+1 can only activate at sorcery speed
-            // and only when at level N.
-            def.activation_restrictions
-                .push(ActivationRestriction::AsSorcery);
-            def.activation_restrictions
-                .push(ActivationRestriction::ClassLevelIs {
-                    level: section.level - 1,
-                });
-            items.push((*level_line, OracleNodeIr::PreLoweredSpell(def)));
+            // The hand-built definition never ran `apply_player_scope_rewrites`,
+            // so `Preserve` — not `single_clause`'s `Apply` default — is what
+            // reproduces it. This is also T8's mandated R2 mitigation: it removes
+            // the one rewrite family that is not inert on shape alone.
+            body.player_scope_rewrite = PlayerScopeRewrite::Preserve;
+            let ir = AbilityIr {
+                source_text: description.clone(),
+                body,
+                shell: AbilityShellIr {
+                    // CR 602.1a: the activation cost, everything before the colon.
+                    cost: Some(parse_oracle_cost(cost_text)),
+                    description: Some(description.clone()),
+                    // CR 602.1b + CR 716.2a: "[Cost]: Level N" means "Activate
+                    // only if this Class is level N-1 and only as a sorcery"
+                    // (CR 602.5d supplies the sorcery-speed timing). The vec is
+                    // applied verbatim, so it is built in the order the
+                    // hand-built site pushed them — which is the REVERSE of the
+                    // order CR 716.2a states them in. That order is a
+                    // pre-existing property of this site, preserved here rather
+                    // than quietly changed inside a byte-identical conversion.
+                    activation_restrictions: vec![
+                        ActivationRestriction::AsSorcery,
+                        ActivationRestriction::ClassLevelIs {
+                            level: section.level - 1,
+                        },
+                    ],
+                    ..AbilityShellIr::default()
+                },
+            };
+            items.push((
+                *level_line,
+                OracleNodeIr::PreLoweredSpell(lower_ability_ir(&ir)),
+            ));
         }
 
         // Parse ability lines for this level section


### PR DESCRIPTION
Plan 05b tranche **T8-A4** — the R2 rows, and the **last sub-tranche of T8**. Follows #6719 (A3).

**One row converted, four excluded with evidence.** The exclusion table is this tranche's headline
deliverable, not the conversion count.

## Why the scope is 1 of 5

§T8 lists five R2 rows (U0-53, U0-62, U0-02, U0-52, U0-38) but its own R2 paragraph caps R2 at
*single-clause bodies with no `sub_ability`*, "anything larger is a recognizer rewrite, not an R2
conversion". **Neither statement wins outright**, and the four exclusions have **three different
reasons** — for two of them the cap is not even the operative axis.

| row | site | cap verdict | action |
|---|---|---|---|
| U0-53 | `oracle_class.rs:118-172` | **under cap** — 1 clause, no `sub_ability` | **CONVERTED** |
| U0-38 | `oracle.rs:5511-5531` | **exceeds cap** | excluded |
| U0-52 | `oracle.rs:6392` | **not an R2 site at all** | excluded |
| U0-02 | `oracle.rs:2164` | passes structural cap, **fails §5.2** | excluded |
| U0-62 | `oracle_class.rs:341-344` | passes structural cap, **fails §5.2** | excluded |

**U0-38 exceeds the cap textually.** `oracle.rs:5519` is
`.sub_ability(AbilityDefinition::new(AbilityKind::Spell, Effect::PreventDamage{..}))` — a two-node
`Choose` → `PreventDamage` body. Corroborating from a second direction: the recensus's **own tranche
table at line 601** assigns U0-38 (and U0-02) to **T10e**, not T8. Two of the document's three
statements agree; the §T8 row list is the outlier.

**U0-52 is not a hand-built-body site.** `oracle.rs:6382` binds `nom_def` **once**; U0-51 emits it when
the dispatcher produced a real effect, and U0-52 emits **the same binding** otherwise. The five
`Effect::unimplemented` shapes the census attributes to this site are produced *inside*
`dispatch_line_nom`. Converting it needs an `AbilityIr` for the fallback branch, and there are exactly
three ways to get one: an IR-returning dispatcher (precisely T10a's stated blocker), re-running the
dispatcher (the census forbids it), or un-lowering the definition (impossible —
`AbilityIr::from_definition` does not exist, by A0's H4 design).

**U0-02 and U0-62: verdict confirmed, reasoning corrected.** Both bodies are `make_unimplemented(...)`
— single clause, no `sub_ability` — so they **pass the structural cap**, and the implied byte-identity
blocker is not real: `Effect::unimplemented("unknown", line)` expands to exactly that literal, so
Gate F is satisfiable and byte-identity is mechanically reachable. **Gate F is not the blocker.**

The verdict holds on firmer ground. §5.2 makes the written CR-faithfulness argument a *mandatory* half
of the gate, and requires it "for the CLASS of text the recognizer handles". **Neither site has a
recognizer.** Both are terminal residuals whose membership is defined **negatively** — whatever every
preceding arm declined. A negatively-defined set has no text class, so the required argument cannot be
written for either site under *any* recipe. That is a structural property, not a judgement call, and
it survives even if the shared residual node is later built. Wrapping the sentinel ad hoc at two sites
would also be the exact per-site special case that node exists to replace.

**The shared residual node was not built** — architecture work, out of scope.

## The converted row: U0-53, the Class level bar

76 of 79 Class abilities. `kind = Activated`, `effect = SetClassLevel{level}`, plus `cost`,
`description`, and `activation_restrictions = [AsSorcery, ClassLevelIs{level-1}]` in that order.

**Labelled correct-by-corpus**, and R1's "no property of any card's text participates" is deliberately
not borrowed. What makes it byte-identical:

- **`Effect::SetClassLevel` occurs exactly once in the whole of `parser/oracle_effect/`** —
  `sequence.rs:6175`, inside `clause_is_dig_lookback_transparent`, a predicate that runs only when an
  antecedent search walks back over *intervening* clauses. A one-clause chain has none, so it is never
  invoked. Every other pass in the assembly tail and in `finalize_effect_chain`'s six passes keys on a
  different `Effect` variant, or on `sub_ability`/`else_ability`/`mode_abilities` presence — none of
  which this body has.
- `PlayerScopeRewrite::Preserve` removes `apply_player_scope_rewrites` by construction.
- The owner-library anchor is doubly inert: its guard needs two phrases the level line cannot contain,
  and the walk beneath it looks for `Effect::Shuffle`/`Effect::RevealTop`, neither expressible here.

**What a future card could violate:** a Class card printing "Level 0" — `section.level - 1` on a `u8`
underflows. Pre-existing, preserved, not introduced.

**What a future commit could violate — the honest limit of R2.** Unlike R1's algebraic identity, this
argument is a *survey of today's pass list*. A pass added later to `finalize_effect_chain` or
`assemble_effect_chain`'s tail that keys on `AbilityKind::Activated`, on chain length, or on
`SetClassLevel` would newly apply here, with nothing in the type system to catch it. **This is why R2
is not correct-by-construction**, stated rather than glossed.

## §5.3

**Reachability, attributed by probe message and never by test name: 21 reachers** — 9 in `--lib`, 12 in
the integration binary. Attribution mattered a third consecutive time: `bandits_talent_level3_…` and
all ten Scavengers-Talent / Party-Dude integration tests name a card and never the recognizer.

**No remediation snapshot was needed** — the first tranche in A1–A4 where that is true. The five Class
two-layer snapshots landed at T1 already witness this site **twice each** (Level 2 and Level 3), across
ten distinct cost shapes. Their `*_ir.snap` payloads were checked to confirm they serialize the full
lowered def including the ordered `activation_restrictions` array — that is *why* the perturbations
discriminate, verified rather than assumed.

| perturbation | result |
|---|---|
| swap restriction order (`ClassLevelIs` before `AsSorcery`) | **RED — 6 tests** |
| drop shell `description` | **RED — 6 tests** |
| drop shell `cost` | **RED — 6 tests** |
| `PlayerScopeRewrite::Apply` instead of `Preserve` | **NULL — 137/137 pass either way** |

**The `Apply`/`Preserve` null deserves emphasis rather than burial.** `Preserve` is one of §T8's two
mandated R2 mitigations, and measured, it is **extensionally inert on today's corpus** — so it supplies
**no evidence** that this conversion is safe. `Preserve` remains the correct value (it is what the
hand-built path did, by construction), but the safety argument rests entirely on the shape analysis
above. This row should not be read as "mitigation applied, therefore safe".

`ChainLoweringMode` is **inapplicable** here rather than null: the recognizer parses no text, it
hand-builds an `Effect` from a parsed level number, so there is no entry point whose mode could be
crossed.

## Gates

```
cargo fmt --all                                      clean
cargo clippy -p engine --lib -- -D warnings          zero warnings
cargo nextest run -p engine --lib                    17851 passed, 6 skipped
cargo nextest run -p engine --test integration       4123 passed, 2 skipped
./scripts/check-prelowered-ratchet.sh                Gate P PASS
./scripts/check-skill-doc.sh                         ✓ oracle-parser skill references valid
./scripts/check-parser-combinators.sh                Gate G PASS / Gate A PASS
```

**Zero snapshot churn**: the entire diff is one line — `M crates/engine/src/parser/oracle_class.rs`.
No files added, no snapshots changed, `.snap.new` count 0.

**Gate P did not lower for `oracle_class.rs`, deliberately.** It stays at 5/5, ledger unedited. That
file has no `DocEmitter`, so there is no `ability_ir_at` seam to hide the token behind; the site now
states phase A's identity inline as `PreLoweredSpell(lower_ability_ir(&ir))` — the same value
`ability_ir_at` computes one file over. The token retires at T9 with the payload swap.

## Harvest (§5.4)

1. **`oracle_class.rs` cited CR 716.4 for the Class level gate — the rule that explicitly disclaims the
   connection.** CR 716.4 (`:6030`) is about *leveler cards* and states they "are **not the same as**
   class level abilities. Level counters do not interact with Class cards, and class levels do not
   interact with leveler cards." The annotated claim is **CR 716.2a**'s (`:6020`). CR 602.5d was
   correct and is kept. **Fixed in this commit.** The U0-53 **census row carries the same wrong
   number** — the recensus needs correcting, which is a maintainer call; no planning doc was edited.
2. **Restriction order is the reverse of CR 716.2a's stated order** ("only if this Class is level N-1
   **and** only as a sorcery"). Directly analogous to A2's Boast/CR 702.142a finding. Semantically
   harmless — the restrictions are a conjunction — and **preserved, not fixed**.
3. **`section.level - 1` is an unguarded `u8` subtraction**; a "Level 0" line would underflow.
   Unreachable today only as a corpus property. Pre-existing.
4. **The `SetClassLevel` single-occurrence grep is reusable** as the mechanical core of any future
   single-leaf-`Effect` R2 argument.
5. **U0-62's residual is reached by two routes, one of which DISCARDS a parsed chain.**
   `oracle_class.rs:332-338`: `is_effect_sentence_candidate` → `parse_effect_chain` → if
   `has_unimplemented`, the parsed def is **thrown away** and the line falls through to
   `make_unimplemented(line)`. Whoever designs the shared residual node must decide whether to preserve
   that discarded partial chain — and doing so is a **behaviour change**, not a conversion.
6. **U0-53 was the last hand-built `AbilityDefinition` body in `oracle_class.rs`** — its
   `AbilityDefinition` import is now unused and was removed.

## Deviation flagged rather than buried

A pre-existing CR citation was corrected inside a byte-identity commit. Justified by CLAUDE.md
("if you are modifying existing game logic, verify existing CR annotations are present and still
accurate"); it changes no code, and leaving a known-wrong CR number in a block being rewritten was the
worse option. Flagged because byte-identity tranches are otherwise strictly no-extras.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle class level-up ability parsing and processing.
  * Ensured level-up effects are consistently converted into the game’s ability system, including activation costs and class-level restrictions.
  * Preserved player scope behavior when applying level-up effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->