### PR TITLE
fix(ai): halt empty NamedChoice escape and refuse DB-less restore (#6393)

### DIFF
--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -6,10 +6,15 @@ import { AdapterError, AdapterErrorCode } from "../types";
 import { buildGameState } from "../../test/factories/gameStateFactory";
 
 const ensureWasmInit = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const resumeMultiplayerHostState = vi.hoisted(() => vi.fn());
 
 vi.mock("../../services/cardData", () => ({
   ensureWasmInit,
   ensureCardDatabase: vi.fn().mockResolvedValue(100),
+}));
+
+vi.mock("@wasm/engine", () => ({
+  resume_multiplayer_host_state: resumeMultiplayerHostState,
 }));
 
 // Mock EngineWorkerClient to avoid actual Worker creation in tests
@@ -360,6 +365,19 @@ describe("WasmAdapter", () => {
       );
       expect(adapter.cardDbLoaded).toBe(false);
       expect(mockWorkerClient.resumeMultiplayerHostState).not.toHaveBeenCalled();
+    });
+
+    it("propagates a queued main-thread fallback resume failure", async () => {
+      mockWorkerClient.initialize.mockRejectedValueOnce(new Error("worker unavailable"));
+      resumeMultiplayerHostState.mockImplementationOnce(() => {
+        throw new Error("resume failed");
+      });
+      await adapter.initialize();
+
+      await expect(adapter.resumeMultiplayerHostState(buildGameState())).rejects.toThrow(
+        "resume failed",
+      );
+      expect(resumeMultiplayerHostState).toHaveBeenCalledOnce();
     });
   });
 

--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -35,8 +35,10 @@ const mockWorkerClient = {
   })),
   getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
   getAiAction: vi.fn().mockResolvedValue(null),
+  getAiFallbackAction: vi.fn().mockResolvedValue(null),
   exportState: vi.fn().mockResolvedValue("{}"),
   restoreState: vi.fn().mockResolvedValue(undefined),
+  resumeMultiplayerHostState: vi.fn().mockResolvedValue(undefined),
   ping: vi.fn().mockResolvedValue("phase-rs engine ready"),
   takeLastPanic: vi.fn().mockResolvedValue(null),
   dispose: vi.fn(),
@@ -324,6 +326,43 @@ describe("WasmAdapter", () => {
     });
   });
 
+  describe("resumeMultiplayerHostState", () => {
+    it("loads the card database then resumes on the worker", async () => {
+      await adapter.initialize();
+      const mockState = buildGameState({
+        turn_number: 3,
+        phase: "PreCombatMain",
+        players: [],
+      });
+
+      await adapter.resumeMultiplayerHostState(mockState);
+      expect(mockWorkerClient.loadCardDbFromUrl).toHaveBeenCalledOnce();
+      expect(mockWorkerClient.resumeMultiplayerHostState).toHaveBeenCalledWith(
+        JSON.stringify(mockState),
+      );
+      expect(mockWorkerClient.loadCardDbFromUrl.mock.invocationCallOrder[0])
+        .toBeLessThan(
+          mockWorkerClient.resumeMultiplayerHostState.mock.invocationCallOrder[0],
+        );
+    });
+
+    it("throws when the card database fails to load and does not resume", async () => {
+      await adapter.initialize();
+      mockWorkerClient.loadCardDbFromUrl.mockRejectedValueOnce(new Error("boom"));
+      const mockState = buildGameState({
+        turn_number: 3,
+        phase: "PreCombatMain",
+        players: [],
+      });
+
+      await expect(adapter.resumeMultiplayerHostState(mockState)).rejects.toThrow(
+        "Card database failed to load",
+      );
+      expect(adapter.cardDbLoaded).toBe(false);
+      expect(mockWorkerClient.resumeMultiplayerHostState).not.toHaveBeenCalled();
+    });
+  });
+
   describe("initializeGame", () => {
     it("delegates to worker client with seed", async () => {
       await adapter.initialize();
@@ -344,6 +383,14 @@ describe("WasmAdapter", () => {
       await adapter.initialize();
       await adapter.getAiAction("Medium", 1);
       expect(mockWorkerClient.getAiAction).toHaveBeenCalledWith("Medium", 1);
+    });
+  });
+
+  describe("getAiFallbackAction", () => {
+    it("delegates to worker client", async () => {
+      await adapter.initialize();
+      await adapter.getAiFallbackAction();
+      expect(mockWorkerClient.getAiFallbackAction).toHaveBeenCalledOnce();
     });
   });
 

--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -306,6 +306,22 @@ describe("WasmAdapter", () => {
       const mockState = buildGameState();
       await expect(adapter.restoreState(mockState)).rejects.toThrow(AdapterError);
     });
+
+    it("throws when the card database fails to load and does not restore", async () => {
+      await adapter.initialize();
+      mockWorkerClient.loadCardDbFromUrl.mockRejectedValueOnce(new Error("boom"));
+      const mockState = buildGameState({
+        turn_number: 3,
+        phase: "PreCombatMain",
+        players: [],
+      });
+
+      await expect(adapter.restoreState(mockState)).rejects.toThrow(
+        "Card database failed to load",
+      );
+      expect(adapter.cardDbLoaded).toBe(false);
+      expect(mockWorkerClient.restoreState).not.toHaveBeenCalled();
+    });
   });
 
   describe("initializeGame", () => {

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -304,6 +304,13 @@ export class EngineWorkerClient {
     );
   }
 
+  async getAiFallbackAction(): Promise<GameAction | null> {
+    return this.request<GameAction | null>(
+      { type: "getAiFallbackAction" },
+      ENGINE_REQUEST_TIMEOUT_MS,
+    );
+  }
+
   async getAiScoredCandidates(
     difficulty: string,
     playerId: number,

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -12,6 +12,7 @@ import init, {
   get_game_state,
   get_filtered_game_state,
   get_ai_action,
+  get_ai_fallback_action,
   get_ai_scored_candidates,
   select_action_from_scores,
   get_legal_actions_js,
@@ -69,6 +70,7 @@ type EngineRequest =
   | { type: "getLegalActionsForViewer"; id: number; viewerId: number }
   | { type: "getViewerSnapshot"; id: number; viewerId: number }
   | { type: "getAiAction"; id: number; difficulty: string; playerId: number }
+  | { type: "getAiFallbackAction"; id: number }
   | {
       type: "getAiScoredCandidates";
       id: number;
@@ -368,6 +370,12 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
       case "getAiAction": {
         const aiResult = get_ai_action(msg.difficulty, msg.playerId);
         result(msg.id, aiResult ?? null);
+        break;
+      }
+
+      case "getAiFallbackAction": {
+        const fallback = get_ai_fallback_action();
+        result(msg.id, fallback ?? null);
         break;
       }
 

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -3535,6 +3535,12 @@ export interface EngineAdapter {
    */
   getSnapshot(): Promise<EngineSnapshot>;
   getAiAction(difficulty: string, playerId: number, waitingForType?: WaitingFor["type"]): Promise<GameAction | null> | GameAction | null;
+  /**
+   * Engine-owned deadlock-safe AI escape action for the current waiting state.
+   * Null when no legal escape exists. Non-Priority AI escape must use this —
+   * never invent from `getLegalActions()` enumeration order (#6393).
+   */
+  getAiFallbackAction?(): Promise<GameAction | null> | GameAction | null;
   resolveAll?(
     requester: number,
     aiSeats: { playerId: number; difficulty: string }[],

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -434,6 +434,20 @@ export class WasmAdapter implements EngineAdapter {
     }
   }
 
+  /**
+   * Engine-owned deadlock-safe escape for AI softlock recovery (#6393).
+   * Null when `fallback_action` has no legal completion.
+   */
+  async getAiFallbackAction(): Promise<GameAction | null> {
+    this.assertInitialized();
+    try {
+      if (this.engine) return await this.engine.getAiFallbackAction();
+      return await this.fallback!.getAiFallbackAction();
+    } catch (err) {
+      throw await classifyEngineErrorAsync(err, this.takePanic);
+    }
+  }
+
 /** Load an EXISTING pool's per-game card data, or dispose it when the game's
    * universe is unbounded (e.g. Momir). Fanning the full ~93MB corpus onto
    * every pool worker costs ~380MB of WASM linear memory per worker — measured
@@ -584,16 +598,20 @@ export class WasmAdapter implements EngineAdapter {
     throw new Error("resolveAll requires worker-based engine");
   }
 
-  async restoreState(state: PersistedGameState): Promise<void> {
-    this.assertInitialized();
+  private async requireCardDbForRestore(): Promise<void> {
     await this.ensureCardDb();
     // Soft-failed ensureCardDb leaves cardDbLoaded false and skips
     // rehydrate_game_from_card_db — restored CardName NamedChoices then have
     // empty legal actions and softlock the AI (#6393). Refuse DB-less restore
-    // the same way warmCardDatabase surfaces load failure.
+    // / P2P host resume the same way warmCardDatabase surfaces load failure.
     if (!this.cardDbLoaded) {
       throw new Error("Card database failed to load");
     }
+  }
+
+  async restoreState(state: PersistedGameState): Promise<void> {
+    this.assertInitialized();
+    await this.requireCardDbForRestore();
     const json = JSON.stringify(state);
     if (this.engine) await this.engine.restoreState(json);
     else await this.fallback!.restoreState(json);
@@ -654,21 +672,12 @@ export class WasmAdapter implements EngineAdapter {
    */
   async resumeMultiplayerHostState(state: PersistedGameState): Promise<void> {
     this.assertInitialized();
+    // Same CARD_DB requirement as restoreState — resume rehydrates abilities
+    // only when the DB is loaded (engine-wasm resume_multiplayer_host_state).
+    await this.requireCardDbForRestore();
     const json = JSON.stringify(state);
-    if (this.engine) {
-      // Ensure the card database is loaded before the engine rehydrates
-      // ability definitions on restore. Same sequential-queue guarantee
-      // as `restoreState`.
-      if (!this.cardDbLoaded) {
-        await this.engine.loadCardDbFromUrl().then(
-          () => { this.cardDbLoaded = true; },
-          () => { /* card DB is best-effort */ },
-        );
-      }
-      await this.engine.resumeMultiplayerHostState(json);
-    } else {
-      this.fallback!.resumeMultiplayerHostState(json);
-    }
+    if (this.engine) await this.engine.resumeMultiplayerHostState(json);
+    else this.fallback!.resumeMultiplayerHostState(json);
   }
 
   /**
@@ -716,10 +725,7 @@ export class WasmAdapter implements EngineAdapter {
    */
   async warmCardDatabase(): Promise<void> {
     await this.initialize();
-    await this.ensureCardDb();
-    if (!this.cardDbLoaded) {
-      throw new Error("Card database failed to load");
-    }
+    await this.requireCardDbForRestore();
   }
 
   /**
@@ -853,6 +859,7 @@ interface MainThreadFallback {
   getLegalActionsForViewer(viewerId: number): Promise<LegalActionsResult>;
   getViewerSnapshot(viewerId: number): Promise<ViewerSnapshot>;
   getAiAction(difficulty: string, playerId: number, waitingForType?: WaitingFor["type"]): Promise<GameAction | null>;
+  getAiFallbackAction(): Promise<GameAction | null>;
   exportState(): Promise<string>;
   restoreState(stateJson: string): Promise<void>;
   resumeMultiplayerHostState(stateJson: string): void;
@@ -965,6 +972,12 @@ async function createMainThreadFallback(): Promise<MainThreadFallback> {
     getAiAction: (difficulty: string, playerId: number) =>
       enqueue(() => {
         const r = wasm.get_ai_action(difficulty, playerId);
+        return (r ?? null) as GameAction | null;
+      }),
+
+    getAiFallbackAction: () =>
+      enqueue(() => {
+        const r = wasm.get_ai_fallback_action();
         return (r ?? null) as GameAction | null;
       }),
 

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -587,6 +587,13 @@ export class WasmAdapter implements EngineAdapter {
   async restoreState(state: PersistedGameState): Promise<void> {
     this.assertInitialized();
     await this.ensureCardDb();
+    // Soft-failed ensureCardDb leaves cardDbLoaded false and skips
+    // rehydrate_game_from_card_db — restored CardName NamedChoices then have
+    // empty legal actions and softlock the AI (#6393). Refuse DB-less restore
+    // the same way warmCardDatabase surfaces load failure.
+    if (!this.cardDbLoaded) {
+      throw new Error("Card database failed to load");
+    }
     const json = JSON.stringify(state);
     if (this.engine) await this.engine.restoreState(json);
     else await this.fallback!.restoreState(json);

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -677,7 +677,7 @@ export class WasmAdapter implements EngineAdapter {
     await this.requireCardDbForRestore();
     const json = JSON.stringify(state);
     if (this.engine) await this.engine.resumeMultiplayerHostState(json);
-    else this.fallback!.resumeMultiplayerHostState(json);
+    else await this.fallback!.resumeMultiplayerHostState(json);
   }
 
   /**
@@ -862,7 +862,7 @@ interface MainThreadFallback {
   getAiFallbackAction(): Promise<GameAction | null>;
   exportState(): Promise<string>;
   restoreState(stateJson: string): Promise<void>;
-  resumeMultiplayerHostState(stateJson: string): void;
+  resumeMultiplayerHostState(stateJson: string): Promise<void>;
   setMultiplayerMode(enabled: boolean): void;
   applySeatMutation(stateJson: string, mutationJson: string): Promise<unknown>;
   projectSeatView(stateJson: string): Promise<unknown>;
@@ -986,9 +986,8 @@ async function createMainThreadFallback(): Promise<MainThreadFallback> {
     restoreState: (stateJson: string) =>
       enqueue(() => wasm.restore_game_state(stateJson)),
 
-    resumeMultiplayerHostState: (stateJson: string) => {
-      enqueue(() => wasm.resume_multiplayer_host_state(stateJson));
-    },
+    resumeMultiplayerHostState: (stateJson: string) =>
+      enqueue(() => wasm.resume_multiplayer_host_state(stateJson)),
 
     setMultiplayerMode: (enabled: boolean) => {
       enqueue(() => wasm.set_multiplayer_mode(enabled));

--- a/client/src/game/controllers/__tests__/aiController.test.ts
+++ b/client/src/game/controllers/__tests__/aiController.test.ts
@@ -292,6 +292,91 @@ describe("aiController stuck-fallback (issue #484)", () => {
     controller.dispose();
   });
 
+  it("halts on the first empty NamedChoice escape instead of fabricating PassPriority", async () => {
+    const getAiAction = vi.fn(async () => null);
+    const getLegalActions = vi.fn(
+      async (): Promise<LegalActionsResult> => ({
+        actions: [],
+        autoPassRecommended: false,
+      }),
+    );
+    const waitingFor: WaitingFor = {
+      type: "NamedChoice",
+      data: {
+        player: 1,
+        choice_type: "CardName",
+        options: [],
+        source: gollumNamedChoiceSource(300),
+      },
+    };
+    const state = buildGameState({
+      waiting_for: waitingFor,
+      priority_player: 1,
+      active_player: 1,
+    });
+    storeState = {
+      gameState: state,
+      waitingFor: state.waiting_for,
+      adapter: { getAiAction, getLegalActions },
+    };
+    dispatchAction.mockResolvedValue(undefined);
+
+    const controller = createAIController({ seats: [{ playerId: 1, difficulty: "Medium" }] });
+    controller.start();
+
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+      await flushMicrotasks();
+    }
+
+    expect(getLegalActions).toHaveBeenCalledOnce();
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(notifyEngineLost).toHaveBeenCalledWith("ai-controller-stuck:NamedChoice");
+    // Internal stop() deactivates scheduling — no retry storm after the halt.
+    expect(getAiAction).toHaveBeenCalledOnce();
+
+    controller.dispose();
+  });
+
+  it("halts when non-Priority escape has no adapter instead of fabricating PassPriority", async () => {
+    const waitingFor: WaitingFor = {
+      type: "NamedChoice",
+      data: {
+        player: 1,
+        choice_type: "CardName",
+        options: [],
+        source: gollumNamedChoiceSource(300),
+      },
+    };
+    const state = buildGameState({
+      waiting_for: waitingFor,
+      priority_player: 1,
+      active_player: 1,
+    });
+    // Without an adapter, getAiAction resolves null and escape returns null
+    // for non-Priority — halt instead of fabricating PassPriority (#6393).
+    storeState = {
+      gameState: state,
+      waitingFor: state.waiting_for,
+      adapter: null,
+    };
+    dispatchAction.mockRejectedValue(new Error("no adapter"));
+
+    const controller = createAIController({ seats: [{ playerId: 1, difficulty: "Medium" }] });
+    controller.start();
+
+    for (let i = 0; i < 6; i++) {
+      await vi.advanceTimersByTimeAsync(1000);
+      await flushMicrotasks();
+    }
+
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(notifyEngineLost).toHaveBeenCalledWith("ai-controller-stuck:NamedChoice");
+    expect(notifyEngineLost).toHaveBeenCalledOnce();
+
+    controller.dispose();
+  });
+
   it("uses the first legal action for CastOffer fallback instead of matching the WaitingFor type", async () => {
     const illegalAction = { type: "PassPriority" } as GameAction;
     const legalCastOfferAction = {

--- a/client/src/game/controllers/__tests__/aiController.test.ts
+++ b/client/src/game/controllers/__tests__/aiController.test.ts
@@ -20,8 +20,8 @@ import { buildGameState, buildPriorityWaitingFor, buildStackEntry } from "../../
  * CR 701.15b — so `totalFailures` reached `MAX_TOTAL_FAILURES` (6) and the
  * controller halted via `notifyEngineLost` + `stop()`: the softlock.
  *
- * The fix makes the fallback fetch a guaranteed-legal action from the engine
- * via `adapter.getLegalActions()`. This test reproduces the 3-failure path and
+ * The fix makes non-Priority escape use the engine-owned `getAiFallbackAction`
+ * seam (WASM `fallback_action`). This test reproduces the 3-failure path and
  * asserts the fallback now recovers instead of halting.
  */
 
@@ -193,8 +193,9 @@ describe("aiController stuck-fallback (issue #484)", () => {
     vi.useRealTimers();
   });
 
-  it("recovers via getLegalActions instead of halting on a goaded-creature softlock", async () => {
+  it("recovers via getAiFallbackAction instead of halting on a goaded-creature softlock", async () => {
     const getAiAction = vi.fn(async () => ILLEGAL_DECLARE);
+    const getAiFallbackAction = vi.fn(async () => LEGAL_DECLARE);
     const getLegalActions = vi.fn(
       async (): Promise<LegalActionsResult> => ({
         actions: [LEGAL_DECLARE],
@@ -206,11 +207,11 @@ describe("aiController stuck-fallback (issue #484)", () => {
     storeState = {
       gameState: state,
       waitingFor: state.waiting_for,
-      adapter: { getAiAction, getLegalActions },
+      adapter: { getAiAction, getAiFallbackAction, getLegalActions },
     };
 
     // The engine rejects every illegal DeclareAttackers; it accepts the
-    // goad-compliant one from getLegalActions.
+    // goad-compliant escape from getAiFallbackAction.
     dispatchAction.mockImplementation(async (action: GameAction) => {
       const isLegal =
         action.type === "DeclareAttackers" &&
@@ -235,8 +236,9 @@ describe("aiController stuck-fallback (issue #484)", () => {
       await flushMicrotasks();
     }
 
-    // The fallback dispatched the engine-legal action from getLegalActions...
-    expect(getLegalActions).toHaveBeenCalled();
+    // The fallback dispatched the engine-owned escape action...
+    expect(getAiFallbackAction).toHaveBeenCalled();
+    expect(getLegalActions).not.toHaveBeenCalled();
     const dispatchedLegal = dispatchAction.mock.calls.some(
       ([action]) =>
         action.type === "DeclareAttackers" &&
@@ -251,55 +253,9 @@ describe("aiController stuck-fallback (issue #484)", () => {
     controller.dispose();
   });
 
-  it("falls through to PassPriority when getLegalActions yields only PassPriority", async () => {
-    const getAiAction = vi.fn(async () => ILLEGAL_DECLARE);
-    // Degenerate engine response: no DeclareAttackers entry.
-    const getLegalActions = vi.fn(
-      async (): Promise<LegalActionsResult> => ({
-        actions: [{ type: "PassPriority" } as GameAction],
-        autoPassRecommended: false,
-      }),
-    );
-
-    const state = declareAttackersState();
-    storeState = {
-      gameState: state,
-      waitingFor: state.waiting_for,
-      adapter: { getAiAction, getLegalActions },
-    };
-
-    // Only PassPriority is accepted in this degenerate scenario.
-    dispatchAction.mockImplementation(async (action: GameAction) => {
-      if (action.type === "PassPriority") return undefined;
-      throw new Error("illegal");
-    });
-
-    const controller = createAIController({ seats: [{ playerId: 1, difficulty: "Medium" }] });
-    controller.start();
-
-    for (let i = 0; i < 12; i++) {
-      await vi.advanceTimersByTimeAsync(1000);
-      await flushMicrotasks();
-    }
-
-    const dispatchedPass = dispatchAction.mock.calls.some(
-      ([action]) => action.type === "PassPriority",
-    );
-    expect(dispatchedPass).toBe(true);
-    // `undefined` is never dispatched.
-    expect(dispatchAction.mock.calls.every(([action]) => action != null)).toBe(true);
-
-    controller.dispose();
-  });
-
   it("halts on the first empty NamedChoice escape instead of fabricating PassPriority", async () => {
     const getAiAction = vi.fn(async () => null);
-    const getLegalActions = vi.fn(
-      async (): Promise<LegalActionsResult> => ({
-        actions: [],
-        autoPassRecommended: false,
-      }),
-    );
+    const getAiFallbackAction = vi.fn(async () => null);
     const waitingFor: WaitingFor = {
       type: "NamedChoice",
       data: {
@@ -317,7 +273,7 @@ describe("aiController stuck-fallback (issue #484)", () => {
     storeState = {
       gameState: state,
       waitingFor: state.waiting_for,
-      adapter: { getAiAction, getLegalActions },
+      adapter: { getAiAction, getAiFallbackAction, getLegalActions: vi.fn() },
     };
     dispatchAction.mockResolvedValue(undefined);
 
@@ -329,7 +285,7 @@ describe("aiController stuck-fallback (issue #484)", () => {
       await flushMicrotasks();
     }
 
-    expect(getLegalActions).toHaveBeenCalledOnce();
+    expect(getAiFallbackAction).toHaveBeenCalledOnce();
     expect(dispatchAction).not.toHaveBeenCalled();
     expect(notifyEngineLost).toHaveBeenCalledWith("ai-controller-stuck:NamedChoice");
     // Internal stop() deactivates scheduling — no retry storm after the halt.
@@ -377,25 +333,20 @@ describe("aiController stuck-fallback (issue #484)", () => {
     controller.dispose();
   });
 
-  it("uses the first legal action for CastOffer fallback instead of matching the WaitingFor type", async () => {
+  it("uses the engine-owned escape action for CastOffer fallback", async () => {
     const illegalAction = { type: "PassPriority" } as GameAction;
     const legalCastOfferAction = {
       type: "CascadeChoice",
       data: { choice: { type: "Decline" } },
     } as unknown as GameAction;
     const getAiAction = vi.fn(async () => illegalAction);
-    const getLegalActions = vi.fn(
-      async (): Promise<LegalActionsResult> => ({
-        actions: [legalCastOfferAction],
-        autoPassRecommended: false,
-      }),
-    );
+    const getAiFallbackAction = vi.fn(async () => legalCastOfferAction);
 
     const state = castOfferState();
     storeState = {
       gameState: state,
       waitingFor: state.waiting_for,
-      adapter: { getAiAction, getLegalActions },
+      adapter: { getAiAction, getAiFallbackAction, getLegalActions: vi.fn() },
     };
 
     dispatchAction.mockImplementation(async (action: GameAction) => {
@@ -411,7 +362,7 @@ describe("aiController stuck-fallback (issue #484)", () => {
       await flushMicrotasks();
     }
 
-    expect(getLegalActions).toHaveBeenCalled();
+    expect(getAiFallbackAction).toHaveBeenCalled();
     expect(dispatchAction.mock.calls).toContainEqual([legalCastOfferAction, 1]);
     expect(notifyEngineLost).not.toHaveBeenCalled();
 

--- a/client/src/game/controllers/aiController.ts
+++ b/client/src/game/controllers/aiController.ts
@@ -279,12 +279,20 @@ export function createAIController(config: AIControllerConfig): AIController {
   function pickEscapeAction(
     waitingFor: WaitingFor,
     state: GameState,
-  ): Promise<GameAction> {
+  ): Promise<GameAction | null> {
     if (state.has_pending_cast) {
       return Promise.resolve({ type: "CancelCast" });
     }
     const { adapter } = useGameStore.getState();
-    if (!adapter) return Promise.resolve({ type: "PassPriority" });
+    // Priority may still fabricate PassPriority (the only legal Priority
+    // escape). Non-Priority must never invent PassPriority — the engine
+    // rejects it and the controller softlocks (#6393).
+    if (!adapter) {
+      if (waitingFor.type === "Priority") {
+        return Promise.resolve({ type: "PassPriority" });
+      }
+      return Promise.resolve(null);
+    }
     return adapter.getLegalActions().then((result) => {
       if (waitingFor.type === "Priority") {
         return (
@@ -292,7 +300,7 @@ export function createAIController(config: AIControllerConfig): AIController {
           { type: "PassPriority" }
         );
       }
-      return result.actions[0] ?? { type: "PassPriority" };
+      return result.actions[0] ?? null;
     });
   }
 
@@ -306,6 +314,17 @@ export function createAIController(config: AIControllerConfig): AIController {
     try {
       const fallback = await pickEscapeAction(waitingFor, state);
       if (!isAttemptCurrent(attempt)) return;
+      // Empty non-Priority legal set: halt immediately rather than dispatching
+      // a fabricated PassPriority that the engine rejects in a loop (#6393).
+      if (fallback == null) {
+        debugLog(
+          `AI controller halting: no legal escape for ${waitingFor.type}`,
+          "error",
+        );
+        notifyEngineLost(`ai-controller-stuck:${waitingFor.type}`);
+        stop();
+        return;
+      }
       await dispatchAction(fallback, waitingPlayerId);
       if (!isAttemptCurrent(attempt)) return;
       consecutiveFailures = 0;

--- a/client/src/game/controllers/aiController.ts
+++ b/client/src/game/controllers/aiController.ts
@@ -293,15 +293,20 @@ export function createAIController(config: AIControllerConfig): AIController {
       }
       return Promise.resolve(null);
     }
-    return adapter.getLegalActions().then((result) => {
-      if (waitingFor.type === "Priority") {
+    if (waitingFor.type === "Priority") {
+      return adapter.getLegalActions().then((result) => {
         return (
           result.actions.find((a) => a.type === "PassPriority") ??
           { type: "PassPriority" }
         );
-      }
-      return result.actions[0] ?? null;
-    });
+      });
+    }
+    // Non-Priority: engine owns escape selection via fallback_action. Legal-
+    // action list order is not a decision contract (#6393 review).
+    if (!adapter.getAiFallbackAction) {
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(adapter.getAiFallbackAction());
   }
 
   async function runEscapeFallback(

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -109,6 +109,13 @@ export function export_replay_log(): string;
 export function getFormatRegistry(): any;
 
 /**
+ * Engine-owned AI escape action for the current waiting state.
+ * Same deadlock-safe fallback the search path uses when scoring cannot choose.
+ * Returns null when no legal escape exists.
+ */
+export function get_ai_fallback_action(): any;
+
+/**
  * Get the AI's chosen action for the current game state.
  * `difficulty` is one of: "VeryEasy", "Easy", "Medium", "Hard", "VeryHard",
  * "CEDH" (case-insensitive; see `AiDifficulty::from_label`).
@@ -476,6 +483,7 @@ export interface InitOutput {
     readonly export_replay_log: () => [number, number, number, number];
     readonly getFormatRegistry: () => any;
     readonly get_ai_action: (a: number, b: number, c: number) => [number, number, number];
+    readonly get_ai_fallback_action: () => [number, number, number];
     readonly get_ai_scored_candidates: (a: number, b: number, c: number, d: bigint) => [number, number, number];
     readonly get_card_face_data: (a: number, b: number) => any;
     readonly get_card_parse_details: (a: number, b: number) => any;

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -117,7 +117,8 @@ fn to_js<T: Serialize + ?Sized>(value: &T) -> JsValue {
 
 use phase_ai::config::{create_config_for_players, AiDifficulty, Platform};
 use phase_ai::{
-    choose_action_with_session, score_candidates_with_session, AiSession, SessionCache,
+    choose_action_with_session, fallback_action, score_candidates_with_session, AiSession,
+    SessionCache,
 };
 thread_local! {
     /// Game state uses Cell<Option<T>> with take/set to avoid RefCell borrow poisoning.
@@ -1802,6 +1803,31 @@ pub fn replay_seek_js(target: u32) -> Result<JsValue, JsValue> {
 #[wasm_bindgen]
 pub fn clear_replay_playback() {
     REPLAY_PLAYER.with(|cell| cell.set(None));
+}
+
+/// Engine-owned AI escape action for the current waiting state.
+///
+/// Returns the same deadlock-safe `fallback_action` the search path uses when
+/// scoring cannot choose — never invents from legal-action list order. Null
+/// when no legal escape exists (#6393).
+#[wasm_bindgen]
+pub fn get_ai_fallback_action() -> Result<JsValue, JsValue> {
+    with_state_mut(|state| {
+        // Freshly-restored states carry dirty layers; flush so candidate
+        // generation matches `get_ai_action` / `get_legal_actions_js`.
+        engine::game::layers::flush_layers(state);
+        // Escape uses policy penalties from config (sacrifice ordering); Medium
+        // is the controller's default seat difficulty for softlock recovery.
+        let config = create_config_for_players(
+            AiDifficulty::Medium,
+            Platform::Wasm,
+            state.players.len() as u8,
+        );
+        match fallback_action(state, &config) {
+            Some(action) => Ok(to_js(&action)),
+            None => Ok(JsValue::NULL),
+        }
+    })?
 }
 
 /// Get the AI's chosen action for the current game state.

--- a/crates/phase-ai/src/lib.rs
+++ b/crates/phase-ai/src/lib.rs
@@ -52,7 +52,7 @@ pub use eval::{
     StrategicIntent,
 };
 pub use search::{
-    choose_action, choose_action_with_session, score_candidates, score_candidates_with_session,
-    softmax_select_pairs,
+    choose_action, choose_action_with_session, fallback_action, score_candidates,
+    score_candidates_with_session, softmax_select_pairs,
 };
 pub use session::{deck_pools_fingerprint, AiSession, SessionCache};

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1162,12 +1162,13 @@ fn fallback_action(state: &GameState, config: &AiConfig) -> Option<GameAction> {
             Some(GameAction::SelectCards { cards: Vec::new() })
         }
 
-        // Named choice: pick the first option if available.
-        WaitingFor::NamedChoice { options, .. } => {
-            options.first().map(|choice| GameAction::ChooseOption {
-                choice: choice.clone(),
-            })
-        }
+        // Named choice: prefer an engine-legal ChooseOption. CardName prompts
+        // intentionally keep `options` empty and synthesize candidates from
+        // `all_card_names` (#6248); reading `options.first()` softlocks after
+        // restore when rehydrate succeeded but options stayed empty (#6393).
+        WaitingFor::NamedChoice { .. } => engine::ai_support::legal_actions(state)
+            .into_iter()
+            .find(|a| matches!(a, GameAction::ChooseOption { .. })),
 
         // CR 608.2d: opponent-guess fallback — any printed guess is legal. The
         // hidden-info determinization in `choose_action` already pre-empts this
@@ -5745,6 +5746,61 @@ mod tests {
         assert!(
             random_card_predicate_guess(&state, PlayerId(1), &mut rng).is_none(),
             "ordinary land/nonland kind choices are strategic choices, not random guesses"
+        );
+    }
+
+    /// Issue #6393: CardName NamedChoice keeps `options` empty and synthesizes
+    /// candidates from `all_card_names`. Fallback must ask `legal_actions`, not
+    /// `options.first()`, or restore softlocks after a successful rehydrate.
+    #[test]
+    fn named_choice_card_name_fallback_uses_legal_actions_when_options_empty() {
+        let mut state = make_state();
+        create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Forest".to_string(),
+            Zone::Battlefield,
+        );
+        state.all_card_names = vec!["Forest".to_string(), "Island".to_string()].into();
+        state.waiting_for = WaitingFor::NamedChoice {
+            player: PlayerId(0),
+            choice_type: ChoiceType::CardName,
+            options: Vec::new(),
+            source: None,
+            persist_player: None,
+        };
+
+        let action = fallback_action(&state).expect("fallback returns ChooseOption");
+        assert!(
+            matches!(action, GameAction::ChooseOption { ref choice } if choice == "Forest"),
+            "expected Forest from legal_actions, got {action:?}"
+        );
+    }
+
+    /// Issue #6393: when rehydrate never populated `all_card_names`, CardName
+    /// prompts have zero legal actions — fallback must return None rather than
+    /// inventing an option from the empty `options` list.
+    #[test]
+    fn named_choice_card_name_fallback_none_when_all_card_names_empty() {
+        let mut state = make_state();
+        state.all_card_names = Vec::new().into();
+        state.waiting_for = WaitingFor::NamedChoice {
+            player: PlayerId(0),
+            choice_type: ChoiceType::CardName,
+            options: Vec::new(),
+            source: None,
+            persist_player: None,
+        };
+
+        assert!(
+            engine::ai_support::legal_actions(&state).is_empty(),
+            "test premise: empty all_card_names must yield no legal ChooseOption"
+        );
+        assert_eq!(
+            fallback_action(&state),
+            None,
+            "empty legal set must not fabricate a NamedChoice option"
         );
     }
 

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -783,7 +783,13 @@ pub fn emit_trace_for_candidate(
 /// In release builds we still emit `CancelCast` to keep the match running, but
 /// debug builds panic so the gap surfaces during testing instead of silently
 /// degrading AI play into cast/cancel churn.
-fn fallback_action(state: &GameState, config: &AiConfig) -> Option<GameAction> {
+/// Deadlock-safe escape hatch when tactical scoring cannot produce an action.
+/// The WASM bridge exposes this for client AI-controller escape — callers must
+/// not invent actions from legal-action enumeration order (#6393).
+///
+/// `config` supplies policy penalties used by selection escapes (e.g. sacrifice
+/// value ordering); difficulty/search knobs are unused here.
+pub fn fallback_action(state: &GameState, config: &AiConfig) -> Option<GameAction> {
     // CR 601.2c: A spell's target step must use the engine's current legal
     // target list. `target_slots` is a historical snapshot and can be stale
     // after earlier selections; if no current legal action remains, abort the
@@ -5771,7 +5777,7 @@ mod tests {
             persist_player: None,
         };
 
-        let action = fallback_action(&state).expect("fallback returns ChooseOption");
+        let action = fallback_action_default(&state).expect("fallback returns ChooseOption");
         assert!(
             matches!(action, GameAction::ChooseOption { ref choice } if choice == "Forest"),
             "expected Forest from legal_actions, got {action:?}"
@@ -5798,7 +5804,7 @@ mod tests {
             "test premise: empty all_card_names must yield no legal ChooseOption"
         );
         assert_eq!(
-            fallback_action(&state),
+            fallback_action_default(&state),
             None,
             "empty legal set must not fabricate a NamedChoice option"
         );


### PR DESCRIPTION
## Summary
- NamedChoice AI `fallback_action` now picks a legal `ChooseOption` from `legal_actions` (fixes CardName prompts with empty `options` after restore when `all_card_names` is populated).
- AI controller escape never fabricates `PassPriority` for non-Priority waits — empty legal set notifies `ai-controller-stuck:<type>` and stops immediately.
- `restoreState` hard-fails if the card DB failed to load, so we never soft-restore into a CardName softlock without rehydrate.

Closes #6393

## Test plan
- [x] `cargo test -p phase-ai --lib named_choice_card_name_fallback`
- [x] Vitest: `aiController.test.ts` + `wasm-adapter.test.ts` (51 passed)
- [ ] Manual: restore a mid-game save with an AI NamedChoice (CardName) and confirm either a legal guess advances or restore fails cleanly if the card DB is unavailable

## Validation Failures
- Isolated `/review-impl` subagent unavailable (API/model routing); Bugbot found no bugs. Plan was CLEAN before implement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an engine-provided, deadlock-safe AI fallback action for stalled decision moments, available to both the engine worker and the WASM fallback.
* **Bug Fixes**
  * State restoration and multiplayer resume now fail fast with a clear error when the card database can’t be loaded.
  * Improved AI controller escape handling: it no longer fabricates actions for non-priority waits, and it cleanly halts with a clear “engine lost” notification when no valid escape exists.
  * Fixed card-name choice fallback after rehydration by deriving options from current legal actions (and returning none when no legal choices exist).
* **Tests**
  * Added/updated regression coverage for fallback, halt, and card-database failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->