### PR TITLE
fix(parser): Plan 05b T9a — route U0-39 through lower_ability_ir

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -59,7 +59,7 @@ use super::oracle_dispatch::dispatch_line_nom;
 use super::oracle_effect::sequence::try_parse_same_is_true_continuation;
 use super::oracle_effect::{
     lower_ability_ir, lower_effect_chain_ir, parse_ability_ir_with_context,
-    parse_additional_cost_instead_condition_fragment, parse_effect_chain, parse_effect_chain_ir,
+    parse_additional_cost_instead_condition_fragment, parse_effect_chain,
     parse_effect_chain_with_context, rewrite_condition_keyword,
     try_parse_temporal_delayed_trigger_ability,
 };
@@ -5556,9 +5556,26 @@ pub(crate) fn parse_oracle_ir(
         {
             ctx.subject = None;
             ctx.actor = None;
-            let effect_ir = parse_effect_chain_ir(&line, AbilityKind::Spell, &mut ctx);
-            if !has_unimplemented(&lower_effect_chain_ir(&effect_ir)) {
-                emitter.emit_at(item_line, OracleNodeIr::Spell(effect_ir));
+            // Routed through `parse_ability_ir_with_context` + `ability_ir_at`,
+            // i.e. `lower_ability_ir`, which is what `parse_effect_chain_with_context`
+            // has always been. #6123 converted this site to the raw pair
+            // `parse_effect_chain_ir` + `lower_effect_chain_ir` while hoisting the
+            // Class-H replacement producers, which silently dropped three things the
+            // entry point had been supplying: `finalize_effect_chain`, the
+            // owner-library reveal anchor, and the `WithContext` whole-body
+            // recognizer set. That made this the only spell path in the parser
+            // lowering a whole ability body without them. Restored here.
+            //
+            // The guard runs on `lower_ability_ir(&ir)` for the same reason the
+            // effect fallback below does: whether to emit at all is control flow,
+            // and `has_unimplemented` reads a lowered root, so the predicate must
+            // see the definition this site will actually emit. `lower_ability_ir`
+            // is a pure `&AbilityIr -> AbilityDefinition`, so lowering here and
+            // again in `ability_ir_at` repeats one computation rather than
+            // performing two different ones.
+            let ir = parse_ability_ir_with_context(&line, AbilityKind::Spell, &mut ctx);
+            if !has_unimplemented(&lower_ability_ir(&ir)) {
+                emitter.ability_ir_at(item_line, ir);
                 i += 1;
                 continue;
             }

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -311,6 +311,22 @@ pub(crate) enum OracleNodeIr {
     /// Unit 3b replaces this payload with `AbilityIr { source, body, shell }` so
     /// the activation metadata the router currently applies around the chain
     /// becomes typed IR rather than a pre-lowered `AbilityDefinition`.
+    ///
+    /// PLAN-05 DEBT (2026-07-28, Plan 05b T9a): no producer, on purpose and
+    /// temporarily. The one site that constructed this variant (`oracle.rs`, the
+    /// instant/sorcery prevention recognizer, U0-39) was the only spell path
+    /// lowering a whole ability body without `finalize_effect_chain`, the
+    /// owner-library reveal anchor, and the `WithContext` whole-body recognizer
+    /// set, because it lowered through `lower_effect_chain_ir` rather than
+    /// `lower_ability_ir`. T9a routed it through `ability_ir_at` like every other
+    /// phase-A producer, which is precisely the precondition `ability_ir_at`'s
+    /// doc block names for phase B. T9b re-constructs this variant for **all**
+    /// spell producers at once by swapping the payload to `AbilityIr` and
+    /// flipping `ability_ir_at`'s body — so the allow is deleted there, not
+    /// carried. Kept (rather than removed) because the readers, the two
+    /// exhaustive `doc.rs` matches, and the `finish()` slot accounting are the
+    /// surface T9b lands on.
+    #[allow(dead_code)]
     Spell(EffectChainIr),
     /// Triggered ability.
     Trigger(TriggerNodeIr),

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -138,6 +138,61 @@ fn questing_beast() {
 }
 
 // ---------------------------------------------------------------------------
+// CR 615.1a prevention spells — the instant/sorcery prevention recognizer
+// ---------------------------------------------------------------------------
+//
+// CR 615.1a: "Effects that use the word 'prevent' are prevention effects."
+// That sentence *is* this recognizer's admission test: it claims an
+// instant/sorcery line containing both "prevent" and "damage" (excluding the
+// CR 614.15 ability-word self-replacement printings) and lowers the whole line
+// as a resolving spell chain rather than a standing replacement definition.
+//
+// **Why these two fixtures exist.** 153 cards in the pool reach that site and,
+// before Plan 05b T9a, NOT ONE of them was snapshotted — the only spell path
+// that lowered a whole ability body without `finalize_effect_chain`, the
+// owner-library reveal anchor, and the `WithContext` whole-body recognizer set
+// was also the one with no two-layer guard. T9a routed it through
+// `lower_ability_ir` (via `ability_ir_at`) and measured a zero full-pool delta;
+// these pin that result so T9b's payload swap — which lands on this exact
+// recognizer — cannot move it silently.
+//
+// Both texts are verbatim MTGJSON, not paraphrases: a paraphrase can take a
+// different parser branch and go green while the real card stays broken.
+
+/// The canonical single-clause prevention spell — the whole card is the
+/// prevention sentence, so the chain has exactly one clause and no `sub_ability`.
+#[test]
+fn fog_prevention_spell() {
+    let (ir, lowered) = parse_two_layer(
+        "Prevent all combat damage that would be dealt this turn.",
+        "Fog",
+        &["Instant"],
+        &[],
+    );
+    insta::assert_json_snapshot!("fog_ir", &ir);
+    insta::assert_json_snapshot!("fog_lowered", &lowered);
+}
+
+/// The multi-clause case the recognizer was written for. The site's own comment
+/// cites this shape verbatim — "preserve any preceding clauses ('You gain 1 life
+/// for each ...')" — because the prevention marker sits in the SECOND sentence,
+/// so a replacement classifier reaching the line first would drop the life gain.
+/// This is the fixture that exercises chain assembly and `lower_ability_ir`'s
+/// pinned chain → finalize → anchor → `sub_link` order, rather than a
+/// degenerate one-clause body that would take the same path either way.
+#[test]
+fn blunt_the_assault_prevention_spell_preserves_preceding_clause() {
+    let (ir, lowered) = parse_two_layer(
+        "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn.",
+        "Blunt the Assault",
+        &["Instant"],
+        &[],
+    );
+    insta::assert_json_snapshot!("blunt_the_assault_ir", &ir);
+    insta::assert_json_snapshot!("blunt_the_assault_lowered", &lowered);
+}
+
+// ---------------------------------------------------------------------------
 // Casting restrictions / permissions
 // ---------------------------------------------------------------------------
 

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_ir.snap
@@ -1,0 +1,79 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 110,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "GainLife",
+            "amount": {
+              "type": "Ref",
+              "qty": {
+                "type": "ObjectCount",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Creature"
+                  ],
+                  "controller": null,
+                  "properties": []
+                }
+              }
+            }
+          },
+          "cost": null,
+          "sub_ability": {
+            "kind": "Spell",
+            "effect": {
+              "type": "PreventDamage",
+              "amount": "All",
+              "target": {
+                "type": "Any"
+              },
+              "scope": "CombatDamage"
+            },
+            "cost": null,
+            "sub_ability": null,
+            "duration": "UntilEndOfTurn",
+            "description": null,
+            "target_prompt": null,
+            "condition": null,
+            "optional_targeting": false,
+            "optional": false,
+            "forward_result": false,
+            "sub_link": "SequentialSibling"
+          },
+          "duration": null,
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn.",
+  "card_name": "Blunt the Assault"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_lowered.snap
@@ -1,0 +1,61 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "GainLife",
+        "amount": {
+          "type": "Ref",
+          "qty": {
+            "type": "ObjectCount",
+            "filter": {
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": null,
+              "properties": []
+            }
+          }
+        }
+      },
+      "cost": null,
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "PreventDamage",
+          "amount": "All",
+          "target": {
+            "type": "Any"
+          },
+          "scope": "CombatDamage"
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": "UntilEndOfTurn",
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false,
+        "sub_link": "SequentialSibling"
+      },
+      "duration": null,
+      "description": null,
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_ir.snap
@@ -1,0 +1,50 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 56,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "Prevent all combat damage that would be dealt this turn."
+      },
+      "node": {
+        "PreLoweredSpell": {
+          "kind": "Spell",
+          "effect": {
+            "type": "PreventDamage",
+            "amount": "All",
+            "target": {
+              "type": "Any"
+            },
+            "scope": "CombatDamage"
+          },
+          "cost": null,
+          "sub_ability": null,
+          "duration": "UntilEndOfTurn",
+          "description": null,
+          "target_prompt": null,
+          "condition": null,
+          "optional_targeting": false,
+          "optional": false,
+          "forward_result": false
+        }
+      }
+    }
+  ],
+  "source_text": "Prevent all combat damage that would be dealt this turn.",
+  "card_name": "Fog"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_lowered.snap
@@ -1,0 +1,32 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Spell",
+      "effect": {
+        "type": "PreventDamage",
+        "amount": "All",
+        "target": {
+          "type": "Any"
+        },
+        "scope": "CombatDamage"
+      },
+      "cost": null,
+      "sub_ability": null,
+      "duration": "UntilEndOfTurn",
+      "description": null,
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}


### PR DESCRIPTION
Plan 05b **T9a** — the U0-39 lowering fix, deliberately isolated ahead of T9b's payload swap so its
behavioural delta is reviewable on its own rather than buried in ~51 files of re-serialization.

Follows #6720, which completed T8.

**The measured full-pool delta is ZERO — and that is a proven semantic no-op, not an unapplied probe.**
That distinction is the entire point of the unit.

## What changed

U0-39 (the instant/sorcery prevention-text recognizer) was **the only spell path in the parser that
lowered a whole ability body without `finalize_effect_chain`, the owner-library reveal anchor, the
`WithContext` whole-body recognizer set, or CR 707.9a printed-slot stamping.** It now routes through
`ability_ir_at`, phase A's designated seam:

```rust
let ir = parse_ability_ir_with_context(&line, AbilityKind::Spell, &mut ctx);
if !has_unimplemented(&lower_ability_ir(&ir)) {
    emitter.ability_ir_at(item_line, ir);
```

No new machinery: `ability_ir_at` already exists, and the effect fallback at `oracle.rs:6353` already
uses this exact `has_unimplemented(&lower_ability_ir(&ir))` idiom — its comment even reads *"same shape
the prevention-text site above already uses."* U0-39 simply stops being the odd one out.

**`OracleNodeIr::Spell`'s payload is untouched.** T9b is intact.

## #6123's story: incidental, and the recensus understates it

The commit is `refactor(parser): hoist Class-H replacement producers to the oracle document IR seam`.
Its body describes only the replacement hoist and **never mentions a spell path**. The U0-39 change is
one unremarked hunk among twenty in `oracle.rs`:

```diff
-let def = parse_effect_chain_with_context(&line, AbilityKind::Spell, &mut ctx);
-if !has_unimplemented(&def) {
-    emitter.ability_at(item_line, def);
+let effect_ir = parse_effect_chain_ir(&line, AbilityKind::Spell, &mut ctx);
+if !has_unimplemented(&lower_effect_chain_ir(&effect_ir)) {
+    emitter.emit_at(item_line, OracleNodeIr::Spell(effect_ir));
```

It dropped **three** mechanisms, not the two §T9 records — the `WithContext` whole-body bypasses
(conditional protection, for-each-attacker-copy-blocker, face-down pile, Balance equalization) went
too, because `parse_effect_chain_with_context` ran `try_parse_chain_bypass` before lowering.

**What let it through review is the interesting part: the commit's byte-identity claim was TRUE.**
Byte-identity cannot see a semantic narrowing whose reach is empty. This is the canonical case for
§5.4's "byte-identity with no harvest is a signal".

## The measurement

**Population, stated and evidenced.** The real `AtomicCards.json` was symlinked into the worktree
(§5.1.3's void-evidence trap: a worktree carries only `test_fixture.json`, so generating there measures
a fixture population). Both runs: **34,739 cards / 35,516 faces**, 450 set files, 92.1% implemented,
output **99,201,978 bytes**. The fixture population is ~519 KB and cannot produce those numbers. All
symlinks removed; tree clean.

**Result: `sha256 c3f8431c…`, byte-identical before and after. `cmp` → IDENTICAL.**

**Liveness — zero was treated as broken until proven otherwise (§5.3), three independent ways:**

1. **The compiler witnesses it.** `warning: variant Spell is never constructed` — `oracle.rs:5561` was
   the *sole* construction site pool-wide, so that warning is only possible if the edit took effect.
2. **Disable-probe went RED.** Gating the site off diverged the export at char 1,137,839. The
   population does reach this code and it does matter.
3. **Instrumented count: 155 reaches across 153 distinct cards** (Fog, Darkness, Awe Strike,
   Comeuppance, Deflecting Palm, Blunt the Assault…). Two cards have two qualifying lines.

**Mechanism-by-mechanism attribution**, computed per reach on cloned `ParseContext`s:

| mechanism | reach / 155 | evidence |
|---|---|---|
| `finalize_effect_chain` (6 passes) | **0** | `def_same=true` ×155 |
| owner-library reveal anchor | **0** | needs two phrases jointly; jq over the 173 prevent+damage instant/sorcery faces → `[]` |
| `WithContext` whole-body bypasses | **0** | `bypass_fired=false` ×155 |
| CR 707.9a printed-slot stamping | **0** | all 7 pool-wide `RetainPrintedAbilityFromSource` carriers are permanents |
| `has_unimplemented` gate | **0 flips** | 148 emit / 7 decline, identical both ways |

That last row was a genuine risk worth measuring: `fold_additional_combat_attacker_restriction` and
`fold_speed_floor_sentences` *consume* `Effect::Unimplemented` children, so finalize can remove an
unimplemented node and flip the gate — changing *which lines the site claims*. It never fires here.

**Nothing is made worse — vacuously, but provably.** The 7 declined reaches fall through to Priority 8+
exactly as before: unchanged honest reds, not new ones.

## So what is the value?

A latent-defect fix plus a conformance change. Any *future* prevention card touching finalize, the
anchor, a bypass, or stamping would have silently misparsed. It also makes U0-39 satisfy phase A's
precondition for T9b — `ability_ir_at`'s own doc block says phase B flips its body "and every producer
is already correct."

**The honest caveat, stated plainly: the value is entirely prospective.** There is no
revert-flipping runtime test, because reverting changes no output. No such test was fabricated.

## Snapshot guards — closing the hole that let #6123 through

**None of the 153 cards reaching U0-39 was snapshotted.** The one spell path with a silent semantic
narrowing was also the one with no two-layer guard. T9b lands on this exact recognizer, so two
fixtures were added, both verbatim from the pool:

- **Fog** — `Prevent all combat damage that would be dealt this turn.` Canonical single clause.
- **Blunt the Assault** — `You gain 1 life for each creature on the battlefield. Prevent all combat
  damage that would be dealt this turn.` The **non-degenerate** fixture: the prevention marker is in
  the *second* sentence, which is verbatim what the site's own comment cites as its reason for
  existing. Lowers to `GainLife{Ref(ObjectCount(Creature))}` with `PreventDamage` chained as
  `sub_link: SequentialSibling` — two instructions in the order written, **CR 608.2c**. Both clauses
  preserved.

A one-clause-only fixture would have taken the same path either way and proven nothing about chain
assembly, hence the pair. All four snapshots were read before acceptance.

## Gates

```
cargo fmt --all                                      clean
cargo clippy -p engine --lib -- -D warnings          zero warnings
cargo nextest run -p engine --lib                    17857 passed, 6 skipped
cargo nextest run -p engine --test integration       4132 passed, 2 skipped
./scripts/check-prelowered-ratchet.sh                Gate P PASS
./scripts/check-skill-doc.sh                         ✓ oracle-parser skill references valid
./scripts/check-parser-combinators.sh                Gate G PASS / Gate A PASS
```

**Zero existing snapshots changed; zero `*_ir.snap` modified.** `git diff --name-status` is 4 A / 3 M,
all three modified files source. `.snap.new` count 0. No pre-existing test failed — nothing in the
suite pinned the post-#6123 behavior. Ledger never edited.

Parser string-dispatch diff gate: clean (the change removes a call and adds none). CR-annotation diff
gate: **zero CR numbers added or changed**, so nothing to verify — though every rule cited in the
commit bodies was grep-verified with its text read: CR 615.1/615.1a, 608.2c, 707.9a, 614.15,
108.3/400.3, 602.1/602.1a, 601.2b.

## One judgement call worth reviewing

Routing through `lower_ability_ir` while keeping the node as `Spell(EffectChainIr)` genuinely requires
T9b, because the anchor needs `source_text` and `EffectChainIr` does not carry it. Rather than stop,
the **producer** was sent through `ability_ir_at`, which already builds the `AbilityIr` and calls
`lower_ability_ir`. Payload untouched, goal achieved.

Consequence: `OracleNodeIr::Spell` loses its only producer and carries a dated `#[allow(dead_code)]`
with a PLAN-05 DEBT block. **T9b deletes that allow** when it flips `ability_ir_at`'s body and
re-constructs the variant for every producer at once. The variant is kept rather than removed because
the two exhaustive `doc.rs` matches and `finish()`'s slot accounting are the surface T9b lands on.

**Ratchet honesty:** Gate P passes, but note *why*. `ability_ir_at` deliberately avoids the literal
`PreLowered` token (its doc block says so, to keep the ratchet monotone), so the token count is
unchanged while the semantic count of pre-lowered spell producers went **up by one**. By design, not
evasion — but the gate did not measure what its name suggests here. This is another instance of the
already-known property that the ratchet tracks helper deletion, not producer conversion.

## Harvest (§5.4)

1. **The recensus's U0-39 row is incomplete** — #6123 dropped the `WithContext` bypass set as well as
   finalize + anchor. §T9 and the census row should say three mechanisms. Reach today: zero.
2. **Recensus harvest item 4 upgraded from "plausible/latent" to provably unreachable** — only 7 cards
   pool-wide carry `RetainPrintedAbilityFromSource` and all 7 are permanents, so the CR 707.9a
   mis-index could never fire on an `is_spell` site.
3. **A coverage hole, not a code defect: 153/153 cards reaching U0-39 had no snapshot.** Closed here.
   Worth asking which *other* converted sites have reaching populations and no two-layer guard — this
   is the failure mode that let #6123 through, and the same probe measures it.
4. **`fold_additional_combat_attacker_restriction` / `fold_speed_floor_sentences` consume
   `Effect::Unimplemented`,** so `finalize_effect_chain` can change `has_unimplemented`'s answer. Any
   site whose emit gate reads it *pre*-finalize can claim a different set of lines than one reading
   post-finalize. Zero flips here, but the pattern deserves a grep across the remaining gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of damage-prevention effects on instant and sorcery spells.
  * Preserved preceding effects when parsing multi-clause prevention abilities.

* **Tests**
  * Added coverage for Fog and Blunt the Assault to verify correct parsing and ability output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->