### PR TITLE
Add Deathbringer Regent

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -15700,6 +15700,49 @@ mod tests {
         }
     }
 
+    /// CR 603.4 + CR 109.2: Deathbringer Regent's threshold counts any
+    /// player's other creatures on the battlefield.
+    #[test]
+    fn test_there_are_n_or_more_other_creatures_on_battlefield() {
+        let (rest, c) =
+            parse_inner_condition("there are five or more other creatures on the battlefield")
+                .unwrap();
+        assert_eq!(rest, "");
+        match c {
+            StaticCondition::QuantityComparison {
+                lhs:
+                    QuantityExpr::Ref {
+                        qty: QuantityRef::ObjectCount { filter },
+                    },
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 5 },
+            } => match filter {
+                TargetFilter::Typed(tf) => {
+                    assert!(
+                        tf.type_filters.contains(&TypeFilter::Creature),
+                        "expected creature filter, got {:?}",
+                        tf.type_filters
+                    );
+                    assert_eq!(tf.controller, None);
+                    assert!(
+                        tf.properties.contains(&FilterProp::Another),
+                        "expected Another prop, got {:?}",
+                        tf.properties
+                    );
+                    assert!(
+                        tf.properties.contains(&FilterProp::InZone {
+                            zone: Zone::Battlefield
+                        }),
+                        "expected battlefield-only count, got {:?}",
+                        tf.properties
+                    );
+                }
+                other => panic!("expected typed creature filter, got {other:?}"),
+            },
+            other => panic!("expected ObjectCount GE 5, got {other:?}"),
+        }
+    }
+
     /// SEMANTIC CORRECTNESS: the there-form scopes to exactly the stated
     /// objects. "there are no Zombies on the battlefield" (Sarcomancy) counts
     /// only the Zombie subtype, NOT all creatures.

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -7923,6 +7923,26 @@ fn parse_entered_this_turn_under_opponent_control(
 /// continuous "as long as" gates), both of which re-read the condition against
 /// live game state at check time.
 fn parse_there_are_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
+    parse_there_are_conditions_with_quantity(input, nom_quantity::parse_quantity_ref)
+}
+
+/// Narrow fallback for a caller that owns the comma separating an
+/// intervening-if from its trigger effect. The caller first tries the complete
+/// generic condition grammar; this only handles the strict battlefield-count
+/// noun phrase followed by that clause boundary.
+pub(crate) fn parse_there_are_battlefield_count_clause(
+    input: &str,
+) -> OracleResult<'_, StaticCondition> {
+    parse_there_are_conditions_with_quantity(
+        input,
+        nom_quantity::parse_type_count_on_battlefield_clause,
+    )
+}
+
+fn parse_there_are_conditions_with_quantity(
+    input: &str,
+    parse_quantity: for<'a> fn(&'a str) -> OracleResult<'a, QuantityRef>,
+) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("there are ").parse(input)?;
     let (rest, prefix) = opt(parse_strict_comparator_prefix).parse(rest)?;
     let (rest, n) = parse_number(rest)?;
@@ -7954,7 +7974,7 @@ fn parse_there_are_conditions(input: &str) -> OracleResult<'_, StaticCondition> 
             ),
         ));
     }
-    let (rest, qty) = nom_quantity::parse_quantity_ref.parse(rest)?;
+    let (rest, qty) = parse_quantity(rest)?;
     Ok((
         rest,
         make_quantity_comparison(
@@ -15701,9 +15721,10 @@ mod tests {
     }
 
     /// CR 603.4 + CR 109.2: Deathbringer Regent's threshold counts any
-    /// player's other creatures on the battlefield.
+    /// player's other creatures on the battlefield when given its complete
+    /// condition clause.
     #[test]
-    fn test_there_are_n_or_more_other_creatures_on_battlefield() {
+    fn deathbringer_regent_noun_clause_is_battlefield_scoped() {
         let (rest, c) =
             parse_inner_condition("there are five or more other creatures on the battlefield")
                 .unwrap();

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -7,7 +7,7 @@
 use crate::parser::oracle_nom::error::OracleError;
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until, take_while1};
-use nom::combinator::{all_consuming, map, map_res, opt, value};
+use nom::combinator::{all_consuming, eof, map, map_res, opt, peek, value};
 use nom::multi::separated_list1;
 use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
@@ -940,7 +940,7 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         // extremum. Distinctive "the player with the " prefix; no ordering
         // hazard with sibling arms.
         parse_player_with_extremum_cards_in_hand,
-        // CR 118.9 / CR 601.3: bare "<type> on the battlefield" object count.
+        // Bare "<type> on the battlefield" object count.
         // Placed LAST (lowest priority) so every specific arm — notably
         // `parse_greatest_commander_mana_value_ref` for "the greatest mana value
         // of a commander you own on the battlefield" — wins first; this fallback
@@ -951,33 +951,64 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     .parse(input)
 }
 
-/// CR 118.9 + CR 601.3: "<type> on the battlefield" → count of matching objects
-/// on the battlefield. The GE / "N or more" sibling of `parse_no_on_battlefield`
+/// "<type> on the battlefield" → count of matching objects on the battlefield.
+/// The GE / "N or more" sibling of `parse_no_on_battlefield`
 /// (`oracle_nom/condition.rs`, which emits the `== 0` form); reached after a
 /// parent combinator (`parse_there_are_conditions`) has consumed the "there are
 /// N or more " quantifier, leaving the bare noun phrase (Blasphemous Edict's
 /// "creatures on the battlefield").
 ///
-/// The full phrase is decoded by `parse_type_phrase`, so the " on the
-/// battlefield" locative is re-attached as `FilterProp::InZone { Battlefield }`
-/// exactly as the for-each battlefield-count fallback does
-/// (`oracle_quantity::parse_type_phrase_with_ctx`) — this arm therefore produces
-/// byte-identical `ObjectCount` filters for any for-each clause it now intercepts
-/// at the shared `parse_quantity_ref` seam. Its remainder is either empty or the
-/// trigger clause's leading comma, allowing callers to retain the effect text
-/// without re-parsing this grammar. The competing zone-disjunction form remains
+/// The phrase must be fully consumed here. Context-specific callers that own a
+/// clause boundary (such as cast-and-condition trigger parsing) split it before
+/// using this shared grammar. The competing zone-disjunction form remains
 /// rejected so its dedicated commander-mana-value arm can claim it.
 fn parse_type_count_on_battlefield(input: &str) -> OracleResult<'_, QuantityRef> {
+    parse_type_count_on_battlefield_with_boundary(input, BattlefieldCountBoundary::CompletePhrase)
+}
+
+/// The same count grammar when the enclosing caller owns a comma-delimited
+/// clause boundary. Keep this separate from `parse_quantity_ref`: generic
+/// condition extraction must not consume an effect tail as a quantity suffix.
+pub(crate) fn parse_type_count_on_battlefield_clause(input: &str) -> OracleResult<'_, QuantityRef> {
+    parse_type_count_on_battlefield_with_boundary(input, BattlefieldCountBoundary::Clause)
+}
+
+enum BattlefieldCountBoundary {
+    CompletePhrase,
+    Clause,
+}
+
+fn parse_type_count_on_battlefield_with_boundary(
+    input: &str,
+    boundary: BattlefieldCountBoundary,
+) -> OracleResult<'_, QuantityRef> {
     let (after_anchor, _) = take_until(" on the battlefield").parse(input)?;
     let (rest, _) = tag(" on the battlefield").parse(after_anchor)?;
-    if !rest.is_empty() && !rest.starts_with(',') {
-        return Err(oracle_err(input));
-    }
-    let type_text = &input[..input.len() - after_anchor.len()];
+    let (type_text, needs_battlefield_presence) = match boundary {
+        BattlefieldCountBoundary::CompletePhrase => {
+            if !rest.trim().is_empty() {
+                return Err(oracle_err(input));
+            }
+            (input, false)
+        }
+        BattlefieldCountBoundary::Clause => {
+            let (rest, _) = peek(alt((eof, tag(",")))).parse(rest)?;
+            if rest.is_empty() {
+                (input, false)
+            } else {
+                (&input[..input.len() - after_anchor.len()], true)
+            }
+        }
+    };
     let (filter, type_rest) = parse_type_phrase(type_text);
     if matches!(filter, TargetFilter::Any) || !type_rest.trim().is_empty() {
         return Err(oracle_err(input));
     }
+    let filter = if needs_battlefield_presence {
+        super::condition::inject_battlefield_presence(filter)
+    } else {
+        filter
+    };
     Ok((rest, QuantityRef::ObjectCount { filter }))
 }
 
@@ -5500,10 +5531,27 @@ mod tests {
     }
 
     #[test]
-    fn type_count_on_battlefield_preserves_comma_tail() {
-        let (rest, parsed) =
-            parse_type_count_on_battlefield("other creatures on the battlefield, then draw a card")
-                .expect("a comma starts the next trigger clause");
+    fn type_count_on_battlefield_accepts_eof_tail() {
+        let (rest, parsed) = parse_type_count_on_battlefield("other creatures on the battlefield")
+            .expect("EOF terminates the noun clause");
+        assert_eq!(rest, "");
+        assert!(matches!(parsed, QuantityRef::ObjectCount { .. }));
+    }
+
+    #[test]
+    fn type_count_on_battlefield_rejects_comma_tail() {
+        assert!(parse_type_count_on_battlefield(
+            "other creatures on the battlefield, then draw a card"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn type_count_on_battlefield_clause_preserves_comma_tail() {
+        let (rest, parsed) = parse_type_count_on_battlefield_clause(
+            "other creatures on the battlefield, then draw a card",
+        )
+        .expect("the caller owns the clause boundary");
         assert_eq!(rest, ", then draw a card");
         assert!(matches!(parsed, QuantityRef::ObjectCount { .. }));
     }
@@ -5514,6 +5562,14 @@ mod tests {
             "creatures on the battlefield or in the command zone"
         )
         .is_err());
+    }
+
+    #[test]
+    fn type_count_on_battlefield_rejects_non_comma_textual_tail() {
+        assert!(
+            parse_type_count_on_battlefield("creatures on the battlefield then draw a card")
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -5500,6 +5500,22 @@ mod tests {
     }
 
     #[test]
+    fn type_count_on_battlefield_rejects_comma_tail() {
+        assert!(parse_type_count_on_battlefield(
+            "other creatures on the battlefield, then draw a card"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn type_count_on_battlefield_rejects_command_zone_disjunction() {
+        assert!(parse_type_count_on_battlefield(
+            "creatures on the battlefield or in the command zone"
+        )
+        .is_err());
+    }
+
+    #[test]
     fn for_each_opponent_dealt_damage_is_event_context_player_count() {
         for phrase in [
             "opponent dealt damage",

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -963,22 +963,22 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
 /// exactly as the for-each battlefield-count fallback does
 /// (`oracle_quantity::parse_type_phrase_with_ctx`) — this arm therefore produces
 /// byte-identical `ObjectCount` filters for any for-each clause it now intercepts
-/// at the shared `parse_quantity_ref` seam. Guarded two ways so it stays strictly
-/// additive on that high-traffic surface: the phrase must END with the battlefield
-/// locative (rejecting "…on the battlefield or in the command zone", which its
-/// dedicated commander-mana-value arm claims), and the type phrase must fully
-/// consume and be non-`Any`.
+/// at the shared `parse_quantity_ref` seam. Its remainder is either empty or the
+/// trigger clause's leading comma, allowing callers to retain the effect text
+/// without re-parsing this grammar. The competing zone-disjunction form remains
+/// rejected so its dedicated commander-mana-value arm can claim it.
 fn parse_type_count_on_battlefield(input: &str) -> OracleResult<'_, QuantityRef> {
     let (after_anchor, _) = take_until(" on the battlefield").parse(input)?;
-    let (after_anchor, _) = tag(" on the battlefield").parse(after_anchor)?;
-    if !after_anchor.trim().is_empty() {
+    let (rest, _) = tag(" on the battlefield").parse(after_anchor)?;
+    if !rest.is_empty() && !rest.starts_with(',') {
         return Err(oracle_err(input));
     }
-    let (filter, type_rest) = parse_type_phrase(input);
+    let type_text = &input[..input.len() - after_anchor.len()];
+    let (filter, type_rest) = parse_type_phrase(type_text);
     if matches!(filter, TargetFilter::Any) || !type_rest.trim().is_empty() {
         return Err(oracle_err(input));
     }
-    Ok(("", QuantityRef::ObjectCount { filter }))
+    Ok((rest, QuantityRef::ObjectCount { filter }))
 }
 
 /// CR 109.3 + CR 205.3m: Parse "the greatest/fewest/total number of
@@ -5500,11 +5500,12 @@ mod tests {
     }
 
     #[test]
-    fn type_count_on_battlefield_rejects_comma_tail() {
-        assert!(parse_type_count_on_battlefield(
-            "other creatures on the battlefield, then draw a card"
-        )
-        .is_err());
+    fn type_count_on_battlefield_preserves_comma_tail() {
+        let (rest, parsed) =
+            parse_type_count_on_battlefield("other creatures on the battlefield, then draw a card")
+                .expect("a comma starts the next trigger clause");
+        assert_eq!(rest, ", then draw a card");
+        assert!(matches!(parsed, QuantityRef::ObjectCount { .. }));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4819,26 +4819,7 @@ fn parse_cast_and_condition_intervening_if(input: &str) -> OracleResult<'_, Trig
     ))
     .parse(rest)?;
     let (rest, _) = tag(" and ").parse(rest)?;
-    let (rest, sc) = match parse_inner_condition(rest) {
-        Ok(parsed) => parsed,
-        // Deathbringer Regent's threshold ends at the trigger-clause comma.
-        // Keep this boundary narrowly scoped to the exact "there are … on the
-        // battlefield," form: a generic comma split would truncate valid
-        // comma-separated conditions (for example source-zone Oxford lists).
-        Err(_) => {
-            let (_, _) = tag("there are ").parse(rest)?;
-            let (after_prefix, _) = take_until(" on the battlefield,").parse(rest)?;
-            let condition_len = rest.len() - after_prefix.len() + " on the battlefield".len();
-            let condition_text = &rest[..condition_len];
-            let comma_tail = &rest[condition_len..];
-            let (condition_rest, sc) = parse_inner_condition(condition_text)?;
-            if !condition_rest.trim().is_empty() {
-                return Err(oracle_err(input));
-            }
-            (comma_tail, sc)
-        }
-        Err(error) => return Err(error),
-    };
+    let (rest, sc) = parse_inner_condition(rest)?;
     let cond_b = static_condition_to_trigger_condition(&sc).ok_or_else(|| oracle_err(input))?;
     let cond_a = zone.map_or(
         TriggerCondition::WasCast {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -21,7 +21,9 @@ use super::oracle_ir::trigger::{
 };
 use super::oracle_modal::try_parse_inline_modal_ir;
 use super::oracle_nom::condition::parse_elided_subject_state_condition;
-use super::oracle_nom::condition::parse_inner_condition;
+use super::oracle_nom::condition::{
+    parse_inner_condition, parse_there_are_battlefield_count_clause,
+};
 use super::oracle_nom::condition::{parse_source_counters_exist, parse_source_has_counters};
 use super::oracle_nom::error::{oracle_err, OracleResult};
 use super::oracle_nom::filter::{
@@ -4819,7 +4821,11 @@ fn parse_cast_and_condition_intervening_if(input: &str) -> OracleResult<'_, Trig
     ))
     .parse(rest)?;
     let (rest, _) = tag(" and ").parse(rest)?;
-    let (rest, sc) = parse_inner_condition(rest)?;
+    // First use the complete shared condition grammar: some conditions own
+    // commas themselves (for example, multi-zone lists). Only the strict
+    // battlefield-count noun phrase needs the clause-aware fallback below.
+    let (rest, sc) =
+        parse_inner_condition(rest).or_else(|_| parse_there_are_battlefield_count_clause(rest))?;
     let cond_b = static_condition_to_trigger_condition(&sc).ok_or_else(|| oracle_err(input))?;
     let cond_a = zone.map_or(
         TriggerCondition::WasCast {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4795,33 +4795,59 @@ fn parse_cast_from_zone_intervening_if(input: &str) -> OracleResult<'_, TriggerC
     Ok((rest, scoped_you_cast_from_zone(zone)))
 }
 
-/// CR 603.4 + CR 404.1 + CR 205.3: "if you cast it/them and <game-state condition>"
-/// — cast-provenance AND a second conjunct (Ran and Shaw: "if you cast them and
-/// there are three or more Dragon and/or Lesson cards in your graveyard"). The
-/// "you cast it/them" conjunct binds the unscoped `WasCast` (matching the sibling
-/// "if you cast it" convention at the bare handler below — the meaningful ETB
-/// discriminator is cast vs put-into-play, and the caster controls their own
-/// creature). The second conjunct is delegated to `parse_inner_condition` (the
-/// shared game-state authority) and bridged via `static_condition_to_trigger_condition`,
-/// so the graveyard multi-subtype "and/or" threshold (CR 404.1 owner-specific
-/// graveyard, CR 205.3 subtypes) rides the existing `ZoneCardCount` path with no
-/// new combinator. Both conjuncts fold into `TriggerCondition::And`, mirroring the
-/// BB4 Fearless conjunction `parse_typed_attacked_this_combat_conjunction`. MUST be
-/// registered before the bare "if you cast it" handler, which strips only the cast
-/// conjunct and would drop the second clause.
-fn parse_cast_them_and_graveyard_count_intervening_if(
-    input: &str,
-) -> OracleResult<'_, TriggerCondition> {
+/// CR 603.4 + CR 601.2: Parse "if you cast it/them [from <zone>] and
+/// <game-state condition>" as a cast-provenance AND a second conjunct. The
+/// game-state side is delegated to `parse_inner_condition` and bridged through
+/// `static_condition_to_trigger_condition`, keeping all quantity/filter grammar
+/// in its shared authority. A zoned cast uses the same caster/owner scoping as
+/// the simple "if you cast it from <zone>" handler; the unzoned form preserves
+/// the established bare `WasCast` representation used by Ran and Shaw.
+///
+/// This must be registered before the simple positive zoned and bare cast
+/// scanners: either scanner would otherwise consume only the cast prefix and
+/// silently discard the trailing conjunct.
+fn parse_cast_and_condition_intervening_if(input: &str) -> OracleResult<'_, TriggerCondition> {
     let (rest, _) = tag("if ").parse(input)?;
     let (rest, _) = alt((tag("you cast them"), tag("you cast it"))).parse(rest)?;
+    let (rest, zone) = opt(preceded(
+        tag(" from "),
+        alt((
+            value(Zone::Hand, tag("your hand")),
+            value(Zone::Graveyard, tag("your graveyard")),
+            value(Zone::Exile, tag("exile")),
+        )),
+    ))
+    .parse(rest)?;
     let (rest, _) = tag(" and ").parse(rest)?;
-    let (rest, sc) = parse_inner_condition(rest)?;
-    let cond_b = static_condition_to_trigger_condition(&sc).ok_or_else(|| oracle_err(input))?;
-    let cond_a = TriggerCondition::WasCast {
-        zone: None,
-        controller: None,
-        owner: None,
+    let (rest, sc) = match parse_inner_condition(rest) {
+        Ok(parsed) => parsed,
+        // Deathbringer Regent's threshold ends at the trigger-clause comma.
+        // Keep this boundary narrowly scoped to the exact "there are … on the
+        // battlefield," form: a generic comma split would truncate valid
+        // comma-separated conditions (for example source-zone Oxford lists).
+        Err(_) => {
+            let (_, _) = tag("there are ").parse(rest)?;
+            let (after_prefix, _) = take_until(" on the battlefield,").parse(rest)?;
+            let condition_len = rest.len() - after_prefix.len() + " on the battlefield".len();
+            let condition_text = &rest[..condition_len];
+            let comma_tail = &rest[condition_len..];
+            let (condition_rest, sc) = parse_inner_condition(condition_text)?;
+            if !condition_rest.trim().is_empty() {
+                return Err(oracle_err(input));
+            }
+            (comma_tail, sc)
+        }
+        Err(error) => return Err(error),
     };
+    let cond_b = static_condition_to_trigger_condition(&sc).ok_or_else(|| oracle_err(input))?;
+    let cond_a = zone.map_or(
+        TriggerCondition::WasCast {
+            zone: None,
+            controller: None,
+            owner: None,
+        },
+        scoped_you_cast_from_zone,
+    );
     Ok((
         rest,
         TriggerCondition::And {
@@ -4944,11 +4970,11 @@ fn extract_if_condition_with_card_name(
         );
     }
 
-    // CR 603.4 + CR 601.2: "if you cast it from your hand/graveyard/exile" —
-    // positive zone-specific cast check. The entering object must have been cast
-    // from the named zone. MUST precede the zoneless "if you cast it" arm.
+    // CR 603.4 + CR 601.2: "if you cast it/them [from <zone>] and <game-state
+    // condition>". This must precede both simple positive and bare cast scanners,
+    // which otherwise truncate the condition after its cast-provenance prefix.
     if let Some((before, condition, rest)) =
-        scan_preceded(&lower, parse_cast_from_zone_intervening_if)
+        scan_preceded(&lower, parse_cast_and_condition_intervening_if)
     {
         let pos = before.len();
         let clause_len = lower.len() - before.len() - rest.len();
@@ -4958,13 +4984,10 @@ fn extract_if_condition_with_card_name(
         );
     }
 
-    // CR 603.4 + CR 404.1 + CR 205.3: "if you cast it/them and <game-state
-    // condition>" — cast-provenance AND a second conjunct (Ran and Shaw's
-    // graveyard-count gate). MUST precede the bare "if you cast it" handler
-    // below: that handler strips only the cast conjunct and would silently drop
-    // the trailing And clause, truncating the condition.
+    // CR 603.4 + CR 601.2: simple positive zone-specific cast check. Keep this
+    // after the conjunction scanner so an `and <condition>` tail cannot be lost.
     if let Some((before, condition, rest)) =
-        scan_preceded(&lower, parse_cast_them_and_graveyard_count_intervening_if)
+        scan_preceded(&lower, parse_cast_from_zone_intervening_if)
     {
         let pos = before.len();
         let clause_len = lower.len() - before.len() - rest.len();

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -24,6 +24,48 @@ use crate::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
 use crate::types::replacements::ReplacementEvent;
 use crate::types::statics::{CastFrequency, StaticMode};
 
+#[test]
+fn extract_hand_cast_battlefield_threshold_leaves_effect_text() {
+    let (cleaned, condition) = extract_if_condition(
+        "if you cast it from your hand and there are five or more other creatures on the battlefield, destroy all other creatures",
+    );
+    assert_eq!(cleaned, "destroy all other creatures");
+
+    let TriggerCondition::And { conditions } = condition.expect("expected conjunction") else {
+        panic!("expected cast-and-threshold trigger condition");
+    };
+    assert_eq!(conditions.len(), 2);
+    assert!(matches!(
+        &conditions[0],
+        TriggerCondition::WasCast {
+            zone: Some(crate::types::zones::Zone::Hand),
+            controller: Some(ControllerRef::You),
+            owner: Some(ControllerRef::You),
+        }
+    ));
+    let TriggerCondition::QuantityComparison {
+        lhs:
+            QuantityExpr::Ref {
+                qty:
+                    QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(filter),
+                    },
+            },
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Fixed { value: 5 },
+    } = &conditions[1]
+    else {
+        panic!("expected other-creature threshold, got {:?}", conditions[1]);
+    };
+    assert_eq!(filter.type_filters, vec![TypeFilter::Creature]);
+    assert!(filter
+        .properties
+        .contains(&FilterProp::OtherThanTriggerObject));
+    assert!(filter.properties.contains(&FilterProp::InZone {
+        zone: crate::types::zones::Zone::Battlefield,
+    }));
+}
+
 // --- Fix B: damage-recipient qualifier (player axis preserved + object axis added) ---
 
 #[test]

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -66,6 +66,86 @@ fn extract_hand_cast_battlefield_threshold_leaves_effect_text() {
     }));
 }
 
+/// The zoned cast-and-condition parser shares its condition branch across all
+/// supported origin zones. These focused extractor cases prove the graveyard
+/// owner scope and shared-exile owner scope without inventing a runtime card.
+#[test]
+fn extract_zoned_cast_and_threshold_preserves_graveyard_and_exile_scopes() {
+    for (origin, expected_zone, expected_owner) in [
+        ("your graveyard", Zone::Graveyard, Some(ControllerRef::You)),
+        ("exile", Zone::Exile, None),
+    ] {
+        let input = format!(
+            "if you cast it from {origin} and there are five or more other creatures on the battlefield, destroy all other creatures"
+        );
+        let (cleaned, condition) = extract_if_condition(&input);
+        assert_eq!(cleaned, "destroy all other creatures");
+
+        let Some(TriggerCondition::And { conditions }) = condition else {
+            panic!("expected {origin} cast-and-threshold conjunction, got {condition:?}");
+        };
+        assert_eq!(conditions.len(), 2);
+        match &conditions[0] {
+            TriggerCondition::WasCast {
+                zone: Some(zone),
+                controller: Some(ControllerRef::You),
+                owner,
+            } => {
+                assert_eq!(zone, &expected_zone, "unexpected origin zone for {origin}");
+                assert_eq!(
+                    owner, &expected_owner,
+                    "unexpected owner scope for {origin}"
+                );
+            }
+            other => panic!("expected scoped WasCast for {origin}, got {other:?}"),
+        }
+        assert!(matches!(
+            &conditions[1],
+            TriggerCondition::QuantityComparison {
+                comparator: Comparator::GE,
+                rhs: QuantityExpr::Fixed { value: 5 },
+                ..
+            }
+        ));
+    }
+}
+
+#[test]
+fn extract_cast_and_condition_keeps_condition_internal_commas() {
+    let (cleaned, condition) = extract_if_condition(
+        "if you cast it and ~ is in your graveyard, in your hand, or in exile, draw a card",
+    );
+    assert_eq!(cleaned, "draw a card");
+    let Some(TriggerCondition::And { conditions }) = condition else {
+        panic!("expected cast-and-zone-list conjunction, got {condition:?}");
+    };
+    assert!(matches!(conditions[0], TriggerCondition::WasCast { .. }));
+    assert!(matches!(
+        &conditions[1],
+        TriggerCondition::Or { conditions: zones } if zones.len() == 3
+    ));
+}
+
+#[test]
+fn extract_cast_and_condition_keeps_grouped_number() {
+    let (cleaned, condition) = extract_if_condition(
+        "if you cast it and there are 1,000 or more other creatures on the battlefield, destroy all other creatures",
+    );
+    assert_eq!(cleaned, "destroy all other creatures");
+    let Some(TriggerCondition::And { conditions }) = condition else {
+        panic!("expected cast-and-threshold conjunction, got {condition:?}");
+    };
+    assert!(matches!(conditions[0], TriggerCondition::WasCast { .. }));
+    assert!(matches!(
+        &conditions[1],
+        TriggerCondition::QuantityComparison {
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 1000 },
+            ..
+        }
+    ));
+}
+
 // --- Fix B: damage-recipient qualifier (player axis preserved + object axis added) ---
 
 #[test]

--- a/crates/engine/tests/integration/l02_bb2_cast_origin.rs
+++ b/crates/engine/tests/integration/l02_bb2_cast_origin.rs
@@ -23,9 +23,10 @@ use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle::parse_oracle_text;
 use engine::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use engine::types::ability::{
-    AbilityCondition, Comparator, CountScope, QuantityExpr, QuantityRef, TriggerCondition,
-    TypeFilter, ZoneRef,
+    AbilityCondition, Comparator, CountScope, FilterProp, QuantityExpr, QuantityRef, TargetFilter,
+    TriggerCondition, TypeFilter, ZoneRef,
 };
+use engine::types::actions::GameAction;
 use engine::types::card_type::Supertype;
 use engine::types::counter::CounterType;
 use engine::types::game_state::CastingVariant;
@@ -58,6 +59,10 @@ const RAN_AND_SHAW: &str = "Flying, firebending 2\n\
 When Ran and Shaw enter, if you cast them and there are three or more Dragon and/or Lesson \
 cards in your graveyard, create a token that's a copy of Ran and Shaw, except it's not legendary.\n\
 {3}{R}: Dragons you control get +2/+0 until end of turn.";
+
+const DEATHBRINGER_REGENT: &str = "Flying\nWhen this creature enters, if you cast it from your hand and there are five or more other creatures on the battlefield, destroy all other creatures.";
+
+const MURDER: &str = "Destroy target creature.";
 
 /// A vanilla {0} reanimation sorcery: the entering permanent is *put onto the
 /// battlefield* (never cast), so its `cast_from_zone` stays `None` (CR 400.7).
@@ -247,6 +252,87 @@ fn ran_and_shaw_trigger_condition_is_cast_and_graveyard_count() {
         !has_condition_if_swallow(&parsed),
         "Condition_If must clear once the And-fold attaches"
     );
+}
+
+/// Deathbringer Regent: the generic cast-and-condition scanner must retain both
+/// the owner/caster-scoped hand provenance and the shared quantity condition.
+/// Revert-probe: remove its optional `from <zone>` grammar or register it after
+/// the simple zoned scanner → the condition is truncated or swallowed.
+#[test]
+fn deathbringer_regent_trigger_condition_is_hand_cast_and_other_creature_count() {
+    let parsed = parse(DEATHBRINGER_REGENT, "Deathbringer Regent", &["Creature"]);
+    let cond = first_trigger_condition(&parsed).expect("Regent ETB must carry a condition");
+    let conditions = match cond {
+        TriggerCondition::And { conditions } => conditions,
+        other => panic!("expected And[..], got {other:?}"),
+    };
+    assert_eq!(conditions.len(), 2, "hand-cast AND other-creature-count");
+    assert_eq!(
+        conditions[0],
+        TriggerCondition::WasCast {
+            zone: Some(Zone::Hand),
+            controller: Some(engine::types::ability::ControllerRef::You),
+            owner: Some(engine::types::ability::ControllerRef::You),
+        },
+        "first conjunct scopes both caster and owner for 'you cast it from your hand'"
+    );
+    match &conditions[1] {
+        TriggerCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 5 },
+        } => match filter {
+            TargetFilter::Typed(tf) => {
+                assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+                assert_eq!(
+                    tf.controller, None,
+                    "all creatures count, regardless of controller"
+                );
+                assert!(
+                    tf.properties.contains(&FilterProp::OtherThanTriggerObject),
+                    "'other creatures' must exclude the entering Regent, got {:?}",
+                    tf.properties
+                );
+                assert!(
+                    tf.properties.contains(&FilterProp::InZone {
+                        zone: Zone::Battlefield
+                    }),
+                    "the threshold must only count battlefield creatures, got {:?}",
+                    tf.properties
+                );
+            }
+            other => panic!("expected Typed creature filter, got {other:?}"),
+        },
+        other => panic!("expected ObjectCount >= 5, got {other:?}"),
+    }
+    assert!(
+        !has_condition_if_swallow(&parsed),
+        "Condition_If must clear once the full conjunction attaches"
+    );
+}
+
+/// The generalized scanner requires an `and <condition>` tail, so a simple
+/// zoned cast gate still reaches the pre-existing positive-zone parser rather
+/// than being misclassified as a conjunction.
+#[test]
+fn simple_zoned_cast_gate_remains_a_single_condition() {
+    let parsed = parse(
+        "When Testcard enters, if you cast it from your hand, draw a card.",
+        "Testcard",
+        &["Creature"],
+    );
+    assert_eq!(
+        first_trigger_condition(&parsed),
+        Some(TriggerCondition::WasCast {
+            zone: Some(Zone::Hand),
+            controller: Some(engine::types::ability::ControllerRef::You),
+            owner: Some(engine::types::ability::ControllerRef::You),
+        })
+    );
+    assert!(!has_condition_if_swallow(&parsed));
 }
 
 // ===========================================================================
@@ -670,6 +756,199 @@ fn ran_and_shaw_opponent_graveyard_dragon_uncounted() {
         None,
         "opponent's Dragon does not count toward your graveyard → no copy"
     );
+}
+
+// ===========================================================================
+// R — Deathbringer Regent (Channel B, zoned cast-and-condition conjunction)
+// ===========================================================================
+
+/// Hand-cast Regent with five other creatures: both intervening-if conjuncts
+/// hold, so the ETB destroys every other creature while retaining Regent.
+#[test]
+fn deathbringer_regent_hand_cast_with_five_other_creatures_wipes_them() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let others: Vec<_> = (0..5)
+        .map(|i| {
+            scenario
+                .add_creature(P0, &format!("Other Creature {i}"), 1, 1)
+                .id()
+        })
+        .collect();
+    let mut b = scenario.add_creature_to_hand_from_oracle(
+        P0,
+        "Deathbringer Regent",
+        5,
+        6,
+        DEATHBRINGER_REGENT,
+    );
+    b.with_mana_cost(engine::types::mana::ManaCost::generic(0));
+    let regent = b.id();
+    let mut runner = scenario.build();
+
+    let out = runner.cast(regent).resolve();
+    assert_eq!(
+        out.zone_of(regent),
+        Zone::Battlefield,
+        "the entering Regent is excluded by 'other creatures'"
+    );
+    for other in others {
+        assert_eq!(
+            out.zone_of(other),
+            Zone::Graveyard,
+            "five other creatures satisfy the count, so Regent destroys {other:?}"
+        );
+    }
+}
+
+/// Four other creatures miss the quantity conjunct, so the ETB never reaches
+/// its destroy effect even though the Regent was cast from the correct zone.
+#[test]
+fn deathbringer_regent_hand_cast_with_four_other_creatures_does_not_wipe() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let others: Vec<_> = (0..4)
+        .map(|i| {
+            scenario
+                .add_creature(P0, &format!("Other Creature {i}"), 1, 1)
+                .id()
+        })
+        .collect();
+    let mut b = scenario.add_creature_to_hand_from_oracle(
+        P0,
+        "Deathbringer Regent",
+        5,
+        6,
+        DEATHBRINGER_REGENT,
+    );
+    b.with_mana_cost(engine::types::mana::ManaCost::generic(0));
+    let regent = b.id();
+    let mut runner = scenario.build();
+
+    let out = runner.cast(regent).resolve();
+    assert_eq!(out.zone_of(regent), Zone::Battlefield);
+    for other in others {
+        assert_eq!(
+            out.zone_of(other),
+            Zone::Battlefield,
+            "four other creatures fail the count conjunct, so {other:?} survives"
+        );
+    }
+}
+
+/// Reanimation supplies the count but not the cast-from-hand provenance, so
+/// the conjunction is false and all five other creatures remain.
+#[test]
+fn deathbringer_regent_reanimated_with_five_other_creatures_does_not_wipe() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let others: Vec<_> = (0..5)
+        .map(|i| {
+            scenario
+                .add_creature(P0, &format!("Other Creature {i}"), 1, 1)
+                .id()
+        })
+        .collect();
+    let mut b = scenario.add_creature_to_graveyard(P0, "Deathbringer Regent", 5, 6);
+    b.from_oracle_text(DEATHBRINGER_REGENT);
+    let regent = b.id();
+    let mut reanimate = scenario.add_spell_to_hand_from_oracle(P0, "Reanimate", false, REANIMATE);
+    reanimate.with_mana_cost(engine::types::mana::ManaCost::generic(0));
+    let reanimate = reanimate.id();
+    let mut runner = scenario.build();
+
+    let out = runner.cast(reanimate).target_object(regent).resolve();
+    assert_eq!(
+        out.zone_of(regent),
+        Zone::Battlefield,
+        "reach-guard: reanimation put Regent onto the battlefield"
+    );
+    for other in others {
+        assert_eq!(
+            out.zone_of(other),
+            Zone::Battlefield,
+            "put-into-play is not a hand cast, so {other:?} survives"
+        );
+    }
+}
+
+/// The quantity side of an intervening-if is rechecked at resolution. Regent
+/// triggers with five others, then Murder removes one while its trigger waits
+/// on the stack; with only four left, the trigger resolves without wiping.
+#[test]
+fn deathbringer_regent_rechecks_other_creature_count_at_resolution() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let others: Vec<_> = (0..5)
+        .map(|i| {
+            scenario
+                .add_creature(P0, &format!("Other Creature {i}"), 1, 1)
+                .id()
+        })
+        .collect();
+    let victim = others[0];
+    let mut regent_builder = scenario.add_creature_to_hand_from_oracle(
+        P0,
+        "Deathbringer Regent",
+        5,
+        6,
+        DEATHBRINGER_REGENT,
+    );
+    regent_builder.with_mana_cost(engine::types::mana::ManaCost::generic(0));
+    let regent = regent_builder.id();
+    let mut murder_builder = scenario.add_spell_to_hand_from_oracle(P0, "Murder", true, MURDER);
+    murder_builder.with_mana_cost(engine::types::mana::ManaCost::generic(0));
+    let murder = murder_builder.id();
+    let mut runner = scenario.build();
+
+    // Resolve Regent through the live priority protocol. Its ETB has passed the
+    // creation check and now waits on the stack above the empty spell stack.
+    runner.cast(regent).commit();
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes to resolve Regent");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P1 passes to resolve Regent");
+    assert_eq!(runner.state().objects[&regent].zone, Zone::Battlefield);
+    assert!(
+        !runner.state().stack.is_empty(),
+        "five others at entry must create Regent's intervening-if trigger"
+    );
+
+    // Cast and resolve the response through the scenario cast/target pipeline,
+    // leaving Regent's already-created trigger underneath it on the live stack.
+    runner.cast(murder).target_object(victim).commit();
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes to resolve Murder");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P1 passes to resolve Murder");
+    assert_eq!(
+        runner.state().objects[&victim].zone,
+        Zone::Graveyard,
+        "reach-guard: Murder removed one of the five counted creatures"
+    );
+    assert!(
+        !runner.state().stack.is_empty(),
+        "Regent's trigger remains on the stack for its resolution-time recheck"
+    );
+
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes to resolve Regent's trigger");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P1 passes to resolve Regent's trigger");
+    assert_eq!(runner.state().objects[&regent].zone, Zone::Battlefield);
+    for other in others.into_iter().skip(1) {
+        assert_eq!(
+            runner.state().objects[&other].zone,
+            Zone::Battlefield,
+            "only four others remain at resolution, so Regent does not destroy {other:?}"
+        );
+    }
 }
 
 // ===========================================================================

--- a/crates/engine/tests/integration/l02_bb2_cast_origin.rs
+++ b/crates/engine/tests/integration/l02_bb2_cast_origin.rs
@@ -762,16 +762,18 @@ fn ran_and_shaw_opponent_graveyard_dragon_uncounted() {
 // R — Deathbringer Regent (Channel B, zoned cast-and-condition conjunction)
 // ===========================================================================
 
-/// Hand-cast Regent with five other creatures: both intervening-if conjuncts
-/// hold, so the ETB destroys every other creature while retaining Regent.
+/// Hand-cast Regent with five other creatures split across both players:
+/// both intervening-if conjuncts hold, so the ETB destroys every other
+/// creature while retaining Regent.
 #[test]
 fn deathbringer_regent_hand_cast_with_five_other_creatures_wipes_them() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let others: Vec<_> = (0..5)
         .map(|i| {
+            let controller = if i == 4 { P1 } else { P0 };
             scenario
-                .add_creature(P0, &format!("Other Creature {i}"), 1, 1)
+                .add_creature(controller, &format!("Other Creature {i}"), 1, 1)
                 .id()
         })
         .collect();


### PR DESCRIPTION
## Summary

Adds Deathbringer Regent's hand-cast, five-other-creatures intervening-if trigger, including its resolution-time recheck.

## Files changed

- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/parser/oracle_trigger_tests.rs`
- `crates/engine/src/parser/oracle_nom/condition.rs`
- `crates/engine/src/parser/oracle_nom/quantity.rs`
- `crates/engine/tests/integration/l02_bb2_cast_origin.rs`

## Track

Developer

## LLM

Model: gpt-5.6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 603.4, CR 601.2, CR 109.2.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — `EXIT_STATUS=0`
- `cargo clippy-strict` — `EXIT_STATUS=0`
- `cargo test -p engine` — 4164 passed, 0 failed; `EXIT_STATUS=0`
- `./scripts/gen-card-data.sh` — `EXIT_STATUS=0`
- `cargo coverage` — `EXIT_STATUS=0`
- `cargo semantic-audit` — `EXIT_STATUS=0`
- `./scripts/check-parser-combinators.sh` — PASS

## Gate A

Gate A PASS head=c635e067cad128d23b292b46eedf948b1ebc273e base=d947f97469a5de1c332701f2062e1852d81ca011

## Anchored on

- `crates/engine/src/parser/oracle_trigger.rs:4784` — existing zoned cast-provenance intervening-if parser
- `crates/engine/src/parser/oracle_nom/condition.rs:7925` — existing `there are N or more` condition parser

## Final review-impl

Final review-impl PASS head=c635e067cad128d23b292b46eedf948b1ebc273e

## Claimed parse impact

Deathbringer Regent

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced parsing for intervening-if triggers that combine cast provenance (optionally from a specified zone list) with battlefield “there are …” quantity checks.
  * Improved handling of comma-delimited clause boundaries for battlefield-count phrases.
* **Bug Fixes**
  * Fixed trigger condition extraction so the trailing “and <game-state condition>” portion is preserved correctly.
  * Improved numeric threshold and zone-list preservation to ensure quantity comparisons are accurate.
* **Tests**
  * Added unit and integration coverage for Deathbringer Regent-style “five or more other creatures” scenarios, including resolution-time rechecking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->