### PR TITLE
fix(frontend): don't drop queued PayCost responses under turn control

### DIFF
--- a/client/src/game/__tests__/dispatchTurnControlPayCostQueue.test.ts
+++ b/client/src/game/__tests__/dispatchTurnControlPayCostQueue.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression (#6431): "I can't pay the sacrifice a mountain cost on Lava Dart
+ * while controlling my opponent with Emrakul, the Promised End."
+ *
+ * CR 723.5: under a turn-control effect (Emrakul, the Promised End;
+ * Mindslaver) the controller makes the controlled player's decisions. The
+ * engine models this by keeping the WaitingFor's semantic `player` field on
+ * the controlled seat while re-deriving `gameState.priority_player` to the
+ * authorized submitter (`sync_priority_player_from_waiting_for` in
+ * `public_state.rs`, for every single-actor WaitingFor variant).
+ *
+ * `dispatch.ts`'s `waitingForActorMatches` — used by `queuedLocalActionStillApplies`
+ * to decide whether a queued local action is still valid once the animation
+ * mutex releases — only consulted `gameState.priority_player` for the
+ * `"Priority"` WaitingFor variant. Every other single-actor variant (notably
+ * `PayCost`, the prompt Lava Dart's flashback "Sacrifice a Mountain" cost
+ * uses) fell through to a bare `fields.player === actor` check. Under
+ * Emrakul's turn control that field names the controlled seat (P1), not the
+ * controller actually submitting the action (P0) — so the queued
+ * `SelectCards` response sacrificing the Mountain was misjudged "stale" and
+ * silently dropped, exactly matching "I click the Mountain and nothing
+ * happens."
+ *
+ * This test drives the REAL `dispatchAction` pipeline: P0 casts the
+ * flashback spell (as P1's authorized submitter), and — while that action's
+ * animation window is still open (so the dispatch mutex is held) — P0
+ * immediately submits the Mountain as the sacrifice cost target. That second
+ * action must reach `adapter.submitAction`, not be dropped.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  EngineAdapter,
+  EngineSnapshot,
+  GameAction,
+  GameState,
+  LegalActionsResult,
+  SubmitResult,
+} from "../../adapter/types";
+import { nextSnapshotSeq } from "../../adapter/types";
+import { useGameStore } from "../../stores/gameStore";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import {
+  buildGameState,
+  buildLegalActionsResult,
+  buildPriorityWaitingFor,
+} from "../../test/factories/gameStateFactory";
+import { dispatchAction } from "../dispatch";
+
+const MOUNTAIN_ID = 10;
+
+// P0 controls P1's turn (CR 723): the flashback cast and its PayCost prompt
+// are both P1's decisions, submitted by P0.
+const PRIORITY = buildPriorityWaitingFor({ data: { player: 1 } });
+
+function buildPayCostWaitingFor(): GameState["waiting_for"] {
+  // A fresh object every call — mirrors a real commit producing a
+  // brand-new (structurally equal) WaitingFor, so `Object.is` genuinely
+  // differs from whatever was captured when the second action was queued.
+  return {
+    type: "PayCost",
+    data: {
+      player: 1,
+      kind: "Sacrifice",
+      choices: [MOUNTAIN_ID],
+      count: 1,
+      min_count: 1,
+      resume: {
+        type: "Spell",
+        data: {
+          spell: {
+            object_id: 1,
+            card_id: 1,
+            ability: { targets: [] },
+            cost: { type: "NoCost" },
+          },
+        },
+      },
+    },
+  } as unknown as GameState["waiting_for"];
+}
+
+const CAST_ACTION = {
+  type: "CastSpell",
+  data: { object_id: 1, card_id: 1, targets: [], payment_mode: "Auto" },
+} as unknown as GameAction;
+
+const SACRIFICE_ACTION = {
+  type: "SelectCards",
+  data: { cards: [MOUNTAIN_ID] },
+} as unknown as GameAction;
+
+const PRIORITY_STATE = buildGameState({
+  waiting_for: PRIORITY,
+  active_player: 1,
+  priority_player: 0,
+  turn_number: 3,
+});
+
+const PRIORITY_LEGAL = buildLegalActionsResult({ actions: [CAST_ACTION] });
+const PAY_COST_LEGAL = buildLegalActionsResult({ actions: [SACRIFICE_ACTION] });
+
+/**
+ * An engine that advances Priority{player:1} -> PayCost{player:1} once, on a
+ * schedule the test controls (`advance()`) — modelling the flashback cast
+ * resolving into its sacrifice-cost prompt during the first action's
+ * animation window.
+ */
+function fakeEngine() {
+  let advanced = false;
+  return {
+    advance: () => {
+      advanced = true;
+    },
+    state: (): GameState =>
+      advanced
+        ? buildGameState({
+            waiting_for: buildPayCostWaitingFor(),
+            active_player: 1,
+            priority_player: 0,
+            turn_number: 3,
+          })
+        : PRIORITY_STATE,
+    legal: (): LegalActionsResult => (advanced ? PAY_COST_LEGAL : PRIORITY_LEGAL),
+  };
+}
+
+function seedStore(adapter: EngineAdapter): void {
+  useGameStore.setState({
+    gameId: null,
+    gameMode: "ai",
+    adapter,
+    gameState: PRIORITY_STATE,
+    waitingFor: PRIORITY,
+    legalActions: [CAST_ACTION],
+    events: [],
+    eventHistory: [],
+    logHistory: [],
+    nextLogSeq: 0,
+    stateHistory: [],
+    turnCheckpoints: [],
+    lastCommittedSeq: 0,
+  });
+}
+
+const baseAdapter = (): Pick<
+  EngineAdapter,
+  "initialize" | "initializeGame" | "restoreState" | "getAiAction" | "estimateBracket" | "dispose"
+> => ({
+  initialize: vi.fn().mockResolvedValue(undefined),
+  initializeGame: vi.fn().mockResolvedValue({ events: [] } as SubmitResult),
+  restoreState: vi.fn(),
+  getAiAction: vi.fn().mockReturnValue(null),
+  estimateBracket: vi.fn().mockResolvedValue(null),
+  dispose: vi.fn(),
+});
+
+describe("turn-control PayCost queueing (#6431)", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+    // A non-zero multiplier keeps a real animation window open across the
+    // second dispatch call, which is the window the queued action lands in.
+    usePreferencesStore.setState({ animationSpeedMultiplier: 1 });
+    vi.useFakeTimers();
+  });
+
+  it("submits a queued sacrifice-cost response instead of dropping it as stale", async () => {
+    const engine = fakeEngine();
+    const adapter: EngineAdapter = {
+      ...baseAdapter(),
+      submitAction: vi.fn(async (): Promise<SubmitResult> => ({
+        events: [{ type: "LifeChanged", data: { player_id: 1, amount: -3 } }],
+        log_entries: [],
+      })),
+      getState: vi.fn(async () => engine.state()),
+      getLegalActions: vi.fn(async () => engine.legal()),
+      getSnapshot: vi.fn(async (): Promise<EngineSnapshot> => ({
+        state: engine.state(),
+        legalResult: engine.legal(),
+        seq: nextSnapshotSeq(),
+      })),
+    };
+    seedStore(adapter);
+
+    // P0 casts the flashback spell as P1's authorized submitter. The engine
+    // resolves the cast into its PayCost{player:1} prompt synchronously
+    // within this call (before `submitAction`'s promise has even settled),
+    // so it must be visible to the `getSnapshot()` fetch this dispatch is
+    // about to make — advance it right away, before any microtask runs.
+    const castDispatch = dispatchAction(CAST_ACTION, 0);
+    engine.advance();
+
+    // Let submitAction + getSnapshot settle; the animation window (from the
+    // LifeChanged event) is now open, holding the dispatch mutex — the store
+    // itself is NOT updated yet (commit happens only after the animation
+    // window closes below).
+    await vi.advanceTimersByTimeAsync(0);
+
+    // P0 immediately clicks the Mountain to pay the sacrifice cost, while
+    // the first action's animation window is still open — this is queued
+    // (mutex held), capturing the store's still-stale `waitingFor` (Priority)
+    // as `next.waitingFor`.
+    const sacrificeDispatch = dispatchAction(SACRIFICE_ACTION, 0);
+
+    await vi.runAllTimersAsync();
+    await castDispatch;
+    await sacrificeDispatch;
+
+    // The queued SelectCards action must have reached the engine — not been
+    // silently dropped as a stale response to a changed prompt.
+    expect(adapter.submitAction).toHaveBeenCalledWith(SACRIFICE_ACTION, 0);
+    expect(adapter.submitAction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -180,10 +180,22 @@ function waitingForActorMatches(
   if (typeof data !== "object" || data === null) return false;
   const fields = data as Record<string, unknown>;
 
-  if (waitingFor.type === "Priority") {
+  // CR 723: under a turn-control effect (Emrakul, the Promised End;
+  // Mindslaver; etc.) a single-actor WaitingFor's `player` field names the
+  // semantic seat whose decision this is, which can differ from the
+  // authenticated actor actually submitting it (the controller). The engine
+  // keeps `gameState.priority_player` synced to the authorized submitter for
+  // whichever WaitingFor is current — for every single-actor variant, not
+  // just "Priority" (`sync_priority_player_from_waiting_for` in
+  // `public_state.rs` runs off `WaitingFor::acting_player()`, which every
+  // single-actor variant implements). Every variant carrying a `player`
+  // field must therefore consult it too, not only "Priority" — otherwise a
+  // queued action for e.g. a flashback sacrifice-cost PayCost prompt gets
+  // dropped as "stale" purely because the controller's id doesn't match the
+  // controlled seat's id (#6431).
+  if ("player" in fields) {
     return fields.player === actor || gameState?.priority_player === actor;
   }
-  if (fields.player === actor) return true;
 
   const pending = fields.pending;
   return (

--- a/crates/engine/tests/integration/issue_6431_lava_dart_flashback_control_turn.rs
+++ b/crates/engine/tests/integration/issue_6431_lava_dart_flashback_control_turn.rs
@@ -1,0 +1,81 @@
+//! Building-block coverage for issue #6431: under Emrakul-style turn control
+//! (CR 723), a flashback cost that sacrifices a permanent must be paid from
+//! the semantic caster's own permanents — the controlled player's, not the
+//! controller's.
+//!
+//! Lava Dart: "Flashback—Sacrifice a Mountain." (CR 702.34a additional cost,
+//! CR 601.2h). While P0 controls P1's turn via an Emrakul-style effect (CR
+//! 723.5), P1's own Lava Dart sits in P1's graveyard and P1 controls a
+//! Mountain. P0, authorized to make P1's choices, must be able to pay the
+//! flashback cost by sacrificing P1's Mountain.
+//!
+//! The engine-side cost/target plumbing this test exercises (`player`
+//! threaded through `handle_cast_spell_with_payment_mode` →
+//! `pay_additional_cost` → `find_eligible_sacrifice_targets`) was already
+//! correct on `main`. The reported defect turned out to live in the frontend
+//! dispatch queue (`client/src/game/dispatch.ts`'s `waitingForActorMatches`),
+//! which dropped the queued sacrifice-cost response as "stale" under turn
+//! control — see `client/src/game/__tests__/dispatchTurnControlPayCostQueue.test.ts`
+//! for that regression. This test stays as building-block coverage pinning
+//! the engine's half of the contract.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::game_state::{CastingVariant, WaitingFor};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+#[test]
+fn lava_dart_flashback_sacrifice_payable_under_turn_control() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mountain = scenario.add_basic_land(P1, ManaColor::Red);
+    let lava_dart = scenario
+        .add_spell_to_graveyard(P1, "Lava Dart", true)
+        .from_oracle_text(
+            "Lava Dart deals 1 damage to any target.\n\
+             Flashback\u{2014}Sacrifice a Mountain. (You may cast this card from your \
+             graveyard for its flashback cost. Then exile it.)",
+        )
+        .id();
+    let mut runner = scenario.build();
+
+    {
+        let state = runner.state_mut();
+        // CR 723: P0 controls P1's turn.
+        state.active_player = P1;
+        state.turn_decision_controller = Some(P0);
+        // P1 holds priority; sync re-derives the authorized submitter (P0).
+        engine::game::public_state::sync_waiting_for(state, &WaitingFor::Priority { player: P1 });
+    }
+
+    let outcome = runner
+        .cast(lava_dart)
+        .casting_variant(CastingVariant::Flashback)
+        .target_player(P0)
+        .sacrifice_with(&[mountain])
+        .try_resolve();
+
+    let outcome = outcome.unwrap_or_else(|err| {
+        panic!(
+            "P0 (controlling P1's turn) must be able to pay Lava Dart's flashback \
+             Sacrifice-a-Mountain cost with P1's own Mountain, got: {err:?}"
+        )
+    });
+
+    assert_eq!(
+        outcome.zone_of(mountain),
+        Zone::Graveyard,
+        "the sacrificed Mountain must have moved to the graveyard"
+    );
+    assert!(
+        outcome.state().exile.contains(&lava_dart),
+        "CR 702.34a: a spell cast via flashback is exiled instead of going anywhere else \
+         when it leaves the stack"
+    );
+    assert_eq!(
+        outcome.life_delta(P0),
+        -1,
+        "Lava Dart must deal 1 damage to its target"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -615,6 +615,7 @@ mod issue_6157_gold_token_auto_mana_payment;
 mod issue_629_fractured_sanity_cycling;
 mod issue_6403_moonmist_mass_transform;
 mod issue_6416_extra_turn_resume_order;
+mod issue_6431_lava_dart_flashback_control_turn;
 mod issue_6498_portent_of_calamity;
 mod issue_6499_flickering_ward_protection_exemption;
 mod issue_6500_loreseekers_stone_hand_cost;


### PR DESCRIPTION
## Summary

Fixes #6431 — "I can't pay the sacrifice a mountain cost on Lava Dart while controlling my opponent with Emrakul, the Promised End."

The root cause is **not** in the Rust engine's cost-payment pipeline (verified end-to-end via a new integration test — the `player` identity is correctly threaded through `handle_cast_spell_with_payment_mode` → `pay_additional_cost` → `find_eligible_sacrifice_targets` under CR 723 turn control). It's a frontend dedup bug:

`client/src/game/dispatch.ts`'s `waitingForActorMatches` — used by `queuedLocalActionStillApplies` to decide whether a queued local action is still valid once the animation mutex releases — only fell back to `gameState.priority_player` (the engine-derived authorized submitter) for the `"Priority"` `WaitingFor` variant. Every other single-actor variant, notably `PayCost` (the prompt Lava Dart's flashback "Sacrifice a Mountain" cost uses), fell through to a bare `fields.player === actor` check. Under a CR 723 turn-control effect (Emrakul, the Promised End; Mindslaver), that field names the *controlled* seat, not the controller actually submitting the action — so the queued sacrifice-cost response was misjudged "stale" and silently dropped, exactly matching "I click the Mountain and nothing happens."

- Extends the `priority_player` fallback to every `WaitingFor` variant carrying a `player` field (matching `WaitingFor::acting_player()`'s single-actor semantics on the Rust side, which is what `sync_priority_player_from_waiting_for` keys off).
- This mirrors the identical pattern already established in `p2p-adapter.ts` (`resolveHostAiSeatFor` / `authorizedSubmitter`) and `aiController.ts` for this same CR 723 concern — `dispatch.ts` was simply missed when that pattern was introduced.

## Test plan

- [x] `client/src/game/__tests__/dispatchTurnControlPayCostQueue.test.ts` — new regression test driving the real `dispatchAction` pipeline; confirmed it fails against the pre-fix code (`dropping stale queued action SelectCards: waitingFor changed`) and passes with the fix.
- [x] `crates/engine/tests/integration/issue_6431_lava_dart_flashback_control_turn.rs` — new engine-level building-block test pinning that the Rust cast/cost pipeline already pays Lava Dart's flashback Sacrifice-a-Mountain cost correctly under turn control (passes on `main`, kept as regression coverage).
- [x] `cargo fmt --all`, `cargo clippy -p engine --tests -- -D warnings` clean.
- [x] `cargo test -p engine --test integration` — 4159 passed, 0 failed.
- [x] `npx tsc --noEmit`, `npx eslint` clean on changed files.
- [x] Full frontend `vitest run` — 2403 passed; the only 2 failures are pre-existing environment issues unrelated to this change (missing `mana-font` npm module, missing `jq` binary).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed queued actions during turn-control effects so valid responses are no longer incorrectly discarded.
  - Improved handling of flashback costs when one player controls another player’s turn.
  - Ensured sacrificed cards move to the graveyard, flashed-back spells are exiled, and damage resolves correctly in controlled-turn scenarios.

- **Tests**
  - Added regression coverage for queued cost payments and turn-control interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->