### PR TITLE
fix(ai): preserve viable payment continuations

### DIFF
--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -3,6 +3,7 @@ mod combat_withdrawal;
 mod context;
 mod copy;
 pub mod filter;
+mod payment_continuation;
 
 use std::collections::{HashMap, HashSet};
 
@@ -44,6 +45,11 @@ pub use copy::{
 };
 pub use filter::{
     BasicLegalityFilter, CandidateFilter, FilterCost, FilterPipeline, SimulationFilter,
+};
+pub use payment_continuation::{
+    classify_payment_continuation, witness_payment_continuation, AcceptedPaymentSuccessor,
+    PaymentContinuationRoot, PaymentContinuationState, PaymentContinuationUnsupported,
+    PAYMENT_CONTINUATION_MAX_REDUCER_ATTEMPTS,
 };
 
 /// Filter `candidate_actions` down to the actions that are actually legal now.

--- a/crates/engine/src/ai_support/payment_continuation.rs
+++ b/crates/engine/src/ai_support/payment_continuation.rs
@@ -1,0 +1,777 @@
+//! Reducer-backed safety witness for AI payment continuations.
+//!
+//! The engine is the sole authority for mana spending restrictions, payment
+//! ordering, and the nested mana-ability state machine. This module therefore
+//! never estimates capacity or infers payable colors: it accepts an AI edge
+//! only after bounded reducer simulation reaches the matching root's real stack
+//! finalization.
+
+use std::collections::BTreeSet;
+
+use crate::ai_support::legal_actions;
+use crate::game::engine::apply_as_current_for_simulation;
+use crate::types::actions::GameAction;
+use crate::types::events::GameEvent;
+use crate::types::game_state::{
+    CollectEvidenceResume, CostResume, DeferredLifeCostResume, GameState, ManaAbilityCostCursor,
+    ManaAbilityResume, ManaChoiceContext, PendingCast, PendingCostMoveResume, PendingManaAbility,
+    StackEntryKind, WaitingFor,
+};
+use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::player::PlayerId;
+
+/// Maximum reducer applications made while witnessing one proposed successor.
+///
+/// The supplied action counts as one application. The bound is per witness,
+/// not per candidate list: callers that inspect `A` raw payment candidates may
+/// therefore cause at most `PAYMENT_CONTINUATION_MAX_REDUCER_ATTEMPTS * A`
+/// applications.
+pub const PAYMENT_CONTINUATION_MAX_REDUCER_ATTEMPTS: usize = 64;
+
+/// Mode-free identity of the announced spell or activated ability being paid.
+///
+/// CR 601.2f–i / CR 602.2b: the total cost is locked, paid, and then finalized
+/// as the specific announced spell or activated ability. `ConvokeMode` is an
+/// immediate-carrier grammar guard, not root identity: several later carriers
+/// do not preserve it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PaymentContinuationRoot {
+    Spell {
+        object_id: ObjectId,
+        card_id: CardId,
+        payer: PlayerId,
+    },
+    Activation {
+        source_id: ObjectId,
+        ability_index: usize,
+        payer: PlayerId,
+    },
+}
+
+/// A payment state classification for AI consumers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PaymentContinuationState {
+    /// This is not one of the spell/activation mana-payment carriers owned by
+    /// this oracle. Existing one-step AI behavior remains authoritative.
+    NotAffiliated,
+    /// The state is a supported carrier for this exact payment root.
+    Affiliated(PaymentContinuationRoot),
+    /// The state advertises an in-flight payment root, but its typed authority
+    /// cannot prove the root safely. Consumers must fail closed, never fall
+    /// through to an unrelated first-legal policy.
+    UnsupportedAffiliated(PaymentContinuationUnsupported),
+}
+
+/// Why an affiliated-looking carrier cannot be witnessed safely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaymentContinuationUnsupported {
+    MissingPendingCast,
+    MissingOuterPayer,
+    PayerMismatch,
+    RootMismatch,
+    UnsupportedDeferredManaRoot,
+    MissingSpellPlaceholder,
+}
+
+/// An accepted edge together with its already-applied immediate successor.
+///
+/// Reusing this state prevents AI callers from applying the selected reducer
+/// edge a second time after the oracle already proved its completion witness.
+#[derive(Debug, Clone)]
+pub struct AcceptedPaymentSuccessor {
+    pub action: GameAction,
+    pub state: GameState,
+}
+
+/// Classify the current payment carrier without guessing cross-carrier state.
+pub fn classify_payment_continuation(state: &GameState) -> PaymentContinuationState {
+    if let Some(deferred) = state.pending_deferred_life_cost_resume.as_ref() {
+        return classify_deferred_life_root(state, deferred);
+    }
+
+    match &state.waiting_for {
+        // CR 601.2g–h: during the ordinary mana-payment window, the visible
+        // payer and live pending cast jointly identify the payment root.
+        WaitingFor::ManaPayment { player, .. } => classify_global_root(state, *player),
+        // CR 601.2f–h: submitting Phyrexian choices remains part of the same
+        // cost payment. The prompt's object must agree with the announced root.
+        WaitingFor::PhyrexianPayment {
+            player,
+            spell_object,
+            ..
+        } => match root_from_global(state, *player) {
+            Ok(root) if root.object_id() == *spell_object => {
+                PaymentContinuationState::Affiliated(root)
+            }
+            Ok(_) => PaymentContinuationState::UnsupportedAffiliated(
+                PaymentContinuationUnsupported::RootMismatch,
+            ),
+            Err(reason) => PaymentContinuationState::UnsupportedAffiliated(reason),
+        },
+        WaitingFor::PayCost {
+            resume: CostResume::ManaAbility { mana_ability },
+            ..
+        }
+        | WaitingFor::PayManaAbilityMana {
+            pending_mana_ability: mana_ability,
+            ..
+        }
+        | WaitingFor::PayAmountChoice {
+            pending_mana_ability: Some(mana_ability),
+            ..
+        } => classify_pending_mana_ability(state, mana_ability),
+        WaitingFor::ChooseManaColor {
+            context: ManaChoiceContext::ManaAbility(mana_ability),
+            ..
+        } => classify_pending_mana_ability(state, mana_ability),
+        WaitingFor::CollectEvidenceChoice { resume, .. } => match resume.as_ref() {
+            CollectEvidenceResume::ManaAbility {
+                pending_mana_ability,
+            } => classify_pending_mana_ability(state, pending_mana_ability),
+            CollectEvidenceResume::Casting { .. } | CollectEvidenceResume::Effect { .. } => {
+                PaymentContinuationState::NotAffiliated
+            }
+        },
+        _ => classify_parked_cost_move_root(state),
+    }
+}
+
+/// Return an already-applied successor only when a bounded reducer search can
+/// finish the same announced root.
+///
+/// CR 601.2h / CR 602.2b: partial payment cannot certify success. The witness
+/// rejects cancellation and requires the actual spell/ability finalization
+/// delta after the original root has disappeared from every typed authority.
+pub fn witness_payment_continuation(
+    state: &GameState,
+    action: &GameAction,
+) -> Option<AcceptedPaymentSuccessor> {
+    let PaymentContinuationState::Affiliated(root) = classify_payment_continuation(state) else {
+        return None;
+    };
+    if matches!(action, GameAction::CancelCast) {
+        return None;
+    }
+
+    let baseline = WitnessBaseline::capture(state, &root)?;
+    let mut successor = state.clone();
+    let first_result = apply_as_current_for_simulation(&mut successor, action.clone()).ok()?;
+    let mut attempts = 1;
+    record_witness_attempts(attempts);
+    let mut events = first_result.events;
+
+    if witness_completion(&successor, &root, &baseline, &mut events, &mut attempts) {
+        record_witness_attempts(attempts);
+        Some(AcceptedPaymentSuccessor {
+            action: action.clone(),
+            state: successor,
+        })
+    } else {
+        record_witness_attempts(attempts);
+        None
+    }
+}
+
+#[derive(Debug, Clone)]
+struct WitnessBaseline {
+    pre_stack_ids: BTreeSet<ObjectId>,
+    completion: CompletionBaseline,
+}
+
+#[derive(Debug, Clone)]
+enum CompletionBaseline {
+    Spell {
+        entry_id: ObjectId,
+        object_id: ObjectId,
+        card_id: CardId,
+        controller: PlayerId,
+    },
+    Activation,
+}
+
+impl WitnessBaseline {
+    fn capture(state: &GameState, root: &PaymentContinuationRoot) -> Option<Self> {
+        let pre_stack_ids = state.stack.iter().map(|entry| entry.id).collect();
+        let completion = match root {
+            PaymentContinuationRoot::Spell {
+                object_id,
+                card_id,
+                payer,
+            } => {
+                let entry = state.stack.iter().find(|entry| entry.id == *object_id)?;
+                let StackEntryKind::Spell {
+                    card_id: entry_card_id,
+                    ability: None,
+                    actual_mana_spent: 0,
+                    ..
+                } = &entry.kind
+                else {
+                    return None;
+                };
+                if *entry_card_id != *card_id
+                    || entry.controller != *payer
+                    || state.stack_paid_facts.contains_key(object_id)
+                {
+                    return None;
+                }
+                CompletionBaseline::Spell {
+                    entry_id: entry.id,
+                    object_id: *object_id,
+                    card_id: *card_id,
+                    controller: *payer,
+                }
+            }
+            PaymentContinuationRoot::Activation { .. } => CompletionBaseline::Activation,
+        };
+        Some(Self {
+            pre_stack_ids,
+            completion,
+        })
+    }
+}
+
+fn witness_completion(
+    state: &GameState,
+    root: &PaymentContinuationRoot,
+    baseline: &WitnessBaseline,
+    events: &mut Vec<GameEvent>,
+    attempts: &mut usize,
+) -> bool {
+    if !root_present(state, root) {
+        return finalized_root_matches(state, root, baseline, events);
+    }
+    if *attempts >= PAYMENT_CONTINUATION_MAX_REDUCER_ATTEMPTS {
+        return false;
+    }
+
+    match classify_payment_continuation(state) {
+        PaymentContinuationState::Affiliated(current_root) if current_root == *root => {}
+        PaymentContinuationState::Affiliated(_)
+        | PaymentContinuationState::NotAffiliated
+        | PaymentContinuationState::UnsupportedAffiliated(_) => return false,
+    }
+
+    let mut actions = legal_actions(state);
+    actions.sort_by(|left, right| left.cmp_stable(right));
+    for next_action in actions {
+        if matches!(next_action, GameAction::CancelCast)
+            || *attempts >= PAYMENT_CONTINUATION_MAX_REDUCER_ATTEMPTS
+        {
+            continue;
+        }
+
+        *attempts += 1;
+        let mut next_state = state.clone();
+        let Ok(result) = apply_as_current_for_simulation(&mut next_state, next_action) else {
+            continue;
+        };
+        let event_len = events.len();
+        events.extend(result.events);
+        if witness_completion(&next_state, root, baseline, events, attempts) {
+            return true;
+        }
+        events.truncate(event_len);
+    }
+    false
+}
+
+fn finalized_root_matches(
+    state: &GameState,
+    root: &PaymentContinuationRoot,
+    baseline: &WitnessBaseline,
+    events: &[GameEvent],
+) -> bool {
+    match (&baseline.completion, root) {
+        (
+            CompletionBaseline::Spell {
+                entry_id,
+                object_id,
+                card_id,
+                controller,
+            },
+            PaymentContinuationRoot::Spell { .. },
+        ) => {
+            let Some(entry) = state.stack.iter().find(|entry| entry.id == *entry_id) else {
+                return false;
+            };
+            let StackEntryKind::Spell {
+                card_id: entry_card_id,
+                actual_mana_spent: entry_spent,
+                ..
+            } = &entry.kind
+            else {
+                return false;
+            };
+            let Some(paid) = state.stack_paid_facts.get(object_id) else {
+                return false;
+            };
+            *entry_card_id == *card_id
+                && entry.controller == *controller
+                && *entry_spent == paid.actual_mana_spent
+                && events.iter().any(|event| {
+                    matches!(
+                        event,
+                        GameEvent::SpellCast {
+                            card_id: event_card_id,
+                            controller: event_controller,
+                            object_id: event_object_id,
+                        } if *event_card_id == *card_id
+                            && *event_controller == *controller
+                            && *event_object_id == *object_id
+                    )
+                })
+        }
+        (
+            CompletionBaseline::Activation,
+            PaymentContinuationRoot::Activation {
+                source_id,
+                ability_index,
+                payer,
+            },
+        ) => {
+            state.stack.iter().any(|entry| {
+                !baseline.pre_stack_ids.contains(&entry.id)
+                    && entry.source_id == *source_id
+                    && entry.controller == *payer
+                    && matches!(
+                        &entry.kind,
+                        StackEntryKind::ActivatedAbility {
+                            source_id: entry_source_id,
+                            ability,
+                        } if *entry_source_id == *source_id
+                            && ability.ability_index == Some(*ability_index)
+                    )
+            }) && events.iter().any(|event| {
+                matches!(
+                    event,
+                    GameEvent::AbilityActivated {
+                        player_id,
+                        source_id: event_source_id,
+                        ..
+                    } if *player_id == *payer && *event_source_id == *source_id
+                )
+            })
+        }
+        _ => false,
+    }
+}
+
+fn classify_global_root(state: &GameState, payer: PlayerId) -> PaymentContinuationState {
+    match root_from_global(state, payer) {
+        Ok(root) => PaymentContinuationState::Affiliated(root),
+        Err(reason) => PaymentContinuationState::UnsupportedAffiliated(reason),
+    }
+}
+
+fn classify_pending_mana_ability(
+    state: &GameState,
+    pending: &PendingManaAbility,
+) -> PaymentContinuationState {
+    match root_from_pending_mana_ability(state, pending) {
+        Ok(Some(root)) => PaymentContinuationState::Affiliated(root),
+        Ok(None) => PaymentContinuationState::NotAffiliated,
+        Err(reason) => PaymentContinuationState::UnsupportedAffiliated(reason),
+    }
+}
+
+fn classify_parked_cost_move_root(state: &GameState) -> PaymentContinuationState {
+    let Some(resume) = state.pending_cost_move_resume.as_ref() else {
+        return PaymentContinuationState::NotAffiliated;
+    };
+    match resume {
+        PendingCostMoveResume::ManaAbilityPayment { pending, cursor } => {
+            match root_from_pending_mana_and_cursor(state, pending, cursor) {
+                Ok(Some(root)) => PaymentContinuationState::Affiliated(root),
+                Ok(None) => PaymentContinuationState::NotAffiliated,
+                Err(reason) => PaymentContinuationState::UnsupportedAffiliated(reason),
+            }
+        }
+        PendingCostMoveResume::CollectEvidencePayment { resume, .. } => match resume.as_ref() {
+            CollectEvidenceResume::ManaAbility {
+                pending_mana_ability,
+            } => classify_pending_mana_ability(state, pending_mana_ability),
+            CollectEvidenceResume::Casting { .. } | CollectEvidenceResume::Effect { .. } => {
+                PaymentContinuationState::NotAffiliated
+            }
+        },
+        PendingCostMoveResume::DelveManaPayment { player, .. } => {
+            classify_global_root(state, *player)
+        }
+        // These are distinct cost/resolution continuations. They intentionally
+        // retain their existing policies rather than being misidentified from a
+        // coincidental PendingCast elsewhere in state.
+        PendingCostMoveResume::Cast { .. }
+        | PendingCostMoveResume::SacrificeForCost { .. }
+        | PendingCostMoveResume::WardSacrificePayment { .. }
+        | PendingCostMoveResume::ReplacementMayCost { .. }
+        | PendingCostMoveResume::Foretell { .. }
+        | PendingCostMoveResume::UnlessBouncePayment { .. }
+        | PendingCostMoveResume::LoyaltyActivation { .. } => {
+            PaymentContinuationState::NotAffiliated
+        }
+    }
+}
+
+fn classify_deferred_life_root(
+    state: &GameState,
+    deferred: &DeferredLifeCostResume,
+) -> PaymentContinuationState {
+    match deferred {
+        DeferredLifeCostResume::Cast {
+            player,
+            pending: Some(pending),
+            ..
+        } => PaymentContinuationState::Affiliated(root_from_pending_cast(pending, *player)),
+        DeferredLifeCostResume::Cast { pending: None, .. } => {
+            PaymentContinuationState::UnsupportedAffiliated(
+                PaymentContinuationUnsupported::MissingPendingCast,
+            )
+        }
+        DeferredLifeCostResume::ManaRoot { player, resume, .. } => match resume.as_ref() {
+            ManaAbilityResume::ManaPayment {
+                outer_player: Some(outer_player),
+                ..
+            } if outer_player == player => classify_global_root(state, *player),
+            ManaAbilityResume::ManaPayment { .. } => {
+                PaymentContinuationState::UnsupportedAffiliated(
+                    PaymentContinuationUnsupported::PayerMismatch,
+                )
+            }
+            ManaAbilityResume::PhyrexianCastPayment { .. }
+            | ManaAbilityResume::FinalizePendingManaPayment { .. } => {
+                PaymentContinuationState::UnsupportedAffiliated(
+                    PaymentContinuationUnsupported::UnsupportedDeferredManaRoot,
+                )
+            }
+            ManaAbilityResume::Priority
+            | ManaAbilityResume::CompanionToHand { .. }
+            | ManaAbilityResume::EndContinuousEffect { .. }
+            | ManaAbilityResume::UnlessPayment { .. }
+            | ManaAbilityResume::EffectPayCost { .. } => PaymentContinuationState::NotAffiliated,
+        },
+        DeferredLifeCostResume::PayAmount { .. } => PaymentContinuationState::NotAffiliated,
+    }
+}
+
+fn root_from_global(
+    state: &GameState,
+    payer: PlayerId,
+) -> Result<PaymentContinuationRoot, PaymentContinuationUnsupported> {
+    state
+        .pending_cast
+        .as_deref()
+        .map(|pending| root_from_pending_cast(pending, payer))
+        .ok_or(PaymentContinuationUnsupported::MissingPendingCast)
+}
+
+fn root_from_pending_cast(pending: &PendingCast, payer: PlayerId) -> PaymentContinuationRoot {
+    match pending.activation_ability_index {
+        Some(ability_index) => PaymentContinuationRoot::Activation {
+            source_id: pending.object_id,
+            ability_index,
+            payer,
+        },
+        None => PaymentContinuationRoot::Spell {
+            object_id: pending.object_id,
+            card_id: pending.card_id,
+            payer,
+        },
+    }
+}
+
+fn root_from_pending_mana_ability(
+    state: &GameState,
+    pending: &PendingManaAbility,
+) -> Result<Option<PaymentContinuationRoot>, PaymentContinuationUnsupported> {
+    let mut root = None;
+    record_root_from_resume(state, &pending.resume, &mut root)?;
+    if let Some(resume) = pending.cost_move_resume.as_ref() {
+        record_root_from_resume(state, resume, &mut root)?;
+    }
+    Ok(root)
+}
+
+fn root_from_pending_mana_and_cursor(
+    state: &GameState,
+    pending: &PendingManaAbility,
+    cursor: &ManaAbilityCostCursor,
+) -> Result<Option<PaymentContinuationRoot>, PaymentContinuationUnsupported> {
+    let mut root = root_from_pending_mana_ability(state, pending)?;
+    record_root_from_cursor(state, cursor, &mut root)?;
+    Ok(root)
+}
+
+fn record_root_from_cursor(
+    state: &GameState,
+    cursor: &ManaAbilityCostCursor,
+    root: &mut Option<PaymentContinuationRoot>,
+) -> Result<(), PaymentContinuationUnsupported> {
+    let Some(parent) = cursor.parent.as_deref() else {
+        return Ok(());
+    };
+    let parent_root = root_from_pending_mana_ability(state, &parent.pending)?;
+    merge_root(root, parent_root)?;
+    record_root_from_cursor(state, &parent.cursor, root)
+}
+
+fn record_root_from_resume(
+    state: &GameState,
+    resume: &ManaAbilityResume,
+    root: &mut Option<PaymentContinuationRoot>,
+) -> Result<(), PaymentContinuationUnsupported> {
+    let next = match resume {
+        ManaAbilityResume::ManaPayment {
+            outer_player: Some(payer),
+            ..
+        } => Some(root_from_global(state, *payer)?),
+        ManaAbilityResume::ManaPayment {
+            outer_player: None, ..
+        } => return Err(PaymentContinuationUnsupported::MissingOuterPayer),
+        ManaAbilityResume::PhyrexianCastPayment { caster, .. } => {
+            Some(root_from_global(state, *caster)?)
+        }
+        ManaAbilityResume::FinalizePendingManaPayment { player } => {
+            Some(root_from_global(state, *player)?)
+        }
+        ManaAbilityResume::Priority
+        | ManaAbilityResume::CompanionToHand { .. }
+        | ManaAbilityResume::EndContinuousEffect { .. }
+        | ManaAbilityResume::UnlessPayment { .. }
+        | ManaAbilityResume::EffectPayCost { .. } => None,
+    };
+    merge_root(root, next)
+}
+
+fn merge_root(
+    existing: &mut Option<PaymentContinuationRoot>,
+    next: Option<PaymentContinuationRoot>,
+) -> Result<(), PaymentContinuationUnsupported> {
+    let Some(next) = next else {
+        return Ok(());
+    };
+    if let Some(existing) = existing {
+        if *existing != next {
+            return Err(PaymentContinuationUnsupported::RootMismatch);
+        }
+    } else {
+        *existing = Some(next);
+    }
+    Ok(())
+}
+
+fn root_present(state: &GameState, root: &PaymentContinuationRoot) -> bool {
+    state
+        .pending_cast
+        .as_deref()
+        .is_some_and(|pending| pending_matches_root(pending, root))
+        || state
+            .waiting_for
+            .pending_cast_ref()
+            .is_some_and(|pending| pending_matches_root(pending, root))
+        || waiting_for_contains_root(&state.waiting_for, root)
+        || pending_cost_move_contains_root(state.pending_cost_move_resume.as_ref(), root)
+        || deferred_life_contains_root(state.pending_deferred_life_cost_resume.as_ref(), root)
+}
+
+fn waiting_for_contains_root(waiting_for: &WaitingFor, root: &PaymentContinuationRoot) -> bool {
+    match waiting_for {
+        WaitingFor::PayCost {
+            resume: CostResume::ManaAbility { mana_ability },
+            ..
+        }
+        | WaitingFor::PayManaAbilityMana {
+            pending_mana_ability: mana_ability,
+            ..
+        }
+        | WaitingFor::PayAmountChoice {
+            pending_mana_ability: Some(mana_ability),
+            ..
+        } => pending_mana_contains_root(mana_ability, root),
+        WaitingFor::ChooseManaColor {
+            context: ManaChoiceContext::ManaAbility(mana_ability),
+            ..
+        } => pending_mana_contains_root(mana_ability, root),
+        WaitingFor::CollectEvidenceChoice { resume, .. } => match resume.as_ref() {
+            CollectEvidenceResume::Casting { pending_cast, .. } => {
+                pending_matches_root(pending_cast, root)
+            }
+            CollectEvidenceResume::ManaAbility {
+                pending_mana_ability,
+            } => pending_mana_contains_root(pending_mana_ability, root),
+            CollectEvidenceResume::Effect { .. } => false,
+        },
+        _ => false,
+    }
+}
+
+fn pending_cost_move_contains_root(
+    resume: Option<&PendingCostMoveResume>,
+    root: &PaymentContinuationRoot,
+) -> bool {
+    match resume {
+        Some(PendingCostMoveResume::Cast {
+            pending: Some(pending),
+            ..
+        }) => pending_matches_root(pending, root),
+        Some(PendingCostMoveResume::SacrificeForCost { pending, .. }) => {
+            pending_matches_root(pending, root)
+        }
+        Some(PendingCostMoveResume::ManaAbilityPayment { pending, cursor }) => {
+            pending_mana_contains_root(pending, root) || cursor_contains_root(cursor, root)
+        }
+        Some(PendingCostMoveResume::CollectEvidencePayment { resume, .. }) => match resume.as_ref()
+        {
+            CollectEvidenceResume::Casting { pending_cast, .. } => {
+                pending_matches_root(pending_cast, root)
+            }
+            CollectEvidenceResume::ManaAbility {
+                pending_mana_ability,
+            } => pending_mana_contains_root(pending_mana_ability, root),
+            CollectEvidenceResume::Effect { .. } => false,
+        },
+        Some(PendingCostMoveResume::Cast { pending: None, .. })
+        | Some(PendingCostMoveResume::WardSacrificePayment { .. })
+        | Some(PendingCostMoveResume::ReplacementMayCost { .. })
+        | Some(PendingCostMoveResume::Foretell { .. })
+        | Some(PendingCostMoveResume::DelveManaPayment { .. })
+        | Some(PendingCostMoveResume::UnlessBouncePayment { .. })
+        | Some(PendingCostMoveResume::LoyaltyActivation { .. })
+        | None => false,
+    }
+}
+
+fn deferred_life_contains_root(
+    deferred: Option<&DeferredLifeCostResume>,
+    root: &PaymentContinuationRoot,
+) -> bool {
+    matches!(
+        deferred,
+        Some(DeferredLifeCostResume::Cast {
+            pending: Some(pending),
+            ..
+        }) if pending_matches_root(pending, root)
+    )
+}
+
+fn pending_mana_contains_root(
+    pending: &PendingManaAbility,
+    root: &PaymentContinuationRoot,
+) -> bool {
+    mana_resume_matches_root(&pending.resume, root)
+        || pending
+            .cost_move_resume
+            .as_ref()
+            .is_some_and(|resume| mana_resume_matches_root(resume, root))
+}
+
+fn cursor_contains_root(cursor: &ManaAbilityCostCursor, root: &PaymentContinuationRoot) -> bool {
+    cursor.parent.as_deref().is_some_and(|parent| {
+        pending_mana_contains_root(&parent.pending, root)
+            || cursor_contains_root(&parent.cursor, root)
+    })
+}
+
+fn mana_resume_matches_root(resume: &ManaAbilityResume, root: &PaymentContinuationRoot) -> bool {
+    match (resume, root) {
+        (
+            ManaAbilityResume::ManaPayment {
+                outer_player: Some(player),
+                ..
+            },
+            PaymentContinuationRoot::Spell { payer, .. }
+            | PaymentContinuationRoot::Activation { payer, .. },
+        ) => player == payer,
+        (
+            ManaAbilityResume::PhyrexianCastPayment { caster, .. },
+            PaymentContinuationRoot::Spell { payer, .. }
+            | PaymentContinuationRoot::Activation { payer, .. },
+        ) => caster == payer,
+        (
+            ManaAbilityResume::FinalizePendingManaPayment { player },
+            PaymentContinuationRoot::Spell { payer, .. }
+            | PaymentContinuationRoot::Activation { payer, .. },
+        ) => player == payer,
+        _ => false,
+    }
+}
+
+fn pending_matches_root(pending: &PendingCast, root: &PaymentContinuationRoot) -> bool {
+    match root {
+        PaymentContinuationRoot::Spell {
+            object_id, card_id, ..
+        } => {
+            pending.activation_ability_index.is_none()
+                && pending.object_id == *object_id
+                && pending.card_id == *card_id
+        }
+        PaymentContinuationRoot::Activation {
+            source_id,
+            ability_index,
+            ..
+        } => {
+            pending.object_id == *source_id
+                && pending.activation_ability_index == Some(*ability_index)
+        }
+    }
+}
+
+impl PaymentContinuationRoot {
+    fn object_id(&self) -> ObjectId {
+        match self {
+            PaymentContinuationRoot::Spell { object_id, .. } => *object_id,
+            PaymentContinuationRoot::Activation { source_id, .. } => *source_id,
+        }
+    }
+}
+
+// This counter deliberately records one witness invocation's reducer work;
+// callers may invoke the oracle once per raw action, so it is not a global
+// candidate-list cap. Kept test-only so production hot paths stay allocation-
+// and synchronization-free.
+#[cfg(test)]
+static LAST_WITNESS_REDUCER_ATTEMPTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+fn record_witness_attempts(attempts: usize) {
+    LAST_WITNESS_REDUCER_ATTEMPTS.store(attempts, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(not(test))]
+fn record_witness_attempts(_: usize) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direct_mana_payment_without_a_live_root_fails_closed() {
+        let mut state = GameState::new_two_player(1);
+        state.waiting_for = WaitingFor::ManaPayment {
+            player: PlayerId(0),
+            convoke_mode: None,
+        };
+
+        assert_eq!(
+            classify_payment_continuation(&state),
+            PaymentContinuationState::UnsupportedAffiliated(
+                PaymentContinuationUnsupported::MissingPendingCast
+            )
+        );
+    }
+
+    #[test]
+    fn witness_attempts_remain_bounded_per_proposed_action() {
+        let mut state = GameState::new_two_player(1);
+        state.waiting_for = WaitingFor::ManaPayment {
+            player: PlayerId(0),
+            convoke_mode: None,
+        };
+
+        assert!(witness_payment_continuation(&state, &GameAction::CancelCast).is_none());
+        assert!(
+            LAST_WITNESS_REDUCER_ATTEMPTS.load(std::sync::atomic::Ordering::Relaxed)
+                <= PAYMENT_CONTINUATION_MAX_REDUCER_ATTEMPTS
+        );
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1093,6 +1093,7 @@ mod owner_life_change_routing_3351;
 mod pact_of_negation_upkeep_payment;
 mod park_heights_pegasus_draw_condition_runtime;
 mod parker_luck;
+mod payment_continuation;
 mod plagon_toughness_combat_damage;
 mod plague_drone_gain_life_lose_life;
 mod planar_birth_owners_control_1126;

--- a/crates/engine/tests/integration/payment_continuation.rs
+++ b/crates/engine/tests/integration/payment_continuation.rs
@@ -1,0 +1,226 @@
+//! Production-path regressions for the reducer-backed AI payment witness.
+
+use engine::ai_support::{
+    classify_payment_continuation, legal_actions, witness_payment_continuation,
+    PaymentContinuationRoot, PaymentContinuationState,
+};
+use engine::game::engine::apply_as_current_for_simulation;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{
+    AbilityCost, AbilityDefinition, AbilityKind, Effect, ManaProduction, QuantityExpr,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, ManaChoice, StackEntryKind, WaitingFor};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use std::sync::Arc;
+
+const DRAW_ORACLE: &str = "Draw a card.";
+
+/// Reach the live CR 601.2g–i manual-payment carrier through the normal cast
+/// reducer, rather than manufacturing a pending-cast terminal state.
+fn manual_spell_payment_state() -> engine::types::game_state::GameState {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Witnessed Draw", true, DRAW_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..2)
+            .map(|_| ManaUnit::new(ManaType::Colorless, spell, false, Vec::new()))
+            .collect(),
+    );
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: Vec::new(),
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("manual cast must reach a live payment carrier");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ManaPayment { .. }
+    ));
+    runner.state().clone()
+}
+
+/// Reach a real mana-ability colour prompt nested in an announced `{1}{U}`
+/// payment. The one-use tap-cost producer emits exactly two mana in any ordered
+/// combination of blue and red, so every colour product is reducer-legal but
+/// only products containing blue complete the announced spell.
+fn flexible_mana_payment_state() -> engine::types::game_state::GameState {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Flexible Witness", true, DRAW_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 1,
+        })
+        .id();
+    let source = scenario.add_creature(P0, "Flexible Source", 1, 1).id();
+    let mut runner = scenario.build();
+    let ability = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::Mana {
+            produced: ManaProduction::AnyCombination {
+                count: QuantityExpr::Fixed { value: 2 },
+                color_options: vec![ManaColor::Blue, ManaColor::Red],
+            },
+            restrictions: Vec::new(),
+            grants: Vec::new(),
+            expiry: None,
+            target: None,
+        },
+    )
+    .cost(AbilityCost::Tap);
+    let source_object = runner.state_mut().objects.get_mut(&source).unwrap();
+    Arc::make_mut(&mut source_object.abilities).push(ability);
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: Vec::new(),
+            payment_mode: CastPaymentMode::Manual,
+        })
+        .expect("manual cast reaches the live mana-payment carrier");
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: source,
+            ability_index: 0,
+        })
+        .expect("the real zero-cost mana ability is activatable while paying");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ChooseManaColor { .. }
+    ));
+    runner.state().clone()
+}
+
+#[test]
+fn witnessed_manual_payment_requires_real_spell_finalization() {
+    let state = manual_spell_payment_state();
+    let PaymentContinuationState::Affiliated(PaymentContinuationRoot::Spell {
+        object_id,
+        card_id,
+        payer,
+    }) = classify_payment_continuation(&state)
+    else {
+        panic!("production manual payment must classify as its announced spell root");
+    };
+    let placeholder = state
+        .stack
+        .iter()
+        .find(|entry| entry.id == object_id)
+        .expect("CR 601.2a announcement placeholder is present");
+    assert!(matches!(
+        placeholder.kind,
+        StackEntryKind::Spell {
+            ability: None,
+            actual_mana_spent: 0,
+            ..
+        }
+    ));
+    assert!(
+        !state.stack_paid_facts.contains_key(&object_id),
+        "the announced placeholder has no paid facts before CR 601.2i"
+    );
+
+    let completing = legal_actions(&state)
+        .into_iter()
+        .find_map(|action| witness_payment_continuation(&state, &action))
+        .expect("at least one reducer-legal row must complete the announced root");
+    let entry = completing
+        .state
+        .stack
+        .iter()
+        .find(|entry| entry.id == object_id)
+        .expect("the same announced stack entry remains after finalization");
+    let StackEntryKind::Spell {
+        card_id: finalized_card_id,
+        actual_mana_spent,
+        ..
+    } = &entry.kind
+    else {
+        panic!("payment witness must retag the announcement as a finalized spell");
+    };
+    let paid = completing
+        .state
+        .stack_paid_facts
+        .get(&object_id)
+        .expect("finalization installs paid facts for the announced entry");
+    assert_eq!(*finalized_card_id, card_id);
+    assert_eq!(entry.controller, payer);
+    assert!(
+        *actual_mana_spent > 0,
+        "the nonzero production cost was paid"
+    );
+    assert_eq!(*actual_mana_spent, paid.actual_mana_spent);
+    assert!(completing.state.pending_cast.is_none());
+}
+
+#[test]
+fn cancellation_is_never_a_payment_witness() {
+    let state = manual_spell_payment_state();
+    assert!(
+        witness_payment_continuation(&state, &GameAction::CancelCast).is_none(),
+        "CancelCast remains reducer-legal but cannot certify root finalization"
+    );
+}
+
+#[test]
+fn flexible_mana_witness_keeps_every_completing_product() {
+    let state = flexible_mana_payment_state();
+    let mut actions = legal_actions(&state);
+    actions.sort_by(|left, right| left.cmp_stable(right));
+    let expected = [
+        GameAction::ChooseManaColor {
+            choice: ManaChoice::Combination(vec![ManaType::Blue, ManaType::Blue]),
+            count: 1,
+        },
+        GameAction::ChooseManaColor {
+            choice: ManaChoice::Combination(vec![ManaType::Blue, ManaType::Red]),
+            count: 1,
+        },
+        GameAction::ChooseManaColor {
+            choice: ManaChoice::Combination(vec![ManaType::Red, ManaType::Blue]),
+            count: 1,
+        },
+        GameAction::ChooseManaColor {
+            choice: ManaChoice::Combination(vec![ManaType::Red, ManaType::Red]),
+            count: 1,
+        },
+    ];
+    assert_eq!(
+        actions, expected,
+        "the live carrier exposes all four products"
+    );
+
+    for action in &actions {
+        let mut simulated = state.clone();
+        apply_as_current_for_simulation(&mut simulated, action.clone())
+            .expect("every generated colour product remains reducer-legal");
+    }
+
+    let accepted: Vec<_> = actions
+        .iter()
+        .filter_map(|action| witness_payment_continuation(&state, action))
+        .collect();
+    assert_eq!(
+        accepted
+            .iter()
+            .map(|accepted| &accepted.action)
+            .collect::<Vec<_>>(),
+        expected[..3].iter().collect::<Vec<_>>(),
+        "only the products that leave blue available complete the exact root"
+    );
+    assert!(accepted
+        .iter()
+        .all(|accepted| accepted.state.pending_cast.is_none()));
+}

--- a/crates/engine/tests/integration/payment_continuation.rs
+++ b/crates/engine/tests/integration/payment_continuation.rs
@@ -220,7 +220,4 @@ fn flexible_mana_witness_keeps_every_completing_product() {
         expected[..3].iter().collect::<Vec<_>>(),
         "only the products that leave blue available complete the exact root"
     );
-    assert!(accepted
-        .iter()
-        .all(|accepted| accepted.state.pending_cast.is_none()));
 }

--- a/crates/phase-ai/src/mana_colors.rs
+++ b/crates/phase-ai/src/mana_colors.rs
@@ -100,40 +100,6 @@ fn push_color(colors: &mut Vec<ManaType>, mana_type: ManaType) {
     }
 }
 
-/// Pick which color a flexible mana source (dual land, Mox Opal, City of Brass)
-/// should produce when answering a `ManaChoicePrompt::SingleColor` *during a
-/// pending cast*. The AI must produce the color the in-flight spell actually
-/// demands, not the first option in the list: tapping a U/R source for {R} when
-/// the spell needs {U} strands the colored pip and dead-ends the ManaPayment.
-///
-/// Returns the first option whose WUBRG colored demand of the pending cast is
-/// nonzero; if none of the options match a demanded color (generic-only cost, no
-/// pending cast), falls back to the first option — identical to the old `first()`
-/// behavior, so this is a strict improvement everywhere.
-///
-/// Limitation: `pending_cast.cost` is the FULL locked outer cost, not decremented
-/// per-pip as colors are produced. Demand is therefore exact for single-colored-pip
-/// costs (the repro: {2}{U}, {5}{U}) and a strict improvement over `first()` for
-/// all costs. Incremental per-pip demand tracking for multi-colored-pip costs
-/// (e.g. {U}{U}{R}, where two blues must be produced before red) is a documented
-/// follow-up, out of scope here.
-pub(crate) fn demand_aware_single_color(
-    options: &[ManaType],
-    state: &GameState,
-) -> Option<ManaType> {
-    let demand: ColorDemand = state
-        .pending_cast
-        .as_deref()
-        .map(|pc| outer_cost_color_demand(&pc.cost))
-        .unwrap_or([0u32; 5]);
-
-    options
-        .iter()
-        .copied()
-        .find(|&opt| color_is_demanded(demand, opt))
-        .or_else(|| options.first().copied())
-}
-
 /// Whether `mana_type` satisfies a colored pip the in-flight cost still demands.
 /// WUBRG demand slot per color; Colorless has no slot, so it never satisfies a
 /// colored pip.
@@ -155,9 +121,7 @@ fn color_is_demanded(demand: ColorDemand, mana_type: ManaType) -> bool {
 /// would*, i.e. taking this row strands the demanded pip in a `ManaPayment`
 /// dead-end (a U/R dual tapped for {R} against a {2}{U} spell).
 ///
-/// This is the [`demand_aware_single_color`] rule for the OTHER shape the same
-/// choice takes. That helper answers a `ManaChoicePrompt::SingleColor` prompt; here
-/// the color is instead carried in each `TapLandForMana` candidate's
+/// The color is carried in each `TapLandForMana` candidate's
 /// `ManaSourceSelection::mana_type`, so the choice is expressed as a *set of
 /// candidates* and must be resolved by eliminating the stranding ones rather than
 /// by returning a color.
@@ -168,10 +132,6 @@ fn color_is_demanded(demand: ColorDemand, mana_type: ManaType) -> bool {
 /// false — tapping it for an undemanded color may still be a fine way to pay
 /// generic.
 ///
-/// Shares [`demand_aware_single_color`]'s limitation: `pending_cast.cost` is the
-/// full locked outer cost, not decremented per-pip as colors are produced, so
-/// demand is exact for single-colored-pip costs and a strict improvement for the
-/// rest.
 pub(crate) fn tap_strands_demanded_color(
     state: &GameState,
     player: PlayerId,
@@ -206,62 +166,6 @@ mod tests {
     use engine::types::identifiers::{CardId, ObjectId};
     use engine::types::mana::{ManaCost, ManaCostShard};
     use engine::types::player::PlayerId;
-
-    fn state_with_cost(shards: Vec<ManaCostShard>, generic: u32) -> GameState {
-        let mut state = GameState::new_two_player(42);
-        state.pending_cast = Some(Box::new(PendingCast::new(
-            ObjectId(100),
-            CardId(100),
-            ResolvedAbility::new(
-                Effect::Draw {
-                    count: QuantityExpr::Fixed { value: 0 },
-                    target: TargetFilter::Controller,
-                },
-                Vec::new(),
-                ObjectId(100),
-                PlayerId(0),
-            ),
-            ManaCost::Cost { shards, generic },
-        )));
-        state
-    }
-
-    #[test]
-    fn picks_demanded_blue_over_first_red() {
-        // {2}{U}: a U/R source offered [Red, Blue] must produce Blue (the
-        // demanded color), not Red (the first option).
-        let state = state_with_cost(vec![ManaCostShard::Blue], 2);
-        assert_eq!(
-            demand_aware_single_color(&[ManaType::Red, ManaType::Blue], &state),
-            Some(ManaType::Blue)
-        );
-    }
-
-    #[test]
-    fn generic_only_cost_falls_back_to_first() {
-        // {2}: no colored demand, so the first option (Red) is fine.
-        let state = state_with_cost(Vec::new(), 2);
-        assert_eq!(
-            demand_aware_single_color(&[ManaType::Red, ManaType::Blue], &state),
-            Some(ManaType::Red)
-        );
-    }
-
-    #[test]
-    fn no_pending_cast_falls_back_to_first() {
-        let state = GameState::new_two_player(42);
-        assert!(state.pending_cast.is_none());
-        assert_eq!(
-            demand_aware_single_color(&[ManaType::Red, ManaType::Blue], &state),
-            Some(ManaType::Red)
-        );
-    }
-
-    #[test]
-    fn empty_options_returns_none() {
-        let state = state_with_cost(vec![ManaCostShard::Blue], 2);
-        assert_eq!(demand_aware_single_color(&[], &state), None);
-    }
 
     /// Battlefield fixture: one land for `P0` with `oracle_text`, plus a pending
     /// cast of `{2}{U}` — the shape of the measured `Metallic Rebuke` repro.

--- a/crates/phase-ai/src/planner/mod.rs
+++ b/crates/phase-ai/src/planner/mod.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
 use engine::ai_support::{
-    build_decision_context, AiDecisionContext, CandidateAction, TacticalClass,
+    build_decision_context, classify_payment_continuation, witness_payment_continuation,
+    AiDecisionContext, CandidateAction, PaymentContinuationState, TacticalClass,
 };
 use engine::game::engine::apply_as_current_for_simulation;
 use engine::game::players;
@@ -26,6 +27,99 @@ use crate::policies::PolicyRegistry;
 pub struct RankedCandidate {
     pub candidate: CandidateAction,
     pub score: f64,
+    pub(crate) payment_successor: Option<GameState>,
+}
+
+impl RankedCandidate {
+    pub fn new(candidate: CandidateAction, score: f64) -> Self {
+        Self {
+            candidate,
+            score,
+            payment_successor: None,
+        }
+    }
+
+    pub(crate) fn with_payment_successor(
+        candidate: CandidateAction,
+        score: f64,
+        state: GameState,
+    ) -> Self {
+        Self {
+            candidate,
+            score,
+            payment_successor: Some(state),
+        }
+    }
+}
+
+/// A raw engine candidate plus the first reducer successor already witnessed
+/// for an affiliated payment root. This stays private to planning: the engine
+/// owns both the carrier classification and the finalization proof.
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedCandidate {
+    pub candidate: CandidateAction,
+    pub payment_successor: Option<GameState>,
+}
+
+/// Fail closed for affiliated payment states before ranking or width limits.
+///
+/// The accepted successor is retained so a planning edge does not apply its
+/// first reducer action once for the witness and again for search.
+pub(crate) fn prepare_payment_candidates(
+    state: &GameState,
+    candidates: impl IntoIterator<Item = CandidateAction>,
+) -> Vec<PreparedCandidate> {
+    match classify_payment_continuation(state) {
+        PaymentContinuationState::NotAffiliated => candidates
+            .into_iter()
+            .map(|candidate| PreparedCandidate {
+                candidate,
+                payment_successor: None,
+            })
+            .collect(),
+        PaymentContinuationState::UnsupportedAffiliated(_) => Vec::new(),
+        PaymentContinuationState::Affiliated(_) => candidates
+            .into_iter()
+            .filter_map(|candidate| {
+                witness_payment_continuation(state, &candidate.action).map(|accepted| {
+                    PreparedCandidate {
+                        candidate,
+                        payment_successor: Some(accepted.state),
+                    }
+                })
+            })
+            .collect(),
+    }
+}
+
+pub(crate) fn rank_prepared_candidates<F>(
+    candidates: impl IntoIterator<Item = PreparedCandidate>,
+    mut scorer: F,
+    limit: usize,
+) -> Vec<RankedCandidate>
+where
+    F: FnMut(&CandidateAction) -> f64,
+{
+    let mut ranked: Vec<RankedCandidate> = candidates
+        .into_iter()
+        .map(|prepared| {
+            let score = scorer(&prepared.candidate);
+            match prepared.payment_successor {
+                Some(state) => {
+                    RankedCandidate::with_payment_successor(prepared.candidate, score, state)
+                }
+                None => RankedCandidate::new(prepared.candidate, score),
+            }
+        })
+        .collect();
+    ranked.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.candidate.action.cmp_stable(&b.candidate.action))
+    });
+    ranked.truncate(limit);
+    ranked
 }
 
 #[derive(Debug, Clone)]
@@ -76,6 +170,7 @@ impl SearchBudget {
 pub struct PolicyPrior {
     pub candidate: CandidateAction,
     pub prior: f64,
+    pub(crate) payment_successor: Option<GameState>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -721,7 +816,10 @@ impl<'a> PlannerServices<'a> {
             if out.len() == sample_count || self.deadline.expired() {
                 break;
             }
-            if let Some(sim) = self.apply_candidate(state, &prior.candidate) {
+            let sim = prior
+                .payment_successor
+                .or_else(|| self.apply_candidate(state, &prior.candidate));
+            if let Some(sim) = sim {
                 out.push((prior.prior, sim));
             }
         }
@@ -1104,17 +1202,28 @@ impl<'a> PlannerServices<'a> {
         // (`apply_candidate` → None), mirroring the beam path. This removes one
         // clone-and-apply-per-candidate probe (`state_clone_for_legality`).
         let ctx = self.build_decision_context(state);
+        let candidates = prepare_payment_candidates(state, ctx.candidates.clone());
         let scoring_player = state.waiting_for.acting_player().unwrap_or(self.ai_player);
+        let mut priors = self.policy_priors(
+            state,
+            &ctx,
+            &candidates
+                .iter()
+                .map(|prepared| prepared.candidate.clone())
+                .collect::<Vec<_>>(),
+            scoring_player,
+            SearchDepth::Lookahead,
+        );
+        for prior in &mut priors {
+            prior.payment_successor = candidates
+                .iter()
+                .find(|prepared| prepared.candidate.action == prior.candidate.action)
+                .and_then(|prepared| prepared.payment_successor.clone());
+        }
         PlannerEvaluation {
             // Rollout leaf: every node reached here is deep lookahead, never the
             // committed decision, so board-wide/affordability policies self-gate.
-            priors: self.policy_priors(
-                state,
-                &ctx,
-                &ctx.candidates,
-                scoring_player,
-                SearchDepth::Lookahead,
-            ),
+            priors,
             value: self.evaluate_for_planner(state),
         }
     }
@@ -1243,15 +1352,16 @@ impl BeamContinuationPlanner {
         // path (planner_evaluation → sample_backfilled_continuations) applies the
         // same skip: illegal candidates are dropped when apply_candidate returns
         // None during backfill sampling, not by an upfront clone-per-candidate probe.
-        if ctx.candidates.is_empty() {
+        let candidates = prepare_payment_candidates(state, ctx.candidates.clone());
+        if candidates.is_empty() {
             return services.evaluate_state_quiesced(state);
         }
 
         let node_player = state.waiting_for.acting_player();
         let is_maximizing = node_player.is_none_or(|player| player == services.ai_player);
         let scoring_player = node_player.unwrap_or(services.ai_player);
-        let mut ranked = rank_candidates(
-            ctx.candidates.clone(),
+        let mut ranked = rank_prepared_candidates(
+            candidates,
             // Interior beam node: `search_value` is always entered ≥1 ply below
             // the decision root, so move-ordering scoring runs in lookahead.
             |candidate| {
@@ -1285,7 +1395,11 @@ impl BeamContinuationPlanner {
             if services.deadline.expired() {
                 break;
             }
-            let Some(sim) = services.apply_candidate(state, &ranked.candidate) else {
+            let Some(sim) = ranked
+                .payment_successor
+                .clone()
+                .or_else(|| services.apply_candidate(state, &ranked.candidate))
+            else {
                 continue;
             };
             let value = self.search_value(&sim, depth - 1, ply + 1, alpha, beta, services, budget)
@@ -1357,27 +1471,25 @@ pub fn rank_candidates<F>(
 where
     F: FnMut(&CandidateAction) -> f64,
 {
-    let mut ranked: Vec<RankedCandidate> = candidates
-        .into_iter()
-        .map(|candidate| RankedCandidate {
-            score: scorer(&candidate),
+    rank_prepared_candidates(
+        candidates.into_iter().map(|candidate| PreparedCandidate {
             candidate,
-        })
-        .collect();
-    ranked.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            // Issue #4878: without this tie-break, equal-score candidates fall
-            // back to `ranked`'s pre-sort (enumeration) order, which is not
-            // guaranteed stable across processes — mirrors search.rs:1956/2205.
-            .then_with(|| a.candidate.action.cmp_stable(&b.candidate.action))
-    });
-    ranked.truncate(limit);
-    ranked
+            payment_successor: None,
+        }),
+        |candidate| scorer(candidate),
+        limit,
+    )
 }
 
 pub fn apply_candidate(state: &GameState, candidate: &CandidateAction) -> Option<GameState> {
+    match classify_payment_continuation(state) {
+        PaymentContinuationState::Affiliated(_) => {
+            return witness_payment_continuation(state, &candidate.action)
+                .map(|accepted| accepted.state);
+        }
+        PaymentContinuationState::UnsupportedAffiliated(_) => return None,
+        PaymentContinuationState::NotAffiliated => {}
+    }
     let mut sim = state.clone();
     apply_as_current_for_simulation(&mut sim, candidate.action.clone()).ok()?;
     Some(sim)
@@ -2265,10 +2377,12 @@ mod tests {
         let illegal_prior = PolicyPrior {
             candidate: illegal.clone(),
             prior: 0.9,
+            payment_successor: None,
         };
         let legal_prior = PolicyPrior {
             candidate: legal.clone(),
             prior: 0.1,
+            payment_successor: None,
         };
 
         // sample_count=1: the high-prior illegal candidate is backfilled past, and
@@ -2293,10 +2407,12 @@ mod tests {
         let legal_a = PolicyPrior {
             candidate: legal.clone(),
             prior: 0.2,
+            payment_successor: None,
         };
         let legal_b = PolicyPrior {
             candidate: legal.clone(),
             prior: 0.15,
+            payment_successor: None,
         };
         let two = services.sample_backfilled_continuations(
             &state,
@@ -2324,6 +2440,49 @@ mod tests {
                 )
                 .is_empty(),
             "all-illegal priors yield no continuations"
+        );
+    }
+
+    #[test]
+    fn retained_payment_successor_bypasses_inapplicable_rollout_fallback() {
+        let state = make_state_with_land();
+        let config = create_config(AiDifficulty::VeryHard, Platform::Native);
+        let policies = PolicyRegistry::default();
+        let services = PlannerServices::new_default(PlayerId(0), &config, &policies);
+        let fallback = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id: ObjectId(99999),
+                ability_index: 0,
+            },
+            metadata: ActionMetadata::for_actor(Some(PlayerId(0)), TacticalClass::Mana),
+        };
+        assert!(
+            services.apply_candidate(&state, &fallback).is_none(),
+            "reach-guard: the hostile fallback cannot be applied at this root"
+        );
+        let retained = services
+            .apply_candidate(
+                &state,
+                &CandidateAction {
+                    action: GameAction::PassPriority,
+                    metadata: ActionMetadata::for_actor(Some(PlayerId(0)), TacticalClass::Pass),
+                },
+            )
+            .expect("reach-guard: a concrete retained successor exists");
+        let sampled = services.sample_backfilled_continuations(
+            &state,
+            vec![PolicyPrior {
+                candidate: fallback,
+                prior: 1.0,
+                payment_successor: Some(retained.clone()),
+            }],
+            1,
+        );
+        assert_eq!(sampled.len(), 1);
+        assert_eq!(
+            quick_state_hash(&sampled[0].1),
+            quick_state_hash(&retained),
+            "rollout consumes the witnessed successor instead of retrying its hostile fallback"
         );
     }
 
@@ -2898,13 +3057,13 @@ mod tests {
     // ---- U2: move ordering (killers) + witness counters ----
 
     fn ranked_candidate(action: GameAction, score: f64) -> RankedCandidate {
-        RankedCandidate {
-            candidate: CandidateAction {
+        RankedCandidate::new(
+            CandidateAction {
                 action,
                 metadata: ActionMetadata::for_actor(Some(PlayerId(0)), TacticalClass::Pass),
             },
             score,
-        }
+        )
     }
 
     // V1: a beta cutoff records the cutting move as the ply's primary killer.

--- a/crates/phase-ai/src/policies/registry.rs
+++ b/crates/phase-ai/src/policies/registry.rs
@@ -415,6 +415,12 @@ impl Default for PolicyRegistry {
             Box::new(super::cost_reduction::CostReductionPolicy),
             Box::new(super::draw_payoff::DrawPayoffPolicy),
         ];
+        Self::from_policies(policies)
+    }
+}
+
+impl PolicyRegistry {
+    fn from_policies(policies: Vec<Box<dyn TacticalPolicy>>) -> Self {
         let mut by_kind: HashMap<DecisionKind, Vec<usize>> = HashMap::new();
         for (idx, policy) in policies.iter().enumerate() {
             for kind in policy.decision_kinds() {
@@ -423,9 +429,13 @@ impl Default for PolicyRegistry {
         }
         Self { policies, by_kind }
     }
-}
 
-impl PolicyRegistry {
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn for_tests(policies: Vec<Box<dyn TacticalPolicy>>) -> Self {
+        Self::from_policies(policies)
+    }
+
     /// Return a process-wide shared `PolicyRegistry`, constructed once on first
     /// access. Policies are stateless (`TacticalPolicy: Send + Sync`, no
     /// interior mutability by construction), so a single instance safely
@@ -576,7 +586,11 @@ impl PolicyRegistry {
             return candidates
                 .iter()
                 .cloned()
-                .map(|candidate| PolicyPrior { candidate, prior })
+                .map(|candidate| PolicyPrior {
+                    candidate,
+                    prior,
+                    payment_successor: None,
+                })
                 .collect();
         }
         let shifted: Vec<f64> = raw_scores
@@ -600,7 +614,11 @@ impl PolicyRegistry {
             return candidates
                 .iter()
                 .cloned()
-                .map(|candidate| PolicyPrior { candidate, prior })
+                .map(|candidate| PolicyPrior {
+                    candidate,
+                    prior,
+                    payment_successor: None,
+                })
                 .collect();
         }
 
@@ -611,6 +629,7 @@ impl PolicyRegistry {
             .map(|(candidate, prior)| PolicyPrior {
                 candidate,
                 prior: prior / total,
+                payment_successor: None,
             })
             .collect()
     }

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -11,7 +11,10 @@
 
 use std::collections::HashMap;
 
-use engine::ai_support::legal_actions;
+use engine::ai_support::{
+    classify_payment_continuation, legal_actions, witness_payment_continuation,
+    PaymentContinuationState,
+};
 use engine::game::combat::AttackTarget;
 use engine::game::engine::{apply_for_simulation, EngineError};
 use engine::types::game_state::{ManaChoice, ManaChoicePrompt};
@@ -19,7 +22,6 @@ use engine::types::{
     CoreType, GameAction, GameState, ObjectId, PayCostKind, Phase, PlayerId, WaitingFor,
 };
 
-use crate::mana_colors::demand_aware_single_color;
 use web_time::{Duration, Instant};
 
 /// How far into the opponent's upcoming turn to project.
@@ -157,12 +159,17 @@ pub fn project_to(
             });
         }
 
-        let (actor, action, is_policy_choice) = resolve_choice(&state, ai_player, target_opponent)?;
+        let (actor, action, is_policy_choice, witnessed_successor) =
+            resolve_choice(&state, ai_player, target_opponent)?;
         if is_policy_choice {
             choice_count += 1;
         }
 
-        apply_for_simulation(&mut state, actor, action).map_err(BailReason::EngineRejected)?;
+        if let Some(successor) = witnessed_successor {
+            state = successor;
+        } else {
+            apply_for_simulation(&mut state, actor, action).map_err(BailReason::EngineRejected)?;
+        }
 
         if matches!(state.waiting_for, WaitingFor::GameOver { .. }) {
             return Err(BailReason::GameOverDuringProjection);
@@ -283,7 +290,7 @@ fn resolve_choice(
     state: &GameState,
     ai_player: PlayerId,
     target_opponent: PlayerId,
-) -> Result<(PlayerId, GameAction, bool), BailReason> {
+) -> Result<(PlayerId, GameAction, bool, Option<GameState>), BailReason> {
     // Impossible-mid-game gates.
     match &state.waiting_for {
         WaitingFor::MulliganDecision { .. }
@@ -310,6 +317,22 @@ fn resolve_choice(
         return Err(BailReason::NoLegalAction {
             waiting_for: format!("{:?}", state.waiting_for),
         });
+    }
+
+    match classify_payment_continuation(state) {
+        PaymentContinuationState::NotAffiliated => {}
+        PaymentContinuationState::UnsupportedAffiliated(_) => {
+            return Err(BailReason::NoLegalManaPayment);
+        }
+        PaymentContinuationState::Affiliated(_) => {
+            let mut actions = actions;
+            actions.sort_by(|left, right| left.cmp_stable(right));
+            let accepted = actions
+                .into_iter()
+                .find_map(|action| witness_payment_continuation(state, &action))
+                .ok_or(BailReason::NoLegalManaPayment)?;
+            return Ok((acting, accepted.action, true, Some(accepted.state)));
+        }
     }
 
     // Policy dispatch on WaitingFor kind + actor identity.
@@ -354,9 +377,7 @@ fn resolve_choice(
                 | PayCostKind::TapCreatures { .. },
             ..
         }
-        | WaitingFor::ManaPayment { .. }
         | WaitingFor::DefilerPayment { .. }
-        | WaitingFor::PhyrexianPayment { .. }
         | WaitingFor::CombatTaxPayment { .. }
         | WaitingFor::HarmonizeTapChoice { .. }
         | WaitingFor::AlternativeCastChoice { .. }
@@ -368,14 +389,12 @@ fn resolve_choice(
                 .ok_or(BailReason::NoLegalManaPayment)?
         }
 
-        // CR 106.3 + CR 608.2d: Mana-color choice during payment. The
-        // SingleColor prompt must produce the color the pending cost demands —
-        // projecting an arbitrary color (the old `actions.first()`) can strand a
-        // colored pip and dead-end the projected ManaPayment, mirroring the live
-        // AI bug fixed in `search.rs`. Combination / AnyCombination keep
-        // first-legal, matching the `fallback_action` shapes.
+        // Non-payment color choices retain their established first-legal policy.
+        // Affiliated mana-ability choices return through the witness above.
         WaitingFor::ChooseManaColor { choice, .. } => match choice {
-            ManaChoicePrompt::SingleColor { options } => demand_aware_single_color(options, state)
+            ManaChoicePrompt::SingleColor { options } => options
+                .first()
+                .copied()
                 .map(|color| GameAction::ChooseManaColor {
                     choice: ManaChoice::SingleColor(color),
                     count: 1,
@@ -491,7 +510,7 @@ fn resolve_choice(
     };
 
     let is_policy_choice = !matches!(action, GameAction::PassPriority);
-    Ok((acting, action, is_policy_choice))
+    Ok((acting, action, is_policy_choice, None))
 }
 
 fn pick_pass_or_first(actions: &[GameAction]) -> GameAction {
@@ -630,7 +649,7 @@ mod tests {
             schema: engine::analysis::decision_template::ShortcutDecisionSchema::default(),
         };
 
-        let (_actor, action, is_policy_choice) =
+        let (_actor, action, is_policy_choice, _successor) =
             resolve_choice(&state, PlayerId(0), PlayerId(1)).expect("the offer has legal actions");
         assert_eq!(action, GameAction::DeclineShortcut);
         assert!(
@@ -687,7 +706,7 @@ mod tests {
     #[test]
     fn projection_declines_precast_shortcut_offer() {
         let state = precast_offer_state();
-        let (_, action, is_policy_choice) =
+        let (_, action, is_policy_choice, _successor) =
             resolve_choice(&state, PlayerId(0), PlayerId(1)).expect("offer has a legal decline");
 
         assert!(matches!(

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -26,11 +26,10 @@ use crate::combat_ai::{choose_attackers_with_targets_with_profile, choose_blocke
 use crate::config::{AiConfig, PlannerMode, ThreatAwareness};
 use crate::context::AiContext;
 use crate::features::DeckFeatures;
-use crate::mana_colors::demand_aware_single_color;
 use crate::plan::{PlanSnapshot, PlanState};
 use crate::planner::{
-    apply_candidate, BeamContinuationPlanner, ContinuationPlanner, PlannerServices,
-    RankedCandidate, RungStat, SearchBudget,
+    apply_candidate, prepare_payment_candidates, BeamContinuationPlanner, ContinuationPlanner,
+    PlannerServices, PreparedCandidate, RankedCandidate, RungStat, SearchBudget,
 };
 use crate::policies::context::{PolicyContext, SearchDepth};
 use crate::policies::copy_value::score_legend_rule_keep;
@@ -198,28 +197,6 @@ pub fn choose_action_with_session(
         let context = build_ai_context_with_session(state, ai_player, config, Arc::clone(session));
         if let Some(action) = deterministic_choice(state, ai_player, config, &[], Some(&context)) {
             return Some(action);
-        }
-    }
-
-    // CR 106.3 + CR 608.2d: Selecting which color a flexible mana source
-    // produces while paying for a spell is mechanical, not a policy judgment —
-    // the AI must produce the color the in-flight cost demands. `candidates.rs`
-    // enumerates *every* color option, so `score_candidates` is always non-empty
-    // and the old `fallback_action` SingleColor arm never fired on the normal
-    // path; the scorer then picked an arbitrary (first-enumerated) color,
-    // tapping a U/R dual for {R} when the spell needed {U} and stranding the pip
-    // (ManaPayment dead-end). This deterministic pre-emption — parallel to the
-    // TributeChoice and SearchChoice pre-emptions above — is the real fix.
-    if let WaitingFor::ChooseManaColor {
-        choice: ManaChoicePrompt::SingleColor { ref options },
-        ..
-    } = state.waiting_for
-    {
-        if let Some(color) = demand_aware_single_color(options, state) {
-            return Some(GameAction::ChooseManaColor {
-                choice: ManaChoice::SingleColor(color),
-                count: 1,
-            });
         }
     }
 
@@ -1649,40 +1626,36 @@ pub fn fallback_action(state: &GameState, config: &AiConfig) -> Option<GameActio
         }
 
         // Mana-related states: picking a color or paying mana.
-        WaitingFor::ChooseManaColor { choice, .. } => {
-            match choice {
-                ManaChoicePrompt::SingleColor { options } => {
-                    // Defense-in-depth: the primary fix is the pre-emption in
-                    // `choose_action_with_session`; this honors the demanded
-                    // color too should this path ever be reached.
-                    demand_aware_single_color(options, state).map(|color| {
-                        GameAction::ChooseManaColor {
-                            choice: ManaChoice::SingleColor(color),
-                            count: 1,
-                        }
-                    })
-                }
-                ManaChoicePrompt::Combination { options } => {
-                    options.first().map(|combo| GameAction::ChooseManaColor {
-                        choice: ManaChoice::Combination(combo.clone()),
+        WaitingFor::ChooseManaColor { choice, .. } => match choice {
+            ManaChoicePrompt::SingleColor { options } => {
+                options
+                    .first()
+                    .copied()
+                    .map(|color| GameAction::ChooseManaColor {
+                        choice: ManaChoice::SingleColor(color),
                         count: 1,
                     })
-                }
-                ManaChoicePrompt::AnyCombination { count, options } => {
-                    let combo = vec![
-                        options
-                            .first()
-                            .copied()
-                            .unwrap_or(engine::types::mana::ManaType::Colorless);
-                        *count
-                    ];
-                    Some(GameAction::ChooseManaColor {
-                        choice: ManaChoice::Combination(combo),
-                        count: 1,
-                    })
-                }
             }
-        }
+            ManaChoicePrompt::Combination { options } => {
+                options.first().map(|combo| GameAction::ChooseManaColor {
+                    choice: ManaChoice::Combination(combo.clone()),
+                    count: 1,
+                })
+            }
+            ManaChoicePrompt::AnyCombination { count, options } => {
+                let combo = vec![
+                    options
+                        .first()
+                        .copied()
+                        .unwrap_or(engine::types::mana::ManaType::Colorless);
+                    *count
+                ];
+                Some(GameAction::ChooseManaColor {
+                    choice: ManaChoice::Combination(combo),
+                    count: 1,
+                })
+            }
+        },
         WaitingFor::PayManaAbilityMana { options, .. } => {
             options.first().map(|plan| GameAction::PayManaAbilityMana {
                 payment: plan.clone(),
@@ -1980,6 +1953,57 @@ fn priority_action_is_allowed_by_loop_guards(
     }
 }
 
+/// Rank the root beam after validation and gating, retaining an affiliated
+/// payment candidate's already-witnessed reducer successor through width
+/// truncation. This is the single production seam for root payment ranking;
+/// tests exercise it directly to prove the enabled-search beam boundary.
+fn rank_root_payment_candidates(
+    state: &GameState,
+    decision: &engine::ai_support::AiDecisionContext,
+    prepared: &[PreparedCandidate],
+    gated: &[crate::tactical_gate::GatedCandidate],
+    services: &PlannerServices<'_>,
+    max_branching: usize,
+) -> Vec<RankedCandidate> {
+    let mut ranked: Vec<RankedCandidate> = gated
+        .iter()
+        .map(|gated_candidate| {
+            let score = services.tactical_score(
+                state,
+                decision,
+                &gated_candidate.candidate,
+                services.ai_player,
+                SearchDepth::Root,
+            ) + gated_candidate.penalty;
+            prepared
+                .iter()
+                .find(|prepared_candidate| {
+                    prepared_candidate.candidate.action == gated_candidate.candidate.action
+                })
+                .and_then(|prepared_candidate| prepared_candidate.payment_successor.clone())
+                .map_or_else(
+                    || RankedCandidate::new(gated_candidate.candidate.clone(), score),
+                    |successor| {
+                        RankedCandidate::with_payment_successor(
+                            gated_candidate.candidate.clone(),
+                            score,
+                            successor,
+                        )
+                    },
+                )
+        })
+        .collect();
+    ranked.sort_by(|left, right| {
+        right
+            .score
+            .partial_cmp(&left.score)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| left.candidate.action.cmp_stable(&right.candidate.action))
+    });
+    ranked.truncate(max_branching);
+    ranked
+}
+
 /// Core scoring for a single (possibly determinized) state. Byte-identical to
 /// the pre-feature `score_candidates_with_session` except it threads a shared
 /// `deadline_override` into `PlannerServices` — `None` reproduces the old
@@ -1996,6 +2020,12 @@ fn score_candidates_core(
     }
 
     let ctx = build_decision_context(state);
+    #[cfg(test)]
+    let policies = session
+        .policy_registry_override
+        .as_deref()
+        .unwrap_or_else(|| PolicyRegistry::shared());
+    #[cfg(not(test))]
     let policies = PolicyRegistry::shared();
     let context = build_ai_context_with_session(state, ai_player, config, Arc::clone(session));
 
@@ -2021,7 +2051,14 @@ fn score_candidates_core(
 
     let mut services =
         PlannerServices::with_deadline(ai_player, config, policies, context, deadline_override);
-    let candidates = services.validate_candidates(state, ctx.candidates.clone());
+    let prepared = prepare_payment_candidates(state, ctx.candidates.clone());
+    let candidates = services.validate_candidates(
+        state,
+        prepared
+            .iter()
+            .map(|candidate| candidate.candidate.clone())
+            .collect(),
+    );
     let gated = gate_candidates(
         state,
         &ctx,
@@ -2052,10 +2089,15 @@ fn score_candidates_core(
     // Deterministic early returns — these don't benefit from search/parallelism.
     // Pass the already-built context so the mulligan branch avoids a second
     // full deck analysis (DeckProfile + SynergyGraph for both players).
-    if let Some(action) =
-        deterministic_choice(state, ai_player, config, &actions, Some(&services.context))
-    {
-        return vec![(action, 1.0)];
+    if matches!(
+        engine::ai_support::classify_payment_continuation(state),
+        engine::ai_support::PaymentContinuationState::NotAffiliated
+    ) {
+        if let Some(action) =
+            deterministic_choice(state, ai_player, config, &actions, Some(&services.context))
+        {
+            return vec![(action, 1.0)];
+        }
     }
 
     // Score actions via search or heuristics
@@ -2096,29 +2138,8 @@ fn score_candidates_core(
         // O(n) linear scan of `gated` per scored candidate — O(n²) overall.
         // GameAction is not Hash, so we can't key a HashMap; carrying the
         // penalty with its candidate is both cheaper and more idiomatic.
-        let mut ranked: Vec<RankedCandidate> = gated
-            .iter()
-            .map(|g| {
-                let tactical = services.tactical_score(
-                    state,
-                    &ctx,
-                    &g.candidate,
-                    ai_player,
-                    SearchDepth::Root,
-                );
-                RankedCandidate {
-                    candidate: g.candidate.clone(),
-                    score: tactical + g.penalty,
-                }
-            })
-            .collect();
-        ranked.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| a.candidate.action.cmp_stable(&b.candidate.action))
-        });
-        ranked.truncate(branching);
+        let ranked =
+            rank_root_payment_candidates(state, &ctx, &prepared, &gated, &services, branching);
 
         run_iterative_deepening(state, ranked, tactical_weight, config, &mut services)
     } else {
@@ -2204,7 +2225,11 @@ fn run_iterative_deepening(
                 completed = false;
                 break;
             }
-            let score = if let Some(sim) = apply_candidate(state, &r.candidate) {
+            let score = if let Some(sim) = r
+                .payment_successor
+                .clone()
+                .or_else(|| apply_candidate(state, &r.candidate))
+            {
                 let cont = planner.evaluate_after_action(&sim, services, &mut budget);
                 cont + (r.score * tactical_weight)
             } else {
@@ -3218,11 +3243,12 @@ pub fn softmax_select_pairs(
 mod tests {
     use super::*;
     use engine::ai_support::{ActionMetadata, AiDecisionContext, CandidateAction, TacticalClass};
+    use engine::game::scenario::{GameScenario, P0};
     use engine::game::zones::create_object;
     use engine::types::ability::{
-        AbilityDefinition, AbilityKind, CategoryChooserScope, ContinuousModification, Duration,
-        Effect, EffectKind, QuantityExpr, ResolvedAbility, StaticDefinition, TargetFilter,
-        TargetRef, TypedFilter,
+        AbilityCost, AbilityDefinition, AbilityKind, CategoryChooserScope, ContinuousModification,
+        Duration, Effect, EffectKind, ManaProduction, QuantityExpr, ResolvedAbility,
+        StaticDefinition, TargetFilter, TargetRef, TypedFilter,
     };
     use engine::types::ability::{ChoiceType, ChosenAttribute};
     use engine::types::card_type::CoreType;
@@ -3232,7 +3258,8 @@ mod tests {
         PromptSourceBinding, StackEntry, StackEntryKind,
     };
     use engine::types::identifiers::{CardId, ObjectId};
-    use engine::types::mana::{ManaCostShard, ManaType, ManaUnit};
+    use engine::types::keywords::Keyword;
+    use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use engine::types::phase::Phase;
     use engine::types::zones::Zone;
     use rand::rngs::SmallRng;
@@ -3240,6 +3267,7 @@ mod tests {
 
     use crate::config::{create_config, AiDifficulty, Platform};
     use crate::policies::context::PolicyContext;
+    use crate::policies::{DecisionKind, PolicyReason, TacticalPolicy};
     use crate::session::SessionCache;
     use crate::test_support::{context_with_plans, default_deck_plan, ramp_deck_plan};
 
@@ -4485,28 +4513,6 @@ mod tests {
         );
     }
 
-    fn pending_cast_with_cost(
-        shards: Vec<engine::types::mana::ManaCostShard>,
-        generic: u32,
-    ) -> Box<engine::types::game_state::PendingCast> {
-        use engine::types::ability::{QuantityExpr, ResolvedAbility, TargetFilter};
-        use engine::types::game_state::PendingCast;
-        Box::new(PendingCast::new(
-            ObjectId(100),
-            CardId(100),
-            ResolvedAbility::new(
-                engine::types::ability::Effect::Draw {
-                    count: QuantityExpr::Fixed { value: 0 },
-                    target: TargetFilter::Controller,
-                },
-                Vec::new(),
-                ObjectId(100),
-                PlayerId(0),
-            ),
-            engine::types::mana::ManaCost::Cost { shards, generic },
-        ))
-    }
-
     fn spell_target_selection_state(
         current_legal_targets: Vec<TargetRef>,
         stale_slot_targets: Vec<TargetRef>,
@@ -4564,21 +4570,13 @@ mod tests {
         state
     }
 
-    /// Minimal ChooseManaColor SingleColor state with the given option list and
-    /// pending cast. The `context` is a degenerate `ResolvingEffect` resume — the
-    /// pre-emption never inspects it, only `choice` and `state.pending_cast`.
-    /// Production Improvise/dual repro paths use `ManaChoiceContext::ManaAbility`,
-    /// but the context variant is irrelevant to the pre-emption (which reads only
-    /// `pending_cast` + `options`), so `ResolvingEffect` is used for fixture
-    /// simplicity.
-    fn choose_mana_color_state(
-        options: Vec<ManaType>,
-        pending: Option<Box<engine::types::game_state::PendingCast>>,
-    ) -> GameState {
+    /// Minimal non-payment mana-color prompt. The production payment path uses
+    /// a live mana-ability carrier below; this fixture is deliberately outside
+    /// that authority so it pins the established first-option fallback.
+    fn non_affiliated_choose_mana_color_state(options: Vec<ManaType>) -> GameState {
         use engine::types::ability::{QuantityExpr, ResolvedAbility, TargetFilter};
         use engine::types::game_state::{ManaChoiceContext, ManaChoicePrompt};
         let mut state = make_state();
-        state.pending_cast = pending;
         let resume = ResolvedAbility::new(
             engine::types::ability::Effect::Draw {
                 count: QuantityExpr::Fixed { value: 0 },
@@ -4597,39 +4595,8 @@ mod tests {
     }
 
     #[test]
-    fn choose_mana_color_preemption_selects_demanded_color() {
-        // Repro: {2}{U} spell, U/R source offered [Red, Blue]. The AI must
-        // produce Blue (demanded) — the old scorer picked the first-enumerated
-        // color (Red) and stranded the {U} pip into a ManaPayment dead-end.
-        // Drives the PUBLIC choose_action path, not fallback_action.
-        let state = choose_mana_color_state(
-            vec![ManaType::Red, ManaType::Blue],
-            Some(pending_cast_with_cost(
-                vec![engine::types::mana::ManaCostShard::Blue],
-                2,
-            )),
-        );
-        let config = create_config(AiDifficulty::Medium, Platform::Native);
-        let mut rng = SmallRng::seed_from_u64(1);
-        assert_eq!(
-            choose_action(&state, PlayerId(0), &config, &mut rng),
-            Some(GameAction::ChooseManaColor {
-                choice: engine::types::game_state::ManaChoice::SingleColor(ManaType::Blue),
-                count: 1,
-            })
-        );
-    }
-
-    #[test]
-    fn choose_mana_color_preemption_selects_demanded_red() {
-        // {1}{R} spell, source offered [Blue, Red] → must produce Red.
-        let state = choose_mana_color_state(
-            vec![ManaType::Blue, ManaType::Red],
-            Some(pending_cast_with_cost(
-                vec![engine::types::mana::ManaCostShard::Red],
-                1,
-            )),
-        );
+    fn non_affiliated_choose_mana_color_uses_first_option() {
+        let state = non_affiliated_choose_mana_color_state(vec![ManaType::Red, ManaType::Blue]);
         let config = create_config(AiDifficulty::Medium, Platform::Native);
         let mut rng = SmallRng::seed_from_u64(1);
         assert_eq!(
@@ -4641,41 +4608,383 @@ mod tests {
         );
     }
 
-    #[test]
-    fn choose_mana_color_preemption_demanded_color_first() {
-        // Demanded color is first here; paired with selects_demanded_color
-        // (demanded second) this proves demand-driven, not positional.
-        let state = choose_mana_color_state(
-            vec![ManaType::Blue, ManaType::Red],
-            Some(pending_cast_with_cost(
-                vec![engine::types::mana::ManaCostShard::Blue],
-                2,
-            )),
-        );
-        let config = create_config(AiDifficulty::Medium, Platform::Native);
-        let mut rng = SmallRng::seed_from_u64(1);
-        assert_eq!(
-            choose_action(&state, PlayerId(0), &config, &mut rng),
-            Some(GameAction::ChooseManaColor {
-                choice: engine::types::game_state::ManaChoice::SingleColor(ManaType::Blue),
-                count: 1,
+    fn flexible_mana_payment_state() -> GameState {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let spell = scenario
+            .add_spell_to_hand_from_oracle(P0, "Flexible AI Witness", true, "Draw a card.")
+            .with_mana_cost(ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 1,
             })
-        );
+            .id();
+        let source = scenario.add_creature(P0, "Flexible AI Source", 1, 1).id();
+        let mut runner = scenario.build();
+        let ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::AnyCombination {
+                    count: QuantityExpr::Fixed { value: 2 },
+                    color_options: vec![ManaColor::Blue, ManaColor::Red],
+                },
+                restrictions: Vec::new(),
+                grants: Vec::new(),
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        let source_object = runner.state_mut().objects.get_mut(&source).unwrap();
+        Arc::make_mut(&mut source_object.abilities).push(ability);
+        let card_id = runner.state().objects[&spell].card_id;
+        runner
+            .act(GameAction::CastSpell {
+                object_id: spell,
+                card_id,
+                targets: Vec::new(),
+                payment_mode: engine::types::game_state::CastPaymentMode::Manual,
+            })
+            .expect("the test spell reaches manual payment");
+        runner
+            .act(GameAction::ActivateAbility {
+                source_id: source,
+                ability_index: 0,
+            })
+            .expect("the real mana ability opens its colour prompt");
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::ChooseManaColor { .. }
+        ));
+        runner.state().clone()
+    }
+
+    fn mana_product(colors: &[ManaType]) -> GameAction {
+        GameAction::ChooseManaColor {
+            choice: engine::types::game_state::ManaChoice::Combination(colors.to_vec()),
+            count: 1,
+        }
+    }
+
+    /// Reach a live CR 702.126a Improvise payment carrier, then leave its last
+    /// mana open for the red-first flexible mana ability. `improvise_taps`
+    /// deliberately differs between the coloured and generic control so each
+    /// still needs exactly one colour allocation after its artifact payment.
+    fn red_first_improvise_payment_state(cost: ManaCost, improvise_taps: usize) -> GameState {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let spell = {
+            let mut builder = scenario.add_spell_to_hand_from_oracle(
+                P0,
+                "Improvise Payment Witness",
+                true,
+                "Draw a card.",
+            );
+            builder.with_mana_cost(cost);
+            builder.with_keyword(Keyword::Improvise);
+            builder.id()
+        };
+        let artifacts: Vec<_> = (0..improvise_taps)
+            .map(|index| {
+                let mut builder =
+                    scenario.add_creature(P0, &format!("Improvise Artifact {index}"), 0, 1);
+                builder.as_artifact();
+                builder.id()
+            })
+            .collect();
+        let source = scenario
+            .add_creature(P0, "Red First Mana Source", 1, 1)
+            .id();
+        let mut runner = scenario.build();
+        let ability = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::Mana {
+                produced: ManaProduction::AnyCombination {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    color_options: vec![ManaColor::Red, ManaColor::Blue],
+                },
+                restrictions: Vec::new(),
+                grants: Vec::new(),
+                expiry: None,
+                target: None,
+            },
+        )
+        .cost(AbilityCost::Tap);
+        Arc::make_mut(
+            &mut runner
+                .state_mut()
+                .objects
+                .get_mut(&source)
+                .unwrap()
+                .abilities,
+        )
+        .push(ability);
+        let card_id = runner.state().objects[&spell].card_id;
+        runner
+            .act(GameAction::CastSpell {
+                object_id: spell,
+                card_id,
+                targets: Vec::new(),
+                payment_mode: engine::types::game_state::CastPaymentMode::Manual,
+            })
+            .expect("the Improvise spell reaches manual payment");
+        for artifact in artifacts {
+            runner
+                .act(GameAction::TapForConvoke {
+                    object_id: artifact,
+                    mana_type: ManaType::Colorless,
+                })
+                .expect("each artifact pays one generic mana through Improvise");
+        }
+        runner
+            .act(GameAction::ActivateAbility {
+                source_id: source,
+                ability_index: 0,
+            })
+            .expect("the real mana ability opens its red-first colour prompt");
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::ChooseManaColor { .. }
+        ));
+        runner.state().clone()
+    }
+
+    struct FlexibleManaPolicy(Arc<std::sync::atomic::AtomicUsize>);
+
+    impl TacticalPolicy for FlexibleManaPolicy {
+        fn id(&self) -> PolicyId {
+            PolicyId::PaymentSelection
+        }
+
+        fn decision_kinds(&self) -> &'static [DecisionKind] {
+            &[DecisionKind::ActivateAbility]
+        }
+
+        fn activation(
+            &self,
+            _: &crate::features::DeckFeatures,
+            _: &GameState,
+            _: PlayerId,
+        ) -> Option<f32> {
+            Some(1.0)
+        }
+
+        fn verdict(&self, context: &PolicyContext<'_>) -> PolicyVerdict {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            match &context.candidate.action {
+                GameAction::ChooseManaColor {
+                    choice: engine::types::game_state::ManaChoice::Combination(colors),
+                    ..
+                } if colors == &[ManaType::Blue, ManaType::Red] => {
+                    PolicyVerdict::critical(15.0, PolicyReason::new("flexible_mana_test"))
+                }
+                GameAction::ChooseManaColor {
+                    choice: engine::types::game_state::ManaChoice::Combination(colors),
+                    ..
+                } if colors == &[ManaType::Red, ManaType::Blue] => {
+                    PolicyVerdict::strong(5.0, PolicyReason::new("flexible_mana_test"))
+                }
+                _ => PolicyVerdict::neutral(PolicyReason::new("flexible_mana_test")),
+            }
+        }
+    }
+
+    fn flexible_mana_session(
+        state: &GameState,
+        calls: Arc<std::sync::atomic::AtomicUsize>,
+    ) -> Arc<AiSession> {
+        let mut session = AiSession::from_game(state);
+        session.policy_registry_override =
+            Some(Arc::new(PolicyRegistry::for_tests(vec![Box::new(
+                FlexibleManaPolicy(calls),
+            )])));
+        Arc::new(session)
     }
 
     #[test]
-    fn choose_mana_color_preemption_no_pending_cast_uses_first() {
-        // No pending cast (e.g. a mana-ability color choice at priority) →
-        // first option, identical to the old behavior.
-        let state = choose_mana_color_state(vec![ManaType::Red, ManaType::Blue], None);
-        let config = create_config(AiDifficulty::Medium, Platform::Native);
-        let mut rng = SmallRng::seed_from_u64(1);
+    fn affiliated_flexible_mana_uses_witnessed_support_in_public_and_enabled_beam_paths() {
+        let state = flexible_mana_payment_state();
+        let all = engine::ai_support::legal_actions(&state);
+        let expected_all = vec![
+            mana_product(&[ManaType::Blue, ManaType::Blue]),
+            mana_product(&[ManaType::Blue, ManaType::Red]),
+            mana_product(&[ManaType::Red, ManaType::Blue]),
+            mana_product(&[ManaType::Red, ManaType::Red]),
+        ];
         assert_eq!(
-            choose_action(&state, PlayerId(0), &config, &mut rng),
-            Some(GameAction::ChooseManaColor {
-                choice: engine::types::game_state::ManaChoice::SingleColor(ManaType::Red),
-                count: 1,
-            })
+            all, expected_all,
+            "live AnyCombination exposes all four products"
+        );
+        let witnessed: Vec<_> = all
+            .iter()
+            .filter_map(|action| engine::ai_support::witness_payment_continuation(&state, action))
+            .collect();
+        let expected = expected_all[..3].to_vec();
+        assert_eq!(
+            witnessed
+                .iter()
+                .map(|accepted| accepted.action.clone())
+                .collect::<Vec<_>>(),
+            expected,
+            "only the three products that can finish the announced root survive"
+        );
+
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let session = flexible_mana_session(&state, Arc::clone(&calls));
+        let mut disabled = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(43);
+        disabled.search.enabled = false;
+        disabled.temperature = 0.25;
+        let scored = score_candidates_with_session(&state, P0, &disabled, &session);
+        assert_eq!(
+            scored
+                .iter()
+                .map(|(action, _)| action.clone())
+                .collect::<Vec<_>>(),
+            expected,
+            "the public scorer retains every witnessed successor and rejects RR"
+        );
+        assert!(calls.load(std::sync::atomic::Ordering::Relaxed) >= 3);
+        assert_eq!(score_of(&scored, &expected[0]), 0.45);
+        assert_eq!(score_of(&scored, &expected[1]), 15.45);
+        assert_eq!(score_of(&scored, &expected[2]), 5.45);
+
+        let max_score = scored
+            .iter()
+            .map(|(_, score)| *score)
+            .fold(f64::NEG_INFINITY, f64::max);
+        let weights: Vec<_> = scored
+            .iter()
+            .map(|(_, score)| ((*score - max_score) / disabled.temperature).exp())
+            .collect();
+        let total: f64 = weights.iter().sum();
+        let mut threshold_rng = SmallRng::seed_from_u64(0);
+        let threshold = threshold_rng.random::<f64>() * total;
+        assert!(
+            weights[0] < threshold && threshold <= weights[0] + weights[1],
+            "the seeded full-support softmax threshold lies in BR's interval"
+        );
+        let mut direct_rng = SmallRng::seed_from_u64(0);
+        assert_eq!(
+            softmax_select_pairs(&scored, disabled.temperature, &mut direct_rng),
+            Some(expected[1].clone()),
+            "the full accepted support selects BR, not stable-first BB"
+        );
+        calls.store(0, std::sync::atomic::Ordering::Relaxed);
+        let mut chooser_rng = SmallRng::seed_from_u64(0);
+        assert_eq!(
+            choose_action_with_session(&state, P0, &disabled, &mut chooser_rng, &session),
+            Some(expected[1].clone()),
+            "the disabled public chooser uses the ordinary full-support softmax path"
+        );
+        assert!(
+            calls.load(std::sync::atomic::Ordering::Relaxed) > 0,
+            "the public chooser reaches tactical policy scoring after its counter reset"
+        );
+
+        calls.store(0, std::sync::atomic::Ordering::Relaxed);
+        let mut enabled = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(43);
+        enabled.search.enabled = true;
+        enabled.search.max_branching = 3;
+        enabled.search.planner_mode = PlannerMode::BeamOnly;
+        enabled.search.determinization_samples = 0;
+        let context = build_ai_context_with_session(&state, P0, &enabled, Arc::clone(&session));
+        let policies = session.policy_registry_override.as_deref().unwrap();
+        let services = PlannerServices::with_deadline(P0, &enabled, policies, context, None);
+        let decision = build_decision_context(&state);
+        let prepared = prepare_payment_candidates(&state, decision.candidates.clone());
+        let validated = services.validate_candidates(
+            &state,
+            prepared
+                .iter()
+                .map(|candidate| candidate.candidate.clone())
+                .collect(),
+        );
+        let gated = gate_candidates(
+            &state,
+            &decision,
+            validated,
+            P0,
+            &enabled,
+            &services.context,
+        );
+        let beam = rank_root_payment_candidates(&state, &decision, &prepared, &gated, &services, 3);
+        assert_eq!(
+            beam.iter()
+                .map(|candidate| candidate.candidate.action.clone())
+                .collect::<Vec<_>>(),
+            vec![
+                expected[1].clone(),
+                expected[2].clone(),
+                expected[0].clone()
+            ],
+            "the enabled root beam ranks BR > RB > BB and retains width three"
+        );
+        assert!(beam
+            .iter()
+            .all(|candidate| candidate.payment_successor.is_some()));
+
+        calls.store(0, std::sync::atomic::Ordering::Relaxed);
+        let enabled_scored = score_candidates_with_session(&state, P0, &enabled, &session);
+        assert_eq!(enabled_scored.len(), 3);
+        assert!(enabled_scored
+            .iter()
+            .all(|(action, _)| expected.contains(action)));
+        assert!(calls.load(std::sync::atomic::Ordering::Relaxed) > 0);
+
+        calls.store(0, std::sync::atomic::Ordering::Relaxed);
+        let mut rng = SmallRng::seed_from_u64(0);
+        let chosen = choose_action_with_session(&state, P0, &enabled, &mut rng, &session);
+        assert!(chosen
+            .as_ref()
+            .is_some_and(|action| expected.contains(action)));
+        assert!(calls.load(std::sync::atomic::Ordering::Relaxed) > 0);
+    }
+
+    #[test]
+    fn improvise_mana_only_strands_mandatory_blue() {
+        let coloured = red_first_improvise_payment_state(
+            ManaCost::Cost {
+                shards: vec![ManaCostShard::Blue],
+                generic: 2,
+            },
+            2,
+        );
+        let generic = red_first_improvise_payment_state(ManaCost::generic(2), 1);
+        let red = mana_product(&[ManaType::Red]);
+        let blue = mana_product(&[ManaType::Blue]);
+
+        let coloured_actions = engine::ai_support::legal_actions(&coloured);
+        assert!(
+            coloured_actions.contains(&red),
+            "the live Metallic-Rebuke-style carrier offers a red allocation"
+        );
+        assert!(
+            coloured_actions.contains(&blue),
+            "the live Metallic-Rebuke-style carrier offers a blue allocation"
+        );
+        assert!(matches!(
+            engine::ai_support::classify_payment_continuation(&coloured),
+            engine::ai_support::PaymentContinuationState::Affiliated(_)
+        ));
+        assert!(
+            engine::ai_support::witness_payment_continuation(&coloured, &red).is_none(),
+            "red cannot pay the mandatory blue shard after Improvise covers only generic mana"
+        );
+        assert!(
+            engine::ai_support::witness_payment_continuation(&coloured, &blue).is_some(),
+            "blue finalizes the coloured Improvise cast"
+        );
+        let generic_actions = engine::ai_support::legal_actions(&generic);
+        assert!(
+            generic_actions.contains(&red),
+            "the paired generic control offers a red allocation"
+        );
+        assert!(
+            generic_actions.contains(&blue),
+            "the paired generic control offers a blue allocation"
+        );
+        assert!(
+            engine::ai_support::witness_payment_continuation(&generic, &red).is_some(),
+            "red remains a valid final allocation when no mandatory blue shard exists"
         );
     }
 
@@ -6614,14 +6923,19 @@ mod tests {
 
     // ---- U2: PV threading + rung witnesses (drive `run_iterative_deepening`) ----
 
-    /// Rebuild the root beam exactly as `score_candidates_core` does (validate ->
-    /// gate -> tactical rank -> #4878 stable sort -> truncate) so tests can drive
-    /// `run_iterative_deepening` directly and inspect the witness state it leaves
-    /// on `services`. `&PlannerServices` — reads only (validate/tactical_score are
-    /// `&self`); the caller owns construction so it controls the deadline/TT.
+    /// Reach the production root beam seam so iterative-deepening tests observe
+    /// the same validation, payment-successor retention, rank, and width path
+    /// that public scoring uses.
     fn build_root_beam(state: &GameState, services: &PlannerServices<'_>) -> Vec<RankedCandidate> {
         let ctx = build_decision_context(state);
-        let candidates = services.validate_candidates(state, ctx.candidates.clone());
+        let prepared = prepare_payment_candidates(state, ctx.candidates.clone());
+        let candidates = services.validate_candidates(
+            state,
+            prepared
+                .iter()
+                .map(|candidate| candidate.candidate.clone())
+                .collect(),
+        );
         let gated = gate_candidates(
             state,
             &ctx,
@@ -6630,30 +6944,25 @@ mod tests {
             services.config,
             &services.context,
         );
-        let mut ranked: Vec<RankedCandidate> = gated
-            .iter()
-            .map(|g| {
-                let tactical = services.tactical_score(
+        let mut gated: Vec<_> = gated
+            .into_iter()
+            .filter(|candidate| {
+                priority_action_is_allowed_by_loop_guards(
                     state,
-                    &ctx,
-                    &g.candidate,
                     services.ai_player,
-                    SearchDepth::Root,
-                );
-                RankedCandidate {
-                    candidate: g.candidate.clone(),
-                    score: tactical + g.penalty,
-                }
+                    &candidate.candidate.action,
+                )
             })
             .collect();
-        ranked.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| a.candidate.action.cmp_stable(&b.candidate.action))
-        });
-        ranked.truncate(services.config.search.max_branching as usize);
-        ranked
+        gated.sort_by(|left, right| left.candidate.action.cmp_stable(&right.candidate.action));
+        rank_root_payment_candidates(
+            state,
+            &ctx,
+            &prepared,
+            &gated,
+            services,
+            services.config.search.max_branching as usize,
+        )
     }
 
     fn score_of(scored: &[(GameAction, f64)], action: &GameAction) -> f64 {
@@ -6662,6 +6971,65 @@ mod tests {
             .find(|(a, _)| a == action)
             .map(|(_, s)| *s)
             .unwrap_or_else(|| panic!("action {action:?} absent from scored output"))
+    }
+
+    #[test]
+    fn retained_root_payment_successor_bypasses_inapplicable_fallback() {
+        let state = make_state();
+        let retained = apply_candidate(
+            &state,
+            &CandidateAction {
+                action: GameAction::PassPriority,
+                metadata: ActionMetadata::for_actor(Some(PlayerId(0)), TacticalClass::Pass),
+            },
+        )
+        .expect("reach-guard: a concrete root successor exists");
+        let hostile = CandidateAction {
+            action: GameAction::ActivateAbility {
+                source_id: ObjectId(99999),
+                ability_index: 0,
+            },
+            metadata: ActionMetadata::for_actor(Some(PlayerId(0)), TacticalClass::Mana),
+        };
+        assert!(
+            apply_candidate(&state, &hostile).is_none(),
+            "reach-guard: the fallback action is inapplicable at the root"
+        );
+        let mut config = create_config(AiDifficulty::Hard, Platform::Native).into_measurement(43);
+        config.search.planner_mode = PlannerMode::BeamOnly;
+        let policies = PolicyRegistry::shared();
+        let mut hostile_services = PlannerServices::new_default(PlayerId(0), &config, policies);
+        let hostile_result = run_iterative_deepening(
+            &state,
+            vec![RankedCandidate::with_payment_successor(
+                hostile,
+                0.0,
+                retained.clone(),
+            )],
+            0.1,
+            &config,
+            &mut hostile_services,
+        );
+        let mut control_services = PlannerServices::new_default(PlayerId(0), &config, policies);
+        let control_result = run_iterative_deepening(
+            &state,
+            vec![RankedCandidate::with_payment_successor(
+                CandidateAction {
+                    action: GameAction::PassPriority,
+                    metadata: ActionMetadata::for_actor(Some(PlayerId(0)), TacticalClass::Pass),
+                },
+                0.0,
+                retained,
+            )],
+            0.1,
+            &config,
+            &mut control_services,
+        );
+        assert_eq!(hostile_result[0].1, control_result[0].1);
+        assert!(
+            hostile_result[0].1 > -900.0,
+            "the retained successor prevents the failed-apply penalty"
+        );
     }
 
     /// Fixture with several cheap castable creatures + an opponent threat, so the
@@ -6880,14 +7248,8 @@ mod tests {
         // (no tactical term interfering with the demonstration).
         let (pass, cast) = pass_and_first_cast(&state);
         let ranked = vec![
-            RankedCandidate {
-                candidate: pass.clone(),
-                score: 0.0,
-            },
-            RankedCandidate {
-                candidate: cast.clone(),
-                score: 0.0,
-            },
+            RankedCandidate::new(pass.clone(), 0.0),
+            RankedCandidate::new(cast.clone(), 0.0),
         ];
         let a = ranked[0].candidate.action.clone();
 
@@ -6990,14 +7352,8 @@ mod tests {
         // from ranked[0] = pass — making a rung-0 rotate observable.
         let (pass, cast) = pass_and_first_cast(&state);
         let ranked = vec![
-            RankedCandidate {
-                candidate: pass.clone(),
-                score: 0.0,
-            },
-            RankedCandidate {
-                candidate: cast.clone(),
-                score: 0.0,
-            },
+            RankedCandidate::new(pass.clone(), 0.0),
+            RankedCandidate::new(cast.clone(), 0.0),
         ];
         let a = ranked[0].candidate.action.clone();
 

--- a/crates/phase-ai/src/session.rs
+++ b/crates/phase-ai/src/session.rs
@@ -22,6 +22,8 @@ use crate::features::DeckFeatures;
 use crate::plan::{derive_snapshot, PlanSnapshot};
 use crate::planner::quick_state_hash;
 use crate::policies::registry::PolicyId;
+#[cfg(test)]
+use crate::policies::PolicyRegistry;
 use crate::projection::{project_to, BailReason, Projection, ProjectionHorizon, ProjectionKey};
 use crate::strategy_profile::StrategyProfile;
 use crate::synergy::SynergyGraph;
@@ -32,7 +34,7 @@ use crate::synergy::SynergyGraph;
 const COMMANDER_ANALYSIS_WEIGHT: u32 = 4;
 
 /// Per-game cache shared by all decisions.
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 pub struct AiSession {
     pub deck_profile: HashMap<PlayerId, DeckProfile>,
     pub features: HashMap<PlayerId, DeckFeatures>,
@@ -44,6 +46,23 @@ pub struct AiSession {
     /// `turn_number` + `active_player`, so stale entries from prior turns
     /// never match — no explicit invalidation needed.
     pub projection_cache: Arc<RwLock<HashMap<ProjectionKey, Arc<Projection>>>>,
+    #[cfg(test)]
+    pub(crate) policy_registry_override: Option<Arc<PolicyRegistry>>,
+}
+
+impl std::fmt::Debug for AiSession {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AiSession")
+            .field("deck_profile", &self.deck_profile)
+            .field("features", &self.features)
+            .field("plan", &self.plan)
+            .field("strategy", &self.strategy)
+            .field("synergy", &self.synergy)
+            .field("memory", &self.memory)
+            .field("projection_cache", &self.projection_cache)
+            .finish()
+    }
 }
 
 impl AiSession {
@@ -84,6 +103,8 @@ impl AiSession {
             synergy,
             memory: Arc::default(),
             projection_cache: Arc::default(),
+            #[cfg(test)]
+            policy_registry_override: None,
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public AI helpers to classify and witness safe payment continuation progress.
  * Planning and projection now reuse witnessed successor states to guide root-payment decisions.
* **Bug Fixes**
  * Cancelled or unsupported payment continuations no longer get treated as successful.
  * Improved mana-choice resolution for single-color and tap-land candidates, reducing unnecessary fallbacks.
* **Tests**
  * Added integration coverage for fail-closed witness behavior, bounded reducer attempts, flexible mana products, and successor-state reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->