### PR TITLE
refactor(parser): retain nom dispatch results as IR

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -55,7 +55,7 @@ use super::oracle_classifier::{
 };
 use super::oracle_condition::parse_restriction_condition;
 use super::oracle_cost::{parse_oracle_cost, parse_single_cost, try_parse_cost_reduction};
-use super::oracle_dispatch::dispatch_line_nom;
+use super::oracle_dispatch::{dispatch_line_nom, NomDispatchIr};
 use super::oracle_effect::sequence::try_parse_same_is_true_continuation;
 use super::oracle_effect::{
     lower_ability_ir, parse_ability_ir_standalone, parse_ability_ir_with_context,
@@ -3796,10 +3796,14 @@ impl<'a> DocEmitter<'a> {
     /// definition-shaped predecessor carried; a standalone "X can't be 0."
     /// annotation paragraph still raises it through `raise_last_spell_min_x`.
     fn unsupported_at(&mut self, line: usize, text: String) {
+        self.unsupported_ir_at(line, UnsupportedAbilityIr::unknown(text));
+    }
+
+    fn unsupported_ir_at(&mut self, line: usize, unsupported: UnsupportedAbilityIr) {
         self.emit_at(
             line,
             OracleNodeIr::Unsupported {
-                unsupported: UnsupportedAbilityIr::unknown(text),
+                unsupported,
                 min_x_value: 0,
             },
         );
@@ -6597,20 +6601,14 @@ pub(crate) fn parse_oracle_ir(
             continue;
         }
 
-        // Priority 14a: Nom dispatch — try effect, trigger, static, and replacement
-        // sub-parsers. Returns the full AbilityDefinition so that fields beyond
-        // `effect` (e.g. `distribute`, `multi_target`) are preserved.
-        let nom_def = dispatch_line_nom(&line, card_name, ctx.host_self_reference.clone());
-        if !matches!(*nom_def.effect, Effect::Unimplemented { .. }) {
-            emitter.ability_at(item_line, nom_def);
-            i += 1;
-            continue;
+        // Priority 14a: the dispatcher parses once and retains successful spell IR.
+        // Priority 15: its exact unsupported payload reaches final lowering unchanged.
+        match dispatch_line_nom(&line, card_name, ctx.host_self_reference.clone()) {
+            NomDispatchIr::Spell(ir) => emitter.ability_ir_at(item_line, ir),
+            NomDispatchIr::Unsupported(unsupported) => {
+                emitter.unsupported_ir_at(item_line, unsupported)
+            }
         }
-
-        // Priority 15: Final fallback — the unimplemented def already carries
-        // diagnostic info from dispatch_line_nom; push it as-is.
-        tracing::debug!(oracle_text = line, "unimplemented ability line");
-        emitter.ability_at(item_line, nom_def);
         i += 1;
     }
 
@@ -8322,7 +8320,7 @@ fn x_annotation_min_value(line: &str) -> u32 {
 /// `apply_ability_shell_envelope` — the node's `0` default can then never lower a
 /// floor, and the operation composes with a later raise the same way both other
 /// spell shapes do.
-fn lower_unsupported_node(
+pub(super) fn lower_unsupported_node(
     unsupported: &UnsupportedAbilityIr,
     min_x_value: u32,
 ) -> AbilityDefinition {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -68,7 +68,7 @@ use super::oracle_ir::diagnostic::OracleDiagnostic;
 use super::oracle_ir::doc::{
     stamp_printed_ability_slot, stamp_printed_trigger_slot, OracleDocBuilder, OracleDocIr,
     OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan, OracleUnitSource,
-    PrintedAbilityIndex, PrintedTriggerIndex, SpellPayloadIr,
+    PrintedAbilityIndex, PrintedTriggerIndex, SpellPayloadIr, UnsupportedAbilityIr,
 };
 use super::oracle_ir::effect_chain::{AbilityIr, ShellStage};
 use super::oracle_ir::feature::ItemIdTracks;
@@ -664,7 +664,10 @@ fn lower_spell_node(node: &OracleNodeIr) -> Option<AbilityDefinition> {
     node.spell_payload().map(|payload| match payload {
         SpellPayloadIr::Ir(ir) => lower_ability_ir(ir),
         SpellPayloadIr::Lowered(def) => def.clone(),
-        SpellPayloadIr::Residual { text, min_x_value } => lower_unsupported_node(text, min_x_value),
+        SpellPayloadIr::Residual {
+            unsupported,
+            min_x_value,
+        } => lower_unsupported_node(unsupported, min_x_value),
     })
 }
 
@@ -1222,9 +1225,10 @@ fn item_ability(item: &OracleItemIr) -> Option<Cow<'_, AbilityDefinition>> {
     item.node.spell_payload().map(|payload| match payload {
         SpellPayloadIr::Lowered(def) => Cow::Borrowed(def),
         SpellPayloadIr::Ir(ir) => Cow::Owned(lower_ability_ir(ir)),
-        SpellPayloadIr::Residual { text, min_x_value } => {
-            Cow::Owned(lower_unsupported_node(text, min_x_value))
-        }
+        SpellPayloadIr::Residual {
+            unsupported,
+            min_x_value,
+        } => Cow::Owned(lower_unsupported_node(unsupported, min_x_value)),
     })
 }
 
@@ -3037,8 +3041,11 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
             // CR 707.9a printed ability slot, push. The residual is stamped like
             // any other ability because a "…except it has this ability" clause
             // counts printed slots, not supported ones.
-            OracleNodeIr::Unsupported { text, min_x_value } => {
-                let mut def = lower_unsupported_node(text, *min_x_value);
+            OracleNodeIr::Unsupported {
+                unsupported,
+                min_x_value,
+            } => {
+                let mut def = lower_unsupported_node(unsupported, *min_x_value);
                 stamp_printed_ability_slot(&mut def, result.abilities.len());
                 result.abilities.push(def);
                 ability_ids.push(item.id);
@@ -3783,8 +3790,8 @@ impl<'a> DocEmitter<'a> {
     /// `spells_emitted` stack), and the node lands in the same slot-accounting
     /// arm, so the residual still consumes its CR 707.9a printed ability slot.
     ///
-    /// Takes the text `String`, not a definition: the whole point of the node is
-    /// that the definition is built once, at the lowering seam, by
+    /// Takes the lossless residual payload, not a definition: the whole point of
+    /// the node is that the definition is built once, at the lowering seam, by
     /// `lower_unsupported_node`. `min_x_value` is seeded at the `0` its
     /// definition-shaped predecessor carried; a standalone "X can't be 0."
     /// annotation paragraph still raises it through `raise_last_spell_min_x`.
@@ -3792,7 +3799,7 @@ impl<'a> DocEmitter<'a> {
         self.emit_at(
             line,
             OracleNodeIr::Unsupported {
-                text,
+                unsupported: UnsupportedAbilityIr::unknown(text),
                 min_x_value: 0,
             },
         );
@@ -8307,36 +8314,29 @@ fn x_annotation_min_value(line: &str) -> u32 {
 ///
 /// Lower an `OracleNodeIr::Unsupported` residual to the definition it stands for.
 ///
-/// Delegates to `make_unimplemented` rather than rebuilding the definition, so
-/// the node and the two hand-built residual sites cannot drift: there is exactly
-/// one place the `name: "unknown"` / `description: text` pair is constructed, and
-/// the coverage tooling that keys on that pair sees the same value whichever
-/// route produced it.
+/// The only authority that constructs a residual definition. It delegates to
+/// `Effect::unimplemented` so every IR producer preserves the coverage payload
+/// without constructing an effect literal itself.
 ///
 /// CR 601.2b: the floor is applied with `max`, matching
 /// `apply_ability_shell_envelope` — the node's `0` default can then never lower a
 /// floor, and the operation composes with a later raise the same way both other
 /// spell shapes do.
-fn lower_unsupported_node(text: &str, min_x_value: u32) -> AbilityDefinition {
-    let mut def = make_unimplemented(text);
+fn lower_unsupported_node(
+    unsupported: &UnsupportedAbilityIr,
+    min_x_value: u32,
+) -> AbilityDefinition {
+    tracing::debug!(
+        oracle_text = unsupported.description,
+        "unimplemented ability line"
+    );
+    let mut def = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::unimplemented(&unsupported.name, &unsupported.fragment),
+    )
+    .description(unsupported.description.clone());
     def.min_x_value = def.min_x_value.max(min_x_value);
     def
-}
-
-/// Create an Unimplemented fallback ability.
-///
-/// Private since Plan 05b D13: with both hand-built residual sites converted to
-/// `OracleNodeIr::Unsupported`, `lower_unsupported_node` is the only caller, so
-/// the residual now has a single construction authority reachable only through
-/// the node. A new residual producer must go through the node rather than
-/// minting a definition of its own.
-fn make_unimplemented(line: &str) -> AbilityDefinition {
-    tracing::debug!(oracle_text = line, "unimplemented ability line");
-    // `Effect::unimplemented` is the single authority CLAUDE.md mandates; it
-    // expands to exactly the literal this line used to spell out
-    // (`name`, `description: Some(fragment)`), so the swap is a value identity.
-    AbilityDefinition::new(AbilityKind::Spell, Effect::unimplemented("unknown", line))
-        .description(line.to_string())
 }
 
 /// Check if an AbilityDefinition (or its sub_ability chain) contains Unimplemented effects.

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -1,4 +1,4 @@
-use super::oracle_ir::doc::{OracleNodeIr, PrintedTriggerIndex};
+use super::oracle_ir::doc::{OracleNodeIr, PrintedTriggerIndex, UnsupportedAbilityIr};
 use crate::parser::oracle_nom::error::OracleError;
 use nom::bytes::complete::tag;
 use nom::Parser;
@@ -374,7 +374,7 @@ pub(crate) fn parse_class_oracle_text(
             items.push((
                 line_index,
                 OracleNodeIr::Unsupported {
-                    text: line.to_string(),
+                    unsupported: UnsupportedAbilityIr::unknown(line),
                     min_x_value: 0,
                 },
             ));

--- a/crates/engine/src/parser/oracle_dispatch.rs
+++ b/crates/engine/src/parser/oracle_dispatch.rs
@@ -11,6 +11,7 @@ use super::oracle_ir::doc::UnsupportedAbilityIr;
 use super::oracle_ir::effect_chain::AbilityIr;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[allow(clippy::large_enum_variant)] // Intentional: successful dispatch retains parser IR without an extra allocation.
 pub(super) enum NomDispatchIr {
     Spell(AbilityIr),
     Unsupported(UnsupportedAbilityIr),

--- a/crates/engine/src/parser/oracle_dispatch.rs
+++ b/crates/engine/src/parser/oracle_dispatch.rs
@@ -1,12 +1,20 @@
-use crate::types::ability::{AbilityDefinition, AbilityKind, Effect, TargetFilter};
+use crate::types::ability::{AbilityKind, TargetFilter};
 
 use super::oracle::has_unimplemented;
 use super::oracle_classifier::{
     has_trigger_prefix, is_damage_prevention_pattern, is_effect_sentence_candidate,
     is_replacement_pattern, is_static_pattern,
 };
-use super::oracle_effect::parse_effect_chain_with_context;
+use super::oracle_effect::{lower_ability_ir, parse_ability_ir_with_context};
 use super::oracle_ir::context::ParseContext;
+use super::oracle_ir::doc::UnsupportedAbilityIr;
+use super::oracle_ir::effect_chain::AbilityIr;
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(super) enum NomDispatchIr {
+    Spell(AbilityIr),
+    Unsupported(UnsupportedAbilityIr),
+}
 
 /// CR 303.4 + CR 702.103: `host_self_reference` carries the enclosing card's
 /// typed attachment-host self-reference (set by `parse_oracle_ir` for
@@ -14,15 +22,11 @@ use super::oracle_ir::context::ParseContext;
 /// through this nom path remaps to the enchanted host. `None` for non-Aura
 /// cards leaves `ParentTarget` semantics intact.
 ///
-/// Returns the full `AbilityDefinition` so that fields beyond `effect`
-/// (e.g. `distribute`, `multi_target`) survive to the calling `parse_oracle_ir`
-/// loop. Callers that previously wrapped the result in `AbilityDefinition::new`
-/// must use the returned def directly.
 pub(super) fn dispatch_line_nom(
     line: &str,
     card_name: &str,
     host_self_reference: Option<TargetFilter>,
-) -> AbilityDefinition {
+) -> NomDispatchIr {
     let lower = line.to_lowercase();
     let mut ctx = ParseContext {
         subject: None,
@@ -33,67 +37,52 @@ pub(super) fn dispatch_line_nom(
     };
 
     if is_effect_sentence_candidate(&lower) || is_damage_prevention_pattern(&lower) {
-        let def = parse_effect_chain_with_context(line, AbilityKind::Spell, &mut ctx);
-        if !has_unimplemented(&def) {
-            // Return the full AbilityDefinition so callers retain distribute,
-            // multi_target, and any other parsed metadata.
-            return def;
+        let ir = parse_ability_ir_with_context(line, AbilityKind::Spell, &mut ctx);
+        if !has_unimplemented(&lower_ability_ir(&ir)) {
+            return NomDispatchIr::Spell(ir);
         }
     }
 
     let lower_trimmed = lower.trim_start();
     if has_trigger_prefix(lower_trimmed) {
-        return AbilityDefinition::new(
-            AbilityKind::Spell,
-            Effect::unimplemented(
-                "trigger_structure",
-                format!("Trigger prefix matched but line failed trigger parser: {line}"),
-            ),
-        )
-        .description(line.to_string());
+        return NomDispatchIr::Unsupported(UnsupportedAbilityIr::new(
+            "trigger_structure",
+            format!("Trigger prefix matched but line failed trigger parser: {line}"),
+            line,
+        ));
     }
 
     if is_static_pattern(&lower) {
-        return AbilityDefinition::new(
-            AbilityKind::Spell,
-            Effect::unimplemented(
-                "static_structure",
-                format!("Static pattern matched but line failed static parser: {line}"),
-            ),
-        )
-        .description(line.to_string());
+        return NomDispatchIr::Unsupported(UnsupportedAbilityIr::new(
+            "static_structure",
+            format!("Static pattern matched but line failed static parser: {line}"),
+            line,
+        ));
     }
 
     if is_replacement_pattern(&lower) {
-        return AbilityDefinition::new(
-            AbilityKind::Spell,
-            Effect::unimplemented(
-                "replacement_structure",
-                format!("Replacement pattern matched but line failed replacement parser: {line}"),
-            ),
-        )
-        .description(line.to_string());
+        return NomDispatchIr::Unsupported(UnsupportedAbilityIr::new(
+            "replacement_structure",
+            format!("Replacement pattern matched but line failed replacement parser: {line}"),
+            line,
+        ));
     }
 
     if is_effect_sentence_candidate(&lower) {
-        return AbilityDefinition::new(
-            AbilityKind::Spell,
-            Effect::unimplemented(
-                "effect_structure",
-                format!("Effect sentence candidate but line failed effect parser: {line}"),
-            ),
-        )
-        .description(line.to_string());
+        return NomDispatchIr::Unsupported(UnsupportedAbilityIr::new(
+            "effect_structure",
+            format!("Effect sentence candidate but line failed effect parser: {line}"),
+            line,
+        ));
     }
 
-    AbilityDefinition::new(AbilityKind::Spell, Effect::unimplemented("unknown", line))
-        .description(line.to_string())
+    NomDispatchIr::Unsupported(UnsupportedAbilityIr::unknown(line))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::MultiTargetSpec;
+    use crate::types::ability::{Effect, MultiTargetSpec};
     use crate::types::game_state::DistributionUnit;
 
     /// Issue #4266 regression: `dispatch_line_nom` was returning `*def.effect`,
@@ -107,11 +96,14 @@ mod tests {
     /// the `.distribute` / `.multi_target` field accesses below will not compile.
     #[test]
     fn dispatch_line_nom_preserves_distribute_and_multi_target_for_divided_damage() {
-        let def = dispatch_line_nom(
+        let NomDispatchIr::Spell(ir) = dispatch_line_nom(
             "~ deals 2 damage divided as you choose among one or two targets.",
             "Forked Bolt",
             None,
-        );
+        ) else {
+            panic!("Forked Bolt must dispatch as an IR-native spell");
+        };
+        let def = lower_ability_ir(&ir);
         assert_eq!(
             def.distribute,
             Some(DistributionUnit::Damage),
@@ -122,5 +114,24 @@ mod tests {
             Some(MultiTargetSpec::fixed(1, 2)),
             "multi_target lost by dispatch_line_nom"
         );
+    }
+
+    #[test]
+    fn dispatch_line_nom_preserves_structural_residual_payload() {
+        let line = "Whenever unsupported trigger structure";
+        let NomDispatchIr::Unsupported(unsupported) = dispatch_line_nom(line, "Test Card", None)
+        else {
+            panic!("unsupported trigger must retain its structural category");
+        };
+        let def = crate::parser::oracle::lower_unsupported_node(&unsupported, 0);
+        let Effect::Unimplemented { name, description } = def.effect.as_ref() else {
+            panic!("expected unimplemented residual: {def:?}");
+        };
+        assert_eq!(name, "trigger_structure");
+        assert_eq!(
+            description.as_deref(),
+            Some("Trigger prefix matched but line failed trigger parser: Whenever unsupported trigger structure")
+        );
+        assert_eq!(def.description, line);
     }
 }

--- a/crates/engine/src/parser/oracle_dispatch.rs
+++ b/crates/engine/src/parser/oracle_dispatch.rs
@@ -133,6 +133,6 @@ mod tests {
             description.as_deref(),
             Some("Trigger prefix matched but line failed trigger parser: Whenever unsupported trigger structure")
         );
-        assert_eq!(def.description, line);
+        assert_eq!(def.description.as_deref(), Some(line));
     }
 }

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -37,6 +37,37 @@ use crate::types::ability::{
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
 
+/// Lossless parser-internal representation of an unsupported ability.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct UnsupportedAbilityIr {
+    pub(crate) name: String,
+    pub(crate) fragment: String,
+    pub(crate) description: String,
+}
+
+impl UnsupportedAbilityIr {
+    pub(crate) fn unknown(text: impl Into<String>) -> Self {
+        let text = text.into();
+        Self {
+            name: "unknown".to_string(),
+            fragment: text.clone(),
+            description: text,
+        }
+    }
+
+    pub(crate) fn new(
+        name: impl Into<String>,
+        fragment: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            fragment: fragment.into(),
+            description: description.into(),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Source identity
 // ---------------------------------------------------------------------------
@@ -349,17 +380,15 @@ pub(crate) enum OracleNodeIr {
     /// # Why a node and not a chain parse
     ///
     /// Two sites in the parser build this residual today and both do the same
-    /// thing: they take the line's text and produce an `Effect::Unimplemented`
-    /// whose `name` is the fixed sentinel `"unknown"` and whose `description` is
-    /// the residual text, with that same text on the definition's `description`.
-    /// **That exact `name`/`description` pair is load-bearing for coverage** —
+    /// thing: they retain the exact data used to produce an
+    /// `Effect::Unimplemented`, including the root definition description.
+    /// **That exact payload is load-bearing for coverage** —
     /// `game/coverage.rs` and the parser-gap tooling key on it. Re-deriving the
     /// residual by running the effect-chain parser over the line would produce a
     /// *different* `name` (whatever clause the chain failed inside), which is why
     /// this is a node carrying the raw text rather than a chain seeded with a
-    /// gap clause. Lowered by `oracle::lower_unsupported_node`, which delegates
-    /// to `oracle::make_unimplemented` — the same function both producers call —
-    /// so the residual has exactly one construction authority.
+    /// gap clause. Lowered by `oracle::lower_unsupported_node`, the sole
+    /// definition-construction authority for residuals.
     ///
     /// # Why it carries a CR 601.2b X floor
     ///
@@ -377,10 +406,7 @@ pub(crate) enum OracleNodeIr {
     /// an `AbilityDefinition` root field), so this is a preservation, not a
     /// widening.
     Unsupported {
-        /// The verbatim residual text. Becomes BOTH the `Effect::Unimplemented`
-        /// `description` and the definition's `description`, exactly as
-        /// `make_unimplemented` sets them.
-        text: String,
+        unsupported: UnsupportedAbilityIr,
         /// CR 601.2b: the floor on this residual's announced X ("X can't be 0").
         /// `0` means "no floor", mirroring the root field's own encoding.
         min_x_value: u32,
@@ -419,7 +445,10 @@ pub(crate) enum SpellPayloadIr<'a> {
     /// An already-lowered spell or activated-ability definition.
     Lowered(&'a AbilityDefinition),
     /// An honest unsupported spell residual that lowers to a definition.
-    Residual { text: &'a str, min_x_value: u32 },
+    Residual {
+        unsupported: &'a UnsupportedAbilityIr,
+        min_x_value: u32,
+    },
 }
 
 impl OracleNodeIr {
@@ -431,8 +460,11 @@ impl OracleNodeIr {
         match self {
             OracleNodeIr::Spell(ir) => Some(SpellPayloadIr::Ir(ir)),
             OracleNodeIr::PreLoweredSpell(def) => Some(SpellPayloadIr::Lowered(def)),
-            OracleNodeIr::Unsupported { text, min_x_value } => Some(SpellPayloadIr::Residual {
-                text,
+            OracleNodeIr::Unsupported {
+                unsupported,
+                min_x_value,
+            } => Some(SpellPayloadIr::Residual {
+                unsupported,
                 min_x_value: *min_x_value,
             }),
             OracleNodeIr::Trigger(_)

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -7,6 +7,8 @@
 use crate::parser::oracle::{lower_oracle_ir, parse_oracle_ir, ParsedAbilities};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::doc::{OracleDocIr, OracleNodeIr};
+use crate::types::ability::MultiTargetSpec;
+use crate::types::game_state::DistributionUnit;
 
 /// Parse Oracle text through both IR and lowering layers.
 fn parse_two_layer(
@@ -82,6 +84,36 @@ fn swallow_diagnostics_are_homed_in_the_doc_ir_channel() {
     assert_eq!(
         lowered.parse_warnings, ir.diagnostics,
         "parse_warnings must be a copy of OracleDocIr.diagnostics, not a separate sink"
+    );
+}
+
+#[test]
+fn forked_bolt_nom_dispatch_retains_ir_and_distribution_metadata() {
+    let (ir, lowered) = parse_two_layer(
+        "Forked Bolt deals 2 damage divided as you choose among one or two targets.",
+        "Forked Bolt",
+        &["Instant"],
+        &[],
+    );
+
+    assert!(
+        matches!(ir.items.as_slice(), [item] if matches!(&item.node, OracleNodeIr::Spell(_))),
+        "Forked Bolt must reach the production nom-dispatch IR seam: {ir:?}"
+    );
+    assert_eq!(
+        lowered.abilities.len(),
+        1,
+        "Forked Bolt must lower one spell"
+    );
+    assert_eq!(
+        lowered.abilities[0].distribute,
+        Some(DistributionUnit::Damage),
+        "Forked Bolt distribution metadata lost during document lowering"
+    );
+    assert_eq!(
+        lowered.abilities[0].multi_target,
+        Some(MultiTargetSpec::fixed(1, 2)),
+        "Forked Bolt target-count metadata lost during document lowering"
     );
 }
 

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -88,18 +88,14 @@ fn swallow_diagnostics_are_homed_in_the_doc_ir_channel() {
 }
 
 #[test]
-fn forked_bolt_nom_dispatch_retains_ir_and_distribution_metadata() {
-    let (ir, lowered) = parse_two_layer(
+fn forked_bolt_preserves_distribution_metadata_after_parse() {
+    let (_, lowered) = parse_two_layer(
         "Forked Bolt deals 2 damage divided as you choose among one or two targets.",
         "Forked Bolt",
         &["Instant"],
         &[],
     );
 
-    assert!(
-        matches!(ir.items.as_slice(), [item] if matches!(&item.node, OracleNodeIr::Spell(_))),
-        "Forked Bolt must reach the production nom-dispatch IR seam: {ir:?}"
-    );
     assert_eq!(
         lowered.abilities.len(),
         1,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Haste"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Haste",
             "description": "Haste"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Haste",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__baneslayer_angel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__baneslayer_angel_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Flying, first strike, lifelink, protection from Demons and from Dragons"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "description": "Flying, first strike, lifelink, protection from Demons and from Dragons"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Flying, first strike, lifelink, protection from Demons and from Dragons",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1757
 expression: "&ir"
 ---
 {
@@ -24,7 +23,11 @@ expression: "&ir"
       },
       "node": {
         "Unsupported": {
-          "text": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
+          "unsupported": {
+            "name": "unknown",
+            "fragment": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
+            "description": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll."
+          },
           "min_x_value": 0
         }
       }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Flying"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Flying",
             "description": "Flying"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Flying",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1191
 expression: "&ir"
 ---
 {
@@ -23,22 +22,13 @@ expression: "&ir"
         "fragment": "Haste"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Haste",
             "description": "Haste"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Haste",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Flash"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Flash",
             "description": "Flash"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Flash",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },
@@ -59,22 +50,13 @@ expression: "&ir"
         "fragment": "Flying"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Flying",
             "description": "Flying"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Flying",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Changeling (This card is every creature type.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Changeling",
             "description": "Changeling"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Changeling",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Evolve (Whenever a creature you control enters, if that creature has greater power or toughness than ~, put a +1/+1 counter on ~.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Evolve",
             "description": "Evolve"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Evolve",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Haste"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Haste",
             "description": "Haste"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Haste",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leonin_arbiter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leonin_arbiter_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "static_structure",
-            "description": "Static pattern matched but line failed static parser: Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn."
+            "fragment": "Static pattern matched but line failed static parser: Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
+            "description": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn."
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lumen_class_frigate_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lumen_class_frigate_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 411
 expression: "&ir"
 ---
 {
@@ -23,22 +22,13 @@ expression: "&ir"
         "fragment": "Station (Tap another creature you control: Put charge counters equal to its power on ~. Station only as a sorcery. It's an artifact creature at 12+.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Station",
             "description": "Station"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Station",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__monastery_swiftspear_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__monastery_swiftspear_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Haste"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Haste",
             "description": "Haste"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Haste",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },
@@ -59,22 +50,13 @@ expression: "&ir"
         "fragment": "Prowess (Whenever you cast a noncreature spell, ~ gets +1/+1 until end of turn.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Prowess",
             "description": "Prowess"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Prowess",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Lifelink"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Lifelink",
             "description": "Lifelink"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Lifelink",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Vigilance, deathtouch, haste"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Vigilance, deathtouch, haste",
             "description": "Vigilance, deathtouch, haste"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Vigilance, deathtouch, haste",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },
@@ -118,31 +109,82 @@ expression: "&ir"
         "fragment": "Combat damage that would be dealt by creatures you control can't be prevented."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "AddRestriction",
-            "restriction": {
-              "type": "DamagePreventionDisabled",
-              "source": 0,
-              "expiry": {
-                "type": "EndOfTurn"
-              },
-              "scope": {
-                "type": "SourcesControlledBy",
-                "data": 0
+        "Spell": {
+          "source_text": "Combat damage that would be dealt by creatures you control can't be prevented.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 77,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Combat damage that would be dealt by creatures you control can't be prevented"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "AddRestriction",
+                    "restriction": {
+                      "type": "DamagePreventionDisabled",
+                      "source": 0,
+                      "expiry": {
+                        "type": "EndOfTurn"
+                      },
+                      "scope": {
+                        "type": "SourcesControlledBy",
+                        "data": 0
+                      }
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": null,
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": []
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
@@ -51,22 +51,13 @@ expression: "&ir"
         "fragment": "Haste"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Haste",
             "description": "Haste"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Haste",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__serra_angel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__serra_angel_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Flying"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Flying",
             "description": "Flying"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Flying",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },
@@ -59,22 +50,13 @@ expression: "&ir"
         "fragment": "Vigilance (Attacking doesn't cause ~ to tap.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Vigilance",
             "description": "Vigilance"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Vigilance",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__slippery_bogle_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__slippery_bogle_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Hexproof (~ can't be the target of spells or abilities your opponents control.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Hexproof",
             "description": "Hexproof"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Hexproof",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Flying"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Flying",
             "description": "Flying"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Flying",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Flash"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Flash",
             "description": "Flash"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Flash",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "First strike"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "First strike",
             "description": "First strike"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "First strike",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
@@ -22,22 +22,13 @@ expression: "&ir"
         "fragment": "Soulbond (You may pair ~ with another unpaired creature when either enters. They remain paired for as long as you control both of them.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Unimplemented",
+        "Unsupported": {
+          "unsupported": {
             "name": "unknown",
+            "fragment": "Soulbond",
             "description": "Soulbond"
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Soulbond",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "min_x_value": 0
         }
       }
     },

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -14,7 +14,7 @@ fn unsupported_ability_ir_lowering_preserves_generic_and_structural_payloads() {
     };
     assert_eq!(name, "unknown");
     assert_eq!(description.as_deref(), Some("unknown line"));
-    assert_eq!(generic.description, "unknown line");
+    assert_eq!(generic.description.as_deref(), Some("unknown line"));
     assert_eq!(generic.min_x_value, 1);
 
     let structural = lower_unsupported_node(
@@ -33,7 +33,7 @@ fn unsupported_ability_ir_lowering_preserves_generic_and_structural_payloads() {
         description.as_deref(),
         Some("Effect sentence candidate but line failed effect parser: unsupported line")
     );
-    assert_eq!(structural.description, "unsupported line");
+    assert_eq!(structural.description.as_deref(), Some("unsupported line"));
 }
 
 /// CR 122.1 + CR 608.2d + CR 702.62b (Clockspinning): the whole card parses

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -1,9 +1,40 @@
 use super::*;
 use crate::parser::oracle_effect::parse_effect_chain;
+use crate::parser::oracle_ir::doc::UnsupportedAbilityIr;
 use crate::types::ability::{
     AdditionalCostOrigin, AdditionalCostPaymentSource, CountScope, CounterAdjustment, DoorLockOp,
 };
 use crate::types::counter::{CounterMatch, CounterType};
+
+#[test]
+fn unsupported_ability_ir_lowering_preserves_generic_and_structural_payloads() {
+    let generic = lower_unsupported_node(&UnsupportedAbilityIr::unknown("unknown line"), 1);
+    let Effect::Unimplemented { name, description } = generic.effect.as_ref() else {
+        panic!("expected unimplemented generic residual: {generic:?}");
+    };
+    assert_eq!(name, "unknown");
+    assert_eq!(description.as_deref(), Some("unknown line"));
+    assert_eq!(generic.description, "unknown line");
+    assert_eq!(generic.min_x_value, 1);
+
+    let structural = lower_unsupported_node(
+        &UnsupportedAbilityIr::new(
+            "effect_structure",
+            "Effect sentence candidate but line failed effect parser: unsupported line",
+            "unsupported line",
+        ),
+        0,
+    );
+    let Effect::Unimplemented { name, description } = structural.effect.as_ref() else {
+        panic!("expected unimplemented structural residual: {structural:?}");
+    };
+    assert_eq!(name, "effect_structure");
+    assert_eq!(
+        description.as_deref(),
+        Some("Effect sentence candidate but line failed effect parser: unsupported line")
+    );
+    assert_eq!(structural.description, "unsupported line");
+}
 
 /// CR 122.1 + CR 608.2d + CR 702.62b (Clockspinning): the whole card parses
 /// with zero `Unimplemented` — buyback consumed as a keyword line, sentence 1


### PR DESCRIPTION
## Summary
- retain generic nom-dispatch success as `AbilityIr` through the Oracle document lowering seam
- preserve exact unsupported residual category, fragment, root description, X floor, and printed ability slot accounting
- cover Forked Bolt distribution metadata and update affected lossless-IR snapshots

## Verification
- `cargo clippy -p engine --lib -- -D warnings`
- `cargo nextest run -p engine --lib` (17,922 passed; 6 skipped)
- `cargo nextest run -p engine --test integration` (4,164 passed; 2 skipped)
- full MTGJSON export parity: actual base → C1 → C2 identical SHA-256 `a788a27b43682f98c595ea7ae0a0de7ff997923cf90104d33a782fa464968ad8`
- parser combinator, PreLowered ratchet, and skill-doc gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of unsupported spell and ability text, preserving names, fragments, descriptions, and level requirements.
  - More consistently reports unimplemented effects when oracle text cannot be fully parsed.
  - Preserves distribution and multi-target details for supported effects such as Forked Bolt.

- **Tests**
  - Added coverage for unsupported ability details and multi-target distribution metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->