### PR TITLE
fix(parser): preserve minimum X through nom dispatch

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3796,15 +3796,20 @@ impl<'a> DocEmitter<'a> {
     /// definition-shaped predecessor carried; a standalone "X can't be 0."
     /// annotation paragraph still raises it through `raise_last_spell_min_x`.
     fn unsupported_at(&mut self, line: usize, text: String) {
-        self.unsupported_ir_at(line, UnsupportedAbilityIr::unknown(text));
+        self.unsupported_ir_at(line, UnsupportedAbilityIr::unknown(text), 0);
     }
 
-    fn unsupported_ir_at(&mut self, line: usize, unsupported: UnsupportedAbilityIr) {
+    fn unsupported_ir_at(
+        &mut self,
+        line: usize,
+        unsupported: UnsupportedAbilityIr,
+        min_x_value: u32,
+    ) {
         self.emit_at(
             line,
             OracleNodeIr::Unsupported {
                 unsupported,
-                min_x_value: 0,
+                min_x_value,
             },
         );
     }
@@ -6604,9 +6609,12 @@ pub(crate) fn parse_oracle_ir(
         // Priority 14a: the dispatcher parses once and retains successful spell IR.
         // Priority 15: its exact unsupported payload reaches final lowering unchanged.
         match dispatch_line_nom(&line, card_name, ctx.host_self_reference.clone()) {
-            NomDispatchIr::Spell(ir) => emitter.ability_ir_at(item_line, ir),
+            NomDispatchIr::Spell(mut ir) => {
+                ir.shell.min_x_value = ir.shell.min_x_value.max(min_x_value);
+                emitter.ability_ir_at(item_line, ir);
+            }
             NomDispatchIr::Unsupported(unsupported) => {
-                emitter.unsupported_ir_at(item_line, unsupported)
+                emitter.unsupported_ir_at(item_line, unsupported, min_x_value)
             }
         }
         i += 1;
@@ -8330,7 +8338,7 @@ pub(super) fn lower_unsupported_node(
     );
     let mut def = AbilityDefinition::new(
         AbilityKind::Spell,
-        Effect::unimplemented(&unsupported.name, &unsupported.fragment),
+        Effect::unimplemented(unsupported.category.legacy_name(), &unsupported.fragment),
     )
     .description(unsupported.description.clone());
     def.min_x_value = def.min_x_value.max(min_x_value);

--- a/crates/engine/src/parser/oracle_dispatch.rs
+++ b/crates/engine/src/parser/oracle_dispatch.rs
@@ -7,7 +7,7 @@ use super::oracle_classifier::{
 };
 use super::oracle_effect::{lower_ability_ir, parse_ability_ir_with_context};
 use super::oracle_ir::context::ParseContext;
-use super::oracle_ir::doc::UnsupportedAbilityIr;
+use super::oracle_ir::doc::{UnsupportedAbilityCategory, UnsupportedAbilityIr};
 use super::oracle_ir::effect_chain::AbilityIr;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
@@ -47,7 +47,7 @@ pub(super) fn dispatch_line_nom(
     let lower_trimmed = lower.trim_start();
     if has_trigger_prefix(lower_trimmed) {
         return NomDispatchIr::Unsupported(UnsupportedAbilityIr::new(
-            "trigger_structure",
+            UnsupportedAbilityCategory::TriggerStructure,
             format!("Trigger prefix matched but line failed trigger parser: {line}"),
             line,
         ));
@@ -55,7 +55,7 @@ pub(super) fn dispatch_line_nom(
 
     if is_static_pattern(&lower) {
         return NomDispatchIr::Unsupported(UnsupportedAbilityIr::new(
-            "static_structure",
+            UnsupportedAbilityCategory::StaticStructure,
             format!("Static pattern matched but line failed static parser: {line}"),
             line,
         ));
@@ -63,7 +63,7 @@ pub(super) fn dispatch_line_nom(
 
     if is_replacement_pattern(&lower) {
         return NomDispatchIr::Unsupported(UnsupportedAbilityIr::new(
-            "replacement_structure",
+            UnsupportedAbilityCategory::ReplacementStructure,
             format!("Replacement pattern matched but line failed replacement parser: {line}"),
             line,
         ));
@@ -71,7 +71,7 @@ pub(super) fn dispatch_line_nom(
 
     if is_effect_sentence_candidate(&lower) {
         return NomDispatchIr::Unsupported(UnsupportedAbilityIr::new(
-            "effect_structure",
+            UnsupportedAbilityCategory::EffectStructure,
             format!("Effect sentence candidate but line failed effect parser: {line}"),
             line,
         ));
@@ -124,6 +124,10 @@ mod tests {
         else {
             panic!("unsupported trigger must retain its structural category");
         };
+        assert_eq!(
+            unsupported.category,
+            UnsupportedAbilityCategory::TriggerStructure
+        );
         let def = crate::parser::oracle::lower_unsupported_node(&unsupported, 0);
         let Effect::Unimplemented { name, description } = def.effect.as_ref() else {
             panic!("expected unimplemented residual: {def:?}");

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -37,10 +37,33 @@ use crate::types::ability::{
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;
 
+/// Closed category for an unsupported ability residual.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub(crate) enum UnsupportedAbilityCategory {
+    Unknown,
+    TriggerStructure,
+    StaticStructure,
+    ReplacementStructure,
+    EffectStructure,
+}
+
+impl UnsupportedAbilityCategory {
+    /// The stable coverage key emitted only when lowering to `Effect::Unimplemented`.
+    pub(crate) const fn legacy_name(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::TriggerStructure => "trigger_structure",
+            Self::StaticStructure => "static_structure",
+            Self::ReplacementStructure => "replacement_structure",
+            Self::EffectStructure => "effect_structure",
+        }
+    }
+}
+
 /// Lossless parser-internal representation of an unsupported ability.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub(crate) struct UnsupportedAbilityIr {
-    pub(crate) name: String,
+    pub(crate) category: UnsupportedAbilityCategory,
     pub(crate) fragment: String,
     pub(crate) description: String,
 }
@@ -49,19 +72,19 @@ impl UnsupportedAbilityIr {
     pub(crate) fn unknown(text: impl Into<String>) -> Self {
         let text = text.into();
         Self {
-            name: "unknown".to_string(),
+            category: UnsupportedAbilityCategory::Unknown,
             fragment: text.clone(),
             description: text,
         }
     }
 
     pub(crate) fn new(
-        name: impl Into<String>,
+        category: UnsupportedAbilityCategory,
         fragment: impl Into<String>,
         description: impl Into<String>,
     ) -> Self {
         Self {
-            name: name.into(),
+            category,
             fragment: fragment.into(),
             description: description.into(),
         }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Haste",
             "description": "Haste"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__baneslayer_angel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__baneslayer_angel_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Flying, first strike, lifelink, protection from Demons and from Dragons",
             "description": "Flying, first strike, lifelink, protection from Demons and from Dragons"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_class_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll.",
             "description": "If you would roll one or more dice, instead roll that many dice plus one and ignore the lowest roll."
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Flying",
             "description": "Flying"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Haste",
             "description": "Haste"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__brazen_borrower_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Flash",
             "description": "Flash"
           },
@@ -52,7 +52,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Flying",
             "description": "Flying"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__changeling_outcast_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Changeling",
             "description": "Changeling"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Evolve",
             "description": "Evolve"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Haste",
             "description": "Haste"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leonin_arbiter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__leonin_arbiter_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "static_structure",
+            "category": "StaticStructure",
             "fragment": "Static pattern matched but line failed static parser: Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn.",
             "description": "Players can't search libraries. Any player may pay {2} for that player to ignore this effect until end of turn."
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lumen_class_frigate_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__lumen_class_frigate_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Station",
             "description": "Station"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__monastery_swiftspear_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__monastery_swiftspear_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Haste",
             "description": "Haste"
           },
@@ -52,7 +52,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Prowess",
             "description": "Prowess"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Lifelink",
             "description": "Lifelink"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Vigilance, deathtouch, haste",
             "description": "Vigilance, deathtouch, haste"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
@@ -53,7 +53,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Haste",
             "description": "Haste"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__serra_angel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__serra_angel_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Flying",
             "description": "Flying"
           },
@@ -52,7 +52,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Vigilance",
             "description": "Vigilance"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__slippery_bogle_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__slippery_bogle_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Hexproof",
             "description": "Hexproof"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Flying",
             "description": "Flying"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Flash",
             "description": "Flash"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thalia_guardian_of_thraben_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "First strike",
             "description": "First strike"
           },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__wolfir_silverheart_ir.snap
@@ -24,7 +24,7 @@ expression: "&ir"
       "node": {
         "Unsupported": {
           "unsupported": {
-            "name": "unknown",
+            "category": "Unknown",
             "fragment": "Soulbond",
             "description": "Soulbond"
           },

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::parser::oracle_effect::parse_effect_chain;
-use crate::parser::oracle_ir::doc::UnsupportedAbilityIr;
+use crate::parser::oracle_ir::doc::{UnsupportedAbilityCategory, UnsupportedAbilityIr};
 use crate::types::ability::{
     AdditionalCostOrigin, AdditionalCostPaymentSource, CountScope, CounterAdjustment, DoorLockOp,
 };
@@ -19,7 +19,7 @@ fn unsupported_ability_ir_lowering_preserves_generic_and_structural_payloads() {
 
     let structural = lower_unsupported_node(
         &UnsupportedAbilityIr::new(
-            "effect_structure",
+            UnsupportedAbilityCategory::EffectStructure,
             "Effect sentence candidate but line failed effect parser: unsupported line",
             "unsupported line",
         ),
@@ -34,6 +34,41 @@ fn unsupported_ability_ir_lowering_preserves_generic_and_structural_payloads() {
         Some("Effect sentence candidate but line failed effect parser: unsupported line")
     );
     assert_eq!(structural.description.as_deref(), Some("unsupported line"));
+}
+
+#[test]
+fn nominal_dispatch_preserves_precomputed_x_floor_for_spells_and_residuals() {
+    let types = ["Creature".to_string()];
+    let spell = parse_oracle_text(
+        "~ deals 2 damage. X can't be 0.",
+        "X Damage",
+        &[],
+        &types,
+        &[],
+    );
+    assert_eq!(spell.abilities.len(), 1);
+    assert_eq!(spell.abilities[0].min_x_value, 1);
+    assert!(
+        !matches!(
+            spell.abilities[0].effect.as_ref(),
+            Effect::Unimplemented { .. }
+        ),
+        "nominal dispatch must retain a parsed spell"
+    );
+
+    let residual = parse_oracle_text(
+        "Frobnicate target creature. X can't be 0.",
+        "X Residual",
+        &[],
+        &types,
+        &[],
+    );
+    assert_eq!(residual.abilities.len(), 1);
+    assert_eq!(residual.abilities[0].min_x_value, 1);
+    assert!(matches!(
+        residual.abilities[0].effect.as_ref(),
+        Effect::Unimplemented { .. }
+    ));
 }
 
 /// CR 122.1 + CR 608.2d + CR 702.62b (Clockspinning): the whole card parses


### PR DESCRIPTION
Follow-up to #6776.

Preserves `min_x_value` after `dispatch_line_nom` returns a spell IR, so Oracle clauses such as `X can't be 0.` remain enforced. It also replaces fallback residual category strings with the closed `UnsupportedAbilityCategory` type.

Verification:
- `cargo fmt --all`
- parser-combinator gate and focused parser tests
- `cargo clippy -p phase-engine --lib -- -D warnings`
- full generated `card-data.json` delta: exactly five entries change, each adding only `min_x_value: 1` (Aeon Chronicler, Benalish Commander, Detritivore, Fungal Behemoth, Roiling Horror).
- CR 601.2b verified locally; the parser already carries its annotation at the X-value constraint seam.