### PR TITLE
fix(parser): Relic of Progenitus first ability targets only a player (#6446)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1631,6 +1631,49 @@ pub(super) fn change_zone_selects_battlefield_permanent(
     matches!(target, TargetFilter::Typed(_))
 }
 
+/// CR 115.10a + CR 608.2d: shared ChangeZone / ChangeZoneAll stack-vs-resolution
+/// classifier. `fragment_lower` must be the moved-object clause / predicate only
+/// — never a subject prefix like "Target player …", which would false-positive
+/// the `"target "` scan and force Stack.
+///
+/// Single authority for both `target_choice_timing_for_clause` and the
+/// `"target player" + ChangeZone` TargetOnly wrap (Strategic Betrayal #6505,
+/// Relic of Progenitus #6446).
+pub(super) fn change_zone_target_choice_timing(
+    origin: Option<Zone>,
+    target: &TargetFilter,
+    has_multi_target: bool,
+    fragment_lower: &str,
+) -> TargetChoiceTiming {
+    let off_battlefield_origin = origin.is_some_and(|zone| zone != Zone::Battlefield)
+        || has_multi_target
+            && target
+                .extract_zones()
+                .iter()
+                .any(|zone| *zone != Zone::Battlefield);
+    if off_battlefield_origin {
+        // Off-BF non-"target " legs (Relic: "exiles a card from their graveyard")
+        // are resolution picks; explicit "target cards …" (Memory's Journey) stay Stack.
+        if nom_primitives::scan_contains(fragment_lower, "target ") {
+            TargetChoiceTiming::Stack
+        } else {
+            TargetChoiceTiming::Resolution
+        }
+    } else if nom_primitives::scan_contains(fragment_lower, "target ") {
+        TargetChoiceTiming::Stack
+    } else if change_zone_selects_battlefield_permanent(origin, target) {
+        // CR 115.1: battlefield non-targeted picks (Sothera / Strategic Betrayal
+        // edict class) resolve via EffectZoneChoice after player_scope rebinding,
+        // not stack targeting.
+        // Graveyard/hand/library seeds without "target" (Deadly Cover-Up) keep
+        // stack-time selection — their filters carry explicit InZone constraints
+        // and origin is None (not off_battlefield_origin above).
+        TargetChoiceTiming::Resolution
+    } else {
+        TargetChoiceTiming::Stack
+    }
+}
+
 pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetChoiceTiming {
     if let Effect::ChooseCounterKind { target } = &clause_ir.parsed.effect {
         let lower = clause_ir
@@ -1700,37 +1743,19 @@ pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetCho
         }
     }
 
-    let Effect::ChangeZone { origin, target, .. } = &clause_ir.parsed.effect else {
-        return TargetChoiceTiming::Stack;
+    let (origin, target) = match &clause_ir.parsed.effect {
+        Effect::ChangeZone { origin, target, .. }
+        | Effect::ChangeZoneAll { origin, target, .. } => (*origin, target),
+        _ => return TargetChoiceTiming::Stack,
     };
-    let off_battlefield_origin = origin.is_some_and(|zone| zone != Zone::Battlefield)
-        || (clause_ir.multi_target.is_some() || clause_ir.parsed.multi_target.is_some())
-            && target
-                .extract_zones()
-                .iter()
-                .any(|zone| *zone != Zone::Battlefield);
     let lower = clause_ir
         .source
         .fragment()
         .unwrap_or_default()
         .to_ascii_lowercase();
-    if off_battlefield_origin {
-        if nom_primitives::scan_contains(&lower, "target ") {
-            TargetChoiceTiming::Stack
-        } else {
-            TargetChoiceTiming::Resolution
-        }
-    } else if nom_primitives::scan_contains(&lower, "target ") {
-        TargetChoiceTiming::Stack
-    } else if change_zone_selects_battlefield_permanent(*origin, target) {
-        // CR 115.1: battlefield non-targeted picks (Sothera edict class) resolve
-        // via EffectZoneChoice after player_scope rebinding, not stack targeting.
-        // Graveyard/hand/library seeds without "target" (Deadly Cover-Up) keep
-        // stack-time selection — their filters carry explicit InZone constraints.
-        TargetChoiceTiming::Resolution
-    } else {
-        TargetChoiceTiming::Stack
-    }
+    let has_multi_target =
+        clause_ir.multi_target.is_some() || clause_ir.parsed.multi_target.is_some();
+    change_zone_target_choice_timing(origin, target, has_multi_target, &lower)
 }
 
 /// CR 303.4f: Aura entering by non-spell means — controller chooses the enchanted object.

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1631,14 +1631,15 @@ pub(super) fn change_zone_selects_battlefield_permanent(
     matches!(target, TargetFilter::Typed(_))
 }
 
-/// CR 115.10a + CR 608.2d: shared ChangeZone / ChangeZoneAll stack-vs-resolution
-/// classifier. `fragment_lower` must be the moved-object clause / predicate only
-/// — never a subject prefix like "Target player …", which would false-positive
-/// the `"target "` scan and force Stack.
+/// CR 115.10a + CR 608.2d: shared ChangeZone stack-vs-resolution classifier.
+/// `fragment_lower` must be the moved-object clause / predicate only — never a
+/// subject prefix like "Target player …", which would false-positive the
+/// `"target "` scan and force Stack.
 ///
-/// Single authority for both `target_choice_timing_for_clause` and the
-/// `"target player" + ChangeZone` TargetOnly wrap (Strategic Betrayal #6505,
-/// Relic of Progenitus #6446).
+/// Used by `target_choice_timing_for_clause` (`ChangeZone` only — mass
+/// `ChangeZoneAll` keeps the historical Stack default there) and by the
+/// `"target player" + ChangeZone/ChangeZoneAll` TargetOnly wrap (Strategic
+/// Betrayal #6505, Relic of Progenitus #6446).
 pub(super) fn change_zone_target_choice_timing(
     origin: Option<Zone>,
     target: &TargetFilter,
@@ -1743,10 +1744,12 @@ pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetCho
         }
     }
 
-    let (origin, target) = match &clause_ir.parsed.effect {
-        Effect::ChangeZone { origin, target, .. }
-        | Effect::ChangeZoneAll { origin, target, .. } => (*origin, target),
-        _ => return TargetChoiceTiming::Stack,
+    // Mass `ChangeZoneAll` stays Stack here (pre-#6446). The TargetOnly wrap
+    // may still stamp Resolution on ChangeZoneAll resolution-picks via the
+    // shared helper; clause-IR timing must not silently reclassify every
+    // off-BF mass move (Bomat Courier / Jace −12 snapshot regressions).
+    let Effect::ChangeZone { origin, target, .. } = &clause_ir.parsed.effect else {
+        return TargetChoiceTiming::Stack;
     };
     let lower = clause_ir
         .source
@@ -1755,7 +1758,7 @@ pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetCho
         .to_ascii_lowercase();
     let has_multi_target =
         clause_ir.multi_target.is_some() || clause_ir.parsed.multi_target.is_some();
-    change_zone_target_choice_timing(origin, target, has_multi_target, &lower)
+    change_zone_target_choice_timing(*origin, target, has_multi_target, &lower)
 }
 
 /// CR 303.4f: Aura entering by non-spell means — controller chooses the enchanted object.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -19506,55 +19506,50 @@ fn lower_subject_predicate_ast(
                     clause.effect,
                     Effect::ChangeZone { .. } | Effect::ChangeZoneAll { .. }
                 ) {
-                    // CR 115.1a + CR 702.21a (issue #6505): distinguish a
-                    // battlefield-wide, NON-targeted resolution pick ("target
-                    // opponent exiles a creature they control", Strategic
-                    // Betrayal) from an off-battlefield or explicitly-targeted
-                    // moved-object leg. Mirror `target_choice_timing_for_clause`
-                    // in lower.rs: a battlefield-selecting ChangeZone with no
-                    // "target " token has its object CHOSEN at resolution, so it
-                    // never becomes a target and Ward on the opponent's own
-                    // creature never fires.
-                    let creature_leg_is_resolution_pick = match &clause.effect {
+                    // CR 115.1c + CR 115.10a + CR 608.2d (issues #6505 / #6446):
+                    // reuse `change_zone_target_choice_timing` so battlefield
+                    // non-"target " picks (Strategic Betrayal) AND off-battlefield
+                    // non-"target " picks (Relic of Progenitus — "exiles a card
+                    // from their graveyard") stamp Resolution. Explicit
+                    // "target cards …" legs (Memory's Journey) stay Stack.
+                    // Scan `pred_lower` only — never the subject "Target player …"
+                    // prefix, which would false-positive the `"target "` gate.
+                    let moved_object_is_resolution_pick = match &clause.effect {
                         Effect::ChangeZone { origin, target, .. }
                         | Effect::ChangeZoneAll { origin, target, .. } => {
-                            lower::change_zone_selects_battlefield_permanent(*origin, target)
-                                && !scan_contains_phrase(&pred_lower, "target ")
+                            lower::change_zone_target_choice_timing(
+                                *origin,
+                                target,
+                                clause.multi_target.is_some(),
+                                &pred_lower,
+                            ) == crate::types::ability::TargetChoiceTiming::Resolution
                         }
                         _ => false,
                     };
-                    // CR 109.4 (issue #1077): "target player exiles a card
-                    // from their graveyard" (Relic of Progenitus, Scrabbling
-                    // Claws, Merrow Bonegnawer, Graveyard Shovel, Grave
-                    // Birthing, Gravestorm) and "target player[s] ... their
-                    // [zone]" (Memory's Journey, above). The moved-object
-                    // filter's possessive "their" parses as
-                    // `Owned { controller: ScopedPlayer }` because the
-                    // zone-suffix parser is scope-agnostic. An off-battlefield
-                    // or targeted leg selects its object on the STACK — before
-                    // the resolution-time `scoped_player` stamp lands — so the
-                    // filter must be rebound to the real declared target now, or
-                    // it stays scoped to the activator instead of the targeted
-                    // player. A battlefield resolution pick (issue #6505) is
-                    // instead bound to the scoped player at resolution, so its
-                    // acting/choosing player is the target opponent, not the
-                    // caster (CR 115.10a — being affected is not choosing).
+                    // CR 115.1c / CR 115.10a / CR 608.2d (issue #6446): Relic-class
+                    // resolution picks keep `Owned{ScopedPlayer}` so the existing
+                    // stack::resolve_top scoped-player stamp binds the chooser to
+                    // the targeted player at resolution (via EffectZoneChoice).
+                    // Stack-timed legs (Memory's Journey — "target cards from
+                    // their graveyard") still rebind to `Owned{TargetPlayer}` so
+                    // the activator announces the cards as stack targets.
+                    // Without Resolution + ScopedPlayer, Relic built THREE stack
+                    // slots: TargetOnly player + companion TargetPlayer slot +
+                    // Stack ChangeZone card slot.
                     //
-                    // CR 109.4 + CR 115.10a (issue #6505, review follow-up): the
-                    // battlefield resolution-pick leg's anaphoric "they control"
-                    // lowered to the default `ControllerRef::You`
+                    // CR 115.10a (issue #6505, review follow-up): the battlefield
+                    // resolution-pick leg's anaphoric "they control" lowered to
+                    // the default `ControllerRef::You`
                     // (oracle_target::parse_controller_suffix, no scope pinned),
                     // so rewrite ONLY this moved-object leg's `You` scope to
-                    // `ScopedPlayer` here — the narrow, targeted replacement for
-                    // the removed whole-clause parse-time pin. The runtime
-                    // `scoped_player` stamp (stack::resolve_top) then binds the
-                    // chooser to the target player. Gated on the "they control"
-                    // anaphor so a "you control" caster leg (also `You`) is never
-                    // mis-rebound; the "their graveyard" leg is already
-                    // `Owned{ScopedPlayer}` (scope-agnostic) and needs no rewrite.
-                    let creature_leg_is_they_control_pick = creature_leg_is_resolution_pick
+                    // `ScopedPlayer` here. The runtime `scoped_player` stamp then
+                    // binds the chooser to the target player. Gated on the "they
+                    // control" anaphor so a "you control" caster leg (also `You`)
+                    // is never mis-rebound; Relic's "their graveyard" leg is
+                    // already `Owned{ScopedPlayer}` and needs no rewrite.
+                    let moved_object_is_they_control_pick = moved_object_is_resolution_pick
                         && scan_contains_phrase(&pred_lower, "they control");
-                    if creature_leg_is_they_control_pick {
+                    if moved_object_is_they_control_pick {
                         match &mut clause.effect {
                             Effect::ChangeZone { target, .. }
                             | Effect::ChangeZoneAll { target, .. } => {
@@ -19566,7 +19561,7 @@ fn lower_subject_predicate_ast(
                             }
                             _ => {}
                         }
-                    } else if !creature_leg_is_resolution_pick {
+                    } else if !moved_object_is_resolution_pick {
                         match &mut clause.effect {
                             Effect::ChangeZone { target, .. }
                             | Effect::ChangeZoneAll { target, .. } => {
@@ -19585,13 +19580,13 @@ fn lower_subject_predicate_ast(
                     // wrapper. Carry it onto the sub-ability so the cast
                     // surfaces N card slots.
                     sub_ability.multi_target = clause.multi_target;
-                    // CR 115.1a + CR 702.21a (issue #6505): a battlefield
-                    // resolution pick is chosen at resolution and never becomes a
-                    // target — stamp Resolution timing (the default is Stack) so
-                    // no BecomesTarget event fires and Ward on the chosen creature
-                    // stays silent. Off-battlefield/targeted legs keep the Stack
-                    // default so their stack-time selection is unchanged.
-                    if creature_leg_is_resolution_pick {
+                    // CR 115.1c + CR 115.10a + CR 608.2d (issues #6505 / #6446):
+                    // Resolution picks are chosen while applying the effect and
+                    // never become targets — stamp Resolution (default is Stack)
+                    // so companion TargetPlayer slots and card object slots are
+                    // deferred, and Ward never fires on a BF resolution pick.
+                    // Stack-timed "target cards …" legs keep the Stack default.
+                    if moved_object_is_resolution_pick {
                         sub_ability.target_choice_timing =
                             crate::types::ability::TargetChoiceTiming::Resolution;
                     }
@@ -20799,22 +20794,16 @@ fn inject_subject_target(effect: &mut Effect, subject: &SubjectPhraseAst) {
         // filter (mirroring the `Sacrifice` arm) so the card is taken from, and
         // the choice presented to, the acting (per-iteration) player.
         //
-        // CR 109.4 + CR 608.2c (issue #1077): "target player exiles a card
-        // from their graveyard" (Relic of Progenitus, Scrabbling Claws, Merrow
-        // Bonegnawer, Graveyard Shovel, Grave Birthing, Gravestorm). The
-        // possessive "their" in the predicate parses as `FilterProp::Owned {
-        // controller: ScopedPlayer }` because the zone-suffix parser is
-        // scope-agnostic (see `rebind_owned_scope`'s doc comment above). For a
-        // genuinely *targeted* subject that stale `ScopedPlayer` property
-        // survives `force_controller` untouched (it only rewrites
-        // `tf.controller`, not nested `properties`), leaving two contradictory
-        // ownership constraints — `controller: TargetPlayer` vs. `Owned:
-        // ScopedPlayer` (which falls back to the activator) — so the filter is
-        // only ever satisfiable when the activator targets themself. Rebind
-        // the nested `ScopedPlayer` refs the same way the `Bounce`/Skullwinder
-        // call site already does; this is a no-op when `effective_ctrl` is
-        // itself `ScopedPlayer` (the untargeted "each player"/Braids case),
-        // so that already-correct path is unaffected.
+        // CR 608.2c (issue #1077 / #6446): Stack-timed player-subject ChangeZones
+        // that reach this inject (not early-returned by the TargetOnly wrap) may
+        // still carry a stale `Owned{ScopedPlayer}` from the scope-agnostic
+        // zone-suffix parser. Rebind nested `ScopedPlayer` refs when the subject
+        // is a genuine stack target (`subject.target.is_some()` → TargetPlayer).
+        // Relic-class resolution picks ("exiles a card from their graveyard"
+        // without the word "target" on the card) are owned by the TargetOnly wrap
+        // — they keep `Owned{ScopedPlayer}` + Resolution timing and never reach
+        // this inject. This rebind is a no-op when `effective_ctrl` is itself
+        // `ScopedPlayer` (the untargeted "each player"/Braids case).
         Effect::ChangeZone { target, .. }
             if player_filter_as_controller_ref(&subject_filter).is_some() =>
         {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -7730,18 +7730,15 @@ fn suffer_the_past_exiles_from_target_player_graveyard() {
 
 #[test]
 fn relic_of_progenitus_target_player_exiles_from_their_graveyard() {
-    // GitHub phase-rs/phase#1077: "target player [verb]s ... from their
-    // [zone]" is a different grammatical shape than Suffer the Past's direct
-    // "target player's graveyard" possessive above — here "target player" is
-    // an explicit target declaration, so the ability lowers to a
-    // `TargetOnly { target: Player }` wrapper around a `sub_ability` holding
-    // the actual `ChangeZone` (mirrors Memory's Journey's "shuffles ... from
-    // their graveyard" wrapping just above in `lower_subject_predicate_ast`).
-    // The zone-suffix parser treats "their" as scope-agnostic
-    // (`Owned { controller: ScopedPlayer }`); this test pins that the
-    // rebind at that wrapping site resolves it to the actual targeted
-    // player, not the activator. Same class also covers Scrabbling Claws,
-    // Merrow Bonegnawer, Graveyard Shovel, Grave Birthing, and Gravestorm.
+    // GitHub phase-rs/phase#6446 (supersedes #1077 Stack+TargetPlayer framing):
+    // "Target player exiles a card from their graveyard." The ability targets
+    // ONLY the player (CR 115.1c). The card is an untargeted resolution choice
+    // by that player (CR 115.10a + CR 608.2d) — `Owned{ScopedPlayer}` +
+    // `TargetChoiceTiming::Resolution` — so companion TargetPlayer and card
+    // object stack slots do not appear (exactly one target slot).
+    // Same class: Scrabbling Claws, Merrow Bonegnawer, Graveyard Shovel,
+    // Grave Birthing, Gravestorm. Contrast Memory's Journey ("target cards
+    // from their graveyard") which stays Stack + Owned{TargetPlayer}.
     let def = parse_effect_chain(
         "Target player exiles a card from their graveyard.",
         AbilityKind::Activated,
@@ -7761,6 +7758,11 @@ fn relic_of_progenitus_target_player_exiles_from_their_graveyard() {
         .sub_ability
         .as_ref()
         .expect("exile effect should be in sub-ability after the player target");
+    assert_eq!(
+        sub.target_choice_timing,
+        TargetChoiceTiming::Resolution,
+        "GY card is chosen at resolution, not announced as a stack target"
+    );
     let Effect::ChangeZone {
         origin,
         destination,
@@ -7790,15 +7792,31 @@ fn relic_of_progenitus_target_player_exiles_from_their_graveyard() {
     );
     assert!(
         typed.properties.contains(&FilterProp::Owned {
-            controller: ControllerRef::TargetPlayer
+            controller: ControllerRef::ScopedPlayer
         }),
-        "target must be constrained to the TARGETED player's graveyard, not the activator's — got {typed:?}"
+        "must keep ScopedPlayer so the targeted player chooses at resolution — got {typed:?}"
     );
     assert!(
         !typed.properties.contains(&FilterProp::Owned {
-            controller: ControllerRef::ScopedPlayer
+            controller: ControllerRef::TargetPlayer
         }),
-        "must not retain the stale scope-agnostic ScopedPlayer binding, got {typed:?}"
+        "must not rebind to TargetPlayer (that forced activator stack targeting) — got {typed:?}"
+    );
+
+    // Exactly one stack slot (the player). Revert Resolution stamp or
+    // TargetPlayer rebind → companion + card slots → len 2 or 3.
+    let state = crate::types::game_state::GameState::new_two_player(42);
+    let resolved = crate::game::ability_utils::build_resolved_from_def(
+        &def,
+        crate::types::identifiers::ObjectId(1),
+        crate::types::player::PlayerId(0),
+    );
+    let slots = crate::game::ability_utils::build_target_slots(&state, &resolved)
+        .expect("Relic first ability must build target slots");
+    assert_eq!(
+        slots.len(),
+        1,
+        "exactly one stack target (the player); got {slots:?}"
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -796,6 +796,7 @@ mod purged_source_matches_filter_lki;
 mod quirion_ranger_activation;
 mod rage_reflection_double_strike_grant;
 mod refurbished_familiar;
+mod relic_of_progenitus_6446;
 mod render_silent_cant_cast;
 mod repro_pilot_crew;
 mod revealed_card_type_disjunction_518;

--- a/crates/engine/tests/integration/relic_of_progenitus_6446.rs
+++ b/crates/engine/tests/integration/relic_of_progenitus_6446.rs
@@ -1,0 +1,248 @@
+//! Issue #6446: Relic of Progenitus first ability — verbatim Oracle text:
+//!   "{T}: Target player exiles a card from their graveyard.
+//!    {1}, Exile this artifact: Exile all graveyards. Draw a card."
+//!
+//! Rules-correct behavior (CR 115.1c + CR 115.10a + CR 608.2d):
+//! the ability targets ONLY the player. That player then CHOOSES — does not
+//! TARGET — a card in THEIR graveyard to exile as the ability resolves.
+//!
+//! The bug had two halves:
+//!   (A) Stack timing + Owned{TargetPlayer} rebind produced THREE stack slots
+//!       (TargetOnly player + companion TargetPlayer + ChangeZone card), and
+//!   (B) the activator chose the card at announcement instead of the targeted
+//!       player at resolution.
+//!
+//! These tests are per-mechanism revert-sensitive; each notes which revert flips
+//! it. Mirror of `strategic_betrayal_6505.rs` for the off-battlefield twin.
+
+use engine::game::ability_utils::{build_resolved_from_def, build_target_slots};
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, ControllerRef, Effect, FilterProp, TargetChoiceTiming, TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const RELIC_ORACLE: &str = "{T}: Target player exiles a card from their graveyard.\n\
+{1}, Exile this artifact: Exile all graveyards. Draw a card.";
+
+fn chain_has_unimplemented(def: &AbilityDefinition) -> bool {
+    fn effect_unimplemented(effect: &Effect) -> bool {
+        matches!(effect, Effect::Unimplemented { .. })
+    }
+    effect_unimplemented(&def.effect)
+        || def
+            .sub_ability
+            .as_deref()
+            .is_some_and(chain_has_unimplemented)
+        || def
+            .else_ability
+            .as_deref()
+            .is_some_and(chain_has_unimplemented)
+}
+
+fn parse_relic_first_ability() -> AbilityDefinition {
+    let parsed = parse_oracle_text(RELIC_ORACLE, "Relic of Progenitus", &[], &[], &[]);
+    let first = parsed
+        .abilities
+        .into_iter()
+        .find(|a| matches!(&*a.effect, Effect::TargetOnly { .. }))
+        .expect("Relic first ability must be TargetOnly player wrap");
+    assert!(
+        !chain_has_unimplemented(&first),
+        "Relic first ability must parse with no Unimplemented; got {first:#?}"
+    );
+    first
+}
+
+fn find_change_zone(def: &AbilityDefinition) -> Option<&AbilityDefinition> {
+    let mut cursor = Some(def);
+    while let Some(node) = cursor {
+        if matches!(*node.effect, Effect::ChangeZone { .. }) {
+            return Some(node);
+        }
+        cursor = node.sub_ability.as_deref();
+    }
+    None
+}
+
+fn graveyard_ids(runner: &GameRunner, player: engine::types::player::PlayerId) -> Vec<ObjectId> {
+    runner.state().players[player.0 as usize]
+        .graveyard
+        .iter()
+        .copied()
+        .collect()
+}
+
+fn first_exile_ability_index(runner: &GameRunner, relic: ObjectId) -> usize {
+    runner.state().objects[&relic]
+        .abilities
+        .iter()
+        .position(|def| matches!(&*def.effect, Effect::TargetOnly { .. }))
+        .expect("Relic must expose the TargetOnly first ability")
+}
+
+/// SHAPE: first ability is TargetOnly{Player} → Resolution ChangeZone with
+/// Owned{ScopedPlayer}. Exactly one stack target slot.
+#[test]
+fn shape_one_player_target_resolution_scoped_owned() {
+    let first = parse_relic_first_ability();
+    let Effect::TargetOnly { target } = &*first.effect else {
+        panic!("expected TargetOnly, got {:?}", first.effect);
+    };
+    assert_eq!(*target, TargetFilter::Player);
+
+    let cz = find_change_zone(&first).expect("ChangeZone exile leg");
+    assert_eq!(
+        cz.target_choice_timing,
+        TargetChoiceTiming::Resolution,
+        "card is chosen at resolution (CR 608.2d), not a stack target"
+    );
+    let Effect::ChangeZone {
+        origin,
+        destination,
+        target,
+        ..
+    } = cz.effect.as_ref()
+    else {
+        unreachable!()
+    };
+    assert_eq!(*origin, Some(Zone::Graveyard));
+    assert_eq!(*destination, Zone::Exile);
+    let TargetFilter::Typed(typed) = target else {
+        panic!("expected typed GY card filter, got {target:?}");
+    };
+    assert!(
+        typed.properties.contains(&FilterProp::Owned {
+            controller: ControllerRef::ScopedPlayer
+        }),
+        "must keep ScopedPlayer for resolution chooser stamp; got {typed:?}"
+    );
+    assert!(
+        !typed.properties.contains(&FilterProp::Owned {
+            controller: ControllerRef::TargetPlayer
+        }),
+        "must not rebind to TargetPlayer; got {typed:?}"
+    );
+
+    let state = engine::types::game_state::GameState::new_two_player(42);
+    let resolved = build_resolved_from_def(&first, ObjectId(1), engine::types::player::PlayerId(0));
+    let slots = build_target_slots(&state, &resolved).expect("slots");
+    assert_eq!(
+        slots.len(),
+        1,
+        "exactly one stack target (the player); companion + card must not appear — got {slots:?}"
+    );
+}
+
+/// E2E: activator targets P1; P1 chooses from P1's GY; P0's GY cards are not
+/// offered. Revert Resolution/ScopedPlayer → wrong chooser or card targets.
+#[test]
+fn end_to_end_targeted_player_chooses_from_own_graveyard() {
+    let _ = parse_relic_first_ability();
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_graveyard(P1, &["Opp GY A", "Opp GY B"]);
+    // Multi-authority hostile: activator also has GY cards — must not be offered.
+    scenario.with_graveyard(P0, &["Activator GY Card"]);
+
+    let relic = scenario
+        .add_creature(P0, "Relic of Progenitus", 0, 0)
+        .as_artifact()
+        .from_oracle_text(RELIC_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let p1_gy = graveyard_ids(&runner, P1);
+    let p0_gy = graveyard_ids(&runner, P0);
+    assert_eq!(p1_gy.len(), 2);
+    assert_eq!(p0_gy.len(), 1);
+
+    let idx = first_exile_ability_index(&runner, relic);
+    let outcome = runner.activate(relic, idx).target_player(P1).resolve();
+
+    match outcome.final_waiting_for() {
+        WaitingFor::EffectZoneChoice { player, cards, .. } => {
+            assert_eq!(*player, P1, "targeted player chooses the exiled card");
+            for id in &p1_gy {
+                assert!(
+                    cards.contains(id),
+                    "P1 GY cards must be offered; got {cards:?}"
+                );
+            }
+            for id in &p0_gy {
+                assert!(
+                    !cards.contains(id),
+                    "activator GY cards must not be offered; got {cards:?}"
+                );
+            }
+        }
+        other => panic!("expected EffectZoneChoice for P1; got {other:?}"),
+    }
+
+    let chosen = p1_gy[0];
+    let unchosen = p1_gy[1];
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![chosen],
+        })
+        .expect("P1 selects a GY card to exile");
+
+    assert_eq!(
+        runner.state().objects[&chosen].zone,
+        Zone::Exile,
+        "chosen card is exiled"
+    );
+    assert_eq!(
+        runner.state().objects[&unchosen].zone,
+        Zone::Graveyard,
+        "unchosen card stays in graveyard"
+    );
+    assert_eq!(
+        runner.state().objects[&p0_gy[0]].zone,
+        Zone::Graveyard,
+        "activator GY card must remain untouched"
+    );
+}
+
+/// Self-target: activator chooses from their own graveyard.
+#[test]
+fn self_target_chooser_is_activator() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_graveyard(P0, &["Own GY A", "Own GY B"]);
+    scenario.with_graveyard(P1, &["Opp GY"]);
+
+    let relic = scenario
+        .add_creature(P0, "Relic of Progenitus", 0, 0)
+        .as_artifact()
+        .from_oracle_text(RELIC_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let p0_gy = graveyard_ids(&runner, P0);
+    let p1_gy = graveyard_ids(&runner, P1);
+    let idx = first_exile_ability_index(&runner, relic);
+    let outcome = runner.activate(relic, idx).target_player(P0).resolve();
+
+    match outcome.final_waiting_for() {
+        WaitingFor::EffectZoneChoice { player, cards, .. } => {
+            assert_eq!(*player, P0);
+            for id in &p0_gy {
+                assert!(cards.contains(id), "own GY must be offered; got {cards:?}");
+            }
+            for id in &p1_gy {
+                assert!(
+                    !cards.contains(id),
+                    "opponent GY must not be offered; got {cards:?}"
+                );
+            }
+        }
+        other => panic!("expected EffectZoneChoice for P0; got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary
- Aligns the TargetOnly "target player" + ChangeZone wrap with the existing `change_zone_target_choice_timing` classifier so Relic-class off-battlefield non-"target" legs stamp `Resolution` and keep `Owned{ScopedPlayer}` (Strategic Betrayal twin for graveyards).
- Collapses the buggy 3 stack targets (player + companion + card) to exactly one player target; the targeted player chooses a GY card via existing `EffectZoneChoice` at resolution (CR 115.1c / 115.10a / 608.2d).
- Updates the Relic unit test and adds integration coverage for shape, E2E chooser (multi-authority), and self-target. Memory's Journey / Strategic Betrayal paths unchanged.

Closes #6446

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo test -p engine --lib relic_of_progenitus_target_player_exiles_from_their_graveyard`
- [x] `cargo test -p engine --test integration relic_of_progenitus_6446` (3 tests)
- [x] `cargo test -p engine --test integration strategic_betrayal_6505` (13 tests)
- [ ] CI clippy / test-engine / card-data

## Validation Failures
Plan review completed clean via isolated agents (2 rounds). Implementation and implementation-review subagents could not be spawned (API usage limit); implementation was done in the orchestrator thread against the approved plan. Isolated `/review-impl` did not run — please give the PR an extra human/architecture pass before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected timing and targeting for graveyard-to-exile “change zone” effects, ensuring resolution-time selection is handled properly.
  - Ensured chooser and offered cards are limited to the targeted player, including correct behavior when the activator is hostile.
  - Prevented additional target slots from appearing during resolution, including for player-only choices.
  - Fixed self-targeting so only the activating player’s eligible graveyard cards are offered.

- **Tests**
  - Added new integration coverage for **Relic of Progenitus** (including Issue `#6446`), verifying chooser type, slot count, and resulting card movement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->