### PR TITLE
Fix activated ability target and cost ordering

### DIFF
--- a/crates/engine/src/ai_support/payment_continuation.rs
+++ b/crates/engine/src/ai_support/payment_continuation.rs
@@ -397,6 +397,11 @@ fn classify_parked_cost_move_root(state: &GameState) -> PaymentContinuationState
         PendingCostMoveResume::DelveManaPayment { player, .. } => {
             classify_global_root(state, *player)
         }
+        // CR 602.2b: The parked mill leg retains the announced activation's
+        // serialized payment root until the replacement choice completes.
+        PendingCostMoveResume::ActivationMillPayment { player, pending } => {
+            PaymentContinuationState::Affiliated(root_from_pending_cast(pending, *player))
+        }
         // These are distinct cost/resolution continuations. They intentionally
         // retain their existing policies rather than being misidentified from a
         // coincidental PendingCast elsewhere in state.
@@ -618,6 +623,9 @@ fn pending_cost_move_contains_root(
         }
         Some(PendingCostMoveResume::ManaAbilityPayment { pending, cursor }) => {
             pending_mana_contains_root(pending, root) || cursor_contains_root(cursor, root)
+        }
+        Some(PendingCostMoveResume::ActivationMillPayment { pending, .. }) => {
+            pending_matches_root(pending, root)
         }
         Some(PendingCostMoveResume::CollectEvidencePayment { resume, .. }) => match resume.as_ref()
         {

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -2416,7 +2416,7 @@ fn collect_target_slots_inner(
         }
     }
 
-    if target_slot_construction_needs_chosen_x(ability) {
+    if target_slot_construction_needs_chosen_x_at_announcement(state, ability) {
         return Err(TargetSlotBuildError::RequiresChosenX);
     }
 
@@ -3072,6 +3072,22 @@ fn target_slot_construction_needs_chosen_x(ability: &ResolvedAbility) -> bool {
                         .as_ref()
                         .is_some_and(|expr| quantity_expr_has_unresolved_x(ability, expr))
             }))
+}
+
+/// CR 107.3m + CR 603.3b: A triggered ability's target filter can refer to the
+/// X paid for the spell that produced its source. That X is not `chosen_x` on
+/// the trigger, but it is already bound on the trigger source before targets
+/// are chosen; only defer target construction when neither authority exists.
+fn target_slot_construction_needs_chosen_x_at_announcement(
+    state: &GameState,
+    ability: &ResolvedAbility,
+) -> bool {
+    target_slot_construction_needs_chosen_x(ability)
+        && ability
+            .trigger_source
+            .as_ref()
+            .and_then(|source| source.source_read(state).cost_x_paid())
+            .is_none()
 }
 
 fn target_filter_needs_chosen_x(ability: &ResolvedAbility, filter: &TargetFilter) -> bool {

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -423,15 +423,67 @@ impl SlotAccumulator {
     }
 }
 
+/// Result of target construction while an ability is being announced.
+///
+/// `RequiresChosenX` is distinct from an illegal target set: CR 601.2b requires
+/// announcing X before the CR 601.2c target declaration can be evaluated.
+pub(crate) enum TargetSlotBuildOutcome {
+    Slots(Vec<TargetSelectionSlot>),
+    RequiresChosenX,
+}
+
+enum TargetSlotBuildError {
+    Engine(EngineError),
+    RequiresChosenX,
+}
+
+impl From<EngineError> for TargetSlotBuildError {
+    fn from(error: EngineError) -> Self {
+        Self::Engine(error)
+    }
+}
+
+pub(crate) fn unresolved_x_target_construction_error() -> EngineError {
+    EngineError::ActionNotAllowed(
+        "Target count requires a resolved quantity before target selection".to_string(),
+    )
+}
+
+impl From<TargetSlotBuildError> for EngineError {
+    fn from(error: TargetSlotBuildError) -> Self {
+        match error {
+            TargetSlotBuildError::Engine(error) => error,
+            TargetSlotBuildError::RequiresChosenX => unresolved_x_target_construction_error(),
+        }
+    }
+}
+
+/// CR 601.2b/c + CR 602.2b: Collect target slots while preserving the
+/// announce-time distinction between an unresolved X and an illegal target set.
+pub(crate) fn build_target_slots_for_announcement(
+    state: &GameState,
+    ability: &ResolvedAbility,
+) -> Result<TargetSlotBuildOutcome, EngineError> {
+    let mut acc = SlotAccumulator::default();
+    match collect_target_slots(state, ability, &mut acc) {
+        Ok(()) => Ok(TargetSlotBuildOutcome::Slots(acc.slots)),
+        Err(TargetSlotBuildError::RequiresChosenX) => Ok(TargetSlotBuildOutcome::RequiresChosenX),
+        Err(TargetSlotBuildError::Engine(error)) => Err(error),
+    }
+}
+
 /// CR 601.2c / CR 602.2b: Collect all target slots for an ability chain. Each targeting
 /// effect in the chain produces a slot whose legal targets are computed from the game state.
 pub fn build_target_slots(
     state: &GameState,
     ability: &ResolvedAbility,
 ) -> Result<Vec<TargetSelectionSlot>, EngineError> {
-    let mut acc = SlotAccumulator::default();
-    collect_target_slots(state, ability, &mut acc)?;
-    Ok(acc.slots)
+    match build_target_slots_for_announcement(state, ability)? {
+        TargetSlotBuildOutcome::Slots(slots) => Ok(slots),
+        TargetSlotBuildOutcome::RequiresChosenX => {
+            Err(TargetSlotBuildError::RequiresChosenX.into())
+        }
+    }
 }
 
 /// CR 601.2b + CR 702.33a/702.194c: "instead" spells with a target-dependent
@@ -2260,7 +2312,7 @@ fn collect_target_slots(
     state: &GameState,
     ability: &ResolvedAbility,
     acc: &mut SlotAccumulator,
-) -> Result<(), EngineError> {
+) -> Result<(), TargetSlotBuildError> {
     let resolved_chooser = ability.target_chooser.as_ref().and_then(|filter| {
         crate::game::targeting::resolve_effect_player_ref(state, ability, filter)
             // A chooser equal to the controller is the CR-601.2c default; leave the
@@ -2342,7 +2394,7 @@ fn collect_target_slots_inner(
     state: &GameState,
     ability: &ResolvedAbility,
     acc: &mut SlotAccumulator,
-) -> Result<(), EngineError> {
+) -> Result<(), TargetSlotBuildError> {
     if let Some(sub_ability) = ability.sub_ability.as_deref().filter(|sub| {
         matches!(
             sub.condition,
@@ -2364,6 +2416,10 @@ fn collect_target_slots_inner(
         }
     }
 
+    if target_slot_construction_needs_chosen_x(ability) {
+        return Err(TargetSlotBuildError::RequiresChosenX);
+    }
+
     // CR 609.7 + CR 601.2c: A source-scoped `PreventDamage` ("prevent all damage
     // target instant or sorcery spell would deal this turn") surfaces the
     // choosable source spell as a target slot. Declared FIRST (CR 601.2c
@@ -2377,9 +2433,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, src_leaf, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2403,9 +2457,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, filter, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2431,9 +2483,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, filter, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2471,9 +2521,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, filter, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2500,9 +2548,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, filter, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2518,9 +2564,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, target, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2561,9 +2605,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, filter, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2608,9 +2650,7 @@ fn collect_target_slots_inner(
                 // No spec means a single mandatory source (defensive — the parser
                 // always attaches an "up to two"/"two" spec for this effect).
                 if source_legal.is_empty() {
-                    return Err(EngineError::ActionNotAllowed(
-                        "No legal targets available".to_string(),
-                    ));
+                    return Err(no_legal_target_slots());
                 }
                 acc.push(TargetSelectionSlot {
                     legal_targets: source_legal,
@@ -2643,9 +2683,7 @@ fn collect_target_slots_inner(
             let recipient_legal =
                 legal_targets_for_ability_filter(state, ability, recipient, &acc.slots);
             if recipient_legal.is_empty() {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets: recipient_legal,
@@ -2691,9 +2729,7 @@ fn collect_target_slots_inner(
             // selection-time recompute so both paths agree.
             let player_targets = companion_target_player_legal_targets(state, ability);
             if player_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets: player_targets,
@@ -2712,9 +2748,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, &filter, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2731,9 +2765,7 @@ fn collect_target_slots_inner(
             let legal_targets =
                 legal_targets_for_ability_filter(state, ability, &filter, &acc.slots);
             if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(EngineError::ActionNotAllowed(
-                    "No legal targets available".to_string(),
-                ));
+                return Err(no_legal_target_slots());
             }
             acc.push(TargetSelectionSlot {
                 legal_targets,
@@ -2767,9 +2799,7 @@ fn collect_target_slots_inner(
                     }
                 } else {
                     if legal_targets.is_empty() && !ability.optional_targeting {
-                        return Err(EngineError::ActionNotAllowed(
-                            "No legal targets available".to_string(),
-                        ));
+                        return Err(no_legal_target_slots());
                     }
                     acc.push(TargetSelectionSlot {
                         legal_targets,
@@ -2800,6 +2830,10 @@ fn collect_target_slots_inner(
         }
     }
     Ok(())
+}
+
+fn no_legal_target_slots() -> TargetSlotBuildError {
+    EngineError::ActionNotAllowed("No legal targets available".to_string()).into()
 }
 
 fn legal_choices_for_ability_filter(
@@ -3009,15 +3043,7 @@ pub fn ability_target_legality_needs_chosen_x(
 }
 
 fn ability_target_legality_needs_chosen_x_inner(ability: &ResolvedAbility) -> bool {
-    triggers::extract_target_filter_from_effect(&ability.effect)
-        .is_some_and(|filter| target_filter_needs_chosen_x(ability, filter))
-        || ability.multi_target.as_ref().is_some_and(|spec| {
-            quantity_expr_has_unresolved_x(ability, &spec.min)
-                || spec
-                    .max
-                    .as_ref()
-                    .is_some_and(|expr| quantity_expr_has_unresolved_x(ability, expr))
-        })
+    target_slot_construction_needs_chosen_x(ability)
         || ability
             .sub_ability
             .as_deref()
@@ -3026,6 +3052,26 @@ fn ability_target_legality_needs_chosen_x_inner(ability: &ResolvedAbility) -> bo
             .else_ability
             .as_deref()
             .is_some_and(ability_target_legality_needs_chosen_x_inner)
+}
+
+/// CR 601.2b/c: The current chain link cannot determine either its target
+/// filter or its target count until its announced X value is available.
+///
+/// This deliberately excludes sub-abilities. `collect_target_slots` traverses
+/// links in declaration order, so an earlier missing mandatory target remains
+/// an immediate illegal-target error instead of being masked by a later
+/// X-dependent target instruction.
+fn target_slot_construction_needs_chosen_x(ability: &ResolvedAbility) -> bool {
+    ability.chosen_x.is_none()
+        && (triggers::extract_target_filter_from_effect(&ability.effect)
+            .is_some_and(|filter| target_filter_needs_chosen_x(ability, filter))
+            || ability.multi_target.as_ref().is_some_and(|spec| {
+                quantity_expr_has_unresolved_x(ability, &spec.min)
+                    || spec
+                        .max
+                        .as_ref()
+                        .is_some_and(|expr| quantity_expr_has_unresolved_x(ability, expr))
+            }))
 }
 
 fn target_filter_needs_chosen_x(ability: &ResolvedAbility, filter: &TargetFilter) -> bool {
@@ -5483,7 +5529,7 @@ fn collect_target_slots_after_deferred_effect(
     state: &GameState,
     sub_ability: Option<&ResolvedAbility>,
     acc: &mut SlotAccumulator,
-) -> Result<(), EngineError> {
+) -> Result<(), TargetSlotBuildError> {
     let Some(sub_ability) = sub_ability else {
         return Ok(());
     };

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -16831,10 +16831,10 @@ pub(super) fn try_finalize_pending_activation_mana_leg(
     pending.activation_cost = remaining;
     pending.activation_ability_index = Some(ability_index);
     pending.activation_residual = ActivationResidual::ManaLeg;
-    let target_selection_settled = matches!(
+    let target_first_interactive_suffix = matches!(
         pending.activation_target_selection,
         ActivationTargetSelection::Settled
-    );
+    ) && pending.activation_cost.is_some();
     let pending_source_id = pending.object_id;
     state.pending_cast = Some(Box::new(pending));
     let waiting = casting_costs::maybe_pause_for_phyrexian_choice(
@@ -16850,11 +16850,11 @@ pub(super) fn try_finalize_pending_activation_mana_leg(
     if let Some(waiting) = waiting {
         return Ok(Some(waiting));
     }
-    if target_selection_settled {
+    if target_first_interactive_suffix {
         // CR 601.2g-h + CR 602.2b: A target-first activation has already
-        // declared its targets. An insufficient or choice-bearing mana leg
-        // therefore exposes ManaPayment rather than invalidating that target
-        // declaration.
+        // declared its targets but still has an unpaid interactive suffix. Its
+        // mana leg therefore exposes ManaPayment rather than invalidating that
+        // target declaration before the suffix can be paid.
         casting_costs::enter_payment_step(state, player, None, events).map(Some)
     } else {
         casting_costs::finalize_automatic_mana_payment(state, player, events).map(Some)
@@ -16886,10 +16886,10 @@ pub(super) fn finalize_pending_activation_mana_payment(
         activation_payment_context(state, pending.object_id, Some(ability_index));
     let activation_ctx = activation_context.as_payment_context();
     let source_id = pending.object_id;
-    let target_selection_settled = matches!(
+    let target_first_interactive_suffix = matches!(
         pending.activation_target_selection,
         ActivationTargetSelection::Settled
-    );
+    ) && pending.activation_cost.is_some();
     state.pending_cast = Some(Box::new(pending));
     if let Some(waiting) = casting_costs::maybe_pause_for_phyrexian_choice(
         state,
@@ -16903,10 +16903,10 @@ pub(super) fn finalize_pending_activation_mana_payment(
     ) {
         return Ok(waiting);
     }
-    if target_selection_settled {
+    if target_first_interactive_suffix {
         // CR 601.2g-h + CR 602.2b: Preserve the manual-payment boundary only
-        // after target declaration; bare activations remain illegal when their
-        // automatic mana payment is unaffordable.
+        // while target declaration still precedes an unpaid interactive suffix;
+        // otherwise an unaffordable activation is illegal immediately.
         casting_costs::enter_payment_step(state, player, None, events)
     } else {
         casting_costs::finalize_automatic_mana_payment(state, player, events)

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -16649,8 +16649,8 @@ pub fn can_activate_ability_now_with_restriction_gates(
         return has_target;
     }
 
-    match build_target_slots(&simulated, &resolved) {
-        Ok(target_slots) => {
+    match build_target_slots_for_announcement(&simulated, &resolved) {
+        Ok(TargetSlotBuildOutcome::Slots(target_slots)) => {
             if target_slots.is_empty() {
                 return true;
             }
@@ -16664,15 +16664,15 @@ pub fn can_activate_ability_now_with_restriction_gates(
                 &ability_def.target_constraints,
             )
         }
-        Err(_) => {
-            ability_target_legality_needs_chosen_x(&resolved, ability_def.distribute.as_ref())
-                && ability_def.cost.as_ref().is_some_and(|cost| {
-                    casting_costs::extract_x_mana_cost(cost).is_some()
-                        || find_non_self_sacrifice_cost(cost)
-                            .is_some_and(|(count, _)| count == u32::MAX)
-                        || casting_costs::activation_cost_needs_x_choice(&resolved, cost)
-                })
+        Ok(TargetSlotBuildOutcome::RequiresChosenX) => {
+            ability_def.cost.as_ref().is_some_and(|cost| {
+                casting_costs::extract_x_mana_cost(cost).is_some()
+                    || find_non_self_sacrifice_cost(cost)
+                        .is_some_and(|(count, _)| count == u32::MAX)
+                    || casting_costs::activation_cost_needs_x_choice(&resolved, cost)
+            })
         }
+        Err(_) => false,
     }
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17616,7 +17616,7 @@ pub fn handle_activate_ability(
                     casting_costs::surface_next_unpaid_interactive_activation_cost(
                         state,
                         player,
-                        &pending_interactive,
+                        &mut pending_interactive,
                         events,
                     )?
                 {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -15410,7 +15410,7 @@ pub fn pay_unless_cost(
 }
 
 /// Walk a cost tree and return the waterbend mana cost if present.
-fn find_waterbend_cost(cost: &AbilityCost) -> Option<&ManaCost> {
+pub(super) fn find_waterbend_cost(cost: &AbilityCost) -> Option<&ManaCost> {
     match cost {
         AbilityCost::Waterbend { cost } => Some(cost),
         AbilityCost::Composite { costs } => costs.iter().find_map(find_waterbend_cost),
@@ -15791,7 +15791,9 @@ pub(super) fn find_collect_evidence_activation_cost(cost: &AbilityCost) -> Optio
 /// selection across the battlefield/graveyard union. Returns `(count,
 /// materials)`. Recurses into `Composite` (the synthesized craft cost is a
 /// `Composite[Mana, Exile{SelfRef}, ExileMaterials]`).
-fn find_craft_materials_cost(cost: &AbilityCost) -> Option<(CostObjectCount, &TargetFilter)> {
+pub(super) fn find_craft_materials_cost(
+    cost: &AbilityCost,
+) -> Option<(CostObjectCount, &TargetFilter)> {
     match cost {
         AbilityCost::ExileMaterials { materials, count } => Some((*count, materials)),
         AbilityCost::Composite { costs } => costs.iter().find_map(find_craft_materials_cost),
@@ -15812,7 +15814,7 @@ pub(super) fn find_tap_creatures_cost(
     }
 }
 
-fn find_targeted_remove_counter_cost(
+pub(super) fn find_targeted_remove_counter_cost(
     cost: &AbilityCost,
 ) -> Option<(
     u32,
@@ -15960,7 +15962,7 @@ pub(crate) fn find_eligible_unattach_for_cost_targets(
         .collect()
 }
 
-fn find_one_of_cost(cost: &AbilityCost) -> Option<&Vec<AbilityCost>> {
+pub(super) fn find_one_of_cost(cost: &AbilityCost) -> Option<&Vec<AbilityCost>> {
     match cost {
         AbilityCost::OneOf { costs } => Some(costs),
         AbilityCost::Composite { costs } => costs.iter().find_map(find_one_of_cost),
@@ -16227,7 +16229,7 @@ pub(crate) fn find_eligible_remove_counter_for_cost_targets(
         .collect()
 }
 
-fn find_eligible_tap_creatures_for_cost(
+pub(super) fn find_eligible_tap_creatures_for_cost(
     state: &GameState,
     player: PlayerId,
     source: ObjectId,
@@ -17615,6 +17617,7 @@ pub fn handle_activate_ability(
                         state,
                         player,
                         &pending_interactive,
+                        events,
                     )?
                 {
                     return Ok(waiting_for);

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -16831,6 +16831,10 @@ pub(super) fn try_finalize_pending_activation_mana_leg(
     pending.activation_cost = remaining;
     pending.activation_ability_index = Some(ability_index);
     pending.activation_residual = ActivationResidual::ManaLeg;
+    let target_selection_settled = matches!(
+        pending.activation_target_selection,
+        ActivationTargetSelection::Settled
+    );
     let pending_source_id = pending.object_id;
     state.pending_cast = Some(Box::new(pending));
     let waiting = casting_costs::maybe_pause_for_phyrexian_choice(
@@ -16846,11 +16850,15 @@ pub(super) fn try_finalize_pending_activation_mana_leg(
     if let Some(waiting) = waiting {
         return Ok(Some(waiting));
     }
-    // CR 601.2g-h + CR 602.2b: The shared payment entry point auto-pays only
-    // when this root is actually payable. A target-first activation with an
-    // insufficient or choice-bearing mana leg must instead expose ManaPayment
-    // after targets are declared, rather than failing target submission.
-    casting_costs::enter_payment_step(state, player, None, events).map(Some)
+    if target_selection_settled {
+        // CR 601.2g-h + CR 602.2b: A target-first activation has already
+        // declared its targets. An insufficient or choice-bearing mana leg
+        // therefore exposes ManaPayment rather than invalidating that target
+        // declaration.
+        casting_costs::enter_payment_step(state, player, None, events).map(Some)
+    } else {
+        casting_costs::finalize_automatic_mana_payment(state, player, events).map(Some)
+    }
 }
 
 /// CR 602.2b + CR 605.3b + CR 616.1: Finalize an activation mana cost that
@@ -16878,6 +16886,10 @@ pub(super) fn finalize_pending_activation_mana_payment(
         activation_payment_context(state, pending.object_id, Some(ability_index));
     let activation_ctx = activation_context.as_payment_context();
     let source_id = pending.object_id;
+    let target_selection_settled = matches!(
+        pending.activation_target_selection,
+        ActivationTargetSelection::Settled
+    );
     state.pending_cast = Some(Box::new(pending));
     if let Some(waiting) = casting_costs::maybe_pause_for_phyrexian_choice(
         state,
@@ -16891,9 +16903,14 @@ pub(super) fn finalize_pending_activation_mana_payment(
     ) {
         return Ok(waiting);
     }
-    // CR 601.2g-h + CR 602.2b: Preserve the same manual-payment boundary when
-    // this already-serialized root resumes after target declaration.
-    casting_costs::enter_payment_step(state, player, None, events)
+    if target_selection_settled {
+        // CR 601.2g-h + CR 602.2b: Preserve the manual-payment boundary only
+        // after target declaration; bare activations remain illegal when their
+        // automatic mana payment is unaffordable.
+        casting_costs::enter_payment_step(state, player, None, events)
+    } else {
+        casting_costs::finalize_automatic_mana_payment(state, player, events)
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17142,8 +17142,8 @@ pub fn handle_activate_ability(
     // before any branch path that pushes this ability onto the stack.
     resolved.ability_index = Some(ability_index);
 
-    // CR 118.3: Pre-check for non-self sacrifice costs — must detour to WaitingFor
-    // before any cost payment, regardless of whether targets were auto-selected.
+    // CR 602.2b + CR 601.2b-i: announcement-only choices are resolved before
+    // entering the shared target-before-cost boundary below.
     if let Some(ref cost) = activation_cost {
         // CR 606.3: `can_activate_ability_now` gates legal-action generation,
         // but direct `GameAction::ActivateAbility` submissions must be rejected
@@ -17261,31 +17261,6 @@ pub fn handle_activate_ability(
                 state.pending_cast = Some(Box::new(pending_leg));
                 return casting_costs::enter_payment_step(state, player, None, events);
             }
-        }
-
-        if let Some((count, sac_filter)) = find_non_self_sacrifice_cost(cost) {
-            let eligible = find_eligible_sacrifice_targets(state, player, source_id, sac_filter);
-            let (min_count, max_count) = sacrifice_cost_bounds(count, eligible.len());
-            if eligible.len() < min_count {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough eligible permanents to sacrifice".into(),
-                ));
-            }
-            let mut pending_sac =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_sac.activation_cost = Some(cost.clone());
-            pending_sac.activation_ability_index = Some(ability_index);
-            pending_sac.deferred_target_selection = true;
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::Sacrifice,
-                choices: eligible,
-                count: max_count,
-                min_count,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_sac),
-                },
-            });
         }
 
         // CR 601.2h + CR 701.9a: A resolved zero-card FromHand discard leg (e.g. Bomat
@@ -17763,12 +17738,6 @@ pub fn handle_activate_ability(
             return Ok(WaitingFor::Priority { player });
         }
 
-        let selection = begin_target_selection_for_ability(
-            state,
-            &resolved,
-            &target_slots,
-            &target_constraints,
-        )?;
         let mut pending_target = PendingCast::new(
             source_id,
             CardId(0),
@@ -17783,13 +17752,13 @@ pub fn handle_activate_ability(
         // America's Throw) reaches the `DistributeAmong` step after its costs are
         // paid. Mirrors the spell target-selection path (`pending_targets.distribute`).
         pending_target.distribute = ability_def.distribute.clone();
-        return Ok(WaitingFor::TargetSelection {
+        return super::casting_targets::begin_activated_target_selection(
+            state,
             player,
-            pending_cast: Box::new(pending_target),
+            pending_target,
             target_slots,
-            mode_labels: Vec::new(),
-            selection,
-        });
+            Vec::new(),
+        );
     }
 
     if let Some(ref cost) = ability_def.cost {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -16846,7 +16846,11 @@ pub(super) fn try_finalize_pending_activation_mana_leg(
     if let Some(waiting) = waiting {
         return Ok(Some(waiting));
     }
-    casting_costs::finalize_automatic_mana_payment(state, player, events).map(Some)
+    // CR 601.2g-h + CR 602.2b: The shared payment entry point auto-pays only
+    // when this root is actually payable. A target-first activation with an
+    // insufficient or choice-bearing mana leg must instead expose ManaPayment
+    // after targets are declared, rather than failing target submission.
+    casting_costs::enter_payment_step(state, player, None, events).map(Some)
 }
 
 /// CR 602.2b + CR 605.3b + CR 616.1: Finalize an activation mana cost that
@@ -16887,7 +16891,9 @@ pub(super) fn finalize_pending_activation_mana_payment(
     ) {
         return Ok(waiting);
     }
-    casting_costs::finalize_automatic_mana_payment(state, player, events)
+    // CR 601.2g-h + CR 602.2b: Preserve the same manual-payment boundary when
+    // this already-serialized root resumes after target declaration.
+    casting_costs::enter_payment_step(state, player, None, events)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17143,7 +17143,24 @@ pub fn handle_activate_ability(
     // CR 603.4: Stamp the printed-ability index for per-turn resolution tracking
     // before any branch path that pushes this ability onto the stack.
     resolved.ability_index = Some(ability_index);
-    let has_effect_targets = !build_target_slots(state, &resolved)?.is_empty();
+    // CR 602.2b + CR 601.2b/c: an X announcement can determine how many
+    // targets an ability has. Before X is chosen, target-slot construction may
+    // reject that specific class of otherwise legal activation; defer only that
+    // X-dependent case through the X round-trip. Every other target-build
+    // failure remains an immediate activation error.
+    let has_effect_targets = match build_target_slots(state, &resolved) {
+        Ok(target_slots) => !target_slots.is_empty(),
+        Err(_)
+            if activation_cost.as_ref().is_some_and(|cost| {
+                ability_target_legality_needs_chosen_x(&resolved, ability_def.distribute.as_ref())
+                    && (casting_costs::extract_x_mana_cost(cost).is_some()
+                        || casting_costs::activation_cost_needs_x_choice(&resolved, cost))
+            }) =>
+        {
+            true
+        }
+        Err(error) => return Err(error),
+    };
 
     // CR 602.2b + CR 601.2b-i: announcement-only choices are resolved before
     // entering the shared target-before-cost boundary below.
@@ -17271,6 +17288,35 @@ pub fn handle_activate_ability(
         }
 
         if !has_effect_targets {
+            // CR 602.2b + CR 601.2c/h: The no-target route shares the same
+            // serialized interactive-cost dispatcher as a target-first
+            // activation after target declaration. In particular, its handlers
+            // remove the paid cost leg before resuming, so a completed exile,
+            // craft, or collect-evidence cost cannot be prompted a second time.
+            let mut pending_interactive =
+                PendingCast::new(source_id, CardId(0), resolved.clone(), ManaCost::NoCost);
+            pending_interactive.activation_cost = Some(cost.clone());
+            pending_interactive.activation_ability_index = Some(ability_index);
+            let initial_activation_cost = pending_interactive.activation_cost.clone();
+            if let Some(waiting_for) =
+                casting_costs::surface_next_unpaid_interactive_activation_cost(
+                    state,
+                    player,
+                    &mut pending_interactive,
+                    events,
+                )?
+            {
+                return Ok(waiting_for);
+            }
+            if pending_interactive.activation_cost != initial_activation_cost {
+                return casting_costs::finish_activated_ability_at_payment_boundary(
+                    state,
+                    player,
+                    pending_interactive,
+                    events,
+                );
+            }
+
             // CR 601.2h + CR 701.9a: A resolved zero-card FromHand discard leg (e.g. Bomat
             // Courier's "Discard your hand" on an empty hand) is paid by doing nothing — the
             // helper returns `Ok(None)` so we FALL THROUGH to the following cost detection

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17141,6 +17141,7 @@ pub fn handle_activate_ability(
     // CR 603.4: Stamp the printed-ability index for per-turn resolution tracking
     // before any branch path that pushes this ability onto the stack.
     resolved.ability_index = Some(ability_index);
+    let has_effect_targets = !build_target_slots(state, &resolved)?.is_empty();
 
     // CR 602.2b + CR 601.2b-i: announcement-only choices are resolved before
     // entering the shared target-before-cost boundary below.
@@ -17177,6 +17178,7 @@ pub fn handle_activate_ability(
             );
             pending_x.activation_cost = remaining;
             pending_x.activation_ability_index = Some(ability_index);
+            pending_x.deferred_target_selection = has_effect_targets;
             // CR 601.2g + CR 601.2h: if a non-self battlefield-removal sub-cost
             // (Sacrifice / battlefield Exile / ReturnToHand) is still
             // outstanding in the residual after X-announcement, mark the
@@ -17213,6 +17215,7 @@ pub fn handle_activate_ability(
             let mut pending_x = PendingCast::new(source_id, CardId(0), resolved, mana_cost);
             pending_x.activation_cost = remaining;
             pending_x.activation_ability_index = Some(ability_index);
+            pending_x.deferred_target_selection = has_effect_targets;
             // CR 601.2f + CR 601.2h: POSITIVE signal — the residual non-mana tail
             // in `activation_cost` is still OUTSTANDING after mana payment, so
             // `push_activated_ability_to_stack` must re-surface a non-self discard
@@ -17250,9 +17253,11 @@ pub fn handle_activate_ability(
         // here — it must fall through to the general target-first path below
         // (CR 601.2c: targets are chosen before costs are paid), where the
         // mana-first `Composite` ordering keeps the post-target payment atomic.
-        let loyalty_no_targets = crate::types::ability::is_loyalty_ability_cost(cost)
-            && build_target_slots(state, &resolved)?.is_empty();
-        if find_non_self_battlefield_removal_cost(cost).is_some() || loyalty_no_targets {
+        let loyalty_no_targets =
+            crate::types::ability::is_loyalty_ability_cost(cost) && !has_effect_targets;
+        if !has_effect_targets
+            && (find_non_self_battlefield_removal_cost(cost).is_some() || loyalty_no_targets)
+        {
             if let Some((mana_cost, remaining)) = casting_costs::extract_mana_leg(cost) {
                 let mut pending_leg = PendingCast::new(source_id, CardId(0), resolved, mana_cost);
                 pending_leg.activation_cost = remaining;
@@ -17263,120 +17268,117 @@ pub fn handle_activate_ability(
             }
         }
 
-        // CR 601.2h + CR 701.9a: A resolved zero-card FromHand discard leg (e.g. Bomat
-        // Courier's "Discard your hand" on an empty hand) is paid by doing nothing — the
-        // helper returns `Ok(None)` so we FALL THROUGH to the following cost detection
-        // rather than surfacing a dead `PayCost { count: 0 }`.
-        if let Some((count, eligible)) =
-            resolve_non_self_discard_requirement(state, player, source_id, cost)?
-        {
-            let mut pending_discard =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_discard.activation_cost = Some(cost.clone());
-            pending_discard.activation_ability_index = Some(ability_index);
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::Discard,
-                choices: eligible,
-                count,
-                min_count: 0,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_discard),
-                },
-            });
-        }
-
-        // CR 701.59a + CR 602.2b: Pre-check for a collect-evidence activation
-        // cost (Kylox's Voltstrider — "Collect evidence 6: This Vehicle becomes
-        // an artifact creature ..."). Collect evidence is an INTERACTIVE cost:
-        // the player chooses which graveyard cards (total mana value >= N) to
-        // exile, so it must detour to `WaitingFor::CollectEvidenceChoice` and be
-        // paid BEFORE the ability reaches the stack — exactly like the
-        // ExileAggregate / non-self exile detours. Without this detour the cost
-        // is a silent no-op in `pay_ability_cost` (it is documented there as
-        // "intercepted before reaching pay_ability_cost"), so the ability would
-        // resolve for free. CR 701.59b payability was already enforced by the
-        // `is_payable` gate above; `begin_cost_payment` re-checks it defensively.
-        // The resume (`CollectEvidenceResume::Casting`, made activation-aware)
-        // pushes the activated ability to the stack once the cards are exiled.
-        // This is the SINGLE-AUTHORITY interactive-cost dispatch: the call site
-        // never inspects cost components beyond routing to the resolver.
-        if let Some(amount) = find_collect_evidence_activation_cost(cost) {
-            let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending.activation_cost = Some(cost.clone());
-            pending.activation_ability_index = Some(ability_index);
-            return super::effects::collect_evidence::begin_cost_payment(
-                state,
-                player,
-                amount,
-                pending,
-                SpellCostSource::Other,
-            );
-        }
-
-        // CR 117.1 + CR 601.2b + CR 602.2b: Pre-check for an `ExileWithAggregate`
-        // cost (Baron Helmut Zemo's Boast — "Exile any number of black cards from
-        // your graveyard with fifteen or more black mana symbols among their mana
-        // costs"). The player chooses any subset of the eligible cards whose
-        // aggregate satisfies the threshold; the handler validates the threshold
-        // and (CR 608.2c) publishes the exiled cards as the tracked set the
-        // `CastCopyOfCard` effect consumes. The effect target is `TrackedSet`
-        // (resolution-time), not a declared target, so no target-selection
-        // detour is needed.
-        if let Some((filter, function, property, comparator, value, zone)) =
-            find_exile_with_aggregate_cost(cost)
-        {
-            let eligible = super::cost_payability::eligible_exile_with_aggregate_objects(
-                state, player, source_id, filter, zone,
-            );
-            // CR 118.3: payability was pre-checked above; re-derive the maximal
-            // aggregate (exile-all) here so an unsatisfiable threshold fails fast.
-            let total =
-                super::quantity::aggregate_property_over(state, &eligible, function, property);
-            if !comparator.evaluate(total, value) {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough eligible cards to reach the exile threshold".into(),
-                ));
+        if !has_effect_targets {
+            // CR 601.2h + CR 701.9a: A resolved zero-card FromHand discard leg (e.g. Bomat
+            // Courier's "Discard your hand" on an empty hand) is paid by doing nothing — the
+            // helper returns `Ok(None)` so we FALL THROUGH to the following cost detection
+            // rather than surfacing a dead `PayCost { count: 0 }`.
+            if let Some((count, eligible)) =
+                resolve_non_self_discard_requirement(state, player, source_id, cost)?
+            {
+                let mut pending_discard =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_discard.activation_cost = Some(cost.clone());
+                pending_discard.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::Discard,
+                    choices: eligible,
+                    count,
+                    min_count: 0,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_discard),
+                    },
+                });
             }
-            let mut pending_agg =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_agg.activation_cost = Some(cost.clone());
-            pending_agg.activation_ability_index = Some(ability_index);
-            let max_count = eligible.len();
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::ExileAggregate {
-                    zone,
-                    function,
-                    property,
-                    comparator,
-                    value,
-                    filter: filter.clone(),
-                },
-                choices: eligible,
-                count: max_count,
-                // CR 601.2b: "any number" reaching the threshold — the threshold
-                // (not a fixed cardinality) is enforced by the handler. A nonzero
-                // GE/Sum threshold can never be met by the empty set, so at least
-                // one card is required; `min_count: 1` is the loose lower bound.
-                min_count: 1,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_agg),
-                },
-            });
-        }
 
-        // CR 118.3 + CR 602.2b: Pre-check for non-self exile-from-hand/graveyard
-        // costs. Untargeted abilities can detour to `WaitingFor::ExileForCost`
-        // immediately; targeted abilities must choose their effect targets first
-        // (CR 601.2c), then `casting_targets::pay_activation_costs_after_target_selection`
-        // surfaces this same cost prompt before the ability reaches the stack.
-        if let Some((count, zone, filter)) = find_non_self_exile(cost) {
-            let has_effect_targets = {
-                let slots = build_target_slots(state, &resolved)?;
-                !slots.is_empty()
-            };
-            if !has_effect_targets {
+            // CR 701.59a + CR 602.2b: Pre-check for a collect-evidence activation
+            // cost (Kylox's Voltstrider — "Collect evidence 6: This Vehicle becomes
+            // an artifact creature ..."). Collect evidence is an INTERACTIVE cost:
+            // the player chooses which graveyard cards (total mana value >= N) to
+            // exile, so it must detour to `WaitingFor::CollectEvidenceChoice` and be
+            // paid BEFORE the ability reaches the stack — exactly like the
+            // ExileAggregate / non-self exile detours. Without this detour the cost
+            // is a silent no-op in `pay_ability_cost` (it is documented there as
+            // "intercepted before reaching pay_ability_cost"), so the ability would
+            // resolve for free. CR 701.59b payability was already enforced by the
+            // `is_payable` gate above; `begin_cost_payment` re-checks it defensively.
+            // The resume (`CollectEvidenceResume::Casting`, made activation-aware)
+            // pushes the activated ability to the stack once the cards are exiled.
+            // This is the SINGLE-AUTHORITY interactive-cost dispatch: the call site
+            // never inspects cost components beyond routing to the resolver.
+            if let Some(amount) = find_collect_evidence_activation_cost(cost) {
+                let mut pending =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending.activation_cost = Some(cost.clone());
+                pending.activation_ability_index = Some(ability_index);
+                return super::effects::collect_evidence::begin_cost_payment(
+                    state,
+                    player,
+                    amount,
+                    pending,
+                    SpellCostSource::Other,
+                );
+            }
+
+            // CR 117.1 + CR 601.2b + CR 602.2b: Pre-check for an `ExileWithAggregate`
+            // cost (Baron Helmut Zemo's Boast — "Exile any number of black cards from
+            // your graveyard with fifteen or more black mana symbols among their mana
+            // costs"). The player chooses any subset of the eligible cards whose
+            // aggregate satisfies the threshold; the handler validates the threshold
+            // and (CR 608.2c) publishes the exiled cards as the tracked set the
+            // `CastCopyOfCard` effect consumes. The effect target is `TrackedSet`
+            // (resolution-time), not a declared target, so no target-selection
+            // detour is needed.
+            if let Some((filter, function, property, comparator, value, zone)) =
+                find_exile_with_aggregate_cost(cost)
+            {
+                let eligible = super::cost_payability::eligible_exile_with_aggregate_objects(
+                    state, player, source_id, filter, zone,
+                );
+                // CR 118.3: payability was pre-checked above; re-derive the maximal
+                // aggregate (exile-all) here so an unsatisfiable threshold fails fast.
+                let total =
+                    super::quantity::aggregate_property_over(state, &eligible, function, property);
+                if !comparator.evaluate(total, value) {
+                    return Err(EngineError::ActionNotAllowed(
+                        "Not enough eligible cards to reach the exile threshold".into(),
+                    ));
+                }
+                let mut pending_agg =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_agg.activation_cost = Some(cost.clone());
+                pending_agg.activation_ability_index = Some(ability_index);
+                let max_count = eligible.len();
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::ExileAggregate {
+                        zone,
+                        function,
+                        property,
+                        comparator,
+                        value,
+                        filter: filter.clone(),
+                    },
+                    choices: eligible,
+                    count: max_count,
+                    // CR 601.2b: "any number" reaching the threshold — the threshold
+                    // (not a fixed cardinality) is enforced by the handler. A nonzero
+                    // GE/Sum threshold can never be met by the empty set, so at least
+                    // one card is required; `min_count: 1` is the loose lower bound.
+                    min_count: 1,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_agg),
+                    },
+                });
+            }
+
+            // CR 118.3 + CR 602.2b: Pre-check for non-self exile-from-hand/graveyard
+            // costs. Untargeted abilities can detour to `WaitingFor::ExileForCost`
+            // immediately; targeted abilities must choose their effect targets first
+            // (CR 601.2c), then `casting_targets::pay_activation_costs_after_target_selection`
+            // surfaces this same cost prompt before the ability reaches the stack.
+            if let Some((count, zone, filter)) = find_non_self_exile(cost) {
                 let narrow_zone = ExileCostSourceZone::try_from_zone(zone)
                     .expect("find_non_self_exile restricts zone to Hand or Graveyard");
                 let eligible = find_eligible_exile_for_cost_targets(
@@ -17406,226 +17408,233 @@ pub fn handle_activate_ability(
                     },
                 });
             }
-        }
 
-        // CR 702.167a/b: Pre-check for a craft materials cost — detour to
-        // `WaitingFor::PayCost { kind: ExileMaterials }` so the player selects
-        // which permanents/graveyard cards to exile across the dual-zone union.
-        // The full `Composite` cost (Mana + self-exile + materials) stays in
-        // `activation_cost`; the mana and self-exile are paid by
-        // `push_activated_ability_to_stack` after the selection completes
-        // (CR 601.2h: remaining costs paid in any order). Mirrors the non-self
-        // exile detour above.
-        if let Some((count, materials)) = find_craft_materials_cost(cost) {
-            let eligible = super::cost_payability::eligible_craft_materials(
-                state, player, source_id, materials,
-            );
-            let min_count = count.min_count();
-            let max_count = count.max_count(eligible.len());
-            if eligible.len() < min_count {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough eligible materials to craft".into(),
-                ));
-            }
-            let mut pending_craft =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_craft.activation_cost = Some(cost.clone());
-            pending_craft.activation_ability_index = Some(ability_index);
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::ExileMaterials {
-                    materials: materials.clone(),
-                },
-                choices: eligible,
-                count: max_count,
-                // CR 702.167a: "one or more" material costs set `min_count < count`;
-                // exact material costs set both bounds to the same value.
-                min_count,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_craft),
-                },
-            });
-        }
-
-        // CR 118.12a: Pre-check for OneOf costs — detour to WaitingFor before any cost payment.
-        if let Some(costs) = find_one_of_cost(cost) {
-            let payable =
-                payable_one_of_activation_branches(state, player, source_id, costs, ability_index);
-            if payable.is_empty() {
-                return Err(EngineError::ActionNotAllowed(
-                    "Cannot pay activation cost".to_string(),
-                ));
-            }
-            let mut pending_one_of =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_one_of.activation_cost = Some(cost.clone());
-            pending_one_of.activation_ability_index = Some(ability_index);
-            return Ok(WaitingFor::ActivationCostOneOfChoice {
-                player,
-                costs: payable,
-                pending_cast: Box::new(pending_one_of),
-            });
-        }
-
-        // CR 118.3: Pre-check for ReturnToHand costs — same WaitingFor detour pattern as
-        // Sacrifice above. Ordering matters for Composite costs: Sacrifice wins if both are
-        // present, but no real cards combine them.
-        if let Some((count, filter)) = find_return_to_hand_cost(cost) {
-            let eligible = find_eligible_return_to_hand_targets(state, player, source_id, filter);
-            if eligible.len() < count as usize {
-                return Err(EngineError::ActionNotAllowed(
-                    "No eligible permanents to return".into(),
-                ));
-            }
-            let mut pending_return =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_return.activation_cost = Some(cost.clone());
-            pending_return.activation_ability_index = Some(ability_index);
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::ReturnToHand,
-                choices: eligible,
-                count: count as usize,
-                min_count: 0,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_return),
-                },
-            });
-        }
-
-        // CR 118.3 + CR 122.1 + CR 602.2b: Pre-check targeted
-        // remove-counter activation costs. The player chooses which matching
-        // permanent supplies the counter before automatic cost components are
-        // paid and the ability is put on the stack.
-        if let Some((count, counter_type, target, selection)) =
-            find_targeted_remove_counter_cost(cost)
-        {
-            let required_count = match selection {
-                CounterCostSelection::SingleObject => count,
-                CounterCostSelection::AmongObjects => 1,
-            };
-            let eligible = find_eligible_remove_counter_for_cost_targets(
-                state,
-                player,
-                source_id,
-                target,
-                counter_type,
-                required_count,
-            );
-            if eligible.is_empty() {
-                return Err(EngineError::ActionNotAllowed(
-                    "No eligible permanents with counters".into(),
-                ));
-            }
-            if selection == CounterCostSelection::AmongObjects {
-                let removable_count = eligible
-                    .iter()
-                    .filter_map(|object_id| state.objects.get(object_id))
-                    .map(|obj| {
-                        removable_counter_count_for_cost_selection(obj, counter_type, selection)
-                    })
-                    .fold(0, u32::saturating_add);
-                if removable_count < count {
+            // CR 702.167a/b: Pre-check for a craft materials cost — detour to
+            // `WaitingFor::PayCost { kind: ExileMaterials }` so the player selects
+            // which permanents/graveyard cards to exile across the dual-zone union.
+            // The full `Composite` cost (Mana + self-exile + materials) stays in
+            // `activation_cost`; the mana and self-exile are paid by
+            // `push_activated_ability_to_stack` after the selection completes
+            // (CR 601.2h: remaining costs paid in any order). Mirrors the non-self
+            // exile detour above.
+            if let Some((count, materials)) = find_craft_materials_cost(cost) {
+                let eligible = super::cost_payability::eligible_craft_materials(
+                    state, player, source_id, materials,
+                );
+                let min_count = count.min_count();
+                let max_count = count.max_count(eligible.len());
+                if eligible.len() < min_count {
                     return Err(EngineError::ActionNotAllowed(
-                        "Not enough eligible counters to remove".into(),
+                        "Not enough eligible materials to craft".into(),
                     ));
                 }
+                let mut pending_craft =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_craft.activation_cost = Some(cost.clone());
+                pending_craft.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::ExileMaterials {
+                        materials: materials.clone(),
+                    },
+                    choices: eligible,
+                    count: max_count,
+                    // CR 702.167a: "one or more" material costs set `min_count < count`;
+                    // exact material costs set both bounds to the same value.
+                    min_count,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_craft),
+                    },
+                });
             }
-            let mut pending_counter =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_counter.activation_cost = Some(cost.clone());
-            pending_counter.activation_ability_index = Some(ability_index);
-            let max_count = match selection {
-                CounterCostSelection::SingleObject => 1,
-                CounterCostSelection::AmongObjects => eligible.len(),
-            };
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::RemoveCounter {
-                    counter_type: counter_type.clone(),
-                    count,
-                    selection,
-                },
-                choices: eligible,
-                count: max_count,
-                min_count: match selection {
-                    CounterCostSelection::SingleObject => 0,
-                    CounterCostSelection::AmongObjects => 1,
-                },
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_counter),
-                },
-            });
-        }
 
-        // CR 118.3: Pre-check for tap-creatures activation costs. Non-mana
-        // activated abilities use the same WaitingFor flow as flashback tap
-        // costs; completion resumes through `finish_pending_cost_or_cast`.
-        if let Some((requirement, filter)) = find_tap_creatures_cost(cost) {
-            // CR 602.1a: Activated-ability tap costs are fixed-count today
-            // (Convoke-style). The aggregate "total power N" form is reserved for
-            // Crew/Saddle/Teamwork, which are not dispatched through this path.
-            let count = requirement.fixed_count().ok_or_else(|| {
-                EngineError::ActionNotAllowed(
-                    "Aggregate-power tap cost is not valid for this activation".into(),
-                )
-            })?;
-            let eligible =
-                find_eligible_tap_creatures_for_cost(state, player, source_id, cost, filter);
-            if eligible.len() < count as usize {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough eligible creatures to tap".into(),
-                ));
-            }
-            let mut pending_tap =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_tap.activation_cost = Some(cost.clone());
-            pending_tap.activation_ability_index = Some(ability_index);
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::TapCreatures { aggregate: None },
-                choices: eligible,
-                count: count as usize,
-                min_count: 0,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_tap),
-                },
-            });
-        }
-
-        // CR 601.2c + CR 601.2h + CR 602.2b: For no-target activations, use
-        // the serialized residual dispatcher for interactive cost kinds not
-        // covered by the earlier specialized detours. Its selected-cost
-        // handlers remove exactly one leg before re-entering the payment
-        // boundary, including repeated and chosen-OneOf costs.
-        if build_target_slots(state, &resolved)?.is_empty() {
-            let mut pending_interactive =
-                PendingCast::new(source_id, CardId(0), resolved.clone(), ManaCost::NoCost);
-            pending_interactive.activation_cost = Some(cost.clone());
-            pending_interactive.activation_ability_index = Some(ability_index);
-            if let Some(waiting_for) =
-                casting_costs::surface_next_unpaid_interactive_activation_cost(
+            // CR 118.12a: Pre-check for OneOf costs — detour to WaitingFor before any cost payment.
+            if let Some(costs) = find_one_of_cost(cost) {
+                let payable = payable_one_of_activation_branches(
                     state,
                     player,
-                    &pending_interactive,
-                )?
-            {
-                return Ok(waiting_for);
+                    source_id,
+                    costs,
+                    ability_index,
+                );
+                if payable.is_empty() {
+                    return Err(EngineError::ActionNotAllowed(
+                        "Cannot pay activation cost".to_string(),
+                    ));
+                }
+                let mut pending_one_of =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_one_of.activation_cost = Some(cost.clone());
+                pending_one_of.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::ActivationCostOneOfChoice {
+                    player,
+                    costs: payable,
+                    pending_cast: Box::new(pending_one_of),
+                });
             }
-        }
 
-        // Waterbend cost: detour to ManaPayment with Waterbend mode.
-        if let Some(wb_cost) = find_waterbend_cost(cost) {
-            let mut pending_wb = PendingCast::new(source_id, CardId(0), resolved, wb_cost.clone());
-            pending_wb.activation_cost = Some(cost.clone());
-            pending_wb.activation_ability_index = Some(ability_index);
-            state.pending_cast = Some(Box::new(pending_wb));
-            return casting_costs::enter_payment_step(
-                state,
-                player,
-                Some(ConvokeMode::Waterbend),
-                events,
-            );
+            // CR 118.3: Pre-check for ReturnToHand costs — same WaitingFor detour pattern as
+            // Sacrifice above. Ordering matters for Composite costs: Sacrifice wins if both are
+            // present, but no real cards combine them.
+            if let Some((count, filter)) = find_return_to_hand_cost(cost) {
+                let eligible =
+                    find_eligible_return_to_hand_targets(state, player, source_id, filter);
+                if eligible.len() < count as usize {
+                    return Err(EngineError::ActionNotAllowed(
+                        "No eligible permanents to return".into(),
+                    ));
+                }
+                let mut pending_return =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_return.activation_cost = Some(cost.clone());
+                pending_return.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::ReturnToHand,
+                    choices: eligible,
+                    count: count as usize,
+                    min_count: 0,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_return),
+                    },
+                });
+            }
+
+            // CR 118.3 + CR 122.1 + CR 602.2b: Pre-check targeted
+            // remove-counter activation costs. The player chooses which matching
+            // permanent supplies the counter before automatic cost components are
+            // paid and the ability is put on the stack.
+            if let Some((count, counter_type, target, selection)) =
+                find_targeted_remove_counter_cost(cost)
+            {
+                let required_count = match selection {
+                    CounterCostSelection::SingleObject => count,
+                    CounterCostSelection::AmongObjects => 1,
+                };
+                let eligible = find_eligible_remove_counter_for_cost_targets(
+                    state,
+                    player,
+                    source_id,
+                    target,
+                    counter_type,
+                    required_count,
+                );
+                if eligible.is_empty() {
+                    return Err(EngineError::ActionNotAllowed(
+                        "No eligible permanents with counters".into(),
+                    ));
+                }
+                if selection == CounterCostSelection::AmongObjects {
+                    let removable_count = eligible
+                        .iter()
+                        .filter_map(|object_id| state.objects.get(object_id))
+                        .map(|obj| {
+                            removable_counter_count_for_cost_selection(obj, counter_type, selection)
+                        })
+                        .fold(0, u32::saturating_add);
+                    if removable_count < count {
+                        return Err(EngineError::ActionNotAllowed(
+                            "Not enough eligible counters to remove".into(),
+                        ));
+                    }
+                }
+                let mut pending_counter =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_counter.activation_cost = Some(cost.clone());
+                pending_counter.activation_ability_index = Some(ability_index);
+                let max_count = match selection {
+                    CounterCostSelection::SingleObject => 1,
+                    CounterCostSelection::AmongObjects => eligible.len(),
+                };
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::RemoveCounter {
+                        counter_type: counter_type.clone(),
+                        count,
+                        selection,
+                    },
+                    choices: eligible,
+                    count: max_count,
+                    min_count: match selection {
+                        CounterCostSelection::SingleObject => 0,
+                        CounterCostSelection::AmongObjects => 1,
+                    },
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_counter),
+                    },
+                });
+            }
+
+            // CR 118.3: Pre-check for tap-creatures activation costs. Non-mana
+            // activated abilities use the same WaitingFor flow as flashback tap
+            // costs; completion resumes through `finish_pending_cost_or_cast`.
+            if let Some((requirement, filter)) = find_tap_creatures_cost(cost) {
+                // CR 602.1a: Activated-ability tap costs are fixed-count today
+                // (Convoke-style). The aggregate "total power N" form is reserved for
+                // Crew/Saddle/Teamwork, which are not dispatched through this path.
+                let count = requirement.fixed_count().ok_or_else(|| {
+                    EngineError::ActionNotAllowed(
+                        "Aggregate-power tap cost is not valid for this activation".into(),
+                    )
+                })?;
+                let eligible =
+                    find_eligible_tap_creatures_for_cost(state, player, source_id, cost, filter);
+                if eligible.len() < count as usize {
+                    return Err(EngineError::ActionNotAllowed(
+                        "Not enough eligible creatures to tap".into(),
+                    ));
+                }
+                let mut pending_tap =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending_tap.activation_cost = Some(cost.clone());
+                pending_tap.activation_ability_index = Some(ability_index);
+                return Ok(WaitingFor::PayCost {
+                    player,
+                    kind: PayCostKind::TapCreatures { aggregate: None },
+                    choices: eligible,
+                    count: count as usize,
+                    min_count: 0,
+                    resume: CostResume::Spell {
+                        spell: Box::new(pending_tap),
+                    },
+                });
+            }
+
+            // CR 601.2c + CR 601.2h + CR 602.2b: For no-target activations, use
+            // the serialized residual dispatcher for interactive cost kinds not
+            // covered by the earlier specialized detours. Its selected-cost
+            // handlers remove exactly one leg before re-entering the payment
+            // boundary, including repeated and chosen-OneOf costs.
+            {
+                let mut pending_interactive =
+                    PendingCast::new(source_id, CardId(0), resolved.clone(), ManaCost::NoCost);
+                pending_interactive.activation_cost = Some(cost.clone());
+                pending_interactive.activation_ability_index = Some(ability_index);
+                if let Some(waiting_for) =
+                    casting_costs::surface_next_unpaid_interactive_activation_cost(
+                        state,
+                        player,
+                        &pending_interactive,
+                    )?
+                {
+                    return Ok(waiting_for);
+                }
+            }
+
+            // Waterbend cost: detour to ManaPayment with Waterbend mode.
+            if let Some(wb_cost) = find_waterbend_cost(cost) {
+                let mut pending_wb =
+                    PendingCast::new(source_id, CardId(0), resolved, wb_cost.clone());
+                pending_wb.activation_cost = Some(cost.clone());
+                pending_wb.activation_ability_index = Some(ability_index);
+                state.pending_cast = Some(Box::new(pending_wb));
+                return casting_costs::enter_payment_step(
+                    state,
+                    player,
+                    Some(ConvokeMode::Waterbend),
+                    events,
+                );
+            }
         }
     }
 
@@ -17637,105 +17646,24 @@ pub fn handle_activate_ability(
         {
             let mut resolved = resolved;
             assign_targets_in_chain(state, &mut resolved, &targets)?;
-
-            if let Some(ref cost) = ability_def.cost {
-                if variable_speed_payment_range(cost, effective_speed(state, player)).is_some() {
-                    return Ok(begin_variable_speed_payment(
-                        state,
-                        player,
-                        source_id,
-                        resolved,
-                        cost.clone(),
-                        ability_index,
-                        ActivationTargetSelection::Settled,
-                    ));
-                }
-                stamp_self_ref_discard_cost_paid_object(state, source_id, &mut resolved, cost);
-                if let Some(waiting) = try_finalize_activation_mana_payment(
-                    state,
-                    player,
-                    source_id,
-                    ability_index,
-                    &resolved,
-                    cost,
-                    ActivationTargetSelection::Settled,
-                    events,
-                )? {
-                    return Ok(waiting);
-                }
-                if let PaymentOutcome::Paused { remaining_cost } = pay_ability_cost_for_activation(
-                    state,
-                    player,
-                    source_id,
-                    cost,
-                    Some(ability_index),
-                    events,
-                )? {
-                    let pending = pending_activation_after_cost_pause(
-                        source_id,
-                        resolved.clone(),
-                        ability_index,
-                        remaining_cost,
-                    );
-                    if let Some(pending) =
-                        casting_costs::attach_pending_cast_to_cost_move(state, Box::new(pending))
-                    {
-                        state.pending_cast = Some(pending);
-                    }
-                    return Ok(state.waiting_for.clone());
-                }
-            }
-
-            let assigned_targets = flatten_targets_in_chain(&resolved);
-            emit_targeting_events(state, &assigned_targets, source_id, player, events);
-
-            // CR 702.170b: plot's grant targets SelfRef (a context-ref), so
-            // `build_target_slots` yields no slot and plot never takes this target
-            // branch — it is intercepted in the no-target path below. Guard the
-            // invariant: a future plot variant reaching here would silently revert
-            // to the on-stack model, so relocate the intercept if this ever fires.
-            debug_assert!(
-                !is_plot_special_action(&ability_def),
-                "plot special action reached the target branch; SelfRef should suppress its target slot"
-            );
-
-            let entry_id = ObjectId(state.next_object_id);
-            state.next_object_id += 1;
-
-            stack::push_to_stack(
+            // CR 602.2b + CR 601.2c: automatic target selection still
+            // declares targets before any activation cost is paid.
+            emit_targeting_events(
                 state,
-                StackEntry {
-                    id: entry_id,
-                    source_id,
-                    controller: player,
-                    kind: StackEntryKind::ActivatedAbility {
-                        source_id,
-                        ability: Box::new(resolved),
-                    },
-                },
-                events,
-            );
-
-            restrictions::record_ability_activation(state, source_id, ability_index);
-            // CR 117.1b: Priority permits unbounded activation. `pending_activations`
-            // is a per-priority-window AI-guard — see `GameState::pending_activations`.
-            state.pending_activations.push((source_id, ability_index));
-            events.push(GameEvent::AbilityActivated {
-                player_id: player,
+                &flatten_targets_in_chain(&resolved),
                 source_id,
-                // CR 606.2: Classify loyalty vs. normal from the source ability cost.
-                kind: super::planeswalker::activated_ability_kind(state, source_id, ability_index),
-            });
-            // CR 702.142b: Emit additional event when a boast ability is activated.
-            super::casting_targets::emit_keyword_ability_event_if_tagged(
-                state,
-                source_id,
-                ability_index,
                 player,
                 events,
             );
-            priority::clear_priority_passes(state);
-            return Ok(WaitingFor::Priority { player });
+            let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+            pending.activation_cost = ability_def.cost.clone();
+            pending.activation_ability_index = Some(ability_index);
+            pending.target_constraints = target_constraints;
+            pending.distribute = ability_def.distribute.clone();
+            pending.begin_activation_trigger_collection();
+            return casting_costs::finish_target_selected_activated_ability_at_payment_boundary(
+                state, player, pending, events,
+            );
         }
 
         let mut pending_target = PendingCast::new(

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -40,9 +40,11 @@ use super::ability_utils::{
     ability_target_legality_needs_chosen_x, additional_cost_instead_spell_has_legal_targets,
     assign_targets_in_chain, auto_select_targets, auto_select_targets_for_ability,
     begin_target_selection, begin_target_selection_for_ability, build_resolved_from_def,
-    build_target_slots, compute_unavailable_modes, filter_references_target_player,
-    flatten_targets_in_chain, has_legal_target_assignment_for_ability, modal_choice_for_player,
+    build_target_slots, build_target_slots_for_announcement, compute_unavailable_modes,
+    filter_references_target_player, flatten_targets_in_chain,
+    has_legal_target_assignment_for_ability, modal_choice_for_player,
     simple_legal_target_assignment_exists_for_ability, target_constraints_from_modal,
+    unresolved_x_target_construction_error, TargetSlotBuildOutcome,
 };
 use super::casting_costs::{self, check_additional_cost_or_pay};
 use super::engine::EngineError;
@@ -17148,23 +17150,21 @@ pub fn handle_activate_ability(
     // reject that specific class of otherwise legal activation; defer only that
     // X-dependent case through the X round-trip. Every other target-build
     // failure remains an immediate activation error.
-    let has_effect_targets = match build_target_slots(state, &resolved) {
-        Ok(target_slots) => !target_slots.is_empty(),
-        // `resolve_multi_target_bounds` fails closed while the exact target
-        // count still depends on X. Do not treat another target-construction
-        // error (for example, a missing mandatory fixed target) as an X
-        // declaration: it must reject the activation immediately.
-        Err(EngineError::ActionNotAllowed(message))
-            if message == "Target count requires a resolved quantity before target selection"
-                && activation_cost.as_ref().is_some_and(|cost| {
-                    ability_target_legality_needs_chosen_x(
-                        &resolved,
-                        ability_def.distribute.as_ref(),
-                    ) && (casting_costs::extract_x_mana_cost(cost).is_some()
-                        || casting_costs::activation_cost_needs_x_choice(&resolved, cost))
-                }) =>
+    let has_effect_targets = match build_target_slots_for_announcement(state, &resolved) {
+        Ok(TargetSlotBuildOutcome::Slots(target_slots)) => !target_slots.is_empty(),
+        // A typed outcome preserves the distinction between a target slot that
+        // cannot yet be evaluated because X is unannounced and a genuinely
+        // illegal target set. Only the former enters the X round-trip.
+        Ok(TargetSlotBuildOutcome::RequiresChosenX)
+            if activation_cost.as_ref().is_some_and(|cost| {
+                casting_costs::extract_x_mana_cost(cost).is_some()
+                    || casting_costs::activation_cost_needs_x_choice(&resolved, cost)
+            }) =>
         {
             true
+        }
+        Ok(TargetSlotBuildOutcome::RequiresChosenX) => {
+            return Err(unresolved_x_target_construction_error());
         }
         Err(error) => return Err(error),
     };

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -17150,12 +17150,19 @@ pub fn handle_activate_ability(
     // failure remains an immediate activation error.
     let has_effect_targets = match build_target_slots(state, &resolved) {
         Ok(target_slots) => !target_slots.is_empty(),
-        Err(_)
-            if activation_cost.as_ref().is_some_and(|cost| {
-                ability_target_legality_needs_chosen_x(&resolved, ability_def.distribute.as_ref())
-                    && (casting_costs::extract_x_mana_cost(cost).is_some()
+        // `resolve_multi_target_bounds` fails closed while the exact target
+        // count still depends on X. Do not treat another target-construction
+        // error (for example, a missing mandatory fixed target) as an X
+        // declaration: it must reject the activation immediately.
+        Err(EngineError::ActionNotAllowed(message))
+            if message == "Target count requires a resolved quantity before target selection"
+                && activation_cost.as_ref().is_some_and(|cost| {
+                    ability_target_legality_needs_chosen_x(
+                        &resolved,
+                        ability_def.distribute.as_ref(),
+                    ) && (casting_costs::extract_x_mana_cost(cost).is_some()
                         || casting_costs::activation_cost_needs_x_choice(&resolved, cost))
-            }) =>
+                }) =>
         {
             true
         }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4338,7 +4338,11 @@ pub(crate) fn target_first_activation_defers_interactive_costs_to_payment_bounda
     };
 
     (matches!(handoff, TargetFirstPaymentHandoff::BeforeManaPayment)
-        && extract_mana_leg(cost).is_some_and(|(mana_cost, _)| !mana_cost.is_without_paying_mana()))
+        && extract_mana_leg(cost).is_some_and(|(mana_cost, _)| !mana_cost.is_without_paying_mana())
+        // CR 601.2g-h: This established class keeps non-self battlefield
+        // removal after the mana window. Other interactive residuals (such as
+        // exile from hand and unattach) retain their dispatcher order.
+        && super::casting::find_non_self_battlefield_removal_cost(cost).is_some())
         || (pending.ability.chosen_x.is_some() && cost_has_targeted_symbolic_counter_removal(cost))
 }
 

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1763,6 +1763,7 @@ pub(crate) fn handle_discard_for_cost(
     let cost_event_end = events.len();
 
     if pending.activation_ability_index.is_some() {
+        pending.mark_activation_cost_committed();
         pending.activation_cost = pending
             .activation_cost
             .take()
@@ -1809,12 +1810,22 @@ fn park_cost_payment_triggers_if_paused(
     cost_event_end: usize,
     waiting_for: &WaitingFor,
 ) {
-    if !matches!(waiting_for, WaitingFor::Priority { .. }) {
-        let cost_events: Vec<GameEvent> = events[cost_event_start..cost_event_end]
-            .iter()
-            .filter(|ev| !matches!(ev, GameEvent::PhaseChanged { .. }))
-            .cloned()
-            .collect();
+    if matches!(waiting_for, WaitingFor::Priority { .. }) {
+        return;
+    }
+
+    let cost_events: Vec<GameEvent> = events[cost_event_start..cost_event_end]
+        .iter()
+        .filter(|ev| !matches!(ev, GameEvent::PhaseChanged { .. }))
+        .cloned()
+        .collect();
+    if let Some(mut collection) = state.take_pending_activation_trigger_collection() {
+        // CR 602.2b + CR 603.3b: A target-first activation owns cost-trigger
+        // collection until its stack entry exists, even when a later payment
+        // prompt has parked the PendingCast between cost components.
+        collection.collect(state, &cost_events);
+        state.restore_pending_activation_trigger_collection(collection);
+    } else {
         crate::game::triggers::collect_triggers_into_deferred(state, &cost_events);
     }
 }
@@ -2153,6 +2164,7 @@ pub(crate) fn resume_interrupted_cost_payment(
             }
         }
         if pending.activation_ability_index.is_some() {
+            pending.mark_activation_cost_committed();
             pending.activation_cost = pending
                 .activation_cost
                 .take()
@@ -2680,13 +2692,19 @@ fn finish_sacrifice_for_cost(
     if matches!(completion, PendingSacrificeCostCompletion::SelectedNonSelf)
         && pending.activation_ability_index.is_some()
     {
+        pending.mark_activation_cost_committed();
         pending.activation_cost = pending
             .activation_cost
             .take()
             .and_then(super::casting::remove_selected_non_self_sacrifice_cost);
     }
 
-    finish_pending_cost_or_cast(state, player, pending, events)
+    let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
+    // CR 602.2b + CR 603.3b: The replacement-resumed sacrifice can itself
+    // reach a later payment prompt. Park this action's final event fragment in
+    // the same activation-local transaction as the earlier fragments.
+    park_cost_payment_triggers_if_paused(state, events, current_start, events.len(), &waiting_for);
+    Ok(waiting_for)
 }
 
 /// CR 601.2h + CR 602.2b + CR 616.1: Continue the exact unpaid suffix of a
@@ -2945,6 +2963,7 @@ pub(crate) fn handle_sacrifice_for_cost(
     );
 
     if pending.activation_ability_index.is_some() {
+        pending.mark_activation_cost_committed();
         pending.activation_cost = pending
             .activation_cost
             .take()
@@ -3046,6 +3065,7 @@ pub(crate) fn handle_unattach_for_cost(
             });
         }
     }
+    pending.mark_activation_cost_committed();
 
     // CR 601.2h: This handler paid exactly one interactive `UnattachFrom` leg.
     // Keep only the unpaid suffix so a later mana-leg root cannot replay the
@@ -3181,6 +3201,7 @@ pub(crate) fn handle_return_to_hand_for_cost(
                 .is_some_and(|obj| obj.zone != Zone::Hand)
         })
         .collect();
+    pending.mark_activation_cost_committed();
     finish_cost_object_moves(
         state,
         player,
@@ -3287,6 +3308,8 @@ pub(crate) fn handle_remove_counter_for_cost(
                 lki: obj.1.snapshot_for_mana_spent(),
             });
     }
+
+    pending.mark_activation_cost_committed();
 
     if let Some(ability_index) = pending.activation_ability_index {
         if let Some(cost) = pending.activation_cost.take() {
@@ -3461,6 +3484,8 @@ pub(crate) fn handle_remove_counter_distribution_for_cost(
         }
     }
 
+    pending.mark_activation_cost_committed();
+
     if let Some(ability_index) = pending.activation_ability_index {
         if let Some(cost) = pending.activation_cost.take() {
             // CR 601.2h + CR 602.2b: The assigned counter payment is complete
@@ -3554,6 +3579,8 @@ pub(crate) fn handle_blight_choice(
         state.pending_cast = Some(Box::new(pending));
         return Ok(state.waiting_for.clone());
     }
+
+    pending.mark_activation_cost_committed();
 
     finish_pending_cost_or_cast(state, player, pending, events)
 }
@@ -4008,6 +4035,7 @@ fn finish_exile_selection_for_cost(
     pending.ability.add_cost_paid_object_ids_recursive(chosen);
 
     if pending.activation_ability_index.is_some() {
+        pending.mark_activation_cost_committed();
         pending.activation_cost = pending
             .activation_cost
             .take()
@@ -12969,6 +12997,7 @@ mod tests {
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         }
@@ -18245,6 +18274,7 @@ mod tests {
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         };
@@ -18381,6 +18411,7 @@ mod tests {
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         };
@@ -18486,6 +18517,7 @@ mod tests {
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         };
@@ -18580,6 +18612,7 @@ mod tests {
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         };
@@ -18707,6 +18740,7 @@ mod tests {
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         };

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4242,6 +4242,21 @@ pub(crate) fn finish_activated_ability_at_payment_boundary(
         );
     }
 
+    // CR 107.1b + CR 601.2f-h: target declaration may have deferred a
+    // targeted remove-X-counters cost. Route that exact residual back through
+    // `enter_payment_step`, its single authority for concretizing X and
+    // selecting the counter source, before any generic cost payment can see
+    // the symbolic sentinel.
+    if pending.ability.chosen_x.is_some()
+        && pending
+            .activation_cost
+            .as_ref()
+            .is_some_and(cost_has_targeted_symbolic_counter_removal)
+    {
+        state.pending_cast = Some(Box::new(pending));
+        return enter_payment_step(state, player, None, events);
+    }
+
     let should_finalize_mana_leg = !matches!(
         pending.activation_residual,
         ActivationResidual::ManaLeg | ActivationResidual::XMana
@@ -4313,6 +4328,22 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
         return Ok(None);
     };
     let source_id = pending.object_id;
+
+    // CR 601.2g-h + CR 602.2b: Once an activation's targets are declared,
+    // a mana leg is still paid before every non-mana component, regardless of
+    // the serialized `Composite` order. Defer the interactive dispatcher to
+    // the payment boundary, which hoists that mana leg and preserves this
+    // root's chosen targets for the remaining cost.
+    if extract_mana_leg(cost).is_some_and(|(mana_cost, _)| !mana_cost.is_without_paying_mana()) {
+        return Ok(None);
+    }
+    // CR 107.1b + CR 601.2f-h: a targeted remove-X-counters cost cannot be
+    // surfaced until the common payment step has substituted the announced X
+    // for its symbolic counter count. The payment step then prompts for the
+    // counter source after all effect targets are fixed.
+    if pending.ability.chosen_x.is_some() && cost_has_targeted_symbolic_counter_removal(cost) {
+        return Ok(None);
+    }
 
     // CR 601.2h + CR 701.9a: A resolved zero-card FromHand discard leg (Lion's Eye Diamond /
     // Bomat Courier's "Discard your hand" on an empty hand) is paid by doing nothing — the

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -1588,6 +1588,22 @@ pub(crate) fn begin_deferred_target_selection(
         let mut ability = pending.ability.clone();
         assign_targets_in_chain(state, &mut ability, &targets)?;
         pending.ability = ability;
+        if pending.activation_ability_index.is_some() {
+            // CR 602.2b + CR 601.2c: automatic target declaration remains
+            // before the activation's payment boundary, including after X was
+            // announced through this deferred route.
+            super::casting::emit_targeting_events(
+                state,
+                &flatten_targets_in_chain(&pending.ability),
+                pending.object_id,
+                pending.ability.controller,
+                events,
+            );
+            pending.begin_activation_trigger_collection();
+            return finish_target_selected_activated_ability_at_payment_boundary(
+                state, player, pending, events,
+            );
+        }
         return finish_pending_cost_or_cast(state, player, pending, events);
     }
     if let Some(targets) = auto_select_targets_for_ability(
@@ -1599,7 +1615,33 @@ pub(crate) fn begin_deferred_target_selection(
         let mut ability = pending.ability.clone();
         assign_targets_in_chain(state, &mut ability, &targets)?;
         pending.ability = ability;
+        if pending.activation_ability_index.is_some() {
+            // CR 602.2b + CR 601.2c: automatic target declaration remains
+            // before the activation's payment boundary, including after X was
+            // announced through this deferred route.
+            super::casting::emit_targeting_events(
+                state,
+                &flatten_targets_in_chain(&pending.ability),
+                pending.object_id,
+                pending.ability.controller,
+                events,
+            );
+            pending.begin_activation_trigger_collection();
+            return finish_target_selected_activated_ability_at_payment_boundary(
+                state, player, pending, events,
+            );
+        }
         return finish_pending_cost_or_cast(state, player, pending, events);
+    }
+
+    if pending.activation_ability_index.is_some() {
+        return super::casting_targets::begin_activated_target_selection(
+            state,
+            player,
+            pending,
+            target_slots,
+            mode_labels,
+        );
     }
 
     let selection = begin_target_selection_for_ability(
@@ -4186,6 +4228,7 @@ pub(crate) fn finish_activated_ability_at_payment_boundary(
         pending.activation_residual,
         pending.activation_target_selection,
         pending.pending_loyalty_activation_player,
+        pending.activation_trigger_collection.clone(),
         events,
     )
 }
@@ -4383,6 +4426,7 @@ pub(super) fn push_activated_ability_to_stack(
     activation_residual: ActivationResidual,
     target_selection: ActivationTargetSelection,
     mut pending_loyalty_activation_player: Option<PlayerId>,
+    activation_trigger_collection: Option<Box<super::triggers::PendingActivationTriggerCollection>>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     // Pay the exact activation-cost suffix still outstanding. Interactive cost
@@ -4411,6 +4455,7 @@ pub(super) fn push_activated_ability_to_stack(
         pending_interactive.activation_ability_index = Some(ability_index);
         pending_interactive.pending_loyalty_activation_player = pending_loyalty_activation_player;
         pending_interactive.activation_target_selection = target_selection;
+        pending_interactive.activation_trigger_collection = activation_trigger_collection.clone();
         if let Some(waiting_for) =
             surface_next_unpaid_interactive_activation_cost(state, player, &pending_interactive)?
         {
@@ -4488,6 +4533,7 @@ pub(super) fn push_activated_ability_to_stack(
                 .then_some(player)
                 .or(pending_loyalty_activation_player);
             pending.activation_target_selection = target_selection;
+            pending.activation_trigger_collection = activation_trigger_collection.clone();
             if let Some(pending) = attach_pending_cast_to_cost_move(state, Box::new(pending)) {
                 state.pending_cast = Some(pending);
             }
@@ -4511,8 +4557,6 @@ pub(super) fn push_activated_ability_to_stack(
     }
 
     if matches!(target_selection, ActivationTargetSelection::Settled) {
-        let assigned_targets = flatten_targets_in_chain(&resolved);
-        emit_targeting_events(state, &assigned_targets, source_id, player, events);
         return push_ability_entry(
             state,
             player,
@@ -4520,6 +4564,7 @@ pub(super) fn push_activated_ability_to_stack(
             ability_index,
             resolved,
             pending_loyalty_activation_player,
+            activation_trigger_collection,
             events,
         );
     }
@@ -4546,6 +4591,7 @@ pub(super) fn push_activated_ability_to_stack(
             ability_index,
             resolved,
             pending_loyalty_activation_player,
+            activation_trigger_collection,
             events,
         );
     }
@@ -4570,6 +4616,7 @@ pub(super) fn push_activated_ability_to_stack(
                 ability_index,
                 resolved,
                 pending_loyalty_activation_player,
+                activation_trigger_collection,
                 events,
             );
         }
@@ -4590,12 +4637,12 @@ pub(super) fn push_activated_ability_to_stack(
                 ability_index,
                 resolved,
                 pending_loyalty_activation_player,
+                activation_trigger_collection,
                 events,
             );
         }
 
-        // Targets need interactive selection
-        let selection = begin_target_selection_for_ability(state, &resolved, &target_slots, &[])?;
+        // Targets need interactive selection.
         let mut pending_act = PendingCast::new(
             source_id,
             CardId(0),
@@ -4612,19 +4659,14 @@ pub(super) fn push_activated_ability_to_stack(
         pending_act.activation_cost = None;
         pending_act.activation_ability_index = Some(ability_index);
         pending_act.pending_loyalty_activation_player = pending_loyalty_activation_player;
-        // CR 601.2c + CR 602.2b: first slot's announcer (activator unless the slot
-        // is "of an opponent's choice").
-        let initial_player = target_slots
-            .first()
-            .and_then(|slot| slot.chooser)
-            .unwrap_or(player);
-        return Ok(WaitingFor::TargetSelection {
-            player: initial_player,
-            pending_cast: Box::new(pending_act),
+        pending_act.activation_trigger_collection = activation_trigger_collection;
+        return super::casting_targets::begin_activated_target_selection(
+            state,
+            player,
+            pending_act,
             target_slots,
-            mode_labels: Vec::new(),
-            selection,
-        });
+            Vec::new(),
+        );
     }
 
     emit_targeting_events(state, &assigned_targets, source_id, player, events);
@@ -4636,6 +4678,7 @@ pub(super) fn push_activated_ability_to_stack(
         ability_index,
         resolved,
         pending_loyalty_activation_player,
+        activation_trigger_collection,
         events,
     )
 }
@@ -4682,6 +4725,7 @@ fn concretize_chosen_x_cost(cost: &AbilityCost, chosen_x: u32) -> AbilityCost {
 }
 
 /// Final step: create stack entry and record activation.
+#[allow(clippy::too_many_arguments)]
 pub(super) fn push_ability_entry(
     state: &mut GameState,
     player: PlayerId,
@@ -4689,6 +4733,7 @@ pub(super) fn push_ability_entry(
     ability_index: usize,
     mut resolved: ResolvedAbility,
     pending_loyalty_activation_player: Option<PlayerId>,
+    activation_trigger_collection: Option<Box<super::triggers::PendingActivationTriggerCollection>>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     let entry_id = ObjectId(state.next_object_id);
@@ -4741,6 +4786,20 @@ pub(super) fn push_ability_entry(
         player,
         events,
     );
+    if let Some(mut collection) = activation_trigger_collection {
+        collection.collect(state, events);
+        let mut deferred_contexts = std::mem::take(&mut state.deferred_triggers);
+        collection.commit_into(state, &mut deferred_contexts);
+        state.deferred_triggers = deferred_contexts;
+        state
+            .consumed_before_priority_trigger_events
+            .extend(events.iter().enumerate().map(|(index, event)| {
+                crate::game::triggers::ConsumedTriggerEventOccurrence {
+                    event: event.clone(),
+                    occurrence: crate::game::triggers::trigger_event_occurrence(events, index),
+                }
+            }));
+    }
     priority::clear_priority_passes(state);
 
     Ok(WaitingFor::Priority { player })
@@ -11813,6 +11872,7 @@ pub fn finalize_mana_payment_with_phyrexian_choices(
                 pending.activation_residual,
                 pending.activation_target_selection,
                 pending.pending_loyalty_activation_player,
+                pending.activation_trigger_collection.clone(),
                 events,
             );
         }
@@ -12896,6 +12956,7 @@ mod tests {
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         }
     }
 
@@ -18171,6 +18232,7 @@ mod tests {
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         };
 
         let result = pay_additional_cost(
@@ -18306,6 +18368,7 @@ mod tests {
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         };
 
         let mut events = Vec::new();
@@ -18410,6 +18473,7 @@ mod tests {
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         };
 
         // Exactly one card is required. Selecting two must fail.
@@ -18503,6 +18567,7 @@ mod tests {
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         };
 
         // `red` is not in the legal-cards list, so the cost handler must reject
@@ -18629,6 +18694,7 @@ mod tests {
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         };
 
         let result = pay_additional_cost(
@@ -21617,6 +21683,7 @@ its replicate cost was paid.)\nDraw a card.";
             Some(&residual),
             ActivationResidual::XMana,
             ActivationTargetSelection::Pending,
+            None,
             None,
             &mut events,
         );

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4470,6 +4470,83 @@ pub(super) fn push_activated_ability_to_stack(
     activation_trigger_collection: Option<Box<super::triggers::PendingActivationTriggerCollection>>,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    // CR 602.2b + CR 601.2c-h: This is also a defensive entry point for
+    // resumed activation roots. If a caller still has both unchosen targets and
+    // an unpaid cost suffix, route it through the same target-first transaction
+    // as `handle_activate_ability`; never pay the suffix and reopen targets.
+    if !matches!(target_selection, ActivationTargetSelection::Settled) {
+        let target_slots = build_target_slots(state, &resolved)?;
+        let assigned_targets = flatten_targets_in_chain(&resolved);
+        if !target_slots.is_empty() {
+            let pending = |resolved: ResolvedAbility| {
+                let mut pending =
+                    PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
+                pending.activation_cost = remaining_cost.cloned();
+                pending.activation_ability_index = Some(ability_index);
+                pending.pending_loyalty_activation_player = pending_loyalty_activation_player;
+                pending.activation_trigger_collection = activation_trigger_collection.clone();
+                pending
+            };
+
+            // A fully assigned or divided target set may arrive from a resumed
+            // root. It is still announced before payment, not pushed directly.
+            if assigned_targets.len() >= target_slots.len() || resolved.distribution.is_some() {
+                let mut pending = pending(resolved);
+                pending.begin_activation_trigger_collection();
+                emit_targeting_events(state, &assigned_targets, source_id, player, events);
+                return finish_target_selected_activated_ability_at_payment_boundary(
+                    state, player, pending, events,
+                );
+            }
+
+            if matches!(
+                resolved.target_selection_mode,
+                crate::types::ability::TargetSelectionMode::Random
+            ) {
+                let targets = random_select_targets_for_ability(state, &target_slots, &[])?;
+                assign_targets_in_chain(state, &mut resolved, &targets)?;
+                let mut pending = pending(resolved);
+                pending.begin_activation_trigger_collection();
+                emit_targeting_events(
+                    state,
+                    &flatten_targets_in_chain(&pending.ability),
+                    source_id,
+                    player,
+                    events,
+                );
+                return finish_target_selected_activated_ability_at_payment_boundary(
+                    state, player, pending, events,
+                );
+            }
+
+            if let Some(targets) =
+                auto_select_targets_for_ability(state, &resolved, &target_slots, &[])?
+            {
+                assign_targets_in_chain(state, &mut resolved, &targets)?;
+                let mut pending = pending(resolved);
+                pending.begin_activation_trigger_collection();
+                emit_targeting_events(
+                    state,
+                    &flatten_targets_in_chain(&pending.ability),
+                    source_id,
+                    player,
+                    events,
+                );
+                return finish_target_selected_activated_ability_at_payment_boundary(
+                    state, player, pending, events,
+                );
+            }
+
+            return super::casting_targets::begin_activated_target_selection(
+                state,
+                player,
+                pending(resolved),
+                target_slots,
+                Vec::new(),
+            );
+        }
+    }
+
     // Pay the exact activation-cost suffix still outstanding. Interactive cost
     // handlers remove the leg they paid before this boundary, so a parked mana
     // root never replays an earlier selection.
@@ -4609,108 +4686,6 @@ pub(super) fn push_activated_ability_to_stack(
             events,
         );
     }
-
-    // CR 602.2b: Check if the ability has targets that need selection.
-    // This handles cases where cost payment (sacrifice, waterbend) detoured
-    // before target selection in handle_activate_ability.
-    let target_slots = build_target_slots(state, &resolved)?;
-    let assigned_targets = flatten_targets_in_chain(&resolved);
-    // CR 601.2d: A divided-effect ability whose `distribution` is already
-    // announced has finalized its targets (a legal "up to N" division may fill
-    // fewer target slots than exist — Captain America's Throw picks 1 of 3), so
-    // it is ready to go on the stack even though `assigned_targets.len()` is below
-    // `target_slots.len()`. Without this the re-check would wrongly re-open target
-    // selection and drop the announced division.
-    if !target_slots.is_empty()
-        && (assigned_targets.len() >= target_slots.len() || resolved.distribution.is_some())
-    {
-        emit_targeting_events(state, &assigned_targets, source_id, player, events);
-        return push_ability_entry(
-            state,
-            player,
-            source_id,
-            ability_index,
-            resolved,
-            pending_loyalty_activation_player,
-            activation_trigger_collection,
-            events,
-        );
-    }
-    if !target_slots.is_empty() {
-        // CR 115.1 + CR 701.9b: Random-target activated abilities — game picks
-        // uniformly via `state.rng`, no controller prompt.
-        if matches!(
-            resolved.target_selection_mode,
-            crate::types::ability::TargetSelectionMode::Random
-        ) {
-            let targets = random_select_targets_for_ability(state, &target_slots, &[])?;
-            let mut resolved = resolved;
-            assign_targets_in_chain(state, &mut resolved, &targets)?;
-
-            let assigned_targets = flatten_targets_in_chain(&resolved);
-            emit_targeting_events(state, &assigned_targets, source_id, player, events);
-
-            return push_ability_entry(
-                state,
-                player,
-                source_id,
-                ability_index,
-                resolved,
-                pending_loyalty_activation_player,
-                activation_trigger_collection,
-                events,
-            );
-        }
-
-        if let Some(targets) =
-            auto_select_targets_for_ability(state, &resolved, &target_slots, &[])?
-        {
-            let mut resolved = resolved;
-            assign_targets_in_chain(state, &mut resolved, &targets)?;
-
-            let assigned_targets = flatten_targets_in_chain(&resolved);
-            emit_targeting_events(state, &assigned_targets, source_id, player, events);
-
-            return push_ability_entry(
-                state,
-                player,
-                source_id,
-                ability_index,
-                resolved,
-                pending_loyalty_activation_player,
-                activation_trigger_collection,
-                events,
-            );
-        }
-
-        // Targets need interactive selection.
-        let mut pending_act = PendingCast::new(
-            source_id,
-            CardId(0),
-            resolved,
-            crate::types::mana::ManaCost::NoCost,
-        );
-        // CR 602.2b: The remainder of the process for activating an ability is
-        // identical to the process for casting a spell listed in rules 601.2b–i.
-        // Note: The engine currently pays non-mana costs (Tap, Sacrifice, etc.)
-        // before target selection, which is a shortcut that deviates from the
-        // strict CR 601.2 order (targets at 601.2c, costs at 601.2h). To prevent
-        // double-payment when target selection resumes, we clear the activation
-        // cost here — it was already consumed above (issue #897 class).
-        pending_act.activation_cost = None;
-        pending_act.activation_ability_index = Some(ability_index);
-        pending_act.pending_loyalty_activation_player = pending_loyalty_activation_player;
-        pending_act.activation_trigger_collection = activation_trigger_collection;
-        return super::casting_targets::begin_activated_target_selection(
-            state,
-            player,
-            pending_act,
-            target_slots,
-            Vec::new(),
-        );
-    }
-
-    emit_targeting_events(state, &assigned_targets, source_id, player, events);
 
     push_ability_entry(
         state,
@@ -21734,6 +21709,56 @@ its replicate cost was paid.)\nDraw a card.";
             None,
             &mut events,
         );
+    }
+
+    #[test]
+    fn direct_push_target_bearing_activation_selects_targets_before_paying_cost() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(7_710),
+            PlayerId(0),
+            "Target-First Direct Source".to_string(),
+            Zone::Battlefield,
+        );
+        let resolved = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Any,
+                damage_source: None,
+                excess: None,
+            },
+            Vec::new(),
+            source,
+            PlayerId(0),
+        );
+        let cost = AbilityCost::Tap;
+        let mut events = Vec::new();
+
+        let waiting = push_activated_ability_to_stack(
+            &mut state,
+            PlayerId(0),
+            source,
+            0,
+            resolved,
+            Some(&cost),
+            ActivationResidual::None,
+            ActivationTargetSelection::Pending,
+            None,
+            None,
+            &mut events,
+        )
+        .expect("direct activation root must enter target selection");
+
+        let WaitingFor::TargetSelection { pending_cast, .. } = waiting else {
+            panic!("expected target selection before the tap cost, got {waiting:?}");
+        };
+        assert_eq!(pending_cast.activation_cost, Some(AbilityCost::Tap));
+        assert!(
+            !state.objects[&source].tapped,
+            "target declaration must precede the activation tap cost"
+        );
+        assert!(state.stack.is_empty());
     }
 
     /// CR 119.4a + CR 810.9a: in 2HG the max X payable via a "pay X life"

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2257,7 +2257,7 @@ pub(crate) fn handle_activation_cost_one_of_choice(
     }
 
     if let Some(waiting_for) =
-        surface_next_unpaid_interactive_activation_cost(state, player, &pending)?
+        surface_next_unpaid_interactive_activation_cost(state, player, &pending, events)?
     {
         return Ok(waiting_for);
     }
@@ -2689,14 +2689,14 @@ fn finish_sacrifice_for_cost(
         current_end,
     );
 
-    if matches!(completion, PendingSacrificeCostCompletion::SelectedNonSelf)
-        && pending.activation_ability_index.is_some()
-    {
+    if pending.activation_ability_index.is_some() {
         pending.mark_activation_cost_committed();
-        pending.activation_cost = pending
-            .activation_cost
-            .take()
-            .and_then(super::casting::remove_selected_non_self_sacrifice_cost);
+        if matches!(completion, PendingSacrificeCostCompletion::SelectedNonSelf) {
+            pending.activation_cost = pending
+                .activation_cost
+                .take()
+                .and_then(super::casting::remove_selected_non_self_sacrifice_cost);
+        }
     }
 
     let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
@@ -4296,9 +4296,10 @@ pub(crate) fn finish_target_selected_activated_ability_at_payment_boundary(
 /// completed handler removes one matching leg, so repeated components and a
 /// chosen `OneOf` branch naturally re-enter here until no selection remains.
 pub(crate) fn surface_next_unpaid_interactive_activation_cost(
-    state: &GameState,
+    state: &mut GameState,
     player: PlayerId,
     pending: &PendingCast,
+    events: &mut Vec<GameEvent>,
 ) -> Result<Option<WaitingFor>, EngineError> {
     let Some(cost) = pending.activation_cost.as_ref() else {
         return Ok(None);
@@ -4322,6 +4323,25 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
                 spell: Box::new(pending.clone()),
             },
         }));
+    }
+
+    if let Some(amount) = super::casting::find_collect_evidence_activation_cost(cost) {
+        let mut pending = pending.clone();
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| matches!(cost, AbilityCost::CollectEvidence { .. }),
+        );
+        return super::effects::collect_evidence::begin_cost_payment(
+            state,
+            player,
+            amount,
+            pending,
+            SpellCostSource::Other,
+        )
+        .map(Some);
     }
 
     if let Some((count, sacrifice_filter)) = super::casting::find_non_self_sacrifice_cost(cost) {
@@ -4372,6 +4392,99 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
         }));
     }
 
+    if let Some((filter, function, property, comparator, value, zone)) =
+        super::casting::find_exile_with_aggregate_cost(cost)
+    {
+        let eligible = super::cost_payability::eligible_exile_with_aggregate_objects(
+            state, player, source_id, filter, zone,
+        );
+        let total = super::quantity::aggregate_property_over(state, &eligible, function, property);
+        if !comparator.evaluate(total, value) {
+            return Err(EngineError::ActionNotAllowed(
+                "Not enough eligible cards to reach the exile threshold".into(),
+            ));
+        }
+        let mut pending = pending.clone();
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| matches!(cost, AbilityCost::ExileWithAggregate { .. }),
+        );
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::ExileAggregate {
+                zone,
+                function,
+                property,
+                comparator,
+                value,
+                filter: filter.clone(),
+            },
+            choices: eligible.clone(),
+            count: eligible.len(),
+            min_count: 1,
+            resume: CostResume::Spell {
+                spell: Box::new(pending),
+            },
+        }));
+    }
+
+    if let Some((count, materials)) = super::casting::find_craft_materials_cost(cost) {
+        let eligible =
+            super::cost_payability::eligible_craft_materials(state, player, source_id, materials);
+        let min_count = count.min_count();
+        let max_count = count.max_count(eligible.len());
+        if eligible.len() < min_count {
+            return Err(EngineError::ActionNotAllowed(
+                "Not enough eligible materials to craft".into(),
+            ));
+        }
+        let mut pending = pending.clone();
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| matches!(cost, AbilityCost::ExileMaterials { .. }),
+        );
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::ExileMaterials {
+                materials: materials.clone(),
+            },
+            choices: eligible,
+            count: max_count,
+            min_count,
+            resume: CostResume::Spell {
+                spell: Box::new(pending),
+            },
+        }));
+    }
+
+    if let Some(costs) = super::casting::find_one_of_cost(cost) {
+        let payable = super::casting::payable_one_of_activation_branches(
+            state,
+            player,
+            source_id,
+            costs,
+            pending
+                .activation_ability_index
+                .expect("activation cost dispatcher requires an ability index"),
+        );
+        if payable.is_empty() {
+            return Err(EngineError::ActionNotAllowed(
+                "Cannot pay activation cost".to_string(),
+            ));
+        }
+        return Ok(Some(WaitingFor::ActivationCostOneOfChoice {
+            player,
+            costs: payable,
+            pending_cast: Box::new(pending.clone()),
+        }));
+    }
+
     if let Some((count, exile_filter)) = super::casting::find_battlefield_exile_cost(cost) {
         let effective_filter =
             super::cost_payability::exile_cost_effective_filter(Some(exile_filter));
@@ -4403,8 +4516,14 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
     }
 
     if let Some((count, filter)) = super::casting::find_unattach_from_cost(cost) {
+        let min_mana_value =
+            super::ability_utils::distribution_targets(&pending.ability).len() as u32;
         let eligible = super::casting::find_eligible_unattach_for_cost_targets(
-            state, player, source_id, filter, 0,
+            state,
+            player,
+            source_id,
+            filter,
+            min_mana_value,
         );
         if eligible.len() < count as usize {
             return Err(EngineError::ActionNotAllowed(
@@ -4447,7 +4566,176 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
         }));
     }
 
+    if let Some((count, counter_type, target, selection)) =
+        super::casting::find_targeted_remove_counter_cost(cost)
+    {
+        let required_count = match selection {
+            CounterCostSelection::SingleObject => count,
+            CounterCostSelection::AmongObjects => 1,
+        };
+        let eligible = super::casting::find_eligible_remove_counter_for_cost_targets(
+            state,
+            player,
+            source_id,
+            target,
+            counter_type,
+            required_count,
+        );
+        if eligible.is_empty() {
+            return Err(EngineError::ActionNotAllowed(
+                "No eligible permanents with counters".into(),
+            ));
+        }
+        if selection == CounterCostSelection::AmongObjects {
+            let removable_count = eligible
+                .iter()
+                .filter_map(|object_id| state.objects.get(object_id))
+                .map(|obj| {
+                    super::casting::removable_counter_count_for_cost_selection(
+                        obj,
+                        counter_type,
+                        selection,
+                    )
+                })
+                .fold(0, u32::saturating_add);
+            if removable_count < count {
+                return Err(EngineError::ActionNotAllowed(
+                    "Not enough eligible counters to remove".into(),
+                ));
+            }
+        }
+        let mut pending = pending.clone();
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| {
+                matches!(
+                    cost,
+                    AbilityCost::RemoveCounter {
+                        target: Some(_),
+                        ..
+                    }
+                )
+            },
+        );
+        let max_count = match selection {
+            CounterCostSelection::SingleObject => 1,
+            CounterCostSelection::AmongObjects => eligible.len(),
+        };
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::RemoveCounter {
+                counter_type: counter_type.clone(),
+                count,
+                selection,
+            },
+            choices: eligible,
+            count: max_count,
+            min_count: match selection {
+                CounterCostSelection::SingleObject => 0,
+                CounterCostSelection::AmongObjects => 1,
+            },
+            resume: CostResume::Spell {
+                spell: Box::new(pending),
+            },
+        }));
+    }
+
+    if let Some((requirement, filter)) = super::casting::find_tap_creatures_cost(cost) {
+        let count = requirement.fixed_count().ok_or_else(|| {
+            EngineError::ActionNotAllowed(
+                "Aggregate-power tap cost is not valid for this activation".into(),
+            )
+        })?;
+        let eligible = super::casting::find_eligible_tap_creatures_for_cost(
+            state, player, source_id, cost, filter,
+        );
+        if eligible.len() < count as usize {
+            return Err(EngineError::ActionNotAllowed(
+                "Not enough eligible creatures to tap".into(),
+            ));
+        }
+        let mut pending = pending.clone();
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| matches!(cost, AbilityCost::TapCreatures { .. }),
+        );
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::TapCreatures { aggregate: None },
+            choices: eligible,
+            count: count as usize,
+            min_count: 0,
+            resume: CostResume::Spell {
+                spell: Box::new(pending),
+            },
+        }));
+    }
+
+    if let Some((waterbend, residual)) = extract_waterbend_activation_cost(cost) {
+        let mut pending = pending.clone();
+        pending.cost = waterbend;
+        pending.activation_cost = residual;
+        state.pending_cast = Some(Box::new(pending));
+        return enter_payment_step(state, player, Some(ConvokeMode::Waterbend), events).map(Some);
+    }
+
     Ok(None)
+}
+
+fn remove_first_activation_cost_matching(
+    cost: AbilityCost,
+    predicate: impl Fn(&AbilityCost) -> bool + Copy,
+) -> Option<AbilityCost> {
+    remove_first_activation_cost_matching_inner(cost, predicate).0
+}
+
+fn remove_first_activation_cost_matching_inner(
+    cost: AbilityCost,
+    predicate: impl Fn(&AbilityCost) -> bool + Copy,
+) -> (Option<AbilityCost>, bool) {
+    if predicate(&cost) {
+        return (None, true);
+    }
+    let AbilityCost::Composite { costs } = cost else {
+        return (Some(cost), false);
+    };
+    let mut removed = false;
+    let mut remaining = Vec::with_capacity(costs.len());
+    for cost in costs {
+        if removed {
+            remaining.push(cost);
+            continue;
+        }
+        let (cost, did_remove) = remove_first_activation_cost_matching_inner(cost, predicate);
+        removed = did_remove;
+        if let Some(cost) = cost {
+            remaining.push(cost);
+        }
+    }
+    let cost = match remaining.len() {
+        0 => None,
+        1 => remaining.into_iter().next(),
+        _ => Some(AbilityCost::Composite { costs: remaining }),
+    };
+    (cost, removed)
+}
+
+fn extract_waterbend_activation_cost(
+    cost: &AbilityCost,
+) -> Option<(ManaCost, Option<AbilityCost>)> {
+    let waterbend = super::casting::find_waterbend_cost(cost)?.clone();
+    Some((
+        waterbend,
+        remove_first_activation_cost_matching(cost.clone(), |cost| {
+            matches!(cost, AbilityCost::Waterbend { .. })
+        }),
+    ))
 }
 
 /// Push an activated ability to the stack after costs are paid.
@@ -4574,9 +4862,12 @@ pub(super) fn push_activated_ability_to_stack(
         pending_interactive.pending_loyalty_activation_player = pending_loyalty_activation_player;
         pending_interactive.activation_target_selection = target_selection;
         pending_interactive.activation_trigger_collection = activation_trigger_collection.clone();
-        if let Some(waiting_for) =
-            surface_next_unpaid_interactive_activation_cost(state, player, &pending_interactive)?
-        {
+        if let Some(waiting_for) = surface_next_unpaid_interactive_activation_cost(
+            state,
+            player,
+            &pending_interactive,
+            events,
+        )? {
             return Ok(waiting_for);
         }
 

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4314,21 +4314,31 @@ pub(crate) fn finish_target_selected_activated_ability_at_payment_boundary(
     finish_activated_ability_at_payment_boundary(state, player, pending, events)
 }
 
-/// CR 601.2c + CR 601.2g-h + CR 602.2b: Targeted activations whose payment
-/// boundary must first process a mana leg or bind announced X defer their
-/// interactive residual until that common boundary has run.
+/// Identifies which target-first activation handoff is deciding whether to
+/// surface an interactive residual before returning to the payment authority.
+#[derive(Clone, Copy)]
+pub(crate) enum TargetFirstPaymentHandoff {
+    BeforeManaPayment,
+    AfterManaPayment,
+}
+
+/// CR 601.2c + CR 601.2g-h + CR 602.2b: Targeted activations whose handoff
+/// must process an unpaid mana leg or bind announced X defer their interactive
+/// residual until that common boundary has run.
 ///
-/// This is deliberately limited to the target-declaration transition. The
-/// shared interactive-cost dispatcher also resumes ordinary activation and
+/// This is deliberately limited to target-first handoffs. The shared
+/// interactive-cost dispatcher also resumes ordinary activation and
 /// craft/material flows, which must retain their established routing.
 pub(crate) fn target_first_activation_defers_interactive_costs_to_payment_boundary(
     pending: &PendingCast,
+    handoff: TargetFirstPaymentHandoff,
 ) -> bool {
     let Some(cost) = pending.activation_cost.as_ref() else {
         return false;
     };
 
-    extract_mana_leg(cost).is_some_and(|(mana_cost, _)| !mana_cost.is_without_paying_mana())
+    (matches!(handoff, TargetFirstPaymentHandoff::BeforeManaPayment)
+        && extract_mana_leg(cost).is_some_and(|(mana_cost, _)| !mana_cost.is_without_paying_mana()))
         || (pending.ability.chosen_x.is_some() && cost_has_targeted_symbolic_counter_removal(cost))
 }
 

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2589,11 +2589,24 @@ fn pause_sacrifice_for_cost(
 /// pipeline cannot collect the same events again.
 fn settle_sacrifice_for_cost_events(
     state: &mut GameState,
+    pending: &mut PendingCast,
     mut deferred_cost_events: Vec<GameEvent>,
     events: &[GameEvent],
     current_start: usize,
     current_end: usize,
 ) {
+    if let Some(collection) = pending.activation_trigger_collection.as_mut() {
+        // CR 602.2b + CR 603.2: an announced target-bearing activation owns
+        // replacement-paused cost events until its stack commit. Earlier action
+        // fragments are not present in this action's event buffer, while the
+        // current fragment is collected once by the eventual stack boundary (or
+        // the next pending-action staging pass).
+        if !deferred_cost_events.is_empty() {
+            collection.collect(state, &deferred_cost_events);
+        }
+        return;
+    }
+
     deferred_cost_events.extend_from_slice(&events[current_start..current_end]);
     if !deferred_cost_events.is_empty() {
         crate::game::triggers::collect_triggers_into_deferred(state, &deferred_cost_events);
@@ -2657,6 +2670,7 @@ fn finish_sacrifice_for_cost(
     // before a later cast/activation prompt can hide this action's event span.
     settle_sacrifice_for_cost_events(
         state,
+        &mut pending,
         deferred_cost_events,
         events,
         current_start,

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2971,14 +2971,13 @@ pub(crate) fn handle_sacrifice_for_cost(
     }
 
     let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
-    if !matches!(waiting_for, WaitingFor::Priority { .. }) {
-        let cost_events: Vec<GameEvent> = events[cost_event_start..]
-            .iter()
-            .filter(|event| !matches!(event, GameEvent::PhaseChanged { .. }))
-            .cloned()
-            .collect();
-        crate::game::triggers::collect_triggers_into_deferred(state, &cost_events);
-    }
+    park_cost_payment_triggers_if_paused(
+        state,
+        events,
+        cost_event_start,
+        events.len(),
+        &waiting_for,
+    );
     Ok(waiting_for)
 }
 

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -4314,6 +4314,24 @@ pub(crate) fn finish_target_selected_activated_ability_at_payment_boundary(
     finish_activated_ability_at_payment_boundary(state, player, pending, events)
 }
 
+/// CR 601.2c + CR 601.2g-h + CR 602.2b: Targeted activations whose payment
+/// boundary must first process a mana leg or bind announced X defer their
+/// interactive residual until that common boundary has run.
+///
+/// This is deliberately limited to the target-declaration transition. The
+/// shared interactive-cost dispatcher also resumes ordinary activation and
+/// craft/material flows, which must retain their established routing.
+pub(crate) fn target_first_activation_defers_interactive_costs_to_payment_boundary(
+    pending: &PendingCast,
+) -> bool {
+    let Some(cost) = pending.activation_cost.as_ref() else {
+        return false;
+    };
+
+    extract_mana_leg(cost).is_some_and(|(mana_cost, _)| !mana_cost.is_without_paying_mana())
+        || (pending.ability.chosen_x.is_some() && cost_has_targeted_symbolic_counter_removal(cost))
+}
+
 /// CR 118.3 + CR 601.2h + CR 602.2b: Surface exactly the next unpaid
 /// interactive activation-cost component from the serialized residual. Every
 /// completed handler removes one matching leg, so repeated components and a
@@ -4328,22 +4346,6 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
         return Ok(None);
     };
     let source_id = pending.object_id;
-
-    // CR 601.2g-h + CR 602.2b: Once an activation's targets are declared,
-    // a mana leg is still paid before every non-mana component, regardless of
-    // the serialized `Composite` order. Defer the interactive dispatcher to
-    // the payment boundary, which hoists that mana leg and preserves this
-    // root's chosen targets for the remaining cost.
-    if extract_mana_leg(cost).is_some_and(|(mana_cost, _)| !mana_cost.is_without_paying_mana()) {
-        return Ok(None);
-    }
-    // CR 107.1b + CR 601.2f-h: a targeted remove-X-counters cost cannot be
-    // surfaced until the common payment step has substituted the announced X
-    // for its symbolic counter count. The payment step then prompts for the
-    // counter source after all effect targets are fixed.
-    if pending.ability.chosen_x.is_some() && cost_has_targeted_symbolic_counter_removal(cost) {
-        return Ok(None);
-    }
 
     // CR 601.2h + CR 701.9a: A resolved zero-card FromHand discard leg (Lion's Eye Diamond /
     // Bomat Courier's "Discard your hand" on an empty hand) is paid by doing nothing — the

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -11693,6 +11693,18 @@ pub fn enter_payment_step(
             });
         }
 
+        if state
+            .pending_cast
+            .as_ref()
+            .is_some_and(|pending| pending.deferred_target_selection)
+        {
+            let pending = *state
+                .pending_cast
+                .take()
+                .expect("checked pending cast presence");
+            return begin_deferred_target_selection(state, player, pending, events);
+        }
+
         let targeted_counter_resume = pending.ability.chosen_x.and_then(|chosen_x| {
             pending
                 .activation_cost
@@ -11716,18 +11728,6 @@ pub fn enter_payment_step(
                 events,
             );
         }
-    }
-
-    if state
-        .pending_cast
-        .as_ref()
-        .is_some_and(|pending| pending.deferred_target_selection)
-    {
-        let pending = *state
-            .pending_cast
-            .take()
-            .expect("checked pending cast presence");
-        return begin_deferred_target_selection(state, player, pending, events);
     }
 
     if state.pending_cast.as_ref().is_some_and(|pending| {

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -2257,7 +2257,7 @@ pub(crate) fn handle_activation_cost_one_of_choice(
     }
 
     if let Some(waiting_for) =
-        surface_next_unpaid_interactive_activation_cost(state, player, &pending, events)?
+        surface_next_unpaid_interactive_activation_cost(state, player, &mut pending, events)?
     {
         return Ok(waiting_for);
     }
@@ -3594,7 +3594,7 @@ pub(crate) fn handle_blight_choice(
 pub(crate) fn handle_cost_type_choice(
     state: &mut GameState,
     player: PlayerId,
-    pending: PendingCast,
+    mut pending: PendingCast,
     options: &[String],
     choice: &str,
     events: &mut Vec<GameEvent>,
@@ -3612,9 +3612,15 @@ pub(crate) fn handle_cost_type_choice(
                 choice.to_string(),
             ));
     }
-    // The behold cost was stashed in `additional_cost_flow` when the choice was
-    // raised; resume it now (the object carries the chosen type, so the behold
-    // dispatch proceeds past the type prompt to the behold selection).
+    if pending.activation_ability_index.is_some() {
+        if let Some(waiting_for) =
+            surface_next_unpaid_interactive_activation_cost(state, player, &mut pending, events)?
+        {
+            return Ok(waiting_for);
+        }
+    }
+    // Spell additional costs stash behold in `additional_cost_flow`; activation
+    // costs retain it in their serialized residual for the shared dispatcher.
     finish_pending_cost_or_cast(state, player, pending, events)
 }
 
@@ -3772,6 +3778,7 @@ pub(crate) fn handle_behold_for_cost(
         if let Some(snapshot) = snapshot {
             pending.ability.set_cost_paid_object_recursive(snapshot);
         }
+        pending.mark_activation_cost_committed();
         return finish_cost_object_moves(
             state,
             player,
@@ -3796,6 +3803,7 @@ pub(crate) fn handle_behold_for_cost(
     if let Some(snapshot) = snapshot {
         pending.ability.set_cost_paid_object_recursive(snapshot);
     }
+    pending.mark_activation_cost_committed();
     finish_pending_cost_or_cast(state, player, pending, events)
 }
 
@@ -4298,7 +4306,7 @@ pub(crate) fn finish_target_selected_activated_ability_at_payment_boundary(
 pub(crate) fn surface_next_unpaid_interactive_activation_cost(
     state: &mut GameState,
     player: PlayerId,
-    pending: &PendingCast,
+    pending: &mut PendingCast,
     events: &mut Vec<GameEvent>,
 ) -> Result<Option<WaitingFor>, EngineError> {
     let Some(cost) = pending.activation_cost.as_ref() else {
@@ -4677,6 +4685,213 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
         }));
     }
 
+    if let Some(AbilityCost::Mill { count }) =
+        first_activation_cost_component_matching(cost, |cost| {
+            matches!(cost, AbilityCost::Mill { .. })
+        })
+    {
+        let count = *count;
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| matches!(cost, AbilityCost::Mill { .. }),
+        );
+        pending.mark_activation_cost_committed();
+        let proposed = crate::types::proposed_event::ProposedEvent::Mill {
+            player_id: player,
+            count,
+            destination: Zone::Graveyard,
+            applied: Default::default(),
+        };
+        match super::replacement::replace_event(state, proposed, events) {
+            super::replacement::ReplacementResult::Execute(event) => {
+                if super::effects::mill::apply_mill_after_replacement(state, event, events)
+                    .map_err(|error| {
+                        EngineError::InvalidAction(format!(
+                            "Mill cost could not be paid: {error:?}"
+                        ))
+                    })?
+                {
+                    return surface_next_unpaid_interactive_activation_cost(
+                        state, player, pending, events,
+                    );
+                }
+            }
+            // CR 701.17b: A prevented mill or a library with too few cards still
+            // pays a mill cost by milling as many cards as possible.
+            super::replacement::ReplacementResult::Prevented => {
+                return surface_next_unpaid_interactive_activation_cost(
+                    state, player, pending, events,
+                );
+            }
+            super::replacement::ReplacementResult::NeedsChoice(choosing_player) => {
+                state.waiting_for =
+                    super::replacement::replacement_choice_waiting_for(choosing_player, state);
+            }
+        }
+        state.pending_cost_move_resume = Some(PendingCostMoveResume::ActivationMillPayment {
+            player,
+            pending: Box::new(pending.clone()),
+        });
+        return Ok(Some(state.waiting_for.clone()));
+    }
+
+    if let Some(AbilityCost::Blight { count }) =
+        first_activation_cost_component_matching(cost, |cost| {
+            matches!(cost, AbilityCost::Blight { .. })
+        })
+    {
+        let creatures: Vec<ObjectId> = state
+            .battlefield
+            .iter()
+            .copied()
+            .filter(|id| {
+                state.objects.get(id).is_some_and(|obj| {
+                    obj.controller == player
+                        && obj.card_types.core_types.contains(&CoreType::Creature)
+                })
+            })
+            .collect();
+        if creatures.is_empty() {
+            return Err(EngineError::ActionNotAllowed(
+                "No creature to blight".to_string(),
+            ));
+        }
+        let mut pending = pending.clone();
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| matches!(cost, AbilityCost::Blight { .. }),
+        );
+        return Ok(Some(WaitingFor::BlightChoice {
+            player,
+            counters: *count,
+            creatures,
+            pending_cast: Box::new(pending),
+        }));
+    }
+
+    if let Some(AbilityCost::Behold {
+        count,
+        filter,
+        action,
+        type_choice,
+    }) = first_activation_cost_component_matching(cost, |cost| {
+        matches!(cost, AbilityCost::Behold { .. })
+    }) {
+        if let Some(choice_type) = type_choice {
+            let already_chosen = state.objects.get(&source_id).is_some_and(|obj| {
+                obj.chosen_attributes.iter().any(|attribute| {
+                    matches!(
+                        attribute,
+                        crate::types::ability::ChosenAttribute::CreatureType(_)
+                    )
+                })
+            });
+            if !already_chosen {
+                let options = super::filter::feasible_behold_creature_types(
+                    state, player, source_id, filter, *count,
+                );
+                if options.is_empty() {
+                    return Err(EngineError::ActionNotAllowed(
+                        "No creature type is feasible to behold".to_string(),
+                    ));
+                }
+                return Ok(Some(WaitingFor::CostTypeChoice {
+                    player,
+                    choice_type: choice_type.clone(),
+                    options,
+                    pending_cast: Box::new(pending.clone()),
+                }));
+            }
+        }
+        let choices = eligible_behold_choices(state, player, source_id, filter);
+        if choices.len() < *count as usize {
+            return Err(EngineError::ActionNotAllowed(
+                "No eligible object to behold".to_string(),
+            ));
+        }
+        let mut pending = pending.clone();
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| matches!(cost, AbilityCost::Behold { .. }),
+        );
+        return Ok(Some(WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::Behold { action: *action },
+            choices,
+            count: *count as usize,
+            min_count: 0,
+            resume: CostResume::Spell {
+                spell: Box::new(pending),
+            },
+        }));
+    }
+
+    if let Some(AbilityCost::Reveal { count, filter }) =
+        first_activation_cost_component_matching(cost, |cost| {
+            matches!(cost, AbilityCost::Reveal { .. })
+        })
+    {
+        if let Some(filter) = filter {
+            let choices =
+                super::casting::find_eligible_reveal_targets(state, player, source_id, filter);
+            if choices.len() < *count as usize {
+                return Err(EngineError::ActionNotAllowed(
+                    "Not enough eligible cards in hand to reveal".to_string(),
+                ));
+            }
+            let mut pending = pending.clone();
+            pending.activation_cost = remove_first_activation_cost_matching(
+                pending
+                    .activation_cost
+                    .take()
+                    .expect("checked activation cost is present"),
+                |cost| matches!(cost, AbilityCost::Reveal { .. }),
+            );
+            return Ok(Some(WaitingFor::PayCost {
+                player,
+                kind: PayCostKind::Reveal,
+                choices,
+                count: *count as usize,
+                min_count: 0,
+                resume: CostResume::Spell {
+                    spell: Box::new(pending),
+                },
+            }));
+        }
+
+        if let Some(obj) = state.objects.get(&source_id) {
+            pending
+                .ability
+                .set_cost_paid_object_recursive(CostPaidObjectSnapshot {
+                    object_id: source_id,
+                    lki: obj.snapshot_for_mana_spent(),
+                });
+            events.push(GameEvent::CardsRevealed {
+                player,
+                card_ids: vec![source_id],
+                card_names: vec![obj.name.clone()],
+            });
+        }
+        pending.activation_cost = remove_first_activation_cost_matching(
+            pending
+                .activation_cost
+                .take()
+                .expect("checked activation cost is present"),
+            |cost| matches!(cost, AbilityCost::Reveal { .. }),
+        );
+        pending.mark_activation_cost_committed();
+        return surface_next_unpaid_interactive_activation_cost(state, player, pending, events);
+    }
+
     if let Some((waterbend, residual)) = extract_waterbend_activation_cost(cost) {
         let mut pending = pending.clone();
         pending.cost = waterbend;
@@ -4686,6 +4901,43 @@ pub(crate) fn surface_next_unpaid_interactive_activation_cost(
     }
 
     Ok(None)
+}
+
+fn first_activation_cost_component_matching(
+    cost: &AbilityCost,
+    predicate: impl Fn(&AbilityCost) -> bool + Copy,
+) -> Option<&AbilityCost> {
+    if predicate(cost) {
+        return Some(cost);
+    }
+    let AbilityCost::Composite { costs } = cost else {
+        return None;
+    };
+    costs
+        .iter()
+        .find_map(|cost| first_activation_cost_component_matching(cost, predicate))
+}
+
+/// CR 602.2b + CR 701.17a + CR 616.1: Resume an activation after its mill
+/// cost's replacement pipeline reaches a terminal outcome. The residual has
+/// already had precisely that `Mill` leg removed before it was parked.
+pub(crate) fn resume_activation_mill_cost_payment(
+    state: &mut GameState,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let Some(PendingCostMoveResume::ActivationMillPayment {
+        player,
+        mut pending,
+    }) = state.pending_cost_move_resume.take()
+    else {
+        unreachable!("matched an activation mill cost continuation")
+    };
+    if let Some(waiting_for) =
+        surface_next_unpaid_interactive_activation_cost(state, player, &mut pending, events)?
+    {
+        return Ok(waiting_for);
+    }
+    finish_pending_cost_or_cast(state, player, *pending, events)
 }
 
 fn remove_first_activation_cost_matching(
@@ -4865,7 +5117,7 @@ pub(super) fn push_activated_ability_to_stack(
         if let Some(waiting_for) = surface_next_unpaid_interactive_activation_cost(
             state,
             player,
-            &pending_interactive,
+            &mut pending_interactive,
             events,
         )? {
             return Ok(waiting_for);
@@ -7251,6 +7503,7 @@ pub(crate) fn handle_reveal_for_cost(
         card_names: revealed_names,
     });
 
+    pending.mark_activation_cost_committed();
     finish_pending_cost_or_cast(state, player, pending, events)
 }
 

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -11715,6 +11715,31 @@ pub fn enter_payment_step(
         });
         if let Some((mut pending, cost, chosen_x)) = targeted_counter_resume {
             let concretized_cost = concretize_chosen_x_cost(&cost, chosen_x);
+            // CR 107.1b + CR 118.3: Choosing X=0 makes a targeted
+            // remove-X-counters component a zero cost. It neither requires an
+            // object choice nor requires that a matching counter exist.
+            if chosen_x == 0 {
+                pending.activation_cost =
+                    remove_first_activation_cost_matching(concretized_cost, |cost| {
+                        matches!(
+                            cost,
+                            AbilityCost::RemoveCounter {
+                                count: 0,
+                                target: Some(_),
+                                ..
+                            }
+                        )
+                    });
+                if let Some(waiting_for) = surface_next_unpaid_interactive_activation_cost(
+                    state,
+                    player,
+                    &mut pending,
+                    events,
+                )? {
+                    return Ok(waiting_for);
+                }
+                return finish_pending_cost_or_cast(state, player, pending, events);
+            }
             let prompt_cost = targeted_remove_counter_choice_cost(&concretized_cost)
                 .unwrap_or_else(|| concretized_cost.clone());
             pending.activation_cost = Some(concretized_cost);

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -4,14 +4,12 @@ use crate::types::ability::{
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    ActivationTargetSelection, CostResume, GameState, PayCostKind, PendingCast,
-    TargetSelectionSlot, WaitingFor,
+    ActivationTargetSelection, GameState, PendingCast, TargetSelectionSlot, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
 use crate::types::player::PlayerId;
-use crate::types::zones::ExileCostSourceZone;
 
 use super::ability_utils::{
     ability_target_legality_needs_chosen_x, assign_selected_slots_in_chain,
@@ -291,6 +289,7 @@ fn maybe_pause_for_cast_distribution(
     player: PlayerId,
     pending: &PendingCast,
     ability: &ResolvedAbility,
+    events: &[GameEvent],
 ) -> Result<Option<WaitingFor>, EngineError> {
     let Some(unit) = &pending.distribute else {
         return Ok(None);
@@ -305,6 +304,7 @@ fn maybe_pause_for_cast_distribution(
     }
     let mut pending_dist = pending.clone();
     pending_dist.ability = Box::new(ability.clone());
+    stage_activation_target_events_before_distribution(state, &mut pending_dist, events);
     state.pending_cast = Some(Box::new(pending_dist));
     Ok(Some(WaitingFor::DistributeAmong {
         player,
@@ -312,6 +312,19 @@ fn maybe_pause_for_cast_distribution(
         targets: assigned_targets,
         unit: unit.clone(),
     }))
+}
+
+/// CR 602.2b + CR 603.3b: A target-bearing activation keeps target-declaration
+/// triggers local while an intervening distribution choice is pending. The later
+/// stack-commit boundary publishes this already-collected prefix with cost events.
+fn stage_activation_target_events_before_distribution(
+    state: &GameState,
+    pending: &mut PendingCast,
+    events: &[GameEvent],
+) {
+    if let Some(collection) = pending.activation_trigger_collection.as_mut() {
+        collection.collect(state, events);
+    }
 }
 
 /// Handle target selection for a pending cast.
@@ -369,7 +382,8 @@ pub(crate) fn handle_select_targets(
         );
     }
 
-    if let Some(waiting_for) = maybe_pause_for_cast_distribution(state, player, &pending, &ability)?
+    if let Some(waiting_for) =
+        maybe_pause_for_cast_distribution(state, player, &pending, &ability, events)?
     {
         return Ok(waiting_for);
     }
@@ -378,12 +392,11 @@ pub(crate) fn handle_select_targets(
         let mut pending = pending;
         pending.ability = ability;
         pending.activation_target_selection = ActivationTargetSelection::Settled;
-        if let Some(waiting_for) = pay_activation_costs_after_target_selection(
-            state,
-            player,
-            &pending,
-            (*pending.ability).clone(),
-        )? {
+        if let Some(waiting_for) =
+            super::casting_costs::surface_next_unpaid_interactive_activation_cost(
+                state, player, &pending, events,
+            )?
+        {
             return Ok(waiting_for);
         }
 
@@ -477,7 +490,7 @@ pub(crate) fn handle_choose_target(
             }
 
             if let Some(waiting_for) =
-                maybe_pause_for_cast_distribution(state, controller, &pending, &ability)?
+                maybe_pause_for_cast_distribution(state, controller, &pending, &ability, events)?
             {
                 return Ok(waiting_for);
             }
@@ -486,12 +499,11 @@ pub(crate) fn handle_choose_target(
                 let mut pending = pending;
                 pending.ability = ability;
                 pending.activation_target_selection = ActivationTargetSelection::Settled;
-                if let Some(waiting_for) = pay_activation_costs_after_target_selection(
-                    state,
-                    controller,
-                    &pending,
-                    (*pending.ability).clone(),
-                )? {
+                if let Some(waiting_for) =
+                    super::casting_costs::surface_next_unpaid_interactive_activation_cost(
+                        state, controller, &pending, events,
+                    )?
+                {
                     return Ok(waiting_for);
                 }
 
@@ -510,86 +522,6 @@ pub(crate) fn handle_choose_target(
             finish_pending_cast_cost_or_pay(state, controller, pending, *ability, cost, events)
         }
     }
-}
-
-fn pay_activation_costs_after_target_selection(
-    state: &mut GameState,
-    player: PlayerId,
-    pending: &PendingCast,
-    assigned_ability: ResolvedAbility,
-) -> Result<Option<WaitingFor>, EngineError> {
-    if let Some(ref activation_cost) = pending.activation_cost {
-        if let Some((count, zone, filter)) = super::casting::find_non_self_exile(activation_cost) {
-            let narrow_zone = ExileCostSourceZone::try_from_zone(zone)
-                .expect("find_non_self_exile restricts zone to Hand or Graveyard");
-            let eligible = super::casting::find_eligible_exile_for_cost_targets(
-                state,
-                player,
-                pending.object_id,
-                narrow_zone,
-                filter,
-            );
-            if eligible.len() < count as usize {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough eligible cards to exile".into(),
-                ));
-            }
-            let mut pending = pending.clone();
-            pending.ability = Box::new(assigned_ability);
-            return Ok(Some(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::ExileFromZone { zone: narrow_zone },
-                choices: eligible,
-                count: count as usize,
-                min_count: 0,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending),
-                },
-            }));
-        }
-
-        // CR 701.3d + CR 601.2c/601.2h: a targeted "unattach a matching
-        // attachment from ~" ability chooses its targets first, then surfaces the
-        // Unattach cost interactively (Captain America's Throw). The chosen
-        // Equipment's mana value drives the divided damage (CR 202.3 + CR 608.2k),
-        // so eligibility narrows to attachments whose mana value is at least the
-        // announced target count (CR 601.2c). Modeled on the non-self exile detour.
-        if let Some((count, filter)) = super::casting::find_unattach_from_cost(activation_cost) {
-            let n = distribution_targets(&assigned_ability).len() as u32;
-            let eligible = super::casting::find_eligible_unattach_for_cost_targets(
-                state,
-                player,
-                pending.object_id,
-                filter,
-                n,
-            );
-            if eligible.is_empty() {
-                // CR 733 / CR 601.2h: unpayable cost — nothing has been detached
-                // (pre-commit revert), so the activation is simply illegal.
-                return Err(EngineError::ActionNotAllowed(
-                    "No eligible Equipment to unattach with mana value >= target count".into(),
-                ));
-            }
-            let mut pending = pending.clone();
-            pending.ability = Box::new(assigned_ability);
-            // CR 601.2h: unattach-from is a required cost — no decline, exactly
-            // `count` selections.
-            return Ok(Some(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::UnattachFrom {
-                    filter: filter.clone(),
-                },
-                choices: eligible,
-                count: count as usize,
-                min_count: count as usize,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending),
-                },
-            }));
-        }
-    }
-
-    Ok(None)
 }
 
 /// CR 602.2b + CR 605.3b + CR 616.1: Resume an automatic activation mana leg
@@ -611,9 +543,10 @@ pub(crate) fn finish_activation_after_automatic_mana_payment(
         pending.activation_target_selection,
         ActivationTargetSelection::Settled
     ) {
-        let ability = (*pending.ability).clone();
         if let Some(waiting) =
-            pay_activation_costs_after_target_selection(state, player, &pending, ability)?
+            super::casting_costs::surface_next_unpaid_interactive_activation_cost(
+                state, player, &pending, events,
+            )?
         {
             return Ok(waiting);
         }

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -22,6 +22,7 @@ use super::ability_utils::{
 use super::casting_costs::{
     cost_has_x, drain_deferred_triggers_after_stack_object_announcement, enter_payment_step,
     finish_pending_cast_cost_or_pay,
+    target_first_activation_defers_interactive_costs_to_payment_boundary,
 };
 use super::engine::EngineError;
 use super::restrictions;
@@ -392,15 +393,17 @@ pub(crate) fn handle_select_targets(
         let mut pending = pending;
         pending.ability = ability;
         pending.activation_target_selection = ActivationTargetSelection::Settled;
-        if let Some(waiting_for) =
-            super::casting_costs::surface_next_unpaid_interactive_activation_cost(
-                state,
-                player,
-                &mut pending,
-                events,
-            )?
-        {
-            return Ok(waiting_for);
+        if !target_first_activation_defers_interactive_costs_to_payment_boundary(&pending) {
+            if let Some(waiting_for) =
+                super::casting_costs::surface_next_unpaid_interactive_activation_cost(
+                    state,
+                    player,
+                    &mut pending,
+                    events,
+                )?
+            {
+                return Ok(waiting_for);
+            }
         }
 
         return super::casting_costs::finish_target_selected_activated_ability_at_payment_boundary(
@@ -502,15 +505,17 @@ pub(crate) fn handle_choose_target(
                 let mut pending = pending;
                 pending.ability = ability;
                 pending.activation_target_selection = ActivationTargetSelection::Settled;
-                if let Some(waiting_for) =
-                    super::casting_costs::surface_next_unpaid_interactive_activation_cost(
-                        state,
-                        controller,
-                        &mut pending,
-                        events,
-                    )?
-                {
-                    return Ok(waiting_for);
+                if !target_first_activation_defers_interactive_costs_to_payment_boundary(&pending) {
+                    if let Some(waiting_for) =
+                        super::casting_costs::surface_next_unpaid_interactive_activation_cost(
+                            state,
+                            controller,
+                            &mut pending,
+                            events,
+                        )?
+                    {
+                        return Ok(waiting_for);
+                    }
                 }
 
                 let waiting_for =

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -394,7 +394,10 @@ pub(crate) fn handle_select_targets(
         pending.activation_target_selection = ActivationTargetSelection::Settled;
         if let Some(waiting_for) =
             super::casting_costs::surface_next_unpaid_interactive_activation_cost(
-                state, player, &pending, events,
+                state,
+                player,
+                &mut pending,
+                events,
             )?
         {
             return Ok(waiting_for);
@@ -501,7 +504,10 @@ pub(crate) fn handle_choose_target(
                 pending.activation_target_selection = ActivationTargetSelection::Settled;
                 if let Some(waiting_for) =
                     super::casting_costs::surface_next_unpaid_interactive_activation_cost(
-                        state, controller, &pending, events,
+                        state,
+                        controller,
+                        &mut pending,
+                        events,
                     )?
                 {
                     return Ok(waiting_for);
@@ -531,7 +537,7 @@ pub(crate) fn handle_choose_target(
 pub(crate) fn finish_activation_after_automatic_mana_payment(
     state: &mut GameState,
     player: PlayerId,
-    pending: PendingCast,
+    mut pending: PendingCast,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
     if pending.activation_ability_index.is_none() {
@@ -545,7 +551,10 @@ pub(crate) fn finish_activation_after_automatic_mana_payment(
     ) {
         if let Some(waiting) =
             super::casting_costs::surface_next_unpaid_interactive_activation_cost(
-                state, player, &pending, events,
+                state,
+                player,
+                &mut pending,
+                events,
             )?
         {
             return Ok(waiting);

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -23,6 +23,7 @@ use super::casting_costs::{
     cost_has_x, drain_deferred_triggers_after_stack_object_announcement, enter_payment_step,
     finish_pending_cast_cost_or_pay,
     target_first_activation_defers_interactive_costs_to_payment_boundary,
+    TargetFirstPaymentHandoff,
 };
 use super::engine::EngineError;
 use super::restrictions;
@@ -393,7 +394,10 @@ pub(crate) fn handle_select_targets(
         let mut pending = pending;
         pending.ability = ability;
         pending.activation_target_selection = ActivationTargetSelection::Settled;
-        if !target_first_activation_defers_interactive_costs_to_payment_boundary(&pending) {
+        if !target_first_activation_defers_interactive_costs_to_payment_boundary(
+            &pending,
+            TargetFirstPaymentHandoff::BeforeManaPayment,
+        ) {
             if let Some(waiting_for) =
                 super::casting_costs::surface_next_unpaid_interactive_activation_cost(
                     state,
@@ -505,7 +509,10 @@ pub(crate) fn handle_choose_target(
                 let mut pending = pending;
                 pending.ability = ability;
                 pending.activation_target_selection = ActivationTargetSelection::Settled;
-                if !target_first_activation_defers_interactive_costs_to_payment_boundary(&pending) {
+                if !target_first_activation_defers_interactive_costs_to_payment_boundary(
+                    &pending,
+                    TargetFirstPaymentHandoff::BeforeManaPayment,
+                ) {
                     if let Some(waiting_for) =
                         super::casting_costs::surface_next_unpaid_interactive_activation_cost(
                             state,
@@ -553,6 +560,9 @@ pub(crate) fn finish_activation_after_automatic_mana_payment(
     if matches!(
         pending.activation_target_selection,
         ActivationTargetSelection::Settled
+    ) && !target_first_activation_defers_interactive_costs_to_payment_boundary(
+        &pending,
+        TargetFirstPaymentHandoff::AfterManaPayment,
     ) {
         if let Some(waiting) =
             super::casting_costs::surface_next_unpaid_interactive_activation_cost(

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -38,10 +38,11 @@ use super::restrictions;
 pub(crate) fn begin_activated_target_selection(
     state: &GameState,
     player: PlayerId,
-    pending_cast: PendingCast,
+    mut pending_cast: PendingCast,
     target_slots: Vec<TargetSelectionSlot>,
     mode_labels: Vec<Option<String>>,
 ) -> Result<WaitingFor, EngineError> {
+    pending_cast.begin_activation_trigger_collection();
     let selection = begin_target_selection_for_ability(
         state,
         &pending_cast.ability,

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -357,6 +357,18 @@ pub(crate) fn handle_select_targets(
     let mut ability = pending.ability.clone();
     assign_targets_in_chain(state, &mut ability, &targets)?;
 
+    if pending.activation_ability_index.is_some() {
+        // CR 602.2b + CR 601.2c: the target event occurs when targets are
+        // declared, before a distribution choice or any activation cost.
+        super::casting::emit_targeting_events(
+            state,
+            &super::ability_utils::flatten_targets_in_chain(&ability),
+            pending.object_id,
+            pending.ability.controller,
+            events,
+        );
+    }
+
     if let Some(waiting_for) = maybe_pause_for_cast_distribution(state, player, &pending, &ability)?
     {
         return Ok(waiting_for);
@@ -451,6 +463,18 @@ pub(crate) fn handle_choose_target(
             // Offering's final slot is opponent-chosen; without re-anchoring here the
             // inbound per-slot `player` (the opponent) would pay and stack the spell.
             let controller = pending.ability.controller;
+
+            if pending.activation_ability_index.is_some() {
+                // CR 602.2b + CR 601.2c: complete the target-declaration event
+                // before any distribution choice or activation cost.
+                super::casting::emit_targeting_events(
+                    state,
+                    &super::ability_utils::flatten_targets_in_chain(&ability),
+                    pending.object_id,
+                    controller,
+                    events,
+                );
+            }
 
             if let Some(waiting_for) =
                 maybe_pause_for_cast_distribution(state, controller, &pending, &ability)?

--- a/crates/engine/src/game/casting_targets.rs
+++ b/crates/engine/src/game/casting_targets.rs
@@ -4,7 +4,8 @@ use crate::types::ability::{
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    ActivationTargetSelection, CostResume, GameState, PayCostKind, PendingCast, WaitingFor,
+    ActivationTargetSelection, CostResume, GameState, PayCostKind, PendingCast,
+    TargetSelectionSlot, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::keywords::Keyword;
@@ -26,6 +27,39 @@ use super::casting_costs::{
 };
 use super::engine::EngineError;
 use super::restrictions;
+
+/// Creates the sole interactive target-declaration boundary for an activated
+/// ability after its announcement-only choices have settled.
+///
+/// CR 602.2b + CR 601.2b-c: Modes and X are announced before targets, and
+/// costs are paid only after the target declaration has completed. Keeping the
+/// prompt construction here prevents cost-specific activation detours from
+/// accidentally moving ahead of target selection.
+pub(crate) fn begin_activated_target_selection(
+    state: &GameState,
+    player: PlayerId,
+    pending_cast: PendingCast,
+    target_slots: Vec<TargetSelectionSlot>,
+    mode_labels: Vec<Option<String>>,
+) -> Result<WaitingFor, EngineError> {
+    let selection = begin_target_selection_for_ability(
+        state,
+        &pending_cast.ability,
+        &target_slots,
+        &pending_cast.target_constraints,
+    )?;
+    let initial_player = target_slots
+        .first()
+        .and_then(|slot| slot.chooser)
+        .unwrap_or(player);
+    Ok(WaitingFor::TargetSelection {
+        player: initial_player,
+        pending_cast: Box::new(pending_cast),
+        target_slots,
+        mode_labels,
+        selection,
+    })
+}
 
 /// Handle mode selection for a modal spell.
 ///

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -7367,6 +7367,20 @@ fn x_cost_activation_defers_exact_target_count_until_x_is_announced() {
         .card_types
         .core_types
         .push(CoreType::Creature);
+    let other_target = create_object(
+        &mut state,
+        CardId(959),
+        PlayerId(1),
+        "Other Target Creature".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&other_target)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
     let mut ability = AbilityDefinition::new(
         AbilityKind::Activated,
         Effect::Destroy {
@@ -7405,6 +7419,9 @@ fn x_cost_activation_defers_exact_target_count_until_x_is_announced() {
     assert!(target_slots[0]
         .legal_targets
         .contains(&TargetRef::Object(target)));
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(other_target)));
 }
 
 /// CR 602.2b + CR 601.2b/c/f: Target legality that depends on X is evaluated
@@ -7429,6 +7446,18 @@ fn x_cost_activation_defers_x_dependent_target_filter_until_x_is_announced() {
     );
     {
         let target_obj = state.objects.get_mut(&target).unwrap();
+        target_obj.card_types.core_types.push(CoreType::Creature);
+        target_obj.mana_cost = ManaCost::generic(2);
+    }
+    let other_target = create_object(
+        &mut state,
+        CardId(960),
+        PlayerId(1),
+        "Other Mana Value Two Creature".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let target_obj = state.objects.get_mut(&other_target).unwrap();
         target_obj.card_types.core_types.push(CoreType::Creature);
         target_obj.mana_cost = ManaCost::generic(2);
     }
@@ -7474,6 +7503,9 @@ fn x_cost_activation_defers_x_dependent_target_filter_until_x_is_announced() {
     assert!(target_slots[0]
         .legal_targets
         .contains(&TargetRef::Object(target)));
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(other_target)));
 }
 
 /// CR 602.2b + CR 601.2b/c/f: An unresolved X target count may defer target
@@ -34841,21 +34873,6 @@ mod remove_counter_cost {
         assert!(matches!(state.waiting_for, WaitingFor::ChooseXValue { .. }));
 
         apply_as_current(&mut state, GameAction::ChooseX { value: 2 }).unwrap();
-        assert!(matches!(
-            state.waiting_for,
-            WaitingFor::PayCost {
-                kind: PayCostKind::RemoveCounter { .. },
-                ..
-            }
-        ));
-
-        apply_as_current(
-            &mut state,
-            GameAction::SelectCards {
-                cards: vec![counter_source],
-            },
-        )
-        .unwrap();
         match &state.waiting_for {
             WaitingFor::TargetSelection {
                 target_slots,
@@ -34872,6 +34889,38 @@ mod remove_counter_cost {
             }
             other => panic!("expected deferred modal target selection, got {other:?}"),
         }
+
+        let target_slots = match &state.waiting_for {
+            WaitingFor::TargetSelection { target_slots, .. } => target_slots,
+            _ => unreachable!("matched TargetSelection above"),
+        };
+        let selected_target = target_slots[0]
+            .legal_targets
+            .first()
+            .cloned()
+            .expect("modal target slot must have a legal creature");
+        apply_as_current(
+            &mut state,
+            GameAction::SelectTargets {
+                targets: vec![selected_target],
+            },
+        )
+        .unwrap();
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::PayCost {
+                kind: PayCostKind::RemoveCounter { .. },
+                ..
+            }
+        ));
+
+        apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![counter_source],
+            },
+        )
+        .unwrap();
     }
 }
 

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -5155,7 +5155,7 @@ fn composite_tap_self_exile_activation_moves_battlefield_source_to_exile() {
 }
 
 #[test]
-fn activated_sacrifice_cost_resumes_to_effect_target_selection() {
+fn activated_sacrifice_cost_selects_effect_target_before_payment() {
     let mut state = setup_game_at_main_phase();
     let source = create_object(
         &mut state,
@@ -5238,22 +5238,8 @@ fn activated_sacrifice_cost_resumes_to_effect_target_selection() {
     add_mana(&mut state, PlayerId(0), ManaType::Colorless, 2);
 
     let waiting = handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new())
-        .expect("activation should ask for the token sacrifice cost first");
+        .expect("activation should ask for its effect target before payment");
     state.waiting_for = waiting;
-    let WaitingFor::PayCost {
-        kind: PayCostKind::Sacrifice,
-        choices: permanents,
-        count,
-        ..
-    } = &state.waiting_for
-    else {
-        panic!("expected PayCost Sacrifice, got {:?}", state.waiting_for);
-    };
-    assert_eq!(*count, 1);
-    assert_eq!(permanents, &vec![token]);
-
-    apply_as_current(&mut state, GameAction::SelectCards { cards: vec![token] })
-        .expect("sacrificing the token should resume activation");
     let WaitingFor::TargetSelection {
         target_slots,
         selection,
@@ -5267,13 +5253,13 @@ fn activated_sacrifice_cost_resumes_to_effect_target_selection() {
         selection
             .current_legal_targets
             .contains(&TargetRef::Object(creature)),
-        "the post-cost target prompt must include the target creature"
+        "the target prompt must include the target creature before payment"
     );
     assert!(
         selection
             .current_legal_targets
             .contains(&TargetRef::Object(other_creature)),
-        "the post-cost target prompt must include each legal target creature"
+        "the target prompt must include each legal target creature before payment"
     );
 
     apply_as_current(
@@ -5283,6 +5269,23 @@ fn activated_sacrifice_cost_resumes_to_effect_target_selection() {
         },
     )
     .expect("target creature should be selectable");
+
+    let WaitingFor::PayCost {
+        kind: PayCostKind::Sacrifice,
+        choices: permanents,
+        count,
+        ..
+    } = &state.waiting_for
+    else {
+        panic!(
+            "expected PayCost Sacrifice after target declaration, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert_eq!(*count, 1);
+    assert_eq!(permanents, &vec![token]);
+    apply_as_current(&mut state, GameAction::SelectCards { cards: vec![token] })
+        .expect("sacrificing the token should resume activation");
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
 
@@ -7334,6 +7337,74 @@ fn x_cost_activated_composite_tap_no_double_payment_on_interactive_targets() {
         "the tap cost is paid exactly once"
     );
     assert_eq!(state.stack.len(), 1, "the activation reaches the stack");
+}
+
+/// CR 602.2b + CR 601.2b/c/f: An X-cost activation whose exact target count
+/// is X cannot build target slots until X is announced. The pre-announcement
+/// target-slot error must defer only this X-dependent declaration, not suppress
+/// ordinary target-legality errors or start paying costs first.
+#[test]
+fn x_cost_activation_defers_exact_target_count_until_x_is_announced() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(954),
+        PlayerId(0),
+        "X Target Relic".to_string(),
+        Zone::Battlefield,
+    );
+    let target = create_object(
+        &mut state,
+        CardId(955),
+        PlayerId(1),
+        "Target Creature".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&target)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+    let mut ability = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Destroy {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+            cant_regenerate: false,
+        },
+    )
+    .cost(AbilityCost::Mana {
+        cost: ManaCost::Cost {
+            shards: vec![ManaCostShard::X],
+            generic: 0,
+        },
+    });
+    ability.multi_target = Some(MultiTargetSpec::exact(QuantityExpr::Ref {
+        qty: QuantityRef::Variable {
+            name: "X".to_string(),
+        },
+    }));
+    Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).push(ability);
+    add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+
+    state.waiting_for =
+        handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new())
+            .expect("the X activation must defer its target count");
+    assert!(matches!(state.waiting_for, WaitingFor::ChooseXValue { .. }));
+
+    apply_as_current(&mut state, GameAction::ChooseX { value: 1 })
+        .expect("announcing X must allow target-slot construction");
+    let WaitingFor::TargetSelection { target_slots, .. } = &state.waiting_for else {
+        panic!(
+            "expected target selection after X announcement, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert_eq!(target_slots.len(), 1);
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(target)));
 }
 
 #[test]

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -7407,6 +7407,57 @@ fn x_cost_activation_defers_exact_target_count_until_x_is_announced() {
         .contains(&TargetRef::Object(target)));
 }
 
+/// CR 602.2b + CR 601.2b/c/f: An unresolved X target count may defer target
+/// declaration, but it cannot conceal a separate mandatory target's absence.
+#[test]
+fn x_target_count_does_not_mask_missing_fixed_target() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(956),
+        PlayerId(0),
+        "Mixed Target Relic".to_string(),
+        Zone::Battlefield,
+    );
+    let mut x_target = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Destroy {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+            cant_regenerate: false,
+        },
+    );
+    x_target.multi_target = Some(MultiTargetSpec::exact(QuantityExpr::Ref {
+        qty: QuantityRef::Variable {
+            name: "X".to_string(),
+        },
+    }));
+    let ability = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Destroy {
+            target: TargetFilter::Typed(TypedFilter::creature()),
+            cant_regenerate: false,
+        },
+    )
+    .cost(AbilityCost::Mana {
+        cost: ManaCost::Cost {
+            shards: vec![ManaCostShard::X],
+            generic: 0,
+        },
+    })
+    .sub_ability(x_target);
+    Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).push(ability);
+    add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
+
+    let error = handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new())
+        .expect_err("the missing fixed target must reject before choosing X");
+    assert!(matches!(
+        error,
+        EngineError::ActionNotAllowed(message) if message == "No legal targets available"
+    ));
+    assert!(state.pending_cast.is_none());
+    assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+}
+
 #[test]
 fn activation_discard_replacement_resumes_and_pays_remaining_composite_cost() {
     let mut state = setup_game_at_main_phase();

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -7232,12 +7232,10 @@ fn x_cost_activated_composite_tap_prompts_for_x_and_taps_on_resolution() {
     );
 }
 
-/// Regression test for issue #897: X-cost activated ability with Composite
-/// {Tap, Mana{X}} cost must NOT attempt to pay the Tap sub-cost a second
-/// time when interactive target selection is required. Before the fix,
-/// `push_activated_ability_to_stack` paid the Tap cost and then stored it
-/// in `pending_act.activation_cost`; the resumed target-selection path in
-/// `casting_targets.rs` would try to pay it again, causing a softlock.
+/// Regression test for issue #897: an X-cost activated ability with Composite
+/// `{T}, {X}` chooses its target after X is announced but before either cost
+/// component is paid. The pending root retains the tap cost through selection,
+/// then pays it exactly once while completing the activation.
 #[test]
 fn x_cost_activated_composite_tap_no_double_payment_on_interactive_targets() {
     let mut state = setup_game_at_main_phase();
@@ -7299,33 +7297,43 @@ fn x_cost_activated_composite_tap_no_double_payment_on_interactive_targets() {
         state.waiting_for
     );
 
-    // Commit X = 2. After mana payment + Tap, the ability needs interactive
-    // target selection (multiple legal targets: both players).
+    // Commit X = 2. X is announced, then the target is selected before the
+    // mana and tap costs are paid (CR 601.2c before CR 601.2h).
     apply_as_current(&mut state, GameAction::ChooseX { value: 2 }).unwrap();
-    // Note: In strict CR 601.2, target selection (601.2c) occurs before cost
-    // payment (601.2h). The engine shortcuts this by paying non-mana costs
-    // first, so the source is already tapped before target selection begins.
     assert!(
-        state.objects[&source].tapped,
-        "source must be tapped after cost payment"
+        !state.objects[&source].tapped,
+        "source must remain untapped while choosing the target"
     );
-    // The waiting_for should be TargetSelection, NOT a softlock/error.
     assert!(
         matches!(state.waiting_for, WaitingFor::TargetSelection { .. }),
         "expected TargetSelection for interactive target choice, got {:?}",
         state.waiting_for
     );
 
-    // Verify the pending_cast does NOT carry activation_cost (no double-pay).
+    // The residual tap cost survives target selection and is paid once after
+    // the target is committed.
     if let WaitingFor::TargetSelection {
         ref pending_cast, ..
     } = state.waiting_for
     {
         assert!(
-            pending_cast.activation_cost.is_none(),
-            "activation_cost must be None after cost was already paid (issue #897)"
+            matches!(pending_cast.activation_cost, Some(AbilityCost::Tap)),
+            "target selection must retain the unpaid tap cost"
         );
     }
+
+    apply_as_current(
+        &mut state,
+        GameAction::SelectTargets {
+            targets: vec![TargetRef::Player(PlayerId(1))],
+        },
+    )
+    .expect("selecting the target must complete payment");
+    assert!(
+        state.objects[&source].tapped,
+        "the tap cost is paid exactly once"
+    );
+    assert_eq!(state.stack.len(), 1, "the activation reaches the stack");
 }
 
 #[test]

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -7407,6 +7407,75 @@ fn x_cost_activation_defers_exact_target_count_until_x_is_announced() {
         .contains(&TargetRef::Object(target)));
 }
 
+/// CR 602.2b + CR 601.2b/c/f: Target legality that depends on X is evaluated
+/// only after X is announced, even when the unannounced value would leave no
+/// legal target.
+#[test]
+fn x_cost_activation_defers_x_dependent_target_filter_until_x_is_announced() {
+    let mut state = setup_game_at_main_phase();
+    let source = create_object(
+        &mut state,
+        CardId(957),
+        PlayerId(0),
+        "X Filter Relic".to_string(),
+        Zone::Battlefield,
+    );
+    let target = create_object(
+        &mut state,
+        CardId(958),
+        PlayerId(1),
+        "Mana Value Two Creature".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let target_obj = state.objects.get_mut(&target).unwrap();
+        target_obj.card_types.core_types.push(CoreType::Creature);
+        target_obj.mana_cost = ManaCost::generic(2);
+    }
+    let ability = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Destroy {
+            target: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                FilterProp::Cmc {
+                    comparator: Comparator::LE,
+                    value: QuantityExpr::Ref {
+                        qty: QuantityRef::Variable {
+                            name: "X".to_string(),
+                        },
+                    },
+                },
+            ])),
+            cant_regenerate: false,
+        },
+    )
+    .cost(AbilityCost::Mana {
+        cost: ManaCost::Cost {
+            shards: vec![ManaCostShard::X],
+            generic: 0,
+        },
+    });
+    Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).push(ability);
+    add_mana(&mut state, PlayerId(0), ManaType::Colorless, 2);
+
+    state.waiting_for =
+        handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new())
+            .expect("the X-dependent filter must defer target legality");
+    assert!(matches!(state.waiting_for, WaitingFor::ChooseXValue { .. }));
+
+    apply_as_current(&mut state, GameAction::ChooseX { value: 2 })
+        .expect("announcing X must make the mana-value-two target legal");
+    let WaitingFor::TargetSelection { target_slots, .. } = &state.waiting_for else {
+        panic!(
+            "expected target selection after X announcement, got {:?}",
+            state.waiting_for
+        );
+    };
+    assert_eq!(target_slots.len(), 1);
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(target)));
+}
+
 /// CR 602.2b + CR 601.2b/c/f: An unresolved X target count may defer target
 /// declaration, but it cannot conceal a separate mandatory target's absence.
 #[test]

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -7517,6 +7517,11 @@ fn x_target_count_does_not_mask_missing_fixed_target() {
     Arc::make_mut(&mut state.objects.get_mut(&source).unwrap().abilities).push(ability);
     add_mana(&mut state, PlayerId(0), ManaType::Colorless, 1);
 
+    assert!(
+        !can_activate_ability_now(&state, PlayerId(0), source, 0),
+        "legal-action generation must not mask the missing fixed target with the later X target"
+    );
+
     let error = handle_activate_ability(&mut state, PlayerId(0), source, 0, &mut Vec::new())
         .expect_err("the missing fixed target must reject before choosing X");
     assert!(matches!(

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -90,6 +90,15 @@ pub enum PublicFinalizeMode {
 /// selected contribution. Once helper payment has started or completed, its
 /// resources may have changed and cancellation cannot roll that prefix back.
 fn ensure_assist_cancellation_is_allowed(state: &GameState) -> Result<(), EngineError> {
+    if state
+        .pending_cast
+        .as_deref()
+        .is_some_and(|pending| pending.activation_cost_committed)
+    {
+        return Err(EngineError::ActionNotAllowed(
+            "Cannot cancel an activation after a cost is paid".to_string(),
+        ));
+    }
     if matches!(
         state
             .pending_cast
@@ -5036,7 +5045,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         (WaitingFor::TargetSelection { player, .. }, GameAction::SelectTargets { targets }) => {
             engine_casting::handle_target_selection_select_targets(
                 state,
@@ -5060,7 +5069,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         (
             WaitingFor::OptionalCostChoice {
                 player,
@@ -5084,7 +5093,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         (
             WaitingFor::ChooseGiftRecipient {
                 player,
@@ -5092,7 +5101,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         // CR 702.47a–e: Splice — caster reveals a card to splice onto the spell
         // (re-offering for the rest), or declines to finish and proceed to targets.
         (
@@ -5117,7 +5126,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         // CR 601.2b: Defiler cycle — player decides whether to pay life for mana reduction.
         (
             WaitingFor::DefilerPayment {
@@ -5143,7 +5152,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         // CR 118.3 + CR 601.2b + CR 605.3b: Player selected objects to pay a
         // cost. The single `PayCost` state dispatches on `kind` (which action)
         // and `resume` (spell-cast vs mana-ability pipeline) to the
@@ -5555,7 +5564,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         // CR 118.3: Player selected permanents to sacrifice as cost.
         (
             WaitingFor::ActivationCostOneOfChoice {
@@ -5579,7 +5588,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         // CR 601.2b + CR 701.4a: player chose the creature type for a pre-choice
         // behold cost; record it and resume behold payment.
         (
@@ -5605,7 +5614,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         // Blight: player selected creature(s) to put -1/-1 counters on as cost.
         (
             WaitingFor::BlightChoice {
@@ -5631,7 +5640,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         (
             WaitingFor::ChooseManaColor {
                 choice, context, ..
@@ -5807,7 +5816,7 @@ fn apply_action(
                 ..
             },
             GameAction::CancelCast,
-        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events),
+        ) => engine_casting::cancel_pending_cast(state, *player, pending_cast, &mut events)?,
         // CR 608.2d: Player decided whether to perform an optional effect ("You may X").
         (WaitingFor::OptionalEffectChoice { .. }, GameAction::DecideOptionalEffect { accept }) => {
             engine_payment_choices::handle_optional_effect_choice(state, accept, &mut events)?
@@ -6037,7 +6046,7 @@ fn apply_action(
             let player = *player;
             match state.pending_cast.take() {
                 Some(pending) => {
-                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)
+                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)?
                 }
                 None => WaitingFor::Priority { player },
             }
@@ -6045,10 +6054,11 @@ fn apply_action(
         (WaitingFor::ChooseXValue { player, .. }, GameAction::CancelCast) => {
             // CR 601.2f + CR 601.2i: Caster may back out before committing to an
             // X value. Pop the stack entry placed at announcement and restore.
+            ensure_assist_cancellation_is_allowed(state)?;
             let player = *player;
             match state.pending_cast.take() {
                 Some(pending) => {
-                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)
+                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)?
                 }
                 None => WaitingFor::Priority { player },
             }
@@ -6227,10 +6237,11 @@ fn apply_action(
             }
         }
         (WaitingFor::AssistChoosePlayer { player, .. }, GameAction::CancelCast) => {
+            ensure_assist_cancellation_is_allowed(state)?;
             let player = *player;
             match state.pending_cast.take() {
                 Some(pending) => {
-                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)
+                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)?
                 }
                 None => WaitingFor::Priority { player },
             }
@@ -6431,7 +6442,7 @@ fn apply_action(
             let player = *player;
             match state.pending_cast.take() {
                 Some(pending) => {
-                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)
+                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)?
                 }
                 None => WaitingFor::Priority { player },
             }
@@ -8295,10 +8306,11 @@ fn apply_action(
         }
         // CR 601.2d: Distribute among targets (casting-time distribution).
         (WaitingFor::DistributeAmong { player, .. }, GameAction::CancelCast) => {
+            ensure_assist_cancellation_is_allowed(state)?;
             let player = *player;
             match state.pending_cast.take() {
                 Some(pending) => {
-                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)
+                    engine_casting::cancel_pending_cast(state, player, &pending, &mut events)?
                 }
                 None => {
                     return Err(EngineError::InvalidAction(

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3174,6 +3174,7 @@ pub(crate) fn drain_pending_cost_move_resume(
                     | PendingCostMoveResume::UnlessBouncePayment { .. }
                     | PendingCostMoveResume::DelveManaPayment { .. }
                     | PendingCostMoveResume::ManaAbilityPayment { .. }
+                    | PendingCostMoveResume::ActivationMillPayment { .. }
                     | PendingCostMoveResume::LoyaltyActivation { .. }
             )
         ),
@@ -3193,6 +3194,7 @@ pub(crate) fn drain_pending_cost_move_resume(
                     | PendingCostMoveResume::UnlessBouncePayment { .. }
                     | PendingCostMoveResume::DelveManaPayment { .. }
                     | PendingCostMoveResume::ManaAbilityPayment { .. }
+                    | PendingCostMoveResume::ActivationMillPayment { .. }
                     | PendingCostMoveResume::LoyaltyActivation { .. }
             )
         ),
@@ -3255,6 +3257,11 @@ pub(crate) fn drain_pending_cost_move_resume(
         Some(PendingCostMoveResume::ManaAbilityPayment { .. })
     ) {
         mana_abilities::resume_mana_ability_cost_move(state, events)?
+    } else if matches!(
+        state.pending_cost_move_resume,
+        Some(PendingCostMoveResume::ActivationMillPayment { .. })
+    ) {
+        casting_costs::resume_activation_mill_cost_payment(state, events)?
     } else if matches!(
         state.pending_cost_move_resume,
         Some(PendingCostMoveResume::LoyaltyActivation { .. })

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -90,20 +90,17 @@ pub enum PublicFinalizeMode {
 /// selected contribution. Once helper payment has started or completed, its
 /// resources may have changed and cancellation cannot roll that prefix back.
 fn ensure_assist_cancellation_is_allowed(state: &GameState) -> Result<(), EngineError> {
-    if state
+    let pending = state
         .pending_cast
         .as_deref()
-        .is_some_and(|pending| pending.activation_cost_committed)
-    {
+        .or_else(|| state.waiting_for.pending_cast_ref());
+    if pending.is_some_and(|pending| pending.activation_cost_committed) {
         return Err(EngineError::ActionNotAllowed(
             "Cannot cancel an activation after a cost is paid".to_string(),
         ));
     }
     if matches!(
-        state
-            .pending_cast
-            .as_deref()
-            .map(|pending| pending.assist_state),
+        pending.map(|pending| pending.assist_state),
         Some(AssistState::PaymentStarted { .. } | AssistState::Paid { .. })
     ) {
         return Err(EngineError::ActionNotAllowed(

--- a/crates/engine/src/game/engine_casting.rs
+++ b/crates/engine/src/game/engine_casting.rs
@@ -19,9 +19,14 @@ pub(super) fn cancel_pending_cast(
     player: PlayerId,
     pending_cast: &PendingCast,
     events: &mut Vec<GameEvent>,
-) -> WaitingFor {
+) -> Result<WaitingFor, EngineError> {
+    if pending_cast.activation_cost_committed {
+        return Err(EngineError::ActionNotAllowed(
+            "Cannot cancel an activation after a cost is paid".to_string(),
+        ));
+    }
     casting::handle_cancel_cast(state, pending_cast, events);
-    WaitingFor::Priority { player }
+    Ok(WaitingFor::Priority { player })
 }
 
 pub(super) fn handle_target_selection_select_targets(

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -227,11 +227,21 @@ fn handle_activated_mode_choice(
         if let Some(targets) = resolved_targets {
             let mut resolved = resolved;
             assign_targets_in_chain(state, &mut resolved, &targets)?;
+            // CR 602.2b + CR 601.2c: automatic target assignment is still a
+            // declaration before activation costs are paid.
+            casting::emit_targeting_events(
+                state,
+                &super::ability_utils::flatten_targets_in_chain(&resolved),
+                source_id,
+                player,
+                events,
+            );
             let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
             pending.activation_cost = ability_cost.clone();
             pending.activation_ability_index = ability_index;
             pending.target_constraints = target_constraints;
             pending.distribute = mode_distribute;
+            pending.begin_activation_trigger_collection();
             casting_costs::finish_target_selected_activated_ability_at_payment_boundary(
                 state, player, pending, events,
             )

--- a/crates/engine/src/game/engine_modes.rs
+++ b/crates/engine/src/game/engine_modes.rs
@@ -1,5 +1,5 @@
 use crate::types::events::GameEvent;
-use crate::types::game_state::{CostResume, GameState, PayCostKind, PendingCast, WaitingFor};
+use crate::types::game_state::{GameState, PendingCast, WaitingFor};
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::mana::ManaCost;
 
@@ -182,41 +182,6 @@ fn handle_activated_mode_choice(
             state.pending_cast = Some(Box::new(pending_x));
             return casting_costs::enter_payment_step(state, player, None, events);
         }
-
-        // CR 118.3 + CR 602.2b: Modal activated abilities detour to the
-        // interactive sacrifice prompt before targets or direct cost payment.
-        // Non-modal activations take this path in `handle_activate_ability`;
-        // without it, `pay_ability_cost` no-ops non-self `Sacrifice` sub-costs.
-        if let Some((count, sac_filter)) = casting::find_non_self_sacrifice_cost(cost) {
-            let eligible =
-                casting::find_eligible_sacrifice_targets(state, player, source_id, sac_filter);
-            let (min_count, max_count) = casting::sacrifice_cost_bounds(count, eligible.len());
-            if eligible.len() < min_count {
-                return Err(EngineError::ActionNotAllowed(
-                    "Not enough eligible permanents to sacrifice".into(),
-                ));
-            }
-            let mut pending_sac =
-                PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
-            pending_sac.activation_cost = Some(cost.clone());
-            pending_sac.activation_ability_index = ability_index;
-            pending_sac.target_constraints = target_constraints_from_modal(&modal);
-            pending_sac.distribute = mode_distribute.clone();
-            pending_sac.deferred_target_selection = true;
-            let mut chosen_modes = indices.clone();
-            chosen_modes.sort_unstable();
-            pending_sac.chosen_modes = chosen_modes;
-            return Ok(WaitingFor::PayCost {
-                player,
-                kind: PayCostKind::Sacrifice,
-                choices: eligible,
-                count: max_count,
-                min_count,
-                resume: CostResume::Spell {
-                    spell: Box::new(pending_sac),
-                },
-            });
-        }
     }
 
     super::layers::flush_layers(state);
@@ -271,30 +236,18 @@ fn handle_activated_mode_choice(
                 state, player, pending, events,
             )
         } else {
-            let selection = begin_target_selection_for_ability(
-                state,
-                &resolved,
-                &target_slots,
-                &target_constraints,
-            )?;
             let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);
             pending.activation_cost = ability_cost;
             pending.activation_ability_index = ability_index;
             pending.target_constraints = target_constraints;
             pending.distribute = mode_distribute;
-            // CR 601.2c + CR 602.2b: first slot's announcer (controller unless the
-            // slot is "of an opponent's choice").
-            let initial_player = target_slots
-                .first()
-                .and_then(|slot| slot.chooser)
-                .unwrap_or(player);
-            Ok(WaitingFor::TargetSelection {
-                player: initial_player,
-                pending_cast: Box::new(pending),
+            super::casting_targets::begin_activated_target_selection(
+                state,
+                player,
+                pending,
                 target_slots,
                 mode_labels,
-                selection,
-            })
+            )
         }
     } else {
         let mut pending = PendingCast::new(source_id, CardId(0), resolved, ManaCost::NoCost);

--- a/crates/engine/src/game/engine_priority.rs
+++ b/crates/engine/src/game/engine_priority.rs
@@ -36,6 +36,8 @@ pub(crate) fn run_post_action_pipeline_from(
     skip_trigger_scan: bool,
     skip_deferred_trigger_drain: bool,
 ) -> Result<WaitingFor, EngineError> {
+    stage_pending_activation_trigger_events(state, events, event_start);
+
     // Capture stack depth before any trigger/SBA processing so we can detect
     // whether new triggered abilities were added during this pipeline pass.
     let stack_before = state.stack.len();
@@ -334,6 +336,39 @@ pub(crate) fn run_post_action_pipeline_from(
         default_wf.clone(),
         default_wf.acting_player(),
     ))
+}
+
+/// Route events emitted while a target-bearing activation remains pending into
+/// its private trigger transaction before the ordinary post-action collector
+/// can observe them.
+///
+/// CR 602.2a-b + CR 603.2: target declaration and cost payment can create
+/// trigger events before the activated ability reaches the stack. These events
+/// remain pending until the activation commits; recording their occurrences in
+/// the consumed buffer preserves the generic collector's exactly-once contract
+/// for this action without making the transaction public state.
+fn stage_pending_activation_trigger_events(
+    state: &mut GameState,
+    events: &[GameEvent],
+    event_start: usize,
+) {
+    let new_events = &events[event_start..];
+    if new_events.is_empty() {
+        return;
+    }
+    let Some(mut collection) = state.take_pending_activation_trigger_collection() else {
+        return;
+    };
+    collection.collect(state, new_events);
+    state.restore_pending_activation_trigger_collection(collection);
+    state
+        .consumed_before_priority_trigger_events
+        .extend(new_events.iter().enumerate().map(|(offset, event)| {
+            triggers::ConsumedTriggerEventOccurrence {
+                event: event.clone(),
+                occurrence: triggers::trigger_event_occurrence(events, event_start + offset),
+            }
+        }));
 }
 
 /// CR 603.3b + CR 608.2g: settles a terminal resolution marker only after its

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -7611,7 +7611,9 @@ fn test_mana_ability_during_mana_payment_stays_in_mana_payment() {
         assist_state: AssistState::NotOffered,
         activation_residual: crate::types::game_state::ActivationResidual::None,
         activation_target_selection: crate::types::game_state::ActivationTargetSelection::Pending,
+        activation_cost_committed: false,
         alt_cost_grant_source: None,
+        activation_trigger_collection: None,
     }));
     state.waiting_for = WaitingFor::ManaPayment {
         player: PlayerId(0),
@@ -8006,7 +8008,9 @@ fn taps_for_mana_multiplier_fires_once_on_color_choice_mana_payment_resume() {
         assist_state: AssistState::NotOffered,
         activation_residual: crate::types::game_state::ActivationResidual::None,
         activation_target_selection: crate::types::game_state::ActivationTargetSelection::Pending,
+        activation_cost_committed: false,
         alt_cost_grant_source: None,
+        activation_trigger_collection: None,
     }));
     state.waiting_for = WaitingFor::ManaPayment {
         player: PlayerId(0),

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -15,7 +15,9 @@ use crate::types::card_type::CardType;
 use crate::types::card_type::{CoreType, Supertype};
 use crate::types::counter::CounterType;
 use crate::types::format::FormatConfig;
-use crate::types::game_state::{CastPaymentMode, CastingVariant, ProductionOverride};
+use crate::types::game_state::{
+    CastPaymentMode, CastingVariant, PendingCast, ProductionOverride, TargetSelectionProgress,
+};
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
 use crate::types::statics::{CastFrequency, StaticMode};
@@ -108,6 +110,34 @@ fn cards_revealed_events_are_remembered_publicly() {
     let mut replay = pre_state;
     replay.apply_resolved_information(&command).unwrap();
     assert_eq!(replay.public_revealed_cards, state.public_revealed_cards);
+}
+
+#[test]
+fn assist_cancellation_rejects_committed_activation_held_by_waiting_for() {
+    let mut state = setup_game_at_main_phase();
+    let mut pending = PendingCast::new(
+        ObjectId(1),
+        CardId(1),
+        ResolvedAbility::new(Effect::NoOp, vec![], ObjectId(1), PlayerId(0)),
+        ManaCost::NoCost,
+    );
+    pending.activation_cost_committed = true;
+    state.waiting_for = WaitingFor::TargetSelection {
+        player: PlayerId(0),
+        pending_cast: Box::new(pending),
+        target_slots: vec![],
+        mode_labels: vec![],
+        selection: TargetSelectionProgress {
+            current_slot: 0,
+            selected_slots: vec![],
+            current_legal_targets: vec![],
+        },
+    };
+
+    assert!(matches!(
+        ensure_assist_cancellation_is_allowed(&state),
+        Err(EngineError::ActionNotAllowed(message)) if message == "Cannot cancel an activation after a cost is paid"
+    ));
 }
 
 /// CR 603.3d regression — reported turn-34 Commander freeze (All Will Be

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -2632,12 +2632,19 @@ fn resolve_ref(
         //
         // CR 107.3e + CR 107.3m + CR 603.7c: When the trigger source itself has
         // no `chosen_x` (SpellCast triggers and similar event triggers do not
-        // have their own cost), fall back to the triggering spell's
+        // have their own cost), first fall back to the triggering spell's
         // `cost_x_paid`. This covers "whenever you cast your first spell with
         // {X} in its mana cost each turn, put X +1/+1 counters on ~" — the X
         // there is the triggering spell's X, not this trigger's X (which
         // doesn't exist). CR 107.3e explicitly permits an ability to refer to
         // X of another object's cost.
+        //
+        // CR 107.3m + CR 603.3b: Trigger target selection happens before the
+        // trigger enters resolution, so `current_trigger_event` is not yet
+        // installed. A self-ETB trigger's bare X in a target-filter threshold
+        // must therefore fall back to its exact source context's cast X; the
+        // context preserves that value across zone changes without rebinding a
+        // later incarnation of the same storage id.
         //
         // Other named variables (set by `NamedChoice` handlers for things like
         // "chosen number") keep their single-responsibility path through
@@ -2651,6 +2658,12 @@ fn resolve_ref(
                     .and_then(crate::game::targeting::extract_source_from_event)
                     .and_then(|id| state.objects.get(&id))
                     .and_then(|obj| obj.cost_x_paid)
+                    .map(u32_to_i32_saturating)
+            })
+            .or_else(|| {
+                trigger_source
+                    .as_ref()
+                    .and_then(|source| source.source_read(state).cost_x_paid())
                     .map(u32_to_i32_saturating)
             })
             .unwrap_or(0),

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -331,6 +331,7 @@ struct VirtualTargetingSource {
 
 impl TriggerCollectionOverlay {
     /// Prepares the virtual source authority for one in-flight activation.
+    #[cfg_attr(not(test), allow(dead_code))] // Reached through the pending activation session.
     pub(crate) fn for_activated_ability(source_id: ObjectId, controller: PlayerId) -> Self {
         Self {
             virtual_targeting_source: Some(VirtualTargetingSource {
@@ -361,7 +362,7 @@ enum TriggerCollectionOperation {
     },
     RecordTriggerFired {
         constraint: Option<TriggerConstraint>,
-        source_context: Option<TriggerSourceContext>,
+        source_context: Box<Option<TriggerSourceContext>>,
         definition_ref: Option<TriggerDefinitionRef>,
         event: GameEvent,
     },
@@ -399,6 +400,7 @@ impl TriggerCollectionSession {
         }
     }
 
+    #[cfg_attr(not(test), allow(dead_code))] // Wired into casting in the next activation step.
     fn transactional(overlay: TriggerCollectionOverlay) -> Self {
         Self {
             overlay,
@@ -420,7 +422,7 @@ impl TriggerCollectionSession {
             state,
             TriggerCollectionOperation::RecordTriggerFired {
                 constraint: matched.constraint.clone(),
-                source_context: matched.pending.ability.trigger_source.clone(),
+                source_context: Box::new(matched.pending.ability.trigger_source.clone()),
                 definition_ref: matched.definition_ref.clone(),
                 event: event.clone(),
             },
@@ -510,6 +512,7 @@ impl TriggerCollectionSession {
         Self::apply_operation(state, operation)
     }
 
+    #[cfg_attr(not(test), allow(dead_code))] // Consumed by the pending-activation commit boundary.
     fn commit(mut self, state: &mut GameState) {
         let Some(operation_journal) = self.operation_journal.take() else {
             return;
@@ -540,7 +543,7 @@ impl TriggerCollectionSession {
                 record_trigger_fired_with_ref(
                     state,
                     constraint.as_ref(),
-                    source_context.as_ref(),
+                    source_context.as_ref().as_ref(),
                     definition_ref.as_ref(),
                     &event,
                 );
@@ -592,12 +595,14 @@ impl TriggerCollectionSession {
 /// against a private state snapshot, retains every semantic collector operation
 /// in order, and exposes one consuming commit path. Dropping it is cancellation:
 /// neither its operations nor its pending contexts escape to the live game.
+#[cfg_attr(not(test), allow(dead_code))] // Casting owns this session in the next activation step.
 pub(crate) struct PendingActivationTriggerCollection {
     staged_state: GameState,
     session: TriggerCollectionSession,
     pending_contexts: Vec<PendingTriggerContext>,
 }
 
+#[cfg_attr(not(test), allow(dead_code))] // Exercised by unit tests until casting adopts it.
 impl PendingActivationTriggerCollection {
     pub(crate) fn for_activated_ability(
         state: &GameState,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7654,7 +7654,7 @@ pub fn check_delayed_triggers(state: &mut GameState, events: &[GameEvent]) -> Ve
     new_events
 }
 
-fn trigger_event_occurrence(events: &[GameEvent], event_index: usize) -> usize {
+pub(crate) fn trigger_event_occurrence(events: &[GameEvent], event_index: usize) -> usize {
     let event = &events[event_index];
     events[..event_index]
         .iter()

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -354,6 +354,7 @@ impl TriggerCollectionOverlay {
 /// owned operations makes their ordering explicit and gives a future
 /// activation-local collector a single seam at which to retain or discard them.
 /// The ordinary collector applies every operation immediately.
+#[derive(Clone)]
 enum TriggerCollectionOperation {
     PrepareEventBatch {
         events: Vec<GameEvent>,
@@ -381,21 +382,31 @@ enum TriggerCollectionOperation {
 
 /// Applies trigger-collection mutations in their collection order.
 ///
-/// This session intentionally owns no game-state borrow. Matching still reads
-/// the live state between operations, exactly as it did before this extraction;
-/// only the mutation authority is centralized. A later transactional caller can
-/// replace immediate application with an activation-local operation journal
-/// without changing any trigger-matching path.
+/// This session intentionally owns no game-state borrow. Ordinary collection
+/// applies each operation to live state immediately; activation-local collection
+/// applies it to a staged clone and retains the same ordered operation journal
+/// for its consuming commit path.
 struct TriggerCollectionSession {
     overlay: TriggerCollectionOverlay,
+    operation_journal: Option<Vec<TriggerCollectionOperation>>,
 }
 
 impl TriggerCollectionSession {
     fn new(overlay: TriggerCollectionOverlay) -> Self {
-        Self { overlay }
+        Self {
+            overlay,
+            operation_journal: None,
+        }
     }
 
-    fn prepare(&self, state: &mut GameState, events: &[GameEvent]) {
+    fn transactional(overlay: TriggerCollectionOverlay) -> Self {
+        Self {
+            overlay,
+            operation_journal: Some(Vec::new()),
+        }
+    }
+
+    fn prepare(&mut self, state: &mut GameState, events: &[GameEvent]) {
         let _ = self.apply(
             state,
             TriggerCollectionOperation::PrepareEventBatch {
@@ -404,7 +415,7 @@ impl TriggerCollectionSession {
         );
     }
 
-    fn record_match(&self, state: &mut GameState, matched: &MatchedTrigger, event: &GameEvent) {
+    fn record_match(&mut self, state: &mut GameState, matched: &MatchedTrigger, event: &GameEvent) {
         let _ = self.apply(
             state,
             TriggerCollectionOperation::RecordTriggerFired {
@@ -438,20 +449,20 @@ impl TriggerCollectionSession {
         );
     }
 
-    fn mark_speed_trigger_used(&self, state: &mut GameState, player: PlayerId) {
+    fn mark_speed_trigger_used(&mut self, state: &mut GameState, player: PlayerId) {
         let _ = self.apply(
             state,
             TriggerCollectionOperation::MarkSpeedTriggerUsed { player },
         );
     }
 
-    fn next_timestamp(&self, state: &mut GameState) -> u64 {
+    fn next_timestamp(&mut self, state: &mut GameState) -> u64 {
         self.apply(state, TriggerCollectionOperation::AllocateTimestamp)
             .expect("timestamp allocation must return the allocated timestamp")
     }
 
     fn record_combat_damage_casting_permission(
-        &self,
+        &mut self,
         state: &mut GameState,
         controller: PlayerId,
         grants_freerunning: bool,
@@ -488,7 +499,30 @@ impl TriggerCollectionSession {
             })
     }
 
-    fn apply(&self, state: &mut GameState, operation: TriggerCollectionOperation) -> Option<u64> {
+    fn apply(
+        &mut self,
+        state: &mut GameState,
+        operation: TriggerCollectionOperation,
+    ) -> Option<u64> {
+        if let Some(operation_journal) = &mut self.operation_journal {
+            operation_journal.push(operation.clone());
+        }
+        Self::apply_operation(state, operation)
+    }
+
+    fn commit(mut self, state: &mut GameState) {
+        let Some(operation_journal) = self.operation_journal.take() else {
+            return;
+        };
+        for operation in operation_journal {
+            let _ = Self::apply_operation(state, operation);
+        }
+    }
+
+    fn apply_operation(
+        state: &mut GameState,
+        operation: TriggerCollectionOperation,
+    ) -> Option<u64> {
         match operation {
             TriggerCollectionOperation::PrepareEventBatch { events } => {
                 super::layers::flush_layers(state);
@@ -546,6 +580,63 @@ impl TriggerCollectionSession {
                 None
             }
         }
+    }
+}
+
+/// Trigger collection held by an announced activated ability until its
+/// activation transaction commits or is cancelled.
+///
+/// CR 602.2a + CR 602.2b: An activation may cross several payment prompts after targets
+/// have produced trigger events, but none of those events become globally
+/// committed until the full activation is complete. This owner runs collection
+/// against a private state snapshot, retains every semantic collector operation
+/// in order, and exposes one consuming commit path. Dropping it is cancellation:
+/// neither its operations nor its pending contexts escape to the live game.
+pub(crate) struct PendingActivationTriggerCollection {
+    staged_state: GameState,
+    session: TriggerCollectionSession,
+    pending_contexts: Vec<PendingTriggerContext>,
+}
+
+impl PendingActivationTriggerCollection {
+    pub(crate) fn for_activated_ability(
+        state: &GameState,
+        source_id: ObjectId,
+        controller: PlayerId,
+    ) -> Self {
+        Self {
+            staged_state: state.clone(),
+            session: TriggerCollectionSession::transactional(
+                TriggerCollectionOverlay::for_activated_ability(source_id, controller),
+            ),
+            pending_contexts: Vec::new(),
+        }
+    }
+
+    /// Collect one event slice emitted while the activation is still pending.
+    ///
+    /// Later slices read the staged state after all earlier collector operations,
+    /// so per-turn trigger constraints and event-observation ledgers behave as
+    /// one uninterrupted collection transaction without touching live state.
+    pub(crate) fn collect(&mut self, events: &[GameEvent]) {
+        let contexts = collect_pending_triggers_with_collection(
+            &mut self.staged_state,
+            events,
+            LogicalZoneTriggerCollection::Ordinary,
+            &mut self.session,
+        );
+        self.pending_contexts.extend(contexts);
+    }
+
+    /// Commit collector consequences exactly once and append the retained
+    /// contexts to the caller's deferred delivery list.
+    pub(crate) fn commit_into(
+        self,
+        state: &mut GameState,
+        deferred_contexts: &mut Vec<PendingTriggerContext>,
+    ) {
+        self.session.commit(state);
+        deferred_contexts.extend(self.pending_contexts);
     }
 }
 
@@ -2532,11 +2623,12 @@ pub(crate) fn collect_pending_triggers_with_overlay(
     events: &[GameEvent],
     overlay: TriggerCollectionOverlay,
 ) -> Vec<PendingTriggerContext> {
+    let mut session = TriggerCollectionSession::new(overlay);
     collect_pending_triggers_with_collection(
         state,
         events,
         LogicalZoneTriggerCollection::Ordinary,
-        overlay,
+        &mut session,
     )
 }
 
@@ -2550,11 +2642,12 @@ pub(crate) fn collect_logical_zone_trigger_segment(
     group: &LogicalZoneChangeGroup,
     events: &[GameEvent],
 ) -> Vec<PendingTriggerContext> {
+    let mut session = TriggerCollectionSession::new(TriggerCollectionOverlay::default());
     collect_pending_triggers_with_collection(
         state,
         events,
         LogicalZoneTriggerCollection::Segment(group),
-        TriggerCollectionOverlay::default(),
+        &mut session,
     )
 }
 
@@ -2972,9 +3065,8 @@ fn collect_pending_triggers_with_collection(
     state: &mut GameState,
     events: &[GameEvent],
     collection: LogicalZoneTriggerCollection<'_>,
-    overlay: TriggerCollectionOverlay,
+    session: &mut TriggerCollectionSession,
 ) -> Vec<PendingTriggerContext> {
-    let session = TriggerCollectionSession::new(overlay);
     // CR 603.6a + CR 611.2e: Continuous effects (including statics that grant
     // triggered abilities to a class — sliver-lord pattern) apply the moment
     // the affected permanent is on the battlefield. The newcomers must be
@@ -19186,6 +19278,79 @@ pub mod tests {
         assert!(
             with_overlay.stack.is_empty(),
             "collection remains non-dispatching; the future activation transaction owns commit"
+        );
+    }
+
+    #[test]
+    fn pending_activation_collection_commits_once_and_drop_discards_everything() {
+        let mut state = setup();
+        state.active_player = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(9),
+            PlayerId(0),
+            "Activation Source".to_string(),
+            Zone::Battlefield,
+        );
+        let ward_target = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "Ward Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let ward = state.objects.get_mut(&ward_target).unwrap();
+        ward.card_types.core_types.push(CoreType::Creature);
+        ward.entered_battlefield_turn = Some(1);
+        ward.keywords
+            .push(Keyword::Ward(WardCost::Mana(ManaCost::generic(2))));
+
+        let tapped = ObjectId(71);
+        let mut pending =
+            PendingActivationTriggerCollection::for_activated_ability(&state, source, PlayerId(1));
+        pending.collect(&[GameEvent::BecomesTarget {
+            target: TargetRef::Object(ward_target),
+            source_id: source,
+        }]);
+        pending.collect(&[GameEvent::PermanentTapped {
+            object_id: tapped,
+            caused_by: None,
+        }]);
+        pending.collect(&[GameEvent::PermanentTapped {
+            object_id: tapped,
+            caused_by: None,
+        }]);
+
+        assert_eq!(
+            pending.staged_state.object_tap_count_this_turn.get(&tapped),
+            Some(&2),
+            "the later pending-payment event must see the earlier staged collector write"
+        );
+        assert_eq!(pending.pending_contexts.len(), 1);
+        assert!(
+            state.object_tap_count_this_turn.is_empty() && state.stack.is_empty(),
+            "pending collection must not mutate or dispatch through live state"
+        );
+
+        let mut deferred = Vec::new();
+        pending.commit_into(&mut state, &mut deferred);
+        assert_eq!(state.object_tap_count_this_turn.get(&tapped), Some(&2));
+        assert_eq!(deferred.len(), 1);
+        assert_eq!(deferred[0].pending.source_id, ward_target);
+
+        let cancelled_tap = ObjectId(72);
+        let mut cancelled =
+            PendingActivationTriggerCollection::for_activated_ability(&state, source, PlayerId(1));
+        cancelled.collect(&[GameEvent::PermanentTapped {
+            object_id: cancelled_tap,
+            caused_by: None,
+        }]);
+        drop(cancelled);
+        assert!(
+            !state
+                .object_tap_count_this_turn
+                .contains_key(&cancelled_tap),
+            "cancelling the activation by dropping its session must discard collector writes"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -355,7 +355,7 @@ impl TriggerCollectionOverlay {
 /// owned operations makes their ordering explicit and gives a future
 /// activation-local collector a single seam at which to retain or discard them.
 /// The ordinary collector applies every operation immediately.
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 enum TriggerCollectionOperation {
     PrepareEventBatch {
         events: Vec<GameEvent>,
@@ -596,7 +596,7 @@ impl TriggerCollectionSession {
 /// event slice. Dropping it is cancellation: neither operations nor contexts
 /// escape to the live game.
 #[cfg_attr(not(test), allow(dead_code))] // Casting owns this session in the next activation step.
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct PendingActivationTriggerCollection {
     overlay: TriggerCollectionOverlay,
     operation_journal: Vec<TriggerCollectionOperation>,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -318,15 +318,18 @@ impl PendingTriggerContext {
 /// pending transaction. The overlay is deliberately narrow: it can answer the
 /// controller of that one targeting source, but cannot alter object lookup,
 /// zones, or the stack.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct TriggerCollectionOverlay {
     virtual_targeting_source: Option<VirtualTargetingSource>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct VirtualTargetingSource {
     source_id: ObjectId,
+    source_occurrence: Option<u64>,
     controller: PlayerId,
+    ability_index: Option<usize>,
+    ability: Option<Box<ResolvedAbility>>,
 }
 
 impl TriggerCollectionOverlay {
@@ -336,15 +339,74 @@ impl TriggerCollectionOverlay {
         Self {
             virtual_targeting_source: Some(VirtualTargetingSource {
                 source_id,
+                source_occurrence: None,
                 controller,
+                ability_index: None,
+                ability: None,
             }),
         }
     }
 
-    fn targeting_source_controller(self, source_id: ObjectId) -> Option<PlayerId> {
+    /// Captures the complete announced activated ability for source-filtered
+    /// becomes-target triggers while the real stack entry does not yet exist.
+    ///
+    /// CR 602.2b + CR 603.2: This is a read-only, transaction-local stack
+    /// projection. It preserves the source occurrence, controller, printed
+    /// ability index, and resolved tag/kind/target facts used by `StackAbility`
+    /// filters without publishing an actual stack object before costs are paid.
+    pub(crate) fn for_prepared_activated_ability(
+        source_id: ObjectId,
+        controller: PlayerId,
+        ability_index: usize,
+        ability: &ResolvedAbility,
+    ) -> Self {
+        Self {
+            virtual_targeting_source: Some(VirtualTargetingSource {
+                source_id,
+                source_occurrence: ability.source_incarnation,
+                controller,
+                ability_index: Some(ability_index),
+                ability: Some(Box::new(ability.clone())),
+            }),
+        }
+    }
+
+    fn targeting_source_controller(&self, source_id: ObjectId) -> Option<PlayerId> {
         self.virtual_targeting_source
+            .as_ref()
             .filter(|source| source.source_id == source_id)
             .map(|source| source.controller)
+    }
+
+    /// Adds an ephemeral activated-ability stack projection to a staged
+    /// collection state. Inserting at the front makes the in-flight occurrence
+    /// authoritative even if an earlier activation from the same permanent is
+    /// already physically on the stack.
+    fn install_virtual_targeting_source(&self, state: &mut GameState) {
+        let Some(source) = self.virtual_targeting_source.as_ref() else {
+            return;
+        };
+        let (Some(ability_index), Some(ability)) = (source.ability_index, source.ability.as_ref())
+        else {
+            return;
+        };
+        let mut ability = (**ability).clone();
+        debug_assert_eq!(ability.source_incarnation, source.source_occurrence);
+        ability.ability_index = Some(ability_index);
+        state.stack.insert(
+            0,
+            StackEntry {
+                // The becomes-target event identifies an activated source by
+                // source id before the physical stack object exists.
+                id: source.source_id,
+                source_id: source.source_id,
+                controller: source.controller,
+                kind: StackEntryKind::ActivatedAbility {
+                    source_id: source.source_id,
+                    ability: Box::new(ability),
+                },
+            },
+        );
     }
 }
 
@@ -622,6 +684,8 @@ impl PendingActivationTriggerCollection {
     #[cfg_attr(not(test), allow(dead_code))] // Called by target/cost continuation roots next.
     pub(crate) fn collect(&mut self, state: &GameState, events: &[GameEvent]) {
         let mut staged_state = self.rebuild_staged_state(state);
+        self.overlay
+            .install_virtual_targeting_source(&mut staged_state);
         let operation_journal = std::mem::take(&mut self.operation_journal);
         let mut session = TriggerCollectionSession::transactional(self.overlay, operation_journal);
         let contexts = collect_pending_triggers_with_collection(
@@ -19301,6 +19365,81 @@ pub mod tests {
             with_overlay.stack.is_empty(),
             "collection remains non-dispatching; the future activation transaction owns commit"
         );
+    }
+
+    #[test]
+    fn prepared_activation_overlay_matches_source_filtered_stack_ability_before_commit() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(9),
+            PlayerId(1),
+            "Prepared Ability Source".to_string(),
+            Zone::Battlefield,
+        );
+        let observer = create_object(
+            &mut state,
+            CardId(10),
+            PlayerId(0),
+            "Ability Observer".to_string(),
+            Zone::Battlefield,
+        );
+        let mut ability = ResolvedAbility::new(
+            Effect::DealDamage {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Any,
+                damage_source: None,
+                excess: None,
+            },
+            vec![TargetRef::Object(observer)],
+            source,
+            PlayerId(1),
+        );
+        ability.source_incarnation = Some(7);
+        ability.context.ability_tag = Some(crate::types::ability::AbilityTag::Backup);
+
+        let overlay = TriggerCollectionOverlay::for_prepared_activated_ability(
+            source,
+            PlayerId(1),
+            4,
+            &ability,
+        );
+        assert_eq!(
+            overlay
+                .virtual_targeting_source
+                .as_ref()
+                .and_then(|source| source.source_occurrence),
+            Some(7),
+            "the pending session must retain the source occurrence"
+        );
+        let mut staged = state.clone();
+        overlay.install_virtual_targeting_source(&mut staged);
+        let projected = staged.stack.front().expect("virtual ability is projected");
+        assert_eq!(projected.controller, PlayerId(1));
+        assert_eq!(
+            projected
+                .ability()
+                .and_then(|ability| ability.ability_index),
+            Some(4),
+            "the projection must preserve the printed activated-ability index"
+        );
+
+        let mut trigger = TriggerDefinition::new(TriggerMode::BecomesTarget);
+        trigger.valid_source = Some(TargetFilter::StackAbility {
+            controller: Some(ControllerRef::Opponent),
+            tag: Some(crate::types::ability::AbilityTag::Backup),
+            kind: Some(crate::types::ability::StackAbilityKind::Activated),
+        });
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(observer),
+            source_id: source,
+        };
+        assert!(super::trigger_matchers::match_becomes_target(
+            &event,
+            &trigger,
+            &crate::game::trigger_matchers::test_trigger_source_context(&staged, observer),
+            &staged,
+        ));
     }
 
     #[test]

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -318,12 +318,12 @@ impl PendingTriggerContext {
 /// pending transaction. The overlay is deliberately narrow: it can answer the
 /// controller of that one targeting source, but cannot alter object lookup,
 /// zones, or the stack.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct TriggerCollectionOverlay {
     virtual_targeting_source: Option<VirtualTargetingSource>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 struct VirtualTargetingSource {
     source_id: ObjectId,
     controller: PlayerId,
@@ -355,7 +355,7 @@ impl TriggerCollectionOverlay {
 /// owned operations makes their ordering explicit and gives a future
 /// activation-local collector a single seam at which to retain or discard them.
 /// The ordinary collector applies every operation immediately.
-#[derive(Clone)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 enum TriggerCollectionOperation {
     PrepareEventBatch {
         events: Vec<GameEvent>,
@@ -401,10 +401,13 @@ impl TriggerCollectionSession {
     }
 
     #[cfg_attr(not(test), allow(dead_code))] // Wired into casting in the next activation step.
-    fn transactional(overlay: TriggerCollectionOverlay) -> Self {
+    fn transactional(
+        overlay: TriggerCollectionOverlay,
+        operation_journal: Vec<TriggerCollectionOperation>,
+    ) -> Self {
         Self {
             overlay,
-            operation_journal: Some(Vec::new()),
+            operation_journal: Some(operation_journal),
         }
     }
 
@@ -512,14 +515,9 @@ impl TriggerCollectionSession {
         Self::apply_operation(state, operation)
     }
 
-    #[cfg_attr(not(test), allow(dead_code))] // Consumed by the pending-activation commit boundary.
-    fn commit(mut self, state: &mut GameState) {
-        let Some(operation_journal) = self.operation_journal.take() else {
-            return;
-        };
-        for operation in operation_journal {
-            let _ = Self::apply_operation(state, operation);
-        }
+    #[cfg_attr(not(test), allow(dead_code))] // Returned to the durable pending carrier.
+    fn into_operation_journal(mut self) -> Vec<TriggerCollectionOperation> {
+        self.operation_journal.take().unwrap_or_default()
     }
 
     fn apply_operation(
@@ -591,57 +589,76 @@ impl TriggerCollectionSession {
 ///
 /// CR 602.2a + CR 602.2b: An activation may cross several payment prompts after targets
 /// have produced trigger events, but none of those events become globally
-/// committed until the full activation is complete. This owner runs collection
-/// against a private state snapshot, retains every semantic collector operation
-/// in order, and exposes one consuming commit path. Dropping it is cancellation:
-/// neither its operations nor its pending contexts escape to the live game.
+/// committed until the full activation is complete. This owner retains only the
+/// virtual source authority, ordered semantic operations, and collected
+/// contexts. Each continuation reconstructs an ephemeral staged clone from the
+/// current live state and replays the operations before collecting its next
+/// event slice. Dropping it is cancellation: neither operations nor contexts
+/// escape to the live game.
 #[cfg_attr(not(test), allow(dead_code))] // Casting owns this session in the next activation step.
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct PendingActivationTriggerCollection {
-    staged_state: GameState,
-    session: TriggerCollectionSession,
+    overlay: TriggerCollectionOverlay,
+    operation_journal: Vec<TriggerCollectionOperation>,
     pending_contexts: Vec<PendingTriggerContext>,
 }
 
 #[cfg_attr(not(test), allow(dead_code))] // Exercised by unit tests until casting adopts it.
 impl PendingActivationTriggerCollection {
-    pub(crate) fn for_activated_ability(
-        state: &GameState,
-        source_id: ObjectId,
-        controller: PlayerId,
-    ) -> Self {
+    #[cfg_attr(not(test), allow(dead_code))] // Construction moves into the activation announcement path next.
+    pub(crate) fn for_activated_ability(source_id: ObjectId, controller: PlayerId) -> Self {
         Self {
-            staged_state: state.clone(),
-            session: TriggerCollectionSession::transactional(
-                TriggerCollectionOverlay::for_activated_ability(source_id, controller),
-            ),
+            overlay: TriggerCollectionOverlay::for_activated_ability(source_id, controller),
+            operation_journal: Vec::new(),
             pending_contexts: Vec::new(),
         }
     }
 
     /// Collect one event slice emitted while the activation is still pending.
     ///
-    /// Later slices read the staged state after all earlier collector operations,
-    /// so per-turn trigger constraints and event-observation ledgers behave as
-    /// one uninterrupted collection transaction without touching live state.
-    pub(crate) fn collect(&mut self, events: &[GameEvent]) {
+    /// Later slices replay the earlier collector operations into a fresh staged
+    /// clone, so per-turn trigger constraints and event-observation ledgers
+    /// behave as one uninterrupted transaction without touching live state.
+    #[cfg_attr(not(test), allow(dead_code))] // Called by target/cost continuation roots next.
+    pub(crate) fn collect(&mut self, state: &GameState, events: &[GameEvent]) {
+        let mut staged_state = self.rebuild_staged_state(state);
+        let operation_journal = std::mem::take(&mut self.operation_journal);
+        let mut session = TriggerCollectionSession::transactional(self.overlay, operation_journal);
         let contexts = collect_pending_triggers_with_collection(
-            &mut self.staged_state,
+            &mut staged_state,
             events,
             LogicalZoneTriggerCollection::Ordinary,
-            &mut self.session,
+            &mut session,
         );
+        self.operation_journal = session.into_operation_journal();
         self.pending_contexts.extend(contexts);
     }
 
     /// Commit collector consequences exactly once and append the retained
     /// contexts to the caller's deferred delivery list.
+    #[cfg_attr(not(test), allow(dead_code))] // Called by the activated stack-push boundary next.
     pub(crate) fn commit_into(
         self,
         state: &mut GameState,
         deferred_contexts: &mut Vec<PendingTriggerContext>,
     ) {
-        self.session.commit(state);
+        for operation in self.operation_journal {
+            let _ = TriggerCollectionSession::apply_operation(state, operation);
+        }
         deferred_contexts.extend(self.pending_contexts);
+    }
+
+    fn rebuild_staged_state(&self, state: &GameState) -> GameState {
+        let mut staged_state = state.clone();
+        for operation in &self.operation_journal {
+            let _ = TriggerCollectionSession::apply_operation(&mut staged_state, operation.clone());
+        }
+        staged_state
+    }
+
+    #[cfg(test)]
+    fn staged_state_for_test(&self, state: &GameState) -> GameState {
+        self.rebuild_staged_state(state)
     }
 }
 
@@ -19312,22 +19329,38 @@ pub mod tests {
 
         let tapped = ObjectId(71);
         let mut pending =
-            PendingActivationTriggerCollection::for_activated_ability(&state, source, PlayerId(1));
-        pending.collect(&[GameEvent::BecomesTarget {
-            target: TargetRef::Object(ward_target),
-            source_id: source,
-        }]);
-        pending.collect(&[GameEvent::PermanentTapped {
-            object_id: tapped,
-            caused_by: None,
-        }]);
-        pending.collect(&[GameEvent::PermanentTapped {
-            object_id: tapped,
-            caused_by: None,
-        }]);
+            PendingActivationTriggerCollection::for_activated_ability(source, PlayerId(1));
+        pending.collect(
+            &state,
+            &[GameEvent::BecomesTarget {
+                target: TargetRef::Object(ward_target),
+                source_id: source,
+            }],
+        );
+        let serialized = serde_json::to_string(&pending)
+            .expect("pending activation collector must serialize for a resumed prompt");
+        let mut pending: PendingActivationTriggerCollection = serde_json::from_str(&serialized)
+            .expect("serialized pending activation collector must restore");
+        pending.collect(
+            &state,
+            &[GameEvent::PermanentTapped {
+                object_id: tapped,
+                caused_by: None,
+            }],
+        );
+        pending.collect(
+            &state,
+            &[GameEvent::PermanentTapped {
+                object_id: tapped,
+                caused_by: None,
+            }],
+        );
 
         assert_eq!(
-            pending.staged_state.object_tap_count_this_turn.get(&tapped),
+            pending
+                .staged_state_for_test(&state)
+                .object_tap_count_this_turn
+                .get(&tapped),
             Some(&2),
             "the later pending-payment event must see the earlier staged collector write"
         );
@@ -19345,11 +19378,14 @@ pub mod tests {
 
         let cancelled_tap = ObjectId(72);
         let mut cancelled =
-            PendingActivationTriggerCollection::for_activated_ability(&state, source, PlayerId(1));
-        cancelled.collect(&[GameEvent::PermanentTapped {
-            object_id: cancelled_tap,
-            caused_by: None,
-        }]);
+            PendingActivationTriggerCollection::for_activated_ability(source, PlayerId(1));
+        cancelled.collect(
+            &state,
+            &[GameEvent::PermanentTapped {
+                object_id: cancelled_tap,
+                caused_by: None,
+            }],
+        );
         drop(cancelled);
         assert!(
             !state

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -676,6 +676,26 @@ impl PendingActivationTriggerCollection {
         }
     }
 
+    /// Creates an activation-local collector with the complete in-flight
+    /// ability available to source-filtered trigger predicates.
+    pub(crate) fn for_prepared_activated_ability(
+        source_id: ObjectId,
+        controller: PlayerId,
+        ability_index: usize,
+        ability: &ResolvedAbility,
+    ) -> Self {
+        Self {
+            overlay: TriggerCollectionOverlay::for_prepared_activated_ability(
+                source_id,
+                controller,
+                ability_index,
+                ability,
+            ),
+            operation_journal: Vec::new(),
+            pending_contexts: Vec::new(),
+        }
+    }
+
     /// Collect one event slice emitted while the activation is still pending.
     ///
     /// Later slices replay the earlier collector operations into a fresh staged
@@ -687,7 +707,8 @@ impl PendingActivationTriggerCollection {
         self.overlay
             .install_virtual_targeting_source(&mut staged_state);
         let operation_journal = std::mem::take(&mut self.operation_journal);
-        let mut session = TriggerCollectionSession::transactional(self.overlay, operation_journal);
+        let mut session =
+            TriggerCollectionSession::transactional(self.overlay.clone(), operation_journal);
         let contexts = collect_pending_triggers_with_collection(
             &mut staged_state,
             events,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -309,6 +309,44 @@ impl PendingTriggerContext {
     }
 }
 
+/// Read-only authority supplied while collecting triggers for an action that has
+/// been prepared but has not yet produced its physical stack entry.
+///
+/// CR 602.2a + CR 602.2b: an activated ability is announced before its targets
+/// are chosen. Target-trigger collection therefore needs the announced
+/// ability's controller even while the activation is represented only by a
+/// pending transaction. The overlay is deliberately narrow: it can answer the
+/// controller of that one targeting source, but cannot alter object lookup,
+/// zones, or the stack.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TriggerCollectionOverlay {
+    virtual_targeting_source: Option<VirtualTargetingSource>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct VirtualTargetingSource {
+    source_id: ObjectId,
+    controller: PlayerId,
+}
+
+impl TriggerCollectionOverlay {
+    /// Prepares the virtual source authority for one in-flight activation.
+    pub(crate) fn for_activated_ability(source_id: ObjectId, controller: PlayerId) -> Self {
+        Self {
+            virtual_targeting_source: Some(VirtualTargetingSource {
+                source_id,
+                controller,
+            }),
+        }
+    }
+
+    fn targeting_source_controller(self, source_id: ObjectId) -> Option<PlayerId> {
+        self.virtual_targeting_source
+            .filter(|source| source.source_id == source_id)
+            .map(|source| source.controller)
+    }
+}
+
 /// Installs one CR 603.7 delayed triggered ability and journals it.
 ///
 /// SINGLE AUTHORITY for adding to `GameState::delayed_triggers`. Every rules
@@ -2278,7 +2316,26 @@ fn collect_pending_triggers(
     state: &mut GameState,
     events: &[GameEvent],
 ) -> Vec<PendingTriggerContext> {
-    collect_pending_triggers_with_collection(state, events, LogicalZoneTriggerCollection::Ordinary)
+    collect_pending_triggers_with_overlay(state, events, TriggerCollectionOverlay::default())
+}
+
+/// Collect trigger contexts using a read-only authority for an announced
+/// activation that has not yet been committed to the physical stack.
+///
+/// This is collection only; callers remain responsible for placing the returned
+/// contexts in the appropriate deferred queue exactly once at their transaction
+/// commit boundary.
+pub(crate) fn collect_pending_triggers_with_overlay(
+    state: &mut GameState,
+    events: &[GameEvent],
+    overlay: TriggerCollectionOverlay,
+) -> Vec<PendingTriggerContext> {
+    collect_pending_triggers_with_collection(
+        state,
+        events,
+        LogicalZoneTriggerCollection::Ordinary,
+        overlay,
+    )
 }
 
 /// Collect one explicit delivery segment of a logical zone-change owner.
@@ -2295,6 +2352,7 @@ pub(crate) fn collect_logical_zone_trigger_segment(
         state,
         events,
         LogicalZoneTriggerCollection::Segment(group),
+        TriggerCollectionOverlay::default(),
     )
 }
 
@@ -2712,6 +2770,7 @@ fn collect_pending_triggers_with_collection(
     state: &mut GameState,
     events: &[GameEvent],
     collection: LogicalZoneTriggerCollection<'_>,
+    overlay: TriggerCollectionOverlay,
 ) -> Vec<PendingTriggerContext> {
     // CR 603.6a + CR 611.2e: Continuous effects (including statics that grant
     // triggered abilities to a class — sliver-lord pattern) apply the moment
@@ -3154,18 +3213,26 @@ fn collect_pending_triggers_with_collection(
                 } = event
                 {
                     if *targeted_id == obj_id {
-                        // Look up source controller. For spells, StackEntry.id matches source_id.
-                        // For activated abilities, StackEntry.source_id matches (the permanent),
-                        // and the fallback via state.objects finds the permanent's controller.
-                        let source_controller = state
-                            .stack
-                            .iter()
-                            .find(|e| {
-                                e.id == *targeting_source_id || e.source_id == *targeting_source_id
-                            })
-                            .map(|e| e.controller)
+                        // Prefer the prepared activation's virtual authority.
+                        // A committed spell/ability still resolves through its
+                        // physical stack entry, then the live source fallback.
+                        let source_controller = overlay
+                            .targeting_source_controller(*targeting_source_id)
                             .or_else(|| {
-                                state.objects.get(targeting_source_id).map(|o| o.controller)
+                                state
+                                    .stack
+                                    .iter()
+                                    .find(|entry| {
+                                        entry.id == *targeting_source_id
+                                            || entry.source_id == *targeting_source_id
+                                    })
+                                    .map(|entry| entry.controller)
+                            })
+                            .or_else(|| {
+                                state
+                                    .objects
+                                    .get(targeting_source_id)
+                                    .map(|obj| obj.controller)
                             });
 
                         // CR 702.21a + CR 611.3 + CR 613.11: An active
@@ -18910,6 +18977,72 @@ pub mod tests {
             state.stack.len(),
             1,
             "No ward trigger should fire for own spells"
+        );
+    }
+
+    #[test]
+    fn activation_overlay_supplies_controller_before_stack_commit() {
+        let make_state = || {
+            let mut state = setup();
+            state.active_player = PlayerId(0);
+            let source = create_object(
+                &mut state,
+                CardId(9),
+                PlayerId(0),
+                "Activation Source".to_string(),
+                Zone::Battlefield,
+            );
+            let creature = create_object(
+                &mut state,
+                CardId(10),
+                PlayerId(0),
+                "Ward Creature".to_string(),
+                Zone::Battlefield,
+            );
+            let obj = state.objects.get_mut(&creature).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.entered_battlefield_turn = Some(1);
+            obj.keywords
+                .push(Keyword::Ward(WardCost::Mana(ManaCost::generic(2))));
+            (state, source, creature)
+        };
+
+        // The source has no StackEntry, and its live controller deliberately
+        // differs from the prepared authority. This proves collection uses the
+        // announce-time controller rather than re-reading mutable battlefield
+        // state while the activation awaits its transaction commit.
+        let (mut without_overlay, prepared_source, ward_target) = make_state();
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(ward_target),
+            source_id: prepared_source,
+        };
+        assert!(
+            collect_pending_triggers(&mut without_overlay, std::slice::from_ref(&event)).is_empty(),
+            "the ordinary collector must use the live source controller"
+        );
+
+        let (mut with_overlay, prepared_source, ward_target) = make_state();
+        let event = GameEvent::BecomesTarget {
+            target: TargetRef::Object(ward_target),
+            source_id: prepared_source,
+        };
+        let pending = collect_pending_triggers_with_overlay(
+            &mut with_overlay,
+            &[event],
+            TriggerCollectionOverlay::for_activated_ability(prepared_source, PlayerId(1)),
+        );
+
+        assert_eq!(
+            pending.len(),
+            1,
+            "opponent-controlled prepared activation must trigger ward"
+        );
+        assert_eq!(pending[0].pending.source_id, ward_target);
+        assert_eq!(pending[0].pending.controller, PlayerId(0));
+        assert!(pending[0].pending.ability.unless_pay.is_some());
+        assert!(
+            with_overlay.stack.is_empty(),
+            "collection remains non-dispatching; the future activation transaction owns commit"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7,8 +7,8 @@ use crate::types::ability::{
     ControllerRef, CopyRetargetPermission, DelayedTriggerCondition, Effect, ModalChoice,
     ObjectScope, OriginConstraint, PlayerFilter, PtValue, QuantityExpr, QuantityRef, RenownSubject,
     ResolvedAbility, SacrificeCost, TargetFilter, TargetRef, TributeOutcome, TriggerCondition,
-    TriggerDefinition, TriggerDefinitionOccurrenceRef, TriggerDefinitionRef, TriggerEntry,
-    TriggerGrantProducerKey, TypeFilter, TypedFilter,
+    TriggerConstraint, TriggerDefinition, TriggerDefinitionOccurrenceRef, TriggerDefinitionRef,
+    TriggerEntry, TriggerGrantProducerKey, TypeFilter, TypedFilter,
 };
 #[cfg(test)]
 use crate::types::ability::{EffectScope, TapStateChange};
@@ -344,6 +344,208 @@ impl TriggerCollectionOverlay {
         self.virtual_targeting_source
             .filter(|source| source.source_id == source_id)
             .map(|source| source.controller)
+    }
+}
+
+/// One stateful consequence of collecting triggered abilities.
+///
+/// Trigger matching is mostly observational, but CR 603 collection also updates
+/// per-turn trigger ledgers and event-observation facts. Keeping those writes as
+/// owned operations makes their ordering explicit and gives a future
+/// activation-local collector a single seam at which to retain or discard them.
+/// The ordinary collector applies every operation immediately.
+enum TriggerCollectionOperation {
+    PrepareEventBatch {
+        events: Vec<GameEvent>,
+    },
+    RecordTriggerFired {
+        constraint: Option<TriggerConstraint>,
+        source_context: Option<TriggerSourceContext>,
+        definition_ref: Option<TriggerDefinitionRef>,
+        event: GameEvent,
+    },
+    RecordBatchedZoneChanges {
+        definition_ref: TriggerDefinitionRef,
+        turn_zone_change_indices: Vec<usize>,
+    },
+    AllocateTimestamp,
+    RecordCombatDamageCastingPermission {
+        controller: PlayerId,
+        grants_freerunning: bool,
+        creature_types: Vec<String>,
+    },
+    MarkSpeedTriggerUsed {
+        player: PlayerId,
+    },
+}
+
+/// Applies trigger-collection mutations in their collection order.
+///
+/// This session intentionally owns no game-state borrow. Matching still reads
+/// the live state between operations, exactly as it did before this extraction;
+/// only the mutation authority is centralized. A later transactional caller can
+/// replace immediate application with an activation-local operation journal
+/// without changing any trigger-matching path.
+struct TriggerCollectionSession {
+    overlay: TriggerCollectionOverlay,
+}
+
+impl TriggerCollectionSession {
+    fn new(overlay: TriggerCollectionOverlay) -> Self {
+        Self { overlay }
+    }
+
+    fn prepare(&self, state: &mut GameState, events: &[GameEvent]) {
+        let _ = self.apply(
+            state,
+            TriggerCollectionOperation::PrepareEventBatch {
+                events: events.to_vec(),
+            },
+        );
+    }
+
+    fn record_match(&self, state: &mut GameState, matched: &MatchedTrigger, event: &GameEvent) {
+        let _ = self.apply(
+            state,
+            TriggerCollectionOperation::RecordTriggerFired {
+                constraint: matched.constraint.clone(),
+                source_context: matched.pending.ability.trigger_source.clone(),
+                definition_ref: matched.definition_ref.clone(),
+                event: event.clone(),
+            },
+        );
+
+        if !matched.batched || !batched_zone_change_batch(&matched.trigger_events) {
+            return;
+        }
+        let Some(definition_ref) = matched.definition_ref.clone() else {
+            return;
+        };
+        let turn_zone_change_indices = matched
+            .trigger_events
+            .iter()
+            .filter_map(|event| match event {
+                GameEvent::ZoneChanged { record, .. } => Some(record.turn_zone_change_index),
+                _ => None,
+            })
+            .collect();
+        let _ = self.apply(
+            state,
+            TriggerCollectionOperation::RecordBatchedZoneChanges {
+                definition_ref,
+                turn_zone_change_indices,
+            },
+        );
+    }
+
+    fn mark_speed_trigger_used(&self, state: &mut GameState, player: PlayerId) {
+        let _ = self.apply(
+            state,
+            TriggerCollectionOperation::MarkSpeedTriggerUsed { player },
+        );
+    }
+
+    fn next_timestamp(&self, state: &mut GameState) -> u64 {
+        self.apply(state, TriggerCollectionOperation::AllocateTimestamp)
+            .expect("timestamp allocation must return the allocated timestamp")
+    }
+
+    fn record_combat_damage_casting_permission(
+        &self,
+        state: &mut GameState,
+        controller: PlayerId,
+        grants_freerunning: bool,
+        creature_types: Vec<String>,
+    ) {
+        let _ = self.apply(
+            state,
+            TriggerCollectionOperation::RecordCombatDamageCastingPermission {
+                controller,
+                grants_freerunning,
+                creature_types,
+            },
+        );
+    }
+
+    fn targeting_source_controller(
+        &self,
+        state: &GameState,
+        source_id: ObjectId,
+    ) -> Option<PlayerId> {
+        self.overlay
+            .targeting_source_controller(source_id)
+            .or_else(|| {
+                state.stack.iter().rev().find_map(|entry| {
+                    (entry.id == source_id || entry.source_id == source_id)
+                        .then_some(entry.controller)
+                })
+            })
+            .or_else(|| {
+                state
+                    .objects
+                    .get(&source_id)
+                    .map(|source| source.controller)
+            })
+    }
+
+    fn apply(&self, state: &mut GameState, operation: TriggerCollectionOperation) -> Option<u64> {
+        match operation {
+            TriggerCollectionOperation::PrepareEventBatch { events } => {
+                super::layers::flush_layers(state);
+                reconcile_off_zone_keyword_triggers(state);
+                observe_object_taps(state, &events);
+                observe_object_counter_placements(state, &events);
+                None
+            }
+            TriggerCollectionOperation::RecordTriggerFired {
+                constraint,
+                source_context,
+                definition_ref,
+                event,
+            } => {
+                record_trigger_fired_with_ref(
+                    state,
+                    constraint.as_ref(),
+                    source_context.as_ref(),
+                    definition_ref.as_ref(),
+                    &event,
+                );
+                None
+            }
+            TriggerCollectionOperation::RecordBatchedZoneChanges {
+                definition_ref,
+                turn_zone_change_indices,
+            } => {
+                for turn_zone_change_index in turn_zone_change_indices {
+                    state
+                        .batched_zone_change_trigger_fired
+                        .insert((definition_ref.clone(), turn_zone_change_index));
+                }
+                None
+            }
+            TriggerCollectionOperation::AllocateTimestamp => Some(state.next_timestamp()),
+            TriggerCollectionOperation::RecordCombatDamageCastingPermission {
+                controller,
+                grants_freerunning,
+                creature_types,
+            } => {
+                if grants_freerunning {
+                    state
+                        .assassin_or_commander_dealt_combat_damage_this_turn
+                        .insert(controller);
+                }
+                state.creature_types_dealt_combat_damage_this_turn.extend(
+                    creature_types
+                        .into_iter()
+                        .map(|creature_type| (controller, creature_type)),
+                );
+                None
+            }
+            TriggerCollectionOperation::MarkSpeedTriggerUsed { player } => {
+                mark_speed_trigger_used(state, player);
+                None
+            }
+        }
     }
 }
 
@@ -2772,6 +2974,7 @@ fn collect_pending_triggers_with_collection(
     collection: LogicalZoneTriggerCollection<'_>,
     overlay: TriggerCollectionOverlay,
 ) -> Vec<PendingTriggerContext> {
+    let session = TriggerCollectionSession::new(overlay);
     // CR 603.6a + CR 611.2e: Continuous effects (including statics that grant
     // triggered abilities to a class — sliver-lord pattern) apply the moment
     // the affected permanent is on the battlefield. The newcomers must be
@@ -2780,8 +2983,6 @@ fn collect_pending_triggers_with_collection(
     // battlefield. Flushing pending layer evaluation here guarantees
     // `obj.trigger_definitions` and `obj.keywords` reflect all active
     // continuous effects before this pass scans for matching triggers.
-    super::layers::flush_layers(state);
-    reconcile_off_zone_keyword_triggers(state);
     // CR 701.26 + CR 603.4: Observe every `PermanentTapped` event in this batch and
     // bump the per-object tap-count ledger BEFORE any trigger condition is checked,
     // so a "first time it became tapped this turn" intervening-if
@@ -2789,14 +2990,13 @@ fn collect_pending_triggers_with_collection(
     // `collect_pending_triggers` is the single chokepoint all trigger collection
     // funnels through (combat declaration, mana taps, cost taps, crew), so combat +
     // effect + crew taps all count here regardless of which producer emitted them.
-    observe_object_taps(state, events);
     // CR 122.1 + CR 603.4: Bump the per-object counter-placement OCCURRENCE ledger
     // for this batch (deduped across a multi-KIND placement) BEFORE any trigger
     // condition is checked, so a "first time counters have been put on it this
     // turn" intervening-if (`FirstTimeObjectCountersAddedThisTurn`) reads
     // occurrence-count == 1 for the placement that just fired. Same chokepoint as
     // the tap ledger, so effect, ETB, and ability counter placements all count.
-    observe_object_counter_placements(state, events);
+    session.prepare(state, events);
     let mut pending: Vec<PendingTriggerContext> = Vec::new();
     // CR 603.2c: Track which batched triggers (source_id, trig_idx) have already
     // fired in this pass so "one or more" triggers fire at most once per batch.
@@ -2955,14 +3155,7 @@ fn collect_pending_triggers_with_collection(
                 if audit_trigger_index {
                     production_matched.insert((obj_id, matched.trig_idx));
                 }
-                record_trigger_fired_with_ref(
-                    state,
-                    matched.constraint.as_ref(),
-                    matched.pending.ability.trigger_source.as_ref(),
-                    matched.definition_ref.as_ref(),
-                    event,
-                );
-                record_matched_batched_zone_change_replay(state, &matched);
+                session.record_match(state, &matched, event);
                 if matched.batched {
                     batched_this_pass.insert((obj_id, matched.trig_idx));
                 }
@@ -3216,24 +3409,8 @@ fn collect_pending_triggers_with_collection(
                         // Prefer the prepared activation's virtual authority.
                         // A committed spell/ability still resolves through its
                         // physical stack entry, then the live source fallback.
-                        let source_controller = overlay
-                            .targeting_source_controller(*targeting_source_id)
-                            .or_else(|| {
-                                state
-                                    .stack
-                                    .iter()
-                                    .find(|entry| {
-                                        entry.id == *targeting_source_id
-                                            || entry.source_id == *targeting_source_id
-                                    })
-                                    .map(|entry| entry.controller)
-                            })
-                            .or_else(|| {
-                                state
-                                    .objects
-                                    .get(targeting_source_id)
-                                    .map(|obj| obj.controller)
-                            });
+                        let source_controller =
+                            session.targeting_source_controller(state, *targeting_source_id);
 
                         // CR 702.21a + CR 611.3 + CR 613.11: An active
                         // `SuppressTriggers { events ∋ BecomesTargeted }` static
@@ -3385,14 +3562,7 @@ fn collect_pending_triggers_with_collection(
                 };
             if !matched_triggers.is_empty() {
                 for matched in matched_triggers {
-                    record_trigger_fired_with_ref(
-                        state,
-                        matched.constraint.as_ref(),
-                        matched.pending.ability.trigger_source.as_ref(),
-                        matched.definition_ref.as_ref(),
-                        event,
-                    );
-                    record_matched_batched_zone_change_replay(state, &matched);
+                    session.record_match(state, &matched, event);
                     if matched.batched {
                         batched_this_pass.insert((*moved_id, matched.trig_idx));
                     }
@@ -3437,14 +3607,7 @@ fn collect_pending_triggers_with_collection(
                     )
                 };
                 for matched in matched_triggers {
-                    record_trigger_fired_with_ref(
-                        state,
-                        matched.constraint.as_ref(),
-                        matched.pending.ability.trigger_source.as_ref(),
-                        matched.definition_ref.as_ref(),
-                        event,
-                    );
-                    record_matched_batched_zone_change_replay(state, &matched);
+                    session.record_match(state, &matched, event);
                     if matched.batched {
                         batched_this_pass.insert((*exploiter, matched.trig_idx));
                     }
@@ -3544,14 +3707,7 @@ fn collect_pending_triggers_with_collection(
                     }
                 }
                 for matched in matched_triggers {
-                    record_trigger_fired_with_ref(
-                        state,
-                        matched.constraint.as_ref(),
-                        matched.pending.ability.trigger_source.as_ref(),
-                        matched.definition_ref.as_ref(),
-                        event,
-                    );
-                    record_matched_batched_zone_change_replay(state, &matched);
+                    session.record_match(state, &matched, event);
                     if matched.batched {
                         batched_this_pass.insert((observer_id, matched.trig_idx));
                     }
@@ -3608,14 +3764,7 @@ fn collect_pending_triggers_with_collection(
                 };
 
                 for matched in matched_triggers {
-                    record_trigger_fired_with_ref(
-                        state,
-                        matched.constraint.as_ref(),
-                        matched.pending.ability.trigger_source.as_ref(),
-                        matched.definition_ref.as_ref(),
-                        event,
-                    );
-                    record_matched_batched_zone_change_replay(state, &matched);
+                    session.record_match(state, &matched, event);
                     if matched.batched {
                         batched_this_pass.insert((obj_id, matched.trig_idx));
                     }
@@ -3692,7 +3841,7 @@ fn collect_pending_triggers_with_collection(
                     // synthesized trigger is only collected from SpellCast,
                     // which is only emitted for an actual cast, so cast-ness is
                     // already implied by the trigger event itself.
-                    let timestamp = state.next_timestamp() as u32;
+                    let timestamp = session.next_timestamp(state) as u32;
                     pending.push(PendingTriggerContext::single(PendingTrigger {
                         source_id: *cast_obj_id,
                         controller: *caster,
@@ -3754,7 +3903,7 @@ fn collect_pending_triggers_with_collection(
                 if let Some(source_context) = &cast_source_context {
                     cascade_ability.set_trigger_source_recursive(source_context.clone());
                 }
-                let timestamp = state.next_timestamp() as u32;
+                let timestamp = session.next_timestamp(state) as u32;
                 pending.push(PendingTriggerContext::single(PendingTrigger {
                     source_id: *cast_obj_id,
                     controller,
@@ -3814,7 +3963,7 @@ fn collect_pending_triggers_with_collection(
                 if let Some(source_context) = &cast_source_context {
                     ripple_ability.set_trigger_source_recursive(source_context.clone());
                 }
-                let timestamp = state.next_timestamp() as u32;
+                let timestamp = session.next_timestamp(state) as u32;
                 pending.push(PendingTriggerContext::single(PendingTrigger {
                     source_id: *cast_obj_id,
                     controller: ripple_controller,
@@ -3929,7 +4078,7 @@ fn collect_pending_triggers_with_collection(
                 if let Some(source_context) = &cast_source_context {
                     casualty_ability.set_trigger_source_recursive(source_context.clone());
                 }
-                let timestamp = state.next_timestamp() as u32;
+                let timestamp = session.next_timestamp(state) as u32;
                 pending.push(PendingTriggerContext::single(PendingTrigger {
                     source_id: *cast_obj_id,
                     controller: dynamically_granted_casualty_instances.1,
@@ -4006,7 +4155,7 @@ fn collect_pending_triggers_with_collection(
                 if let Some(source_context) = &cast_source_context {
                     conspire_ability.set_trigger_source_recursive(source_context.clone());
                 }
-                let timestamp = state.next_timestamp() as u32;
+                let timestamp = session.next_timestamp(state) as u32;
                 pending.push(PendingTriggerContext::single(PendingTrigger {
                     source_id: *cast_obj_id,
                     controller: dynamically_granted_conspire_instances.1,
@@ -4078,7 +4227,7 @@ fn collect_pending_triggers_with_collection(
                     if let Some(source_context) = &cast_source_context {
                         replicate_ability.set_trigger_source_recursive(source_context.clone());
                     }
-                    let timestamp = state.next_timestamp() as u32;
+                    let timestamp = session.next_timestamp(state) as u32;
                     pending.push(PendingTriggerContext::single(PendingTrigger {
                         source_id: *cast_obj_id,
                         controller,
@@ -4136,7 +4285,7 @@ fn collect_pending_triggers_with_collection(
                 if let Some(source_context) = &cast_source_context {
                     demonstrate_ability.set_trigger_source_recursive(source_context.clone());
                 }
-                let timestamp = state.next_timestamp() as u32;
+                let timestamp = session.next_timestamp(state) as u32;
                 pending.push(PendingTriggerContext::single(PendingTrigger {
                     source_id: *cast_obj_id,
                     controller: dynamically_granted_demonstrate_instances.1,
@@ -4256,21 +4405,15 @@ fn collect_pending_triggers_with_collection(
                 // creature types AT DAMAGE TIME (LKI) before any later mutation.
                 let controller = source_obj.controller;
                 let source_subtypes = source_obj.card_types.subtypes.clone();
-                if is_assassin_creature || is_commander {
-                    state
-                        .assassin_or_commander_dealt_combat_damage_this_turn
-                        .insert(controller);
-                }
                 // CR 702.76a: record this source's creature types under its
                 // controller so Prowl can later check "had any of this spell's
                 // creature types". A source with no subtypes contributes nothing.
-                if !source_subtypes.is_empty() {
-                    state.creature_types_dealt_combat_damage_this_turn.extend(
-                        source_subtypes
-                            .into_iter()
-                            .map(|creature_type| (controller, creature_type)),
-                    );
-                }
+                session.record_combat_damage_casting_permission(
+                    state,
+                    controller,
+                    is_assassin_creature || is_commander,
+                    source_subtypes,
+                );
             }
         }
 
@@ -4404,7 +4547,7 @@ fn collect_pending_triggers_with_collection(
                     subject_match_count: None,
                     die_result: None,
                 }));
-                mark_speed_trigger_used(state, trigger_controller);
+                session.mark_speed_trigger_used(state, trigger_controller);
             }
         }
 
@@ -19557,6 +19700,48 @@ pub mod tests {
         observe_object_taps(&mut state, &events);
         assert_eq!(state.object_tap_count_this_turn.get(&a).copied(), Some(2));
         assert_eq!(state.object_tap_count_this_turn.get(&b).copied(), Some(1));
+    }
+
+    /// CR 701.26 + CR 122.1 + CR 603.4: the collector session owns the
+    /// pre-match event-observation write. It preserves the tap ledger's
+    /// per-event count while deduplicating counter placements per object in one
+    /// emitted event batch.
+    #[test]
+    fn trigger_collection_session_applies_event_observation_operation() {
+        let mut state = setup();
+        let tapped = ObjectId(71);
+        let countered = ObjectId(72);
+        let events = vec![
+            GameEvent::PermanentTapped {
+                object_id: tapped,
+                caused_by: None,
+            },
+            GameEvent::PermanentTapped {
+                object_id: tapped,
+                caused_by: None,
+            },
+            GameEvent::CounterAdded {
+                object_id: countered,
+                counter_type: CounterType::Lore,
+                count: 1,
+            },
+            GameEvent::CounterAdded {
+                object_id: countered,
+                counter_type: CounterType::Plus1Plus1,
+                count: 1,
+            },
+        ];
+
+        TriggerCollectionSession::new(TriggerCollectionOverlay::default())
+            .prepare(&mut state, &events);
+
+        assert_eq!(state.object_tap_count_this_turn.get(&tapped), Some(&2));
+        assert_eq!(
+            state
+                .object_counter_placement_count_this_turn
+                .get(&countered),
+            Some(&1),
+        );
     }
 
     /// CR 120.1 + CR 108.3: `DamagedPlayerIsEventSourceOwner` holds only when the

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -19455,7 +19455,7 @@ pub mod tests {
             target: TargetRef::Object(observer),
             source_id: source,
         };
-        assert!(super::trigger_matchers::match_becomes_target(
+        assert!(crate::game::trigger_matchers::match_becomes_target(
             &event,
             &trigger,
             &crate::game::trigger_matchers::test_trigger_source_context(&staged, observer),

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1915,6 +1915,7 @@ mod tests {
             activation_residual: crate::types::game_state::ActivationResidual::None,
             activation_target_selection:
                 crate::types::game_state::ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         })

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -79,6 +79,16 @@ pub(crate) fn capture_library_search_card_view(
 /// viewer is explicitly allowed to see them.
 pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState {
     let mut filtered = state.clone();
+    // Pending activation trigger collection retains source contexts and the
+    // uncommitted event journal solely for rules execution. The pending ability
+    // itself remains public, but this implementation carrier is never part of a
+    // viewer projection — including the activating player's projection.
+    if let Some(pending) = filtered.pending_cast.as_mut() {
+        pending.activation_trigger_collection = None;
+    }
+    if let Some(pending) = filtered.waiting_for.pending_cast_mut() {
+        pending.activation_trigger_collection = None;
+    }
     // Interaction capability authority is trusted persistence state. Viewer
     // projections expose only the actor-scoped opaque opportunity IDs produced
     // by `game::interaction`, never the session/serial/slot minting ledger.
@@ -1906,6 +1916,7 @@ mod tests {
             activation_target_selection:
                 crate::types::game_state::ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         })
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5590,6 +5590,16 @@ pub struct PendingCast {
     /// `Unlimited` grants.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alt_cost_grant_source: Option<ObjectId>,
+    /// CR 602.2a-b + CR 603.2: Trigger consequences from a target-bearing
+    /// activation are collected while its targets and costs are announced, but
+    /// become globally visible only when the ability reaches the stack.
+    ///
+    /// The carrier is durable across interactive cost prompts and is redacted
+    /// from every per-viewer state projection; its journal is engine-private
+    /// implementation state, not public pending-cast information.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) activation_trigger_collection:
+        Option<Box<crate::game::triggers::PendingActivationTriggerCollection>>,
 }
 
 fn default_origin_zone() -> Zone {
@@ -5984,12 +5994,30 @@ impl PendingCast {
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         }
     }
 
     pub fn with_payment_mode(mut self, payment_mode: CastPaymentMode) -> Self {
         self.payment_mode = payment_mode;
         self
+    }
+
+    /// Starts the trigger transaction for an announced, target-bearing
+    /// activated ability.
+    ///
+    /// CR 602.2a-b + CR 603.2: Target declaration can make triggers fire
+    /// before costs are paid, while the activated ability does not exist on
+    /// the physical stack until the announcement completes.
+    pub(crate) fn begin_activation_trigger_collection(&mut self) {
+        if self.activation_trigger_collection.is_none() {
+            self.activation_trigger_collection = Some(Box::new(
+                crate::game::triggers::PendingActivationTriggerCollection::for_activated_ability(
+                    self.object_id,
+                    self.ability.controller,
+                ),
+            ));
+        }
     }
 }
 
@@ -21239,6 +21267,7 @@ mod tests {
                 activation_residual: ActivationResidual::None,
                 activation_target_selection: ActivationTargetSelection::Pending,
                 alt_cost_grant_source: None,
+                activation_trigger_collection: None,
             })
         }
 
@@ -21648,6 +21677,7 @@ mod tests {
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
             alt_cost_grant_source: None,
+            activation_trigger_collection: None,
         });
         let choose_x = WaitingFor::ChooseXValue {
             player: PlayerId(0),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5929,6 +5929,14 @@ pub enum PendingCostMoveResume {
         pending: Box<PendingManaAbility>,
         cursor: ManaAbilityCostCursor,
     },
+    /// CR 602.2b + CR 701.17a + CR 616.1: An activation's deterministic mill
+    /// cost paused while a replacement choice settles. Resume the serialized
+    /// activation suffix only after the mill event has reached a terminal
+    /// replacement outcome.
+    ActivationMillPayment {
+        player: PlayerId,
+        pending: Box<PendingCast>,
+    },
     /// CR 606.4 + CR 614.1a + CR 616.1: A loyalty activation paused on a
     /// counter-cost replacement-ordering choice (e.g. Doubling Season vs an
     /// opponent's Vorinclex halving the loyalty counters). The counter is

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5583,6 +5583,11 @@ pub struct PendingCast {
     /// through a cost-payment continuation without conflating it with cost legs.
     #[serde(default, skip_serializing_if = "ActivationTargetSelection::is_pending")]
     pub activation_target_selection: ActivationTargetSelection,
+    /// CR 601.2h + CR 602.2b: An activation cannot be cancelled once any
+    /// component of its cost has been paid, because that payment is not a
+    /// rollback-able announcement choice.
+    #[serde(default)]
+    pub activation_cost_committed: bool,
     /// CR 118.9 + CR 601.2b: When this cast is offered a once-per-turn
     /// `CastWithAlternativeCost` grant (As Foretold), the granting permanent's id.
     /// Carried across the `OptionalCostChoice` round-trip so the accept handler can
@@ -5993,6 +5998,7 @@ impl PendingCast {
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         }
@@ -6022,6 +6028,14 @@ impl PendingCast {
                     &self.ability,
                 ),
             ));
+        }
+    }
+
+    /// CR 601.2h + CR 602.2b: Marks an announced activation as having paid an
+    /// irreversible cost component, so it can no longer be cancelled.
+    pub(crate) fn mark_activation_cost_committed(&mut self) {
+        if self.activation_ability_index.is_some() {
+            self.activation_cost_committed = true;
         }
     }
 }
@@ -21308,6 +21322,7 @@ mod tests {
                 assist_state: AssistState::NotOffered,
                 activation_residual: ActivationResidual::None,
                 activation_target_selection: ActivationTargetSelection::Pending,
+                activation_cost_committed: false,
                 alt_cost_grant_source: None,
                 activation_trigger_collection: None,
             })
@@ -21718,6 +21733,7 @@ mod tests {
             assist_state: AssistState::NotOffered,
             activation_residual: ActivationResidual::None,
             activation_target_selection: ActivationTargetSelection::Pending,
+            activation_cost_committed: false,
             alt_cost_grant_source: None,
             activation_trigger_collection: None,
         });

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6021,6 +6021,43 @@ impl PendingCast {
     }
 }
 
+impl GameState {
+    /// Temporarily removes the activation-local trigger transaction from the
+    /// pending cast that currently owns it.
+    ///
+    /// `ManaPayment` stores its `PendingCast` in `GameState::pending_cast`;
+    /// every other interactive casting prompt embeds it in `WaitingFor`.
+    /// Keeping that routing distinction here prevents individual cost handlers
+    /// from choosing the wrong continuation carrier.
+    pub(crate) fn take_pending_activation_trigger_collection(
+        &mut self,
+    ) -> Option<Box<crate::game::triggers::PendingActivationTriggerCollection>> {
+        if let Some(pending) = self.pending_cast.as_mut() {
+            return pending.activation_trigger_collection.take();
+        }
+        self.waiting_for
+            .pending_cast_mut()?
+            .activation_trigger_collection
+            .take()
+    }
+
+    /// Restores the transaction removed by
+    /// [`Self::take_pending_activation_trigger_collection`] to the same active
+    /// casting continuation.
+    pub(crate) fn restore_pending_activation_trigger_collection(
+        &mut self,
+        collection: Box<crate::game::triggers::PendingActivationTriggerCollection>,
+    ) {
+        if let Some(pending) = self.pending_cast.as_mut() {
+            pending.activation_trigger_collection = Some(collection);
+            return;
+        }
+        if let Some(pending) = self.waiting_for.pending_cast_mut() {
+            pending.activation_trigger_collection = Some(collection);
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum CollectEvidenceResume {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6011,10 +6011,15 @@ impl PendingCast {
     /// the physical stack until the announcement completes.
     pub(crate) fn begin_activation_trigger_collection(&mut self) {
         if self.activation_trigger_collection.is_none() {
+            let ability_index = self
+                .activation_ability_index
+                .expect("target-bearing activation session requires an ability index");
             self.activation_trigger_collection = Some(Box::new(
-                crate::game::triggers::PendingActivationTriggerCollection::for_activated_ability(
+                crate::game::triggers::PendingActivationTriggerCollection::for_prepared_activated_ability(
                     self.object_id,
                     self.ability.controller,
+                    ability_index,
+                    &self.ability,
                 ),
             ));
         }

--- a/crates/engine/tests/integration/bound_by_moonsilver_sacrifice_source_relative_6017.rs
+++ b/crates/engine/tests/integration/bound_by_moonsilver_sacrifice_source_relative_6017.rs
@@ -26,6 +26,7 @@
 //! CR 613.4c: outside per-recipient layer contexts, "other" is source-relative.
 
 use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::TargetRef;
 use engine::types::actions::GameAction;
 use engine::types::game_state::{PayCostKind, WaitingFor};
 use engine::types::phase::Phase;
@@ -65,15 +66,29 @@ fn bound_by_moonsilver_sacrifice_another_is_source_relative() {
         state.layers_dirty.mark_full();
     }
 
-    // Activate the Aura's "Sacrifice another permanent: Attach ..." ability.
-    // Sacrifice-cost payment is prompted BEFORE target selection, so the
-    // eligible sacrifice set is surfaced immediately.
+    // CR 602.2b + CR 601.2c: declare the attachment target before paying the
+    // "Sacrifice another permanent" cost.
     runner
         .act(GameAction::ActivateAbility {
             source_id: aura,
             ability_index: 0,
         })
         .expect("activating Bound by Moonsilver's sacrifice ability must succeed");
+
+    let WaitingFor::TargetSelection { target_slots, .. } = &runner.state().waiting_for else {
+        panic!(
+            "expected attachment target selection before the sacrifice cost, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert!(target_slots[0]
+        .legal_targets
+        .contains(&TargetRef::Object(host)));
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(host)],
+        })
+        .expect("selecting the Aura's attachment target must succeed");
 
     let choices = match &runner.state().waiting_for {
         WaitingFor::PayCost {

--- a/crates/engine/tests/integration/cost_x_carrier_runtime.rs
+++ b/crates/engine/tests/integration/cost_x_carrier_runtime.rs
@@ -673,7 +673,7 @@ fn filter_mana_value_bound_binds_x_and_destroys_within_bound() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let relic = scenario
-        .add_creature(P1, "Worn Powerstone", 0, 0)
+        .add_creature(P1, "Worn Powerstone", 1, 1)
         .as_artifact()
         .id();
     let ooze = {
@@ -737,7 +737,7 @@ fn filter_mana_value_bound_excludes_targets_above_x() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let relic = scenario
-        .add_creature(P1, "Worn Powerstone", 0, 0)
+        .add_creature(P1, "Worn Powerstone", 1, 1)
         .as_artifact()
         .id();
     let ooze = {

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -1811,6 +1811,102 @@ fn paused_sacrifice_cost_stamps_cross_action_departures_and_collects_dies_once()
 }
 
 #[test]
+fn target_activation_replacement_paused_sacrifice_stages_cost_triggers_until_commit() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Targeted Sacrifice Replacement Witness", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Any,
+                    damage_source: None,
+                    excess: None,
+                },
+            )
+            .cost(AbilityCost::Sacrifice(SacrificeCost::count(
+                TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
+                2,
+            ))),
+        )
+        .id();
+    let first = scenario
+        .add_creature(P0, "First Targeted Sacrifice Witness", 1, 1)
+        .id();
+    let second = scenario
+        .add_creature(P0, "Second Targeted Sacrifice Witness", 1, 1)
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Exile))
+        .with_replacement_definition(redirect_self_moved_to(Zone::Graveyard, Zone::Hand))
+        .id();
+    let target = scenario.add_creature(P1, "Target", 2, 2).id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&first)
+        .unwrap()
+        .trigger_definitions
+        .push(
+            TriggerDefinition::new(TriggerMode::ChangesZone)
+                .valid_card(TargetFilter::SelfRef)
+                .origin(Zone::Battlefield)
+                .destination(Zone::Graveyard)
+                .trigger_zones(vec![Zone::Battlefield])
+                .execute(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::GainLife {
+                        amount: QuantityExpr::Fixed { value: 1 },
+                        player: TargetFilter::Controller,
+                    },
+                )),
+        );
+
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("targeted activation starts with target selection");
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(target)],
+        })
+        .expect("target is declared before the sacrifice cost");
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("second sacrifice reaches the replacement pipeline");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    assert!(
+        runner.state().deferred_triggers.is_empty(),
+        "the first sacrifice event stays inside the pending activation session"
+    );
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("replacement completion commits the activation");
+    assert_eq!(
+        runner
+            .state()
+            .stack
+            .iter()
+            .filter(|entry| matches!(
+                entry.kind,
+                StackEntryKind::TriggeredAbility { source_id, .. } if source_id == first
+            ))
+            .count(),
+        1,
+        "the replacement-paused sacrifice trigger is collected once at activation commit"
+    );
+}
+
+#[test]
 fn self_sacrifice_mana_cost_waits_for_replacement_before_producing_mana() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);

--- a/crates/engine/tests/integration/greater_good_activation.rs
+++ b/crates/engine/tests/integration/greater_good_activation.rs
@@ -607,13 +607,12 @@ fn multi_sacrifice_cost_resolves_through_pipeline() {
     }
 }
 
-/// CR 601.2c + CR 701.21a — non-modal activated abilities with sacrifice
-/// costs must pay that cost before choosing targets when target legality or
-/// effect quantities depend on the sacrificed object. This mirrors Dina-style
-/// abilities that sacrifice one creature, then target another creature with an
-/// effect sized by `CostPaidObject`.
+/// CR 602.2b + CR 601.2c/h — target declaration precedes paying a sacrifice
+/// cost even when the effect's later quantity reads the sacrificed object's
+/// last-known information. This mirrors Dina-style abilities that sacrifice
+/// one creature, then put counters on a target creature based on its power.
 #[test]
-fn sacrifice_cost_defers_target_selection_until_cost_paid_object_exists() {
+fn sacrifice_cost_selects_target_before_cost_paid_object_exists() {
     let ability = AbilityDefinition::new(
         AbilityKind::Activated,
         Effect::PutCounter {
@@ -640,8 +639,7 @@ fn sacrifice_cost_defers_target_selection_until_cost_paid_object_exists() {
         .id();
     let victim_id = scenario.add_creature(P0, "Victim", 3, 3).id();
     let target_id = scenario.add_creature(P0, "Counter Target", 1, 1).id();
-    // A second legal creature target so auto-select does not skip the post-sacrifice
-    // target prompt when only one creature remains after the victim leaves play.
+    // A second legal creature target keeps target selection interactive.
     scenario.add_creature(P0, "Alternate Target", 2, 2);
 
     let mut runner = scenario.build();
@@ -654,35 +652,25 @@ fn sacrifice_cost_defers_target_selection_until_cost_paid_object_exists() {
     assert!(
         matches!(
             &runner.state().waiting_for,
-            engine::types::WaitingFor::PayCost {
-                kind: engine::types::PayCostKind::Sacrifice,
-                ..
-            }
+            engine::types::WaitingFor::TargetSelection { .. }
         ),
-        "activating must prompt for sacrifice before target selection, got {:?}",
+        "activating must prompt for a target before the sacrifice cost, got {:?}",
         runner.state().waiting_for,
     );
-
-    runner
-        .act(GameAction::SelectCards {
-            cards: vec![victim_id],
-        })
-        .expect("selecting the sacrifice victim must succeed");
-
     match &runner.state().waiting_for {
         engine::types::WaitingFor::TargetSelection { target_slots, .. } => {
             assert_eq!(target_slots.len(), 1, "the effect has one target slot");
             let legal_targets = &target_slots[0].legal_targets;
             assert!(
                 legal_targets.contains(&TargetRef::Object(target_id)),
-                "the post-sacrifice target creature must be legal",
+                "the declared target creature must be legal before payment",
             );
             assert!(
-                !legal_targets.contains(&TargetRef::Object(victim_id)),
-                "the sacrificed creature must not remain targetable after cost payment",
+                legal_targets.contains(&TargetRef::Object(victim_id)),
+                "the sacrifice candidate is legal while targets are declared",
             );
         }
-        other => panic!("expected target selection after sacrifice cost, got {other:?}"),
+        other => panic!("expected target selection before sacrifice cost, got {other:?}"),
     }
 
     runner
@@ -690,12 +678,17 @@ fn sacrifice_cost_defers_target_selection_until_cost_paid_object_exists() {
             targets: vec![TargetRef::Object(target_id)],
         })
         .expect("selecting the remaining creature target must succeed");
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![victim_id],
+        })
+        .expect("selecting the sacrifice victim after target declaration must succeed");
     runner.advance_until_stack_empty();
 
     assert_eq!(
         runner.state().objects[&victim_id].zone,
         Zone::Graveyard,
-        "the victim must be sacrificed before target selection",
+        "the victim must be sacrificed after target selection",
     );
     assert_eq!(
         runner.state().objects[&target_id]

--- a/crates/engine/tests/integration/issue_1301_cauldron_of_essence_sacrifice_target.rs
+++ b/crates/engine/tests/integration/issue_1301_cauldron_of_essence_sacrifice_target.rs
@@ -11,13 +11,8 @@
 //! targets were determined. The card's own Oracle rulings confirm this
 //! explicitly: "Because targets are chosen before costs are paid, the target
 //! of Cauldron of Essence's last ability can't be the creature sacrificed to
-//! pay its cost." This engine pays non-self Sacrifice/Discard/Exile
-//! activation costs BEFORE target selection as a documented shortcut (see
-//! `push_activated_ability_to_stack` in `casting_costs.rs`), which let the
-//! just-sacrificed permanent slip back in as a legal "creature card in your
-//! graveyard" target. The fix excludes a cost-paid object that left the
-//! battlefield from legal targets for any other slot of the same activation
-//! (`exclude_cost_paid_object_that_left_battlefield` in `ability_utils.rs`).
+//! pay its cost." The activation pipeline therefore determines legal graveyard
+//! targets before paying the non-self sacrifice cost.
 
 use engine::game::engine::apply_as_current;
 use engine::game::scenario::{GameScenario, P0};
@@ -148,24 +143,19 @@ fn cauldron_of_essence_rejects_sacrificed_creature_as_its_own_return_target() {
     let mut runner = scenario.build();
     engine::game::rehydrate_game_from_card_db(runner.state_mut(), db);
 
-    apply_as_current(
+    let result = apply_as_current(
         runner.state_mut(),
         GameAction::ActivateAbility {
             source_id: cauldron,
             ability_index: 0,
         },
-    )
-    .expect("activating Cauldron of Essence should be legal with lands and a sacrifice target");
-
-    let result = apply_as_current(
-        runner.state_mut(),
-        GameAction::SelectCards { cards: vec![token] },
     );
 
     assert!(
         result.is_err(),
-        "sacrificing the only creature card that could become a graveyard target must fail \
-         the activation rather than silently targeting the sacrificed creature, got {:?}",
+        "without a creature card already in the graveyard, activation must reject before costs \
+         are paid rather than treating the creature to be sacrificed as its future target, got {:?}",
         result
     );
+    assert!(runner.state().battlefield.contains(&token));
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -739,6 +739,7 @@ mod mindblade_render_warrior_intervening_if_2867;
 mod mirror_march_copy_token_exile;
 mod mizzixs_mastery;
 mod mjolnir_hammer_double_damage;
+mod mogg_fanatic_target_before_cost;
 mod mogg_war_marshal_echo_dies_trigger;
 mod morbid_curiosity_cost_paid_mana_value_draw;
 mod morkrut_ashaya_self_sacrifice;

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -2,10 +2,14 @@
 //! sacrifice cost.
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
-use engine::types::ability::TargetRef;
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, SacrificeCost, TargetFilter,
+    TargetRef, TypedFilter,
+};
 use engine::types::actions::GameAction;
 use engine::types::game_state::{PayCostKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
 
 const GOBLIN_BOMBARDMENT: &str =
@@ -132,5 +136,88 @@ fn goblin_bombardment_self_target_sacrifice_reaches_stack_and_fizzles() {
     assert!(
         runner.state().battlefield.contains(&fodder),
         "only the self-targeted Goblin was sacrificed"
+    );
+}
+
+#[test]
+fn target_first_sacrifice_parked_at_mana_payment_cannot_be_cancelled() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Mana-Gated Bombardment", 0, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Any,
+                    damage_source: None,
+                    excess: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Sacrifice(SacrificeCost::count(
+                        TargetFilter::Typed(TypedFilter::creature()),
+                        1,
+                    )),
+                    // CR 107.4e: Hybrid payment is a player decision, so this
+                    // forces the activation to remain at ManaPayment after the
+                    // preceding sacrifice has committed.
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::WhiteBlue],
+                            generic: 0,
+                        },
+                    },
+                ],
+            }),
+        )
+        .id();
+    let fodder = scenario.add_creature(P0, "Committed Fodder", 1, 1).id();
+    let target = scenario.add_creature(P1, "Mana-Gated Target", 1, 1).id();
+    scenario.add_creature_from_oracle(
+        P0,
+        "Cost Trigger Witness",
+        1,
+        1,
+        "Whenever another creature dies, draw a card.",
+    );
+    let mut runner = scenario.build();
+
+    activate(&mut runner, source);
+    choose_target(&mut runner, target);
+    sacrifice(&mut runner, fodder, target);
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment { .. }
+    ));
+    assert!(
+        !runner.state().battlefield.contains(&fodder),
+        "the sacrifice cost remains paid while mana payment is pending"
+    );
+    assert!(runner.state().stack.is_empty());
+    assert!(
+        runner.state().deferred_triggers.is_empty(),
+        "the death trigger must remain local to the uncommitted activation"
+    );
+
+    let error = runner
+        .act(GameAction::CancelCast)
+        .expect_err("a committed activation cost must reject cancellation");
+    assert!(error.to_string().contains("after a cost is paid"));
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment { .. }
+    ));
+    assert!(
+        !runner.state().battlefield.contains(&fodder),
+        "rejecting cancellation must not restore the paid sacrifice"
+    );
+    assert!(runner.state().stack.is_empty());
+    assert!(
+        runner.state().deferred_triggers.is_empty(),
+        "rejecting cancellation must neither leak nor duplicate the local trigger"
     );
 }

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -3,8 +3,8 @@
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, SacrificeCost, TargetFilter,
-    TargetRef, TypedFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, SacrificeCost,
+    TapCreaturesRequirement, TargetFilter, TargetRef, TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::game_state::{PayCostKind, WaitingFor};
@@ -89,7 +89,7 @@ fn goblin_bombardment_targets_before_sacrifice_and_cancel_is_lossless() {
     activate(&mut runner, bombardment);
     choose_target(&mut runner, target);
 
-    let WaitingFor::PayCost { kind, .. } = runner.state().waiting_for else {
+    let WaitingFor::PayCost { ref kind, .. } = runner.state().waiting_for else {
         panic!("target selection must lead to the sacrifice prompt");
     };
     assert_eq!(kind, PayCostKind::Sacrifice);
@@ -137,6 +137,50 @@ fn goblin_bombardment_self_target_sacrifice_reaches_stack_and_fizzles() {
         runner.state().battlefield.contains(&fodder),
         "only the self-targeted Goblin was sacrificed"
     );
+}
+
+#[test]
+fn targeted_activation_surfaces_tap_creatures_cost_after_target_selection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Targeted Tap Cost", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Any,
+                    damage_source: None,
+                    excess: None,
+                },
+            )
+            .cost(AbilityCost::TapCreatures {
+                requirement: TapCreaturesRequirement::count(1),
+                filter: TargetFilter::Typed(TypedFilter::creature()),
+            }),
+        )
+        .id();
+    let payment = scenario.add_creature(P0, "Tap Payment", 1, 1).id();
+    let target = scenario.add_creature(P1, "Tap Cost Target", 1, 1).id();
+    let mut runner = scenario.build();
+
+    activate(&mut runner, source);
+    choose_target(&mut runner, target);
+
+    let WaitingFor::PayCost { kind, choices, .. } = runner.state().waiting_for.clone() else {
+        panic!("target declaration must surface the tap-creatures cost");
+    };
+    assert_eq!(kind, PayCostKind::TapCreatures { aggregate: None });
+    assert!(choices.contains(&payment));
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![payment],
+        })
+        .expect("paying the selected tap-creatures cost must succeed");
+    assert!(runner.state().objects[&payment].tapped);
+    assert_eq!(runner.state().stack.len(), 1);
 }
 
 #[test]

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -5,7 +5,7 @@ use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, BeholdCostAction, CounterCostSelection, Effect,
     QuantityExpr, ReplacementDefinition, SacrificeCost, TapCreaturesRequirement, TargetFilter,
-    TargetRef, TypedFilter, REMOVE_COUNTER_COST_X,
+    TargetRef, TypeFilter, TypedFilter, REMOVE_COUNTER_COST_X,
 };
 use engine::types::actions::GameAction;
 use engine::types::counter::{CounterMatch, CounterType};
@@ -304,7 +304,7 @@ fn target_first_mana_then_targeted_x_counter_cost_binds_x_before_payment_choice(
                     AbilityCost::RemoveCounter {
                         count: REMOVE_COUNTER_COST_X,
                         counter_type: CounterMatch::OfType(charge.clone()),
-                        target: Some(TargetFilter::Typed(TypedFilter::artifact())),
+                        target: Some(TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact))),
                         selection: CounterCostSelection::SingleObject,
                     },
                 ],

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -187,7 +187,7 @@ fn targeted_activation_surfaces_tap_creatures_cost_after_target_selection() {
 }
 
 #[test]
-fn target_first_sacrifice_parked_at_mana_payment_cannot_be_cancelled() {
+fn target_first_mana_payment_precedes_sacrifice_and_can_be_cancelled() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let source = scenario
@@ -209,8 +209,8 @@ fn target_first_sacrifice_parked_at_mana_payment_cannot_be_cancelled() {
                         1,
                     )),
                     // CR 107.4e: Hybrid payment is a player decision, so this
-                    // forces the activation to remain at ManaPayment after the
-                    // preceding sacrifice has committed.
+                    // keeps the activation at ManaPayment before any later
+                    // non-mana cost is paid.
                     AbilityCost::Mana {
                         cost: ManaCost::Cost {
                             shards: vec![ManaCostShard::WhiteBlue],
@@ -234,33 +234,31 @@ fn target_first_sacrifice_parked_at_mana_payment_cannot_be_cancelled() {
 
     activate(&mut runner, source);
     choose_target(&mut runner, target);
-    sacrifice(&mut runner, fodder, target);
 
     assert!(matches!(
         runner.state().waiting_for,
         WaitingFor::ManaPayment { .. }
     ));
     assert!(
-        !runner.state().battlefield.contains(&fodder),
-        "the sacrifice cost remains paid while mana payment is pending"
+        runner.state().battlefield.contains(&fodder),
+        "the sacrifice cost is not paid before the mana-payment step"
     );
     assert!(runner.state().stack.is_empty());
     assert!(
         runner.state().deferred_triggers.is_empty(),
-        "the death trigger must remain local until the activation reaches the stack"
+        "no death trigger exists before the sacrifice cost is paid"
     );
 
-    let error = runner
+    runner
         .act(GameAction::CancelCast)
-        .expect_err("a committed activation cost must reject cancellation");
-    assert!(error.to_string().contains("after a cost is paid"));
+        .expect("an activation may be cancelled before any cost has been paid");
     assert!(matches!(
         runner.state().waiting_for,
-        WaitingFor::ManaPayment { .. }
+        WaitingFor::Priority { .. }
     ));
     assert!(
-        !runner.state().battlefield.contains(&fodder),
-        "rejecting cancellation must not restore the paid sacrifice"
+        runner.state().battlefield.contains(&fodder),
+        "cancelling before payment must preserve the sacrifice fodder"
     );
     assert!(runner.state().stack.is_empty());
     assert!(

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -3,14 +3,17 @@
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, Effect, QuantityExpr, SacrificeCost,
-    TapCreaturesRequirement, TargetFilter, TargetRef, TypedFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, BeholdCostAction, Effect, QuantityExpr,
+    ReplacementDefinition, SacrificeCost, TapCreaturesRequirement, TargetFilter, TargetRef,
+    TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::game_state::{PayCostKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::{EtbTapState, Zone};
 
 const GOBLIN_BOMBARDMENT: &str =
     "Sacrifice a creature: This enchantment deals 1 damage to any target.";
@@ -264,4 +267,184 @@ fn target_first_sacrifice_parked_at_mana_payment_cannot_be_cancelled() {
         runner.state().deferred_triggers.is_empty(),
         "rejecting cancellation must neither leak nor duplicate the local trigger"
     );
+}
+
+fn targeted_damage_cost_ability(cost: AbilityCost) -> AbilityDefinition {
+    AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::DealDamage {
+            amount: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Any,
+            damage_source: None,
+            excess: None,
+        },
+    )
+    .cost(cost)
+}
+
+#[test]
+fn targeted_activation_surfaces_blight_cost_after_target_selection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Targeted Blight Cost", 1, 1)
+        .with_ability_definition(targeted_damage_cost_ability(AbilityCost::Blight {
+            count: 1,
+        }))
+        .id();
+    let blighted = scenario.add_creature(P0, "Blight Payment", 1, 1).id();
+    let target = scenario.add_creature(P1, "Blight Cost Target", 1, 1).id();
+    let mut runner = scenario.build();
+
+    activate(&mut runner, source);
+    choose_target(&mut runner, target);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::BlightChoice { .. }
+    ));
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![blighted],
+        })
+        .expect("paying the target-first blight cost must succeed");
+    assert_eq!(runner.state().stack.len(), 1);
+    assert_eq!(
+        runner.state().objects[&blighted]
+            .counters
+            .get(&engine::types::counter::CounterType::Minus1Minus1),
+        Some(&1),
+    );
+}
+
+#[test]
+fn targeted_activation_surfaces_reveal_cost_after_target_selection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Targeted Reveal Cost", 1, 1)
+        .with_ability_definition(targeted_damage_cost_ability(AbilityCost::Reveal {
+            count: 1,
+            filter: Some(TargetFilter::Typed(TypedFilter::creature())),
+        }))
+        .id();
+    let revealed = scenario
+        .add_creature_to_hand(P0, "Reveal Payment", 1, 1)
+        .id();
+    let target = scenario.add_creature(P1, "Reveal Cost Target", 1, 1).id();
+    let mut runner = scenario.build();
+
+    activate(&mut runner, source);
+    choose_target(&mut runner, target);
+    let WaitingFor::PayCost { kind, choices, .. } = runner.state().waiting_for.clone() else {
+        panic!("target declaration must surface the reveal cost");
+    };
+    assert_eq!(kind, PayCostKind::Reveal);
+    assert!(choices.contains(&revealed));
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![revealed],
+        })
+        .expect("revealing the target-first activation payment must succeed");
+    assert_eq!(runner.state().stack.len(), 1);
+}
+
+#[test]
+fn targeted_activation_surfaces_behold_cost_after_target_selection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Targeted Behold Cost", 1, 1)
+        .with_ability_definition(targeted_damage_cost_ability(AbilityCost::Behold {
+            count: 1,
+            filter: TargetFilter::Typed(TypedFilter::creature()),
+            action: BeholdCostAction::ChooseOrReveal,
+            type_choice: None,
+        }))
+        .id();
+    let behold = scenario.add_creature(P0, "Behold Payment", 1, 1).id();
+    let target = scenario.add_creature(P1, "Behold Cost Target", 1, 1).id();
+    let mut runner = scenario.build();
+
+    activate(&mut runner, source);
+    choose_target(&mut runner, target);
+    let WaitingFor::PayCost { kind, choices, .. } = runner.state().waiting_for.clone() else {
+        panic!("target declaration must surface the behold cost");
+    };
+    assert_eq!(
+        kind,
+        PayCostKind::Behold {
+            action: BeholdCostAction::ChooseOrReveal,
+        }
+    );
+    assert!(choices.contains(&behold));
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![behold],
+        })
+        .expect("beholding the target-first activation payment must succeed");
+    assert_eq!(runner.state().stack.len(), 1);
+}
+
+fn graveyard_exile_replacement(label: &str) -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(Zone::Graveyard)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                origin: None,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        ))
+        .description(label.to_string())
+}
+
+#[test]
+fn target_first_mill_cost_resumes_after_replacement_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Targeted Mill Cost", 1, 1)
+        .with_ability_definition(targeted_damage_cost_ability(AbilityCost::Mill { count: 1 }))
+        .id();
+    let target = scenario.add_creature(P1, "Mill Cost Target", 1, 1).id();
+    let milled = scenario.add_card_to_library_top(P0, "Mill Payment Card");
+    for label in ["Mill Redirect One", "Mill Redirect Two"] {
+        scenario
+            .add_creature(P0, label, 0, 0)
+            .as_enchantment()
+            .with_replacement_definition(graveyard_exile_replacement(label));
+    }
+    let mut runner = scenario.build();
+
+    activate(&mut runner, source);
+    choose_target(&mut runner, target);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    runner
+        .act(GameAction::ChooseReplacement { index: 0 })
+        .expect("choosing the mill redirect must resume the target-first activation");
+
+    assert_eq!(runner.state().objects[&milled].zone, Zone::Exile);
+    assert_eq!(runner.state().stack.len(), 1);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
 }

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -290,7 +290,9 @@ fn targeted_activation_surfaces_blight_cost_after_target_selection() {
             count: 1,
         }))
         .id();
-    let blighted = scenario.add_creature(P0, "Blight Payment", 1, 1).id();
+    // Keep the payment creature alive after the -1/-1 counter so this test
+    // observes the paid cost rather than its later state-based-action cleanup.
+    let blighted = scenario.add_creature(P0, "Blight Payment", 2, 2).id();
     let target = scenario.add_creature(P1, "Blight Cost Target", 1, 1).id();
     let mut runner = scenario.build();
 

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -73,7 +73,7 @@ fn sacrifice(runner: &mut GameRunner, permanent: ObjectId, selected_target: Obje
             runner.state().waiting_for
         );
     };
-    assert_eq!(kind, PayCostKind::Sacrifice);
+    assert_eq!(kind, &PayCostKind::Sacrifice);
     assert!(choices.contains(&permanent));
     assert!(
         runner.state().battlefield.contains(&selected_target),

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -3,14 +3,15 @@
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, BeholdCostAction, Effect, QuantityExpr,
-    ReplacementDefinition, SacrificeCost, TapCreaturesRequirement, TargetFilter, TargetRef,
-    TypedFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, BeholdCostAction, CounterCostSelection, Effect,
+    QuantityExpr, ReplacementDefinition, SacrificeCost, TapCreaturesRequirement, TargetFilter,
+    TargetRef, TypedFilter, REMOVE_COUNTER_COST_X,
 };
 use engine::types::actions::GameAction;
+use engine::types::counter::{CounterMatch, CounterType};
 use engine::types::game_state::{PayCostKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
-use engine::types::mana::{ManaCost, ManaCostShard};
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::replacements::ReplacementEvent;
 use engine::types::zones::{EtbTapState, Zone};
@@ -265,6 +266,125 @@ fn target_first_mana_payment_precedes_sacrifice_and_can_be_cancelled() {
         runner.state().deferred_triggers.is_empty(),
         "rejecting cancellation must neither leak nor duplicate the local trigger"
     );
+}
+
+/// CR 601.2c + CR 601.2g-h + CR 602.2b: an activation with an ordinary mana
+/// leg and a targeted symbolic remove-X-counters cost must lock its effect
+/// target, pay mana, then bind X before it asks which permanent pays counters.
+///
+/// The separate target and counter-source objects make this discriminate the
+/// post-mana continuation: surfacing the symbolic residual directly either
+/// exposes the wrong count or bypasses the counter-source choice entirely.
+#[test]
+fn target_first_mana_then_targeted_x_counter_cost_binds_x_before_payment_choice() {
+    let charge = CounterType::Generic("charge".to_string());
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Mana and Counter Battery", 1, 1)
+        .with_ability_definition(
+            AbilityDefinition::new(
+                AbilityKind::Activated,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Ref {
+                        qty: engine::types::ability::QuantityRef::Variable {
+                            name: "X".to_string(),
+                        },
+                    },
+                    target: TargetFilter::Any,
+                    damage_source: None,
+                    excess: None,
+                },
+            )
+            .cost(AbilityCost::Composite {
+                costs: vec![
+                    AbilityCost::Mana {
+                        cost: ManaCost::generic(1),
+                    },
+                    AbilityCost::RemoveCounter {
+                        count: REMOVE_COUNTER_COST_X,
+                        counter_type: CounterMatch::OfType(charge.clone()),
+                        target: Some(TargetFilter::Typed(TypedFilter::artifact())),
+                        selection: CounterCostSelection::SingleObject,
+                    },
+                ],
+            }),
+        )
+        .id();
+    let counter_source = scenario
+        .add_creature(P0, "Charge Battery", 1, 1)
+        .as_artifact()
+        .id();
+    let target = scenario.add_creature(P1, "Damage Target", 3, 3).id();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(91_001),
+            false,
+            vec![],
+        )],
+    );
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&counter_source)
+        .expect("counter source exists")
+        .counters
+        .insert(charge.clone(), 2);
+
+    activate(&mut runner, source);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ChooseXValue { .. }
+    ));
+    runner
+        .act(GameAction::ChooseX { value: 2 })
+        .expect("X announcement must resume target selection");
+    choose_target(&mut runner, target);
+
+    let WaitingFor::PayCost {
+        kind,
+        choices,
+        count,
+        ..
+    } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "mana payment must resume at the concrete counter-cost choice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(
+        kind,
+        PayCostKind::RemoveCounter {
+            counter_type: CounterMatch::OfType(charge.clone()),
+            count: 2,
+            selection: CounterCostSelection::SingleObject,
+        }
+    );
+    assert_eq!(count, 1, "one counter source must be selected");
+    assert!(choices.contains(&counter_source));
+    assert!(
+        runner.state().battlefield.contains(&target),
+        "the effect target remains declared while the counter source is chosen"
+    );
+    assert!(runner.state().stack.is_empty());
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![counter_source],
+        })
+        .expect("selecting the counter source must pay the bound X cost");
+    assert_eq!(
+        runner.state().objects[&counter_source]
+            .counters
+            .get(&charge),
+        None,
+        "the selected source pays exactly the announced two counters"
+    );
+    assert_eq!(runner.state().stack.len(), 1);
 }
 
 fn targeted_damage_cost_ability(cost: AbilityCost) -> AbilityDefinition {

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -1,5 +1,5 @@
-//! CR 602.2b / CR 601.2c-h — target-bearing sacrifice activations announce
-//! their target before paying the sacrifice cost.
+//! CR 602.2b / CR 601.2c-h — Goblin Bombardment chooses targets before its
+//! sacrifice cost.
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::ability::TargetRef;
@@ -7,34 +7,35 @@ use engine::types::actions::GameAction;
 use engine::types::game_state::{PayCostKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::phase::Phase;
-use engine::types::zones::Zone;
 
-const MOGG_FANATIC: &str = "Sacrifice this creature: It deals 1 damage to any target.";
+const GOBLIN_BOMBARDMENT: &str =
+    "Sacrifice a creature: This enchantment deals 1 damage to any target.";
 
-fn setup() -> (GameRunner, ObjectId, ObjectId) {
+fn setup() -> (GameRunner, ObjectId, ObjectId, ObjectId, ObjectId) {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
-    let fanatic = scenario
-        .add_creature_from_oracle(P0, "Mogg Fanatic", 1, 1, MOGG_FANATIC)
+    let bombardment = scenario
+        .add_creature(P0, "Goblin Bombardment", 0, 0)
+        .as_enchantment()
+        .from_oracle_text(GOBLIN_BOMBARDMENT)
         .id();
-    let target = scenario.add_creature(P1, "Goblin Token", 1, 1).id();
+    let fodder = scenario.add_creature(P0, "Sacrifice Goblin", 1, 1).id();
+    let target = scenario.add_creature(P1, "Target Goblin", 1, 1).id();
+    let self_target = scenario.add_creature(P0, "Self-Target Goblin", 1, 1).id();
     let mut runner = scenario.build();
-    runner
-        .state_mut()
-        .objects
-        .get_mut(&target)
-        .unwrap()
-        .is_token = true;
-    (runner, fanatic, target)
+    for token in [fodder, target, self_target] {
+        runner.state_mut().objects.get_mut(&token).unwrap().is_token = true;
+    }
+    (runner, bombardment, fodder, target, self_target)
 }
 
-fn activate(runner: &mut GameRunner, fanatic: ObjectId) {
+fn activate(runner: &mut GameRunner, bombardment: ObjectId) {
     runner
         .act(GameAction::ActivateAbility {
-            source_id: fanatic,
+            source_id: bombardment,
             ability_index: 0,
         })
-        .expect("Mogg Fanatic activation must enter target selection");
+        .expect("Goblin Bombardment activation must enter target selection");
 }
 
 fn choose_target(runner: &mut GameRunner, target: ObjectId) {
@@ -49,7 +50,7 @@ fn choose_target(runner: &mut GameRunner, target: ObjectId) {
         target_slots[0]
             .legal_targets
             .contains(&TargetRef::Object(target)),
-        "the Goblin token must be targetable before Mogg Fanatic is sacrificed"
+        "the selected Goblin must be targetable before the sacrifice cost"
     );
     runner
         .act(GameAction::SelectTargets {
@@ -58,7 +59,7 @@ fn choose_target(runner: &mut GameRunner, target: ObjectId) {
         .expect("selecting the target must succeed");
 }
 
-fn sacrifice_fanatic(runner: &mut GameRunner, fanatic: ObjectId) {
+fn sacrifice(runner: &mut GameRunner, permanent: ObjectId, selected_target: ObjectId) {
     let WaitingFor::PayCost { kind, choices, .. } = runner.state().waiting_for.clone() else {
         panic!(
             "expected sacrifice cost, got {:?}",
@@ -66,54 +67,70 @@ fn sacrifice_fanatic(runner: &mut GameRunner, fanatic: ObjectId) {
         );
     };
     assert_eq!(kind, PayCostKind::Sacrifice);
-    assert!(choices.contains(&fanatic));
+    assert!(choices.contains(&permanent));
+    assert!(
+        runner.state().battlefield.contains(&selected_target),
+        "the declared target must stay on the battlefield until the sacrifice is paid"
+    );
     runner
         .act(GameAction::SelectCards {
-            cards: vec![fanatic],
+            cards: vec![permanent],
         })
-        .expect("sacrificing Mogg Fanatic must succeed");
+        .expect("sacrificing the chosen Goblin must succeed");
 }
 
 #[test]
-fn mogg_fanatic_target_selection_precedes_sacrifice_and_cancel_is_lossless() {
-    let (mut runner, fanatic, target) = setup();
-    activate(&mut runner, fanatic);
-
-    assert!(
-        runner.state().battlefield.contains(&fanatic),
-        "the sacrifice cost cannot be paid before target selection"
-    );
+fn goblin_bombardment_targets_before_sacrifice_and_cancel_is_lossless() {
+    let (mut runner, bombardment, fodder, target, _) = setup();
+    activate(&mut runner, bombardment);
     choose_target(&mut runner, target);
-    sacrifice_fanatic(&mut runner, fanatic);
 
-    assert_eq!(runner.state().objects[&fanatic].zone, Zone::Graveyard);
+    let WaitingFor::PayCost { kind, .. } = runner.state().waiting_for else {
+        panic!("target selection must lead to the sacrifice prompt");
+    };
+    assert_eq!(kind, PayCostKind::Sacrifice);
+    assert!(runner.state().battlefield.contains(&target));
+    runner
+        .act(GameAction::CancelCast)
+        .expect("the pending sacrifice payment must be cancelable");
+    assert!(runner.state().stack.is_empty());
+    assert!(runner.state().battlefield.contains(&bombardment));
+    assert!(runner.state().battlefield.contains(&fodder));
+    assert!(runner.state().battlefield.contains(&target));
+    assert!(runner.state().deferred_triggers.is_empty());
+
+    let (mut runner, bombardment, fodder, target, _) = setup();
+    activate(&mut runner, bombardment);
+    choose_target(&mut runner, target);
+    sacrifice(&mut runner, fodder, target);
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "the activation reaches the stack"
+    );
     runner.advance_until_stack_empty();
     assert!(
         !runner.state().battlefield.contains(&target),
-        "the announced Goblin token must take the activation's damage"
+        "the untargeted sacrifice must not invalidate the selected Goblin"
     );
-
-    let (mut runner, fanatic, target) = setup();
-    activate(&mut runner, fanatic);
-    runner
-        .act(GameAction::CancelCast)
-        .expect("target selection must be cancelable");
-    assert!(runner.state().battlefield.contains(&fanatic));
-    assert!(runner.state().battlefield.contains(&target));
-    assert!(runner.state().stack.is_empty());
 }
 
 #[test]
-fn mogg_fanatic_self_target_fizzles_after_its_sacrifice_cost() {
-    let (mut runner, fanatic, _target) = setup();
-    activate(&mut runner, fanatic);
-    choose_target(&mut runner, fanatic);
-    sacrifice_fanatic(&mut runner, fanatic);
+fn goblin_bombardment_self_target_sacrifice_reaches_stack_and_fizzles() {
+    let (mut runner, bombardment, fodder, _, self_target) = setup();
+    activate(&mut runner, bombardment);
+    choose_target(&mut runner, self_target);
+    sacrifice(&mut runner, self_target, self_target);
 
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "the activation reaches the stack"
+    );
     runner.advance_until_stack_empty();
-    assert_eq!(runner.state().objects[&fanatic].zone, Zone::Graveyard);
+    assert!(runner.state().stack.is_empty());
     assert!(
-        runner.state().stack.is_empty(),
-        "the ability must leave the stack after its only target became illegal"
+        runner.state().battlefield.contains(&fodder),
+        "only the self-targeted Goblin was sacrificed"
     );
 }

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -200,7 +200,7 @@ fn target_first_sacrifice_parked_at_mana_payment_cannot_be_cancelled() {
     assert!(runner.state().stack.is_empty());
     assert!(
         runner.state().deferred_triggers.is_empty(),
-        "the death trigger must remain local to the uncommitted activation"
+        "the death trigger must remain local until the activation reaches the stack"
     );
 
     let error = runner

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -73,7 +73,7 @@ fn sacrifice(runner: &mut GameRunner, permanent: ObjectId, selected_target: Obje
             runner.state().waiting_for
         );
     };
-    assert_eq!(kind, &PayCostKind::Sacrifice);
+    assert_eq!(kind, PayCostKind::Sacrifice);
     assert!(choices.contains(&permanent));
     assert!(
         runner.state().battlefield.contains(&selected_target),
@@ -95,7 +95,7 @@ fn goblin_bombardment_targets_before_sacrifice_and_cancel_is_lossless() {
     let WaitingFor::PayCost { ref kind, .. } = runner.state().waiting_for else {
         panic!("target selection must lead to the sacrifice prompt");
     };
-    assert_eq!(kind, PayCostKind::Sacrifice);
+    assert_eq!(kind, &PayCostKind::Sacrifice);
     assert!(runner.state().battlefield.contains(&target));
     runner
         .act(GameAction::CancelCast)

--- a/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
+++ b/crates/engine/tests/integration/mogg_fanatic_target_before_cost.rs
@@ -1,0 +1,119 @@
+//! CR 602.2b / CR 601.2c-h — target-bearing sacrifice activations announce
+//! their target before paying the sacrifice cost.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{PayCostKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const MOGG_FANATIC: &str = "Sacrifice this creature: It deals 1 damage to any target.";
+
+fn setup() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let fanatic = scenario
+        .add_creature_from_oracle(P0, "Mogg Fanatic", 1, 1, MOGG_FANATIC)
+        .id();
+    let target = scenario.add_creature(P1, "Goblin Token", 1, 1).id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&target)
+        .unwrap()
+        .is_token = true;
+    (runner, fanatic, target)
+}
+
+fn activate(runner: &mut GameRunner, fanatic: ObjectId) {
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: fanatic,
+            ability_index: 0,
+        })
+        .expect("Mogg Fanatic activation must enter target selection");
+}
+
+fn choose_target(runner: &mut GameRunner, target: ObjectId) {
+    let WaitingFor::TargetSelection { target_slots, .. } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "expected target selection, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert!(
+        target_slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(target)),
+        "the Goblin token must be targetable before Mogg Fanatic is sacrificed"
+    );
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(target)],
+        })
+        .expect("selecting the target must succeed");
+}
+
+fn sacrifice_fanatic(runner: &mut GameRunner, fanatic: ObjectId) {
+    let WaitingFor::PayCost { kind, choices, .. } = runner.state().waiting_for.clone() else {
+        panic!(
+            "expected sacrifice cost, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(kind, PayCostKind::Sacrifice);
+    assert!(choices.contains(&fanatic));
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![fanatic],
+        })
+        .expect("sacrificing Mogg Fanatic must succeed");
+}
+
+#[test]
+fn mogg_fanatic_target_selection_precedes_sacrifice_and_cancel_is_lossless() {
+    let (mut runner, fanatic, target) = setup();
+    activate(&mut runner, fanatic);
+
+    assert!(
+        runner.state().battlefield.contains(&fanatic),
+        "the sacrifice cost cannot be paid before target selection"
+    );
+    choose_target(&mut runner, target);
+    sacrifice_fanatic(&mut runner, fanatic);
+
+    assert_eq!(runner.state().objects[&fanatic].zone, Zone::Graveyard);
+    runner.advance_until_stack_empty();
+    assert!(
+        !runner.state().battlefield.contains(&target),
+        "the announced Goblin token must take the activation's damage"
+    );
+
+    let (mut runner, fanatic, target) = setup();
+    activate(&mut runner, fanatic);
+    runner
+        .act(GameAction::CancelCast)
+        .expect("target selection must be cancelable");
+    assert!(runner.state().battlefield.contains(&fanatic));
+    assert!(runner.state().battlefield.contains(&target));
+    assert!(runner.state().stack.is_empty());
+}
+
+#[test]
+fn mogg_fanatic_self_target_fizzles_after_its_sacrifice_cost() {
+    let (mut runner, fanatic, _target) = setup();
+    activate(&mut runner, fanatic);
+    choose_target(&mut runner, fanatic);
+    sacrifice_fanatic(&mut runner, fanatic);
+
+    runner.advance_until_stack_empty();
+    assert_eq!(runner.state().objects[&fanatic].zone, Zone::Graveyard);
+    assert!(
+        runner.state().stack.is_empty(),
+        "the ability must leave the stack after its only target became illegal"
+    );
+}


### PR DESCRIPTION
- **refactor trigger collection source overlay**
- **extract trigger collection mutations**
- **journal pending activation trigger collection**
- **fix trigger collection journal lint**
- **make pending activation trigger journal durable**
- **route activated targets before sacrifice costs**
- **retain activation trigger transaction in pending casts**
- **stage target activation triggers before costs**
- **preserve pending activation trigger provenance**
- **fix activation cancellation after paid costs**
- **keep parked activation cost triggers local**
- **route direct activation roots through target selection**
- **update x activation target ordering regression**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activated abilities can declare targets before selected activation costs, improving target-first flow and modal/choice-based activations.
  * Added more precise handling for X-dependent activations, deferring target validation until X is chosen.
* **Bug Fixes**
  * Activation-trigger consequences are now collected exactly once and associated with the correct activation context.
  * Corrected “no effect targets” and loyalty/no-target gating so cost/payment prompts appear in the intended order.
  * Prevented cancelling an activation after an irreversible activation cost is paid.
* **Tests**
  * Updated and expanded regression and integration coverage for target-before-cost ordering, correct waiting states, and replacement-trigger timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->