### PR TITLE
fix(client): expose targetable attachments

### DIFF
--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -465,11 +465,15 @@ export const PermanentCard = memo(function PermanentCard({
     (s) => obj && s.gameState?.players?.find((p) => p.id === obj.controller)?.commander_color_identity,
   );
 
-  const openAttachmentFan = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
-    event.stopPropagation();
+  const showAttachmentFan = useCallback(() => {
     dismissPreview();
     setAttachmentFanHost(objectId);
   }, [dismissPreview, objectId, setAttachmentFanHost]);
+
+  const openAttachmentFan = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    showAttachmentFan();
+  }, [showAttachmentFan]);
 
   if (!obj) return null;
 
@@ -685,6 +689,12 @@ export const PermanentCard = memo(function PermanentCard({
       });
     } else if (isValidTarget) {
       dispatchAction({ type: "ChooseTarget", data: { target: { Object: objectId } } });
+    } else if (attachmentsActionable) {
+      // The host is not a legal choice, but one of its attachments is. Open
+      // the full-card chooser rather than requiring a precise click on an
+      // overlapping attachment peek. The fan derives every selectable card
+      // from the engine's current legal-target set.
+      showAttachmentFan();
     } else if (isActivatable) {
       const o = useGameStore.getState().gameState?.objects[objectId];
       // Read the engine-provided action list for this permanent — the mapping

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -14,6 +14,7 @@ import {
   buildPriorityWaitingFor,
   buildTargetSelectionProgress,
   buildTargetSelectionWaitingFor,
+  buildTriggerTargetSelectionWaitingFor,
 } from "../../../test/factories/gameStateFactory.ts";
 import { AttachmentFan } from "../AttachmentFan.tsx";
 import { BoardInteractionContext } from "../BoardInteractionContext.tsx";
@@ -528,6 +529,60 @@ describe("PermanentCard", () => {
 
     expect(container.querySelector('[data-object-id="2"]')).not.toBeNull();
     expect(container.querySelector('[data-object-id="4"]')).not.toBeNull();
+  });
+
+  it("opens the full attachment chooser when a host has a targetable attachment", () => {
+    // Regression: Rampaging Yao Guai can target Darksteel Plate while it is
+    // attached beside Skullclamp on Bastion Protector. The targetable Plate
+    // expands into only a narrow overlapping board peek, so clicking the host
+    // must expose the fan's full-size cards and let the engine-authorized
+    // target dispatch unambiguously.
+    const darksteelPlate = makeObject({
+      id: 4,
+      card_id: 400,
+      attached_to: { type: "Object", data: 1 },
+      attachments: [],
+      name: "Darksteel Plate",
+      power: null,
+      toughness: null,
+      base_power: null,
+      base_toughness: null,
+      card_types: { supertypes: [], core_types: ["Artifact"], subtypes: ["Equipment"] },
+      color: [],
+      base_color: [],
+    });
+    const gameState = makeState();
+    gameState.objects[1] = { ...gameState.objects[1], name: "Bastion Protector", attachments: [2, 4] };
+    gameState.objects[2] = { ...gameState.objects[2], name: "Skullclamp" };
+    gameState.objects[4] = darksteelPlate;
+    gameState.battlefield = [1, 2, 3, 4];
+    const waitingFor = buildTriggerTargetSelectionWaitingFor({
+      data: {
+        player: 0,
+        target_slots: [],
+        selection: buildTargetSelectionProgress({ current_legal_targets: [{ Object: 4 }] }),
+      },
+    });
+    gameState.waiting_for = waitingFor;
+    useGameStore.setState({ gameState, waitingFor });
+    useUiStore.setState({ attachmentFanHostId: null });
+
+    const { container } = renderPermanent(new Set([4]));
+    render(<AttachmentFan />);
+
+    fireEvent.click(container.querySelector('[data-object-id="1"]') as HTMLElement);
+
+    const fan = document.querySelector("[data-attachment-fan]");
+    expect(fan).not.toBeNull();
+    const darksteelCard = fan?.querySelector('[aria-label="Darksteel Plate"]') as HTMLElement;
+    expect(darksteelCard).not.toBeNull();
+
+    fireEvent.click(darksteelCard);
+
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: "ChooseTarget",
+      data: { target: { Object: 4 } },
+    });
   });
 
   it("auto-expands collapsed attachments when one is activatable (re-equip)", () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved attachment targeting on cards.
  - Clicking a card with actionable attachments now opens the attachment chooser, allowing users to select the intended attached card.
  - Selecting an attached card correctly proceeds with target selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->