### PR TITLE
fix(engine): spill unmatched colored cost reductions into generic (#6405)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7685,12 +7685,13 @@ pub(super) fn cost_shard_matches_reduction(
 }
 
 /// CR 118.7b + CR 118.7c + CR 118.7d: Apply one unit of colored/colorless mana
-/// reduction. If the cost still has a matching component, remove it (118.7a
-/// scope). Otherwise — the cost never had that color/colorless component, or
-/// this reduction unit is the excess beyond what the component had left — the
-/// unit spills over to reduce the generic component instead. A reduction can
-/// never touch a mismatched color's pip, and each unit reduces exactly one
-/// cost component (colored/colorless match XOR generic spillover), never both.
+/// reduction. If the cost still has a matching component, remove it. Otherwise
+/// — the cost never had that color/colorless component (118.7b), or this
+/// reduction unit is the excess beyond what the component had left (118.7c/d)
+/// — the unit spills over to reduce the generic component instead. A
+/// reduction can never touch a mismatched color's pip, and each unit reduces
+/// exactly one cost component (colored/colorless match XOR generic
+/// spillover), never both.
 pub(super) fn apply_shard_reduction(
     shards: &mut Vec<ManaCostShard>,
     generic: &mut u32,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7684,17 +7684,32 @@ pub(super) fn cost_shard_matches_reduction(
         || cost_shard == reduction
 }
 
-fn apply_shard_reduction(shards: &mut Vec<ManaCostShard>, reduction: ManaCostShard) {
+/// CR 118.7b + CR 118.7c + CR 118.7d: Apply one unit of colored/colorless mana
+/// reduction. If the cost still has a matching component, remove it (118.7a
+/// scope). Otherwise — the cost never had that color/colorless component, or
+/// this reduction unit is the excess beyond what the component had left — the
+/// unit spills over to reduce the generic component instead. A reduction can
+/// never touch a mismatched color's pip, and each unit reduces exactly one
+/// cost component (colored/colorless match XOR generic spillover), never both.
+pub(super) fn apply_shard_reduction(
+    shards: &mut Vec<ManaCostShard>,
+    generic: &mut u32,
+    reduction: ManaCostShard,
+) {
     if let Some(index) = shards
         .iter()
         .position(|shard| cost_shard_matches_reduction(*shard, reduction))
     {
         shards.remove(index);
+    } else {
+        *generic = generic.saturating_sub(1);
     }
 }
 
-/// CR 601.2f: Apply a single cost modification (reduce or raise) to a mana cost.
-/// ReduceCost removes matching mana symbols and generic mana (not below zero).
+/// CR 601.2f + CR 118.7: Apply a single cost modification (reduce or raise) to a
+/// mana cost. ReduceCost removes matching mana symbols, spilling any unmatched
+/// or excess colored/colorless reduction over to generic mana (CR 118.7b/c/d)
+/// in addition to reducing generic mana directly (CR 118.7a), floored at zero.
 /// RaiseCost adds the specified symbols and generic mana.
 fn apply_cost_mod_to_mana(
     mana_cost: &mut ManaCost,
@@ -7730,7 +7745,7 @@ fn apply_cost_mod_to_mana(
     } else {
         for _ in 0..multiplier {
             for shard in mod_shards {
-                apply_shard_reduction(shards, *shard);
+                apply_shard_reduction(shards, generic, *shard);
             }
         }
         *generic = generic.saturating_sub(mod_generic);

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -6116,13 +6116,10 @@ fn apply_defiler_mana_reduction(
         return;
     };
 
+    // CR 118.7b/c/d: unmatched or excess colored reduction spills over to
+    // generic, same as any other cost reduction (`apply_shard_reduction`).
     for shard in reduction_shards {
-        if let Some(pos) = spell_shards
-            .iter()
-            .position(|candidate| super::casting::cost_shard_matches_reduction(*candidate, *shard))
-        {
-            spell_shards.remove(pos);
-        }
+        super::casting::apply_shard_reduction(spell_shards, spell_generic, *shard);
     }
     *spell_generic = spell_generic.saturating_sub(*reduction_generic);
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -16887,6 +16887,162 @@ mod tests {
         );
     }
 
+    /// CR 118.7b: a Defiler reduction shard with no matching colored component
+    /// in the spell's cost must spill over to reduce generic mana instead of
+    /// being silently dropped. Regression coverage for `apply_defiler_mana_reduction`
+    /// through its actual consumer, `handle_defiler_payment` — a bare
+    /// matching-shard check on `apply_defiler_mana_reduction` alone would not
+    /// catch a future regression that decouples the two.
+    #[test]
+    fn handle_defiler_payment_spills_unmatched_colored_shard_to_generic() {
+        use crate::types::mana::ManaCostShard;
+
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 20;
+
+        let spell_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Test Creature".to_string(),
+            Zone::Hand,
+        );
+
+        let ability = crate::types::ability::ResolvedAbility::new(
+            Effect::Unimplemented {
+                name: "Permanent".to_string(),
+                description: None,
+            },
+            Vec::new(),
+            spell_id,
+            PlayerId(0),
+        );
+
+        // {3} generic, no colored pips at all.
+        let mut pending = PendingCast::new(
+            spell_id,
+            CardId(1),
+            ability,
+            ManaCost::Cost {
+                shards: vec![],
+                generic: 3,
+            },
+        );
+        // Force the reduced cost to land in `state.pending_cast` (rather than
+        // being auto-paid away) so it can be asserted on directly.
+        pending.payment_mode = CastPaymentMode::Manual;
+
+        // A green Defiler reduction unit has nothing to match — it must spill
+        // into generic instead of being dropped.
+        let mana_reduction = ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        };
+
+        let mut events = Vec::new();
+        handle_defiler_payment(
+            &mut state,
+            PlayerId(0),
+            pending,
+            2,
+            &mana_reduction,
+            true,
+            &mut events,
+        )
+        .expect("manual payment step should be entered");
+
+        let pending_cast = state
+            .pending_cast
+            .as_ref()
+            .expect("manual payment mode must stash the reduced pending cast");
+        assert_eq!(
+            pending_cast.cost,
+            ManaCost::Cost {
+                shards: vec![],
+                generic: 2,
+            },
+            "the unmatched green reduction unit must spill over to generic (3 -> 2), not be dropped (3 -> 3)",
+        );
+    }
+
+    /// CR 118.7c: a Defiler reduction that exceeds the spell's matching
+    /// colored component reduces that color to nothing, then spills the
+    /// excess to generic — again exercised through `handle_defiler_payment`
+    /// rather than the private helper directly.
+    #[test]
+    fn handle_defiler_payment_spills_excess_beyond_matching_color_to_generic() {
+        use crate::types::mana::ManaCostShard;
+
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 20;
+
+        let spell_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Test Creature".to_string(),
+            Zone::Hand,
+        );
+
+        let ability = crate::types::ability::ResolvedAbility::new(
+            Effect::Unimplemented {
+                name: "Permanent".to_string(),
+                description: None,
+            },
+            Vec::new(),
+            spell_id,
+            PlayerId(0),
+        );
+
+        // {2}{G}{G}: only two green pips to match against.
+        let mut pending = PendingCast::new(
+            spell_id,
+            CardId(1),
+            ability,
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Green, ManaCostShard::Green],
+                generic: 2,
+            },
+        );
+        pending.payment_mode = CastPaymentMode::Manual;
+
+        // Three green reduction units — one more than the cost has green pips
+        // for. The third must spill the excess into generic.
+        let mana_reduction = ManaCost::Cost {
+            shards: vec![
+                ManaCostShard::Green,
+                ManaCostShard::Green,
+                ManaCostShard::Green,
+            ],
+            generic: 0,
+        };
+
+        let mut events = Vec::new();
+        handle_defiler_payment(
+            &mut state,
+            PlayerId(0),
+            pending,
+            2,
+            &mana_reduction,
+            true,
+            &mut events,
+        )
+        .expect("manual payment step should be entered");
+
+        let pending_cast = state
+            .pending_cast
+            .as_ref()
+            .expect("manual payment mode must stash the reduced pending cast");
+        assert_eq!(
+            pending_cast.cost,
+            ManaCost::Cost {
+                shards: vec![],
+                generic: 1,
+            },
+            "both green pips must be removed and the excess third unit must spill to generic (2 -> 1), not leave generic untouched (2 -> 2)",
+        );
+    }
+
     fn subtype_filter(subtype: &str) -> TargetFilter {
         TargetFilter::Typed(TypedFilter::new(TypeFilter::Subtype(subtype.to_string())))
     }

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -26054,7 +26054,7 @@ fn colored_cost_reduction_spills_excess_beyond_matching_color_to_generic() {
     );
 }
 
-/// CR 118.7a: a reduction shard never reduces a mismatched color's pip — a
+/// CR 118.7b: a reduction shard never reduces a mismatched color's pip — a
 /// {G} cost is untouched by a {W} reduction unit (which instead spills to
 /// generic), so the green pip must survive.
 #[test]

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -25993,6 +25993,91 @@ fn colored_cost_reduction_can_remove_hybrid_symbol_once() {
     );
 }
 
+/// CR 118.7b: a colored reduction shard with no matching component anywhere in
+/// the cost converts to a generic reduction instead of being discarded. Mirrors
+/// Aang, Master of Elements' `{W}{U}{B}{R}{G}` reduction against an all-generic
+/// spell (issue #6405) — none of the five colors are present, so all five
+/// units must spill over to reduce the {5} generic cost to {0}.
+#[test]
+fn colored_cost_reduction_spills_to_generic_when_cost_has_no_matching_color() {
+    let mut cost = ManaCost::Cost {
+        generic: 5,
+        shards: vec![],
+    };
+    let reduction = ManaCost::Cost {
+        generic: 0,
+        shards: vec![
+            ManaCostShard::White,
+            ManaCostShard::Blue,
+            ManaCostShard::Black,
+            ManaCostShard::Red,
+            ManaCostShard::Green,
+        ],
+    };
+    apply_cost_mod_to_mana(&mut cost, &reduction, 1, false);
+    assert_eq!(
+        cost,
+        ManaCost::Cost {
+            generic: 0,
+            shards: vec![],
+        }
+    );
+}
+
+/// CR 118.7c: a colored reduction that exceeds the cost's component of that
+/// color reduces the color to nothing, then spills the excess to generic. A
+/// {2}{R} cost hit by Aang's five-color reduction loses its lone red pip (1
+/// unit) and then 4 more units spill to generic, flooring {2} at {0}.
+#[test]
+fn colored_cost_reduction_spills_excess_beyond_matching_color_to_generic() {
+    let mut cost = ManaCost::Cost {
+        generic: 2,
+        shards: vec![ManaCostShard::Red],
+    };
+    let reduction = ManaCost::Cost {
+        generic: 0,
+        shards: vec![
+            ManaCostShard::White,
+            ManaCostShard::Blue,
+            ManaCostShard::Black,
+            ManaCostShard::Red,
+            ManaCostShard::Green,
+        ],
+    };
+    apply_cost_mod_to_mana(&mut cost, &reduction, 1, false);
+    assert_eq!(
+        cost,
+        ManaCost::Cost {
+            generic: 0,
+            shards: vec![],
+        }
+    );
+}
+
+/// CR 118.7a: a reduction shard never reduces a mismatched color's pip — a
+/// {G} cost is untouched by a {W} reduction unit (which instead spills to
+/// generic), so the green pip must survive.
+#[test]
+fn colored_cost_reduction_never_touches_mismatched_color_pip() {
+    let mut cost = ManaCost::Cost {
+        generic: 0,
+        shards: vec![ManaCostShard::Green],
+    };
+    let reduction = ManaCost::Cost {
+        generic: 0,
+        shards: vec![ManaCostShard::White],
+    };
+    apply_cost_mod_to_mana(&mut cost, &reduction, 1, false);
+    assert_eq!(
+        cost,
+        ManaCost::Cost {
+            generic: 0,
+            shards: vec![ManaCostShard::Green],
+        },
+        "a colored reduction must never cancel a differently-colored pip"
+    );
+}
+
 /// CR 601.2f: "The total cost is the mana cost ... plus all ... cost
 /// increases, and minus all cost reductions. ... If the mana component of the
 /// total cost is reduced to nothing by cost reduction effects, it is considered

--- a/crates/engine/tests/integration/issue_6405_aang_multicolor_cost_reduction.rs
+++ b/crates/engine/tests/integration/issue_6405_aang_multicolor_cost_reduction.rs
@@ -1,0 +1,129 @@
+//! Issue #6405: Aang, Master of Elements — "Spells you cast cost {W}{U}{B}{R}{G}
+//! less to cast. (This can reduce generic costs.)" was not reducing generic
+//! mana at all. The reduction is stored as five colored shards with a generic
+//! component of 0, and `apply_shard_reduction` used to silently drop any
+//! reduction unit that had no matching colored pip left in the spell's cost,
+//! instead of letting it spill over to generic mana.
+//!
+//! CR 118.7b: a colored reduction unit with no matching component in the cost
+//! converts to reducing generic mana. CR 118.7c: a colored reduction that
+//! exceeds the cost's component of that color reduces the color to nothing,
+//! then spills the excess to generic. CR 118.7a: a reduction never touches a
+//! mismatched color's pip.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::parser::oracle_static::parse_static_line;
+use engine::types::ability::{Effect, QuantityExpr, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+
+const AANG_STATIC: &str = "Spells you cast cost {W}{U}{B}{R}{G} less to cast.";
+
+fn add_targeted_spell(scenario: &mut GameScenario, name: &str, cost: ManaCost) -> ObjectId {
+    let mut b = scenario.add_spell_to_hand(P0, name, true);
+    b.with_mana_cost(cost);
+    b.with_ability(Effect::DealDamage {
+        amount: QuantityExpr::Fixed { value: 2 },
+        target: TargetFilter::Any,
+        damage_source: None,
+        excess: None,
+    });
+    b.id()
+}
+
+/// Cast the spell and return the mana value of the battlefield-modified cost
+/// the engine resolved (read at `TargetSelection`, before payment).
+fn resolved_cost_mv(runner: &mut GameRunner, spell_id: ObjectId) -> u32 {
+    let card_id = runner.state().objects[&spell_id].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell_id,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the test spell should begin");
+    match &runner.state().waiting_for {
+        WaitingFor::TargetSelection { pending_cast, .. } => pending_cast.cost.mana_value(),
+        other => panic!("expected TargetSelection after casting, got {other:?}"),
+    }
+}
+
+/// Build a P0 board with Aang's cost reducer plus one test spell of `cost`,
+/// cast it, and return the resolved cost's mana value.
+fn resolved_cost_under_aang(name: &str, cost: ManaCost) -> u32 {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain); // active player = P0
+    scenario
+        .add_creature(P0, "Aang, Master of Elements", 6, 6)
+        .with_static_definition(parse_static_line(AANG_STATIC).expect("Aang static parses"));
+    let spell = add_targeted_spell(&mut scenario, name, cost);
+    let mut runner = scenario.build();
+    resolved_cost_mv(&mut runner, spell)
+}
+
+#[test]
+fn all_generic_spell_is_reduced_by_the_full_five() {
+    // CR 118.7b: none of the five colors are present, so all five reduction
+    // units convert to generic — {5} generic drops to {0}.
+    assert_eq!(
+        resolved_cost_under_aang("Test Generic Spell", ManaCost::generic(5)),
+        0,
+        "a spell with no colored pips must still get the full 5-mana discount",
+    );
+}
+
+#[test]
+fn partially_generic_spell_spills_excess_beyond_matching_color() {
+    // CR 118.7c: the lone red pip cancels one reduction unit; the other four
+    // (white/blue/black/green) have nothing to match, so they spill to
+    // generic — {2}{R} (mana value 3) drops to {0}, not {2}.
+    assert_eq!(
+        resolved_cost_under_aang(
+            "Test Red Spell",
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Red],
+                generic: 2,
+            },
+        ),
+        0,
+        "unmatched colored reduction units must spill over to generic mana",
+    );
+}
+
+#[test]
+fn one_of_each_color_plus_generic_reduces_only_the_matched_pips() {
+    // Every one of the five reduction units matches an exact colored pip, so
+    // none spill over — the {1} generic component is untouched.
+    assert_eq!(
+        resolved_cost_under_aang(
+            "Test Rainbow Spell",
+            ManaCost::Cost {
+                shards: vec![
+                    ManaCostShard::White,
+                    ManaCostShard::Blue,
+                    ManaCostShard::Black,
+                    ManaCostShard::Red,
+                    ManaCostShard::Green,
+                ],
+                generic: 1,
+            },
+        ),
+        1,
+        "a fully-matched colored reduction must not touch the remaining generic mana",
+    );
+}
+
+#[test]
+fn cheap_generic_spell_floors_at_zero_rather_than_underflowing() {
+    // Five spillover-eligible reduction units against a {1} generic spell must
+    // floor the total at {0}, not underflow past zero.
+    assert_eq!(
+        resolved_cost_under_aang("Test Cheap Spell", ManaCost::generic(1)),
+        0,
+        "reduction spillover must floor generic at 0, never go negative",
+    );
+}

--- a/crates/engine/tests/integration/issue_6405_aang_multicolor_cost_reduction.rs
+++ b/crates/engine/tests/integration/issue_6405_aang_multicolor_cost_reduction.rs
@@ -6,10 +6,10 @@
 //! instead of letting it spill over to generic mana.
 //!
 //! CR 118.7b: a colored reduction unit with no matching component in the cost
-//! converts to reducing generic mana. CR 118.7c: a colored reduction that
+//! converts to reducing generic mana — this is also why a reduction never
+//! touches a mismatched color's pip. CR 118.7c: a colored reduction that
 //! exceeds the cost's component of that color reduces the color to nothing,
-//! then spills the excess to generic. CR 118.7a: a reduction never touches a
-//! mismatched color's pip.
+//! then spills the excess to generic.
 
 use engine::game::scenario::{GameRunner, GameScenario, P0};
 use engine::parser::oracle_static::parse_static_line;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -614,6 +614,7 @@ mod issue_6102_ragavan_exile_cast;
 mod issue_6157_gold_token_auto_mana_payment;
 mod issue_629_fractured_sanity_cycling;
 mod issue_6403_moonmist_mass_transform;
+mod issue_6405_aang_multicolor_cost_reduction;
 mod issue_6416_extra_turn_resume_order;
 mod issue_6498_portent_of_calamity;
 mod issue_6499_flickering_ward_protection_exemption;


### PR DESCRIPTION
## Summary
- Aang, Master of Elements — "Spells you cast cost {W}{U}{B}{R}{G} less to cast. (This can reduce generic costs.)" — wasn't reducing generic mana at all. Per CR 118.7b/c, a colored (or colorless) cost reduction that has no matching component in the spell's cost — or exceeds it — must spill the excess over to reduce generic mana, not be discarded.
- Root cause: `apply_shard_reduction` (`crates/engine/src/game/casting.rs`) removed one matching colored pip per reduction unit when present, but silently dropped any unit with no match instead of falling back to generic.
- Fixed the single shared helper (now `pub(super)`) so both call sites — the general `ModifyCost::Reduce` battlefield/self-spell path and the Defiler cost-reduction path (`apply_defiler_mana_reduction` in `casting_costs.rs`, which had the identical bug) — get the CR-correct behavior for free, per the project's single-authority convention.
- A reduction still never cancels a mismatched color's pip (CR 118.7a) and never reduces the same cost component twice.

Closes #6405.

## Test plan
- [x] `cargo test -p engine --lib -- game::casting::tests` — 741 passed, including 4 new unit tests covering: no-match spillover (all-generic spell gets the full 5-mana discount), excess-beyond-match spillover, exact-match-only (no spillover), and mismatched-color-never-touched.
- [x] `cargo test -p engine --lib -- defiler` — 8 passed, including the Defiler-payment test that exercises the other fixed call site.
- [x] New integration suite `crates/engine/tests/integration/issue_6405_aang_multicolor_cost_reduction.rs` (4 tests) drives Aang's actual parsed static ability end-to-end through the cast pipeline against all-generic, partially-colored, fully-colored, and cheap-spell costs — all pass.
- [x] `cargo clippy -p engine --lib --tests -- -D warnings` — clean.
- [x] `cargo fmt --all` — no changes needed beyond the edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multicolor mana-cost reduction so unmatched colored reductions now correctly spill into generic mana.
  * Fixed reduction handling so excess colored reduction reduces matching colored components first, then spills remaining reduction into generic (without producing negative/invalid costs).
  * Ensured mismatched-color reductions never cancel non-matching mana symbols.
* **Tests**
  * Added unit and integration coverage for multicolor spillover, partial matches, zero-cost flooring, and Defiler payment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->