### PR TITLE
refactor(parser): Plan 05b T9b — the payload swap, all nine spell producers at once

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -58,7 +58,7 @@ use super::oracle_cost::{parse_oracle_cost, parse_single_cost, try_parse_cost_re
 use super::oracle_dispatch::dispatch_line_nom;
 use super::oracle_effect::sequence::try_parse_same_is_true_continuation;
 use super::oracle_effect::{
-    lower_ability_ir, lower_effect_chain_ir, parse_ability_ir_with_context,
+    lower_ability_ir, parse_ability_ir_with_context,
     parse_additional_cost_instead_condition_fragment, parse_effect_chain,
     parse_effect_chain_with_context, rewrite_condition_keyword,
     try_parse_temporal_delayed_trigger_ability,
@@ -66,8 +66,9 @@ use super::oracle_effect::{
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
 use super::oracle_ir::doc::{
-    OracleDocBuilder, OracleDocIr, OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan,
-    OracleUnitSource, PrintedAbilityIndex, PrintedTriggerIndex,
+    stamp_printed_ability_slot, stamp_printed_trigger_slot, OracleDocBuilder, OracleDocIr,
+    OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan, OracleUnitSource,
+    PrintedAbilityIndex, PrintedTriggerIndex,
 };
 use super::oracle_ir::effect_chain::{AbilityIr, ShellStage};
 use super::oracle_ir::feature::ItemIdTracks;
@@ -634,7 +635,7 @@ fn parse_begin_game_counter_clause(
 
 fn lower_spell_node(node: &OracleNodeIr) -> Option<AbilityDefinition> {
     match node {
-        OracleNodeIr::Spell(effect_ir) => Some(lower_effect_chain_ir(effect_ir)),
+        OracleNodeIr::Spell(ability_ir) => Some(lower_ability_ir(ability_ir)),
         OracleNodeIr::PreLoweredSpell(definition) => Some(definition.clone()),
         _ => None,
     }
@@ -1166,29 +1167,31 @@ fn item_replacement(item: &OracleItemIr) -> Option<&ReplacementDefinition> {
 ///
 /// Returns `Cow` because the two spell-bearing node shapes own their definition
 /// at different times. A pre-lowered item already holds an `AbilityDefinition`
-/// and lends it out; an IR-native item holds only an `EffectChainIr` and owns no
-/// definition at all until lowering builds one, so it must lower and hand back
-/// the result owned. A plain `&AbilityDefinition` cannot express the second case
-/// — there is nothing to borrow from — and a plain `AbilityDefinition` would
-/// clone the first case at all seven call sites, most of which scan every item
-/// on the card.
+/// and lends it out; an IR-native item holds only an `AbilityIr` decomposition
+/// and owns no definition at all until lowering builds one, so it must lower and
+/// hand back the result owned. A plain `&AbilityDefinition` cannot express the
+/// second case — there is nothing to borrow from — and a plain
+/// `AbilityDefinition` would clone the first case at all seven call sites, most
+/// of which scan every item on the card.
 ///
 /// This is where the trigger side's reasoning stops applying.
 /// `item_trigger` keeps a borrow and pushes exhaustiveness down onto
 /// `TriggerNodeIr::definition()`, because both of its shapes own a
 /// `TriggerDefinition` — `TriggerNodeIr::Assembled` carries one directly. There
 /// is no equivalent layer to push this obligation onto: a spell node's IR
-/// payload is an `EffectChainIr`, not an enum of definition-owning
-/// representations, so both shapes are named here. `_ => None` is safe for the
-/// same reason it is safe there: every remaining variant is genuinely `None`.
+/// payload is an `AbilityIr`, not an enum of definition-owning representations,
+/// so both shapes are named here. `_ => None` is safe for the same reason it is
+/// safe there: every remaining variant is genuinely `None`.
 ///
-/// Lowering is the identity conversion `lower_oracle_ir` (the `Spell` arm) will
-/// perform for the same item, so a relation predicate sees exactly the
-/// definition the relation will later be applied to.
+/// Lowering is the same `lower_ability_ir` call `lower_oracle_ir` (the `Spell`
+/// arm) will make for the same item, so a relation predicate sees exactly the
+/// definition the relation will later be applied to — with one deliberate
+/// exception that cannot matter: the CR 707.9a printed slot, which lowering
+/// stamps afterwards and no relation predicate reads.
 fn item_ability(item: &OracleItemIr) -> Option<Cow<'_, AbilityDefinition>> {
     match &item.node {
         OracleNodeIr::PreLoweredSpell(def) => Some(Cow::Borrowed(def)),
-        OracleNodeIr::Spell(effect_ir) => Some(Cow::Owned(lower_effect_chain_ir(effect_ir))),
+        OracleNodeIr::Spell(ability_ir) => Some(Cow::Owned(lower_ability_ir(ability_ir))),
         _ => None,
     }
 }
@@ -2876,7 +2879,9 @@ fn parse_flash_cleanup_sacrifice_casting_option(
 /// on each item's `OracleNodeIr` payload.
 ///
 /// Core IR variants are lowered through their dedicated lowering functions.
-/// PreLowered variants are identity-lowered (pushed directly to the result).
+/// Pre-lowered variants are identity-lowered (cloned straight into the result).
+/// Either way the spell and trigger arms then stamp the item's CR 707.9a printed
+/// slot, which is why neither is a bare push.
 ///
 /// `ParsedAbilities` stays category-grouped because it is the runtime-facing
 /// type; only *within*-category order and explicit cross-item relations are
@@ -2911,14 +2916,38 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
     let mut trigger_ids: Vec<OracleItemId> = Vec::new();
     let mut static_ids: Vec<OracleItemId> = Vec::new();
     let mut replacement_ids: Vec<OracleItemId> = Vec::new();
+    // CR 707.9a printed slots are resolved in this loop, not in
+    // `OracleDocBuilder::finish` where they used to be. The stamp rewrites the
+    // `placeholder()` (= 0) the dispatch loop baked into each
+    // `RetainPrinted{Trigger,Ability}FromSource` with the enclosing item's
+    // per-category printed slot (CR 603.1 / CR 602.1) — and that needs a
+    // definition to write into, which an IR-native `Spell` item does not have
+    // until `lower_ability_ir` builds one right here. See `finish()`'s doc block
+    // for why the two walks are order-equivalent: both iterate the same
+    // source-ordered `BTreeMap` and count each category separately, so the k-th
+    // spell item is at ability slot k either way.
+    //
+    // The slot IS `result.<category>.len()` at the moment of the push, which is
+    // what makes this the correct seam rather than merely a possible one. Stamped
+    // BEFORE the relation passes below, matching the pre-relation state the
+    // `finish()` walk saw — several of those passes insert into, remove from, and
+    // move ids between the category tracks.
+    //
+    // The match stays EXHAUSTIVE over `OracleNodeIr` (no `_` arm): it is now the
+    // single place a new node variant must declare whether it consumes a printed
+    // slot, an obligation `finish()` used to carry.
     for item in &ir.items {
         match &item.node {
-            OracleNodeIr::Spell(effect_ir) => {
-                result.abilities.push(lower_effect_chain_ir(effect_ir));
+            OracleNodeIr::Spell(ability_ir) => {
+                let mut def = lower_ability_ir(ability_ir);
+                stamp_printed_ability_slot(&mut def, result.abilities.len());
+                result.abilities.push(def);
                 ability_ids.push(item.id);
             }
             OracleNodeIr::Trigger(trigger_node) => {
-                result.triggers.push(lower_trigger_node_ir(trigger_node));
+                let mut def = lower_trigger_node_ir(trigger_node);
+                stamp_printed_trigger_slot(&mut def, result.triggers.len());
+                result.triggers.push(def);
                 trigger_ids.push(item.id);
             }
             OracleNodeIr::Static(static_ir) => {
@@ -2953,7 +2982,9 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
                 result.strive_cost = Some(cost.clone());
             }
             OracleNodeIr::PreLoweredTrigger(def) => {
-                result.triggers.push(def.clone());
+                let mut def = def.clone();
+                stamp_printed_trigger_slot(&mut def, result.triggers.len());
+                result.triggers.push(def);
                 trigger_ids.push(item.id);
             }
             OracleNodeIr::PreLoweredStatic(def) => {
@@ -2965,7 +2996,9 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
                 replacement_ids.push(item.id);
             }
             OracleNodeIr::PreLoweredSpell(def) => {
-                result.abilities.push(def.clone());
+                let mut def = def.clone();
+                stamp_printed_ability_slot(&mut def, result.abilities.len());
+                result.abilities.push(def);
                 ability_ids.push(item.id);
             }
         }
@@ -3600,44 +3633,30 @@ impl<'a> DocEmitter<'a> {
         self.emit_at(line, OracleNodeIr::PreLoweredSpell(def));
     }
 
-    /// The IR seam for spell/activated bodies — Plan 05b Unit 3b, **phase A**.
+    /// The IR seam for spell/activated bodies — Plan 05b Unit 3b, **phase B**.
     ///
-    /// Phase A lowers **eagerly and still emits the pre-lowered node**, which is
-    /// what lets every producer convert one tranche at a time with the node
-    /// payload, `finish()`, `item_ability`, `mutate_last_spell`, `reemit_spell`
-    /// and the cross-line instead-fold all untouched — and therefore with zero
-    /// snapshot churn and a diff a reviewer can actually read. Phase B (T9)
-    /// changes this body to `self.emit_at(line, OracleNodeIr::Spell(ir))` and
-    /// every producer is already correct.
+    /// Every producer that reaches this method is IR-native: the `AbilityIr`
+    /// survives into the document and is lowered once, at the single
+    /// `lower_oracle_ir` seam, instead of being lowered eagerly here and carried
+    /// as an already-assembled `AbilityDefinition`.
     ///
-    /// Written as delegation to `ability_at` rather than as a second emission of
-    /// its own for two reasons. It states the phase-A identity
-    /// `ability_ir_at(l, ir) == ability_at(l, lower_ability_ir(&ir))` literally
-    /// instead of restating it as a separately-maintained copy. And it keeps the
-    /// Plan 05b burn-down ratchet (`scripts/check-prelowered-ratchet.sh`)
-    /// monotone: that gate counts a bare token textually, `oracle.rs` sits
-    /// exactly at its ceiling, and one more occurrence of that token here — in
-    /// code OR in prose — would raise the count and fail a gate whose ceiling may
-    /// only ever decrease.
+    /// **This one line is what phase A bought.** Phase A (T8) routed all nine
+    /// producers through this method while its body still delegated to
+    /// `ability_at(line, lower_ability_ir(&ir))` — byte-identical by
+    /// construction, zero snapshot churn, one readable diff per tranche. Phase B
+    /// then converts all nine at once by changing only which node is emitted, so
+    /// no producer had to be re-reviewed for the payload swap.
     ///
-    /// # CR 707.9a is NOT gapped by this seam
+    /// # CR 707.9a
     ///
-    /// Printed-slot stamping happens only in `OracleDocBuilder::finish`, which
-    /// runs *before* lowering, so a copy-except clause inside an IR-native
-    /// `OracleNodeIr::Spell` body can never be stamped — there is no definition
-    /// to stamp until lowering builds one (`doc.rs`, the `Spell(_)` arm advances
-    /// `ability_slot` without stamping, on purpose). That gap cannot open in
-    /// phase A: this method emits the pre-lowered spell variant, so every
-    /// phase-A-converted producer lands in the corresponding `finish()` arm and
-    /// is stamped by `stamp_retained_printed_slot`, which recurses the whole
-    /// definition (effect, `sub_ability`, `else_ability`, `mode_abilities`). The
-    /// gap becomes reachable exactly when this body switches to
-    /// `OracleNodeIr::Spell(ir)`, so moving the stamp into `lower_oracle_ir`
-    /// belongs to T9 — where it is also the only place it can be done without a
-    /// byte delta on the one pre-existing `Spell` producer, which is deliberately
-    /// not stamped today.
+    /// An IR-native body has no `AbilityDefinition` to stamp a printed slot
+    /// into until lowering builds one, so the stamp cannot live upstream of this
+    /// seam. It lives at `lower_oracle_ir`'s bucketing loop, which lowers the
+    /// body and stamps the result in the same step — see `OracleDocBuilder::
+    /// finish`'s doc block for why moving it there is order-equivalent to the
+    /// `finish()`-time walk it replaced.
     fn ability_ir_at(&mut self, line: usize, ir: AbilityIr) {
-        self.ability_at(line, lower_ability_ir(&ir));
+        self.emit_at(line, OracleNodeIr::Spell(ir));
     }
     fn trigger_at(&mut self, line: usize, def: TriggerDefinition) {
         self.last_trigger = Some(def.clone());
@@ -3744,7 +3763,7 @@ impl<'a> DocEmitter<'a> {
         self.builder.take_last_spell()
     }
 
-    /// Re-emit a spell at a template item's ORIGINAL span — same `first_line`,
+    /// Re-emit a node at a template item's ORIGINAL span — same `first_line`,
     /// bytes, AND `ordinal_within_span`, the key `take_last_spell` just freed.
     ///
     /// m2-shell correction: reuse the original ordinal, never fresh-allocate. The
@@ -3752,37 +3771,52 @@ impl<'a> DocEmitter<'a> {
     /// ordinal would REORDER the spell past any co-located sibling that shares its
     /// `(first_line, start_byte)` (e.g. a `push_same_is_true_*` static + ability
     /// from one line). Original-ordinal re-emit is position- and slot-preserving.
-    fn reemit_spell(&mut self, source: &OracleUnitSource, def: AbilityDefinition) {
+    ///
+    /// Takes an `OracleNodeIr`, not an `AbilityDefinition`, because the two
+    /// re-emitting callers legitimately differ in what they hand back. The
+    /// cross-line "instead" fold genuinely *builds* a new `AbilityDefinition`
+    /// (it moves the popped ability's continuation into `else_ability` and nests
+    /// it under the new one), so it can only re-emit pre-lowered.
+    /// `raise_last_spell_min_x` changes one field in place and must return the
+    /// shape it took — lowering an IR-native node just to reach a root field
+    /// would quietly convert the item back to pre-lowered.
+    fn reemit_node(&mut self, source: &OracleUnitSource, node: OracleNodeIr) {
         let span = source.span().clone();
         let fragment = source.fragment();
         let slot = self.builder.begin_item(span, fragment);
         self.builder
-            .emit(slot, OracleNodeIr::PreLoweredSpell(def))
+            .emit(slot, node)
             .expect("re-emitting at the just-freed original key cannot collide");
     }
 
-    /// The typed `result.abilities.last_mut()` for min_x_value stamping: pop the
-    /// last emitted spell, mutate it, re-emit at its original span. A no-op when
-    /// no spell has been emitted (mirrors `last_mut()` returning `None`).
+    /// CR 601.2b: raise the floor on the last emitted spell's announced X, for a
+    /// standalone "X can't be 0." annotation paragraph.
     ///
-    /// `take_last_spell` pops the emission-ordered spell stack, which equals
-    /// `abilities.last_mut()` regardless of triggers/statics emitted in between.
+    /// The typed replacement for a general `mutate_last_spell(f)` closure
+    /// mutator. Both of that mutator's callers did exactly this one thing, and
+    /// its `impl FnOnce(&mut AbilityDefinition)` signature could only be honored
+    /// by lowering the node — so it could not preserve an IR-native spell, and
+    /// its cousin's single-shape `let .. else { unreachable!() }` destructure of
+    /// the pre-lowered variant would have panicked outright the moment a
+    /// converted producer emitted before a mutating line. A named operation over
+    /// `OracleNodeIr::spell_min_x_mut` cannot express either failure.
     ///
-    /// Reads the popped item through `lower_spell_node`, which accepts BOTH
-    /// spell node shapes. It must: `emit` pushes either shape onto
-    /// `spells_emitted` and `take_last_spell` pops it with no variant filter, so
-    /// a destructure that names one shape panics the parser the first time an
-    /// IR-native spell precedes a mutating line.
-    fn mutate_last_spell(&mut self, f: impl FnOnce(&mut AbilityDefinition)) {
+    /// A no-op when no spell has been emitted (mirrors `abilities.last_mut()`
+    /// returning `None`). `take_last_spell` pops the emission-ordered spell
+    /// stack, which equals `abilities.last_mut()` regardless of
+    /// triggers/statics emitted in between.
+    fn raise_last_spell_min_x(&mut self, min_x_value: u32) {
         let Some(item) = self.builder.take_last_spell() else {
             return;
         };
-        let OracleItemIr { source, node, .. } = item;
-        let Some(mut def) = lower_spell_node(&node) else {
-            unreachable!("`spells_emitted` holds only spell nodes, and both spell shapes lower");
-        };
-        f(&mut def);
-        self.reemit_spell(&source, def);
+        let OracleItemIr {
+            source, mut node, ..
+        } = item;
+        let floor = node.spell_min_x_mut().expect(
+            "`spells_emitted` holds only spell nodes, and both spell shapes carry an X floor",
+        );
+        *floor = (*floor).max(min_x_value);
+        self.reemit_node(&source, node);
     }
 
     /// Finish, producing items already in Oracle source order.
@@ -4187,9 +4221,7 @@ pub(crate) fn parse_oracle_ir(
         let line = strip_x_cant_be_zero_suffix(&line);
         if line.is_empty() {
             if min_x_value > 0 {
-                emitter.mutate_last_spell(|previous| {
-                    previous.min_x_value = previous.min_x_value.max(min_x_value);
-                });
+                emitter.raise_last_spell_min_x(min_x_value);
             }
             // Priority 14: entirely parenthesized reminder text
             i += 1;
@@ -6107,7 +6139,11 @@ pub(crate) fn parse_oracle_ir(
                         });
                         def.else_ability = base.sub_ability.take();
                         base.sub_ability = Some(Box::new(def));
-                        emitter.reemit_spell(&base_source, base);
+                        // Pre-lowered on re-emit, necessarily: the fold produced a
+                        // NEW `AbilityDefinition` by nesting the popped one, and
+                        // `lower_ability_ir` has no inverse to express that as an
+                        // `AbilityIr`.
+                        emitter.reemit_node(&base_source, OracleNodeIr::PreLoweredSpell(base));
                         continue;
                     }
                     // No previous ability to compose with — restore condition and push standalone.
@@ -6280,8 +6316,9 @@ pub(crate) fn parse_oracle_ir(
         // `lower` is bound once from the post-strip line and never rebound, so
         // the empty-line guard above always claims it first. Its own comment
         // called it a "defensive fallback"; it was dead, and it was one of the
-        // two `mutate_last_spell` callers whose destructure asserts a single node
-        // shape.
+        // two callers of the since-retired general `mutate_last_spell` closure
+        // mutator. The surviving caller is the empty-line guard, which now calls
+        // the typed `raise_last_spell_min_x`.
 
         // Priority 14: Ability word — strip prefix and re-classify effect.
         // B7: Known ability words (Threshold, Metalcraft, Delirium, Spell mastery, Revolt)

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -24,7 +24,7 @@
 use std::collections::BTreeMap;
 
 use super::diagnostic::OracleDiagnostic;
-use super::effect_chain::EffectChainIr;
+use super::effect_chain::AbilityIr;
 use super::relation::DocumentRelationIr;
 use super::replacement::ReplacementIr;
 use super::static_ir::StaticIr;
@@ -306,28 +306,22 @@ pub(crate) struct OracleItemIr {
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[allow(clippy::large_enum_variant)] // Intentional: variants carry parser IR directly.
 pub(crate) enum OracleNodeIr {
-    /// Spell or activated ability effect chain.
+    /// Spell or activated ability body — the CR 602.1 activation envelope
+    /// (`AbilityShellIr`) wrapped around a CR 608.2 effect chain.
     ///
-    /// Unit 3b replaces this payload with `AbilityIr { source, body, shell }` so
-    /// the activation metadata the router currently applies around the chain
-    /// becomes typed IR rather than a pre-lowered `AbilityDefinition`.
+    /// The payload is an `AbilityIr`, not a bare `EffectChainIr`: a chain alone
+    /// cannot carry the root-level metadata a recognizer stamps around it (cost,
+    /// activation restrictions, ability tag, the announced-X floor …), so a
+    /// chain-payloaded node forced every producer to lower eagerly and emit the
+    /// pre-lowered spell variant instead. Widening the payload is what let all
+    /// nine phase-A producers become IR-native at once (Plan 05b T9b).
     ///
-    /// PLAN-05 DEBT (2026-07-28, Plan 05b T9a): no producer, on purpose and
-    /// temporarily. The one site that constructed this variant (`oracle.rs`, the
-    /// instant/sorcery prevention recognizer, U0-39) was the only spell path
-    /// lowering a whole ability body without `finalize_effect_chain`, the
-    /// owner-library reveal anchor, and the `WithContext` whole-body recognizer
-    /// set, because it lowered through `lower_effect_chain_ir` rather than
-    /// `lower_ability_ir`. T9a routed it through `ability_ir_at` like every other
-    /// phase-A producer, which is precisely the precondition `ability_ir_at`'s
-    /// doc block names for phase B. T9b re-constructs this variant for **all**
-    /// spell producers at once by swapping the payload to `AbilityIr` and
-    /// flipping `ability_ir_at`'s body — so the allow is deleted there, not
-    /// carried. Kept (rather than removed) because the readers, the two
-    /// exhaustive `doc.rs` matches, and the `finish()` slot accounting are the
-    /// surface T9b lands on.
-    #[allow(dead_code)]
-    Spell(EffectChainIr),
+    /// Lowered by `lower_oracle_ir`'s `Spell` arm through `lower_ability_ir`,
+    /// which is the single authority for chain → finalize → anchor → shell.
+    /// `AbilityIr::from_definition` deliberately does not exist: lowering is not
+    /// invertible, so an already-assembled `AbilityDefinition` belongs in the
+    /// pre-lowered spell variant below, never here.
+    Spell(AbilityIr),
     /// Triggered ability.
     Trigger(TriggerNodeIr),
     /// Static ability.
@@ -355,8 +349,11 @@ pub(crate) enum OracleNodeIr {
     // These four variants carry already-assembled engine definitions rather
     // than typed IR. Unit 4 wired the preprocessors through the document
     // builder, but it did not remove these variants; ordinary dispatch also
-    // still emits them. The IR-native `Spell`/`Trigger`/`Static`/`Replacement`
-    // siblings are dead-coded pending Plan 05 U2's document-seam hoist.
+    // still emits them. All four IR-native siblings now have live producers —
+    // `Static`/`Replacement` from Plan 05b's earlier tranches, `Spell` from T9b,
+    // `Trigger` from the `TriggerNodeIr` hoist — so what remains here is the
+    // burn-down of the *pre-lowered* producers, tracked per file by
+    // `scripts/check-prelowered-ratchet.sh`.
     //
     // Plan 05, not unit 4, removes these variants after U2--U4 have made every
     // producer IR-native. Do not add a new producer of these variants.
@@ -370,6 +367,46 @@ pub(crate) enum OracleNodeIr {
     /// Pre-lowered spell/activated ability from a preprocessor or dispatch path
     /// that constructs an `AbilityDefinition` directly. UNIT-4 DEBT.
     PreLoweredSpell(AbilityDefinition),
+}
+
+impl OracleNodeIr {
+    /// CR 601.2b: the floor on this spell node's announced X ("X can't be 0"),
+    /// whichever shape holds it — `None` for every non-spell node.
+    ///
+    /// Both spell shapes store the floor as a `u32` whose `0` means "no floor",
+    /// but at different layers: a pre-lowered definition carries the resolved
+    /// root field, while an `AbilityIr` carries the shell's pre-lowering stamp.
+    /// They are interchangeable for raising a floor because
+    /// `apply_ability_shell_envelope` applies the shell's value onto the lowered
+    /// root with `max` — so `max`-ing either one yields `max(lowered, v)`.
+    ///
+    /// Exposed as a `&mut u32` rather than a `mutate(f)` closure so the caller
+    /// cannot express anything but a floor change. The general closure mutator
+    /// this replaced had to lower the node to hand out an `&mut
+    /// AbilityDefinition`, which silently converted an IR-native item back to a
+    /// pre-lowered one on re-emit.
+    ///
+    /// Exhaustive over the enum on purpose: a future spell payload must say
+    /// where its floor lives before it can be emitted.
+    pub(crate) fn spell_min_x_mut(&mut self) -> Option<&mut u32> {
+        match self {
+            OracleNodeIr::Spell(ir) => Some(&mut ir.shell.min_x_value),
+            OracleNodeIr::PreLoweredSpell(def) => Some(&mut def.min_x_value),
+            OracleNodeIr::Trigger(_)
+            | OracleNodeIr::Static(_)
+            | OracleNodeIr::Replacement(_)
+            | OracleNodeIr::Keyword(_)
+            | OracleNodeIr::Modal(_)
+            | OracleNodeIr::AdditionalCost(_)
+            | OracleNodeIr::CastingRestriction(_)
+            | OracleNodeIr::CastingOption(_)
+            | OracleNodeIr::SolveCondition(_)
+            | OracleNodeIr::StriveCost(_)
+            | OracleNodeIr::PreLoweredTrigger(_)
+            | OracleNodeIr::PreLoweredStatic(_)
+            | OracleNodeIr::PreLoweredReplacement(_) => None,
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -414,10 +451,19 @@ macro_rules! printed_index_impl {
             /// resolved slot.
             ///
             /// This replaces the former `from_category_vector_len` constructor.
-            /// Deriving the slot from a category-vector length was correct only
-            /// while emission was category-ordered; the source-ordered document
-            /// builder makes that equality false, so the late-bind at `finish()`
-            /// is the single authority and the length constructor is gone.
+            /// Deriving the slot from a category-vector length **at parse time**
+            /// was correct only while emission was category-ordered: that
+            /// constructor read the length as the dispatch loop ran, in EMISSION
+            /// order, and a preprocessor may emit a later line before the loop
+            /// emits an earlier one. The source-ordered document builder makes
+            /// that equality false, so the late-bind is the single authority and
+            /// the length constructor is gone.
+            ///
+            /// Not to be confused with the resolution `lower_oracle_ir` performs
+            /// (`oracle.rs`), which also reads a category-vector length but in
+            /// SOURCE order — it walks the finished, span-keyed item map, so
+            /// there the length and the printed slot genuinely coincide. Same
+            /// expression, different quantity; only the parse-time one is unsound.
             pub(crate) fn placeholder() -> Self {
                 Self(0)
             }
@@ -908,86 +954,42 @@ impl OracleDocBuilder {
     }
 
     /// Finish, producing items already in Oracle source order.
+    ///
+    /// # CR 707.9a printed-slot stamping does NOT happen here
+    ///
+    /// It used to. The stamp resolves each "…except it has this ability" clause
+    /// to its enclosing item's per-category printed slot (CR 603.1 / CR 602.1),
+    /// rewriting the `placeholder()` (= 0) the dispatch loop baked in — and it
+    /// needs an `AbilityDefinition`/`TriggerDefinition` to write into. Once
+    /// `OracleNodeIr::Spell` carries an `AbilityIr`, an item's definition does
+    /// not exist until `lower_oracle_ir` builds it, so a `finish()`-time walk
+    /// could only stamp the pre-lowered shapes and would silently skip every
+    /// IR-native spell. The stamp therefore lives at the single seam that has
+    /// both the definition and the slot: `lower_oracle_ir`'s bucketing loop
+    /// (`oracle.rs`), where the slot IS `result.<category>.len()`.
+    ///
+    /// **The two orders agree, and that is why the move is byte-neutral.** This
+    /// walk counted each category separately over `self.items.values_mut()`;
+    /// `lower_oracle_ir` counts each category separately over `ir.items`. Both
+    /// are the same `BTreeMap` keyed by `(first_line, start_byte, ordinal)`, so
+    /// both visit the identical source-ordered sequence and the k-th spell item
+    /// is at ability slot k in either walk. The stamp is applied inside that
+    /// loop, before any document relation can reorder a category vector, which
+    /// is the same pre-relation state this walk saw.
+    ///
+    /// Nothing between the two seams reads a printed slot: relation discovery
+    /// (`detect_document_relations`) and the swallow audit inspect effect trees
+    /// for shape, never `RetainPrinted{Trigger,Ability}FromSource` indices.
+    ///
+    /// The compile-time obligation moves with the stamp. `lower_oracle_ir`'s
+    /// match is already exhaustive over `OracleNodeIr` with no `_` arm, so a new
+    /// node variant still cannot be added without deciding its slot behavior.
     pub(crate) fn finish(
-        mut self,
+        self,
         source_text: &str,
         card_name: &str,
         diagnostics: Vec<OracleDiagnostic>,
     ) -> OracleDocIr {
-        // CR 707.9a: resolve every "…except it has this ability" printed slot now.
-        //
-        // The load-bearing invariant is PER-CATEGORY COUNTING, not source order.
-        // `values_mut()` visits in source order now that every producer emits at a
-        // real line, but the walk never depended on that: it counts each category
-        // SEPARATELY (`trigger_slot` among triggers, `ability_slot` among
-        // abilities), which is exactly the position `lower_oracle_ir` will give the
-        // definition when it re-buckets items into the per-category vectors of
-        // `ParsedAbilities`. That is why retiring the category-ordered Class façade
-        // — the last producer that visited out of source order — left every stamped
-        // slot unchanged. Each `RetainPrinted{Trigger,Ability}FromSource` is a
-        // self-reference to its enclosing item (CR 603.1 / CR 602.1), stamped with
-        // that item's per-category slot, replacing the `placeholder()` (= 0) the
-        // dispatch loop baked in.
-        //
-        // Match is EXHAUSTIVE over `OracleNodeIr` (no `_`), mirroring `emit`'s
-        // printed-slot match above: a future node variant must fail to compile
-        // here until its slot behavior is decided, rather than being silently
-        // skipped (which would mis-index every later trigger/ability).
-        // `Trigger` is destructured to its one payload variant for the same
-        // reason: adding an IR-native trigger payload must break this match,
-        // because the stamp targets `execute`, which a decomposition does not
-        // have until lowering builds it.
-        let mut trigger_slot = 0usize;
-        let mut ability_slot = 0usize;
-        for item in self.items.values_mut() {
-            match &mut item.node {
-                OracleNodeIr::PreLoweredTrigger(trigger) => {
-                    stamp_trigger_printed_slot(trigger, trigger_slot, PrintedItemKind::Trigger);
-                    trigger_slot += 1;
-                }
-                OracleNodeIr::Trigger(TriggerNodeIr::Assembled { definition, .. }) => {
-                    stamp_trigger_printed_slot(definition, trigger_slot, PrintedItemKind::Trigger);
-                    trigger_slot += 1;
-                }
-                OracleNodeIr::PreLoweredSpell(def) => {
-                    stamp_retained_printed_slot(def, ability_slot, PrintedItemKind::Ability);
-                    ability_slot += 1;
-                }
-                // CR 707.9a printed slots count PRINTED abilities. The set of
-                // variants that advance `ability_slot` here must equal the set
-                // `lower_oracle_ir` (`oracle.rs`) pushes into `result.abilities`,
-                // which is in turn the set `emit` pushes onto `spells_emitted`
-                // above: both spell shapes. Three matches over one set.
-                //
-                // Advances WITHOUT stamping, on purpose — do not try to make this
-                // arm symmetric with the arm above. An IR-native spell body has no
-                // `AbilityDefinition` until lowering builds one, and
-                // `stamp_retained_printed_slot` takes `&mut AbilityDefinition`, so
-                // there is nothing here to stamp. The printed slot is consumed all
-                // the same: skipping the advance stamps every LATER ability one
-                // slot low, silently binding a copy's "except it has this ability"
-                // to the wrong ability.
-                OracleNodeIr::Spell(_) => {
-                    ability_slot += 1;
-                }
-                // Neither stamps nor counts: `RetainPrinted*FromSource` exists only
-                // for the trigger and ability categories (CR 707.9a), so these
-                // carry no slot to rewrite and consume neither counter this walk
-                // maintains. Left explicit (not `_`) so a new slot-bearing node is
-                // a compile error, per the note above.
-                OracleNodeIr::Static(_)
-                | OracleNodeIr::PreLoweredStatic(_)
-                | OracleNodeIr::Replacement(_)
-                | OracleNodeIr::PreLoweredReplacement(_)
-                | OracleNodeIr::Keyword(_)
-                | OracleNodeIr::Modal(_)
-                | OracleNodeIr::AdditionalCost(_)
-                | OracleNodeIr::CastingRestriction(_)
-                | OracleNodeIr::CastingOption(_)
-                | OracleNodeIr::SolveCondition(_)
-                | OracleNodeIr::StriveCost(_) => {}
-            }
-        }
         OracleDocIr {
             items: self.items.into_values().collect(),
             source_text: source_text.to_string(),
@@ -1001,16 +1003,41 @@ impl OracleDocBuilder {
     }
 }
 
-/// Which printed category a finish()-time slot stamp targets.
+/// Which printed category a slot stamp targets.
 ///
 /// A walk parameter local to this module — deliberately NOT a `ParseContext`
 /// field. `ParseContext`'s `current_trigger_index`/`current_ability_index` carry
 /// the parse-time placeholder; this enum only selects which
-/// `RetainPrinted*FromSource` variant `finish()` rewrites for a given item.
+/// `RetainPrinted*FromSource` variant the stamp rewrites for a given item.
+///
+/// Stays private: the two `pub(crate)` entry points below pin the kind that goes
+/// with each category, so a caller can never pair an ability slot with the
+/// trigger variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PrintedItemKind {
     Trigger,
     Ability,
+}
+
+/// CR 707.9a: resolve an ability item's "…except it has this ability" clauses to
+/// `slot`, the item's position among the card's printed abilities.
+///
+/// The lowering-seam entry point (`lower_oracle_ir`, `oracle.rs`). It takes the
+/// definition rather than the node because both spell node shapes converge on
+/// one here: the pre-lowered shape lends its definition and `Spell` has just
+/// been lowered by `lower_ability_ir`, and CR 707.9a does not distinguish them —
+/// a printed ability occupies its printed slot however the parser represented it.
+pub(crate) fn stamp_printed_ability_slot(def: &mut AbilityDefinition, slot: usize) {
+    stamp_retained_printed_slot(def, slot, PrintedItemKind::Ability);
+}
+
+/// CR 707.9a: resolve a trigger item's "…except it has this ability" clauses to
+/// `slot`, the item's position among the card's printed triggered abilities.
+///
+/// Counted on a separate track from abilities (CR 603.1 vs CR 602.1), which is
+/// why an interleaved trigger must never shift an ability slot.
+pub(crate) fn stamp_printed_trigger_slot(trigger: &mut TriggerDefinition, slot: usize) {
+    stamp_trigger_printed_slot(trigger, slot, PrintedItemKind::Trigger);
 }
 
 /// Stamp the resolved printed slot into a pre-lowered trigger's body.

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -6,7 +6,7 @@
 
 use crate::parser::oracle::{lower_oracle_ir, parse_oracle_ir, ParsedAbilities};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
-use crate::parser::oracle_ir::doc::OracleDocIr;
+use crate::parser::oracle_ir::doc::{OracleDocIr, OracleNodeIr};
 
 /// Parse Oracle text through both IR and lowering layers.
 fn parse_two_layer(
@@ -190,6 +190,58 @@ fn blunt_the_assault_prevention_spell_preserves_preceding_clause() {
     );
     insta::assert_json_snapshot!("blunt_the_assault_ir", &ir);
     insta::assert_json_snapshot!("blunt_the_assault_lowered", &lowered);
+}
+
+/// CR 601.2b: a standalone "X can't be 0." annotation paragraph raises the
+/// announced-X floor on the ability printed ABOVE it, and must do so without
+/// converting that ability's node back to the pre-lowered shape.
+///
+/// DISCRIMINATING, and newly so. This line reaches
+/// `DocEmitter::raise_last_spell_min_x`, which pops the last emitted spell item,
+/// edits it, and re-emits it. Its predecessor — the general
+/// `mutate_last_spell(f)` closure mutator — could only hand a closure an
+/// `&mut AbilityDefinition`, so it had to LOWER the popped node first and could
+/// only ever re-emit pre-lowered. Before T9b that was invisible, because the
+/// only IR-native spell producer was unreachable from this line; after the
+/// payload swap nine producers can precede it. Restore the closure mutator and
+/// the `min_x_value` assertion still passes while the node assertion fails —
+/// which is exactly the silent un-conversion this shape guards against.
+///
+/// The prevention line is the fixture because it is a *converted* producer
+/// (U0-39), so `abilities[0]` is genuinely IR-native here; a fallback-parsed
+/// line would emit the pre-lowered shape and make the node assertion vacuous.
+///
+/// Both layers are asserted on purpose. The IR half pins WHERE the floor is
+/// stored (`AbilityShellIr::min_x_value`, pre-lowering); the lowered half pins
+/// that `apply_ability_shell_envelope`'s `max` actually carries it onto the
+/// root, so a floor parked in a shell field nothing reads cannot pass.
+#[test]
+fn a_standalone_x_floor_annotation_raises_an_ir_native_spells_floor() {
+    let (ir, lowered) = parse_two_layer(
+        "Prevent all combat damage that would be dealt this turn.\nX can't be 0.",
+        "Probe",
+        &["Instant"],
+        &[],
+    );
+
+    // Reach-guard: exactly one ability, and it must be the IR-native node —
+    // otherwise the floor assertion below says nothing about the `Spell` arm.
+    assert_eq!(
+        lowered.abilities.len(),
+        1,
+        "expected the prevention spell alone; the annotation paragraph is not an ability, got {:?}",
+        lowered.abilities
+    );
+    assert!(
+        matches!(ir.items[0].node, OracleNodeIr::Spell(_)),
+        "the re-emitted node must stay IR-native, got {:?}",
+        ir.items[0].node
+    );
+
+    assert_eq!(
+        lowered.abilities[0].min_x_value, 1,
+        "the \"X can't be 0.\" annotation must raise the lowered root's floor to 1"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1598
 expression: "&ir"
 ---
 {
@@ -59,45 +60,101 @@ expression: "&ir"
         "fragment": "Boast — {1}: You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn. (Activate only if ~ attacked this turn and only once each turn.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Unimplemented",
-            "name": "change",
-            "description": "change Arni's base power to 1 plus the greatest power among other creatures you control"
+        "Spell": {
+          "source_text": "You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 113,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "change",
+                    "description": "change Arni's base power to 1 plus the greatest power among other creatures you control"
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": true,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 1
-            }
-          },
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "Boast — {1}: You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "OnlyOnceEachTurn"
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [],
+                "generic": 1
+              }
             },
-            {
-              "type": "RequiresCondition",
-              "data": {
-                "condition": {
-                  "type": "SourceAttackedThisTurn"
+            "activation_restrictions": [
+              {
+                "type": "OnlyOnceEachTurn"
+              },
+              {
+                "type": "RequiresCondition",
+                "data": {
+                  "condition": {
+                    "type": "SourceAttackedThisTurn"
+                  }
                 }
               }
-            }
-          ],
-          "ability_tag": {
-            "type": "Boast"
-          },
-          "condition": null,
-          "optional_targeting": false,
-          "optional": true,
-          "forward_result": false
+            ],
+            "ability_tag": {
+              "type": "Boast"
+            },
+            "description": "Boast — {1}: You may change Arni's base power to 1 plus the greatest power among other creatures you control until end of turn.",
+            "stages": [
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 191
 expression: "&ir"
 ---
 {
@@ -22,54 +23,137 @@ expression: "&ir"
         "fragment": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "GainLife",
-            "amount": {
-              "type": "Ref",
-              "qty": {
-                "type": "ObjectCount",
-                "filter": {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": null,
-                  "properties": []
-                }
-              }
-            }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PreventDamage",
-              "amount": "All",
-              "target": {
-                "type": "Any"
+        "Spell": {
+          "source_text": "You gain 1 life for each creature on the battlefield. Prevent all combat damage that would be dealt this turn.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 52,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "You gain 1 life for each creature on the battlefield"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "ObjectCount",
+                        "filter": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": null,
+                          "properties": []
+                        }
+                      }
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "scope": "CombatDamage"
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 54,
+                    "end_byte": 109,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "Prevent all combat damage that would be dealt this turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "PreventDamage",
+                    "amount": "All",
+                    "target": {
+                      "type": "Any"
+                    },
+                    "scope": "CombatDamage"
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 681
 expression: "&ir"
 ---
 {
@@ -66,193 +67,384 @@ expression: "&ir"
         "fragment": "Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Destroy",
-            "target": {
-              "type": "Or",
-              "filters": [
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Artifact"
-                  ],
-                  "controller": "Opponent",
-                  "properties": []
+        "Spell": {
+          "source_text": "Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 75,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Destroy target artifact, enchantment, or nonbasic land an opponent controls"
                 },
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Enchantment"
-                  ],
-                  "controller": "Opponent",
-                  "properties": []
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
                 },
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Land"
-                  ],
-                  "controller": "Opponent",
-                  "properties": [
-                    {
-                      "type": "NotSupertype",
-                      "value": "Basic"
+                "parsed": {
+                  "effect": {
+                    "type": "Destroy",
+                    "target": {
+                      "type": "Or",
+                      "filters": [
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Artifact"
+                          ],
+                          "controller": "Opponent",
+                          "properties": []
+                        },
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Enchantment"
+                          ],
+                          "controller": "Opponent",
+                          "properties": []
+                        },
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Land"
+                          ],
+                          "controller": "Opponent",
+                          "properties": [
+                            {
+                              "type": "NotSupertype",
+                              "value": "Basic"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "cant_regenerate": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 77,
+                    "end_byte": 152,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "That player may search their library for a land card with a basic land type"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": {
+                      "SearchDestination": {
+                        "destination": "Battlefield",
+                        "enter_tapped": false,
+                        "enters_under": null,
+                        "reveal": false,
+                        "attach_host": null
+                      }
                     }
-                  ]
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "SearchLibrary",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Land",
+                        {
+                          "AnyOf": [
+                            {
+                              "Subtype": "Plains"
+                            },
+                            {
+                              "Subtype": "Island"
+                            },
+                            {
+                              "Subtype": "Swamp"
+                            },
+                            {
+                              "Subtype": "Mountain"
+                            },
+                            {
+                              "Subtype": "Forest"
+                            }
+                          ]
+                        }
+                      ],
+                      "controller": null,
+                      "properties": []
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "reveal": false,
+                    "target_player": {
+                      "type": "ParentTargetController"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": true,
+                  "unless_pay": null
+                },
+                "boundary": "Comma",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 2,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 3
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 154,
+                    "end_byte": 181,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 2
+                  },
+                  "fragment": "put it onto the battlefield"
+                },
+                "disposition": {
+                  "Continue": {
+                    "continuation": "SearchResultClauseHandled"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": null,
+                    "destination": "Battlefield",
+                    "target": {
+                      "type": "ParentTarget"
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Then",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 3,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 4
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 188,
+                    "end_byte": 195,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 3
+                  },
+                  "fragment": "shuffle"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Shuffle",
+                    "target": {
+                      "type": "ParentTargetController"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 4,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 5
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 197,
+                    "end_byte": 276,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 4
+                  },
+                  "fragment": "This ability costs {1} less to activate for each legendary creature you control"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "this",
+                    "description": "This ability costs {1} less to activate for each legendary creature you control"
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "Green"
+                    ],
+                    "generic": 1
+                  }
+                },
+                {
+                  "type": "Discard",
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  },
+                  "filter": null,
+                  "random": false,
+                  "self_ref": true
                 }
               ]
             },
-            "cant_regenerate": false
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
-              {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Green"
-                  ],
-                  "generic": 1
-                }
-              },
-              {
-                "type": "Discard",
-                "count": {
-                  "type": "Fixed",
-                  "value": 1
-                },
-                "filter": null,
-                "random": false,
-                "self_ref": true
-              }
+            "activation_zone": "Hand",
+            "description": "Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
+            "stages": [
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
             ]
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "SearchLibrary",
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Land",
-                  {
-                    "AnyOf": [
-                      {
-                        "Subtype": "Plains"
-                      },
-                      {
-                        "Subtype": "Island"
-                      },
-                      {
-                        "Subtype": "Swamp"
-                      },
-                      {
-                        "Subtype": "Mountain"
-                      },
-                      {
-                        "Subtype": "Forest"
-                      }
-                    ]
-                  }
-                ],
-                "controller": null,
-                "properties": []
-              },
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "reveal": false,
-              "target_player": {
-                "type": "ParentTargetController"
-              }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": "Library",
-                "destination": "Battlefield",
-                "target": {
-                  "type": "Any"
-                },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "Shuffle",
-                  "target": {
-                    "type": "ParentTargetController"
-                  }
-                },
-                "cost": null,
-                "sub_ability": null,
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false
-              },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
-            },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": true,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
-          },
-          "duration": null,
-          "description": "Channel — {1}{G}, Discard this card: Destroy target artifact, enchantment, or nonbasic land an opponent controls. That player may search their library for a land card with a basic land type, put it onto the battlefield, then shuffle. This ability costs {1} less to activate for each legendary creature you control.",
-          "target_prompt": null,
-          "activation_zone": "Hand",
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "cost_reduction": {
-            "amount_per": 1,
-            "count": {
-              "type": "Ref",
-              "qty": {
-                "type": "ObjectCount",
-                "filter": {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "HasSupertype",
-                      "value": "Legendary"
-                    }
-                  ]
-                }
-              }
-            }
-          },
-          "forward_result": false,
-          "consumes_source": true
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1503
 expression: "&ir"
 ---
 {
@@ -144,102 +145,173 @@ expression: "&ir"
         "fragment": "Solved — {1}{B}, Sacrifice this ~: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "SearchLibrary",
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                "Card"
-              ],
-              "controller": null,
-              "properties": []
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "reveal": false
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
+        "Spell": {
+          "source_text": "Search your library for a card, put it into your hand, then shuffle",
+          "body": {
+            "clauses": [
               {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Black"
-                  ],
-                  "generic": 1
-                }
-              },
-              {
-                "type": "Sacrifice",
-                "target": {
-                  "type": "SelfRef"
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 53,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Search your library for a card, put it into your hand"
                 },
-                "count": 1
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": {
+                      "SearchDestination": {
+                        "destination": "Hand",
+                        "enter_tapped": false,
+                        "enters_under": null,
+                        "reveal": false,
+                        "attach_host": null
+                      }
+                    }
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "SearchLibrary",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Card"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "reveal": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Then",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 60,
+                    "end_byte": 67,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "shuffle"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Shuffle",
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            ]
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "ChangeZone",
-              "origin": "Library",
-              "destination": "Hand",
-              "target": {
-                "type": "Any"
-              },
-              "owner_library": false,
-              "enter_transformed": false,
-              "enter_tapped": false,
-              "enters_attacking": false
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "Shuffle",
-                "target": {
-                  "type": "Controller"
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "Black"
+                    ],
+                    "generic": 1
+                  }
+                },
+                {
+                  "type": "Sacrifice",
+                  "target": {
+                    "type": "SelfRef"
+                  },
+                  "count": 1
                 }
+              ]
+            },
+            "activation_restrictions": [
+              {
+                "type": "IsSolved"
               },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
-            },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "duration": null,
-          "description": "Solved — {1}{B}, Sacrifice this ~: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "IsSolved"
-            },
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "Solved — {1}{B}, Sacrifice this ~: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery."
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 172
 expression: "&ir"
 ---
 {
@@ -22,25 +23,75 @@ expression: "&ir"
         "fragment": "Prevent all combat damage that would be dealt this turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "PreventDamage",
-            "amount": "All",
-            "target": {
-              "type": "Any"
-            },
-            "scope": "CombatDamage"
+        "Spell": {
+          "source_text": "Prevent all combat damage that would be dealt this turn.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 55,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Prevent all combat damage that would be dealt this turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "PreventDamage",
+                    "amount": "All",
+                    "target": {
+                      "type": "Any"
+                    },
+                    "scope": "CombatDamage"
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1548
 expression: "&ir"
 ---
 {
@@ -86,59 +87,114 @@ expression: "&ir"
         "fragment": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Discard",
-            "count": {
-              "type": "Fixed",
-              "value": 4
-            },
-            "target": {
-              "type": "Player"
-            }
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
+        "Spell": {
+          "source_text": "Target player discards four cards",
+          "body": {
+            "clauses": [
               {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Black",
-                    "Black"
-                  ],
-                  "generic": 5
-                }
-              },
-              {
-                "type": "Discard",
-                "count": {
-                  "type": "Fixed",
-                  "value": 1
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 33,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target player discards four cards"
                 },
-                "filter": null,
-                "random": false,
-                "self_ref": true
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Discard",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 4
+                    },
+                    "target": {
+                      "type": "Player"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            ]
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "activation_zone": "Hand",
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false,
-          "consumes_source": true
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "Black",
+                      "Black"
+                    ],
+                    "generic": 5
+                  }
+                },
+                {
+                  "type": "Discard",
+                  "count": {
+                    "type": "Fixed",
+                    "value": 1
+                  },
+                  "filter": null,
+                  "random": false,
+                  "self_ref": true
+                }
+              ]
+            },
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "activation_zone": "Hand",
+            "description": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
+            "stages": [
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1624
 expression: "&ir"
 ---
 {
@@ -71,92 +72,148 @@ expression: "&ir"
         "fragment": "Forecast — {1}{U}, Reveal this card from your hand: Target creature becomes the color or colors of your choice until end of turn. (Activate only during your upkeep and only once each turn.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Choose",
-            "choice_type": "Color",
-            "persist": false
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
+        "Spell": {
+          "source_text": "Target creature becomes the color or colors of your choice until end of turn",
+          "body": {
+            "clauses": [
               {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Blue"
-                  ],
-                  "generic": 1
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 76,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target creature becomes the color or colors of your choice until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Choose",
+                    "choice_type": "Color",
+                    "persist": false
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "GenericEffect",
+                      "static_abilities": [
+                        {
+                          "mode": "Continuous",
+                          "affected": {
+                            "type": "ParentTarget"
+                          },
+                          "modifications": [
+                            {
+                              "type": "AddChosenColor",
+                              "mode": "Set"
+                            }
+                          ],
+                          "condition": null,
+                          "affected_zone": null,
+                          "effect_zone": null,
+                          "active_zones": [],
+                          "characteristic_defining": false,
+                          "description": "the color or colors of your choice"
+                        }
+                      ],
+                      "duration": "Permanent",
+                      "target": {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Creature"
+                        ],
+                        "controller": null,
+                        "properties": []
+                      }
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": null,
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false
+                  },
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "Blue"
+                    ],
+                    "generic": 1
+                  }
+                },
+                {
+                  "type": "Reveal",
+                  "count": 1
                 }
+              ]
+            },
+            "activation_restrictions": [
+              {
+                "type": "DuringYourUpkeep"
               },
               {
-                "type": "Reveal",
-                "count": 1
+                "type": "OnlyOnceEachTurn"
               }
+            ],
+            "activation_zone": "Hand",
+            "description": "Forecast — {1}{U}, Reveal this card from your hand: Target creature becomes the color or colors of your choice until end of turn.",
+            "stages": [
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
             ]
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "ParentTarget"
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddChosenColor",
-                      "mode": "Set"
-                    }
-                  ],
-                  "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "the color or colors of your choice"
-                }
-              ],
-              "duration": "Permanent",
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": null,
-                "properties": []
-              }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "duration": "UntilEndOfTurn",
-          "description": "Forecast — {1}{U}, Reveal this card from your hand: Target creature becomes the color or colors of your choice until end of turn.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "DuringYourUpkeep"
-            },
-            {
-              "type": "OnlyOnceEachTurn"
-            }
-          ],
-          "activation_zone": "Hand",
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_ir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 524
+assertion_line: 550
 expression: "&ir"
 ---
 {
@@ -106,62 +106,118 @@ expression: "&ir"
         "fragment": "{B}, {T}: Target creature gets -2/-2 until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Pump",
-            "power": {
-              "type": "Fixed",
-              "value": -2
-            },
-            "toughness": {
-              "type": "Fixed",
-              "value": -2
-            },
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            }
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
+        "Spell": {
+          "source_text": "Target creature gets -2/-2 until end of turn",
+          "body": {
+            "clauses": [
               {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Black"
-                  ],
-                  "generic": 0
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 44,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target creature gets -2/-2 until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Pump",
+                    "power": {
+                      "type": "Fixed",
+                      "value": -2
+                    },
+                    "toughness": {
+                      "type": "Fixed",
+                      "value": -2
+                    },
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "Black"
+                    ],
+                    "generic": 0
+                  }
+                },
+                {
+                  "type": "Tap"
                 }
-              },
+              ]
+            },
+            "activation_restrictions": [
               {
-                "type": "Tap"
+                "type": "LevelCounterRange",
+                "data": {
+                  "minimum": 2,
+                  "maximum": 3
+                }
               }
+            ],
+            "description": "{B}, {T}: Target creature gets -2/-2 until end of turn.",
+            "stages": [
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
             ]
-          },
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "{B}, {T}: Target creature gets -2/-2 until end of turn.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "LevelCounterRange",
-              "data": {
-                "minimum": 2,
-                "maximum": 3
-              }
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          }
         }
       }
     },
@@ -236,61 +292,117 @@ expression: "&ir"
         "fragment": "{B}, {T}: Target creature gets -4/-4 until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Pump",
-            "power": {
-              "type": "Fixed",
-              "value": -4
-            },
-            "toughness": {
-              "type": "Fixed",
-              "value": -4
-            },
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            }
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
+        "Spell": {
+          "source_text": "Target creature gets -4/-4 until end of turn",
+          "body": {
+            "clauses": [
               {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Black"
-                  ],
-                  "generic": 0
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 44,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target creature gets -4/-4 until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Pump",
+                    "power": {
+                      "type": "Fixed",
+                      "value": -4
+                    },
+                    "toughness": {
+                      "type": "Fixed",
+                      "value": -4
+                    },
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "Black"
+                    ],
+                    "generic": 0
+                  }
+                },
+                {
+                  "type": "Tap"
                 }
-              },
+              ]
+            },
+            "activation_restrictions": [
               {
-                "type": "Tap"
+                "type": "LevelCounterRange",
+                "data": {
+                  "minimum": 4
+                }
               }
+            ],
+            "description": "{B}, {T}: Target creature gets -4/-4 until end of turn.",
+            "stages": [
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
             ]
-          },
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "{B}, {T}: Target creature gets -4/-4 until end of turn.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "LevelCounterRange",
-              "data": {
-                "minimum": 4
-              }
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_ir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 554
+assertion_line: 580
 expression: "&ir"
 ---
 {
@@ -106,39 +106,94 @@ expression: "&ir"
         "fragment": "{T}: Add {G}{G}."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Mana",
-            "produced": {
-              "type": "Fixed",
-              "colors": [
-                "Green",
-                "Green"
-              ]
-            }
-          },
-          "cost": {
-            "type": "Tap"
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{T}: Add {G}{G}.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "LevelCounterRange",
-              "data": {
-                "minimum": 1,
-                "maximum": 4
+        "Spell": {
+          "source_text": "Add {G}{G}",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 10,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Add {G}{G}"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Mana",
+                    "produced": {
+                      "type": "Fixed",
+                      "colors": [
+                        "Green",
+                        "Green"
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false,
-          "is_mana_ability": true
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Tap"
+            },
+            "activation_restrictions": [
+              {
+                "type": "LevelCounterRange",
+                "data": {
+                  "minimum": 1,
+                  "maximum": 4
+                }
+              }
+            ],
+            "description": "{T}: Add {G}{G}.",
+            "stages": [
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1572
 expression: "&ir"
 ---
 {
@@ -112,108 +113,196 @@ expression: "&ir"
         "fragment": "Exhaust — {5}{B}: Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana. Activate only as a sorcery. (Activate each exhaust ability only once.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "ChangeZone",
-            "origin": "Graveyard",
-            "destination": "Battlefield",
-            "target": {
-              "type": "Or",
-              "filters": [
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "InZone",
-                      "zone": "Graveyard"
-                    }
-                  ]
+        "Spell": {
+          "source_text": "Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 82,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Return target creature or planeswalker card from your graveyard to the battlefield"
                 },
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Planeswalker"
-                  ],
-                  "controller": "You",
-                  "properties": [
-                    {
-                      "type": "InZone",
-                      "zone": "Graveyard"
-                    }
-                  ]
-                }
-              ]
-            },
-            "owner_library": false,
-            "enter_transformed": false,
-            "enter_tapped": false,
-            "enters_attacking": false
-          },
-          "cost": {
-            "type": "Mana",
-            "cost": {
-              "type": "Cost",
-              "shards": [
-                "Black"
-              ],
-              "generic": 5
-            }
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "P1P1",
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  {
-                    "Subtype": "Liliana"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": "Graveyard",
+                    "destination": "Battlefield",
+                    "target": {
+                      "type": "Or",
+                      "filters": [
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": "You",
+                          "properties": [
+                            {
+                              "type": "InZone",
+                              "zone": "Graveyard"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Planeswalker"
+                          ],
+                          "controller": "You",
+                          "properties": [
+                            {
+                              "type": "InZone",
+                              "zone": "Graveyard"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 84,
+                    "end_byte": 114,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "Put a +1/+1 counter on Liliana"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "PutCounter",
+                    "counter_type": "P1P1",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        {
+                          "Subtype": "Liliana"
+                        }
+                      ],
+                      "controller": null,
+                      "properties": []
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [
+                  "Black"
                 ],
-                "controller": null,
-                "properties": []
+                "generic": 5
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "target_choice_timing": "Resolution",
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
-          },
-          "duration": null,
-          "description": "Exhaust — {5}{B}: Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana. Activate only as a sorcery.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              },
+              {
+                "type": "OnlyOnce"
+              }
+            ],
+            "ability_tag": {
+              "type": "Exhaust"
             },
-            {
-              "type": "OnlyOnce"
-            }
-          ],
-          "ability_tag": {
-            "type": "Exhaust"
-          },
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+            "description": "Exhaust — {5}{B}: Return target creature or planeswalker card from your graveyard to the battlefield. Put a +1/+1 counter on Liliana. Activate only as a sorcery.",
+            "stages": [
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
+          }
         }
       }
     }

--- a/crates/engine/tests/integration/ir_spell_node_readers.rs
+++ b/crates/engine/tests/integration/ir_spell_node_readers.rs
@@ -59,24 +59,25 @@ fn retained_ability_slots(parsed: &ParsedAbilities) -> Vec<usize> {
 }
 
 /// CR 707.9a: a printed slot is consumed by the printed ability that occupies
-/// it, whether or not that ability has a definition yet to stamp.
+/// it, whether or not that ability carried a definition to stamp.
 ///
-/// `OracleDocBuilder::finish()` resolves every "…except it has this ability"
-/// clause by walking items in source order and counting each category
-/// separately. An IR-native spell node holds only an effect chain, so there is
-/// nothing to stamp into — but it still occupies an ability slot, because
-/// `lower_oracle_ir` pushes it into `result.abilities` exactly like a
-/// pre-lowered one does.
+/// `lower_oracle_ir` resolves every "…except it has this ability" clause while
+/// bucketing items into the per-category vectors: the slot IS
+/// `result.abilities.len()` at the moment of the push, so an IR-native spell
+/// consumes its slot by being pushed, exactly like a pre-lowered one. (Plan 05b
+/// T9b moved this off `OracleDocBuilder::finish()`, which ran before lowering
+/// and so could only stamp the pre-lowered shapes.)
 ///
-/// DISCRIMINATING: with the `Spell` arm parked in `finish()`'s no-op list this
-/// reads `0`, and the copy grafts the FIRST printed ability — the prevention
-/// spell — instead of itself.
+/// DISCRIMINATING: drop the stamp and this reads `0` — the copy grafts the FIRST
+/// printed ability, the prevention spell, instead of itself. Verified red.
 ///
-/// Line 1 is the shape the only live `OracleNodeIr::Spell` producer emits: an
-/// instant/sorcery prevention line. Line 2 is a synthetic activated ability,
-/// which is the sole source of `RetainPrintedAbilityFromSource`. No printing
-/// pairs the two today — which is exactly why this defect had no corpus witness
-/// and why the full-pool byte gate is silent on it.
+/// Line 1 reaches the instant/sorcery prevention recognizer, an IR-native
+/// (`OracleNodeIr::Spell`) producer. Line 2 is a synthetic activated ability;
+/// `parse_activated_ability_definition` is the only writer of
+/// `ParseContext::current_ability_index` and therefore the only source of
+/// `RetainPrintedAbilityFromSource`, and it is deliberately still pre-lowered.
+/// No printing pairs the two today — which is why this defect had no corpus
+/// witness and why the full-pool byte gate is silent on it.
 #[test]
 fn an_ir_native_spell_consumes_the_printed_ability_slot_it_occupies() {
     let parsed = parse_oracle_text(
@@ -127,13 +128,13 @@ fn an_ir_native_spell_consumes_the_printed_ability_slot_it_occupies() {
 // therefore needs an explicit non-regression witness across the signature
 // change.
 //
-// SCOPE, stated honestly: this witnesses the BORROWED arm. The new IR-native
-// arm has no witness, because no text can currently reach it — the single live
-// `Spell` producer is a prevent-damage spell line, and no relation predicate
-// matches a prevention chain. Verified by construction (removing the new arm
-// leaves these tests green) and by attempting to synthesize a card that pairs
-// the two, which the line splitter refuses to produce. The arm is forward
-// hardening for T8, when `Spell` producers rise from 1 to ~14.
+// SCOPE, stated honestly: this witnesses the BORROWED arm. The IR-native arm is
+// exercised by nine producers as of Plan 05b T9b, but by no *relation predicate*
+// — the relations these tests drive pair ability items whose text reaches the
+// still-pre-lowered fallbacks, and no relation predicate matches a prevention
+// chain or a keyword-activated body. So the IR-native arm remains covered by
+// construction (`item_ability` lowers through the same `lower_ability_ir` the
+// `Spell` bucketing arm calls) rather than by a relation witness.
 // ---------------------------------------------------------------------------
 
 /// Verified against Scryfall 2026-07-27 (`cards/named?exact=Siren's Call`).

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -12,7 +12,7 @@
 # real IR nodes. Every tranche that converts a producer must lower its number
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
-crates/engine/src/parser/oracle.rs         16
+crates/engine/src/parser/oracle.rs         15
 crates/engine/src/parser/oracle_class.rs    5
 
 # --- infrastructure: NOT burn-down targets ----------------------------------


### PR DESCRIPTION
Plan 05b **T9b** — Unit 3b phase B: the payload swap. `OracleNodeIr::Spell`'s payload becomes
`AbilityIr`, converting **all nine spell producers at once**. Follows #6722 (T9a).

One compile-coupled commit — two exhaustive `OracleNodeIr` matches in `doc.rs` force every producer to
move together.

**This is the payoff of T8's five-tranche staging.** Every phase-A producer already routed through
`ability_ir_at`, so the conversion itself is one line: that method stops lowering eagerly and emits the
IR-native node. The alternative was a single cutover where a hundred snapshots and a dozen recognizers
moved at once and no diff was readable.

## Headline: card-data is BYTE-IDENTICAL

`sha256 c3f8431c494c1a9710e08fc15161eab75203a2dc98a5aa35e3f7a993ec43c245` — identical before and
after, `cmp` clean.

- 99,201,978 bytes; **35,516 face-keyed top-level entries, counted by parsing the JSON** rather than
  read off a log line
- Real pool: `AtomicCards.json` + `SetList`/`Meta`/`CardTypes`/`sets`/`decks` symlinked from the main
  checkout, generated from the worktree repo root (§5.1.3 — a worktree carries only
  `test_fixture.json`, so generating against that measures a fixture population and is void, not green)
- Generator rebuilt for both runs
- Baseline **re-measured on this branch's own base**, not inherited from T9a

T9a already absorbed the campaign's one intentional behavioural delta, so byte-identity here is the
expected result and the proof that the swap is semantically neutral.

## Snapshots

**10 changed, all `*_ir`, zero `*_lowered`.** 10 M / 0 A / 0 D; `.snap.new` count 0.

All ten are mechanism 1 (total re-serialization), **machine-checked**: for every file the only node-key
change is `PreLoweredSpell` → `Spell`, and `grep -c 'source_(ability|trigger)_index'` on each diff is
0. Nothing fell outside the expected mechanisms.

Read in full: **`fog_ir`** (single clause — flat def becomes `{source_text, body:{clauses:[1]}, shell}`
with the `PreventDamage` payload preserved verbatim) and **`blunt_the_assault_ir`** (multi-clause —
the old flat root + `sub_ability` + `sub_link: SequentialSibling` becomes two chain clauses with
`boundary: Sentence`, the `sub_link` now derived at lowering).

**`*_lowered` being unchanged is proven, not assumed.** `_ir` is asserted before `_lowered` in the same
test, so a failing `_ir` masks the `_lowered` assertion entirely; the ten were accepted and the suite
re-run — 311/311 pass, zero new `.snap.new`.

**Mechanism 2 did not materialize, and that is a finding rather than a discrepancy:** no `*_ir.snap`
fixture carries a copy-except clause, so the corpus supplies zero evidence about the relocated stamp in
either direction. The two seen-red probes below are what cover it.

## The CR 707.9a stamp move: the conclusion holds, the plan's stated reason did not

The stamp moves from `finish()` to `lower_oracle_ir`'s bucketing loop, where `slot =
result.<category>.len()` at the push.

`doc.rs`'s own doc block argued "the load-bearing invariant is per-category counting, **not** source
order … the walk never depended on that." **That disclaimer is wrong.** Per-category counting alone is
not sufficient — the two walks must also visit the same *sequence*. They do, because both iterate the
same `BTreeMap` keyed by `(first_line, start_byte, ordinal)`. So the conclusion survives while the
stated reason was incomplete; the comment has been rewritten.

Three conditions the plan's argument never mentioned, each verified:

- **No relation predicate and not the swallow audit reads a printed slot** (zero `RetainPrinted` /
  `source_*_index` in `oracle.rs` outside one comment; `swallow_check` never touches `.node`), so
  moving downstream of relation *discovery* is safe.
- **The stamp must land before the relation *application* passes**, which insert into, remove from, and
  move ids between the category tracks. It does.
- **`PrintedAbilityIndex::placeholder`'s doc block reads as forbidding exactly this move.** It does
  not — that sentence is about the retired parse-time `from_category_vector_len`, which read the length
  in *emission* order. Same expression, different quantity. Disambiguated in place, because otherwise
  the next reader concludes this commit is unsound.

Structural bonus: the slot is now the vector length itself, so "consumes a slot" and "is pushed" are a
single operation. The old walk had two counters *predicting* a vector they did not own; that drift is
now unrepresentable.

## Non-vacuity — both directions watched go red

- Drop the relocated stamp → Thespian's Stage reads `RetainPrintedAbilityFromSource(0)` instead of
  `(1)`. Red, then reverted.
- Restore the closure mutator → the new min-X test's node assertion fails while its floor assertion
  still passes. Red, then reverted.

Both probes removed (`grep -c PROBE` = 0). New test
`a_standalone_x_floor_annotation_raises_an_ir_native_spells_floor` pins the path that only became
reachable in this commit.

**Compiler witness:** `lower_effect_chain_ir` became an unused import in `oracle.rs` — no spell path
there lowers a bare chain any more. That is the invariant the swap exists to establish, asserted
mechanically rather than by grep.

## Gates (all on the final commit)

```
cargo fmt --all                                      clean
cargo clippy -p engine --lib -- -D warnings          zero warnings
cargo nextest run -p engine --lib                    17858 / 17858 passed
cargo nextest run -p engine --test integration       4132 / 4132 passed
./scripts/check-prelowered-ratchet.sh                Gate P PASS  (oracle.rs 16 → 15)
./scripts/check-skill-doc.sh                         ✓ oracle-parser skill references valid
./scripts/check-parser-combinators.sh                Gate G PASS / Gate A PASS
```

Parser string-dispatch diff gate: no output (PASS). CR diff gate: 601.2b, 602.1, 603.1, 608.2, 707.9a
— zero unverified, each rule's **text** read rather than its existence checked.

**Ratchet caveat, stated plainly.** The burn-down moved by **one incidental prose mention, not by
nine.** `ability_ir_at` never contained the literal token, so converting nine semantic producers is
invisible to a textual gate. `doc.rs` stays at ceiling because `spell_min_x_mut`'s match is exhaustive
and four arms name a pre-lowered variant — it feeds an `.expect()`, so a `_` arm would convert a future
compile error into a runtime panic. The match was kept and the cost paid in prose instead. The ledger
was never edited upward.

## Deferred: U0-40

Confirmed **not** done by T3 (`oracle.rs:5595` still calls `drain_result_vectors`), and **not
compile-coupled** — the swap compiles and both suites pass without it.

The analysis was done and it is **byte-safe by construction**: `collect_source_in_zones` ignores
`StaticCondition::ChosenLabelIs` so `active_zones` stays empty, and `bind_counter_anaphor_to_recipient`
only rewrites `ObjectScope::Anaphoric` while these modifications are fixed P/T (the recognizer returns
false unless power and toughness are both `Some`). Both `lower_static_ir` transforms provably no-op and
`lower_replacement_ir` is identity. Emission order must stay abilities → statics → replacements to
preserve `ordinal_within_span`.

It was nonetheless left out, deliberately: it introduces the new heterogeneous `Vec<OracleNodeIr>`
mechanism the recensus says to introduce once, and it needs its **own** isolated full-pool measurement.
Bundling a new mechanism into the one commit whose entire value is an isolated byte-identity
measurement would defeat that measurement. The analysis above is the brief for the follow-up.

## For reviewers

- **The stamp's IR-native *ability* arm is structurally unreachable today.**
  `parse_activated_ability_definition` is the only writer of `ParseContext::current_ability_index` and
  therefore the only source of `RetainPrintedAbilityFromSource`, and it is still pre-lowered
  (U0-28/31, T10b). So the move is byte-neutral **because of that**, not by luck, and it becomes
  load-bearing the moment that router converts. **Do not read the green byte gate as evidence the
  IR-native stamping path works** — it is covered by construction plus the two seen-red probes.
- **`reemit_node`'s instead-fold caller must stay pre-lowered.** The fold builds a genuinely new
  `AbilityDefinition` and `lower_ability_ir` has no inverse. Do not "fix" it to emit `Spell`.
- The three standalone "X can't be 0." cards remain a pre-existing misparse (annotation at line index 0
  ⇒ `take_last_spell()` is `None`), unchanged here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Spell definitions now retain their native structure through parsing and emission, improving consistency for activated abilities.
  * Printed ability and trigger slots are assigned in source order for more reliable document relationships.
  * Announced-X adjustments now preserve the original spell representation.

* **Bug Fixes**
  * Fixed handling of standalone “X can’t be 0” annotations.
  * Improved re-emission of spell text while preserving source positions and ordering.

* **Tests**
  * Added regression coverage for announced-X handling and native spell nodes.
  * Updated integration scenarios for slot assignment and document relations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->