### PR TITLE
refactor(parser): Plan 05b T10c — the die-result branch table as IR (U0-45)

### DIFF
--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -164,6 +164,7 @@ pub(crate) fn parse_class_oracle_text(
                     ],
                     ..AbilityShellIr::default()
                 },
+                die_results: vec![],
             };
             items.push((
                 *level_line,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26858,7 +26858,8 @@ pub(crate) enum ChainLoweringMode {
 ///
 /// # The order is pinned and behavior-load-bearing
 ///
-/// **chain → finalize → anchor → `sub_link` → envelope stamps → stages.**
+/// **chain → die results → finalize → anchor → `sub_link` → envelope stamps →
+/// stages.**
 ///
 /// It is not an aesthetic choice: it reproduces what the whole-body recognizers
 /// in `oracle.rs` do by hand. Every one of them stamps its root fields *after*
@@ -26866,6 +26867,14 @@ pub(crate) enum ChainLoweringMode {
 /// runs the `extract_*` folds last. Reordering — in particular running a stage
 /// before the stamps — changes output, because both stages write root fields
 /// that a stamp may also write. Do not reorder for elegance.
+///
+/// CR 706.3b: the die-result table is part of the *same* ability as the roll, so
+/// it is attached before `finalize_effect_chain` rather than after — finalize and
+/// the anchor then see the complete effect, exactly as they would for an ability
+/// whose table was printed inline. Attaching it later would hand those two a
+/// `RollDie` with an empty results vector and then mutate the result behind them.
+/// The step is a no-op on an empty `die_results`, which is what keeps every
+/// non-die producer byte-identical.
 pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     let mut def = lower_effect_chain_ir(&ir.body);
     if !ir.die_results.is_empty() {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -100,8 +100,8 @@ use crate::types::ability::{
     ChoiceType, ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard,
     ConjureSource, ContinuousModification, ControlWindow, ControllerRef, CopyChooseScope,
     CopyRetargetPermission, CopyScale, DamageModification, DamageSource, DelayedTriggerCondition,
-    DelayedTriggerLifetime, DoubleTarget, Duration, Effect, EffectOutcomeSignal, EffectScope,
-    FilterProp, GameRestriction, GuessSubject, IntensityScope, IterationKindBinding,
+    DelayedTriggerLifetime, DieResultBranch, DoubleTarget, Duration, Effect, EffectOutcomeSignal,
+    EffectScope, FilterProp, GameRestriction, GuessSubject, IntensityScope, IterationKindBinding,
     KeeperConstraint, LibraryPosition, ManaProduction, ManaSpendPermission, MultiTargetSpec,
     NumberDistinctness, ObjectProperty, ObjectScope, OriginConstraint, PerpetualModification,
     PlayPermissionInvalidation, PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount,
@@ -156,8 +156,8 @@ use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
-    EffectChainIr, OtherwiseKind, PlayerScopeRewrite, PriorModifier, ReplaceMeaningKind,
-    ReplicateKind, ShellStage,
+    DieResultBranchIr, EffectChainIr, OtherwiseKind, PlayerScopeRewrite, PriorModifier,
+    ReplaceMeaningKind, ReplicateKind, ShellStage,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -26868,6 +26868,21 @@ pub(crate) enum ChainLoweringMode {
 /// that a stamp may also write. Do not reorder for elegance.
 pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     let mut def = lower_effect_chain_ir(&ir.body);
+    if !ir.die_results.is_empty() {
+        if let Some(Effect::RollDie { results, .. }) =
+            super::oracle_special::find_terminal_roll_die(&mut def)
+        {
+            *results = ir
+                .die_results
+                .iter()
+                .map(|DieResultBranchIr { min, max, effect }| DieResultBranch {
+                    min: *min,
+                    max: *max,
+                    effect: Box::new(lower_ability_ir(effect)),
+                })
+                .collect();
+        }
+    }
     finalize_effect_chain(&mut def);
     apply_owner_library_reveal_anchor_from_text(&mut def, &ir.source_text);
     // CR 608.2c: a root the chain cannot describe (it has no previous boundary).
@@ -26972,6 +26987,7 @@ pub(crate) fn parse_ability_ir(
             source_text: text.to_string(),
             body,
             shell: AbilityShellIr::default(),
+            die_results: vec![],
         };
     }
     if let Some(body) = parse_for_each_attacker_copy_blocker_ir(text, kind, ctx) {
@@ -26979,6 +26995,7 @@ pub(crate) fn parse_ability_ir(
             source_text: text.to_string(),
             body,
             shell: AbilityShellIr::default(),
+            die_results: vec![],
         };
     }
     if let ChainLoweringMode::WithContext = mode {
@@ -26987,6 +27004,7 @@ pub(crate) fn parse_ability_ir(
                 source_text: text.to_string(),
                 body,
                 shell: AbilityShellIr::default(),
+                die_results: vec![],
             };
         }
     }
@@ -27000,12 +27018,14 @@ pub(crate) fn parse_ability_ir(
                 sub_link: Some(SubAbilityLink::SequentialSibling),
                 ..AbilityShellIr::default()
             },
+            die_results: vec![],
         };
     }
     AbilityIr {
         source_text: text.to_string(),
         body: parse_effect_chain_ir(text, kind, ctx),
         shell: AbilityShellIr::default(),
+        die_results: vec![],
     }
 }
 

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -368,6 +368,15 @@ pub(crate) enum ShellStage {
     ExtractManaSpendTrigger,
 }
 
+/// CR 706.3a: one row of a die-roll results table — a possible-result range and
+/// the effect associated with it ("N1–N2" or "N+").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DieResultBranchIr {
+    pub(crate) min: u8,
+    pub(crate) max: u8,
+    pub(crate) effect: Box<AbilityIr>,
+}
+
 /// An effect chain plus the root-level metadata applied around it.
 ///
 /// Lowered by `lower_ability_ir`, which is the single authority for
@@ -390,6 +399,10 @@ pub(crate) struct AbilityIr {
     pub(crate) source_text: String,
     pub(crate) body: EffectChainIr,
     pub(crate) shell: AbilityShellIr,
+    /// Result-table rows supplied by a whole-body die-roll recognizer.
+    ///
+    /// Empty is the default for every ordinary ability IR and is a lowering no-op.
+    pub(crate) die_results: Vec<DieResultBranchIr>,
 }
 
 /// CR 608.2c + CR 601.2c: Subject of a "does the same / does so" effect-replication

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1598
 expression: "&ir"
 ---
 {
@@ -154,7 +153,8 @@ expression: "&ir"
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 191
 expression: "&ir"
 ---
 {
@@ -153,7 +152,8 @@ expression: "&ir"
           },
           "shell": {
             "sub_link": null
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 681
 expression: "&ir"
 ---
 {
@@ -444,7 +443,8 @@ expression: "&ir"
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1503
 expression: "&ir"
 ---
 {
@@ -311,7 +310,8 @@ expression: "&ir"
               }
             ],
             "description": "Solved — {1}{B}, Sacrifice this ~: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery."
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 172
 expression: "&ir"
 ---
 {
@@ -91,7 +90,8 @@ expression: "&ir"
           },
           "shell": {
             "sub_link": null
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1548
 expression: "&ir"
 ---
 {
@@ -194,7 +193,8 @@ expression: "&ir"
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1624
 expression: "&ir"
 ---
 {
@@ -213,7 +212,8 @@ expression: "&ir"
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 550
 expression: "&ir"
 ---
 {
@@ -217,7 +216,8 @@ expression: "&ir"
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
-          }
+          },
+          "die_results": []
         }
       }
     },
@@ -402,7 +402,8 @@ expression: "&ir"
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 580
 expression: "&ir"
 ---
 {
@@ -193,7 +192,8 @@ expression: "&ir"
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
-          }
+          },
+          "die_results": []
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1572
 expression: "&ir"
 ---
 {
@@ -302,7 +301,8 @@ expression: "&ir"
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
-          }
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -255,7 +255,7 @@ pub(super) fn attach_die_result_branches_to_chain(
     j
 }
 
-fn find_terminal_roll_die(def: &mut AbilityDefinition) -> Option<&mut Effect> {
+pub(crate) fn find_terminal_roll_die(def: &mut AbilityDefinition) -> Option<&mut Effect> {
     if matches!(&*def.effect, Effect::RollDie { results, .. } if results.is_empty()) {
         return Some(&mut *def.effect);
     }

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -17,7 +17,11 @@ use crate::types::statics::StaticMode;
 
 use super::oracle_cost::{parse_or_separated_mana_costs, parse_single_cost};
 use super::oracle_effect::imperative::try_parse_die_result_line;
-use super::oracle_effect::{capitalize, parse_effect_chain};
+use super::oracle_effect::{
+    capitalize, lower_ability_ir, parse_ability_ir_standalone, parse_effect_chain,
+};
+use super::oracle_ir::ast::parsed_clause;
+use super::oracle_ir::effect_chain::{AbilityIr, AbilityShellIr, DieResultBranchIr, EffectChainIr};
 use super::oracle_nom::bridge::nom_on_lower;
 use super::oracle_nom::condition::parse_inner_condition;
 use super::oracle_nom::error::OracleResult;
@@ -265,7 +269,8 @@ pub(crate) fn find_terminal_roll_die(def: &mut AbilityDefinition) -> Option<&mut
     None
 }
 
-/// CR 706: Try to parse a die roll table starting at line `i`.
+/// CR 706.3b: The die-roll instruction and its associated results table are
+/// part of one ability, so this consumes the table lines into the header's IR.
 /// CR 706.2: Also extracts an optional "and add/subtract X" modifier
 /// from the header line so the resolver can shift the natural result before
 /// branch lookup (Deck of Many Things, Diviner's Portent, Gale's Redirection).
@@ -289,11 +294,10 @@ pub(super) fn try_parse_die_roll_table(
         }
         if let Some((min, max, effect_text)) = try_parse_die_result_line(&table_line) {
             let effect_text = strip_die_table_flavor_label(effect_text);
-            let branch_def = parse_effect_chain(effect_text, kind);
-            branches.push(DieResultBranch {
+            branches.push(DieResultBranchIr {
                 min,
                 max,
-                effect: Box::new(branch_def),
+                effect: Box::new(parse_ability_ir_standalone(effect_text, kind)),
             });
             has_branches = true;
             j += 1;
@@ -302,18 +306,29 @@ pub(super) fn try_parse_die_roll_table(
         }
     }
 
-    let mut def = AbilityDefinition::new(
-        kind,
-        Effect::RollDie {
-            // CR 706.1: result-table rolls are single-die ("roll a d20 ...").
-            count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
-            sides,
-            results: branches,
-            modifier,
+    let ir = AbilityIr {
+        source_text: line.to_string(),
+        body: EffectChainIr::single_clause(
+            line,
+            kind,
+            parsed_clause(Effect::RollDie {
+                // CR 706.1: result-table rolls are single-die ("roll a d20 ...").
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                sides,
+                results: vec![],
+                modifier,
+            }),
+            None,
+            None,
+            false,
+        ),
+        shell: AbilityShellIr {
+            description: Some(line.to_string()),
+            ..AbilityShellIr::default()
         },
-    );
-    def.description = Some(line.to_string());
-    Some((def, if has_branches { j } else { i + 1 }))
+        die_results: branches,
+    };
+    Some((lower_ability_ir(&ir), if has_branches { j } else { i + 1 }))
 }
 
 /// CR 706.1a + CR 706.2: Parse the header line of a die-roll table, returning


### PR DESCRIPTION
Plan 05b **T10c** — converts **U0-45**, the CR 706 die-roll table producer, to real IR. Follows #6733.

This is the only die row that owns its whole definition. The other five *mutate a definition someone else already lowered* and are a strictly harder seam — they stay out. T10c ships the type; **T10d spends it.**

| # | commit | producers |
|---|---|---|
| 1 | `DieResultBranchIr` + `AbilityIr.die_results` | **zero** |
| 2 | convert `try_parse_die_roll_table` | 1 |
| 3 | pin the new step into the documented lowering order | — |

## The branch bodies are R1 — the identity is the function body

Each row's effect was `parse_effect_chain(effect_text, kind)`. That call **is** `lower_ability_ir(&parse_ability_ir_standalone(effect_text, kind))` — the entire body of `parse_effect_chain`, not a claim about it. Splitting it moves *where* lowering happens, never *what* it produces.

`Box<AbilityIr>` rather than `Box<EffectChainIr>` is load-bearing, not style: `lower_effect_chain_ir` skips `finalize_effect_chain` and the owner-library anchor, both of which `parse_effect_chain` runs today.

## CR 706.3a is the row shape; CR 706.3b decides where the table lives

> **706.3a** … The possible results indicated could be a single number, a range of numbers with two endpoints in the form "N1–N2," or a range with a single endpoint in the form "N+." …

That is `{min, max, effect}` verbatim.

> **706.3b** An instruction to roll one or more dice, any instructions to modify that roll printed in the same paragraph, any additional instructions based on the result of the roll, and the associated results table **are all part of one ability.**

So the table is not a sibling document item that happens to follow — carrying it inside the `AbilityIr` is what the rules describe, and the same sentence licenses the line-consumption (`next_i`) behaviour: those following lines are not independent abilities. Both rules were grep-verified and their **text read**, not existence-checked.

## The risk that had to be measured rather than argued

Today U0-45's definition is built by `AbilityDefinition::new` and **never passes through `finalize_effect_chain` or `apply_owner_library_reveal_anchor_from_text`.** Routing it through `lower_ability_ir` subjects it to both for the first time, across ~113 die cards.

Both were *expected* inert — a one-clause chain has no continuations to finalize, and the anchor is text-driven off `source_text`, which here is a `"Roll a dN…"` header with no owner-library reveal phrasing. **But that is an R2 argument about today's corpus, not an identity.** This campaign's one landed defect (#6123) passed review precisely because its byte-identity claim was true while its reach argument was untested. So it was measured.

```
FULL-POOL BYTE-IDENTICAL
2737d0783ece3443cb0041323114ee06eaa06f8e30431f817784e4dd5312f289   6cedb28c44  base
2737d0783ece3443cb0041323114ee06eaa06f8e30431f817784e4dd5312f289   commit 1
2737d0783ece3443cb0041323114ee06eaa06f8e30431f817784e4dd5312f289   commit 2
```

Neither mechanism fired. Three fresh generator builds, distinct target dirs, `MTGJSON_SKIP_REFRESH=1`, real `AtomicCards.json` (158,014,511 bytes — resolved and size-checked, since the fixture population would be void evidence rather than a green).

*Stated rather than buried:* the measured revisions differ from the shipped ones by the ten accepted `.snap` files and commit 3's doc comment. That was **verified mechanically**, not asserted — every differing line is either a `.snap` fixture or a `///` line, so no generator input or code path differs and the hashes carry to the tip.

## Commit 1 is inert by construction

`die_results` defaults to empty and the applier is guarded on non-empty, so every pre-existing producer lowers exactly as before — the same defer-on-default property that made the A0 shell widening byte-identical. The existing `find_terminal_roll_die` walk is **reused**, not duplicated; only its visibility changed.

Ten `*_ir.snap` fixtures moved, all the identical schema addition (`"die_results": []`) and nothing else. The `_ir`/`_lowered` masking trap was handled correctly: the ten `_ir` assertions were accepted, then the snapshot module was **re-run** to confirm the `_lowered` assertions that follow them still pass. Zero `*.snap.new` pending.

## Commit 3 — the ordering doc had gone stale, and it is the load-bearing kind

`lower_ability_ir`'s doc declares itself the single authority on a sequence that is *"pinned and behavior-load-bearing"*, ending **"Do not reorder for elegance."** Commit 1 inserted a step into that sequence without it appearing there.

Attaching die results **before** `finalize_effect_chain` is a real decision: finalize and the anchor then see the complete effect, exactly as they would for an ability whose table was printed inline. Attaching later would hand those two a `RollDie` with an empty results vector and then mutate the result behind them. That reasoning now lives in the doc that claims to own the order.

## Gates

```
cargo fmt --all                                 clean
clippy -p engine --lib -- -D warnings           zero warnings
cargo nextest run -p engine --lib               17909 passed, 6 skipped
cargo nextest run -p engine --test integration   4159 passed, 2 skipped
Gate P (PreLowered ratchet)                     PASS — no movement expected; this row's
                                                producer was never a PreLowered token
check-parser-combinators.sh                     Gate G PASS / Gate A PASS
check-skill-doc.sh                              PASS
*.snap.new pending                              0
```

## Scope held

The five `attach_die_result_branches_to_chain` call sites are **untouched** — they mutate an already-lowered definition and return an advanced line index, which is a different and harder problem. They are U0-28 (T10b) and U0-30/32/49 (T10d), and T10d inherits `DieResultBranchIr` from here.

One behaviour worth naming for a reviewer: the applier silently no-ops if the walk finds no terminal `RollDie`. That mirrors the existing `attach_die_result_branches_to_chain`, which returns early on the same condition — house convention rather than a new failure mode, and unreachable from the single producer, which always builds a `RollDie` root.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and displaying die-roll result tables with range-based outcomes.
  * Die-roll outcomes can now include nested effects and abilities.

* **Bug Fixes**
  * Improved handling of activated abilities and die-roll results to ensure outcomes are applied consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->