### PR TITLE
refactor(parser): Plan 05b — U0-61 and U0-40, the two rows T9 unblocked

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3700,6 +3700,30 @@ impl<'a> DocEmitter<'a> {
         self.last_static.as_ref()
     }
 
+    /// Emit a heterogeneous IR node sequence at one line, in the order the
+    /// recognizer produced it. The IR-native counterpart of
+    /// `drain_result_vectors`: a recognizer that yields more than one CATEGORY
+    /// of node (Plan 05b U0-40 yields statics + a replacement) returns them as
+    /// one ordered `Vec<OracleNodeIr>` instead of pushing into a scratch
+    /// `ParsedAbilities` whose drain order is fixed by category rather than by
+    /// the recognizer.
+    ///
+    /// Nodes are dispatched through the typed `*_ir_at` helpers rather than
+    /// straight to `emit_at`, so the per-category `last_*` peek mirrors stay
+    /// maintained — `parsed_result_recently_granted_flashback` reads
+    /// `last_static()` mid-loop, and `drain_result_vectors` (via `static_at`)
+    /// maintains it today. Emitting these nodes raw would silently stop
+    /// updating it.
+    fn emit_ir_nodes_at(&mut self, item_line: usize, nodes: Vec<OracleNodeIr>) {
+        for node in nodes {
+            match node {
+                OracleNodeIr::Static(ir) => self.static_ir_at(item_line, ir),
+                OracleNodeIr::Trigger(ir) => self.trigger_ir_at(item_line, ir),
+                other => self.emit_at(item_line, other),
+            }
+        }
+    }
+
     /// Move every vector item a `&mut ParsedAbilities`-taking mutator just pushed
     /// into the builder at `item_line`, then clear them. Used for the complex
     /// cross-file mutators (modal / enters-replacement lowering) that the (B)
@@ -5624,15 +5648,31 @@ pub(crate) fn parse_oracle_ir(
             // generic `parse_replacement_sentence_sequence` / `parse_replacement_line`
             // parsers so those don't claim the "becomes your choice of" line as a
             // plain choice/animate and drop the per-mode gated statics.
-            if is_as_enters_becomes_choice_pattern(&lower)
-                && lower_as_enters_becomes_choice_modal(&line, &mut result)
-            {
-                emitter.drain_result_vectors(item_line, &mut result);
-                if result.modal.is_some() {
-                    modal_line.get_or_insert(item_line);
+            //
+            // Plan 05b U0-40: the recognizer returns typed IR nodes instead of
+            // pushing into the shared scratch. Emission order reproduces
+            // `drain_result_vectors`' CATEGORY order exactly — the face-up
+            // residual (an ability) first, then the per-mode statics, then the
+            // choice replacement — because `emit_at` stamps
+            // `ordinal_within_span` in emission order. Emitting directly rather
+            // than draining the scratch is safe for the same reason the
+            // `lower_as_enters_or_face_up_counters` site below gives: every
+            // other `&mut result` handoff in this loop is drain-followed, so the
+            // vectors are provably empty here. `result.modal` is a SINGLETON,
+            // which `drain_result_vectors` never touched either, so the check
+            // below is unchanged.
+            if is_as_enters_becomes_choice_pattern(&lower) {
+                if let Some(modal_ir) = lower_as_enters_becomes_choice_modal(&line) {
+                    if let Some(residual) = modal_ir.face_up_residual {
+                        emitter.ability_at(item_line, residual);
+                    }
+                    emitter.emit_ir_nodes_at(item_line, modal_ir.nodes);
+                    if result.modal.is_some() {
+                        modal_line.get_or_insert(item_line);
+                    }
+                    i += 1;
+                    continue;
                 }
-                i += 1;
-                continue;
             }
             // CR 614.1c + CR 708.11: dual "As ~ enters[ or is turned face up],
             // put X +1/+1 counters on it, where X is …" (Crowd-Control Warden).

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -16,7 +16,7 @@ use super::oracle_classifier::{
     is_effect_sentence_candidate, is_granted_static_line, is_replacement_pattern, is_static_pattern,
 };
 use super::oracle_cost::parse_oracle_cost;
-use super::oracle_effect::{lower_ability_ir, parse_effect_chain};
+use super::oracle_effect::{lower_ability_ir, parse_ability_ir_standalone, parse_effect_chain};
 use super::oracle_ir::ast::parsed_clause;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::effect_chain::{
@@ -330,10 +330,25 @@ pub(crate) fn parse_class_oracle_text(
             }
 
             // Effect/spell-like lines (e.g., "You may play an additional land...")
+            //
+            // Mode-preserving hoist (Plan 05b U0-61): `parse_effect_chain(t, k)`
+            // **is** `lower_ability_ir(&parse_ability_ir_standalone(t, k))` —
+            // that is the function's body, not a claim about it
+            // (`oracle_effect/mod.rs`). So splitting it into its two halves
+            // moves *where* the lowering happens without changing *what* it
+            // produces: the node now carries the IR, and `lower_oracle_ir`
+            // performs the same `lower_ability_ir` this line used to.
+            //
+            // The gate keeps reading a LOWERED definition, as at U0-12 and
+            // U0-39: whether to emit is control flow, and `has_unimplemented`
+            // is defined over an `AbilityDefinition`, so the predicate must see
+            // the definition this site will actually emit. A second
+            // `has_unimplemented` over `EffectChainIr` would be a rival
+            // authority free to diverge from this one.
             if is_effect_sentence_candidate(&lower) {
-                let def = parse_effect_chain(line, AbilityKind::Spell);
-                if !has_unimplemented(&def) {
-                    items.push((line_index, OracleNodeIr::PreLoweredSpell(def)));
+                let ir = parse_ability_ir_standalone(line, AbilityKind::Spell);
+                if !has_unimplemented(&lower_ability_ir(&ir)) {
+                    items.push((line_index, OracleNodeIr::Spell(ir)));
                     continue;
                 }
             }

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -15,7 +15,9 @@ use super::oracle_effect::{
     parse_named_choice_object, try_parse_named_choice, try_parse_named_choice_conjunction,
 };
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::doc::OracleNodeIr;
 use super::oracle_ir::replacement::ReplacementIr;
+use super::oracle_ir::static_ir::StaticIr;
 use super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower, split_once_on_lower};
 use super::oracle_nom::condition::{
     parse_attached_subject_target_filter, parse_inner_condition,
@@ -2577,6 +2579,33 @@ fn color_label_word(color: crate::types::mana::ManaColor) -> &'static str {
     }
 }
 
+/// The IR emission for one "As ~ enters, it becomes your choice of …" line
+/// (Plan 05b U0-40).
+///
+/// # Emission order is load-bearing
+///
+/// This recognizer used to push into a scratch `ParsedAbilities` that
+/// `drain_result_vectors` then emitted in ITS fixed order — abilities, then
+/// triggers, then statics, then replacements — regardless of the order the
+/// pushes happened in. `emit_at` stamps `ordinal_within_span` in emission
+/// order, so emitting in any other order renumbers them. The caller therefore
+/// emits `face_up_residual` FIRST and `nodes` after, and `nodes` itself is
+/// ordered statics-then-replacement — none of which is the order this
+/// recognizer constructs them in.
+pub(crate) struct AsEntersChoiceModalIr {
+    /// CR 614.1e residual, `None` when the line has no "or is turned face up"
+    /// half. A bare `AbilityDefinition` rather than a node, so the caller emits
+    /// it through `ability_at`: it is a fixed strict-failure marker with no
+    /// parsed body to carry, and Plan 05b's burn-down ratchet keeps every
+    /// pre-lowered construction inside `oracle.rs` — constructing one here would
+    /// move a producer into a file the ledger does not track. Giving it a real
+    /// IR node is U0-62's residual-node question, which this row does not answer.
+    pub(crate) face_up_residual: Option<AbilityDefinition>,
+    /// The heterogeneous node sequence: one `Static` per mode, then the single
+    /// `Replacement`.
+    pub(crate) nodes: Vec<OracleNodeIr>,
+}
+
 /// CR 208.2b (governing) + CR 614.1c + CR 614.12a + CR 205.1b: lower the modal
 /// "As ~ enters, it becomes your choice of <profile_1>, <profile_2>, [or]
 /// <profile_N>" as-enters replacement (Primal Plasma, Primal Clay, Corrupted
@@ -2609,26 +2638,23 @@ fn color_label_word(color: crate::types::mana::ManaColor) -> &'static str {
 /// (a modal P/T as-enters replacement, not a CR 607.2d anchor-word linked
 /// ability). No `614.12c` annotation appears in this lowering.
 ///
-/// Returns `true` when a modal replacement + statics were emitted; `false` when
-/// the line was an honest gap (fewer than two parseable P/T profiles, a mode
-/// missing P/T, or a duplicate-label collision) so the caller can fall through.
-pub(crate) fn lower_as_enters_becomes_choice_modal(
-    text: &str,
-    result: &mut super::oracle::ParsedAbilities,
-) -> bool {
+/// Returns the IR emission for the line; `None` when the line was an honest gap
+/// (fewer than two parseable P/T profiles, a mode missing P/T, or a
+/// duplicate-label collision) so the caller can fall through.
+pub(crate) fn lower_as_enters_becomes_choice_modal(text: &str) -> Option<AsEntersChoiceModalIr> {
     type VE<'a> = OracleError<'a>;
     let lower = text.to_lowercase();
 
     // nom-frame: "as " + `~` self-anchor + the "becomes your choice of" pivot.
     let Ok((after_as, _)) = tag::<_, _, VE>("as ").parse(lower.as_str()) else {
-        return false;
+        return None;
     };
     let Ok((after_subject, subject_lower)) = take_until::<_, _, VE>(" enters").parse(after_as)
     else {
-        return false;
+        return None;
     };
     if subject_lower.trim() != "~" {
-        return false;
+        return None;
     }
     let Ok((tail_lower, _)) = alt((
         tag::<_, _, VE>(" enters, it becomes your choice of "),
@@ -2636,7 +2662,7 @@ pub(crate) fn lower_as_enters_becomes_choice_modal(
         tag(" enters or is turned face up, it becomes your choice of "),
     ))
     .parse(after_subject) else {
-        return false;
+        return None;
     };
 
     // CR 614.1e: "or is turned face up" is a separate replacement class not yet
@@ -2646,9 +2672,7 @@ pub(crate) fn lower_as_enters_becomes_choice_modal(
 
     // Recover the ORIGINAL-case descriptor tail — subtype proper-noun casing
     // (e.g. "Wall") is load-bearing for `parse_animation_spec`.
-    let Some(desc_start) = text.len().checked_sub(tail_lower.len()) else {
-        return false;
-    };
+    let desc_start = text.len().checked_sub(tail_lower.len())?;
     let descriptor_original = text[desc_start..].trim().trim_end_matches('.').trim();
 
     // CR 205.1b: strip the "in addition to its other types" marker once, and
@@ -2690,7 +2714,7 @@ pub(crate) fn lower_as_enters_becomes_choice_modal(
     )
     .parse(modes_text);
     let Ok((_, profiles)) = profile_split else {
-        return false;
+        return None;
     };
 
     // Per profile: parse the animation spec, require fixed P/T, synthesize the
@@ -2703,14 +2727,12 @@ pub(crate) fn lower_as_enters_becomes_choice_modal(
         let (profile_body, _) = opt(alt((tag::<_, _, VE>("a "), tag("an "))))
             .parse(profile.trim())
             .unwrap_or((profile.trim(), None));
-        let Some(spec) = super::oracle_effect::animation::parse_animation_spec(
+        let spec = super::oracle_effect::animation::parse_animation_spec(
             profile_body.trim(),
             &mut ParseContext::default(),
-        ) else {
-            return false;
-        };
+        )?;
         if spec.power.is_none() || spec.toughness.is_none() {
-            return false;
+            return None;
         }
         labels.push(synthesize_mode_label(&spec));
         mode_mods.push(
@@ -2723,7 +2745,7 @@ pub(crate) fn lower_as_enters_becomes_choice_modal(
 
     // Require >= 2 modes (CR 208.2b lists "two or more").
     if labels.len() < 2 {
-        return false;
+        return None;
     }
     // Collision guard: duplicate synthesized labels would make the gate
     // ambiguous. Abort rather than emit an unusable modal (honest gap).
@@ -2731,7 +2753,7 @@ pub(crate) fn lower_as_enters_becomes_choice_modal(
         // allow-noncombinator: `Vec<String>` slice containment (label collision
         // check), not string parsing dispatch.
         if labels[..idx].contains(label) {
-            return false;
+            return None;
         }
     }
 
@@ -2752,7 +2774,6 @@ pub(crate) fn lower_as_enters_becomes_choice_modal(
         // CR 614.1c: battlefield-entry-scoped as-enters replacement.
         .destination_zone(Zone::Battlefield)
         .description(text.to_string());
-    result.replacements.push(choice_replacement);
 
     // Per mode: a continuous static gated on `ChosenLabelIs { label }`. Inline the
     // `ChosenLabelIs` composition (these fresh statics carry no pre-existing
@@ -2766,31 +2787,46 @@ pub(crate) fn lower_as_enters_becomes_choice_modal(
     // choice is persisted, and that `Labeled` re-layer flushes the gated
     // `ChosenLabelIs` statics below before state-based actions run — without it the
     // creature would keep its printed P/T (e.g. 0/0) and die to SBAs.
-    for (label, mods) in labels.iter().zip(mode_mods) {
-        // CR 208.2b: chosen-mode P/T (+ additional characteristics) applied as a
-        // Layer-7b continuous effect while this label was chosen at entry.
-        result.statics.push(
+    let mode_statics: Vec<StaticDefinition> = labels
+        .iter()
+        .zip(mode_mods)
+        .map(|(label, mods)| {
+            // CR 208.2b: chosen-mode P/T (+ additional characteristics) applied as a
+            // Layer-7b continuous effect while this label was chosen at entry.
             StaticDefinition::continuous()
                 .affected(TargetFilter::SelfRef)
                 .modifications(mods)
                 .condition(StaticCondition::ChosenLabelIs {
                     label: label.clone(),
-                }),
-        );
-    }
+                })
+        })
+        .collect();
 
-    // CR 614.1e: "or is turned face up" is a separate replacement class not yet
-    // supported for modal choice. Surface it as an honest `Effect::unimplemented`
-    // (coverage-red) instead of silently dropping the face-up entry path — do NOT
-    // emit any `TurnFaceUp` replacement.
-    if has_face_up {
-        result.abilities.push(AbilityDefinition::new(
-            AbilityKind::Spell,
-            Effect::unimplemented("modal-enters-face-up", "or is turned face up"),
-        ));
-    }
+    // Assembled in `drain_result_vectors`' order — see this function's doc block.
+    let mut nodes: Vec<OracleNodeIr> = Vec::with_capacity(mode_statics.len() + 1);
+    nodes.extend(
+        mode_statics
+            .into_iter()
+            .map(|def| OracleNodeIr::Static(StaticIr::from_definition(text, def))),
+    );
+    nodes.push(OracleNodeIr::Replacement(ReplacementIr::from_definition(
+        text,
+        choice_replacement,
+    )));
 
-    true
+    Some(AsEntersChoiceModalIr {
+        // CR 614.1e: "or is turned face up" is a separate replacement class not
+        // yet supported for modal choice. Surface it as an honest
+        // `Effect::unimplemented` (coverage-red) instead of silently dropping the
+        // face-up entry path — do NOT emit any `TurnFaceUp` replacement.
+        face_up_residual: has_face_up.then(|| {
+            AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::unimplemented("modal-enters-face-up", "or is turned face up"),
+            )
+        }),
+        nodes,
+    })
 }
 
 /// nom combinator: the mode separator between profiles (", or " / ", " / " or ").

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -13,7 +13,7 @@
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
 crates/engine/src/parser/oracle.rs         15
-crates/engine/src/parser/oracle_class.rs    5
+crates/engine/src/parser/oracle_class.rs    4
 
 # --- infrastructure: NOT burn-down targets ----------------------------------
 # The variant declarations and their consumers. These legitimately survive


### PR DESCRIPTION
Plan 05b — the two rows T9 unblocked: **U0-61** (the Class effect-sentence recognizer) and **U0-40**
(the heterogeneous IR node mechanism). Follows #6724, which completed Unit 3b.

These were the only remaining rows needing no design decision. Everything else left in the plan —
U0-62 and all nine T10 sub-units — is blocked on rulings and is untouched here.

One commit per row.

## U0-61 — byte-identical by construction, and the identity is the function body

`parse_effect_chain(t, k)` **is** `lower_ability_ir(&parse_ability_ir_standalone(t, k))`. That is not a
doc claim; it is the entire body at `oracle_effect/mod.rs:26761-26763`:

```rust
pub fn parse_effect_chain(text: &str, kind: AbilityKind) -> AbilityDefinition {
    lower_ability_ir(&parse_ability_ir_standalone(text, kind))
}
```

Splitting the call into its two halves moves **where** lowering happens, not **what** it produces. No
corpus argument is used or needed — this is the same algebraic identity every T8 R1 row relied on.

The recensus's warning was precisely calibrated: this could not land before the `Spell` payload carried
`AbilityIr`, because emitting `Spell(EffectChainIr)` would have lowered via `lower_effect_chain_ir` and
dropped `finalize_effect_chain` + the owner-library anchor — the exact defect #6722 spent a PR fixing
at U0-39. #6724 removed the hazard.

`has_unimplemented` keeps reading a **lowered** def (`has_unimplemented(&lower_ability_ir(&ir))`), the
U0-12/U0-39 shape. No IR-level predicate was invented — a second authority over `EffectChainIr` would
be free to diverge from the real one.

Scope held to line 334. `oracle_class.rs:398` (the class-level trigger `execute`) and the
`make_unimplemented` fallback (U0-62, blocked on a ruling) are untouched.

**Ratchet LOWERED: `oracle_class.rs` 5 → 4**, count now equal to ceiling.

## U0-40 — which `drain_result_vectors` caller, and how we know

`drain_result_vectors` has two callers and **one of them is U0-18, which belongs to T10h and is
blocked**. Since line numbers in `oracle.rs` have drifted ~+300 across this campaign, proximity to the
census's cited line could not settle it. Four independent lines of evidence identify **`oracle.rs:5630`**:

1. **Content** — `:4304` sits inside `if let Some((block, next_i)) = parse_oracle_block(..)` and calls
   `lower_oracle_block`, which is verbatim the U0-18 census row. `:5630` is guarded by
   `is_as_enters_becomes_choice_pattern`.
2. **CR citations** — the in-code annotation at `:5642` is "CR 208.2b + CR 614.1c + CR 614.12a", exactly
   the U0-40 census row's citations.
3. **Drift** — `:5630` is +304 from the cited ~5326; `:4304` is +161 from U0-18's cited 4094, the
   census's own recorded drift for that row.
4. **Population** — the census names aquamorph entity / primal clay / primal plasma, exactly the cards
   this recognizer's frame matches.

`:4304` is unmodified, and `drain_result_vectors` itself is unmodified — U0-18 still uses it unchanged.

## The inherited safety argument held, but one of its REASONS was wrong

U0-40's byte-safety analysis was carried over from T9b's executor and **verified rather than
inherited**. Three claims confirmed as stated; one had a wrong reason and was not shipped as written:

- **`lower_replacement_ir` is identity** — confirmed, literally `ir.definition.clone()`.
- **`collect_source_in_zones` ignores `ChosenLabelIs`** — confirmed; it matches only
  `SourceInZone`/`And`/`Or`/`Not`, so `zones` stays empty and the `!zones.is_empty()` guard never fires.
  Corroborated in the artifact: every static of all four cards has `"active_zones":[]`.
- **`bind_counter_anaphor_to_recipient` is inert** — conclusion confirmed, **reason corrected**. The
  inherited reason was "these modifications are fixed P/T (the recognizer returns false unless power
  and toughness are both `Some`)". That guard does **not** exclude dynamic P/T: `parse_animation_spec`'s
  "where X is …" path sets `spec.dynamic_power` *before* the fixed-P/T parse and is not gated on it,
  and `split_animation_dynamic_pt_clause` can fire after `split_animation_base_pt_clause` has already
  set fixed P/T, so both can coexist — and `SetPowerDynamic`/`SetToughnessDynamic` *are* in the
  Some-arm. **The real reason:** `bind_anaphoric_counters` rewrites only `CountersOn { scope:
  Anaphoric }`; that scope is produced by exactly one combinator (`parse_deferred_counter_pronoun`) and
  survives only through the two `_deferred` entry points, whose only non-test callers are both in
  `oracle_static/anthem.rs`. The animation path reaches neither. Corroborated: all 43 modifications
  across the four cards are in the `None` arm, with zero `Dynamic|CountersOn|Anaphoric` occurrences.
- **Emission order must stay abilities → statics → replacements** — confirmed and preserved by
  construction, matching `drain_result_vectors` deliberately. See the caveat below.

## Full-pool measurement

Baseline re-measured on this branch's own base, not inherited.

- base: `sha256 c3f8431c494c1a9710e08fc15161eab75203a2dc98a5aa35e3f7a993ec43c245`, 99,201,978 bytes
- tip (both rows): **identical hash, identical size**; `cmp` byte-identical

**Population is real:** 35,516 face-keyed entries, generated from the worktree repo root against the
main checkout's `AtomicCards.json` (158 MB) symlinked in, `MTGJSON_SKIP_REFRESH=1`, generator rebuilt
fresh at each commit. The fixture population is 519 KB and cannot produce those numbers. Coverage
percentages and **all** parse-warning counts are identical base vs tip, including the span-sensitive
swallowed-clause audit (963 warnings / 868 cards).

**Liveness — the probe was watched go red, not assumed** (§5.3: a probe that shows nothing is broken
until proven otherwise):

1. **Compiler witness** — the signature change `(&str, &mut ParsedAbilities) -> bool` →
   `(&str) -> Option<AsEntersChoiceModalIr>` forced the call site.
2. **Reach, read from the artifact** — U0-40's four cards all carry the recognizer's output. Notably
   aquamorph entity has 2 statics / 1 replacement / **1 ability** (the CR 614.1e face-up residual), so
   the residual-first ordering branch is **live, not dead**. U0-61's single pool ability is
   `rogue class` → `CastFromZone` **with a `sub_ability`** — i.e. it exercises `finalize_effect_chain`,
   the exact machinery #6724 was the prerequisite for.
3. **Disable probe watched red** — forcing `lower_as_enters_becomes_choice_modal` to return `None`
   moved the filtered output hash `ec05c400…` → `2781bafd…`; aquamorph entity went 2 statics/1 rep →
   **0/0**, primal plasma 3/1 → **0/0**. The gate destroys exactly what the conversion produces. Probe
   fully reverted.

## Gates (all on the final commit, re-run after commit)

```
cargo fmt --all                                      clean
cargo clippy -p engine --lib -- -D warnings          zero warnings
cargo nextest run -p engine --lib                    17858 passed, 6 skipped
cargo nextest run -p engine --test integration       4132 passed, 2 skipped
./scripts/check-prelowered-ratchet.sh                Gate P PASS  (oracle_class.rs 5 → 4)
./scripts/check-skill-doc.sh                         ✓ oracle-parser skill references valid
./scripts/check-parser-combinators.sh                Gate G PASS / Gate A PASS
```

**Zero snapshots changed** — the diff is four source/ledger files only, `.snap.new` count 0. Stated
honestly: that is **vacuous** for these rows, since neither row's cards are in the `parse_two_layer`
corpus, so the snapshot gate supplied no signal here. The byte measurement and the disable probe are
the evidence.

**CR gate**: exactly two numbers added — CR 208.2b and CR 614.1e — zero unverified, text read rather
than existence checked.

## Judgement call worth a look

The charter said U0-40 keeps "one residual `PreLoweredSpell` … which the caller can emit directly."
Putting it in the node vector made **Gate P fail immediately** — the gate counts the token textually
and `oracle_replacement.rs` has no ledger entry, so a new pre-lowered producer in an untracked file is
exactly what it exists to catch. The residual is therefore a bare `Option<AbilityDefinition>` field on
the returned struct, emitted via the existing `ability_at`. That follows the charter's own wording and
keeps the burn-down honest.

`emit_ir_nodes_at` dispatches through the typed `*_ir_at` helpers rather than raw `emit_at`, because
`static_at` maintains the `last_static` peek mirror that `parsed_result_recently_granted_flashback`
reads mid-loop — raw emission would have silently stopped updating it.

## Harvest (§5.4)

1. **Stale doc in `oracle_static/shared.rs`** — `bind_counter_anaphor_to_recipient`'s doc says
   `parse_counter_object_scope` "parks those pronouns on `ObjectScope::Anaphoric`". **False**: that
   combinator has no `Anaphoric` arm at all and yields only `Source`/`Target`. The real producer is
   `parse_deferred_counter_pronoun`. The doc names the wrong combinator.
2. **The inherited U0-40 safety reason was wrong** (above), though the conclusion held.
3. **The `result.modal` check at the U0-40 site is incidental.**
   `lower_as_enters_becomes_choice_modal` never wrote `result.modal`, and `result` is shared across the
   dispatch loop, so the check can only ever observe a modal set by an *earlier* line. Preserved
   verbatim for byte-identity, but it is dead-or-cross-line-leaky as written.
4. **Census undercount** — the U0-40 row says "3 cards"; it is **4**. Corrupted Shapeshifter also
   reaches it. Mercurial Transformation carries "becomes your choice of" but lacks the "As ~ enters"
   frame and correctly does not.
5. **Ordering caveat for review:** card-data byte-identity is *weak* evidence for the
   abilities → statics → replacements ordering specifically — a cross-category reorder is largely
   unobservable there, since within-category order is untouched and the replacement is a singleton. The
   order is preserved by construction; the corroboration is that the span-sensitive swallowed-clause
   counts are also unchanged.
6. **Cheap liveness instrument:** `oracle-gen --output X --filter "A|B"` runs in seconds against the
   real pool and diffs cleanly. Given a full-pool regen costs ~5 min plus ~7 GB of `tool`-profile
   artifacts, future tranches should reach for it first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved parsing of modal “as enters, it becomes your choice” abilities, including ordered effects and face-up variants.
  * Improved recognition and lowering of spell-like effect text.

* **Bug Fixes**
  * Fixed ordering and state tracking when processing mixed ability results.
  * Improved handling of unsupported or partially parsed modal effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->