### PR TITLE
refactor(parser): Plan 05b — the shared residual node and `optional` on the ability shell

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -637,6 +637,16 @@ fn lower_spell_node(node: &OracleNodeIr) -> Option<AbilityDefinition> {
     match node {
         OracleNodeIr::Spell(ability_ir) => Some(lower_ability_ir(ability_ir)),
         OracleNodeIr::PreLoweredSpell(definition) => Some(definition.clone()),
+        // The residual is a spell shape, so it must answer here. The `_` arm
+        // below would have silently made it `None`, and this reader feeds
+        // `last_ability_definition()` — the mid-loop peek behind
+        // `parsed_result_recently_granted_flashback` and the cross-line
+        // "instead" fold's `previous_spell`. A `None` there is not a compile
+        // error; it is a behavior change on a DIFFERENT card from the converted
+        // one, which per-card byte-identity cannot catch.
+        OracleNodeIr::Unsupported { text, min_x_value } => {
+            Some(lower_unsupported_node(text, *min_x_value))
+        }
         _ => None,
     }
 }
@@ -1192,6 +1202,11 @@ fn item_ability(item: &OracleItemIr) -> Option<Cow<'_, AbilityDefinition>> {
     match &item.node {
         OracleNodeIr::PreLoweredSpell(def) => Some(Cow::Borrowed(def)),
         OracleNodeIr::Spell(ability_ir) => Some(Cow::Owned(lower_ability_ir(ability_ir))),
+        // Third spell shape, owned for the same reason the IR-native one is: the
+        // residual node holds text, not a definition, so one is built here.
+        OracleNodeIr::Unsupported { text, min_x_value } => {
+            Some(Cow::Owned(lower_unsupported_node(text, *min_x_value)))
+        }
         _ => None,
     }
 }
@@ -2940,6 +2955,16 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
         match &item.node {
             OracleNodeIr::Spell(ability_ir) => {
                 let mut def = lower_ability_ir(ability_ir);
+                stamp_printed_ability_slot(&mut def, result.abilities.len());
+                result.abilities.push(def);
+                ability_ids.push(item.id);
+            }
+            // Same three steps as the two arms around it: lower, stamp the
+            // CR 707.9a printed ability slot, push. The residual is stamped like
+            // any other ability because a "…except it has this ability" clause
+            // counts printed slots, not supported ones.
+            OracleNodeIr::Unsupported { text, min_x_value } => {
+                let mut def = lower_unsupported_node(text, *min_x_value);
                 stamp_printed_ability_slot(&mut def, result.abilities.len());
                 result.abilities.push(def);
                 ability_ids.push(item.id);
@@ -8184,6 +8209,24 @@ fn x_annotation_min_value(line: &str) -> u32 {
 
 /// Primary nom-based dispatcher for Oracle text lines.
 ///
+/// Lower an `OracleNodeIr::Unsupported` residual to the definition it stands for.
+///
+/// Delegates to `make_unimplemented` rather than rebuilding the definition, so
+/// the node and the two hand-built residual sites cannot drift: there is exactly
+/// one place the `name: "unknown"` / `description: text` pair is constructed, and
+/// the coverage tooling that keys on that pair sees the same value whichever
+/// route produced it.
+///
+/// CR 601.2b: the floor is applied with `max`, matching
+/// `apply_ability_shell_envelope` — the node's `0` default can then never lower a
+/// floor, and the operation composes with a later raise the same way both other
+/// spell shapes do.
+fn lower_unsupported_node(text: &str, min_x_value: u32) -> AbilityDefinition {
+    let mut def = make_unimplemented(text);
+    def.min_x_value = def.min_x_value.max(min_x_value);
+    def
+}
+
 /// Create an Unimplemented fallback ability.
 pub(super) fn make_unimplemented(line: &str) -> AbilityDefinition {
     tracing::debug!(oracle_text = line, "unimplemented ability line");

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -58,7 +58,7 @@ use super::oracle_cost::{parse_oracle_cost, parse_single_cost, try_parse_cost_re
 use super::oracle_dispatch::dispatch_line_nom;
 use super::oracle_effect::sequence::try_parse_same_is_true_continuation;
 use super::oracle_effect::{
-    lower_ability_ir, parse_ability_ir_with_context,
+    lower_ability_ir, parse_ability_ir_standalone, parse_ability_ir_with_context,
     parse_additional_cost_instead_condition_fragment, parse_effect_chain,
     parse_effect_chain_with_context, rewrite_condition_keyword,
     try_parse_temporal_delayed_trigger_ability,
@@ -411,7 +411,31 @@ pub fn oracle_text_allows_commander(oracle_text: &str, card_name: &str) -> bool 
 /// tooling can read the shape of the action; the resolution guard in
 /// `effects/mod.rs` skips it during stack resolution regardless of what the
 /// inner effect happens to be.
-fn try_parse_mulligan_time_ability(line: &str, lower: &str) -> Option<AbilityDefinition> {
+///
+/// # The conversion is by construction, not by corpus (Plan 05b U0-43)
+///
+/// `parse_effect_chain(t, k)` **is**
+/// `lower_ability_ir(&parse_ability_ir_standalone(t, k))` — that is the entire
+/// body of `parse_effect_chain` in `oracle_effect/mod.rs`, not a claim about it.
+/// So splitting it into its two halves moves *where* the lowering happens
+/// without changing *what* it produces, and both root stamps ride the shell,
+/// applied after lowering exactly as the two lines they replace applied them.
+/// No property of any card's text participates in the argument, so a future
+/// printing reaching this recognizer is covered too.
+///
+/// `parse_ability_ir_standalone` is the mode-pinned wrapper for a site whose
+/// original called `parse_effect_chain`; the argument list is unchanged, so the
+/// `ChainLoweringMode` is inherited mechanically rather than by judgment.
+///
+/// **`clauses[0].parsed.optional` is deliberately NOT used.** CR 103.5b's "you
+/// may perform that action" is a property of the whole printed ability, and the
+/// shell stamps it unconditionally after lowering. Routing it through clause 0
+/// instead would subject it to `assemble_effect_chain`'s conditional clause→root
+/// mapping (four suppressions plus a `SearchOutsideGame` arm that forces
+/// `optional = false`) and would additionally assume clause 0 becomes the
+/// emitted root, which `ClauseDisposition` does not guarantee. See
+/// `AbilityShellIr::optional`.
+fn try_parse_mulligan_time_ability(line: &str, lower: &str) -> Option<AbilityIr> {
     let (_, rest) = nom_on_lower(line, lower, |input| {
         let (input, _) = tag("any time you could mulligan and ").parse(input)?;
         let (input, _) = alt((
@@ -422,9 +446,12 @@ fn try_parse_mulligan_time_ability(line: &str, lower: &str) -> Option<AbilityDef
         Ok((input, ()))
     })?;
 
-    let mut def = parse_effect_chain(rest, AbilityKind::Mulligan).description(line.to_string());
-    def.optional = true;
-    Some(def)
+    let mut ir = parse_ability_ir_standalone(rest, AbilityKind::Mulligan);
+    // CR 103.5b: "the player MAY perform that action" — the optionality is
+    // printed on the ability, so it is stamped on the shell, not on a clause.
+    ir.shell.optional = true;
+    ir.shell.description = Some(line.to_string());
+    Some(ir)
 }
 
 fn try_parse_opening_hand_reveal_delayed_trigger(
@@ -5799,8 +5826,8 @@ pub(crate) fn parse_oracle_ir(
         // (Serum Powder, No-Regrets Egret). Mulligan-time abilities never resolve
         // through the stack — see `AbilityKind::Mulligan` and the guard in
         // `effects/mod.rs`. Runtime dispatch lives in `mulligan.rs`.
-        if let Some(def) = try_parse_mulligan_time_ability(&line, &lower) {
-            emitter.ability_at(item_line, def);
+        if let Some(ir) = try_parse_mulligan_time_ability(&line, &lower) {
+            emitter.ability_ir_at(item_line, ir);
             i += 1;
             continue;
         }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1217,8 +1217,13 @@ fn item_replacement(item: &OracleItemIr) -> Option<&ReplacementDefinition> {
 /// `TriggerDefinition` — `TriggerNodeIr::Assembled` carries one directly. There
 /// is no equivalent layer to push this obligation onto: a spell node's IR
 /// payload is an `AbilityIr`, not an enum of definition-owning representations,
-/// so both shapes are named here. `_ => None` is safe for the same reason it is
-/// safe there: every remaining variant is genuinely `None`.
+/// so all three shapes are named here. `_ => None` is safe for the same reason
+/// it is safe there: every remaining variant is genuinely `None`.
+///
+/// The wildcard is nonetheless a hazard for the NEXT spell-shaped variant: it
+/// absorbs one silently, and this reader is an `and_then` target, so the result
+/// is a behavior change with no compile error. Deleting it is tracked with the
+/// pre-lowered variants' eventual removal, which rewrites these arms anyway.
 ///
 /// Lowering is the same `lower_ability_ir` call `lower_oracle_ir` (the `Spell`
 /// arm) will make for the same item, so a relation predicate sees exactly the
@@ -3913,7 +3918,7 @@ impl<'a> DocEmitter<'a> {
             source, mut node, ..
         } = item;
         let floor = node.spell_min_x_mut().expect(
-            "`spells_emitted` holds only spell nodes, and both spell shapes carry an X floor",
+            "`spells_emitted` holds only spell nodes, and all three spell shapes carry an X floor",
         );
         *floor = (*floor).max(min_x_value);
         self.reemit_node(&source, node);
@@ -6240,12 +6245,12 @@ pub(crate) fn parse_oracle_ir(
                             node: base_node,
                             ..
                         } = base_item;
-                        // Both spell node shapes, via the shared reader:
+                        // All three spell node shapes, via the shared reader:
                         // `pop_last_spell` pops `spells_emitted`, which `emit`
-                        // fills from either shape with no variant filter.
+                        // fills from any of them with no variant filter.
                         let Some(mut base) = lower_spell_node(&base_node) else {
                             unreachable!(
-                                "`spells_emitted` holds only spell nodes, and both spell shapes lower"
+                                "`spells_emitted` holds only spell nodes, and all three spell shapes lower"
                             );
                         };
                         // Save the base ability's continuation chain in else_ability

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -68,7 +68,7 @@ use super::oracle_ir::diagnostic::OracleDiagnostic;
 use super::oracle_ir::doc::{
     stamp_printed_ability_slot, stamp_printed_trigger_slot, OracleDocBuilder, OracleDocIr,
     OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan, OracleUnitSource,
-    PrintedAbilityIndex, PrintedTriggerIndex,
+    PrintedAbilityIndex, PrintedTriggerIndex, SpellPayloadIr,
 };
 use super::oracle_ir::effect_chain::{AbilityIr, ShellStage};
 use super::oracle_ir::feature::ItemIdTracks;
@@ -661,21 +661,11 @@ fn parse_begin_game_counter_clause(
 }
 
 fn lower_spell_node(node: &OracleNodeIr) -> Option<AbilityDefinition> {
-    match node {
-        OracleNodeIr::Spell(ability_ir) => Some(lower_ability_ir(ability_ir)),
-        OracleNodeIr::PreLoweredSpell(definition) => Some(definition.clone()),
-        // The residual is a spell shape, so it must answer here. The `_` arm
-        // below would have silently made it `None`, and this reader feeds
-        // `last_ability_definition()` — the mid-loop peek behind
-        // `parsed_result_recently_granted_flashback` and the cross-line
-        // "instead" fold's `previous_spell`. A `None` there is not a compile
-        // error; it is a behavior change on a DIFFERENT card from the converted
-        // one, which per-card byte-identity cannot catch.
-        OracleNodeIr::Unsupported { text, min_x_value } => {
-            Some(lower_unsupported_node(text, *min_x_value))
-        }
-        _ => None,
-    }
+    node.spell_payload().map(|payload| match payload {
+        SpellPayloadIr::Ir(ir) => lower_ability_ir(ir),
+        SpellPayloadIr::Lowered(def) => def.clone(),
+        SpellPayloadIr::Residual { text, min_x_value } => lower_unsupported_node(text, min_x_value),
+    })
 }
 
 fn parsed_result_recently_granted_flashback(emitter: &DocEmitter<'_>) -> bool {
@@ -1211,19 +1201,17 @@ fn item_replacement(item: &OracleItemIr) -> Option<&ReplacementDefinition> {
 /// `AbilityDefinition` would clone the first case at all seven call sites, most
 /// of which scan every item on the card.
 ///
-/// This is where the trigger side's reasoning stops applying.
-/// `item_trigger` keeps a borrow and pushes exhaustiveness down onto
-/// `TriggerNodeIr::definition()`, because both of its shapes own a
-/// `TriggerDefinition` — `TriggerNodeIr::Assembled` carries one directly. There
-/// is no equivalent layer to push this obligation onto: a spell node's IR
-/// payload is an `AbilityIr`, not an enum of definition-owning representations,
-/// so all three shapes are named here. `_ => None` is safe for the same reason
-/// it is safe there: every remaining variant is genuinely `None`.
+/// `OracleNodeIr::spell_payload()` supplies the spell-side equivalent of
+/// `TriggerNodeIr::definition()`: it is exhaustive over `OracleNodeIr` and
+/// returns the three spell payload representations. This reader then matches
+/// that closed representation without a wildcard, so a fourth spell payload
+/// must be handled here and in `lower_spell_node` at compile time.
 ///
-/// The wildcard is nonetheless a hazard for the NEXT spell-shaped variant: it
-/// absorbs one silently, and this reader is an `and_then` target, so the result
-/// is a behavior change with no compile error. Deleting it is tracked with the
-/// pre-lowered variants' eventual removal, which rewrites these arms anyway.
+/// `item_trigger` still keeps a borrow and pushes its own exhaustiveness down
+/// onto `TriggerNodeIr::definition()`, because both of its shapes own a
+/// `TriggerDefinition`. The spell layer differs only in its representations:
+/// the IR-native and residual payloads must be lowered into owned definitions,
+/// while the already-lowered payload can lend its definition.
 ///
 /// Lowering is the same `lower_ability_ir` call `lower_oracle_ir` (the `Spell`
 /// arm) will make for the same item, so a relation predicate sees exactly the
@@ -1231,16 +1219,13 @@ fn item_replacement(item: &OracleItemIr) -> Option<&ReplacementDefinition> {
 /// exception that cannot matter: the CR 707.9a printed slot, which lowering
 /// stamps afterwards and no relation predicate reads.
 fn item_ability(item: &OracleItemIr) -> Option<Cow<'_, AbilityDefinition>> {
-    match &item.node {
-        OracleNodeIr::PreLoweredSpell(def) => Some(Cow::Borrowed(def)),
-        OracleNodeIr::Spell(ability_ir) => Some(Cow::Owned(lower_ability_ir(ability_ir))),
-        // Third spell shape, owned for the same reason the IR-native one is: the
-        // residual node holds text, not a definition, so one is built here.
-        OracleNodeIr::Unsupported { text, min_x_value } => {
-            Some(Cow::Owned(lower_unsupported_node(text, *min_x_value)))
+    item.node.spell_payload().map(|payload| match payload {
+        SpellPayloadIr::Lowered(def) => Cow::Borrowed(def),
+        SpellPayloadIr::Ir(ir) => Cow::Owned(lower_ability_ir(ir)),
+        SpellPayloadIr::Residual { text, min_x_value } => {
+            Cow::Owned(lower_unsupported_node(text, min_x_value))
         }
-        _ => None,
-    }
+    })
 }
 
 /// CR 607.2d: the trigger side of document-relation discovery.

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -2179,9 +2179,12 @@ fn push_graveyard_keyword_same_is_true_tail(
         );
     }
     if !unqualified.is_empty() {
-        emitter.ability_at(
+        // Plan 05b U0-02. The residual text is unchanged, so the coverage key
+        // (`name: "unknown"` / `description` = this string) is unchanged; only
+        // WHEN the definition is built moves, from here to `lower_oracle_ir`.
+        emitter.unsupported_at(
             item_line,
-            make_unimplemented(&format!("the same is true for {}", unqualified.join(", "))),
+            format!("the same is true for {}", unqualified.join(", ")),
         );
     }
     true
@@ -3682,6 +3685,27 @@ impl<'a> DocEmitter<'a> {
     /// `finish()`-time walk it replaced.
     fn ability_ir_at(&mut self, line: usize, ir: AbilityIr) {
         self.emit_at(line, OracleNodeIr::Spell(ir));
+    }
+    /// Emit the honest-failure residual for a line the parser could not model.
+    ///
+    /// Mirrors `ability_at`, which is what it replaces: no peek mirror to
+    /// maintain (the ability peek is pop-aware, read from the builder's
+    /// `spells_emitted` stack), and the node lands in the same slot-accounting
+    /// arm, so the residual still consumes its CR 707.9a printed ability slot.
+    ///
+    /// Takes the text `String`, not a definition: the whole point of the node is
+    /// that the definition is built once, at the lowering seam, by
+    /// `lower_unsupported_node`. `min_x_value` is seeded at the `0` its
+    /// definition-shaped predecessor carried; a standalone "X can't be 0."
+    /// annotation paragraph still raises it through `raise_last_spell_min_x`.
+    fn unsupported_at(&mut self, line: usize, text: String) {
+        self.emit_at(
+            line,
+            OracleNodeIr::Unsupported {
+                text,
+                min_x_value: 0,
+            },
+        );
     }
     fn trigger_at(&mut self, line: usize, def: TriggerDefinition) {
         self.last_trigger = Some(def.clone());
@@ -8228,16 +8252,19 @@ fn lower_unsupported_node(text: &str, min_x_value: u32) -> AbilityDefinition {
 }
 
 /// Create an Unimplemented fallback ability.
-pub(super) fn make_unimplemented(line: &str) -> AbilityDefinition {
+///
+/// Private since Plan 05b D13: with both hand-built residual sites converted to
+/// `OracleNodeIr::Unsupported`, `lower_unsupported_node` is the only caller, so
+/// the residual now has a single construction authority reachable only through
+/// the node. A new residual producer must go through the node rather than
+/// minting a definition of its own.
+fn make_unimplemented(line: &str) -> AbilityDefinition {
     tracing::debug!(oracle_text = line, "unimplemented ability line");
-    AbilityDefinition::new(
-        AbilityKind::Spell,
-        Effect::Unimplemented {
-            name: "unknown".to_string(),
-            description: Some(line.to_string()),
-        },
-    )
-    .description(line.to_string())
+    // `Effect::unimplemented` is the single authority CLAUDE.md mandates; it
+    // expands to exactly the literal this line used to spell out
+    // (`name`, `description: Some(fragment)`), so the swap is a value identity.
+    AbilityDefinition::new(AbilityKind::Spell, Effect::unimplemented("unknown", line))
+        .description(line.to_string())
 }
 
 /// Check if an AbilityDefinition (or its sub_ability chain) contains Unimplemented effects.

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -11,7 +11,7 @@ use crate::types::ability::{
 use crate::types::triggers::TriggerMode;
 use crate::types::zones::Zone;
 
-use super::oracle::{has_unimplemented, make_unimplemented};
+use super::oracle::has_unimplemented;
 use super::oracle_classifier::{
     is_effect_sentence_candidate, is_granted_static_line, is_replacement_pattern, is_static_pattern,
 };
@@ -353,10 +353,29 @@ pub(crate) fn parse_class_oracle_text(
                 }
             }
 
-            // Fallback: unimplemented
+            // Fallback: the honest-failure residual (Plan 05b U0-62).
+            //
+            // Two routes reach here, and **the discard on the second one is
+            // deliberate and preserved exactly.** Route one is a line no
+            // recognizer above claimed at all. Route two is an effect-sentence
+            // candidate whose chain DID parse, but whose lowered root contains an
+            // `Unimplemented` — that `ir` is thrown away and the residual is
+            // rebuilt from `line`. Keeping the partial chain instead would be a
+            // *behavior* change, not a conversion: it would name the failed
+            // clause rather than the fixed `"unknown"` sentinel and would move
+            // the coverage key. `ir` is scoped inside the `if` block above, so
+            // the discard is structural here rather than a convention a later
+            // edit could quietly drop.
+            //
+            // `min_x_value: 0` is the floor the discarded shape carried:
+            // `AbilityDefinition::new` defaults it to 0 and nothing on either
+            // route raises it before this point.
             items.push((
                 line_index,
-                OracleNodeIr::PreLoweredSpell(make_unimplemented(line)),
+                OracleNodeIr::Unsupported {
+                    text: line.to_string(),
+                    min_x_value: 0,
+                },
             ));
         }
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26928,6 +26928,14 @@ fn apply_ability_shell_envelope(def: &mut AbilityDefinition, shell: &AbilityShel
     def.min_x_value = def.min_x_value.max(shell.min_x_value);
     // CR 707.10: monotone OR, so a `false` default can never clear the flag.
     def.cant_be_copied |= shell.cant_be_copied;
+    // CR 608.2d: the controller's "you may" choice. Monotone OR for the same
+    // reason as `cant_be_copied` — and here the reason is load-bearing rather
+    // than merely tidy: `lower_effect_chain_ir` legitimately sets this from the
+    // printed text, so an assignment would let every producer building a
+    // `default()` shell CLEAR a flag the chain had already established. The OR is
+    // what keeps `AbilityShellIr::default()` a no-op and the widening
+    // byte-identical by construction.
+    def.optional |= shell.optional;
     if let Some(description) = &shell.description {
         def.description = Some(description.clone());
     }

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -343,6 +343,53 @@ pub(crate) enum OracleNodeIr {
     /// Strive per-target surcharge.
     StriveCost(ManaCost),
 
+    /// A printed line no recognizer claimed — the shared honest-failure
+    /// residual, in IR form.
+    ///
+    /// # Why a node and not a chain parse
+    ///
+    /// Two sites in the parser build this residual today and both do the same
+    /// thing: they take the line's text and produce an `Effect::Unimplemented`
+    /// whose `name` is the fixed sentinel `"unknown"` and whose `description` is
+    /// the residual text, with that same text on the definition's `description`.
+    /// **That exact `name`/`description` pair is load-bearing for coverage** —
+    /// `game/coverage.rs` and the parser-gap tooling key on it. Re-deriving the
+    /// residual by running the effect-chain parser over the line would produce a
+    /// *different* `name` (whatever clause the chain failed inside), which is why
+    /// this is a node carrying the raw text rather than a chain seeded with a
+    /// gap clause. Lowered by `oracle::lower_unsupported_node`, which delegates
+    /// to `oracle::make_unimplemented` — the same function both producers call —
+    /// so the residual has exactly one construction authority.
+    ///
+    /// # Why it carries a CR 601.2b X floor
+    ///
+    /// The residual is a *spell* for every accounting purpose: it is emitted
+    /// through the ability channel, it occupies a CR 707.9a printed ability slot,
+    /// and it lands on the `spells_emitted` stack. That makes it reachable by
+    /// `DocEmitter::raise_last_spell_min_x`, whose `spell_min_x_mut().expect(..)`
+    /// is sound only while **every** node on that stack can name where its floor
+    /// lives. Carrying `min_x_value` keeps that invariant total. Omitting it
+    /// would not merely lose a floor — it would turn a compile-time-guaranteed
+    /// `Some` into a runtime panic on a structurally reachable path, which is the
+    /// failure mode the exhaustive matches over this enum exist to prevent.
+    ///
+    /// The pre-lowered spell shape this replaces already carried the field (it is
+    /// an `AbilityDefinition` root field), so this is a preservation, not a
+    /// widening.
+    // Producers arrive in the next commit, which deletes this allow rather than
+    // moving it. Landing the variant with zero producers is what makes the
+    // infrastructure byte-identical by construction.
+    #[allow(dead_code)]
+    Unsupported {
+        /// The verbatim residual text. Becomes BOTH the `Effect::Unimplemented`
+        /// `description` and the definition's `description`, exactly as
+        /// `make_unimplemented` sets them.
+        text: String,
+        /// CR 601.2b: the floor on this residual's announced X ("X can't be 0").
+        /// `0` means "no floor", mirroring the root field's own encoding.
+        min_x_value: u32,
+    },
+
     // -----------------------------------------------------------------------
     // PLAN-05 DEBT — pre-lowered escape hatches.
     //
@@ -392,6 +439,11 @@ impl OracleNodeIr {
         match self {
             OracleNodeIr::Spell(ir) => Some(&mut ir.shell.min_x_value),
             OracleNodeIr::PreLoweredSpell(def) => Some(&mut def.min_x_value),
+            // The residual is a spell for slot accounting, so it is reachable
+            // here and must name its floor. `lower_unsupported_node` applies it
+            // with `max`, so raising it here composes the same way the other two
+            // shapes do.
+            OracleNodeIr::Unsupported { min_x_value, .. } => Some(min_x_value),
             OracleNodeIr::Trigger(_)
             | OracleNodeIr::Static(_)
             | OracleNodeIr::Replacement(_)
@@ -861,7 +913,14 @@ impl OracleDocBuilder {
             // Pushing IS the increment: `ability_index()` reads `spells_emitted.len()`.
             // Reached only after the duplicate/conflict/fragment early-returns above,
             // so a rejected `emit` mutates neither counter.
-            OracleNodeIr::Spell(_) | OracleNodeIr::PreLoweredSpell(_) => {
+            // The residual joins this arm because it lowers to an
+            // `AbilityDefinition` pushed onto `result.abilities` exactly like the
+            // other two spell shapes — so it consumes a printed ability slot, and
+            // omitting it would shift every ability printed after an unrecognized
+            // line one CR 707.9a slot low.
+            OracleNodeIr::Spell(_)
+            | OracleNodeIr::PreLoweredSpell(_)
+            | OracleNodeIr::Unsupported { .. } => {
                 self.spells_emitted.push(slot.id);
             }
             OracleNodeIr::Trigger(_) | OracleNodeIr::PreLoweredTrigger(_) => {

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -416,12 +416,17 @@ impl OracleNodeIr {
     /// CR 601.2b: the floor on this spell node's announced X ("X can't be 0"),
     /// whichever shape holds it — `None` for every non-spell node.
     ///
-    /// Both spell shapes store the floor as a `u32` whose `0` means "no floor",
-    /// but at different layers: a pre-lowered definition carries the resolved
-    /// root field, while an `AbilityIr` carries the shell's pre-lowering stamp.
-    /// They are interchangeable for raising a floor because
-    /// `apply_ability_shell_envelope` applies the shell's value onto the lowered
-    /// root with `max` — so `max`-ing either one yields `max(lowered, v)`.
+    /// All three spell shapes store the floor as a `u32` whose `0` means "no
+    /// floor", but at three different layers: a pre-lowered definition carries
+    /// the resolved root field, an `AbilityIr` carries the shell's pre-lowering
+    /// stamp, and the residual carries it on the node itself (it holds text, not
+    /// a definition, so there is no root or shell to put it on until
+    /// `lower_unsupported_node` builds one).
+    ///
+    /// All three are interchangeable for raising a floor because every path
+    /// applies its value with `max` — `apply_ability_shell_envelope` for the
+    /// shell, `lower_unsupported_node` for the residual — so `max`-ing any of
+    /// them yields `max(lowered, v)`.
     ///
     /// Exposed as a `&mut u32` rather than a `mutate(f)` closure so the caller
     /// cannot express anything but a floor change. The general closure mutator
@@ -1078,9 +1083,10 @@ enum PrintedItemKind {
 /// `slot`, the item's position among the card's printed abilities.
 ///
 /// The lowering-seam entry point (`lower_oracle_ir`, `oracle.rs`). It takes the
-/// definition rather than the node because both spell node shapes converge on
-/// one here: the pre-lowered shape lends its definition and `Spell` has just
-/// been lowered by `lower_ability_ir`, and CR 707.9a does not distinguish them —
+/// definition rather than the node because all three spell node shapes converge
+/// on one here: the pre-lowered shape lends its definition, `Spell` has just
+/// been lowered by `lower_ability_ir`, and the residual has just been built by
+/// `lower_unsupported_node`. CR 707.9a does not distinguish them —
 /// a printed ability occupies its printed slot however the parser represented it.
 pub(crate) fn stamp_printed_ability_slot(def: &mut AbilityDefinition, slot: usize) {
     stamp_retained_printed_slot(def, slot, PrintedItemKind::Ability);

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -412,7 +412,45 @@ pub(crate) enum OracleNodeIr {
     PreLoweredSpell(AbilityDefinition),
 }
 
+/// Borrowed representation of the three spell payload shapes.
+pub(crate) enum SpellPayloadIr<'a> {
+    /// An IR-native spell or activated-ability body.
+    Ir(&'a AbilityIr),
+    /// An already-lowered spell or activated-ability definition.
+    Lowered(&'a AbilityDefinition),
+    /// An honest unsupported spell residual that lowers to a definition.
+    Residual { text: &'a str, min_x_value: u32 },
+}
+
 impl OracleNodeIr {
+    /// Returns this node's spell payload, if it has one.
+    ///
+    /// Exhaustive over the enum on purpose: a future spell payload must enter
+    /// this layer before a reader can lower or borrow it.
+    pub(crate) fn spell_payload(&self) -> Option<SpellPayloadIr<'_>> {
+        match self {
+            OracleNodeIr::Spell(ir) => Some(SpellPayloadIr::Ir(ir)),
+            OracleNodeIr::PreLoweredSpell(def) => Some(SpellPayloadIr::Lowered(def)),
+            OracleNodeIr::Unsupported { text, min_x_value } => Some(SpellPayloadIr::Residual {
+                text,
+                min_x_value: *min_x_value,
+            }),
+            OracleNodeIr::Trigger(_)
+            | OracleNodeIr::Static(_)
+            | OracleNodeIr::Replacement(_)
+            | OracleNodeIr::Keyword(_)
+            | OracleNodeIr::Modal(_)
+            | OracleNodeIr::AdditionalCost(_)
+            | OracleNodeIr::CastingRestriction(_)
+            | OracleNodeIr::CastingOption(_)
+            | OracleNodeIr::SolveCondition(_)
+            | OracleNodeIr::StriveCost(_)
+            | OracleNodeIr::PreLoweredTrigger(_)
+            | OracleNodeIr::PreLoweredStatic(_)
+            | OracleNodeIr::PreLoweredReplacement(_) => None,
+        }
+    }
+
     /// CR 601.2b: the floor on this spell node's announced X ("X can't be 0"),
     /// whichever shape holds it — `None` for every non-spell node.
     ///

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -376,10 +376,6 @@ pub(crate) enum OracleNodeIr {
     /// The pre-lowered spell shape this replaces already carried the field (it is
     /// an `AbilityDefinition` root field), so this is a preservation, not a
     /// widening.
-    // Producers arrive in the next commit, which deletes this allow rather than
-    // moving it. Landing the variant with zero producers is what makes the
-    // infrastructure byte-identical by construction.
-    #[allow(dead_code)]
     Unsupported {
         /// The verbatim residual text. Becomes BOTH the `Effect::Unimplemented`
         /// `description` and the definition's `description`, exactly as

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -142,8 +142,13 @@ impl EffectChainIr {
 /// widening satisfies the categorical-boundary rule rather than straddling rule
 /// sections.
 ///
-/// **This is 10 of `AbilityDefinition`'s 38 root fields, deliberately not a
-/// mirror of the root.** Fields excluded on purpose — `effect`, `sub_ability`,
+/// **This is 12 of `AbilityDefinition`'s 38 root fields, deliberately not a
+/// mirror of the root.** (Counted from the source: this struct has thirteen
+/// fields, twelve of which mirror a root field; `stages` is a transform list,
+/// not a root field. A0's "10" counted the fields that tranche *added* and
+/// omitted the pre-existing `sub_link`, so it read one low even before
+/// `optional` arrived.) Fields
+/// excluded on purpose — `effect`, `sub_ability`,
 /// `else_ability`, `condition` — are all CR 608.2 resolution tree and are
 /// already expressible as `ClauseIr`/`ClauseDisposition`. A shell that mirrored
 /// the root would re-open the escape hatch this type exists to close.
@@ -263,6 +268,55 @@ pub(crate) struct AbilityShellIr {
     /// and UI provenance. `Some(_)` overrides; `None` defers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) description: Option<String>,
+
+    /// CR 608.2d: the controller chooses whether to perform the effect
+    /// ("You may …"). Applied as a monotone OR, never an assignment.
+    ///
+    /// # This is the one field that is NOT the CR 602.1 activation envelope
+    ///
+    /// Everything else on this shell partitions along the seam CR 602.1 (:2514)
+    /// draws — cost before the colon, activation instructions after it. `optional`
+    /// does not: CR 608.2d (`MagicCompRules.txt:2795`) places the choice
+    /// *"while applying the effect"*, which is CR 608.2 resolution, the half this
+    /// type deliberately leaves to [`EffectChainIr`]. So its presence here is an
+    /// explicit, named exception rather than an extension of the partition, and
+    /// this doc block is where the exception is justified.
+    ///
+    /// # Why the exception is nonetheless correct
+    ///
+    /// The mechanical requirement is that `optional` be stamped
+    /// **unconditionally, after lowering** — which is exactly what the
+    /// game-start recognizers (`AbilityKind::Mulligan`, `BeginGame`) do by hand
+    /// today: they call the chain parser, then set `def.optional = true` on the
+    /// result. The alternative — expressing the flag on the first clause and
+    /// letting assembly carry it to the root — is **not** equivalent:
+    /// `assemble_effect_chain` maps a clause's optionality to the root
+    /// conditionally, through four suppressions plus a `SearchOutsideGame` arm
+    /// that forces `optional = false`. A recognizer whose printed text says
+    /// "you may" would silently lose the flag on any input that took one of
+    /// those arms. Named, so the claim is checkable: the `clause_ir.parsed
+    /// .optional` propagation in `assemble_effect_chain` is suppressed for
+    /// `Effect::GrantCastingPermission`, for `is_lingering_cast_from_zone`, for
+    /// `is_join_forces_pay_any_amount_mana_cost` and for
+    /// `is_pay_to_end_effect_termination`, and a following arm sets
+    /// `def.optional = false` outright for `Effect::SearchOutsideGame`. It also
+    /// assumes clause 0 becomes the emitted root, which `ClauseDisposition` does
+    /// not guarantee. The shell is the only place the stamp can be unconditional
+    /// *and* survive the IR conversion, so the field lives here and the
+    /// categorical impurity is paid knowingly.
+    ///
+    /// # Why a monotone OR
+    ///
+    /// `def.optional |= shell.optional`, mirroring `cant_be_copied`. The `false`
+    /// default can then never clear a flag lowering established, so
+    /// `AbilityShellIr::default()` stays a no-op and the widening is
+    /// byte-identical by construction — A0's defer-on-default property, which is
+    /// the whole reason a shell field can be added without touching any existing
+    /// producer. An assignment would break it: every unconverted site building a
+    /// `default()` shell would begin clearing an `optional` that
+    /// `lower_effect_chain_ir` had legitimately set from the printed "you may".
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) optional: bool,
 
     /// Chain-**structure** folds to run after the field stamps, in list order.
     ///

--- a/crates/engine/src/parser/oracle_ir/feature.rs
+++ b/crates/engine/src/parser/oracle_ir/feature.rs
@@ -465,7 +465,12 @@ pub(crate) fn scope_to_unit(
             }
             OracleNodeIr::CastingRestriction(r) => scoped.casting_restrictions.push(r.clone()),
             OracleNodeIr::CastingOption(o) => scoped.casting_options.push(o.clone()),
-            OracleNodeIr::Spell(_)
+            // The residual contributes through the ability id track above, like
+            // every other spell shape: it lowers into `result.abilities`, so the
+            // `pick` over `tracks.abilities` already attributes it to this unit.
+            // Adding it here as well would double-count it as unit evidence.
+            OracleNodeIr::Unsupported { .. }
+            | OracleNodeIr::Spell(_)
             | OracleNodeIr::Trigger(_)
             | OracleNodeIr::Static(_)
             | OracleNodeIr::Replacement(_)

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1309
+assertion_line: 1757
 expression: "&ir"
 ---
 {
@@ -23,22 +23,9 @@ expression: "&ir"
         "fragment": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
-            "name": "unknown",
-            "description": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll."
-          },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+        "Unsupported": {
+          "text": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
+          "min_x_value": 0
         }
       }
     },

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -13,7 +13,7 @@
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
 crates/engine/src/parser/oracle.rs         15
-crates/engine/src/parser/oracle_class.rs    4
+crates/engine/src/parser/oracle_class.rs    3
 
 # --- infrastructure: NOT burn-down targets ----------------------------------
 # The variant declarations and their consumers. These legitimately survive

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -12,14 +12,15 @@
 # real IR nodes. Every tranche that converts a producer must lower its number
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
-crates/engine/src/parser/oracle.rs         15
+crates/engine/src/parser/oracle.rs         13
 crates/engine/src/parser/oracle_class.rs    3
 
 # --- infrastructure: NOT burn-down targets ----------------------------------
 # The variant declarations and their consumers. These legitimately survive
 # until the last producer is gone and the variants themselves are deleted, so
 # they are ceilings only — they are not expected to reach 0 before then.
-crates/engine/src/parser/oracle_ir/doc.rs      16
+# 20 includes spell_payload's exhaustive consumer arms, not producers.
+crates/engine/src/parser/oracle_ir/doc.rs      20
 crates/engine/src/parser/oracle_ir/feature.rs   9
 
 # Prose references in the T1 witness-corpus comment.


### PR DESCRIPTION
Plan 05b — the two designs the maintainer ruled on: a **shared residual node** and **`optional` on the ability shell**. Follows #6726.

These were the last two rows blocked on a decision rather than on work. With them landed, §6's closing criterion — deleting the pre-lowered spell variants — becomes reachable for the first time.

Five commits, one concern each. Commits 1 and 3 convert nothing: infrastructure lands byte-identical by construction, then producers move under their own reviewable diff. That staging is what made T8-A0 reviewable and is deliberate.

| # | commit | producers |
|---|---|---|
| 1 | add `OracleNodeIr::Unsupported` | **zero** |
| 2 | convert U0-62 (`oracle_class.rs`) + U0-02 (`oracle.rs`) | 2 |
| 3 | add `optional` to `AbilityShellIr` | **zero** |
| 4 | convert U0-43, the CR 103.5b mulligan recognizer | 1 |
| 5 | name the third spell shape in the prose that says two | — |
| 6 | centralize spell payload classification (review feedback) | — |

## The residual node, and why the discard is load-bearing

`oracle_class.rs` reaches its residual by two routes, and on one of them the chain parser **runs**, `has_unimplemented` is true, and the parsed definition is **thrown away** before `make_unimplemented(line)` is built fresh. Preserving that partial chain would be a *behavior change* — it would name the failed clause rather than the fixed `"unknown"` sentinel, moving the coverage key. Discarding it is what keeps the conversion byte-identical.

The node therefore takes `text` and nothing from the discarded IR, and `ir` is **scoped inside the `if` block**, so the discard is structural rather than a convention a later edit could quietly drop.

## `Unsupported` carries an X floor — soundness, not corpus

Shape landed: `Unsupported { text: String, min_x_value: u32 }`.

`raise_last_spell_min_x` does `node.spell_min_x_mut().expect(..)`, and the residual is emitted onto `spells_emitted` — so it **is** a spell for slot accounting and can be handed to that assertion. A text-only variant would have to answer `None` there, converting a compile-time-guaranteed `Some` into a runtime panic on a structurally reachable path. The pre-lowered shape already carried the floor as an `AbilityDefinition` root field, so this preserves a floor rather than inventing one.

The reachability probe says `raise_last_spell_min_x` is **never** reached with a residual node in either test binary. Reported as a null: the field is **soundness-preserving, not corpus-required**, and the argument stands independently of today's corpus.

## The two `_ => None` readers, and the layer that was actually missing

`lower_spell_node` and `item_ability` both ended in a wildcard, so the new variant compiled clean and
silently became a non-spell. The dangerous one is `lower_spell_node`: it is the `and_then` target
behind `last_ability_definition()`, read mid-loop by `parsed_result_recently_granted_flashback` and by
the cross-line "instead" fold. A `None` there is neither a compile error nor a panic — it is a
behavior change on a *different* card from the converted one, which per-card byte-identity cannot
catch.

Commit 6 removes both, but **not** by enumerating `=> None` arms. The file had already diagnosed
itself. `item_trigger`'s doc:

> The exhaustiveness obligation lives on `TriggerNodeIr::definition()`, not on this match, and that
> is the correct layer.

and `item_ability`'s, explaining why the spell side could not do the same:

> There is no equivalent layer to push this obligation onto: a spell node's IR payload is an
> `AbilityIr`, not an enum of definition-owning representations, so all three shapes are named here.

So the wildcard was a symptom; the missing layer was the defect. `OracleNodeIr::spell_payload() ->
Option<SpellPayloadIr<'_>>` now supplies it — exhaustive over all 16 variants with no wildcard,
sitting beside its sibling `spell_min_x_mut`, which already carries the same "which variants are
spell-shaped" obligation for the X floor. Both readers then match a **closed three-variant**
representation, so a fourth spell shape breaks both at compile time.

Enumerating thirteen `=> None` arms in each reader would have stated the classification a third and
fourth time. This states it once and deletes two copies.

### It moves Gate P the right way

The naive fix collides with the ratchet: `oracle.rs` sat at exactly its ceiling of 15, and the arms
name three pre-lowered variants twice each — 21, gate fails. The ratchet is a textual grep and
cannot tell a *producer* (debt) from a `=> None` *exhaustiveness arm* (the opposite of debt).

Pushing the obligation down instead means `oracle.rs` stops naming `PreLoweredSpell` in both readers:

```
crates/engine/src/parser/oracle.rs        15 -> 13     (a burn-down improvement)
crates/engine/src/parser/oracle_ir/doc.rs 16 -> 20
```

`doc.rs` is the ledger's own *"infrastructure: NOT burn-down targets"* section — where the variant
declarations and their consumers are explicitly expected to live until the variants are deleted. **No
gate was modified and no burn-down ceiling was raised.**

### Three sibling readers are deliberately left alone

`item_replacement`, `item_trigger`, and `item_static` have the identical `_ => None` shape.
CodeRabbit flagged two of the five; the class has five. They are untouched by this PR and their
hazard is unchanged by it, so generalising the layer to the trigger/static/replacement sides is its
own reviewable diff rather than a rider here.

Worth recording for whoever takes it: `item_trigger`'s doc argues its wildcard is safe because *"a
new trigger representation is a new `TriggerNodeIr` variant, so it breaks that match at compile time
before it can reach here."* That is precisely the assumption this plan falsified on the spell side —
`Unsupported` landed on `OracleNodeIr`, not inside `AbilityIr`. The premise should be re-tested, not
inherited.

## `optional` on the shell — a monotone OR, and why that is load-bearing

`def.optional |= shell.optional`, placed beside `cant_be_copied`. Never an assignment: `lower_effect_chain_ir` legitimately sets `optional` from a printed "you may", so an assignment would let any producer building a `default()` shell **clear** a flag the chain had already established. The OR keeps `AbilityShellIr::default()` a no-op, which is what makes the widening byte-identical by construction — no existing producer was touched.

The field doc states plainly that this is the one field that is **not** the CR 602.1 activation envelope. CR 608.2d places the choice "while applying the effect" — CR 608.2 resolution, the half `EffectChainIr` owns. It lives on the shell specifically so it can be stamped **unconditionally after lowering**, matching what the game-start recognizers do by hand, and thereby bypassing `assemble_effect_chain`'s conditional clause→root mapping — four suppressions plus an arm that forces `optional = false` for `SearchOutsideGame`. That was read in the source, not taken from the brief.

## U0-43 is by construction, and the identity is the function body

`parse_effect_chain(t, k)` **is** `lower_ability_ir(&parse_ability_ir_standalone(t, k))` — the entire body in `oracle_effect/mod.rs`, not a claim about it. Splitting the call moves *where* lowering happens, not *what* it produces. Both stamps ride the shell: `description` as an `Option` override, `optional` as a monotone OR against `true`, value-identical to the `def.optional = true` it replaces on every input.

**`clauses[0].parsed.optional` is deliberately NOT set.** Routing it through clause 0 would subject it to the conditional mapping above, and would additionally assume clause 0 becomes the emitted root — which `ClauseDisposition` does not guarantee.

## Measurement

The claim is that this PR changes no generated card data. It is measured **against the PR's own
base**, not against the commits' original authoring base:

```
FULL-POOL BYTE-IDENTICAL
2737d0783ece3443cb0041323114ee06eaa06f8e30431f817784e4dd5312f289   55c5d8dc11  (PR base)
2737d0783ece3443cb0041323114ee06eaa06f8e30431f817784e4dd5312f289   68f8ea665f  (tip)
```

Generator rebuilt fresh on each side, run from the worktree repo root against the real
`AtomicCards.json` (158,014,511 bytes — `readlink -f` resolved and size-checked, since a run against
the 507 KiB `test_fixture.json` would be void evidence rather than a green), `MTGJSON_SKIP_REFRESH=1`,
identical MTGJSON sidecars symlinked on both sides.

**Why this was re-measured rather than inherited.** Two earlier measurements existed and *neither
covered this PR against its actual base*: commits 1–4 were measured identical on `fd59ea48f8`, their
authoring base, and commit 6 on `77caacb159`. Commits 1–4 were cherry-picked onto `55c5d8dc11` and
never re-measured there. The gap was covered only by the argument that the three intervening commits
never reference `OracleNodeIr`, the pre-lowered variants, or `AbilityShellIr` — which is weaker than
it reads, because those commits are **parser fixes** and commit 2 changed which lines fall through to
the residual path. A new recognizer that stops a line reaching `make_unimplemented` would interact
without naming any of those types. So it was measured instead of argued.

Commit 6's own base/tip pair was additionally recorded **before** its implementation began, so that
identity claim is not circular.

**Probe verified applied**, not assumed: the filtered output for commit 2 (38 Class faces ∪ 33 "same
is true" cards → 76 exported faces) contains exactly the three residuals the census predicted —
Barbarian Class, Gourmand's Talent, and Cairn Wanderer's `the same is true for landwalk, protection`.
Commit 4's population (No-Regrets Egret, Serum Powder) still exports `kind: Mulligan`,
`optional: true`, full printed line as `description`.

*Stated rather than buried:* D13's original run lacked `SetList.json` and emitted "legality inference
will be degraded". The measurements above supply it, so they are production-shaped as well as
mutually comparable.

## Reachability (§5.3) — every null reported as a null

| probe | `--lib` | `--test integration` |
|---|---|---|
| Class residual (U0-62) | REACHED | REACHED |
| "same is true" residual (U0-02) | REACHED | NULL |
| mulligan (U0-43) | REACHED | NULL |
| `raise_last_spell_min_x`, any node | REACHED | NULL |
| `raise_last_spell_min_x`, **residual** node | **NULL** | **NULL** |

Attributed by probe message, never by test name. Probes run before any perturbation and fully reverted.

## Gates

```
cargo fmt --all                                 clean
clippy -p engine --lib -- -D warnings           zero warnings
cargo nextest run -p engine --lib               17909 passed, 6 skipped
cargo nextest run -p engine --test integration   4159 passed, 2 skipped
Gate P (PreLowered ratchet)                     PASS   oracle_class.rs 4 -> 3, oracle.rs 15 -> 13
check-skill-doc.sh                              PASS
check-parser-combinators.sh                     Gate G PASS / Gate A PASS
*.snap.new pending                              0
```

CR-annotation diff gate: **zero UNVERIFIED**. CR 103.5b, 601.2b, 602.1, 608.2, 608.2d, 707.9a — text read, not existence checked.

**Snapshots:** exactly one `*_ir.snap` moved (`barbarian_class_ir`, the fixture carrying a residual) — same text, same floor, now the typed node. **Zero `*_lowered.snap` changes, asserted rather than assumed:** the `_ir`/`_lowered` masking trap was hit deliberately, the `_ir` accepted, and the test **re-run** to confirm `_lowered` passes unchanged.

## Two findings worth a reviewer's attention

**The textual ratchet is blind to producers routing through a shared emitter helper.** Two producers were converted; the ratchet moved once. U0-02's producer was `emitter.ability_at(line, make_unimplemented(..))` — the counted token lives once inside `ability_at`'s body, not at the producer, so converting it reduces the textual count by **zero**. `oracle.rs` legitimately stays at 15 and the ledger was **not** touched upward. The discriminating measure is the `ability_at` call-site count: **18 → 17** at commit 2, **17 → 16** at commit 4.

**`make_unimplemented` was hand-constructing an `Effect::Unimplemented` literal**, the pattern CLAUDE.md gates and `check-parser-combinators.sh` enforces elsewhere. Replaced with the sanctioned `Effect::unimplemented` constructor (value-identical) and made private, so the residual's single-authority property is real rather than conventional.

## Also harvested, not fixed

- `oracle_dispatch.rs` builds the same `Effect::unimplemented("unknown", line)` pair via the sanctioned constructor — a third producer of this coverage key, and the natural next member of the `Unsupported` family. Not a census row; out of scope here.
- `SKILL.md` claims 26 pre-lowered references in `oracle.rs`; the actual count is 15, and was 15 before this PR. Drift, not gated by `check-skill-doc.sh` (which does not check prose counts).
- The shell's doc block said it mirrored 10 of `AbilityDefinition`'s root fields; counted from source it was already off by one before this PR, having omitted the pre-existing `sub_link`. Corrected with the count derived from source.

## Base note

D13's four commits were authored on `fd59ea48f8`; commit 6 answers review feedback on top. Rather
than reason about whether the cherry-pick preserved byte-identity, the whole PR was **re-measured
against its actual base** `55c5d8dc11` — see Measurement above. The queue re-validates.
