### PR TITLE
Add Scholarship Sponsor and Enigma Ridges

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -20382,6 +20382,102 @@ mod tests {
         );
     }
 
+    /// Scholarship Sponsor / Enigma Ridges lower one scoped search with a
+    /// ParentTarget delivery and a ledger-scoped shuffle tail. Trigger setup
+    /// recursively stamps provenance on both children, but that provenance is
+    /// not delivery behavior: after splitting, the plain delivery must still
+    /// enter the simultaneous-search protocol and the shuffle must be its
+    /// once-after-all-searches tail.
+    #[test]
+    fn triggered_uneven_land_search_detaches_shuffle_before_batch_admission() {
+        const ORACLE: &str = "When this creature enters, each player who controls fewer lands than the player who controls the most lands searches their library for a number of basic land cards less than or equal to the difference, puts those cards onto the battlefield tapped, then shuffles.";
+
+        // Use the real ETB lowerer, not merely a standalone effect parse. A
+        // `ChangesZone` trigger carries an event source, so this exercises the
+        // event-source anaphor rewrite that must leave a SearchLibrary
+        // delivery's ParentTarget intact.
+        let trigger =
+            crate::parser::oracle_trigger::parse_trigger_line(ORACLE, "Scholarship Sponsor");
+        let definition = trigger
+            .execute
+            .as_deref()
+            .expect("Scholarship Sponsor ETB has an execute chain");
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(900),
+            PlayerId(0),
+            "Scoped trigger source".to_string(),
+            Zone::Battlefield,
+        );
+        let mut ability = build_resolved_from_def(definition, source, PlayerId(0));
+        let trigger_source = {
+            let source_object = state
+                .objects
+                .get(&source)
+                .expect("trigger source exists for provenance capture");
+            crate::game::triggers::trigger_source_context_for_latch(&state, source_object)
+        };
+        let definition_ref = crate::types::ability::TriggerDefinitionRef {
+            source: trigger_source.identity.reference,
+            occurrence: crate::types::ability::TriggerDefinitionOccurrenceRef::Unmaterialized,
+        };
+        ability.set_trigger_source_recursive(trigger_source);
+        ability.set_trigger_definition_ref_recursive(definition_ref);
+
+        let scope = ability
+            .player_scope
+            .clone()
+            .expect("uneven-land search retains its player scope");
+        assert!(
+            scoped_library_search::has_only_detachable_shuffle_tail(&ability),
+            "the raw chain has only the searched-this-way shuffle after delivery"
+        );
+
+        let (scoped, after_scope) = split_player_scope_chain(&ability, &scope);
+        assert!(
+            scoped.player_scope.is_none(),
+            "the split template owns one scoped iteration rather than re-entering it"
+        );
+        let delivery = scoped
+            .sub_ability
+            .as_deref()
+            .expect("the search keeps its ParentTarget delivery");
+        assert!(
+            matches!(
+                &delivery.effect,
+                Effect::ChangeZone {
+                    target: TargetFilter::ParentTarget,
+                    ..
+                }
+            ),
+            "the ETB event-source rewrite must not capture the search-result delivery"
+        );
+        assert!(
+            delivery.trigger_source.is_some() && delivery.trigger_definition_ref.is_some(),
+            "trigger provenance is recursively present on the otherwise plain delivery"
+        );
+        assert!(
+            delivery.sub_ability.is_none() && delivery.sub_link == SubAbilityLink::ContinuationStep,
+            "the scoped template is exactly SearchLibrary followed by plain delivery"
+        );
+        assert!(
+            scoped_library_search::supports_simultaneous_delivery(&scoped),
+            "trigger provenance must not reject an otherwise batch-safe delivery"
+        );
+
+        let shuffle = after_scope.expect("the searched-this-way shuffle detaches after scope");
+        assert!(matches!(shuffle.effect, Effect::Shuffle { .. }));
+        assert!(matches!(
+            shuffle.player_scope,
+            Some(PlayerFilter::PerformedActionThisWay {
+                action: PlayerActionKind::SearchedLibrary,
+                ..
+            })
+        ));
+        assert_eq!(shuffle.sub_link, SubAbilityLink::SequentialSibling);
+    }
+
     #[test]
     fn player_scope_preserves_controller_for_you_quantities() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/game/effects/scoped_library_search.rs
+++ b/crates/engine/src/game/effects/scoped_library_search.rs
@@ -14,12 +14,14 @@ use crate::types::player::PlayerId;
 use crate::types::zones::Zone;
 
 /// CR 101.4 + CR 701.23i: A scoped self-library search can use the simultaneous
-/// protocol only when its immediate continuation is the ordinary parent-target
-/// library-to-battlefield delivery. Other search shapes retain the established
-/// sequential player-scope resolver rather than being coerced into a subtly
-/// different timing model.
+/// protocol only when its immediate continuation is a plain parent-target
+/// library-to-battlefield delivery without a reveal, or a plain
+/// library-to-hand delivery with a reveal. Other search shapes retain the
+/// established sequential player-scope resolver rather than being coerced into
+/// a subtly different timing model.
 pub(crate) fn supports_simultaneous_delivery(ability: &ResolvedAbility) -> bool {
     let Effect::SearchLibrary {
+        reveal,
         target_player,
         source_zones,
         ..
@@ -42,8 +44,7 @@ pub(crate) fn supports_simultaneous_delivery(ability: &ResolvedAbility) -> bool 
     if !is_plain_parent_target_delivery(delivery) {
         return false;
     }
-    matches!(
-        &delivery.effect,
+    match &delivery.effect {
         Effect::ChangeZone {
             origin: Some(Zone::Library),
             destination: Zone::Battlefield,
@@ -58,8 +59,34 @@ pub(crate) fn supports_simultaneous_delivery(ability: &ResolvedAbility) -> bool 
             face_down_profile: None,
             enters_modified_if: None,
             ..
-        } if enter_with_counters.is_empty() && conditional_enter_with_counters.is_empty()
-    )
+        } if !*reveal
+            && enter_with_counters.is_empty()
+            && conditional_enter_with_counters.is_empty() =>
+        {
+            true
+        }
+        Effect::ChangeZone {
+            origin: Some(Zone::Library),
+            destination: Zone::Hand,
+            target: TargetFilter::ParentTarget,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters,
+            conditional_enter_with_counters,
+            face_down_profile: None,
+            enters_modified_if: None,
+        } if *reveal
+            && enter_with_counters.is_empty()
+            && conditional_enter_with_counters.is_empty() =>
+        {
+            true
+        }
+        _ => false,
+    }
 }
 
 /// The player-scope splitter normally peels the once-after-all-searches shuffle
@@ -88,9 +115,12 @@ pub(crate) fn has_only_detachable_shuffle_tail(ability: &ResolvedAbility) -> boo
 /// supported `Effect::ChangeZone` fields may enter it. Every checked field
 /// would otherwise require `resolve_ability_chain` to preserve behavior.
 fn is_plain_parent_target_delivery(delivery: &ResolvedAbility) -> bool {
-    delivery.trigger_source.is_none()
-        && delivery.trigger_definition_ref.is_none()
-        && delivery.targets.is_empty()
+    // Trigger instantiation stamps source/definition provenance recursively on
+    // every continuation. The scoped protocol consumes this child as a typed
+    // `ZoneMoveRequest`, where neither provenance field changes the delivery;
+    // rejecting them would make an otherwise identical triggered search fall
+    // back to sequential resolution while the spell form batches correctly.
+    delivery.targets.is_empty()
         && delivery.sub_ability.is_none()
         && delivery.else_ability.is_none()
         && delivery.duration.is_none()
@@ -920,6 +950,51 @@ mod tests {
         )
         .sub_ability(delivery);
         (state, search, cards)
+    }
+
+    /// The batch shortcut is deliberately limited to the two delivery shapes
+    /// whose visible information and movement timing it implements itself.
+    #[test]
+    fn simultaneous_delivery_accepts_only_unrevealed_battlefield_or_revealed_hand() {
+        let (_, revealed_hand, _) = three_player_scoped_search(true);
+        assert!(
+            supports_simultaneous_delivery(&revealed_hand),
+            "a revealed plain library-to-hand delivery is batch-safe"
+        );
+
+        let (_, unrevealed_hand, _) = three_player_scoped_search(false);
+        assert!(
+            !supports_simultaneous_delivery(&unrevealed_hand),
+            "an unrevealed library-to-hand delivery is outside the shortcut"
+        );
+
+        let (_, mut revealed_battlefield, _) = three_player_scoped_search(true);
+        let delivery = revealed_battlefield
+            .sub_ability
+            .as_deref_mut()
+            .expect("fixture supplies a delivery child");
+        let Effect::ChangeZone { destination, .. } = &mut delivery.effect else {
+            panic!("fixture delivery must be ChangeZone");
+        };
+        *destination = Zone::Battlefield;
+        assert!(
+            !supports_simultaneous_delivery(&revealed_battlefield),
+            "a revealed library-to-battlefield delivery is outside the shortcut"
+        );
+
+        let (_, mut unrevealed_battlefield, _) = three_player_scoped_search(false);
+        let delivery = unrevealed_battlefield
+            .sub_ability
+            .as_deref_mut()
+            .expect("fixture supplies a delivery child");
+        let Effect::ChangeZone { destination, .. } = &mut delivery.effect else {
+            panic!("fixture delivery must be ChangeZone");
+        };
+        *destination = Zone::Battlefield;
+        assert!(
+            supports_simultaneous_delivery(&unrevealed_battlefield),
+            "the established plain library-to-battlefield shortcut remains valid"
+        );
     }
 
     /// A child rider cannot be represented by the typed batch move request.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13453,6 +13453,182 @@ fn parse_threshold_land_balance_ir(
     })
 }
 
+/// The terminal delivery grammar of an uneven-land search. These are distinct
+/// because only the hand form publicly reveals the found cards before delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnevenLandSearchDelivery {
+    TappedBattlefield,
+    RevealedHand,
+}
+
+/// CR 101.4a + CR 701.23a/e/i: Whole-chain recognizer for the shared
+/// cross-player land catch-up search (Scholarship Sponsor / Enigma Ridges).
+///
+/// The player predicate, extremum, bounded difference, basic-land search, and
+/// delivery are independently typed. The two delivery grammars are deliberately
+/// closed: unrevealed cards enter the battlefield tapped, while revealed cards
+/// go to hand. This makes the scoped-search protocol's privacy and delivery
+/// eligibility visible in the resulting effect tree rather than dispatching on
+/// card names or residual strings.
+fn parse_uneven_land_search_ir(
+    text: &str,
+    kind: AbilityKind,
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
+    let lower = text.to_lowercase();
+    let ((extremum, delivery), _) = nom_on_lower(text, &lower, |input| {
+        let (input, _) =
+            tag("each player who controls fewer lands than the player who controls the ")
+                .parse(input)?;
+        let saved = input;
+        let (input, extremum) = alt((
+            value(AggregateFunction::Max, tag("most")),
+            value(AggregateFunction::Min, tag("fewest")),
+        ))
+        .parse(input)?;
+        // The comparison subject is only coherent with the maximum land count:
+        // every matching player must have fewer lands than that maximum.
+        if extremum != AggregateFunction::Max {
+            return Err(nom::Err::Error(OracleError::new(
+                saved,
+                nom::error::ErrorKind::Verify,
+            )));
+        }
+        let (input, _) = tag(
+            " lands searches their library for a number of basic land cards less than or equal to the difference, ",
+        )
+        .parse(input)?;
+        let (input, delivery) = alt((
+            value(
+                UnevenLandSearchDelivery::TappedBattlefield,
+                tag("puts those cards onto the battlefield tapped, then shuffles"),
+            ),
+            value(
+                UnevenLandSearchDelivery::RevealedHand,
+                tag("reveals them, puts them into their hand, then shuffles"),
+            ),
+        ))
+        .parse(input)?;
+        let (input, _) = opt(tag(".")).parse(input)?;
+        let (input, _) = eof.parse(input)?;
+        Ok((input, (extremum, delivery)))
+    })?;
+
+    let lands = TargetFilter::Typed(TypedFilter::land());
+    let basic_lands =
+        TargetFilter::Typed(
+            TypedFilter::land().properties(vec![FilterProp::HasSupertype {
+                value: Supertype::Basic,
+            }]),
+        );
+    let scoped_lands =
+        TargetFilter::Typed(TypedFilter::land().controller(ControllerRef::ScopedPlayer));
+    let maximum_lands = QuantityExpr::Ref {
+        qty: QuantityRef::ControlledByEachPlayer {
+            filter: lands.clone(),
+            aggregate: extremum,
+        },
+    };
+    let difference = QuantityExpr::Difference {
+        left: Box::new(maximum_lands.clone()),
+        right: Box::new(QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount {
+                filter: scoped_lands,
+            },
+        }),
+    };
+
+    let (destination, enter_tapped, reveal) = match delivery {
+        UnevenLandSearchDelivery::TappedBattlefield => (
+            Zone::Battlefield,
+            crate::types::zones::EtbTapState::Tapped,
+            false,
+        ),
+        UnevenLandSearchDelivery::RevealedHand => (
+            Zone::Hand,
+            crate::types::zones::EtbTapState::Unspecified,
+            true,
+        ),
+    };
+    let mut shuffle = AbilityDefinition::new(
+        kind,
+        Effect::Shuffle {
+            target: TargetFilter::Controller,
+        },
+    )
+    .player_scope(PlayerFilter::PerformedActionThisWay {
+        relation: PlayerRelation::All,
+        action: crate::types::events::PlayerActionKind::SearchedLibrary,
+    });
+    // The final "searched this way" shuffle is a distinct instruction, not a
+    // result-delivery continuation. It remains physically attached as the
+    // delivery tail so the scoped-search executor can detach and batch it.
+    shuffle.sub_link = SubAbilityLink::SequentialSibling;
+    let delivery = AbilityDefinition::new(
+        kind,
+        Effect::ChangeZone {
+            origin: Some(Zone::Library),
+            destination,
+            target: TargetFilter::ParentTarget,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: Vec::new(),
+            conditional_enter_with_counters: Vec::new(),
+            face_down_profile: None,
+            enters_modified_if: None,
+        },
+    )
+    .sub_ability(shuffle);
+    let mut search = parsed_clause(Effect::SearchLibrary {
+        filter: basic_lands,
+        count: QuantityExpr::up_to(difference),
+        reveal,
+        target_player: None,
+        selection_constraint: crate::types::ability::SearchSelectionConstraint::None,
+        split: None,
+        source_zones: vec![Zone::Library],
+    });
+    search.sub_ability = Some(Box::new(delivery));
+
+    let mut builder = ClauseIrBuilder::new(text);
+    builder
+        .clause(
+            text,
+            search,
+            None,
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .player_scope(Some(PlayerFilter::ControlsCount {
+            relation: PlayerRelation::All,
+            filter: lands,
+            comparator: Comparator::LT,
+            count: Box::new(maximum_lands),
+        }))
+        .push();
+
+    Some(EffectChainIr {
+        clauses: builder.finish(),
+        kind,
+        continuation_kind: Some(kind),
+        // This is an `each player who ...` instruction, not an already-local
+        // effect. Retain the scope in the lowered ability so the resolver can
+        // split the search/delivery/shuffle chain and use its simultaneous
+        // scoped-search protocol.
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
+        chain_rounding: None,
+        actor: ctx.actor.clone(),
+        in_trigger: ctx.in_trigger,
+        repeat_until: None,
+    })
+}
+
 /// CR 121.1 + CR 402.1 + CR 608.2e: Whole-line interceptor for the "catch up to
 /// the player with the most cards in hand" equalize-upward draw (Tales of the
 /// Ancestors). Structured like [`parse_balance_equalization_ir`]: the
@@ -27524,6 +27700,9 @@ pub(crate) fn parse_effect_chain_ir(
         return ir;
     }
     if let Some(ir) = parse_threshold_land_balance_ir(text, kind, ctx) {
+        return ir;
+    }
+    if let Some(ir) = parse_uneven_land_search_ir(text, kind, ctx) {
         return ir;
     }
     if let Some(ir) = parse_return_target_and_same_name_from_your_graveyard_ir(text, kind, ctx) {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -48589,6 +48589,236 @@ fn threshold_land_balance_rejects_nonbasic_search_variant() {
     assert!(matches!(def.effect.as_ref(), Effect::Unimplemented { .. }));
 }
 
+const SCHOLARSHIP_SPONSOR_SEARCH: &str = "Each player who controls fewer lands than the player who controls the most lands searches their library for a number of basic land cards less than or equal to the difference, puts those cards onto the battlefield tapped, then shuffles.";
+const ENIGMA_RIDGES_SEARCH: &str = "Each player who controls fewer lands than the player who controls the most lands searches their library for a number of basic land cards less than or equal to the difference, reveals them, puts them into their hand, then shuffles.";
+const FEWEST_LANDS_SEARCH: &str = "Each player who controls fewer lands than the player who controls the fewest lands searches their library for a number of basic land cards less than or equal to the difference, puts those cards onto the battlefield tapped, then shuffles.";
+
+fn assert_uneven_land_search_shape(
+    text: &str,
+    expected_reveal: bool,
+    expected_destination: Zone,
+    expected_tapped: crate::types::zones::EtbTapState,
+) {
+    let def = parse_effect_chain(text, AbilityKind::Spell);
+    let Effect::SearchLibrary {
+        filter,
+        count,
+        reveal,
+        target_player,
+        source_zones,
+        ..
+    } = def.effect.as_ref()
+    else {
+        panic!("expected SearchLibrary root, got {:?}", def.effect);
+    };
+    assert_eq!(*reveal, expected_reveal);
+    assert!(target_player.is_none());
+    assert_eq!(source_zones, &vec![Zone::Library]);
+    assert_eq!(
+        filter,
+        &TargetFilter::Typed(
+            TypedFilter::land().properties(vec![FilterProp::HasSupertype {
+                value: Supertype::Basic,
+            }])
+        ),
+        "the search selection is exactly basic land cards"
+    );
+
+    let QuantityExpr::UpTo { max } = count else {
+        panic!("expected an up-to difference bound, got {count:?}");
+    };
+    let QuantityExpr::Difference { left, right } = max.as_ref() else {
+        panic!("expected max-land-count minus scoped-land-count, got {max:?}");
+    };
+    assert!(matches!(
+        left.as_ref(),
+        QuantityExpr::Ref {
+            qty: QuantityRef::ControlledByEachPlayer {
+                filter: TargetFilter::Typed(lands),
+                aggregate: AggregateFunction::Max,
+            },
+        } if lands == &TypedFilter::land()
+    ));
+    assert!(matches!(
+        right.as_ref(),
+        QuantityExpr::Ref {
+            qty: QuantityRef::ObjectCount {
+                filter: TargetFilter::Typed(lands),
+            },
+        } if lands == &TypedFilter::land().controller(ControllerRef::ScopedPlayer)
+    ));
+
+    let Some(PlayerFilter::ControlsCount {
+        relation,
+        filter: scoped_population,
+        comparator,
+        count: scope_count,
+    }) = &def.player_scope
+    else {
+        panic!(
+            "expected fewer-than-most player scope, got {:?}",
+            def.player_scope
+        );
+    };
+    assert_eq!(*relation, PlayerRelation::All);
+    assert_eq!(*comparator, Comparator::LT);
+    assert_eq!(scoped_population, &TargetFilter::Typed(TypedFilter::land()));
+    assert_eq!(scope_count.as_ref(), left.as_ref());
+
+    let delivery = def
+        .sub_ability
+        .as_deref()
+        .expect("search must have a ParentTarget delivery continuation");
+    assert!(matches!(
+        delivery.effect.as_ref(),
+        Effect::ChangeZone {
+            origin: Some(Zone::Library),
+            destination,
+            target: TargetFilter::ParentTarget,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters,
+            conditional_enter_with_counters,
+            face_down_profile: None,
+            enters_modified_if: None,
+        } if *destination == expected_destination
+            && *enter_tapped == expected_tapped
+            && enter_with_counters.is_empty()
+            && conditional_enter_with_counters.is_empty()
+    ));
+    let shuffle = delivery
+        .sub_ability
+        .as_deref()
+        .expect("delivery must retain the searched-this-way shuffle tail");
+    assert!(matches!(
+        shuffle.effect.as_ref(),
+        Effect::Shuffle {
+            target: TargetFilter::Controller,
+        }
+    ));
+    assert!(matches!(
+        shuffle.player_scope,
+        Some(PlayerFilter::PerformedActionThisWay {
+            relation: PlayerRelation::All,
+            action: crate::types::events::PlayerActionKind::SearchedLibrary,
+        })
+    ));
+    assert_eq!(
+        shuffle.sub_link,
+        crate::types::ability::SubAbilityLink::SequentialSibling,
+        "the final searched-this-way shuffle remains an independent instruction"
+    );
+    assert!(
+        !tree_has_unimplemented(&def),
+        "the whole search/delivery/shuffle chain must be typed: {def:#?}"
+    );
+}
+
+/// Scholarship Sponsor and Enigma Ridges differ only on the closed delivery
+/// axis. The common player predicate and bounded difference stay typed rather
+/// than becoming a card-specific string dispatch.
+#[test]
+fn uneven_land_search_lowers_both_delivery_grammars() {
+    assert_uneven_land_search_shape(
+        SCHOLARSHIP_SPONSOR_SEARCH,
+        false,
+        Zone::Battlefield,
+        crate::types::zones::EtbTapState::Tapped,
+    );
+    assert_uneven_land_search_shape(
+        ENIGMA_RIDGES_SEARCH,
+        true,
+        Zone::Hand,
+        crate::types::zones::EtbTapState::Unspecified,
+    );
+}
+
+/// `fewest` fails semantic verification through the production effect parser;
+/// it must never lower to the typed maximum-relative search used by the valid
+/// `fewer than the player who controls the most` instruction.
+#[test]
+fn uneven_land_search_rejects_fewest_nonvacuously() {
+    let fewest = parse_effect_chain(FEWEST_LANDS_SEARCH, AbilityKind::Spell);
+    assert!(
+        !matches!(
+            fewest.effect.as_ref(),
+            Effect::SearchLibrary {
+                count: QuantityExpr::UpTo { max },
+                ..
+            } if matches!(
+                max.as_ref(),
+                QuantityExpr::Difference { left, .. }
+                    if matches!(
+                        left.as_ref(),
+                        QuantityExpr::Ref {
+                            qty: QuantityRef::ControlledByEachPlayer {
+                                aggregate: AggregateFunction::Max,
+                                ..
+                            },
+                        }
+                    )
+            )
+        ),
+        "fewest must not lower to a maximum-relative typed SearchLibrary"
+    );
+    assert_uneven_land_search_shape(
+        SCHOLARSHIP_SPONSOR_SEARCH,
+        false,
+        Zone::Battlefield,
+        crate::types::zones::EtbTapState::Tapped,
+    );
+}
+
+/// Production card routing: the ETB and planeswalk trigger front doors must
+/// preserve the typed search chain, and Enigma Ridges' independent chaos line
+/// must not introduce an unrelated residual `Unimplemented` node.
+#[test]
+fn scholarship_sponsor_and_enigma_ridges_full_cards_have_no_unimplemented() {
+    let sponsor = parse_oracle_text(
+        "When this creature enters, each player who controls fewer lands than the player who controls the most lands searches their library for a number of basic land cards less than or equal to the difference, puts those cards onto the battlefield tapped, then shuffles.",
+        "Scholarship Sponsor",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    assert_eq!(sponsor.triggers.len(), 1, "Scholarship Sponsor has one ETB");
+    let sponsor_execute = sponsor.triggers[0]
+        .execute
+        .as_deref()
+        .expect("Scholarship Sponsor ETB must have an effect chain");
+    assert!(
+        !tree_has_unimplemented(sponsor_execute),
+        "Scholarship Sponsor ETB must be completely typed: {sponsor_execute:#?}"
+    );
+
+    let enigma = parse_oracle_text(
+        "When you planeswalk to Enigma Ridges, each player who controls fewer lands than the player who controls the most lands searches their library for a number of basic land cards less than or equal to the difference, reveals them, puts them into their hand, then shuffles.\nWhenever chaos ensues, draw a card, then you may put a land card from your hand onto the battlefield.",
+        "Enigma Ridges",
+        &[],
+        &["Plane".to_string()],
+        &[],
+    );
+    assert_eq!(
+        enigma.triggers.len(),
+        2,
+        "Enigma Ridges has two plane triggers"
+    );
+    for trigger in &enigma.triggers {
+        let execute = trigger
+            .execute
+            .as_deref()
+            .expect("each Enigma Ridges trigger must have an effect chain");
+        assert!(
+            !tree_has_unimplemented(execute),
+            "Enigma Ridges trigger must be completely typed: {execute:#?}"
+        );
+    }
+}
+
 /// Issue #5760: U.S.Agent, John Walker creates an Equipment token, then
 /// "Attach it to ~" in a following sentence. "It" is the just-created
 /// Equipment (`LastCreated`); "~" is U.S.Agent itself (`SelfRef`). Before the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -51,8 +51,9 @@ use crate::types::ability::{
     DestinationConstraint, DieResultFilter, Effect, FilterProp, ObjectScope, OriginConstraint,
     ParsedCondition, PlayerFilter, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef,
     RenownSubject, SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, SharedQuality,
-    StaticCondition, TapCreaturesRequirement, TargetFilter, TriggerCondition, TriggerConstraint,
-    TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier, ZoneChangeClause,
+    StaticCondition, SubAbilityLink, TapCreaturesRequirement, TargetFilter, TriggerCondition,
+    TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
+    ZoneChangeClause,
 };
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
@@ -2053,6 +2054,25 @@ fn lift_parent_target_to_triggering_source(effect: &mut Effect) {
     }
 }
 
+/// Return the first independent sibling after a search-result continuation.
+///
+/// `SearchLibrary` passes its found cards to continuation links through
+/// `ParentTarget`; that dataflow ends at the first `SequentialSibling`, whose
+/// effect is an independent instruction and may again refer to the trigger
+/// event source.
+fn first_independent_sibling_after_search(
+    search: &mut AbilityDefinition,
+) -> Option<&mut AbilityDefinition> {
+    let mut node = search.sub_ability.as_deref_mut();
+    while let Some(link) = node {
+        if link.sub_link == SubAbilityLink::SequentialSibling {
+            return Some(link);
+        }
+        node = link.sub_ability.as_deref_mut();
+    }
+    None
+}
+
 /// CR 608.2k + CR 603.7c: Recurse `lift_parent_target_to_triggering_source`
 /// through an ability's effect AND every chained `sub_ability`. Required
 /// for the punisher-trigger class: a chained Tergrid-shape ability like
@@ -2070,6 +2090,20 @@ fn lift_parent_target_to_triggering_source_in_ability(ability: &mut AbilityDefin
     // ("put that card …, then create a token") still lift correctly.
     let mut node = Some(ability);
     while let Some(link) = node {
+        // CR 701.23a: A library search's continuation receives the found cards
+        // as its parent targets. In an event-source-bearing trigger, the
+        // search still belongs to the trigger event, but "those cards" after
+        // the search does not: it denotes the cards chosen from the library.
+        // Skip only that continuation, then resume at a sequential sibling.
+        // Otherwise an ETB such as Scholarship Sponsor rewrites its found-card
+        // delivery from `ParentTarget` to `TriggeringSource` and can neither
+        // deliver the searched cards nor enter the scoped simultaneous-search
+        // path. A later independent sibling still needs its ordinary
+        // event-source rewrite.
+        if matches!(link.effect.as_ref(), Effect::SearchLibrary { .. }) {
+            node = first_independent_sibling_after_search(link);
+            continue;
+        }
         if introduces_chosen_object_target(link.effect.as_ref()) {
             break;
         }

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -14083,6 +14083,70 @@ fn trigger_necropotence_you_discard_exile_from_graveyard() {
     }
 }
 
+/// CR 701.23a + CR 608.2k: a search result is the parent target of its
+/// delivery continuation, even inside an ETB whose event source would
+/// otherwise lift `ParentTarget` to `TriggeringSource`. That protection ends
+/// at an independent sibling: a later "that creature" still denotes the
+/// entering creature.
+#[test]
+fn event_source_lift_skips_search_delivery_but_resumes_at_independent_sibling() {
+    let sponsor = parse_trigger_line(
+        "When this creature enters, each player who controls fewer lands than the player who controls the most lands searches their library for a number of basic land cards less than or equal to the difference, puts those cards onto the battlefield tapped, then shuffles.",
+        "Scholarship Sponsor",
+    );
+    let sponsor_search = sponsor
+        .execute
+        .as_deref()
+        .expect("Scholarship Sponsor ETB must have an execute chain");
+    assert!(matches!(
+        sponsor_search.effect.as_ref(),
+        Effect::SearchLibrary { .. }
+    ));
+    let sponsor_delivery = sponsor_search
+        .sub_ability
+        .as_deref()
+        .expect("Scholarship Sponsor search must retain its delivery");
+    assert!(
+        matches!(
+            sponsor_delivery.effect.as_ref(),
+            Effect::ChangeZone {
+                target: TargetFilter::ParentTarget,
+                ..
+            }
+        ),
+        "the search-result delivery must remain ParentTarget"
+    );
+
+    let synthetic = parse_trigger_line(
+        "When this creature enters, search your library for a basic land card, put it onto the battlefield, then shuffle. Then exile that creature.",
+        "Search Boundary Fixture",
+    );
+    let mut node = synthetic.execute.as_deref();
+    let mut saw_search = false;
+    let mut independent_exile_target = None;
+    while let Some(ability) = node {
+        match ability.effect.as_ref() {
+            Effect::SearchLibrary { .. } => saw_search = true,
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                target,
+                ..
+            } => independent_exile_target = Some(target.clone()),
+            _ => {}
+        }
+        node = ability.sub_ability.as_deref();
+    }
+    assert!(
+        saw_search,
+        "the synthetic trigger must retain its search root"
+    );
+    assert_eq!(
+        independent_exile_target,
+        Some(TargetFilter::TriggeringSource),
+        "the independent post-search sibling must still bind to the entering creature"
+    );
+}
+
 /// CR 701.9a + CR 603.2c: type qualifier on the discarded card must be
 /// preserved so a "discards a land card" trigger fires only on land
 /// discards (Aclazotz, Deepest Betrayal class).

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -813,6 +813,7 @@ mod saddle_state_model;
 mod saruman_white_hand_amass;
 mod sba_lethal_damage_redirect_single_application;
 mod scarab_god_regression;
+mod scholarship_sponsor;
 mod screaming_nemesis_combat_damage_multi_trigger;
 mod screaming_nemesis_life_lock;
 mod season_points_budget_modal;

--- a/crates/engine/tests/integration/scholarship_sponsor.rs
+++ b/crates/engine/tests/integration/scholarship_sponsor.rs
@@ -258,6 +258,15 @@ fn scholarship_sponsor_tied_land_counts_open_no_search() {
         .collect();
 
     runner.cast(sponsor).resolve();
+    assert_eq!(
+        runner.state().objects[&sponsor].zone,
+        Zone::Battlefield,
+        "the sponsor must resolve so its ETB reaches the tied-land branch"
+    );
+    assert!(
+        runner.state().pending_scoped_library_search.is_none(),
+        "a tie must finish without parking a scoped-search frame"
+    );
     assert!(
         !matches!(runner.state().waiting_for, WaitingFor::SearchChoice { .. }),
         "a three-way tie has no player with fewer lands and must not open a search"

--- a/crates/engine/tests/integration/scholarship_sponsor.rs
+++ b/crates/engine/tests/integration/scholarship_sponsor.rs
@@ -1,0 +1,459 @@
+//! Scholarship Sponsor — ETB catch-up searches use the scoped-search protocol.
+//!
+//! The cast pipeline must retain the parser's `each player who controls fewer
+//! lands` scope. That routes the two private searches through the shared
+//! collection/delivery path: no selected land moves before the final player
+//! chooses, then every selected basic land enters tapped under its searcher's
+//! control and only those searchers shuffle.
+
+use engine::database::synthesis::synthesize_planechase;
+use engine::game::printed_cards::apply_card_face_to_object;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::triggers::process_triggers;
+use engine::game::zones::create_object;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::actions::GameAction;
+use engine::types::card::CardFace;
+use engine::types::card_type::{CoreType, Supertype};
+use engine::types::events::{GameEvent, PlayerActionKind};
+use engine::types::game_state::{GameState, WaitingFor};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::proposed_event::SearchFoundDisposition;
+use engine::types::zones::Zone;
+
+const P2: PlayerId = PlayerId(2);
+const SCHOLARSHIP_SPONSOR_ORACLE: &str = "When this creature enters, each player who controls fewer lands than the player who controls the most lands searches their library for a number of basic land cards less than or equal to the difference, puts those cards onto the battlefield tapped, then shuffles.";
+const ENIGMA_RIDGES_ORACLE: &str = "When you planeswalk to Enigma Ridges, each player who controls fewer lands than the player who controls the most lands searches their library for a number of basic land cards less than or equal to the difference, reveals them, puts them into their hand, then shuffles.\nWhenever chaos ensues, draw a card, then you may put a land card from your hand onto the battlefield.";
+
+fn add_basic_land_to_library(state: &mut GameState, player: PlayerId) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(state.next_object_id),
+        player,
+        "Forest".to_string(),
+        Zone::Library,
+    );
+    let object = state
+        .objects
+        .get_mut(&id)
+        .expect("created library card must exist");
+    object.card_types.core_types.push(CoreType::Land);
+    object.card_types.supertypes.push(Supertype::Basic);
+    object.base_card_types = object.card_types.clone();
+    id
+}
+
+fn sponsor_scenario() -> (GameScenario, ObjectId) {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let sponsor = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Scholarship Sponsor",
+            3,
+            3,
+            SCHOLARSHIP_SPONSOR_ORACLE,
+        )
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::White],
+            generic: 3,
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::White, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+        ],
+    );
+    (scenario, sponsor)
+}
+
+/// CR 101.4 + CR 603.3b + CR 701.23: Casting Scholarship Sponsor must deliver
+/// the parsed ETB through the normal trigger stack and scoped search resolver.
+/// Reverting its IR scope rewrite to `Preserve` leaves this cast path without
+/// the two-player APNAP `SearchChoice` protocol this test asserts.
+#[test]
+fn scholarship_sponsor_cast_collects_three_player_searches_before_tapped_delivery() {
+    let (mut scenario, sponsor) = sponsor_scenario();
+    for _ in 0..5 {
+        scenario.add_basic_land(P0, ManaColor::Green);
+    }
+    for _ in 0..4 {
+        scenario.add_basic_land(P1, ManaColor::Blue);
+    }
+    for _ in 0..3 {
+        scenario.add_basic_land(P2, ManaColor::White);
+    }
+
+    let mut runner = scenario.build();
+    let p1_forest = add_basic_land_to_library(runner.state_mut(), P1);
+    let p2_forest_a = add_basic_land_to_library(runner.state_mut(), P2);
+    let p2_forest_b = add_basic_land_to_library(runner.state_mut(), P2);
+
+    runner.cast(sponsor).resolve();
+    let WaitingFor::SearchChoice {
+        player,
+        cards,
+        count,
+        up_to,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "Scholarship Sponsor ETB must enter P1's scoped search, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(*player, P1);
+    assert_eq!(*count, 1, "P1 is one land behind the five-land leader");
+    assert!(*up_to);
+    assert!(cards.contains(&p1_forest));
+
+    let p1_selection = runner
+        .act(GameAction::SelectCards {
+            cards: vec![p1_forest],
+        })
+        .expect("P1's matching basic land is a legal private search choice");
+    assert!(
+        !p1_selection.events.iter().any(|event| matches!(
+            event,
+            GameEvent::PlayerPerformedAction {
+                action: PlayerActionKind::ShuffledLibrary,
+                ..
+            }
+        )),
+        "the searched-this-way shuffle must wait for P2's APNAP choice"
+    );
+    for land in [p1_forest, p2_forest_a, p2_forest_b] {
+        assert_eq!(
+            runner.state().objects[&land].zone,
+            Zone::Library,
+            "no selected land moves before the final scoped player chooses"
+        );
+    }
+    let pending = runner
+        .state()
+        .pending_scoped_library_search
+        .as_ref()
+        .expect("P1's selection must remain in the shared scoped-search frame");
+    let engine::types::game_state::ScopedLibrarySearchPhase::CollectSelections {
+        selections,
+        frozen_dispositions,
+        ..
+    } = &pending.phase
+    else {
+        panic!("P1's selection must remain in the selection-collection phase");
+    };
+    let p1_incarnation = runner.state().objects[&p1_forest].incarnation;
+    assert!(
+        selections.iter().any(|(player, cards)| {
+            *player == P1
+                && cards.len() == 1
+                && cards[0].object_id == p1_forest
+                && cards[0].incarnation == p1_incarnation
+        }),
+        "P1's original SearchFound survivor must be retained for shared delivery"
+    );
+    assert!(
+        frozen_dispositions.iter().any(|frozen| {
+            frozen.searcher == P1
+                && frozen.identity.object_id == p1_forest
+                && frozen.identity.incarnation == p1_incarnation
+                && frozen.disposition == SearchFoundDisposition::Original
+        }),
+        "P1's original survivor must be frozen before the next private choice"
+    );
+
+    let WaitingFor::SearchChoice {
+        player,
+        cards,
+        count,
+        up_to,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "P1's answer must advance to P2's private search, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(*player, P2);
+    assert_eq!(*count, 2, "P2 is two lands behind the five-land leader");
+    assert!(*up_to);
+    assert!(cards.contains(&p2_forest_a) && cards.contains(&p2_forest_b));
+
+    let zone_changes_before_delivery = runner.state().zone_changes_this_turn.len();
+    let delivery = runner
+        .act(GameAction::SelectCards {
+            cards: vec![p2_forest_a, p2_forest_b],
+        })
+        .expect("P2's two matching basics are legal private search choices");
+    let delivered_to_battlefield: Vec<_> = runner
+        .state()
+        .zone_changes_this_turn
+        .iter()
+        .skip(zone_changes_before_delivery)
+        .filter_map(|change| match change {
+            change
+                if change.from_zone == Some(Zone::Library)
+                    && change.to_zone == Zone::Battlefield
+                    && [p1_forest, p2_forest_a, p2_forest_b].contains(&change.object_id) =>
+            {
+                Some(change.object_id)
+            }
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        delivered_to_battlefield.len(),
+        3,
+        "the final scoped choice must issue one real library-to-battlefield delivery per selected land"
+    );
+    for (land, controller) in [(p1_forest, P1), (p2_forest_a, P2), (p2_forest_b, P2)] {
+        let object = &runner.state().objects[&land];
+        assert_eq!(object.zone, Zone::Battlefield);
+        assert_eq!(object.controller, controller);
+        assert!(
+            object.tapped,
+            "Scholarship Sponsor's found land enters tapped"
+        );
+    }
+    let shufflers: Vec<_> = delivery
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::PlayerPerformedAction {
+                player_id,
+                action: PlayerActionKind::ShuffledLibrary,
+                ..
+            } => Some(*player_id),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        shufflers,
+        vec![P1, P2],
+        "only players who searched this way shuffle once after the shared delivery"
+    );
+}
+
+#[test]
+fn scholarship_sponsor_tied_land_counts_open_no_search() {
+    let (mut scenario, sponsor) = sponsor_scenario();
+    for player in [P0, P1, P2] {
+        for _ in 0..4 {
+            scenario.add_basic_land(player, ManaColor::Green);
+        }
+    }
+    let mut runner = scenario.build();
+    let libraries: Vec<_> = [P0, P1, P2]
+        .into_iter()
+        .map(|player| add_basic_land_to_library(runner.state_mut(), player))
+        .collect();
+
+    runner.cast(sponsor).resolve();
+    assert!(
+        !matches!(runner.state().waiting_for, WaitingFor::SearchChoice { .. }),
+        "a three-way tie has no player with fewer lands and must not open a search"
+    );
+    assert!(libraries
+        .iter()
+        .all(|id| runner.state().objects[id].zone == Zone::Library));
+}
+
+/// Enigma Ridges uses the same scoped resolver as Scholarship Sponsor but has
+/// the public reveal-to-hand delivery. Its parsed plane trigger must pass through
+/// the real planeswalk event matcher and trigger stack before the search chain
+/// resolves.
+#[test]
+fn enigma_ridges_reveals_only_after_the_final_scoped_search_choice() {
+    let mut state = GameState::new(engine::types::format::FormatConfig::free_for_all(), 3, 42);
+    let enigma = create_object(
+        &mut state,
+        CardId(900),
+        P0,
+        "Enigma Ridges".to_string(),
+        Zone::Command,
+    );
+    {
+        let plane = state
+            .objects
+            .get_mut(&enigma)
+            .expect("Enigma Ridges source exists");
+        plane.card_types.core_types.push(CoreType::Plane);
+        plane.base_card_types = plane.card_types.clone();
+    }
+    for (player, count) in [(P0, 5), (P1, 4), (P2, 3)] {
+        for _ in 0..count {
+            let card_id = CardId(state.next_object_id);
+            let land = create_object(
+                &mut state,
+                card_id,
+                player,
+                "Land".to_string(),
+                Zone::Battlefield,
+            );
+            let object = state.objects.get_mut(&land).expect("land exists");
+            object.card_types.core_types.push(CoreType::Land);
+            object.base_card_types = object.card_types.clone();
+        }
+    }
+    let p1_forest = add_basic_land_to_library(&mut state, P1);
+    let p2_forest_a = add_basic_land_to_library(&mut state, P2);
+    let p2_forest_b = add_basic_land_to_library(&mut state, P2);
+
+    let parsed = parse_oracle_text(
+        ENIGMA_RIDGES_ORACLE,
+        "Enigma Ridges",
+        &[],
+        &["Plane".to_string()],
+        &["Echoir".to_string()],
+    );
+    let mut face = CardFace {
+        name: "Enigma Ridges".to_string(),
+        card_type: state.objects[&enigma].card_types.clone(),
+        triggers: parsed.triggers,
+        ..Default::default()
+    };
+    synthesize_planechase(&mut face);
+    apply_card_face_to_object(
+        state
+            .objects
+            .get_mut(&enigma)
+            .expect("Enigma Ridges source exists"),
+        &face,
+    );
+
+    let planeswalked = [GameEvent::Planeswalked {
+        player_id: P0,
+        from: None,
+        to: Some(enigma),
+    }];
+    process_triggers(&mut state, &planeswalked);
+    assert!(
+        state.stack.iter().any(|entry| entry.source_id == enigma),
+        "the parsed planeswalk-to trigger must be placed on the stack"
+    );
+    let mut runner = GameRunner::from_state(state);
+
+    for _ in 0..3 {
+        if matches!(runner.state().waiting_for, WaitingFor::SearchChoice { .. }) {
+            break;
+        }
+        assert!(
+            matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+            "the parsed Enigma Ridges trigger must resolve from the normal stack, got {:?}",
+            runner.state().waiting_for
+        );
+        runner
+            .act(GameAction::PassPriority)
+            .expect("priority pass resolves the stacked Enigma Ridges trigger");
+    }
+
+    let WaitingFor::SearchChoice {
+        player,
+        cards,
+        count,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "the first Enigma Ridges search must belong to P1, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(*player, P1);
+    assert_eq!(*count, 1);
+    assert!(cards.contains(&p1_forest));
+
+    let first_selection = runner
+        .act(GameAction::SelectCards {
+            cards: vec![p1_forest],
+        })
+        .expect("P1 chooses the revealed basic land from their library");
+    assert!(
+        !first_selection
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::CardsRevealed { .. })),
+        "P1's private choice must not reveal a card while P2 still chooses"
+    );
+    for land in [p1_forest, p2_forest_a, p2_forest_b] {
+        assert_eq!(runner.state().objects[&land].zone, Zone::Library);
+        assert!(
+            !runner.state().revealed_cards.contains(&land),
+            "the found card remains hidden until the shared delivery boundary"
+        );
+    }
+
+    let WaitingFor::SearchChoice {
+        player,
+        cards,
+        count,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "P1's answer must advance to P2's search, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(*player, P2);
+    assert_eq!(*count, 2);
+    assert!(cards.contains(&p2_forest_a) && cards.contains(&p2_forest_b));
+
+    let final_selection = runner
+        .act(GameAction::SelectCards {
+            cards: vec![p2_forest_a, p2_forest_b],
+        })
+        .expect("P2 chooses both revealed basics from their library");
+    let first_reveal = final_selection
+        .events
+        .iter()
+        .position(|event| matches!(event, GameEvent::CardsRevealed { .. }))
+        .expect("the shared hand delivery publishes the selected cards");
+    let first_delivery = final_selection
+        .events
+        .iter()
+        .position(|event| {
+            matches!(
+                event,
+                GameEvent::ZoneChanged { object_id, .. }
+                    if *object_id == p1_forest || *object_id == p2_forest_a || *object_id == p2_forest_b
+            )
+        })
+        .expect("the selected cards move from libraries to hands");
+    assert!(
+        first_reveal < first_delivery,
+        "Enigma Ridges must reveal the selected cards before the shared library-to-hand delivery"
+    );
+    let revealed: Vec<_> = final_selection
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::CardsRevealed { card_ids, .. } => Some(card_ids.clone()),
+            _ => None,
+        })
+        .flatten()
+        .collect();
+    assert_eq!(
+        revealed.len(),
+        3,
+        "the terminal public reveal must account for every selected land exactly once"
+    );
+    assert!(
+        [p1_forest, p2_forest_a, p2_forest_b]
+            .into_iter()
+            .all(|land| revealed.contains(&land)),
+        "the terminal public reveal must identify the same lands that are delivered to hand"
+    );
+    for land in [p1_forest, p2_forest_a, p2_forest_b] {
+        assert_eq!(runner.state().objects[&land].zone, Zone::Hand);
+    }
+}


### PR DESCRIPTION
## Summary

Adds typed, simultaneous catch-up land searches for Scholarship Sponsor and Enigma Ridges. It preserves search-result targeting inside ETB trigger rewriting and supports both tapped battlefield and revealed hand delivery.

## Files changed

- Parser grammar and exact parser coverage for the shared uneven-land search
- Scoped library-search admission and delivery support for revealed hand delivery
- Trigger target-lifting boundary and regressions
- Sponsor and Enigma runtime integration tests

## Track

Developer

## LLM

Model: gpt-5.6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 101.4, CR 603.3b, CR 701.23a/e/i, CR 701.24a.

## Verification

- [x] Required checks ran clean.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- Pre-commit validation batch: format, focused parser/scoped/integration tests, strict clippy, full engine suite (4,134 passed), card-data generation, coverage, and semantic audit — all clean.

## Gate A

Gate A PASS head=506b2fc9dc4c08831328a7ed3b9d8b9262e93ffe base=6b29e0d72025be07c609cb6f992d2524267519b1

## Anchored on

- crates/engine/src/game/effects/scoped_library_search.rs:22 — typed simultaneous scoped-delivery admission
- crates/engine/src/parser/oracle_trigger.rs:2057 — event-source target-lifting boundary

## Final review-impl

Final review-impl PASS head=506b2fc9dc4c08831328a7ed3b9d8b9262e93ffe

## Claimed parse impact

- Scholarship Sponsor
- Enigma Ridges

## Scope Expansion

Includes Enigma Ridges because it has the same relative-land search with the closely related reveal-to-hand delivery.

## Validation Failures

None.

## CI Failures

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for “each player who controls fewer lands” uneven-land search effects, including tapped battlefield vs revealed-to-hand variants with post-search shuffling.
  - Improved handling of scoped, shared searches to enable correct simultaneous delivery semantics.

- **Bug Fixes**
  - Fixed ETB/trigger sequencing so search results keep the correct targeting/provenance across chained effects.
  - Ensured independent sequential effects after searches bind to the correct event source, preventing mis-scoped trigger behavior.

- **Tests**
  - Added oracle parsing and integration coverage for Scholarship Sponsor and Enigma Ridges scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->