### PR TITLE
refactor(parser): retain trigger die tables in trigger IR

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -107,7 +107,9 @@ use super::oracle_static::{
     try_parse_graveyard_keyword_grant_static, try_parse_top_of_library_cast_permission,
     GrantedCastKeywordKind,
 };
-use super::oracle_trigger::{lower_trigger_node_ir, parse_trigger_lines_at_index};
+use super::oracle_trigger::{
+    lower_trigger_ir, lower_trigger_node_ir, parse_trigger_lines_at_index,
+};
 use super::oracle_util::{
     normalize_card_name_refs, parse_mana_symbols, parse_number, split_same_is_true_static_tail,
     strip_reminder_text, TextPair, GRANTING_SELF_PLACEHOLDER,
@@ -1210,11 +1212,10 @@ fn item_replacement(item: &OracleItemIr) -> Option<&ReplacementDefinition> {
 /// that closed representation without a wildcard, so a fourth spell payload
 /// must be handled here and in `lower_spell_node` at compile time.
 ///
-/// `item_trigger` still keeps a borrow and pushes its own exhaustiveness down
-/// onto `TriggerNodeIr::definition()`, because both of its shapes own a
-/// `TriggerDefinition`. The spell layer differs only in its representations:
-/// the IR-native and residual payloads must be lowered into owned definitions,
-/// while the already-lowered payload can lend its definition.
+/// `item_trigger` uses the trigger-side equivalent of `item_ability`: an
+/// assembled node lends its definition, while a parsed node lowers into an
+/// owned `Cow`. Relations therefore observe the same definition document
+/// lowering will publish without fabricating a pre-lowered representation.
 ///
 /// Lowering is the same `lower_ability_ir` call `lower_oracle_ir` (the `Spell`
 /// arm) will make for the same item, so a relation predicate sees exactly the
@@ -1241,15 +1242,18 @@ fn item_ability(item: &OracleItemIr) -> Option<Cow<'_, AbilityDefinition>> {
 /// the regression would surface on a DIFFERENT card from the converted one,
 /// where per-card byte-identity cannot catch it.
 ///
-/// The exhaustiveness obligation lives on `TriggerNodeIr::definition()`, not on
-/// this match, and that is the correct layer: a new trigger representation is a
-/// new `TriggerNodeIr` variant, so it breaks that match at compile time before
-/// it can reach here. Enumerating `OracleNodeIr` instead would add nothing —
-/// every other variant is genuinely `None`.
-fn item_trigger(item: &OracleItemIr) -> Option<&TriggerDefinition> {
+/// The match is exhaustive over `TriggerNodeIr`, so a new trigger
+/// representation cannot silently evade relation discovery. Every other
+/// `OracleNodeIr` variant is genuinely `None` here.
+fn item_trigger(item: &OracleItemIr) -> Option<Cow<'_, TriggerDefinition>> {
     match &item.node {
-        OracleNodeIr::Trigger(node) => node.definition(),
-        OracleNodeIr::PreLoweredTrigger(def) => Some(def),
+        OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) => {
+            Some(Cow::Owned(lower_trigger_ir(trigger)))
+        }
+        OracleNodeIr::Trigger(TriggerNodeIr::Assembled { definition, .. }) => {
+            Some(Cow::Borrowed(definition))
+        }
+        OracleNodeIr::PreLoweredTrigger(def) => Some(Cow::Borrowed(def)),
         _ => None,
     }
 }
@@ -1543,9 +1547,12 @@ fn detect_linked_choice_type_statics(
                 )
             });
             let is_dig = item_ability(item).is_some_and(|def| ability_chain_has_dig(&def))
-                || item_trigger(item)
-                    .and_then(|trigger| trigger.execute.as_deref())
-                    .is_some_and(ability_chain_has_dig);
+                || item_trigger(item).is_some_and(|trigger| {
+                    trigger
+                        .execute
+                        .as_deref()
+                        .is_some_and(ability_chain_has_dig)
+                });
             if is_cost_reducer || is_dig {
                 retarget.push(item.id);
             }
@@ -1668,8 +1675,8 @@ fn chosen_subtype_kind_from_persisted_choice_items(
         .or_else(|| {
             items
                 .iter()
-                .filter_map(|item| item_trigger(item)?.execute.as_deref())
-                .find_map(chosen_subtype_kind_from_ability)
+                .filter_map(|item| item_trigger(item).and_then(|trigger| trigger.execute.clone()))
+                .find_map(|ability| chosen_subtype_kind_from_ability(&ability))
         })
 }
 
@@ -1765,7 +1772,8 @@ fn detect_linked_choice_persisted_player(
     let has_durable_reader = items.iter().any(|item| {
         item_static(item).is_some_and(static_references_source_chosen_player)
             || item_ability(item).is_some_and(|def| ability_references_source_chosen_player(&def))
-            || item_trigger(item).is_some_and(trigger_references_source_chosen_player)
+            || item_trigger(item)
+                .is_some_and(|trigger| trigger_references_source_chosen_player(&trigger))
     });
     if !has_durable_reader {
         return;
@@ -1774,9 +1782,12 @@ fn detect_linked_choice_persisted_player(
         .iter()
         .filter(|item| {
             item_ability(item).is_some_and(|def| ability_chain_has_player_choice(&def))
-                || item_trigger(item)
-                    .and_then(|trigger| trigger.execute.as_deref())
-                    .is_some_and(ability_chain_has_player_choice)
+                || item_trigger(item).is_some_and(|trigger| {
+                    trigger
+                        .execute
+                        .as_deref()
+                        .is_some_and(ability_chain_has_player_choice)
+                })
         })
         .map(|item| item.id)
         .collect();
@@ -3505,13 +3516,14 @@ fn trigger_is_etb_exile_pending_duration(def: &TriggerDefinition) -> bool {
 fn detect_etb_exile_ltb_return(items: &[OracleItemIr], relations: &mut Vec<DocumentRelationIr>) {
     let ltb_return = items
         .iter()
-        .find(|item| item_trigger(item).is_some_and(trigger_is_ltb_return));
+        .find(|item| item_trigger(item).is_some_and(|trigger| trigger_is_ltb_return(&trigger)));
 
     let (ltb, outcome) = match ltb_return {
         Some(ltb) => (ltb, LinkedReturnOutcome::DurationStamped),
         None => {
             let Some(ltb) = items.iter().find(|item| {
-                item_trigger(item).is_some_and(trigger_is_ltb_return_with_entry_modifier)
+                item_trigger(item)
+                    .is_some_and(|trigger| trigger_is_ltb_return_with_entry_modifier(&trigger))
             }) else {
                 return;
             };
@@ -3526,7 +3538,8 @@ fn detect_etb_exile_ltb_return(items: &[OracleItemIr], relations: &mut Vec<Docum
     };
 
     for item in items {
-        if item_trigger(item).is_some_and(trigger_is_etb_exile_pending_duration) {
+        if item_trigger(item).is_some_and(|trigger| trigger_is_etb_exile_pending_duration(&trigger))
+        {
             relations.push(DocumentRelationIr::EtbExileLtbReturn {
                 etb_exile: item.id,
                 ltb_return: ltb.id,

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -96,8 +96,8 @@ use super::oracle_saga::{is_saga_chapter, parse_saga_chapters};
 use super::oracle_spacecraft::parse_spacecraft_threshold_lines;
 use super::oracle_special::{
     attach_die_result_branches_to_chain, normalize_self_refs_for_static,
-    parse_cumulative_upkeep_keyword, parse_defiler_cost_reduction, parse_harmonize_keyword,
-    parse_mayhem_keyword, parse_solve_condition, try_parse_die_roll_table,
+    parse_cumulative_upkeep_keyword, parse_defiler_cost_reduction, parse_die_result_branches_ir,
+    parse_harmonize_keyword, parse_mayhem_keyword, parse_solve_condition, try_parse_die_roll_table,
 };
 use super::oracle_static::{
     is_speed_unlock_sentence, lower_static_ir, parse_alternative_keyword_cost,
@@ -109,6 +109,7 @@ use super::oracle_static::{
 };
 use super::oracle_trigger::{
     lower_trigger_ir, lower_trigger_node_ir, parse_trigger_lines_at_index,
+    parse_trigger_lines_at_index_ir,
 };
 use super::oracle_util::{
     normalize_card_name_refs, parse_mana_symbols, parse_number, split_same_is_true_static_tail,
@@ -1251,7 +1252,7 @@ fn item_trigger(item: &OracleItemIr) -> Option<Cow<'_, TriggerDefinition>> {
             Some(Cow::Owned(lower_trigger_ir(trigger)))
         }
         OracleNodeIr::Trigger(TriggerNodeIr::Assembled { definition, .. }) => {
-            Some(Cow::Borrowed(definition))
+            Some(Cow::Borrowed(definition.as_ref()))
         }
         OracleNodeIr::PreLoweredTrigger(def) => Some(Cow::Borrowed(def)),
         _ => None,
@@ -5106,24 +5107,28 @@ pub(crate) fn parse_oracle_ir(
             // CR 707.9a: Pass the running trigger count as the base index so
             // any "and it has this ability" except clause in this trigger's
             // body resolves to the correct printed-trigger slot.
-            let mut triggers = parse_trigger_lines_at_index(
+            let mut triggers = parse_trigger_lines_at_index_ir(
                 &line,
                 card_name,
                 Some(PrintedTriggerIndex::placeholder()),
                 &mut ctx,
             );
             i += 1;
-            // CR 706: If the trigger's effect ends with "roll a dN", consume
-            // subsequent d20 table lines and attach them as die result branches.
+            // CR 706.3b: Preserve table rows as trigger IR until body lowering
+            // attaches them before finalization.
             if has_roll_die_pattern(&lower) {
-                if let Some(last) = triggers.last_mut() {
-                    if let Some(ref mut execute) = last.execute {
-                        i = attach_die_result_branches_to_chain(execute, &lines, i);
-                    }
+                if let Some(last) = triggers
+                    .last_mut()
+                    .filter(|trigger| trigger.has_terminal_roll_die())
+                {
+                    let (branches, next_line) =
+                        parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
+                    last.die_results = branches;
+                    i = next_line;
                 }
             }
             for __item in triggers {
-                emitter.trigger_at(item_line, __item);
+                emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(__item)));
             }
             continue;
         }
@@ -5158,7 +5163,7 @@ pub(crate) fn parse_oracle_ir(
             }
             if has_trigger_prefix(&effect_lower) {
                 // CR 707.9a: Thread the running trigger count as the base index.
-                let mut triggers = parse_trigger_lines_at_index(
+                let mut triggers = parse_trigger_lines_at_index_ir(
                     &effect_text,
                     card_name,
                     Some(PrintedTriggerIndex::placeholder()),
@@ -5167,20 +5172,26 @@ pub(crate) fn parse_oracle_ir(
                 // B7: Attach ability-word condition as fallback when extract_if_condition
                 // doesn't recognize the intervening-if pattern.
                 for trigger in &mut triggers {
-                    if trigger.condition.is_none() {
-                        trigger.condition = ability_word_to_trigger_condition(&aw_name);
+                    if trigger.partial_def.condition.is_none()
+                        && trigger.modifiers.intervening_if.is_none()
+                    {
+                        trigger.partial_def.condition = ability_word_to_trigger_condition(&aw_name);
                     }
                 }
                 i += 1;
                 if has_roll_die_pattern(&effect_lower) {
-                    if let Some(last) = triggers.last_mut() {
-                        if let Some(ref mut execute) = last.execute {
-                            i = attach_die_result_branches_to_chain(execute, &lines, i);
-                        }
+                    if let Some(last) = triggers
+                        .last_mut()
+                        .filter(|trigger| trigger.has_terminal_roll_die())
+                    {
+                        let (branches, next_line) =
+                            parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
+                        last.die_results = branches;
+                        i = next_line;
                     }
                 }
                 for __item in triggers {
-                    emitter.trigger_at(item_line, __item);
+                    emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(__item)));
                 }
                 continue;
             }
@@ -6519,7 +6530,7 @@ pub(crate) fn parse_oracle_ir(
             // Try as trigger
             if has_trigger_prefix(&effect_lower) {
                 // CR 707.9a: Thread the running trigger count as the base index.
-                let mut triggers = parse_trigger_lines_at_index(
+                let mut triggers = parse_trigger_lines_at_index_ir(
                     &effect_text,
                     card_name,
                     Some(PrintedTriggerIndex::placeholder()),
@@ -6528,14 +6539,18 @@ pub(crate) fn parse_oracle_ir(
                 i += 1;
                 // CR 706: Consume subsequent d20 table lines for triggered die rolls.
                 if has_roll_die_pattern(&effect_lower) {
-                    if let Some(last) = triggers.last_mut() {
-                        if let Some(ref mut execute) = last.execute {
-                            i = attach_die_result_branches_to_chain(execute, &lines, i);
-                        }
+                    if let Some(last) = triggers
+                        .last_mut()
+                        .filter(|trigger| trigger.has_terminal_roll_die())
+                    {
+                        let (branches, next_line) =
+                            parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
+                        last.die_results = branches;
+                        i = next_line;
                     }
                 }
                 for __item in triggers {
-                    emitter.trigger_at(item_line, __item);
+                    emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(__item)));
                 }
                 continue;
             }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -75,7 +75,7 @@ use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
 use super::oracle_ir::static_ir::StaticIr;
-use super::oracle_ir::trigger::TriggerNodeIr;
+use super::oracle_ir::trigger::{TriggerIr, TriggerNodeIr};
 pub use super::oracle_keyword::keyword_display_name;
 use super::oracle_keyword::{
     is_keyword_cost_line, is_kicker_family_line, parse_kicker_additional_cost_line,
@@ -4024,6 +4024,31 @@ impl<'a> DocEmitter<'a> {
     }
 }
 
+/// Attaches a following die-result table to every terminal die-roll trigger
+/// produced from one printed line. Compound triggers share that line's table.
+///
+/// CR 706.3b: A die result table belongs to the die roll it follows. Leave the
+/// scanner at `start_line` when no trigger owns a terminal die roll so ordinary
+/// dispatch can retain the following lines.
+fn attach_trigger_die_result_branches(
+    triggers: &mut [TriggerIr],
+    lines: &[&str],
+    start_line: usize,
+) -> usize {
+    if !triggers.iter().any(TriggerIr::has_terminal_roll_die) {
+        return start_line;
+    }
+
+    let (branches, next_line) = parse_die_result_branches_ir(lines, start_line, AbilityKind::Spell);
+    for trigger in triggers
+        .iter_mut()
+        .filter(|trigger| trigger.has_terminal_roll_die())
+    {
+        trigger.die_results = branches.clone();
+    }
+    next_line
+}
+
 /// Produce an `OracleDocIr` from Oracle text — the IR-production half of the
 /// parse/lower split (Phase 49, Plan 03).
 ///
@@ -5117,15 +5142,7 @@ pub(crate) fn parse_oracle_ir(
             // CR 706.3b: Preserve table rows as trigger IR until body lowering
             // attaches them before finalization.
             if has_roll_die_pattern(&lower) {
-                if let Some(last) = triggers
-                    .last_mut()
-                    .filter(|trigger| trigger.has_terminal_roll_die())
-                {
-                    let (branches, next_line) =
-                        parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
-                    last.die_results = branches;
-                    i = next_line;
-                }
+                i = attach_trigger_die_result_branches(&mut triggers, &lines, i);
             }
             for __item in triggers {
                 emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(__item)));
@@ -5180,15 +5197,7 @@ pub(crate) fn parse_oracle_ir(
                 }
                 i += 1;
                 if has_roll_die_pattern(&effect_lower) {
-                    if let Some(last) = triggers
-                        .last_mut()
-                        .filter(|trigger| trigger.has_terminal_roll_die())
-                    {
-                        let (branches, next_line) =
-                            parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
-                        last.die_results = branches;
-                        i = next_line;
-                    }
+                    i = attach_trigger_die_result_branches(&mut triggers, &lines, i);
                 }
                 for __item in triggers {
                     emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(__item)));
@@ -6539,15 +6548,7 @@ pub(crate) fn parse_oracle_ir(
                 i += 1;
                 // CR 706: Consume subsequent d20 table lines for triggered die rolls.
                 if has_roll_die_pattern(&effect_lower) {
-                    if let Some(last) = triggers
-                        .last_mut()
-                        .filter(|trigger| trigger.has_terminal_roll_die())
-                    {
-                        let (branches, next_line) =
-                            parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
-                        last.die_results = branches;
-                        i = next_line;
-                    }
+                    i = attach_trigger_die_result_branches(&mut triggers, &lines, i);
                 }
                 for __item in triggers {
                     emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(__item)));

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26877,21 +26877,7 @@ pub(crate) enum ChainLoweringMode {
 /// non-die producer byte-identical.
 pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     let mut def = lower_effect_chain_ir(&ir.body);
-    if !ir.die_results.is_empty() {
-        if let Some(Effect::RollDie { results, .. }) =
-            super::oracle_special::find_terminal_roll_die(&mut def)
-        {
-            *results = ir
-                .die_results
-                .iter()
-                .map(|DieResultBranchIr { min, max, effect }| DieResultBranch {
-                    min: *min,
-                    max: *max,
-                    effect: Box::new(lower_ability_ir(effect)),
-                })
-                .collect();
-        }
-    }
+    attach_die_result_branches_before_finalization(&mut def, &ir.die_results);
     finalize_effect_chain(&mut def);
     apply_owner_library_reveal_anchor_from_text(&mut def, &ir.source_text);
     // CR 608.2c: a root the chain cannot describe (it has no previous boundary).
@@ -26910,6 +26896,29 @@ pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
         }
     }
     def
+}
+
+/// CR 706.3b: Attach typed die-result branches before finalization so every
+/// caller lowers each branch through the same `lower_ability_ir` authority.
+pub(crate) fn attach_die_result_branches_before_finalization(
+    def: &mut AbilityDefinition,
+    die_results: &[DieResultBranchIr],
+) {
+    if die_results.is_empty() {
+        return;
+    }
+    if let Some(Effect::RollDie { results, .. }) =
+        super::oracle_special::find_terminal_roll_die(def)
+    {
+        *results = die_results
+            .iter()
+            .map(|DieResultBranchIr { min, max, effect }| DieResultBranch {
+                min: *min,
+                max: *max,
+                effect: Box::new(lower_ability_ir(effect)),
+            })
+            .collect();
+    }
 }
 
 /// Apply the CR 602.1 activation envelope onto an already-lowered root.

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -7,7 +7,9 @@
 use crate::parser::oracle::{lower_oracle_ir, parse_oracle_ir, ParsedAbilities};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::doc::{OracleDocIr, OracleNodeIr};
+use crate::parser::oracle_ir::trigger::TriggerNodeIr;
 use crate::types::ability::MultiTargetSpec;
+use crate::types::ability::{Effect, TriggerCondition};
 use crate::types::game_state::DistributionUnit;
 
 /// Parse Oracle text through both IR and lowering layers.
@@ -33,6 +35,179 @@ fn parse_two_layer_with_keywords(
     let mut ir = parse_oracle_ir(oracle_text, card_name, &keywords, &types, &subtypes);
     let lowered = lower_oracle_ir(&mut ir);
     (ir, lowered)
+}
+
+/// CR 706.3b: ordinary trigger dispatch retains a die-result table in native
+/// trigger IR and attaches it to the terminal roll before finalization.
+#[test]
+fn direct_trigger_die_table_is_ir_native_and_lowers_as_one_ability() {
+    let (ir, lowered) = parse_two_layer(
+        "Whenever this creature attacks, roll a d20.\n1—9 | Create a Treasure token. (It's an artifact with \"{T}, Sacrifice this token: Add one mana of any color.\")\n10—19 | Create two Treasure tokens.\n20 | Create three Treasure tokens.",
+        "Hoarding Ogre",
+        &["Creature"],
+        &["Giant"],
+    );
+
+    assert_eq!(
+        ir.items.len(),
+        1,
+        "result rows must not become document items"
+    );
+    let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &ir.items[0].node else {
+        panic!(
+            "expected a native parsed trigger, got {:?}",
+            ir.items[0].node
+        );
+    };
+    assert_eq!(trigger.die_results.len(), 3);
+    assert_eq!(
+        trigger
+            .die_results
+            .iter()
+            .map(|branch| (branch.min, branch.max))
+            .collect::<Vec<_>>(),
+        vec![(1, 9), (10, 19), (20, 20)]
+    );
+
+    let execute = lowered.triggers[0]
+        .execute
+        .as_deref()
+        .expect("Hoarding Ogre trigger must have an execute ability");
+    let Effect::RollDie { results, .. } = execute.effect.as_ref() else {
+        panic!(
+            "expected terminal roll-die effect, got {:?}",
+            execute.effect
+        );
+    };
+    assert_eq!(results.len(), 3);
+    assert!(
+        results
+            .iter()
+            .all(|branch| !matches!(branch.effect.effect.as_ref(), Effect::Unimplemented { .. })),
+        "table branches must be lowered through the ordinary ability authority: {results:?}"
+    );
+}
+
+/// The ability-word trigger route is likewise native IR. Its existing fallback
+/// condition is applied only when trigger parsing did not already find one.
+#[test]
+fn ability_word_trigger_table_is_ir_native_and_preserves_condition_fallback() {
+    let (ir, lowered) = parse_two_layer(
+        "Wild Magic Surge — Whenever this creature attacks, roll a d20.\n1—9 | Exile the top card of your library. You may play it this turn.\n10—19 | Exile the top two cards of your library. You may play them this turn.\n20 | Exile the top three cards of your library. You may play them this turn.",
+        "Chaos Channeler",
+        &["Creature"],
+        &["Human", "Shaman"],
+    );
+    let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &ir.items[0].node else {
+        panic!("expected a native parsed ability-word trigger");
+    };
+    assert_eq!(trigger.die_results.len(), 3);
+    assert!(matches!(
+        lowered.triggers[0].execute.as_deref().map(|execute| execute.effect.as_ref()),
+        Some(Effect::RollDie { results, .. }) if results.len() == 3
+    ));
+
+    let (threshold_ir, threshold_lowered) = parse_two_layer(
+        "Threshold — Whenever this creature attacks, draw a card.",
+        "Threshold Fixture",
+        &["Creature"],
+        &[],
+    );
+    let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(threshold)) = &threshold_ir.items[0].node
+    else {
+        panic!("expected a native parsed threshold trigger");
+    };
+    assert!(
+        threshold.modifiers.intervening_if.is_none(),
+        "fixture must exercise the ability-word fallback rather than an explicit if clause"
+    );
+    assert!(matches!(
+        threshold_lowered.triggers[0].condition,
+        Some(TriggerCondition::QuantityComparison { .. })
+    ));
+
+    let (shoreline_ir, shoreline_lowered) = parse_two_layer(
+        "Delirium — Whenever this creature deals combat damage to a player, draw a card. Then discard a card unless there are seven or more cards in your graveyard.",
+        "Shoreline Looter",
+        &["Creature"],
+        &["Rat", "Rogue"],
+    );
+    let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(shoreline)) = &shoreline_ir.items[0].node
+    else {
+        panic!("expected a native parsed Shoreline Looter trigger");
+    };
+    assert!(shoreline.partial_def.condition.is_none());
+    assert!(
+        shoreline.modifiers.intervening_if.is_some(),
+        "parsed intervening-if must suppress the ability-word fallback"
+    );
+    assert!(matches!(
+        shoreline_lowered.triggers[0].condition,
+        Some(TriggerCondition::Not { .. })
+    ));
+}
+
+/// The table scanner consumes only actual rows. A following ordinary line stays
+/// available to document dispatch, while unsupported table text remains honest.
+#[test]
+fn trigger_die_table_scanner_preserves_non_table_and_unsupported_rows() {
+    let (non_table_ir, non_table_lowered) = parse_two_layer(
+        "Whenever this creature attacks, roll a d20.\nDraw a card.",
+        "Non-table Fixture",
+        &["Creature"],
+        &[],
+    );
+    assert_eq!(
+        non_table_ir.items.len(),
+        2,
+        "ordinary next line must remain dispatched"
+    );
+    assert!(matches!(
+        non_table_ir.items[0].node,
+        OracleNodeIr::Trigger(_)
+    ));
+    assert!(matches!(non_table_ir.items[1].node, OracleNodeIr::Spell(_)));
+    assert!(matches!(
+        non_table_lowered.abilities[0].effect.as_ref(),
+        Effect::Draw { .. }
+    ));
+
+    let (_, unsupported_lowered) = parse_two_layer(
+        "Whenever this creature attacks, roll a d20.\n1—20 | Frobnicate target creature.",
+        "Unsupported Table Fixture",
+        &["Creature"],
+        &[],
+    );
+    let execute = unsupported_lowered.triggers[0]
+        .execute
+        .as_deref()
+        .expect("trigger must still lower");
+    let Effect::RollDie { results, .. } = execute.effect.as_ref() else {
+        panic!("expected roll die");
+    };
+    assert!(matches!(
+        results[0].effect.effect.as_ref(),
+        Effect::Unimplemented { .. }
+    ));
+
+    let (mastiff_ir, mastiff_lowered) = parse_two_layer(
+        "Whenever this creature attacks, roll a d20 for each player being attacked and ignore all but the highest roll.\n1—9 | This creature deals damage equal to its power to you.\n10—19 | This creature deals damage equal to its power to defending player.\n20 | This creature deals damage equal to its power to each opponent.",
+        "Iron Mastiff",
+        &["Artifact", "Creature"],
+        &["Dog"],
+    );
+    let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(mastiff)) = &mastiff_ir.items[0].node else {
+        panic!("expected a native parsed Iron Mastiff trigger");
+    };
+    assert!(
+        !mastiff.has_terminal_roll_die(),
+        "unsupported multi-player roll must not consume a result table"
+    );
+    assert_eq!(mastiff_ir.items.len(), 4);
+    assert!(mastiff_ir.items[1..]
+        .iter()
+        .all(|item| matches!(item.node, OracleNodeIr::Unsupported { .. })));
+    assert_eq!(mastiff_lowered.abilities.len(), 3);
 }
 
 /// ISSUES #17: the swallow audit's findings must live in the doc IR's diagnostics

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -88,6 +88,99 @@ fn direct_trigger_die_table_is_ir_native_and_lowers_as_one_ability() {
     );
 }
 
+/// CR 603.2 + CR 706.3b: Each trigger produced by a compound trigger line owns
+/// the following die-result table when its body ends in that line's die roll.
+#[test]
+fn compound_trigger_die_table_attaches_to_every_terminal_roll() {
+    let (ir, lowered) = parse_two_layer(
+        "Whenever this creature attacks and whenever this creature blocks, roll a d20.\n1—9 | Draw a card.\n10—20 | Create a Treasure token.",
+        "Compound Die Fixture",
+        &["Creature"],
+        &[],
+    );
+
+    assert_eq!(
+        ir.items.len(),
+        2,
+        "result rows must not become document items"
+    );
+    for item in &ir.items {
+        let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &item.node else {
+            panic!(
+                "expected native parsed compound triggers, got {:?}",
+                item.node
+            );
+        };
+        assert_eq!(trigger.die_results.len(), 2);
+    }
+
+    assert_eq!(lowered.triggers.len(), 2);
+    for trigger in &lowered.triggers {
+        assert!(matches!(
+            trigger.execute.as_deref().map(|execute| execute.effect.as_ref()),
+            Some(Effect::RollDie { results, .. }) if results.len() == 2
+        ));
+    }
+
+    let (shared_subject_ir, shared_subject_lowered) = parse_two_layer(
+        "Whenever this creature attacks, blocks, or becomes the target of a spell, roll a d20.\n1—9 | Draw a card.\n10—20 | Create a Treasure token.",
+        "Shared Subject Die Fixture",
+        &["Creature"],
+        &[],
+    );
+    assert_eq!(shared_subject_ir.items.len(), 3);
+    assert_eq!(shared_subject_lowered.triggers.len(), 3);
+    for (item, trigger) in shared_subject_ir
+        .items
+        .iter()
+        .zip(&shared_subject_lowered.triggers)
+    {
+        let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(parsed)) = &item.node else {
+            panic!("expected a native parsed shared-subject trigger");
+        };
+        assert_eq!(parsed.die_results.len(), 2);
+        assert!(matches!(
+            trigger.execute.as_deref().map(|execute| execute.effect.as_ref()),
+            Some(Effect::RollDie { results, .. }) if results.len() == 2
+        ));
+    }
+}
+
+/// CR 118.12 + CR 603.12 + CR 706.3b: A reflexive payment owns its nested
+/// terminal die roll, so the parent trigger's result rows lower into that
+/// `When you do` sub-ability.
+#[test]
+fn reflexive_payment_trigger_retains_die_table_on_nested_roll() {
+    let (ir, lowered) = parse_two_layer(
+        "Whenever this creature attacks, you may pay {1}. When you do, roll a d20.\n1—9 | Draw a card.\n10—20 | Create a Treasure token.",
+        "Reflexive Die Fixture",
+        &["Creature"],
+        &[],
+    );
+
+    let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &ir.items[0].node else {
+        panic!("expected a native parsed trigger");
+    };
+    assert!(trigger.has_terminal_roll_die());
+    assert_eq!(trigger.die_results.len(), 2);
+
+    let pay = lowered.triggers[0]
+        .execute
+        .as_deref()
+        .expect("trigger must have an execute ability");
+    let Effect::PayCost { .. } = pay.effect.as_ref() else {
+        panic!("expected reflexive payment root, got {:?}", pay.effect);
+    };
+    let reflexive_roll = pay
+        .sub_ability
+        .as_deref()
+        .expect("payment must retain its reflexive sub-ability");
+    assert!(matches!(
+        reflexive_roll.effect.as_ref(),
+        Effect::RollDie { results, .. } if results.len() == 2
+    ));
+}
+
 /// The ability-word trigger route is likewise native IR. Its existing fallback
 /// condition is applied only when trigger parsing did not already find one.
 #[test]

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
@@ -50,52 +50,119 @@ expression: "&ir"
         "fragment": "Whenever ~ attacks, exile the top card of your library face down. (You can't look at it.)"
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Attacks",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "ExileTop",
-              "player": {
-                "type": "Controller"
+        "Trigger": {
+          "Parsed": {
+            "condition": "Attacks",
+            "partial_def": {
+              "mode": "Attacks",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "position": {
-                "type": "Top"
-              },
-              "face_down": true
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever ~ attacks, exile the top card of your library face down.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 44,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "exile the top card of your library face down"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "ExileTop",
+                        "player": {
+                          "type": "Controller"
+                        },
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "position": {
+                          "type": "Top"
+                        },
+                        "face_down": true
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "exile the top card of your library face down.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever ~ attacks, exile the top card of your library face down.",
+            "die_results": []
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bonecrusher_giant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bonecrusher_giant_ir.snap
@@ -22,50 +22,117 @@ expression: "&ir"
         "fragment": "Whenever ~ becomes the target of a spell, ~ deals 2 damage to that spell's controller."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "BecomesTarget",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "DealDamage",
-              "amount": {
-                "type": "Fixed",
-                "value": 2
+        "Trigger": {
+          "Parsed": {
+            "condition": "BecomesTarget",
+            "partial_def": {
+              "mode": "BecomesTarget",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "target": {
-                "type": "TriggeringSpellController"
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": {
+                "type": "StackSpell"
+              },
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 43,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "~ deals 2 damage to that spell's controller"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "target": {
+                          "type": "TriggeringSpellController"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": {
-            "type": "StackSpell"
-          },
-          "description": "Whenever ~ becomes the target of a spell, ~ deals 2 damage to that spell's controller.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "~ deals 2 damage to that spell's controller.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever ~ becomes the target of a spell, ~ deals 2 damage to that spell's controller.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_crimson_pulse_ir.snap
@@ -22,69 +22,170 @@ expression: "&ir"
         "fragment": "When this ~ enters, discard a card, then draw two cards."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Discard",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "target": {
-                "type": "Controller"
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 14,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "discard a card"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Discard",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Then",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 21,
+                        "end_byte": 35,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "draw two cards"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Draw",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "Draw",
-                "count": {
-                  "type": "Fixed",
-                  "value": 2
-                },
-                "target": {
-                  "type": "Controller"
-                }
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
+            "modifiers": {
               "optional": false,
-              "forward_result": false
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "discard a card, then draw two cards.",
+              "relative_player_scope": null
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When this ~ enters, discard a card, then draw two cards.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "source_text": "When this ~ enters, discard a card, then draw two cards.",
+            "die_results": []
+          }
         }
       }
     },
@@ -146,74 +247,175 @@ expression: "&ir"
         "fragment": "Solved — At the beginning of your upkeep, discard your hand, then draw two cards."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Discard",
-              "count": {
-                "type": "Ref",
-                "qty": {
-                  "type": "HandSize",
-                  "player": {
-                    "type": "Controller"
-                  }
-                }
+        "Trigger": {
+          "Parsed": {
+            "condition": "Phase",
+            "partial_def": {
+              "mode": "Phase",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": "Upkeep",
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": {
+                "type": "OnlyDuringYourTurn"
               },
-              "target": {
-                "type": "Controller"
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 17,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "discard your hand"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Discard",
+                        "count": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "HandSize",
+                            "player": {
+                              "type": "Controller"
+                            }
+                          }
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Then",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 24,
+                        "end_byte": 38,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "draw two cards"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Draw",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "Draw",
-                "count": {
-                  "type": "Fixed",
-                  "value": 2
-                },
-                "target": {
-                  "type": "Controller"
-                }
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
+            "modifiers": {
               "optional": false,
-              "forward_result": false
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Any"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "discard your hand, then draw two cards.",
+              "relative_player_scope": null
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "Upkeep",
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of your upkeep, discard your hand, then draw two cards.",
-          "constraint": {
-            "type": "OnlyDuringYourTurn"
-          },
-          "condition": null,
-          "batched": false
+            "source_text": "At the beginning of your upkeep, discard your hand, then draw two cards.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
@@ -22,67 +22,134 @@ expression: "&ir"
         "fragment": "When this ~ enters, create a 2/1 black Skeleton creature token and suspect it. (It has menace and can't block.)"
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Token",
-              "name": "Skeleton",
-              "power": {
-                "type": "Fixed",
-                "value": 2
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "toughness": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "types": [
-                "Creature",
-                "Skeleton"
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "colors": [
-                "Black"
-              ],
-              "keywords": [],
-              "tapped": false,
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "owner": {
-                "type": "Controller"
-              },
-              "enters_attacking": false
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When this ~ enters, create a 2/1 black Skeleton creature token and suspect it.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 57,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "create a 2/1 black Skeleton creature token and suspect it"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Token",
+                        "name": "Skeleton",
+                        "power": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "toughness": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "types": [
+                          "Creature",
+                          "Skeleton"
+                        ],
+                        "colors": [
+                          "Black"
+                        ],
+                        "keywords": [],
+                        "tapped": false,
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "owner": {
+                          "type": "Controller"
+                        },
+                        "enters_attacking": false
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "create a 2/1 black skeleton creature token and suspect it.",
+              "relative_player_scope": null
+            },
+            "source_text": "When this ~ enters, create a 2/1 black Skeleton creature token and suspect it.",
+            "die_results": []
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__caustic_bronco_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__caustic_bronco_ir.snap
@@ -22,137 +22,329 @@ expression: "&ir"
         "fragment": "Whenever ~ attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if ~ isn't saddled. Otherwise, each opponent loses that much life."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Attacks",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "RevealTop",
-              "player": {
-                "type": "Controller"
+        "Trigger": {
+          "Parsed": {
+            "condition": "Attacks",
+            "partial_def": {
+              "mode": "Attacks",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "count": 1
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": null,
-                "destination": "Hand",
-                "target": {
-                  "type": "ParentTarget"
-                },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "LoseLife",
-                  "amount": {
-                    "type": "Ref",
-                    "qty": {
-                      "type": "ObjectManaValue",
-                      "scope": {
-                        "type": "Demonstrative"
-                      }
-                    }
-                  },
-                  "target": {
-                    "type": "Controller"
-                  }
-                },
-                "cost": null,
-                "sub_ability": null,
-                "else_ability": {
-                  "kind": "Spell",
-                  "effect": {
-                    "type": "LoseLife",
-                    "amount": {
-                      "type": "Ref",
-                      "qty": {
-                        "type": "ObjectManaValue",
-                        "scope": {
-                          "type": "Demonstrative"
-                        }
-                      }
-                    }
-                  },
-                  "cost": null,
-                  "sub_ability": null,
-                  "duration": null,
-                  "description": null,
-                  "target_prompt": null,
-                  "condition": null,
-                  "optional_targeting": false,
-                  "optional": false,
-                  "forward_result": false,
-                  "player_scope": {
-                    "type": "Opponent"
-                  }
-                },
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": {
-                  "type": "Not",
-                  "condition": {
-                    "type": "SourceMatchesFilter",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [],
-                      "controller": null,
-                      "properties": [
-                        {
-                          "type": "IsSaddled"
-                        }
-                      ]
-                    }
-                  }
-                },
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false,
-                "sub_link": "SequentialSibling"
-              },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
               "optional": false,
-              "forward_result": false
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever ~ attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if ~ isn't saddled. Otherwise, each opponent loses that much life.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 35,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "reveal the top card of your library"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Dig",
+                        "player": {
+                          "type": "Controller"
+                        },
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "destination": null,
+                        "keep_count": null,
+                        "up_to": false,
+                        "filter": {
+                          "type": "Any"
+                        },
+                        "rest_destination": null,
+                        "reveal": true,
+                        "enter_tapped": false
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Comma",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 40,
+                        "end_byte": 61,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "put it into your hand"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "ChangeZone",
+                        "origin": null,
+                        "destination": "Hand",
+                        "target": {
+                          "type": "ParentTarget"
+                        },
+                        "owner_library": false,
+                        "enter_transformed": false,
+                        "enter_tapped": false,
+                        "enters_attacking": false
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 2,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 3
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 63,
+                        "end_byte": 127,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 2
+                      },
+                      "fragment": "You lose life equal to that card's mana value if ~ isn't saddled"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "ObjectManaValue",
+                            "scope": {
+                              "type": "Demonstrative"
+                            }
+                          }
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": {
+                      "type": "Not",
+                      "condition": {
+                        "type": "SourceMatchesFilter",
+                        "filter": {
+                          "type": "Typed",
+                          "type_filters": [],
+                          "controller": null,
+                          "properties": [
+                            {
+                              "type": "IsSaddled"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 3,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 4
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 129,
+                        "end_byte": 174,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 3
+                      },
+                      "fragment": "Otherwise, each opponent loses that much life"
+                    },
+                    "disposition": {
+                      "BranchOtherwise": {
+                        "else_def": {
+                          "kind": "Spell",
+                          "effect": {
+                            "type": "LoseLife",
+                            "amount": {
+                              "type": "Ref",
+                              "qty": {
+                                "type": "EventContextAmount"
+                              }
+                            }
+                          },
+                          "cost": null,
+                          "sub_ability": null,
+                          "duration": null,
+                          "description": null,
+                          "target_prompt": null,
+                          "condition": null,
+                          "optional_targeting": false,
+                          "optional": false,
+                          "forward_result": false,
+                          "player_scope": {
+                            "type": "Opponent"
+                          }
+                        },
+                        "kind": "Bound"
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "otherwise_placeholder",
+                        "description": null
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "reveal the top card of your library and put it into your hand. you lose life equal to that card's mana value if ~ isn't saddled. otherwise, each opponent loses that much life.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever ~ attacks, reveal the top card of your library and put it into your hand. You lose life equal to that card's mana value if ~ isn't saddled. Otherwise, each opponent loses that much life.",
+            "die_results": []
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chalice_of_the_void_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 993
 expression: "&ir"
 ---
 {
@@ -84,64 +83,131 @@ expression: "&ir"
         "fragment": "Whenever a player casts a spell with mana value equal to the number of charge counters on ~, counter that spell."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "SpellCast",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Counter",
-              "target": {
-                "type": "TriggeringSource"
+        "Trigger": {
+          "Parsed": {
+            "condition": "SpellCast",
+            "partial_def": {
+              "mode": "SpellCast",
+              "execute": null,
+              "valid_card": {
+                "type": "Typed",
+                "type_filters": [
+                  "Card"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "Cmc",
+                    "comparator": "EQ",
+                    "value": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "CountersOn",
+                        "scope": {
+                          "type": "Source"
+                        },
+                        "counter_type": "charge"
+                      }
+                    }
+                  }
+                ]
+              },
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 18,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "counter that spell"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Counter",
+                        "target": {
+                          "type": "TriggeringSource"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              "Card"
-            ],
-            "controller": null,
-            "properties": [
-              {
-                "type": "Cmc",
-                "comparator": "EQ",
-                "value": {
-                  "type": "Ref",
-                  "qty": {
-                    "type": "CountersOn",
-                    "scope": {
-                      "type": "Source"
-                    },
-                    "counter_type": "charge"
-                  }
-                }
-              }
-            ]
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever a player casts a spell with mana value equal to the number of charge counters on ~, counter that spell.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Player"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "counter that spell.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever a player casts a spell with mana value equal to the number of charge counters on ~, counter that spell.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__conclave_mentor_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 453
 expression: "&ir"
 ---
 {
@@ -72,50 +71,117 @@ expression: "&ir"
         "fragment": "When ~ dies, you gain life equal to its power."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GainLife",
-              "amount": {
-                "type": "Ref",
-                "qty": {
-                  "type": "Power",
-                  "scope": {
-                    "type": "Anaphoric"
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": "Battlefield",
+              "destination": "Graveyard",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 32,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "you gain life equal to its power"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "GainLife",
+                        "amount": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "Power",
+                            "scope": {
+                              "type": "Anaphoric"
+                            }
+                          }
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   }
-                }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": "Battlefield",
-          "destination": "Graveyard",
-          "trigger_zones": [
-            "Graveyard"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ dies, you gain life equal to its power.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "you gain life equal to its power.",
+              "relative_player_scope": null
+            },
+            "source_text": "When ~ dies, you gain life equal to its power.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dark_confidant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dark_confidant_ir.snap
@@ -22,95 +22,241 @@ expression: "&ir"
         "fragment": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "RevealTop",
-              "player": {
-                "type": "Controller"
-              },
-              "count": 1
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": null,
-                "destination": "Hand",
-                "target": {
-                  "type": "ParentTarget"
-                },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "LoseLife",
-                  "amount": {
-                    "type": "Ref",
-                    "qty": {
-                      "type": "ObjectManaValue",
-                      "scope": {
-                        "type": "Anaphoric"
-                      }
-                    }
-                  },
-                  "target": {
-                    "type": "Controller"
-                  }
-                },
-                "cost": null,
-                "sub_ability": null,
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false,
-                "sub_link": "SequentialSibling"
-              },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
+        "Trigger": {
+          "Parsed": {
+            "condition": "Phase",
+            "partial_def": {
+              "mode": "Phase",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": "Upkeep",
               "optional": false,
-              "forward_result": false
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": {
+                "type": "OnlyDuringYourTurn"
+              },
+              "condition": null,
+              "batched": false
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "Upkeep",
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
-          "constraint": {
-            "type": "OnlyDuringYourTurn"
-          },
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 35,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "reveal the top card of your library"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Dig",
+                        "player": {
+                          "type": "Controller"
+                        },
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "destination": null,
+                        "keep_count": null,
+                        "up_to": false,
+                        "filter": {
+                          "type": "Any"
+                        },
+                        "rest_destination": null,
+                        "reveal": true,
+                        "enter_tapped": false
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Comma",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 40,
+                        "end_byte": 68,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "put that card into your hand"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "ChangeZone",
+                        "origin": null,
+                        "destination": "Hand",
+                        "target": {
+                          "type": "ParentTarget"
+                        },
+                        "owner_library": false,
+                        "enter_transformed": false,
+                        "enter_tapped": false,
+                        "enters_attacking": false
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 2,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 3
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 70,
+                        "end_byte": 107,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 2
+                      },
+                      "fragment": "You lose life equal to its mana value"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "ObjectManaValue",
+                            "scope": {
+                              "type": "Anaphoric"
+                            }
+                          }
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Any"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "reveal the top card of your library and put that card into your hand. you lose life equal to its mana value.",
+              "relative_player_scope": null
+            },
+            "source_text": "At the beginning of your upkeep, reveal the top card of your library and put that card into your hand. You lose life equal to its mana value.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__edgewall_innkeeper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__edgewall_innkeeper_ir.snap
@@ -22,55 +22,122 @@ expression: "&ir"
         "fragment": "Whenever you cast a creature spell that has an Adventure, draw a card. (It doesn't need to have gone on the adventure first.)"
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "SpellCast",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Draw",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Trigger": {
+          "Parsed": {
+            "condition": "SpellCast",
+            "partial_def": {
+              "mode": "SpellCast",
+              "execute": null,
+              "valid_card": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": null,
+                "properties": []
               },
-              "target": {
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": {
                 "type": "Controller"
+              },
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 11,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "draw a card"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Draw",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": null,
-            "properties": []
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": {
-            "type": "Controller"
-          },
-          "valid_source": null,
-          "description": "Whenever you cast a creature spell that has an Adventure, draw a card.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Controller"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "draw a card.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever you cast a creature spell that has an Adventure, draw a card.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__eidolon_of_the_great_revel_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__eidolon_of_the_great_revel_ir.snap
@@ -22,62 +22,129 @@ expression: "&ir"
         "fragment": "Whenever a player casts a spell with mana value 3 or less, ~ deals 2 damage to that player."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "SpellCast",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "DealDamage",
-              "amount": {
-                "type": "Fixed",
-                "value": 2
+        "Trigger": {
+          "Parsed": {
+            "condition": "SpellCast",
+            "partial_def": {
+              "mode": "SpellCast",
+              "execute": null,
+              "valid_card": {
+                "type": "Typed",
+                "type_filters": [
+                  "Card"
+                ],
+                "controller": null,
+                "properties": [
+                  {
+                    "type": "Cmc",
+                    "comparator": "LE",
+                    "value": {
+                      "type": "Fixed",
+                      "value": 3
+                    }
+                  }
+                ]
               },
-              "target": {
-                "type": "TriggeringPlayer"
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 31,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "~ deals 2 damage to that player"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "target": {
+                          "type": "TriggeringPlayer"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              "Card"
-            ],
-            "controller": null,
-            "properties": [
-              {
-                "type": "Cmc",
-                "comparator": "LE",
-                "value": {
-                  "type": "Fixed",
-                  "value": 3
-                }
-              }
-            ]
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever a player casts a spell with mana value 3 or less, ~ deals 2 damage to that player.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Player"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "~ deals 2 damage to that player.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever a player casts a spell with mana value 3 or less, ~ deals 2 damage to that player.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fevered_visions_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fevered_visions_ir.snap
@@ -22,95 +22,195 @@ expression: "&ir"
         "fragment": "At the beginning of each player's end step, that player draws a card. If the player is your opponent and has four or more cards in hand, ~ deals 2 damage to that player."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Draw",
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "target": {
-                "type": "ScopedPlayer"
-              }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "DealDamage",
-                "amount": {
-                  "type": "Fixed",
-                  "value": 2
-                },
-                "target": {
-                  "type": "ScopedPlayer"
-                }
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
+        "Trigger": {
+          "Parsed": {
+            "condition": "Phase",
+            "partial_def": {
+              "mode": "Phase",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": "End",
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
               "description": null,
-              "target_prompt": null,
-              "condition": {
-                "type": "And",
-                "conditions": [
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
                   {
-                    "type": "ScopedPlayerMatches",
-                    "filter": {
-                      "type": "Opponent"
-                    }
-                  },
-                  {
-                    "type": "QuantityCheck",
-                    "lhs": {
-                      "type": "Ref",
-                      "qty": {
-                        "type": "HandSize",
-                        "player": {
-                          "type": "ScopedPlayer"
-                        }
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 24,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "that player draws a card"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
                       }
                     },
-                    "comparator": "GE",
-                    "rhs": {
-                      "type": "Fixed",
-                      "value": 4
-                    }
+                    "parsed": {
+                      "effect": {
+                        "type": "Draw",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "ScopedPlayer"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 26,
+                        "end_byte": 124,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "If the player is your opponent and has four or more cards in hand, ~ deals 2 damage to that player"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "target": {
+                          "type": "ScopedPlayer"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": {
+                      "type": "And",
+                      "conditions": [
+                        {
+                          "type": "ScopedPlayerMatches",
+                          "filter": {
+                            "type": "Opponent"
+                          }
+                        },
+                        {
+                          "type": "QuantityCheck",
+                          "lhs": {
+                            "type": "Ref",
+                            "qty": {
+                              "type": "HandSize",
+                              "player": {
+                                "type": "ScopedPlayer"
+                              }
+                            }
+                          },
+                          "comparator": "GE",
+                          "rhs": {
+                            "type": "Fixed",
+                            "value": 4
+                          }
+                        }
+                      ]
+                    },
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   }
-                ]
-              },
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "End",
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of each player's end step, that player draws a card. If the player is your opponent and has four or more cards in hand, ~ deals 2 damage to that player.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Any"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "that player draws a card. if the player is your opponent and has four or more cards in hand, ~ deals 2 damage to that player.",
+              "relative_player_scope": "ScopedPlayer"
+            },
+            "source_text": "At the beginning of each player's end step, that player draws a card. If the player is your opponent and has four or more cards in hand, ~ deals 2 damage to that player.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__goblin_guide_ir.snap
@@ -50,74 +50,174 @@ expression: "&ir"
         "fragment": "Whenever ~ attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Attacks",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "RevealTop",
-              "player": {
-                "type": "DefendingPlayer"
+        "Trigger": {
+          "Parsed": {
+            "condition": "Attacks",
+            "partial_def": {
+              "mode": "Attacks",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "count": 1
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": null,
-                "destination": "Hand",
-                "target": {
-                  "type": "ParentTarget"
-                },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": {
-                "type": "RevealedHasCardType",
-                "card_types": [
-                  "Land"
-                ]
-              },
-              "optional_targeting": false,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
               "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever ~ attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 54,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "defending player reveals the top card of their library"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "RevealTop",
+                        "player": {
+                          "type": "DefendingPlayer"
+                        },
+                        "count": 1
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 56,
+                        "end_byte": 112,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "If it's a land card, that player puts it into their hand"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "ChangeZone",
+                        "origin": null,
+                        "destination": "Hand",
+                        "target": {
+                          "type": "ParentTarget"
+                        },
+                        "owner_library": false,
+                        "enter_transformed": false,
+                        "enter_tapped": false,
+                        "enters_attacking": false
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": {
+                      "type": "RevealedHasCardType",
+                      "card_types": [
+                        "Land"
+                      ]
+                    },
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "defending player reveals the top card of their library. if it's a land card, that player puts it into their hand.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever ~ attacks, defending player reveals the top card of their library. If it's a land card, that player puts it into their hand.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jaws_of_defeat_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jaws_of_defeat_ir.snap
@@ -22,75 +22,145 @@ expression: "&ir"
         "fragment": "Whenever a creature you control enters, target opponent loses life equal to the difference between that creature's power and its toughness."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "LoseLife",
-              "amount": {
-                "type": "Difference",
-                "left": {
-                  "type": "Ref",
-                  "qty": {
-                    "type": "Power",
-                    "scope": {
-                      "type": "Demonstrative"
-                    }
-                  }
-                },
-                "right": {
-                  "type": "Ref",
-                  "qty": {
-                    "type": "Toughness",
-                    "scope": {
-                      "type": "Demonstrative"
-                    }
-                  }
-                }
-              },
-              "target": {
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
                 "type": "Typed",
-                "type_filters": [],
-                "controller": "Opponent",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
                 "properties": []
+              },
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 98,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "target opponent loses life equal to the difference between that creature's power and its toughness"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                          "type": "Difference",
+                          "left": {
+                            "type": "Ref",
+                            "qty": {
+                              "type": "Power",
+                              "scope": {
+                                "type": "Demonstrative"
+                              }
+                            }
+                          },
+                          "right": {
+                            "type": "Ref",
+                            "qty": {
+                              "type": "Toughness",
+                              "scope": {
+                                "type": "Demonstrative"
+                              }
+                            }
+                          }
+                        },
+                        "target": {
+                          "type": "Typed",
+                          "type_filters": [],
+                          "controller": "Opponent",
+                          "properties": []
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              "Creature"
-            ],
-            "controller": "You",
-            "properties": []
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": {
-            "type": "Player"
-          },
-          "valid_source": null,
-          "description": "Whenever a creature you control enters, target opponent loses life equal to the difference between that creature's power and its toughness.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Typed",
+                "type_filters": [
+                  "Creature"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "target opponent loses life equal to the difference between that creature's power and its toughness.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever a creature you control enters, target opponent loses life equal to the difference between that creature's power and its toughness.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_ir.snap
@@ -98,68 +98,237 @@ expression: "&ir"
         "fragment": "At the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Mana",
-              "produced": {
-                "type": "Colorless",
-                "count": {
-                  "type": "Ref",
-                  "qty": {
-                    "type": "ObjectCount",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Artifact"
-                      ],
-                      "controller": "You",
-                      "properties": []
-                    }
-                  }
-                }
-              },
-              "restrictions": [
-                {
-                  "SpellTypeOrAbilityActivation": {
-                    "spell_type": "Artifact",
-                    "ability": "Any"
-                  }
-                }
+        "Trigger": {
+          "Parsed": {
+            "condition": "Phase",
+            "partial_def": {
+              "mode": "Phase",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "expiry": "EndOfTurn"
+              "phase": "Upkeep",
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": {
+                "type": "OnlyDuringYourTurn"
+              },
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "is_mana_ability": true
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "Upkeep",
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
-          "constraint": {
-            "type": "OnlyDuringYourTurn"
-          },
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 37,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "add {C} for each artifact you control"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Mana",
+                        "produced": {
+                          "type": "Colorless",
+                          "count": {
+                            "type": "Ref",
+                            "qty": {
+                              "type": "ObjectCount",
+                              "filter": {
+                                "type": "Typed",
+                                "type_filters": [
+                                  "Artifact"
+                                ],
+                                "controller": "You",
+                                "properties": []
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 39,
+                        "end_byte": 90,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "This mana can't be spent to cast nonartifact spells"
+                    },
+                    "disposition": {
+                      "Continue": {
+                        "continuation": {
+                          "ManaRestriction": {
+                            "restrictions": [
+                              {
+                                "SpellTypeOrAbilityActivation": {
+                                  "spell_type": "Artifact",
+                                  "ability": "Any"
+                                }
+                              }
+                            ],
+                            "grants": []
+                          }
+                        }
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "can't",
+                        "description": "can't be spent to cast nonartifact spells"
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 2,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 3
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 92,
+                        "end_byte": 159,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 2
+                      },
+                      "fragment": "Until end of turn, you don't lose this mana as steps and phases end"
+                    },
+                    "disposition": {
+                      "ModifyPrior": {
+                        "modifier": {
+                          "ManaRetention": "EndOfTurn"
+                        }
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "mana_retention_placeholder",
+                        "description": null
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Any"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "add {c} for each artifact you control. this mana can't be spent to cast nonartifact spells. until end of turn, you don't lose this mana as steps and phases end.",
+              "relative_player_scope": null
+            },
+            "source_text": "At the beginning of your upkeep, add {C} for each artifact you control. This mana can't be spent to cast nonartifact spells. Until end of turn, you don't lose this mana as steps and phases end.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kathril_aspect_warper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kathril_aspect_warper_ir.snap
@@ -22,108 +22,61 @@ expression: "&ir"
         "fragment": "When ~ enters, put a flying counter on any creature you control if a creature card in your graveyard has flying. Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 counter on ~ for each counter put on a creature this way."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "flying",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": "You",
-                "properties": []
-              }
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "PutCounter",
-                "counter_type": "first strike",
-                "count": {
-                  "type": "Fixed",
-                  "value": 1
-                },
-                "target": {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": "You",
-                  "properties": []
-                }
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "PutCounter",
-                  "counter_type": "double strike",
-                  "count": {
-                    "type": "Fixed",
-                    "value": 1
-                  },
-                  "target": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  }
-                },
-                "cost": null,
-                "sub_ability": {
-                  "kind": "Spell",
-                  "effect": {
-                    "type": "PutCounter",
-                    "counter_type": "deathtouch",
-                    "count": {
-                      "type": "Fixed",
-                      "value": 1
-                    },
-                    "target": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": []
-                    }
-                  },
-                  "cost": null,
-                  "sub_ability": {
-                    "kind": "Spell",
-                    "effect": {
-                      "type": "PutCounter",
-                      "counter_type": "hexproof",
-                      "count": {
-                        "type": "Fixed",
-                        "value": 1
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
                       },
-                      "target": {
-                        "type": "Typed",
-                        "type_filters": [
-                          "Creature"
-                        ],
-                        "controller": "You",
-                        "properties": []
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 96,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "put a flying counter on any creature you control if a creature card in your graveyard has flying"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
                       }
                     },
-                    "cost": null,
-                    "sub_ability": {
-                      "kind": "Spell",
+                    "parsed": {
                       "effect": {
                         "type": "PutCounter",
-                        "counter_type": "indestructible",
+                        "counter_type": "flying",
                         "count": {
                           "type": "Fixed",
                           "value": 1
@@ -137,377 +90,15 @@ expression: "&ir"
                           "properties": []
                         }
                       },
-                      "cost": null,
-                      "sub_ability": {
-                        "kind": "Spell",
-                        "effect": {
-                          "type": "PutCounter",
-                          "counter_type": "lifelink",
-                          "count": {
-                            "type": "Fixed",
-                            "value": 1
-                          },
-                          "target": {
-                            "type": "Typed",
-                            "type_filters": [
-                              "Creature"
-                            ],
-                            "controller": "You",
-                            "properties": []
-                          }
-                        },
-                        "cost": null,
-                        "sub_ability": {
-                          "kind": "Spell",
-                          "effect": {
-                            "type": "PutCounter",
-                            "counter_type": "menace",
-                            "count": {
-                              "type": "Fixed",
-                              "value": 1
-                            },
-                            "target": {
-                              "type": "Typed",
-                              "type_filters": [
-                                "Creature"
-                              ],
-                              "controller": "You",
-                              "properties": []
-                            }
-                          },
-                          "cost": null,
-                          "sub_ability": {
-                            "kind": "Spell",
-                            "effect": {
-                              "type": "PutCounter",
-                              "counter_type": "reach",
-                              "count": {
-                                "type": "Fixed",
-                                "value": 1
-                              },
-                              "target": {
-                                "type": "Typed",
-                                "type_filters": [
-                                  "Creature"
-                                ],
-                                "controller": "You",
-                                "properties": []
-                              }
-                            },
-                            "cost": null,
-                            "sub_ability": {
-                              "kind": "Spell",
-                              "effect": {
-                                "type": "PutCounter",
-                                "counter_type": "trample",
-                                "count": {
-                                  "type": "Fixed",
-                                  "value": 1
-                                },
-                                "target": {
-                                  "type": "Typed",
-                                  "type_filters": [
-                                    "Creature"
-                                  ],
-                                  "controller": "You",
-                                  "properties": []
-                                }
-                              },
-                              "cost": null,
-                              "sub_ability": {
-                                "kind": "Spell",
-                                "effect": {
-                                  "type": "PutCounter",
-                                  "counter_type": "vigilance",
-                                  "count": {
-                                    "type": "Fixed",
-                                    "value": 1
-                                  },
-                                  "target": {
-                                    "type": "Typed",
-                                    "type_filters": [
-                                      "Creature"
-                                    ],
-                                    "controller": "You",
-                                    "properties": []
-                                  }
-                                },
-                                "cost": null,
-                                "sub_ability": {
-                                  "kind": "Spell",
-                                  "effect": {
-                                    "type": "PutCounter",
-                                    "counter_type": "P1P1",
-                                    "count": {
-                                      "type": "Ref",
-                                      "qty": {
-                                        "type": "TrackedSetSize"
-                                      }
-                                    },
-                                    "target": {
-                                      "type": "SelfRef"
-                                    }
-                                  },
-                                  "cost": null,
-                                  "sub_ability": null,
-                                  "duration": null,
-                                  "description": null,
-                                  "target_prompt": null,
-                                  "condition": null,
-                                  "optional_targeting": false,
-                                  "optional": false,
-                                  "forward_result": false,
-                                  "sub_link": "SequentialSibling"
-                                },
-                                "duration": null,
-                                "description": null,
-                                "target_prompt": null,
-                                "condition": {
-                                  "type": "QuantityCheck",
-                                  "lhs": {
-                                    "type": "Ref",
-                                    "qty": {
-                                      "type": "ObjectCount",
-                                      "filter": {
-                                        "type": "Typed",
-                                        "type_filters": [
-                                          "Creature"
-                                        ],
-                                        "controller": "You",
-                                        "properties": [
-                                          {
-                                            "type": "InZone",
-                                            "zone": "Graveyard"
-                                          },
-                                          {
-                                            "type": "WithKeyword",
-                                            "value": "Vigilance"
-                                          }
-                                        ]
-                                      }
-                                    }
-                                  },
-                                  "comparator": "GE",
-                                  "rhs": {
-                                    "type": "Fixed",
-                                    "value": 1
-                                  }
-                                },
-                                "optional_targeting": false,
-                                "optional": false,
-                                "target_choice_timing": "Resolution",
-                                "forward_result": false,
-                                "sub_link": "SequentialSibling",
-                                "sibling_condition": "ReplicatedOrBranch"
-                              },
-                              "duration": null,
-                              "description": null,
-                              "target_prompt": null,
-                              "condition": {
-                                "type": "QuantityCheck",
-                                "lhs": {
-                                  "type": "Ref",
-                                  "qty": {
-                                    "type": "ObjectCount",
-                                    "filter": {
-                                      "type": "Typed",
-                                      "type_filters": [
-                                        "Creature"
-                                      ],
-                                      "controller": "You",
-                                      "properties": [
-                                        {
-                                          "type": "InZone",
-                                          "zone": "Graveyard"
-                                        },
-                                        {
-                                          "type": "WithKeyword",
-                                          "value": "Trample"
-                                        }
-                                      ]
-                                    }
-                                  }
-                                },
-                                "comparator": "GE",
-                                "rhs": {
-                                  "type": "Fixed",
-                                  "value": 1
-                                }
-                              },
-                              "optional_targeting": false,
-                              "optional": false,
-                              "target_choice_timing": "Resolution",
-                              "forward_result": false,
-                              "sub_link": "SequentialSibling",
-                              "sibling_condition": "ReplicatedOrBranch"
-                            },
-                            "duration": null,
-                            "description": null,
-                            "target_prompt": null,
-                            "condition": {
-                              "type": "QuantityCheck",
-                              "lhs": {
-                                "type": "Ref",
-                                "qty": {
-                                  "type": "ObjectCount",
-                                  "filter": {
-                                    "type": "Typed",
-                                    "type_filters": [
-                                      "Creature"
-                                    ],
-                                    "controller": "You",
-                                    "properties": [
-                                      {
-                                        "type": "InZone",
-                                        "zone": "Graveyard"
-                                      },
-                                      {
-                                        "type": "WithKeyword",
-                                        "value": "Reach"
-                                      }
-                                    ]
-                                  }
-                                }
-                              },
-                              "comparator": "GE",
-                              "rhs": {
-                                "type": "Fixed",
-                                "value": 1
-                              }
-                            },
-                            "optional_targeting": false,
-                            "optional": false,
-                            "target_choice_timing": "Resolution",
-                            "forward_result": false,
-                            "sub_link": "SequentialSibling",
-                            "sibling_condition": "ReplicatedOrBranch"
-                          },
-                          "duration": null,
-                          "description": null,
-                          "target_prompt": null,
-                          "condition": {
-                            "type": "QuantityCheck",
-                            "lhs": {
-                              "type": "Ref",
-                              "qty": {
-                                "type": "ObjectCount",
-                                "filter": {
-                                  "type": "Typed",
-                                  "type_filters": [
-                                    "Creature"
-                                  ],
-                                  "controller": "You",
-                                  "properties": [
-                                    {
-                                      "type": "InZone",
-                                      "zone": "Graveyard"
-                                    },
-                                    {
-                                      "type": "WithKeyword",
-                                      "value": "Menace"
-                                    }
-                                  ]
-                                }
-                              }
-                            },
-                            "comparator": "GE",
-                            "rhs": {
-                              "type": "Fixed",
-                              "value": 1
-                            }
-                          },
-                          "optional_targeting": false,
-                          "optional": false,
-                          "target_choice_timing": "Resolution",
-                          "forward_result": false,
-                          "sub_link": "SequentialSibling",
-                          "sibling_condition": "ReplicatedOrBranch"
-                        },
-                        "duration": null,
-                        "description": null,
-                        "target_prompt": null,
-                        "condition": {
-                          "type": "QuantityCheck",
-                          "lhs": {
-                            "type": "Ref",
-                            "qty": {
-                              "type": "ObjectCount",
-                              "filter": {
-                                "type": "Typed",
-                                "type_filters": [
-                                  "Creature"
-                                ],
-                                "controller": "You",
-                                "properties": [
-                                  {
-                                    "type": "InZone",
-                                    "zone": "Graveyard"
-                                  },
-                                  {
-                                    "type": "WithKeyword",
-                                    "value": "Lifelink"
-                                  }
-                                ]
-                              }
-                            }
-                          },
-                          "comparator": "GE",
-                          "rhs": {
-                            "type": "Fixed",
-                            "value": 1
-                          }
-                        },
-                        "optional_targeting": false,
-                        "optional": false,
-                        "target_choice_timing": "Resolution",
-                        "forward_result": false,
-                        "sub_link": "SequentialSibling",
-                        "sibling_condition": "ReplicatedOrBranch"
-                      },
                       "duration": null,
-                      "description": null,
-                      "target_prompt": null,
-                      "condition": {
-                        "type": "QuantityCheck",
-                        "lhs": {
-                          "type": "Ref",
-                          "qty": {
-                            "type": "ObjectCount",
-                            "filter": {
-                              "type": "Typed",
-                              "type_filters": [
-                                "Creature"
-                              ],
-                              "controller": "You",
-                              "properties": [
-                                {
-                                  "type": "InZone",
-                                  "zone": "Graveyard"
-                                },
-                                {
-                                  "type": "WithKeyword",
-                                  "value": "Indestructible"
-                                }
-                              ]
-                            }
-                          }
-                        },
-                        "comparator": "GE",
-                        "rhs": {
-                          "type": "Fixed",
-                          "value": 1
-                        }
-                      },
-                      "optional_targeting": false,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
                       "optional": false,
-                      "target_choice_timing": "Resolution",
-                      "forward_result": false,
-                      "sub_link": "SequentialSibling",
-                      "sibling_condition": "ReplicatedOrBranch"
+                      "unless_pay": null
                     },
-                    "duration": null,
-                    "description": null,
-                    "target_prompt": null,
+                    "boundary": "Sentence",
                     "condition": {
                       "type": "QuantityCheck",
                       "lhs": {
@@ -527,7 +118,7 @@ expression: "&ir"
                               },
                               {
                                 "type": "WithKeyword",
-                                "value": "Hexproof"
+                                "value": "Flying"
                               }
                             ]
                           }
@@ -539,193 +130,162 @@ expression: "&ir"
                         "value": 1
                       }
                     },
-                    "optional_targeting": false,
-                    "optional": false,
-                    "target_choice_timing": "Resolution",
-                    "forward_result": false,
-                    "sub_link": "SequentialSibling",
-                    "sibling_condition": "ReplicatedOrBranch"
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   },
-                  "duration": null,
-                  "description": null,
-                  "target_prompt": null,
-                  "condition": {
-                    "type": "QuantityCheck",
-                    "lhs": {
-                      "type": "Ref",
-                      "qty": {
-                        "type": "ObjectCount",
-                        "filter": {
-                          "type": "Typed",
-                          "type_filters": [
-                            "Creature"
-                          ],
-                          "controller": "You",
-                          "properties": [
-                            {
-                              "type": "InZone",
-                              "zone": "Graveyard"
-                            },
-                            {
-                              "type": "WithKeyword",
-                              "value": "Deathtouch"
-                            }
-                          ]
-                        }
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 98,
+                        "end_byte": 236,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance"
+                    },
+                    "disposition": {
+                      "ReplicatePerKeyword": {
+                        "keywords": [
+                          "FirstStrike",
+                          "DoubleStrike",
+                          "Deathtouch",
+                          "Hexproof",
+                          "Indestructible",
+                          "Lifelink",
+                          "Menace",
+                          "Reach",
+                          "Trample",
+                          "Vigilance"
+                        ],
+                        "kind": "CounterPlacement"
                       }
                     },
-                    "comparator": "GE",
-                    "rhs": {
-                      "type": "Fixed",
-                      "value": 1
-                    }
-                  },
-                  "optional_targeting": false,
-                  "optional": false,
-                  "target_choice_timing": "Resolution",
-                  "forward_result": false,
-                  "sub_link": "SequentialSibling",
-                  "sibling_condition": "ReplicatedOrBranch"
-                },
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": {
-                  "type": "QuantityCheck",
-                  "lhs": {
-                    "type": "Ref",
-                    "qty": {
-                      "type": "ObjectCount",
-                      "filter": {
-                        "type": "Typed",
-                        "type_filters": [
-                          "Creature"
-                        ],
-                        "controller": "You",
-                        "properties": [
-                          {
-                            "type": "InZone",
-                            "zone": "Graveyard"
-                          },
-                          {
-                            "type": "WithKeyword",
-                            "value": "DoubleStrike"
-                          }
-                        ]
-                      }
-                    }
-                  },
-                  "comparator": "GE",
-                  "rhs": {
-                    "type": "Fixed",
-                    "value": 1
-                  }
-                },
-                "optional_targeting": false,
-                "optional": false,
-                "target_choice_timing": "Resolution",
-                "forward_result": false,
-                "sub_link": "SequentialSibling",
-                "sibling_condition": "ReplicatedOrBranch"
-              },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": {
-                "type": "QuantityCheck",
-                "lhs": {
-                  "type": "Ref",
-                  "qty": {
-                    "type": "ObjectCount",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "InZone",
-                          "zone": "Graveyard"
-                        },
-                        {
-                          "type": "WithKeyword",
-                          "value": "FirstStrike"
-                        }
-                      ]
-                    }
-                  }
-                },
-                "comparator": "GE",
-                "rhs": {
-                  "type": "Fixed",
-                  "value": 1
-                }
-              },
-              "optional_targeting": false,
-              "optional": false,
-              "target_choice_timing": "Resolution",
-              "forward_result": false,
-              "sub_link": "SequentialSibling",
-              "sibling_condition": "ReplicatedOrBranch"
-            },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": {
-              "type": "QuantityCheck",
-              "lhs": {
-                "type": "Ref",
-                "qty": {
-                  "type": "ObjectCount",
-                  "filter": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": [
-                      {
-                        "type": "InZone",
-                        "zone": "Graveyard"
+                    "parsed": {
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "repeat_process_for_keywords_placeholder",
+                        "description": null
                       },
-                      {
-                        "type": "WithKeyword",
-                        "value": "Flying"
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 2,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 3
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 243,
+                        "end_byte": 311,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 2
+                      },
+                      "fragment": "put a +1/+1 counter on ~ for each counter put on a creature this way"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
                       }
-                    ]
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "PutCounter",
+                        "counter_type": "P1P1",
+                        "count": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "TrackedSetSize"
+                          }
+                        },
+                        "target": {
+                          "type": "SelfRef"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   }
-                }
-              },
-              "comparator": "GE",
-              "rhs": {
-                "type": "Fixed",
-                "value": 1
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "optional_targeting": false,
-            "optional": false,
-            "target_choice_timing": "Resolution",
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ enters, put a flying counter on any creature you control if a creature card in your graveyard has flying. Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 counter on ~ for each counter put on a creature this way.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "put a flying counter on any creature you control if a creature card in your graveyard has flying. repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. then put a +1/+1 counter on ~ for each counter put on a creature this way.",
+              "relative_player_scope": null
+            },
+            "source_text": "When ~ enters, put a flying counter on any creature you control if a creature card in your graveyard has flying. Repeat this process for first strike, double strike, deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. Then put a +1/+1 counter on ~ for each counter put on a creature this way.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__kroxa_titan_ir.snap
@@ -22,54 +22,121 @@ expression: "&ir"
         "fragment": "When ~ enters, sacrifice it unless it escaped."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Sacrifice",
-              "target": {
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
                 "type": "SelfRef"
               },
-              "count": {
-                "type": "Fixed",
-                "value": 1
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 12,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "sacrifice it"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Sacrifice",
+                        "target": {
+                          "type": "SelfRef"
+                        },
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ enters, sacrifice it unless it escaped.",
-          "constraint": null,
-          "condition": {
-            "type": "Not",
-            "condition": {
-              "type": "CastVariantPaid",
-              "variant": "Escape"
-            }
-          },
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": {
+                "type": "Not",
+                "condition": {
+                  "type": "CastVariantPaid",
+                  "variant": "Escape"
+                }
+              },
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "sacrifice it unless it escaped.",
+              "relative_player_scope": null
+            },
+            "source_text": "When ~ enters, sacrifice it unless it escaped.",
+            "die_results": []
+          }
         }
       }
     },
@@ -91,99 +158,199 @@ expression: "&ir"
         "fragment": "Whenever ~ enters or attacks, each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "EntersOrAttacks",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Discard",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Trigger": {
+          "Parsed": {
+            "condition": "EntersOrAttacks",
+            "partial_def": {
+              "mode": "EntersOrAttacks",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "target": {
-                "type": "Controller"
-              }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "LoseLife",
-                "amount": {
-                  "type": "Fixed",
-                  "value": 3
-                },
-                "target": {
-                  "type": "ScopedPlayer"
-                }
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
               "description": null,
-              "target_prompt": null,
-              "condition": {
-                "type": "And",
-                "conditions": [
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
                   {
-                    "type": "Not",
-                    "condition": {
-                      "type": "ZoneChangedThisWay",
-                      "filter": {
-                        "type": "Typed",
-                        "type_filters": [
-                          "Card",
-                          {
-                            "Non": "Land"
-                          }
-                        ],
-                        "controller": null,
-                        "properties": []
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 29,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "each opponent discards a card"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
                       }
-                    }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Discard",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Then",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": {
+                      "type": "Opponent"
+                    },
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   },
                   {
-                    "type": "ScopedPlayerMatches",
-                    "filter": {
-                      "type": "Opponent"
-                    }
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 36,
+                        "end_byte": 105,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "each opponent who didn't discard a nonland card this way loses 3 life"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "LoseLife",
+                        "amount": {
+                          "type": "Fixed",
+                          "value": 3
+                        },
+                        "target": {
+                          "type": "ScopedPlayer"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": {
+                      "type": "And",
+                      "conditions": [
+                        {
+                          "type": "Not",
+                          "condition": {
+                            "type": "ZoneChangedThisWay",
+                            "filter": {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Card",
+                                {
+                                  "Non": "Land"
+                                }
+                              ],
+                              "controller": null,
+                              "properties": []
+                            }
+                          }
+                        },
+                        {
+                          "type": "ScopedPlayerMatches",
+                          "filter": {
+                            "type": "Opponent"
+                          }
+                        }
+                      ]
+                    },
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   }
-                ]
-              },
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "player_scope": {
-              "type": "Opponent"
-            }
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever ~ enters or attacks, each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever ~ enters or attacks, each opponent discards a card, then each opponent who didn't discard a nonland card this way loses 3 life.",
+            "die_results": []
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
@@ -22,75 +22,168 @@ expression: "&ir"
         "fragment": "Whenever another creature or planeswalker you control enters, mill two cards."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Mill",
-              "count": {
-                "type": "Fixed",
-                "value": 2
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Planeswalker"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  }
+                ]
               },
-              "target": {
-                "type": "Controller"
-              },
-              "destination": "Graveyard"
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Or",
-            "filters": [
-              {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": "You",
-                "properties": [
+            "body": {
+              "EffectChain": {
+                "clauses": [
                   {
-                    "type": "Another"
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 14,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "mill two cards"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Mill",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "target": {
+                          "type": "Controller"
+                        },
+                        "destination": "Graveyard"
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Creature"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Planeswalker"
+                    ],
+                    "controller": "You",
+                    "properties": [
+                      {
+                        "type": "Another"
+                      }
+                    ]
                   }
                 ]
               },
-              {
-                "type": "Typed",
-                "type_filters": [
-                  "Planeswalker"
-                ],
-                "controller": "You",
-                "properties": [
-                  {
-                    "type": "Another"
-                  }
-                ]
-              }
-            ]
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever another creature or planeswalker you control enters, mill two cards.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "mill two cards.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever another creature or planeswalker you control enters, mill two cards.",
+            "die_results": []
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__luminarch_aspirant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__luminarch_aspirant_ir.snap
@@ -22,54 +22,121 @@ expression: "&ir"
         "fragment": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "P1P1",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Trigger": {
+          "Parsed": {
+            "condition": "Phase",
+            "partial_def": {
+              "mode": "Phase",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": "BeginCombat",
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": {
+                "type": "OnlyDuringYourTurn"
               },
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 50,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "put a +1/+1 counter on target creature you control"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "PutCounter",
+                        "counter_type": "P1P1",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": "You",
+                          "properties": []
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
                 ],
-                "controller": "You",
-                "properties": []
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "BeginCombat",
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
-          "constraint": {
-            "type": "OnlyDuringYourTurn"
-          },
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Any"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "put a +1/+1 counter on target creature you control.",
+              "relative_player_scope": null
+            },
+            "source_text": "At the beginning of combat on your turn, put a +1/+1 counter on target creature you control.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mishra_eminent_one_ir.snap
@@ -22,168 +22,282 @@ expression: "&ir"
         "fragment": "At the beginning of combat on your turn, create a token that's a copy of target noncreature artifact you control, except its name is ~'s Warform and it's a 4/4 Construct artifact creature in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "CopyTokenOf",
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Artifact",
-                  {
-                    "Non": "Creature"
-                  }
-                ],
-                "controller": "You",
-                "properties": []
-              },
-              "owner": {
-                "type": "Controller"
-              },
-              "enters_attacking": false,
-              "tapped": false,
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "additional_modifications": [
-                {
-                  "type": "SetPower",
-                  "value": 4
-                },
-                {
-                  "type": "SetToughness",
-                  "value": 4
-                },
-                {
-                  "type": "AddSubtype",
-                  "subtype": "Construct"
-                },
-                {
-                  "type": "AddType",
-                  "core_type": "Artifact"
-                },
-                {
-                  "type": "AddType",
-                  "core_type": "Creature"
-                },
-                {
-                  "type": "SetName",
-                  "name": "Mishra's Warform"
-                }
-              ]
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "GenericEffect",
-                "static_abilities": [
-                  {
-                    "mode": "Continuous",
-                    "affected": {
-                      "type": "LastCreated"
-                    },
-                    "modifications": [
-                      {
-                        "type": "AddKeyword",
-                        "keyword": "Haste"
-                      }
-                    ],
-                    "condition": null,
-                    "affected_zone": null,
-                    "effect_zone": null,
-                    "active_zones": [],
-                    "characteristic_defining": false,
-                    "description": "gain haste"
-                  }
-                ],
-                "duration": "UntilEndOfTurn",
-                "target": {
-                  "type": "LastCreated"
-                }
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "CreateDelayedTrigger",
-                  "condition": {
-                    "type": "AtNextPhase",
-                    "phase": "End"
-                  },
-                  "effect": {
-                    "kind": "Spell",
-                    "effect": {
-                      "type": "Sacrifice",
-                      "target": {
-                        "type": "LastCreated"
-                      },
-                      "count": {
-                        "type": "Fixed",
-                        "value": 1
-                      }
-                    },
-                    "cost": null,
-                    "sub_ability": null,
-                    "duration": null,
-                    "description": null,
-                    "target_prompt": null,
-                    "condition": null,
-                    "optional_targeting": false,
-                    "optional": false,
-                    "forward_result": false
-                  },
-                  "uses_tracked_set": false
-                },
-                "cost": null,
-                "sub_ability": null,
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false,
-                "sub_link": "SequentialSibling"
-              },
-              "duration": "UntilEndOfTurn",
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
+        "Trigger": {
+          "Parsed": {
+            "condition": "Phase",
+            "partial_def": {
+              "mode": "Phase",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": "BeginCombat",
               "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": {
+                "type": "OnlyDuringYourTurn"
+              },
+              "condition": null,
+              "batched": false
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "BeginCombat",
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of combat on your turn, create a token that's a copy of target noncreature artifact you control, except its name is ~'s Warform and it's a 4/4 Construct artifact creature in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
-          "constraint": {
-            "type": "OnlyDuringYourTurn"
-          },
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 177,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "create a token that's a copy of target noncreature artifact you control, except its name is ~'s Warform and it's a 4/4 Construct artifact creature in addition to its other types"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "CopyTokenOf",
+                        "target": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Artifact",
+                            {
+                              "Non": "Creature"
+                            }
+                          ],
+                          "controller": "You",
+                          "properties": []
+                        },
+                        "owner": {
+                          "type": "Controller"
+                        },
+                        "enters_attacking": false,
+                        "tapped": false,
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "additional_modifications": [
+                          {
+                            "type": "SetPower",
+                            "value": 4
+                          },
+                          {
+                            "type": "SetToughness",
+                            "value": 4
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Construct"
+                          },
+                          {
+                            "type": "AddType",
+                            "core_type": "Artifact"
+                          },
+                          {
+                            "type": "AddType",
+                            "core_type": "Creature"
+                          },
+                          {
+                            "type": "SetName",
+                            "name": "Mishra's Warform"
+                          }
+                        ]
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 179,
+                        "end_byte": 211,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "It gains haste until end of turn"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "GenericEffect",
+                        "static_abilities": [
+                          {
+                            "mode": "Continuous",
+                            "affected": {
+                              "type": "SelfRef"
+                            },
+                            "modifications": [
+                              {
+                                "type": "AddKeyword",
+                                "keyword": "Haste"
+                              }
+                            ],
+                            "condition": null,
+                            "affected_zone": null,
+                            "effect_zone": null,
+                            "active_zones": [],
+                            "characteristic_defining": false,
+                            "description": "gain haste"
+                          }
+                        ],
+                        "duration": "UntilEndOfTurn",
+                        "target": null
+                      },
+                      "duration": "UntilEndOfTurn",
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 2,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 3
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 213,
+                        "end_byte": 263,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 2
+                      },
+                      "fragment": "Sacrifice it at the beginning of the next end step"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Sacrifice",
+                        "target": {
+                          "type": "SelfRef"
+                        },
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": {
+                      "type": "AtNextPhase",
+                      "phase": "End"
+                    },
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Any"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "create a token that's a copy of target noncreature artifact you control, except its name is ~'s warform and it's a 4/4 construct artifact creature in addition to its other types. it gains haste until end of turn. sacrifice it at the beginning of the next end step.",
+              "relative_player_scope": null
+            },
+            "source_text": "At the beginning of combat on your turn, create a token that's a copy of target noncreature artifact you control, except its name is ~'s Warform and it's a 4/4 Construct artifact creature in addition to its other types. It gains haste until end of turn. Sacrifice it at the beginning of the next end step.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__murderous_rider_ir.snap
@@ -50,51 +50,118 @@ expression: "&ir"
         "fragment": "When ~ dies, put it on the bottom of its owner's library."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutAtLibraryPosition",
-              "target": {
-                "type": "ParentTarget"
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "position": {
-                "type": "Bottom"
+              "origin": "Battlefield",
+              "destination": "Graveyard",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 43,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "put it on the bottom of its owner's library"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "PutAtLibraryPosition",
+                        "target": {
+                          "type": "ParentTarget"
+                        },
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "position": {
+                          "type": "Bottom"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": "Battlefield",
-          "destination": "Graveyard",
-          "trigger_zones": [
-            "Graveyard"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ dies, put it on the bottom of its owner's library.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "put it on the bottom of its owner's library.",
+              "relative_player_scope": null
+            },
+            "source_text": "When ~ dies, put it on the bottom of its owner's library.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 723
 expression: "&ir"
 ---
 {
@@ -52,87 +51,235 @@ expression: "&ir"
         "fragment": "Whenever ~ deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "DamageDone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "ExileTop",
-              "player": {
-                "type": "Controller"
+        "Trigger": {
+          "Parsed": {
+            "condition": "DamageDone",
+            "partial_def": {
+              "mode": "DamageDone",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "CombatOnly",
+              "secondary": false,
+              "valid_target": {
+                "type": "Player"
               },
-              "count": {
-                "type": "Fixed",
-                "value": 1
+              "valid_source": {
+                "type": "SelfRef"
               },
-              "position": {
-                "type": "Top"
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 43,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "exile the top card of each player's library"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "ExileTop",
+                        "player": {
+                          "type": "Controller"
+                        },
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "position": {
+                          "type": "Top"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": {
+                      "type": "All"
+                    },
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 45,
+                        "end_byte": 95,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "Until end of turn, you may play one of those cards"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "CastFromZone",
+                        "target": {
+                          "type": "ParentTarget"
+                        },
+                        "without_paying_mana_cost": false,
+                        "mode": "Play",
+                        "duration": "UntilEndOfTurn"
+                      },
+                      "duration": "UntilEndOfTurn",
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": true,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 2,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 3
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 97,
+                        "end_byte": 192,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 2
+                      },
+                      "fragment": "If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost"
+                    },
+                    "disposition": {
+                      "ModifyPrior": {
+                        "modifier": {
+                          "AltCost": {
+                            "type": "PayLife",
+                            "amount": {
+                              "type": "Ref",
+                              "qty": {
+                                "type": "SelfManaValue"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "alt_cost_rider_placeholder",
+                        "description": null
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "CastFromZone",
-                "target": {
-                  "type": "TrackedSet",
-                  "id": 0
-                },
-                "without_paying_mana_cost": false,
-                "mode": "Play",
-                "alt_ability_cost": {
-                  "type": "PayLife",
-                  "amount": {
-                    "type": "Ref",
-                    "qty": {
-                      "type": "SelfManaValue"
-                    }
-                  }
-                },
-                "duration": "UntilEndOfTurn"
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": "UntilEndOfTurn",
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
+            "modifiers": {
               "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "exile the top card of each player's library. until end of turn, you may play one of those cards. if you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
+              "relative_player_scope": "TargetPlayer"
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "player_scope": {
-              "type": "All"
-            }
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "CombatOnly",
-          "secondary": false,
-          "valid_target": {
-            "type": "Player"
-          },
-          "valid_source": {
-            "type": "SelfRef"
-          },
-          "description": "Whenever ~ deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "source_text": "Whenever ~ deals combat damage to a player, exile the top card of each player's library. Until end of turn, you may play one of those cards. If you cast a spell this way, pay life equal to its mana value rather than paying its mana cost.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__odric_lunarch_marshal_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__odric_lunarch_marshal_ir.snap
@@ -22,537 +22,222 @@ expression: "&ir"
         "fragment": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "FirstStrike"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "FirstStrike"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Flying"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Flying"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Deathtouch"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Deathtouch"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "DoubleStrike"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "DoubleStrike"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Haste"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Haste"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Hexproof"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Hexproof"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Indestructible"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Indestructible"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Lifelink"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Lifelink"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Menace"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Menace"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Reach"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Reach"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Skulk"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Skulk"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Trample"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Trample"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                },
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": []
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Vigilance"
-                    }
-                  ],
-                  "condition": {
-                    "type": "IsPresent",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Creature"
-                      ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "WithKeyword",
-                          "value": "Vigilance"
-                        }
-                      ]
-                    }
-                  },
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain first strike"
-                }
+        "Trigger": {
+          "Parsed": {
+            "condition": "Phase",
+            "partial_def": {
+              "mode": "Phase",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "duration": "UntilEndOfTurn",
-              "target": null
+              "phase": "BeginCombat",
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "BeginCombat",
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 100,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "creatures you control gain first strike until end of turn if a creature you control has first strike"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "GenericEffect",
+                        "static_abilities": [
+                          {
+                            "mode": "Continuous",
+                            "affected": {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Creature"
+                              ],
+                              "controller": "You",
+                              "properties": []
+                            },
+                            "modifications": [
+                              {
+                                "type": "AddKeyword",
+                                "keyword": "FirstStrike"
+                              }
+                            ],
+                            "condition": null,
+                            "affected_zone": null,
+                            "effect_zone": null,
+                            "active_zones": [],
+                            "characteristic_defining": false,
+                            "description": "gain first strike"
+                          }
+                        ],
+                        "duration": "UntilEndOfTurn",
+                        "target": null
+                      },
+                      "duration": "UntilEndOfTurn",
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": {
+                      "type": "QuantityCheck",
+                      "lhs": {
+                        "type": "Ref",
+                        "qty": {
+                          "type": "ObjectCount",
+                          "filter": {
+                            "type": "Typed",
+                            "type_filters": [
+                              "Creature"
+                            ],
+                            "controller": "You",
+                            "properties": [
+                              {
+                                "type": "WithKeyword",
+                                "value": "FirstStrike"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "comparator": "GE",
+                      "rhs": {
+                        "type": "Fixed",
+                        "value": 1
+                      }
+                    },
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 102,
+                        "end_byte": 245,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance"
+                    },
+                    "disposition": {
+                      "ReplicatePerKeyword": {
+                        "keywords": [
+                          "Flying",
+                          "Deathtouch",
+                          "DoubleStrike",
+                          "Haste",
+                          "Hexproof",
+                          "Indestructible",
+                          "Lifelink",
+                          "Menace",
+                          "Reach",
+                          "Skulk",
+                          "Trample",
+                          "Vigilance"
+                        ],
+                        "kind": "StaticGrant"
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "same_is_true_for_placeholder",
+                        "description": null
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Any"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "creatures you control gain first strike until end of turn if a creature you control has first strike. the same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
+              "relative_player_scope": null
+            },
+            "source_text": "At the beginning of each combat, creatures you control gain first strike until end of turn if a creature you control has first strike. The same is true for flying, deathtouch, double strike, haste, hexproof, indestructible, lifelink, menace, reach, skulk, trample, and vigilance.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
@@ -206,60 +206,127 @@ expression: "&ir"
         "fragment": "Whenever ~ deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "DamageDone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "DealDamage",
-              "amount": {
-                "type": "Ref",
-                "qty": {
-                  "type": "EventContextAmount"
-                }
-              },
-              "target": {
+        "Trigger": {
+          "Parsed": {
+            "condition": "DamageDone",
+            "partial_def": {
+              "mode": "DamageDone",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "CombatOnly",
+              "secondary": false,
+              "valid_target": {
                 "type": "Typed",
-                "type_filters": [
-                  "Planeswalker"
-                ],
-                "controller": "TargetPlayer",
+                "type_filters": [],
+                "controller": "Opponent",
                 "properties": []
+              },
+              "valid_source": {
+                "type": "SelfRef"
+              },
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 69,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "it deals that much damage to target planeswalker that player controls"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "DealDamage",
+                        "amount": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "EventContextAmount"
+                          }
+                        },
+                        "target": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Planeswalker"
+                          ],
+                          "controller": "TargetPlayer",
+                          "properties": []
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "CombatOnly",
-          "secondary": false,
-          "valid_target": {
-            "type": "Typed",
-            "type_filters": [],
-            "controller": "Opponent",
-            "properties": []
-          },
-          "valid_source": {
-            "type": "SelfRef"
-          },
-          "description": "Whenever ~ deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "it deals that much damage to target planeswalker that player controls.",
+              "relative_player_scope": "TargetPlayer"
+            },
+            "source_text": "Whenever ~ deals combat damage to an opponent, it deals that much damage to target planeswalker that player controls.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__reckless_bushwhacker_ir.snap
@@ -79,83 +79,150 @@ expression: "&ir"
         "fragment": "When ~ enters, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": "You",
-                    "properties": [
-                      {
-                        "type": "Another"
-                      }
-                    ]
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddPower",
-                      "value": 1
-                    },
-                    {
-                      "type": "AddToughness",
-                      "value": 0
-                    },
-                    {
-                      "type": "AddKeyword",
-                      "keyword": "Haste"
-                    }
-                  ],
-                  "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "get +1/+0 and gain haste"
-                }
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "duration": "UntilEndOfTurn",
-              "target": null
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ enters, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
-          "constraint": null,
-          "condition": {
-            "type": "CastVariantPaid",
-            "variant": "Surge"
-          },
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 70,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "other creatures you control get +1/+0 and gain haste until end of turn"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "GenericEffect",
+                        "static_abilities": [
+                          {
+                            "mode": "Continuous",
+                            "affected": {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Creature"
+                              ],
+                              "controller": "You",
+                              "properties": [
+                                {
+                                  "type": "Another"
+                                }
+                              ]
+                            },
+                            "modifications": [
+                              {
+                                "type": "AddPower",
+                                "value": 1
+                              },
+                              {
+                                "type": "AddToughness",
+                                "value": 0
+                              },
+                              {
+                                "type": "AddKeyword",
+                                "keyword": "Haste"
+                              }
+                            ],
+                            "condition": null,
+                            "affected_zone": null,
+                            "effect_zone": null,
+                            "active_zones": [],
+                            "characteristic_defining": false,
+                            "description": "get +1/+0 and gain haste"
+                          }
+                        ],
+                        "duration": "UntilEndOfTurn",
+                        "target": null
+                      },
+                      "duration": "UntilEndOfTurn",
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": {
+                "type": "CastVariantPaid",
+                "variant": "Surge"
+              },
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
+              "relative_player_scope": null
+            },
+            "source_text": "When ~ enters, if its surge cost was paid, other creatures you control get +1/+0 and gain haste until end of turn.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__smugglers_copter_ir.snap
@@ -50,73 +50,173 @@ expression: "&ir"
         "fragment": "Whenever ~ attacks or blocks, you may draw a card. If you do, discard a card."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "AttacksOrBlocks",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Draw",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Trigger": {
+          "Parsed": {
+            "condition": "AttacksOrBlocks",
+            "partial_def": {
+              "mode": "AttacksOrBlocks",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
               },
-              "target": {
-                "type": "Controller"
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 19,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "you may draw a card"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Draw",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": true,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 21,
+                        "end_byte": 46,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "If you do, discard a card"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Discard",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": {
+                      "type": "EffectOutcome",
+                      "signal": "OptionalEffectPerformed"
+                    },
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "Discard",
-                "count": {
-                  "type": "Fixed",
-                  "value": 1
-                },
-                "target": {
-                  "type": "Controller"
-                }
+            "modifiers": {
+              "optional": true,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
               },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": {
-                "type": "EffectOutcome",
-                "signal": "OptionalEffectPerformed"
-              },
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "you may draw a card. if you do, discard a card.",
+              "relative_player_scope": null
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": true,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": true,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever ~ attacks or blocks, you may draw a card. If you do, discard a card.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "source_text": "Whenever ~ attacks or blocks, you may draw a card. If you do, discard a card.",
+            "die_results": []
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__snapcaster_mage_ir.snap
@@ -50,100 +50,216 @@ expression: "&ir"
         "fragment": "When ~ enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost. (You may cast that card from your graveyard for its flashback cost. Then exile it.)"
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "ParentTarget"
-                  },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": {
-                        "Flashback": {
-                          "type": "Mana",
-                          "data": {
-                            "type": "SelfManaCost"
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain flashback"
-                }
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "duration": "UntilEndOfTurn",
-              "target": {
-                "type": "Or",
-                "filters": [
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
                   {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Instant"
-                    ],
-                    "controller": "You",
-                    "properties": [
-                      {
-                        "type": "InZone",
-                        "zone": "Graveyard"
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 82,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "target instant or sorcery card in your graveyard gains flashback until end of turn"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
                       }
-                    ]
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "GenericEffect",
+                        "static_abilities": [
+                          {
+                            "mode": "Continuous",
+                            "affected": {
+                              "type": "ParentTarget"
+                            },
+                            "modifications": [
+                              {
+                                "type": "AddKeyword",
+                                "keyword": {
+                                  "Flashback": {
+                                    "type": "Mana",
+                                    "data": {
+                                      "type": "SelfManaCost"
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "condition": null,
+                            "affected_zone": null,
+                            "effect_zone": null,
+                            "active_zones": [],
+                            "characteristic_defining": false,
+                            "description": "gain flashback"
+                          }
+                        ],
+                        "duration": "UntilEndOfTurn",
+                        "target": {
+                          "type": "Or",
+                          "filters": [
+                            {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Instant"
+                              ],
+                              "controller": "You",
+                              "properties": [
+                                {
+                                  "type": "InZone",
+                                  "zone": "Graveyard"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Sorcery"
+                              ],
+                              "controller": "You",
+                              "properties": [
+                                {
+                                  "type": "InZone",
+                                  "zone": "Graveyard"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      },
+                      "duration": "UntilEndOfTurn",
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   },
                   {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Sorcery"
-                    ],
-                    "controller": "You",
-                    "properties": [
-                      {
-                        "type": "InZone",
-                        "zone": "Graveyard"
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 84,
+                        "end_byte": 128,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "The flashback cost is equal to its mana cost"
+                    },
+                    "disposition": {
+                      "Continue": {
+                        "continuation": "SelfCostKeywordCostClarification"
                       }
-                    ]
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "the",
+                        "description": "The flashback cost is equal to its mana cost"
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   }
-                ]
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "target instant or sorcery card in your graveyard gains flashback until end of turn. the flashback cost is equal to its mana cost.",
+              "relative_player_scope": null
+            },
+            "source_text": "When ~ enters, target instant or sorcery card in your graveyard gains flashback until end of turn. The flashback cost is equal to its mana cost.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
@@ -22,97 +22,183 @@ expression: "&ir"
         "fragment": "When ~ enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "SearchLibrary",
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Artifact",
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
                   {
-                    "Subtype": "Equipment"
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 83,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "you may search your library for an Equipment card, reveal it, put it into your hand"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": {
+                          "SearchDestination": {
+                            "destination": "Hand",
+                            "enter_tapped": false,
+                            "enters_under": null,
+                            "reveal": true,
+                            "attach_host": null
+                          }
+                        }
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "SearchLibrary",
+                        "filter": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Artifact",
+                            {
+                              "Subtype": "Equipment"
+                            }
+                          ],
+                          "controller": null,
+                          "properties": []
+                        },
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "reveal": true
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Then",
+                    "condition": null,
+                    "is_optional": true,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 90,
+                        "end_byte": 97,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "shuffle"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Shuffle",
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
                   }
                 ],
-                "controller": null,
-                "properties": []
-              },
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "reveal": true
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": "Library",
-                "destination": "Hand",
-                "target": {
-                  "type": "Any"
-                },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": {
                 "kind": "Spell",
-                "effect": {
-                  "type": "Shuffle",
-                  "target": {
-                    "type": "Controller"
-                  }
-                },
-                "cost": null,
-                "sub_ability": null,
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false
-              },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": true,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": true,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": true,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "you may search your library for an equipment card, reveal it, put it into your hand, then shuffle.",
+              "relative_player_scope": null
+            },
+            "source_text": "When ~ enters, you may search your library for an Equipment card, reveal it, put it into your hand, then shuffle.",
+            "die_results": []
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_library_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_library_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 799
 expression: "&ir"
 ---
 {
@@ -23,77 +22,229 @@ expression: "&ir"
         "fragment": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Phase",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Draw",
-              "count": {
-                "type": "Fixed",
-                "value": 2
+        "Trigger": {
+          "Parsed": {
+            "condition": "Phase",
+            "partial_def": {
+              "mode": "Phase",
+              "execute": null,
+              "valid_card": null,
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": "Draw",
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": {
+                "type": "OnlyDuringYourTurn"
               },
-              "target": {
-                "type": "Controller"
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 33,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "you may draw two additional cards"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Draw",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "target": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": null,
+                    "is_optional": true,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 1,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 2
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 35,
+                        "end_byte": 91,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 1
+                      },
+                      "fragment": "If you do, choose two cards in your hand drawn this turn"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "ChooseDrawnThisTurnPayOrTopdeck",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 2
+                        },
+                        "life_payment": {
+                          "type": "Fixed",
+                          "value": 4
+                        },
+                        "player": {
+                          "type": "Controller"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": "Sentence",
+                    "condition": {
+                      "type": "EffectOutcome",
+                      "signal": "OptionalEffectPerformed"
+                    },
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  },
+                  {
+                    "id": 2,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 3
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 93,
+                        "end_byte": 167,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 2
+                      },
+                      "fragment": "For each of those cards, pay 4 life or put the card on top of your library"
+                    },
+                    "disposition": {
+                      "DrawnThisTurnFollowup": {
+                        "life_payment": {
+                          "type": "Fixed",
+                          "value": 4
+                        }
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Unimplemented",
+                        "name": "drawn_this_turn_pay_or_topdeck_placeholder",
+                        "description": null
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChooseDrawnThisTurnPayOrTopdeck",
-                "count": {
-                  "type": "Fixed",
-                  "value": 2
-                },
-                "life_payment": {
-                  "type": "Fixed",
-                  "value": 4
-                },
-                "player": {
-                  "type": "Controller"
-                }
+            "modifiers": {
+              "optional": true,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Any"
               },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": {
-                "type": "EffectOutcome",
-                "signal": "OptionalEffectPerformed"
-              },
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "you may draw two additional cards. if you do, choose two cards in your hand drawn this turn. for each of those cards, pay 4 life or put the card on top of your library.",
+              "relative_player_scope": null
             },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": true,
-            "forward_result": false
-          },
-          "valid_card": null,
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": "Draw",
-          "optional": true,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
-          "constraint": {
-            "type": "OnlyDuringYourTurn"
-          },
-          "condition": null,
-          "batched": false
+            "source_text": "At the beginning of your draw step, you may draw two additional cards. If you do, choose two cards in your hand drawn this turn. For each of those cards, pay 4 life or put the card on top of your library.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__themberchaud_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__themberchaud_ir.snap
@@ -22,76 +22,134 @@ expression: "&ir"
         "fragment": "When ~ enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "DamageAll",
-              "amount": {
-                "type": "Ref",
-                "qty": {
-                  "type": "ObjectCount",
-                  "filter": {
-                    "type": "Typed",
-                    "type_filters": [
-                      {
-                        "Subtype": "Mountain"
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "SelfRef"
+              },
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 119,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
                       }
-                    ],
-                    "controller": "You",
-                    "properties": []
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "DamageAll",
+                        "amount": {
+                          "type": "Ref",
+                          "qty": {
+                            "type": "Variable",
+                            "name": "X"
+                          }
+                        },
+                        "target": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": null,
+                          "properties": [
+                            {
+                              "type": "Another"
+                            },
+                            {
+                              "type": "WithoutKeyword",
+                              "value": "Flying"
+                            }
+                          ]
+                        },
+                        "player_filter": {
+                          "type": "All"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": "the number of Mountains you control",
+                    "unless_pay": null
                   }
-                }
-              },
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
                 ],
-                "controller": null,
-                "properties": [
-                  {
-                    "type": "Another"
-                  },
-                  {
-                    "type": "WithoutKeyword",
-                    "value": "Flying"
-                  }
-                ]
-              },
-              "player_filter": {
-                "type": "All"
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "SelfRef"
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "When ~ enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "SelfRef"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "he deals x damage to each other creature without flying and each player, where x is the number of mountains you control.",
+              "relative_player_scope": null
+            },
+            "source_text": "When ~ enters, he deals X damage to each other creature without flying and each player, where X is the number of Mountains you control.",
+            "die_results": []
+          }
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tireless_tracker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__tireless_tracker_ir.snap
@@ -22,46 +22,118 @@ expression: "&ir"
         "fragment": "Landfall — Whenever a land you control enters, investigate. (Create a Clue token. It's an artifact with \"{2}, Sacrifice ~: Draw a card.\")"
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "ChangesZone",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Investigate"
+        "Trigger": {
+          "Parsed": {
+            "condition": "ChangesZone",
+            "partial_def": {
+              "mode": "ChangesZone",
+              "execute": null,
+              "valid_card": {
+                "type": "Typed",
+                "type_filters": [
+                  "Land"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "origin": null,
+              "destination": "Battlefield",
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              "Land"
-            ],
-            "controller": "You",
-            "properties": []
-          },
-          "origin": null,
-          "destination": "Battlefield",
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever a land you control enters, investigate.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 11,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "investigate"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Investigate"
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
+              }
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Typed",
+                "type_filters": [
+                  "Land"
+                ],
+                "controller": "You",
+                "properties": []
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "investigate.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever a land you control enters, investigate.",
+            "die_results": []
+          }
         }
       }
     },
@@ -83,56 +155,123 @@ expression: "&ir"
         "fragment": "Whenever you sacrifice a Clue, put a +1/+1 counter on ~."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "Sacrificed",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutCounter",
-              "counter_type": "P1P1",
-              "count": {
-                "type": "Fixed",
-                "value": 1
+        "Trigger": {
+          "Parsed": {
+            "condition": "Sacrificed",
+            "partial_def": {
+              "mode": "Sacrificed",
+              "execute": null,
+              "valid_card": {
+                "type": "Typed",
+                "type_filters": [
+                  {
+                    "Subtype": "Clue"
+                  }
+                ],
+                "controller": "You",
+                "properties": []
               },
-              "target": {
-                "type": "SelfRef"
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
+              ],
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": null,
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
+            },
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 24,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "put a +1/+1 counter on ~"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "PutCounter",
+                        "counter_type": "P1P1",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "target": {
+                          "type": "SelfRef"
+                        }
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
+                ],
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Typed",
-            "type_filters": [
-              {
-                "Subtype": "Clue"
-              }
-            ],
-            "controller": "You",
-            "properties": []
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": null,
-          "valid_source": null,
-          "description": "Whenever you sacrifice a Clue, put a +1/+1 counter on ~.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Controller"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "put a +1/+1 counter on ~.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever you sacrifice a Clue, put a +1/+1 counter on ~.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__young_pyromancer_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__young_pyromancer_ir.snap
@@ -22,87 +22,154 @@ expression: "&ir"
         "fragment": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token."
       },
       "node": {
-        "PreLoweredTrigger": {
-          "mode": "SpellCast",
-          "execute": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Token",
-              "name": "Elemental",
-              "power": {
-                "type": "Fixed",
-                "value": 1
+        "Trigger": {
+          "Parsed": {
+            "condition": "SpellCast",
+            "partial_def": {
+              "mode": "SpellCast",
+              "execute": null,
+              "valid_card": {
+                "type": "Or",
+                "filters": [
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Instant"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  },
+                  {
+                    "type": "Typed",
+                    "type_filters": [
+                      "Sorcery"
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                ]
               },
-              "toughness": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "types": [
-                "Creature",
-                "Elemental"
+              "origin": null,
+              "destination": null,
+              "trigger_zones": [
+                "Battlefield"
               ],
-              "colors": [
-                "Red"
-              ],
-              "keywords": [],
-              "tapped": false,
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "owner": {
+              "phase": null,
+              "optional": false,
+              "damage_kind": "Any",
+              "secondary": false,
+              "valid_target": {
                 "type": "Controller"
               },
-              "enters_attacking": false
+              "valid_source": null,
+              "description": null,
+              "constraint": null,
+              "condition": null,
+              "batched": false
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "valid_card": {
-            "type": "Or",
-            "filters": [
-              {
-                "type": "Typed",
-                "type_filters": [
-                  "Instant"
+            "body": {
+              "EffectChain": {
+                "clauses": [
+                  {
+                    "id": 0,
+                    "source": {
+                      "id": {
+                        "item": 0,
+                        "ordinal": 1
+                      },
+                      "span": {
+                        "first_line": 0,
+                        "last_line": 0,
+                        "start_byte": 0,
+                        "end_byte": 41,
+                        "precision": "ChainRelative",
+                        "ordinal_within_span": 0
+                      },
+                      "fragment": "create a 1/1 red Elemental creature token"
+                    },
+                    "disposition": {
+                      "Emit": {
+                        "followup": null,
+                        "intrinsic": null
+                      }
+                    },
+                    "parsed": {
+                      "effect": {
+                        "type": "Token",
+                        "name": "Elemental",
+                        "power": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "toughness": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "types": [
+                          "Creature",
+                          "Elemental"
+                        ],
+                        "colors": [
+                          "Red"
+                        ],
+                        "keywords": [],
+                        "tapped": false,
+                        "count": {
+                          "type": "Fixed",
+                          "value": 1
+                        },
+                        "owner": {
+                          "type": "Controller"
+                        },
+                        "enters_attacking": false
+                      },
+                      "duration": null,
+                      "sub_ability": null,
+                      "distribute": null,
+                      "multi_target": null,
+                      "condition": null,
+                      "optional": false,
+                      "unless_pay": null
+                    },
+                    "boundary": null,
+                    "condition": null,
+                    "is_optional": false,
+                    "opponent_may_scope": null,
+                    "repeat_for": null,
+                    "player_scope": null,
+                    "starting_with": null,
+                    "delayed_condition": null,
+                    "prefix_delayed_condition": null,
+                    "multi_target": null,
+                    "where_x_expression": null,
+                    "unless_pay": null
+                  }
                 ],
-                "controller": null,
-                "properties": []
-              },
-              {
-                "type": "Typed",
-                "type_filters": [
-                  "Sorcery"
-                ],
-                "controller": null,
-                "properties": []
+                "kind": "Spell",
+                "continuation_kind": null,
+                "player_scope_rewrite": "Apply",
+                "chain_rounding": null,
+                "actor": null,
+                "in_trigger": true,
+                "repeat_until": null
               }
-            ]
-          },
-          "origin": null,
-          "destination": null,
-          "trigger_zones": [
-            "Battlefield"
-          ],
-          "phase": null,
-          "optional": false,
-          "damage_kind": "Any",
-          "secondary": false,
-          "valid_target": {
-            "type": "Controller"
-          },
-          "valid_source": null,
-          "description": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
-          "constraint": null,
-          "condition": null,
-          "batched": false
+            },
+            "modifiers": {
+              "optional": false,
+              "unless_pay": null,
+              "intervening_if": null,
+              "trigger_subject": {
+                "type": "Controller"
+              },
+              "first_time_limit": null,
+              "constraint": null,
+              "has_up_to": false,
+              "effect_lower": "create a 1/1 red elemental creature token.",
+              "relative_player_scope": null
+            },
+            "source_text": "Whenever you cast an instant or sorcery spell, create a 1/1 red Elemental creature token.",
+            "die_results": []
+          }
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -42,12 +42,11 @@ use crate::types::triggers::TriggerMode;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) enum TriggerNodeIr {
     /// Native parsed trigger decomposition, lowered only at the document seam.
-    #[allow(dead_code)] // C1 installs the IR seam; C2 adds its producers.
     Parsed(Box<TriggerIr>),
     /// Already-assembled definition from a recognizer that builds its own.
     /// `lower_trigger_node_ir` returns it untouched.
     Assembled {
-        definition: TriggerDefinition,
+        definition: Box<TriggerDefinition>,
         /// The recognizer's own input text — provenance only. Document lowering
         /// derives spans and fragments from the emitting line, never from here.
         source_text: String,
@@ -58,7 +57,7 @@ impl TriggerNodeIr {
     /// Wrap a recognizer-produced trigger definition for source-ordered emission.
     pub(crate) fn from_definition(source_text: &str, definition: TriggerDefinition) -> Self {
         Self::Assembled {
-            definition,
+            definition: Box::new(definition),
             source_text: source_text.to_string(),
         }
     }
@@ -86,6 +85,19 @@ pub(crate) struct TriggerIr {
     /// CR 706.3b result-table rows for the terminal die roll in this trigger.
     /// They remain IR until trigger-body lowering attaches them before finalization.
     pub(crate) die_results: Vec<DieResultBranchIr>,
+}
+
+impl TriggerIr {
+    /// Whether the body ends in the typed die-roll node that owns a result table.
+    pub(crate) fn has_terminal_roll_die(&self) -> bool {
+        let Some(TriggerBody::EffectChain(chain)) = &self.body else {
+            return false;
+        };
+        chain
+            .clauses
+            .last()
+            .is_some_and(|clause| matches!(clause.parsed.effect, Effect::RollDie { .. }))
+    }
 }
 
 /// The body of a trigger. Whole-body recognizers retain their typed payloads

--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -90,13 +90,18 @@ pub(crate) struct TriggerIr {
 impl TriggerIr {
     /// Whether the body ends in the typed die-roll node that owns a result table.
     pub(crate) fn has_terminal_roll_die(&self) -> bool {
-        let Some(TriggerBody::EffectChain(chain)) = &self.body else {
+        let chain = match &self.body {
+            Some(TriggerBody::EffectChain(chain)) => chain,
+            Some(TriggerBody::ReflexivePayment(reflexive)) => &reflexive.effect_chain,
+            Some(TriggerBody::Modal(_))
+            | Some(TriggerBody::Vote(_))
+            | Some(TriggerBody::Pile(_))
+            | None => return false,
+        };
+        let Some(clause) = chain.clauses.last() else {
             return false;
         };
-        chain
-            .clauses
-            .last()
-            .is_some_and(|clause| matches!(clause.parsed.effect, Effect::RollDie { .. }))
+        matches!(clause.parsed.effect, Effect::RollDie { .. })
     }
 }
 

--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use super::ast::parsed_clause;
 use super::context::ParseContext;
-use super::effect_chain::EffectChainIr;
+use super::effect_chain::{DieResultBranchIr, EffectChainIr};
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, ChoiceType, ControllerRef, Effect, ModalChoice,
     TargetFilter, TargetSelectionMode, TriggerCondition, TriggerConstraint, TriggerDefinition,
@@ -39,15 +39,11 @@ use crate::types::triggers::TriggerMode;
 /// mechanism that RETIRES that debt. Reusing it would make the burn-down metric
 /// count the fix as debt, so the number would rise as the debt fell.
 ///
-/// One variant today, deliberately. The IR-native sibling (`Parsed`, boxing a
-/// `TriggerIr`) is added by the tranche that lands its first producer, not
-/// before: adding it now would need a `#[allow(dead_code)]` and a CR 707.9a
-/// slot-stamp arm that cannot be written until lowering runs (the stamp targets
-/// `execute`, which does not exist pre-lowering), leaving a latent panic behind.
-/// Adding the variant later instead turns every match site into a compile
-/// error, which is the stronger forcing function.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) enum TriggerNodeIr {
+    /// Native parsed trigger decomposition, lowered only at the document seam.
+    #[allow(dead_code)] // C1 installs the IR seam; C2 adds its producers.
+    Parsed(Box<TriggerIr>),
     /// Already-assembled definition from a recognizer that builds its own.
     /// `lower_trigger_node_ir` returns it untouched.
     Assembled {
@@ -64,17 +60,6 @@ impl TriggerNodeIr {
         Self::Assembled {
             definition,
             source_text: source_text.to_string(),
-        }
-    }
-
-    /// The assembled definition, when one exists.
-    ///
-    /// Returns `Option` rather than `&TriggerDefinition` because a future
-    /// IR-native variant has no definition before lowering — CR 607.2d relation
-    /// discovery must see `None` there, not a fabricated definition.
-    pub(crate) fn definition(&self) -> Option<&TriggerDefinition> {
-        match self {
-            Self::Assembled { definition, .. } => Some(definition),
         }
     }
 }
@@ -98,6 +83,9 @@ pub(crate) struct TriggerIr {
     pub(crate) modifiers: TriggerModifiers,
     /// Original oracle text for description/provenance.
     pub(crate) source_text: String,
+    /// CR 706.3b result-table rows for the terminal die roll in this trigger.
+    /// They remain IR until trigger-body lowering attaches them before finalization.
+    pub(crate) die_results: Vec<DieResultBranchIr>,
 }
 
 /// The body of a trigger. Whole-body recognizers retain their typed payloads

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -269,6 +269,40 @@ pub(crate) fn find_terminal_roll_die(def: &mut AbilityDefinition) -> Option<&mut
     None
 }
 
+/// CR 706.3b: Parse contiguous result-table rows into typed branch IR.
+///
+/// A non-table first line is not consumed, so the ordinary document dispatcher
+/// can still classify it. Empty separator rows become consumed only when they
+/// actually precede at least one result row.
+pub(crate) fn parse_die_result_branches_ir(
+    lines: &[&str],
+    start_line: usize,
+    kind: AbilityKind,
+) -> (Vec<DieResultBranchIr>, usize) {
+    let mut branches = Vec::new();
+    let mut j = start_line;
+    while j < lines.len() {
+        let table_line = strip_reminder_text(lines[j].trim());
+        if table_line.is_empty() {
+            j += 1;
+            continue;
+        }
+        if let Some((min, max, effect_text)) = try_parse_die_result_line(&table_line) {
+            let effect_text = strip_die_table_flavor_label(effect_text);
+            branches.push(DieResultBranchIr {
+                min,
+                max,
+                effect: Box::new(parse_ability_ir_standalone(effect_text, kind)),
+            });
+            j += 1;
+        } else {
+            break;
+        }
+    }
+    let next_line = if branches.is_empty() { start_line } else { j };
+    (branches, next_line)
+}
+
 /// CR 706.3b: The die-roll instruction and its associated results table are
 /// part of one ability, so this consumes the table lines into the header's IR.
 /// CR 706.2: Also extracts an optional "and add/subtract X" modifier
@@ -283,28 +317,7 @@ pub(super) fn try_parse_die_roll_table(
     let lower = line.to_lowercase();
     let (sides, modifier) = parse_roll_die_sides_with_modifier(&lower)?;
 
-    let mut branches = Vec::new();
-    let mut has_branches = false;
-    let mut j = i + 1;
-    while j < lines.len() {
-        let table_line = strip_reminder_text(lines[j].trim());
-        if table_line.is_empty() {
-            j += 1;
-            continue;
-        }
-        if let Some((min, max, effect_text)) = try_parse_die_result_line(&table_line) {
-            let effect_text = strip_die_table_flavor_label(effect_text);
-            branches.push(DieResultBranchIr {
-                min,
-                max,
-                effect: Box::new(parse_ability_ir_standalone(effect_text, kind)),
-            });
-            has_branches = true;
-            j += 1;
-        } else {
-            break;
-        }
-    }
+    let (branches, next_line) = parse_die_result_branches_ir(lines, i + 1, kind);
 
     let ir = AbilityIr {
         source_text: line.to_string(),
@@ -328,7 +341,7 @@ pub(super) fn try_parse_die_roll_table(
         },
         die_results: branches,
     };
-    Some((lower_ability_ir(&ir), if has_branches { j } else { i + 1 }))
+    Some((lower_ability_ir(&ir), next_line))
 }
 
 /// CR 706.1a + CR 706.2: Parse the header line of a die-roll table, returning

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9,13 +9,14 @@ use nom::Parser;
 
 use super::oracle_effect::conditions::source_saddled_filter;
 use super::oracle_effect::{
-    condition_text_is_rehomeable, lower_effect_chain_ir, parse_effect_chain_ir,
-    try_parse_reanimator_aura_etb_effect_ir, try_parse_reanimator_aura_grant_etb_effect_ir,
+    attach_die_result_branches_before_finalization, condition_text_is_rehomeable,
+    lower_effect_chain_ir, parse_effect_chain_ir, try_parse_reanimator_aura_etb_effect_ir,
+    try_parse_reanimator_aura_grant_etb_effect_ir,
 };
 use super::oracle_ir::ast::parsed_clause;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::doc::PrintedTriggerIndex;
-use super::oracle_ir::effect_chain::EffectChainIr;
+use super::oracle_ir::effect_chain::{DieResultBranchIr, EffectChainIr};
 use super::oracle_ir::trigger::{
     FirstTimeLimit, ReflexivePaymentIr, TriggerBody, TriggerIr, TriggerModifiers, TriggerNodeIr,
 };
@@ -1474,6 +1475,7 @@ pub(crate) fn parse_trigger_line_with_index_ir(
             relative_player_scope,
         },
         source_text: text.to_string(),
+        die_results: Vec::new(),
     }
 }
 
@@ -1533,8 +1535,10 @@ fn mode_exposes_subject_batch(mode: &TriggerMode) -> bool {
 fn lower_trigger_effect_chain(
     chain_ir: &EffectChainIr,
     modifiers: &TriggerModifiers,
+    die_results: &[DieResultBranchIr],
 ) -> AbilityDefinition {
     let mut ability = lower_effect_chain_ir(chain_ir);
+    attach_die_result_branches_before_finalization(&mut ability, die_results);
     crate::parser::oracle_effect::finalize_effect_chain(&mut ability);
     if effect_adds_mana_to_triggering_player(&modifiers.effect_lower)
         && matches!(
@@ -1583,6 +1587,7 @@ fn lower_trigger_effect_chain(
 /// which nothing added to `lower_trigger_ir` can invalidate.
 pub(crate) fn lower_trigger_node_ir(ir: &TriggerNodeIr) -> TriggerDefinition {
     match ir {
+        TriggerNodeIr::Parsed(trigger) => lower_trigger_ir(trigger),
         TriggerNodeIr::Assembled { definition, .. } => definition.clone(),
     }
 }
@@ -1593,12 +1598,14 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
 
     // Lower the body
     let execute = match &ir.body {
-        Some(TriggerBody::EffectChain(chain_ir)) => {
-            Some(Box::new(lower_trigger_effect_chain(chain_ir, modifiers)))
-        }
+        Some(TriggerBody::EffectChain(chain_ir)) => Some(Box::new(lower_trigger_effect_chain(
+            chain_ir,
+            modifiers,
+            &ir.die_results,
+        ))),
         Some(TriggerBody::ReflexivePayment(reflexive)) => {
             let mut reflexive_ability =
-                lower_trigger_effect_chain(&reflexive.effect_chain, modifiers);
+                lower_trigger_effect_chain(&reflexive.effect_chain, modifiers, &[]);
             reflexive_ability.condition = Some(AbilityCondition::WhenYouDo);
 
             let mut pay_ability = AbilityDefinition::new(
@@ -1614,16 +1621,18 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
             Some(Box::new(pay_ability))
         }
         Some(TriggerBody::Modal(modal)) => Some(Box::new(
-            lower_trigger_effect_chain(&modal.marker, modifiers)
+            lower_trigger_effect_chain(&modal.marker, modifiers, &[])
                 .with_modal(modal.choice.clone(), modal.mode_abilities.clone()),
         )),
         Some(TriggerBody::Vote(vote)) => Some(Box::new(lower_trigger_effect_chain(
             &vote.effect_chain(AbilityKind::Spell),
             modifiers,
+            &[],
         ))),
         Some(TriggerBody::Pile(pile)) => Some(Box::new(lower_trigger_effect_chain(
             &pile.effect_chain(AbilityKind::Spell),
             modifiers,
+            &[],
         ))),
         None => None,
     };

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1588,7 +1588,7 @@ fn lower_trigger_effect_chain(
 pub(crate) fn lower_trigger_node_ir(ir: &TriggerNodeIr) -> TriggerDefinition {
     match ir {
         TriggerNodeIr::Parsed(trigger) => lower_trigger_ir(trigger),
-        TriggerNodeIr::Assembled { definition, .. } => definition.clone(),
+        TriggerNodeIr::Assembled { definition, .. } => (**definition).clone(),
     }
 }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1605,7 +1605,7 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
         ))),
         Some(TriggerBody::ReflexivePayment(reflexive)) => {
             let mut reflexive_ability =
-                lower_trigger_effect_chain(&reflexive.effect_chain, modifiers, &[]);
+                lower_trigger_effect_chain(&reflexive.effect_chain, modifiers, &ir.die_results);
             reflexive_ability.condition = Some(AbilityCondition::WhenYouDo);
 
             let mut pay_ability = AbilityDefinition::new(


### PR DESCRIPTION
## Summary
- represent the three trigger-dispatch routes as native `TriggerIr` document nodes
- retain die-result rows in trigger IR and attach them through the shared pre-finalization lowering authority
- preserve legacy B7 condition behavior and leave unsupported non-typed die rolls (Iron Mastiff) for ordinary dispatch

## Scope
- U0-30 direct trigger route
- U0-32 flavor-word trigger route
- U0-49 ability-word trigger route (currently shadowed by U0-32; intentionally no fallback)

## Verification
- `cargo fmt --all`
- parser-combinator, prelowered-ratchet, and skill-doc gates
- strict engine clippy for each atomic commit
- focused Hoarding Ogre, Chaos Channeler/B7, and Iron Mastiff regression tests
- full-pool `card-data.json` parity: base → C1 and C1 → C2 byte-identical (`6acf82389e3ccaaf2e9fad6a39143395f60eef90e42d60183827004a870af4ed`)
- independent review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle trigger parsing for die-roll result tables, preserving result ranges and associated effects.
  * Ensured non-table lines are handled correctly instead of being consumed as table entries.
  * Improved support for ability-word triggers and trigger conditions.
  * Increased accuracy when detecting relationships between triggered abilities, including exile and return effects.

* **Tests**
  * Added coverage for die-roll tables, ability-word triggers, multi-player rolls, and unsupported follow-up lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->