### PR TITLE
refactor(parser): Plan 05b T10f — cross-line self-replacement as a document relation (U0-46)

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1262,7 +1262,8 @@ fn item_static(item: &OracleItemIr) -> Option<&StaticDefinition> {
 /// list, pairing producer/consumer items by `OracleItemId`. Runs at parse time;
 /// both the main and Class document-construction paths converge here.
 fn finalize_document_relations(mut doc: OracleDocIr, types: &[String]) -> OracleDocIr {
-    doc.relations = detect_document_relations(&doc.items, types);
+    doc.relations
+        .extend(detect_document_relations(&doc.items, types));
     doc
 }
 
@@ -3111,10 +3112,11 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
     //
     // PLACEMENT PIN: first fold a CR 614.15 self-replacement override back into
     // its base ability, recreating the pre-lowering single-item shape and
-    // restamping printed ability slots. Then the two enters-choice relations run,
-    // followed by the within-item `reconcile_host_bound_phase_outs` chain repair
-    // (NOT a document relation — it belongs to unit 7), then the persisted-player
-    // relation, then the swallow audit, then the two enters/attack relations —
+    // restamping printed ability slots. The swallow audit omits that consumed
+    // override item but retains it in IR snapshots. Then the two enters-choice
+    // relations run, followed by the within-item `reconcile_host_bound_phase_outs`
+    // chain repair (NOT a document relation — it belongs to unit 7), then the
+    // persisted-player relation, then the swallow audit, then the two enters/attack relations —
     // reproducing the exact order the five standalone passes ran in
     // (choose-counter → self-chosen type → host-bound → persisted-player → swallow
     // → etb-exile → punisher). Order is behavior-load-bearing: the swallow audit
@@ -3165,6 +3167,20 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
     // diagnostics channel, and those are two borrows of the same `ir`. Appending
     // preserves the ordering the channel guarantees (parse-time diagnostics first,
     // then swallow findings).
+    let audit_items = ir
+        .items
+        .iter()
+        .filter(|item| {
+            !ir.relations.iter().any(|relation| {
+                let DocumentRelationIr::SelfReplacementOverride { override_item, .. } = relation
+                else {
+                    return false;
+                };
+                *override_item == item.id
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
     let tracks = ItemIdTracks {
         abilities: &ability_ids,
         triggers: &trigger_ids,
@@ -3173,7 +3189,7 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
     };
     let mut swallow_diagnostics = Vec::new();
     super::swallow_check::check_swallowed_clauses(
-        &ir.items,
+        &audit_items,
         &ir.source_text,
         &result,
         &tracks,
@@ -3704,13 +3720,13 @@ impl<'a> DocEmitter<'a> {
     /// sound: `emit` only rejects a duplicate `(first_line, start_byte, ordinal)`
     /// key or an overlapping same-ordinal sibling, and the single-authority
     /// ordinal makes every same-line item's key distinct.
-    fn emit_at(&mut self, line: usize, node: OracleNodeIr) {
+    fn emit_at(&mut self, line: usize, node: OracleNodeIr) -> OracleItemId {
         let span = self.exact_span(line);
         let fragment = self.lines[line];
         let slot = self.builder.begin_item(span, Some(fragment));
         self.builder.emit(slot, node).expect(
             "single-authority ordinals keep same-line item keys distinct, so emit cannot reject",
-        );
+        )
     }
 
     /// Emit an item spanning `first_line..=last_line` (a multi-line unit, e.g. a
@@ -3729,10 +3745,10 @@ impl<'a> DocEmitter<'a> {
             .expect("single-authority ordinals keep multi-line item keys distinct");
     }
 
-    fn ability_at(&mut self, line: usize, def: AbilityDefinition) {
+    fn ability_at(&mut self, line: usize, def: AbilityDefinition) -> OracleItemId {
         // No ability clone: the ability peek is pop-aware, read from the builder's
         // `spells_emitted` stack (see `last_ability_node`).
-        self.emit_at(line, OracleNodeIr::PreLoweredSpell(def));
+        self.emit_at(line, OracleNodeIr::PreLoweredSpell(def))
     }
 
     /// The IR seam for spell/activated bodies — Plan 05b Unit 3b, **phase B**.
@@ -3813,6 +3829,9 @@ impl<'a> DocEmitter<'a> {
     fn last_ability_node(&self) -> Option<&OracleNodeIr> {
         self.builder.peek_last_spell_node()
     }
+    fn last_ability_id(&self) -> Option<OracleItemId> {
+        self.builder.peek_last_spell_id()
+    }
     fn last_ability_definition(&self) -> Option<AbilityDefinition> {
         self.last_ability_node().and_then(lower_spell_node)
     }
@@ -3842,7 +3861,9 @@ impl<'a> DocEmitter<'a> {
             match node {
                 OracleNodeIr::Static(ir) => self.static_ir_at(item_line, ir),
                 OracleNodeIr::Trigger(ir) => self.trigger_ir_at(item_line, ir),
-                other => self.emit_at(item_line, other),
+                other => {
+                    self.emit_at(item_line, other);
+                }
             }
         }
     }
@@ -4050,6 +4071,7 @@ pub(crate) fn parse_oracle_ir(
     // are emitted through the builder instead. The singletons are emitted post-loop
     // at their captured source line.
     let mut emitter = DocEmitter::new(&lines);
+    let mut document_relations = Vec::new();
     let mut additional_cost_line: Option<usize> = None;
     let mut solve_condition_line: Option<usize> = None;
     let mut strive_cost_line: Option<usize> = None;
@@ -6248,9 +6270,9 @@ pub(crate) fn parse_oracle_ir(
             }
             // CR 608.2c + CR 614.15: Cross-line "instead" self-replacement — a
             // separate printed line (usually an ability word, per CR 614.15)
-            // replaces the preceding ability's effect. Compose them so the engine
-            // resolves the binary choice: the "instead" sub carries the condition;
-            // the base ability becomes the fallback when it is not met.
+            // replaces the preceding ability's effect. Emit the paragraph as its
+            // own document item, then record the parse-time relation so lowering
+            // can bind it to the preceding item's stable id.
             // CR 614.15: the residual self-replacement printings. The three gates above
             // recognize the shapes we can BIND: the whole-clause forms (bare trailing
             // "instead", ", instead <effect>", "<effect> instead if <cond>") and the
@@ -6276,41 +6298,20 @@ pub(crate) fn parse_oracle_ir(
                 && !scan_contains(&effect_line_lower, "would");
 
             if is_instead || is_cross_line_dig_alt || is_instead_replacement_line(&effect_line) {
-                if let Some(condition) = def.condition.take() {
-                    if let Some(base_item) = emitter.pop_last_spell() {
-                        // Re-emit the merged ability at the BASE item's ORIGINAL
-                        // span (recoverable from the popped item) — NOT the current
-                        // line — so the composed ability keeps the base's printed
-                        // slot and source position.
-                        let OracleItemIr {
-                            source: base_source,
-                            node: base_node,
-                            ..
-                        } = base_item;
-                        // All three spell node shapes, via the shared reader:
-                        // `pop_last_spell` pops `spells_emitted`, which `emit`
-                        // fills from any of them with no variant filter.
-                        let Some(mut base) = lower_spell_node(&base_node) else {
+                if def.condition.is_some() {
+                    if let Some(base) = emitter.last_ability_id() {
+                        let Some(_) = previous_spell else {
                             unreachable!(
                                 "`spells_emitted` holds only spell nodes, and all three spell shapes lower"
                             );
                         };
-                        // Save the base ability's continuation chain in else_ability
-                        // so the engine can run it when the condition is NOT met.
-                        def.condition = Some(AbilityCondition::ConditionInstead {
-                            inner: Box::new(condition),
+                        let override_item = emitter.ability_at(item_line, def);
+                        document_relations.push(DocumentRelationIr::SelfReplacementOverride {
+                            base,
+                            override_item,
                         });
-                        def.else_ability = base.sub_ability.take();
-                        base.sub_ability = Some(Box::new(def));
-                        // Pre-lowered on re-emit, necessarily: the fold produced a
-                        // NEW `AbilityDefinition` by nesting the popped one, and
-                        // `lower_ability_ir` has no inverse to express that as an
-                        // `AbilityIr`.
-                        emitter.reemit_node(&base_source, OracleNodeIr::PreLoweredSpell(base));
                         continue;
                     }
-                    // No previous ability to compose with — restore condition and push standalone.
-                    def.condition = Some(condition);
                 } else if emitter.last_ability_node().is_some() {
                     // CR 614.6: "If an event is replaced, it never happens."
                     //
@@ -6631,7 +6632,8 @@ pub(crate) fn parse_oracle_ir(
         emitter.strive_cost_at(strive_cost_line.unwrap_or(0), cost);
     }
 
-    let doc = emitter.finish(oracle_text, card_name, std::mem::take(&mut ctx.diagnostics));
+    let mut doc = emitter.finish(oracle_text, card_name, std::mem::take(&mut ctx.diagnostics));
+    doc.relations = document_relations;
     finalize_document_relations(doc, types)
 }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3923,14 +3923,6 @@ impl<'a> DocEmitter<'a> {
         self.emit_at(line, OracleNodeIr::Modal(m));
     }
 
-    /// Remove and return the most recently emitted spell item — the typed
-    /// `result.abilities.pop()` for the cross-line "instead" fold. The caller
-    /// folds it into a new ability and re-emits via `reemit_spell` at the base
-    /// item's ORIGINAL span.
-    fn pop_last_spell(&mut self) -> Option<OracleItemIr> {
-        self.builder.take_last_spell()
-    }
-
     /// Re-emit a node at a template item's ORIGINAL span — same `first_line`,
     /// bytes, AND `ordinal_within_span`, the key `take_last_spell` just freed.
     ///
@@ -3940,14 +3932,18 @@ impl<'a> DocEmitter<'a> {
     /// `(first_line, start_byte)` (e.g. a `push_same_is_true_*` static + ability
     /// from one line). Original-ordinal re-emit is position- and slot-preserving.
     ///
-    /// Takes an `OracleNodeIr`, not an `AbilityDefinition`, because the two
-    /// re-emitting callers legitimately differ in what they hand back. The
-    /// cross-line "instead" fold genuinely *builds* a new `AbilityDefinition`
-    /// (it moves the popped ability's continuation into `else_ability` and nests
-    /// it under the new one), so it can only re-emit pre-lowered.
-    /// `raise_last_spell_min_x` changes one field in place and must return the
-    /// shape it took — lowering an IR-native node just to reach a root field
-    /// would quietly convert the item back to pre-lowered.
+    /// Takes an `OracleNodeIr`, not an `AbilityDefinition`: the sole remaining
+    /// caller, `raise_last_spell_min_x`, changes one field in place and must
+    /// return the shape it took — lowering an IR-native node just to reach a root
+    /// field would quietly convert the item back to pre-lowered.
+    ///
+    /// It had a second caller until Plan 05b T10f: the cross-line "instead" fold
+    /// popped the base spell, nested it under a new definition, and re-emitted
+    /// pre-lowered at the base's span. That fold is now
+    /// `DocumentRelationIr::SelfReplacementOverride` (CR 614.15) — both paragraphs
+    /// stay emitted and lowering binds them by id — so nothing pops-and-rebuilds
+    /// here any more. `pop_last_spell`, the wrapper that served only that fold,
+    /// went with it; `take_last_spell` itself is still live beneath this method.
     fn reemit_node(&mut self, source: &OracleUnitSource, node: OracleNodeIr) {
         let span = source.span().clone();
         let fragment = source.fragment();

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1282,6 +1282,59 @@ fn position_of(ids: &[OracleItemId], id: OracleItemId) -> Option<usize> {
     ids.iter().position(|candidate| *candidate == id)
 }
 
+// --- CR 614.15: separate ability-word paragraph → self-replacement override ---
+
+/// Fold a self-replacement override paragraph into the preceding ability by its
+/// document ids. Both items were lowered and stamped in source order first; this
+/// pass removes the override and its parallel id entry together, then restamps
+/// the surviving ability slots so the temporary item cannot shift a later
+/// CR 707.9a `RetainPrintedAbilityFromSource` reference.
+fn apply_self_replacement_override(
+    result: &mut ParsedAbilities,
+    relations: &[DocumentRelationIr],
+    ability_ids: &mut Vec<OracleItemId>,
+) {
+    for relation in relations {
+        let DocumentRelationIr::SelfReplacementOverride {
+            base,
+            override_item,
+        } = relation
+        else {
+            continue;
+        };
+        let Some(base_pos) = position_of(ability_ids, *base) else {
+            continue;
+        };
+        let Some(override_pos) = position_of(ability_ids, *override_item) else {
+            continue;
+        };
+        if base_pos == override_pos {
+            continue;
+        }
+
+        let mut override_def = result.abilities.remove(override_pos);
+        ability_ids.remove(override_pos);
+        let base_pos = if override_pos < base_pos {
+            base_pos - 1
+        } else {
+            base_pos
+        };
+        let condition = override_def.condition.take().expect(
+            "self-replacement override relations are emitted only for conditioned abilities",
+        );
+        override_def.condition = Some(AbilityCondition::ConditionInstead {
+            inner: Box::new(condition),
+        });
+        let base = &mut result.abilities[base_pos];
+        override_def.else_ability = base.sub_ability.take();
+        base.sub_ability = Some(Box::new(override_def));
+
+        for (slot, def) in result.abilities.iter_mut().enumerate() {
+            stamp_printed_ability_slot(def, slot);
+        }
+    }
+}
+
 // --- CR 607.2d + CR 614.1c: enters-choice → chosen-dependent ETB counter ------
 
 /// Pair the "as this enters, choose a creature type/color" replacement (producer)
@@ -3056,14 +3109,18 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
     // its lowered definition through the parallel `_ids` tracks — the single
     // authority, replacing the former five lowered-shape post-passes.
     //
-    // PLACEMENT PIN: the two enters-choice relations run first, then the
-    // within-item `reconcile_host_bound_phase_outs` chain repair (NOT a document
-    // relation — it belongs to unit 7), then the persisted-player relation, then
-    // the swallow audit, then the two enters/attack relations — reproducing the
-    // exact order the five standalone passes ran in (choose-counter → self-chosen
-    // type → host-bound → persisted-player → swallow → etb-exile → punisher).
-    // Order is behavior-load-bearing: the swallow audit reads `result` between the
-    // player-persist and the etb-exile/punisher applications.
+    // PLACEMENT PIN: first fold a CR 614.15 self-replacement override back into
+    // its base ability, recreating the pre-lowering single-item shape and
+    // restamping printed ability slots. Then the two enters-choice relations run,
+    // followed by the within-item `reconcile_host_bound_phase_outs` chain repair
+    // (NOT a document relation — it belongs to unit 7), then the persisted-player
+    // relation, then the swallow audit, then the two enters/attack relations —
+    // reproducing the exact order the five standalone passes ran in
+    // (choose-counter → self-chosen type → host-bound → persisted-player → swallow
+    // → etb-exile → punisher). Order is behavior-load-bearing: the swallow audit
+    // reads `result` between the player-persist and the etb-exile/punisher
+    // applications.
+    apply_self_replacement_override(&mut result, &ir.relations, &mut ability_ids);
     apply_linked_choice_etb_counter(&mut result, &ir.relations, &mut replacement_ids);
     apply_linked_choice_type_statics(
         &mut result,

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -1051,6 +1051,13 @@ impl OracleDocBuilder {
         self.items.values().find(|i| i.id == id).map(|i| &i.node)
     }
 
+    /// Peek the most-recently emitted spell item's stable document id. The same
+    /// emission-order stack backs the node peek, so a cross-item relation can
+    /// name the preceding spell without removing or re-emitting it.
+    pub(crate) fn peek_last_spell_id(&self) -> Option<OracleItemId> {
+        self.spells_emitted.last().copied()
+    }
+
     /// Finish, producing items already in Oracle source order.
     ///
     /// # CR 707.9a printed-slot stamping does NOT happen here

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -608,8 +608,10 @@ pub(crate) enum ReplaceMeaningKind {
     /// CR 608.2c: pop the prior def; wrap this alternative def with the prior as its
     /// `else_ability` (dig-instead alternative).
     DigAlt(Box<AbilityDefinition>),
-    /// CR 614.1a + CR 608.2c: multi-clause base + "instead" override via Cow-swap;
-    /// tail clauses stashed in the override's `else_ability`.
+    /// CR 614.1a + CR 608.2c: within one effect chain, a clause replaces a prior
+    /// clause's definition via Cow-swap; tail clauses are stashed in the
+    /// override's `else_ability`. This remains distinct from the cross-document-
+    /// item `DocumentRelationIr::SelfReplacementOverride` relation.
     Instead(Box<AbilityDefinition>),
     /// CR 608.2c: build this clause's def from `parsed` + condition, attach as the
     /// prior def's `sub_ability` (keyword-instead override).

--- a/crates/engine/src/parser/oracle_ir/relation.rs
+++ b/crates/engine/src/parser/oracle_ir/relation.rs
@@ -61,6 +61,19 @@ pub(crate) enum DocumentRelationIr {
         coerce: OracleItemId,
         punisher: OracleItemId,
     },
+    /// CR 614.15: A separate ability-word-prefixed paragraph (`override_item`)
+    /// can create a self-replacement effect for the preceding ability paragraph
+    /// (`base`). This relation binds that printed form across document items,
+    /// preserving the base item's source span and printed ability slot when
+    /// lowering folds the override into it.
+    ///
+    /// This is the cross-document-item boundary. `ReplaceMeaningKind::Instead`
+    /// remains the within-one-effect-chain form, where a clause replaces a prior
+    /// clause during one `parse_effect_chain` call.
+    SelfReplacementOverride {
+        base: OracleItemId,
+        override_item: OracleItemId,
+    },
     /// CR 607.2d: A "choose a [value]" producer linked to an ability that reads
     /// "the chosen [value]" back. One parameterized relation; `LinkedChoiceKind`
     /// distinguishes the value kind and the consumer surface that reads it.

--- a/crates/engine/tests/integration/cross_line_instead_override_branch.rs
+++ b/crates/engine/tests/integration/cross_line_instead_override_branch.rs
@@ -246,8 +246,12 @@ fn gather_the_pack_binds_the_partial_override_as_an_alternative_dig() {
 ///
 /// Without this, a regression that degraded the branch back to an honest-red
 /// sibling would still pass the runtime assertion.
+///
+/// The dispatch loop only emits the two printed items; this branch can now be
+/// assembled only when the document relation for this real CR 614.15 printing
+/// is recorded and applied during lowering.
 #[test]
-fn anoint_with_affliction_binds_the_cross_line_override_as_a_branch() {
+fn anoint_with_affliction_relation_binds_the_cross_line_override_as_a_branch() {
     let parsed = parse_oracle_text(
         ANOINT,
         "Anoint with Affliction",

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -12,7 +12,7 @@
 # real IR nodes. Every tranche that converts a producer must lower its number
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
-crates/engine/src/parser/oracle.rs         13
+crates/engine/src/parser/oracle.rs         12
 crates/engine/src/parser/oracle_class.rs    3
 
 # --- infrastructure: NOT burn-down targets ----------------------------------


### PR DESCRIPTION
Plan 05b **T10f** — converts **U0-46**, the cross-line CR 614.15 self-replacement fold, to a document relation. Follows #6742.

A separate ability-word-prefixed paragraph that replaces the *preceding* ability's effect ("Raid — If you attacked this turn, **instead** Arrow Storm deals 5 damage…"). Today the parser **pops** the previously-emitted spell item, nests the override into it, and re-emits at the base's original span. That pop-and-rebuild is the last thing in `oracle.rs` that reaches backwards into already-emitted document state.

| # | commit | producers |
|---|---|---|
| 1 | `DocumentRelationIr::SelfReplacementOverride` + the apply pass | **zero** |
| 2 | convert U0-46: emit both paragraphs, bind them by id | 1 |
| 3 | delete the now-dead emitter wrapper; tighten the ledger | — |

## CR 614.15 is the rules warrant, and it names this population verbatim

> **614.15.** Some replacement effects are not continuous effects. Rather, they are an effect of a resolving spell or ability that replace part or all of that spell or ability's own effect(s). Such effects are called self-replacement effects. The text creating a self-replacement effect is usually part of the ability whose effect is being replaced, **but the text can be a separate ability, particularly when preceded by an ability word.** …

The rules describe the separate ability-word-prefixed paragraph as one of the two *printed* forms. The relation exists to bind that printed form to the ability it replaces.

### The design's stated cost was a misattributed rule

The recensus framed design (b)'s cost as *"momentarily puts a standalone override ability in the doc IR — which CR 614.6 forbids publishing."* **CR 614.6 says nothing of the kind.** It reads, in full:

> **614.6.** If an event is replaced, it never happens. A modified event occurs instead, which may in turn trigger abilities. Note that the modified event may contain instructions that can't be carried out, in which case the impossible instruction is simply ignored.

That is the semantics of a replaced *event*; it makes no statement about document representation. So no comment in this PR claims it does — writing one would plant a false CR annotation, the exact defect the CR gate exists to prevent.

**The two existing CR 614.6 annotations at `oracle.rs:6258` and `:6282` are untouched, deliberately.** They invoke 614.6 about *runtime semantics* — publishing an unbindable override as an independent ability makes the engine perform the base effect **and** the replacement, so the replaced event did happen. Different claim, correctly cited. A finding that a citation was misapplied in one place is not a licence to sweep every instance of the number.

CR 614.15 (`:3122`), 614.6 (`:3076`), 614.1a (`:3056`), 608.2c (`:2793`) and 707.9a (`:5646`) were each grep-verified and their **text read**.

### The boundary between two "instead" mechanisms, stated at both types

- `ReplaceMeaningKind::Instead` — **within one chain**: a clause replaces a prior clause's def inside a single `parse_effect_chain`. Unchanged here.
- `DocumentRelationIr::SelfReplacementOverride` — **across document items**: a paragraph replaces a paragraph, preserving the base's span and printed slot.

Without that written down, the next agent duplicates one into the other.

## Full-pool byte identity

```
8a034e7ff8  base       2737d0783ece3443cb0041323114ee06eaa06f8e30431f817784e4dd5312f289
a2bdd10d88  commit 1   2737d0783ece3443cb0041323114ee06eaa06f8e30431f817784e4dd5312f289   cmp exit 0
ca81f32fbf  commit 2   2737d0783ece3443cb0041323114ee06eaa06f8e30431f817784e4dd5312f289   cmp exit 0
```

Fresh generator build each side, distinct target dir, `MTGJSON_SKIP_REFRESH=1`, real `AtomicCards.json` (158,014,511 bytes — resolved and size-checked, since the fixture population would be void evidence rather than a green).

## The risk byte identity could NOT have caught, and how it was actually settled

This is the part worth reviewing.

Today the fold **pops** the base and re-emits ONE item, so the override paragraph never becomes a document item. Under this design **both** are emitted — and `stamp_printed_ability_slot` runs at push time, **before** the relation passes (the PLACEMENT PIN deliberately fixes that order). So every ability emitted after the override would take a printed slot one higher, and a later removal does not restamp.

**A clean hash would not have detected this.** `stamp_printed_ability_slot` only rewrites the placeholder inside `ContinuousModification::RetainPrintedAbilityFromSource`; an ability carrying no such modification is unaffected. The defect bites only a card with **both** a cross-line "instead" fold **and** a later `RetainPrintedAbilityFromSource`. A green hash proves *that intersection is empty*, not *that the slot handling is correct*.

Settled two ways instead:

1. **By construction** — the apply pass removes the override and its parallel `ability_ids` entry at the same index, then **restamps every surviving ability by its post-fold index**. The offset cannot survive, whatever the corpus contains.
2. **By enumeration** — a fresh `AtomicCards.json` census (reminder text stripped, printed lines split, non-first lines matching the parser's short ability-word grammar and containing "instead") finds **95 unique cards**, of which **64** are in the spell-only dispatcher subset. Of all 95, **zero** carry a later line containing `except it has this ability` — the sole parser surface for `RetainPrintedAbilityFromSource`.

*The charter said 90 cards. The measured figure on current input is 95/64; the method is stated above rather than the old number repeated.*

## The swallow audit — a real red, and why the fix is a correction rather than a silencer

Commit 2's first full run went **red**: 2 failures, Arrow Storm and Lightning Surge. That was a genuine regression, not noise, and it is worth being precise about what caused it.

The swallow audit ("the parser must never silently discard Oracle text") is per item and resolves each item's id through the parallel `_ids` tracks. The relation pass **consumes** the override's id — it is removed from `ability_ids` entirely, not moved to another track as `apply_linked_choice_copy_chosen_host` does. So the audit found an item with no reachable lowered evidence and reported its whole fragment as swallowed. The text was in fact represented, nested under the base's `sub_ability`; it was simply no longer addressable.

The fix omits relation-consumed items from the audit while **retaining them in the document IR**. That restores the pre-existing audit shape exactly: before this PR the override paragraph was never an item, so its fragment was never audited either. The audit's coverage is unchanged, not narrowed.

**And that claim is measured, not argued.** `parse_warnings` is serialized into `card-data.json` — 914 non-empty instances across the pool — so the byte-identical full-pool hash *is* a whole-corpus comparison of swallow-audit output, including every card that carries a warning.

Worth naming for a reviewer: the dangerous failure mode on this row is not a crash but a **relation under-fire** — the fold silently stops happening and the override republishes as an independent ability, which is the CR 614.6 semantic defect `oracle.rs:6258` exists to prevent (Anoint with Affliction exiled a creature with zero poison counters). The existing `cross_line_instead_override_branch` integration test is the guard: with the inline fold deleted, its assertion of one top-level ability plus a `ConditionInstead` branch can only be satisfied through the relation path.

## `finalize_document_relations` assigned where it needed to extend

`doc.relations = detect_document_relations(…)` would have clobbered any relation recorded during dispatch. It now **extends**. Dispatch is the right place to detect this one: `is_cross_line_dig_alt` is a parse-time fact — whether `try_parse_dig_instead_alternative` succeeded against the previous line's def — and is not recoverable from item text after assembly, so a post-assembly detector would silently under-fire. The Class route contributes no dispatch producers and reaches the extend with an empty vector.

## The closed enum — the class was selector-shaped, not wildcard-shaped

`DocumentRelationIr` is documented closed. Grep found **zero** `_ =>` / `_ if` arms over it or over `LinkedChoiceKind`. The class a wildcard grep alone would miss is the **six** `let DocumentRelationIr::… else { continue }` appliers; the new pass is the seventh. Enumerated rather than sampled — on #6733 a reviewer's list of two turned out to be a class of five.

## Commit 3 — dead code, and a doc that had gone stale with it

Deleting the fold left `pop_last_spell` with no callers, so `clippy -D warnings` failed on it. Deleted rather than `#[expect(dead_code)]`-ed for a later unit: it is a two-line private wrapper over `take_last_spell`, which stays live for `raise_last_spell_min_x`, and git history restores it if U0-47 wants it back. Keeping dead code alive for a hypothetical future requirement is the thing CLAUDE.md prohibits.

`reemit_node`'s doc argued its `OracleNodeIr` parameter from *"the two re-emitting callers legitimately differ in what they hand back"* — there is one caller now. Restated on that caller's own terms, with a note on where the other went.

Gate P's ledger is tightened **13 → 12**, a genuine burn-down: the deleted re-emission expression carried one pre-lowered spell token. The ledger's own contract is that a tranche converting a producer lowers its ceiling in the same commit, otherwise the burn-down is invisible in `git log` and a later change drifts back up to a stale ceiling.

## Gates

```
cargo fmt --all                                 clean
clippy -p engine --lib -- -D warnings           zero warnings
cargo nextest run -p engine --lib               17914 passed, 6 skipped
cargo nextest run -p engine --test integration   4164 passed (1 slow), 2 skipped
Gate P (PreLowered ratchet)                     PASS — oracle.rs 13 -> 12, ceiling tightened
check-parser-combinators.sh                     Gate G PASS / Gate A PASS
check-skill-doc.sh                              PASS
*.snap changes                                  none
*.snap.new pending                              0
```

No fixture exercised the new IR shape, so the ruled `*_ir.snap` dev-artifact concession was never spent. Had one, the churn would have been justified on dev-artifact grounds alone — **not** as a trade against a CR 614.6 representation cost, which was found not to exist.

## Scope held

U0-47 (T10g) is untouched: `reemit_node` and its `raise_last_spell_min_x` caller stay, as does the `unreachable!` asserting the three-lowerable-spell-shape invariant. `ReplaceMeaningKind::Instead` still embeds a `Box<AbilityDefinition>` — latent pre-lowered debt of the family §6 wants gone, recorded rather than touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved parsing of “begin the game with” effects, including starting counters and follow-up effects.
  - Preserved conditional starting-game effects, including restrictions based on who starts.

- **Bug Fixes**
  - Corrected cross-line “instead” handling so replacement effects are combined with the intended ability rather than treated as separate abilities.
  - Improved ability tracking and printed-form association for complex replacement effects.

- **Tests**
  - Added regression coverage for cross-line replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->