### PR TITLE
fix(engine): resolution-time X-mana payment pays colored pips, not just generic (#6410)

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2350,7 +2350,11 @@ export type LoopCollapseAxis = "Tokens" | "Counters" | "Life" | "Mixed";
 
 export type PayableResource =
   | { type: "Energy" }
-  | { type: "ManaGeneric"; data: { per_x: number } }
+  // CR 107.1b + CR 107.3 + CR 118.1: `base_cost` is the UNCONCRETIZED mana
+  // cost (still carrying the X shard alongside any colored/generic pips,
+  // e.g. `{X}{W}{U}{B}`) — the engine concretizes X into it and pays the
+  // full result, so colored requirements are never dropped (#6410).
+  | { type: "ManaGeneric"; data: { base_cost: ManaCost } }
   | { type: "Counters" }
   | { type: "Speed" }
   // CR 732.2a: not a resource payment — the finite count an accepted

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2350,7 +2350,7 @@ export type LoopCollapseAxis = "Tokens" | "Counters" | "Life" | "Mixed";
 
 export type PayableResource =
   | { type: "Energy" }
-  // CR 107.1b + CR 107.3 + CR 118.1: `base_cost` is the UNCONCRETIZED mana
+  // CR 107.3f + CR 118.1 + CR 118.12: `base_cost` is the UNCONCRETIZED mana
   // cost (still carrying the X shard alongside any colored/generic pips,
   // e.g. `{X}{W}{U}{B}`) — the engine concretizes X into it and pays the
   // full result, so colored requirements are never dropped (#6410).

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -100,6 +100,12 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 23 — PayableResource::ManaGeneric changed from { per_x } to
+ *      { base_cost: ManaCost } (#6410) — a GameState payload field type
+ *      change, and base_cost intentionally carries no serde default (a
+ *      missing base_cost must fail deserialization, not silently resolve
+ *      to a zero-cost payment), so old and new peers can't parse each
+ *      other's serialized state.
  * 22 — Viewer interaction projections and semantic object-action identities.
  * 21 — Native P2P host bridge identity and server-authored state revisions.
  * 20 — Actor-scoped priority-passing settings and filtered per-player state.
@@ -114,7 +120,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 22;
+export const PROTOCOL_VERSION = 23;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v15", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(15);
+  it("pins the P2P wire protocol to v16", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(16);
   });
 
   it("defaults shortcut actions for a v15 payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -68,6 +68,12 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * of silently corrupting state.
  *
  * Bumps to date:
+ *  16 — PayableResource::ManaGeneric changed from { per_x } to
+ *       { base_cost: ManaCost } (#6410) — a GameState payload field type
+ *       change, and base_cost intentionally carries no serde default (a
+ *       missing base_cost must fail deserialization, not silently resolve
+ *       to a zero-cost payment), so old and new peers can't parse each
+ *       other's serialized snapshots.
  *   1 — pre-compression JSON-serialization era (no longer in production)
  *   2 — gzip + version-prefixed binary wire format
  *   3 — Planechase state and action payloads in game_setup/reconnect snapshots
@@ -85,7 +91,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 15 as const;
+export const WIRE_PROTOCOL_VERSION = 16 as const;
 
 export type P2PMessage =
   | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string }

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -5,7 +5,7 @@ use crate::game::{casting, casting_costs};
 use crate::types::ability::{AbilityCost, Effect, QuantityExpr, QuantityRef};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, PayableResource, WaitingFor};
-use crate::types::mana::{ManaCost, ManaCostShard};
+use crate::types::mana::ManaCost;
 use crate::types::player::PlayerId;
 
 use super::{EffectError, ResolvedAbility};
@@ -89,13 +89,14 @@ pub fn resolve(
         AbilityCost::Mana { cost: mana_cost }
             if payment_ability.chosen_x.is_none() && casting_costs::cost_has_x(mana_cost) =>
         {
-            let per_x = mana_x_shard_count(mana_cost);
             let max = max_resolution_mana_x_value(state, payer, ability.source_id, mana_cost);
             let max =
                 trigger_event_amount_for_x_payment(state).map_or(max, |amount| max.min(amount));
             state.waiting_for = WaitingFor::PayAmountChoice {
                 player: payer,
-                resource: PayableResource::ManaGeneric { per_x },
+                resource: PayableResource::ManaGeneric {
+                    base_cost: mana_cost.clone(),
+                },
                 min: 0,
                 max,
                 accumulated: 0,
@@ -288,19 +289,6 @@ fn resolve_ability_cost_payment(
         Err(e) => Err(EffectError::InvalidParam(format!(
             "resolution-time cost payment failed: {e:?}"
         ))),
-    }
-}
-
-fn mana_x_shard_count(cost: &ManaCost) -> u32 {
-    match cost {
-        ManaCost::Cost { shards, .. } => shards
-            .iter()
-            .filter(|shard| matches!(shard, ManaCostShard::X))
-            .count() as u32,
-        ManaCost::NoCost
-        | ManaCost::SelfManaCost
-        | ManaCost::SelfManaValue
-        | ManaCost::SelfManaCostReduced { .. } => 0,
     }
 }
 
@@ -1617,7 +1605,15 @@ mod tests {
         resolve_ability_chain(&mut state, &pay, &mut events, 0).unwrap();
         match &state.waiting_for {
             WaitingFor::PayAmountChoice { resource, max, .. } => {
-                assert_eq!(*resource, PayableResource::ManaGeneric { per_x: 1 });
+                assert_eq!(
+                    *resource,
+                    PayableResource::ManaGeneric {
+                        base_cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::X],
+                            generic: 0,
+                        },
+                    }
+                );
                 assert_eq!(*max, 3);
             }
             other => panic!("expected PayAmountChoice, got {other:?}"),
@@ -1640,6 +1636,155 @@ mod tests {
         ));
         assert_eq!(state.players[0].hand.len(), 2);
         assert_eq!(state.players[0].mana_pool.mana.len(), 1);
+    }
+
+    /// CR 107.3a + CR 601.2f + CR 601.2h: Elenda and Azor's attack trigger
+    /// pays `{X}{W}{U}{B}`, not a pure X cost (#6410 — the player attacked,
+    /// paid an amount, and drew that many cards WITHOUT ever being charged
+    /// {W}{U}{B}). The resolution-time X-payment prompt must concretize X
+    /// into the FULL original cost — colored pips included — not substitute a
+    /// synthetic all-generic cost that silently drops them.
+    #[test]
+    fn pay_x_plus_colored_mana_requires_the_colored_pips() {
+        use crate::game::effects::resolve_ability_chain;
+        use crate::game::engine_resolution_choices::{
+            handle_resolution_choice, ResolutionChoiceOutcome,
+        };
+        use crate::game::zones::create_object;
+        use crate::types::actions::GameAction;
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCostShard;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Elenda and Azor".to_string(),
+            Zone::Battlefield,
+        );
+        for n in 0..5 {
+            create_object(
+                &mut state,
+                CardId(100 + n),
+                PlayerId(0),
+                format!("Card {n}"),
+                Zone::Library,
+            );
+        }
+        // Exactly {W}{U}{B} plus 4 colorless — enough to pay X=4 ({4}{W}{U}{B})
+        // and no more, so a fix that ever drops the colored requirement would
+        // still pass a naive "enough total mana" check but leave W/U/B
+        // untapped in the pool.
+        for color in [ManaType::White, ManaType::Blue, ManaType::Black] {
+            state.players[0].mana_pool.add(ManaUnit {
+                color,
+                source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
+                supertype: None,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+            });
+        }
+        for _ in 0..4 {
+            state.players[0].mana_pool.add(ManaUnit {
+                color: ManaType::Colorless,
+                source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
+                supertype: None,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: vec![],
+                grants: vec![],
+                expiry: None,
+            });
+        }
+
+        let draw = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        let mut pay = ResolvedAbility::new(
+            Effect::PayCost {
+                cost: AbilityCost::Mana {
+                    cost: ManaCost::Cost {
+                        shards: vec![
+                            ManaCostShard::X,
+                            ManaCostShard::White,
+                            ManaCostShard::Blue,
+                            ManaCostShard::Black,
+                        ],
+                        generic: 0,
+                    },
+                },
+                scale: None,
+                payer: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        pay.sub_ability = Some(Box::new(draw));
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &pay, &mut events, 0).unwrap();
+        match &state.waiting_for {
+            WaitingFor::PayAmountChoice { resource, max, .. } => {
+                assert_eq!(
+                    *resource,
+                    PayableResource::ManaGeneric {
+                        base_cost: ManaCost::Cost {
+                            shards: vec![
+                                ManaCostShard::X,
+                                ManaCostShard::White,
+                                ManaCostShard::Blue,
+                                ManaCostShard::Black
+                            ],
+                            generic: 0,
+                        },
+                    },
+                    "base_cost must carry the colored pips alongside X, not just per_x"
+                );
+                // 4 colorless available for the X portion after W/U/B are spoken for.
+                assert_eq!(*max, 4);
+            }
+            other => panic!("expected PayAmountChoice, got {other:?}"),
+        }
+
+        let waiting_for = state.waiting_for.clone();
+        let outcome = handle_resolution_choice(
+            &mut state,
+            waiting_for,
+            GameAction::SubmitPayAmount { amount: 4 },
+            &mut events,
+        )
+        .unwrap();
+        assert!(matches!(
+            outcome,
+            ResolutionChoiceOutcome::WaitingFor(_)
+                | ResolutionChoiceOutcome::WaitingForWithInlineTriggers(_)
+                | ResolutionChoiceOutcome::WaitingForWithParkedObservers(_)
+                | ResolutionChoiceOutcome::ActionResult(_)
+        ));
+        // All 7 mana units (4 colorless for X + W + U + B) must be spent —
+        // the pre-fix code paid only 4 generic and left W/U/B untapped.
+        assert!(
+            state.players[0].mana_pool.mana.is_empty(),
+            "W/U/B must be paid alongside the X-derived generic, pool: {:?}",
+            state.players[0].mana_pool.mana
+        );
+        assert_eq!(state.players[0].hand.len(), 4, "drew X=4 cards");
     }
 
     /// CR 603.2 + CR 603.5 + CR 107.3a + CR 608.2c + CR 119.3 + CR 121.1:
@@ -1760,7 +1905,15 @@ mod tests {
         let waiting = handle_optional_effect_choice(&mut state, true, &mut events).unwrap();
         match &waiting {
             WaitingFor::PayAmountChoice { resource, max, .. } => {
-                assert_eq!(*resource, PayableResource::ManaGeneric { per_x: 1 });
+                assert_eq!(
+                    *resource,
+                    PayableResource::ManaGeneric {
+                        base_cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::X],
+                            generic: 0,
+                        },
+                    }
+                );
                 assert_eq!(
                     *max, 3,
                     "PayAmountChoice max must be capped by life gained (3), got {max} \

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -1638,12 +1638,16 @@ mod tests {
         assert_eq!(state.players[0].mana_pool.mana.len(), 1);
     }
 
-    /// CR 107.3a + CR 601.2f + CR 601.2h: Elenda and Azor's attack trigger
-    /// pays `{X}{W}{U}{B}`, not a pure X cost (#6410 — the player attacked,
-    /// paid an amount, and drew that many cards WITHOUT ever being charged
-    /// {W}{U}{B}). The resolution-time X-payment prompt must concretize X
-    /// into the FULL original cost — colored pips included — not substitute a
-    /// synthetic all-generic cost that silently drops them.
+    /// CR 107.3f + CR 118.12: Elenda and Azor's attack trigger resolves
+    /// `Effect::PayCost` for `{X}{W}{U}{B}`, not a pure X cost — this is a
+    /// resolution-time cost on a triggered ability's effect text ("you may
+    /// pay ... If you do, ..."), not a spell/activated-ability cost
+    /// announced at cast/activation time (CR 601 doesn't apply here). #6410:
+    /// the player attacked, paid an amount, and drew that many cards
+    /// WITHOUT ever being charged {W}{U}{B}. The resolution-time X-payment
+    /// prompt must concretize X into the FULL original cost — colored pips
+    /// included — not substitute a synthetic all-generic cost that silently
+    /// drops them.
     #[test]
     fn pay_x_plus_colored_mana_requires_the_colored_pips() {
         use crate::game::effects::resolve_ability_chain;

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -89,20 +89,34 @@ pub fn resolve(
         AbilityCost::Mana { cost: mana_cost }
             if payment_ability.chosen_x.is_none() && casting_costs::cost_has_x(mana_cost) =>
         {
-            let max = max_resolution_mana_x_value(state, payer, ability.source_id, mana_cost);
-            let max =
-                trigger_event_amount_for_x_payment(state).map_or(max, |amount| max.min(amount));
-            state.waiting_for = WaitingFor::PayAmountChoice {
-                player: payer,
-                resource: PayableResource::ManaGeneric {
-                    base_cost: mana_cost.clone(),
-                },
-                min: 0,
-                max,
-                accumulated: 0,
-                source_id: ability.source_id,
-                pending_mana_ability: None,
-            };
+            match resolution_mana_x_max(state, payer, ability.source_id, mana_cost) {
+                Some(max) => {
+                    let max = trigger_event_amount_for_x_payment(state)
+                        .map_or(max, |amount| max.min(amount));
+                    state.waiting_for = WaitingFor::PayAmountChoice {
+                        player: payer,
+                        resource: PayableResource::ManaGeneric {
+                            base_cost: mana_cost.clone(),
+                        },
+                        min: 0,
+                        max,
+                        accumulated: 0,
+                        source_id: ability.source_id,
+                        pending_mana_ability: None,
+                    };
+                }
+                // CR 608.2d + CR 118.12: not even X=0 is payable — the
+                // cost's fixed portion (colored/generic pips alongside X,
+                // e.g. `{X}{W}` with no white available) can't be paid
+                // regardless of what X is chosen, so there is no legal
+                // amount to offer. Presenting a `[0, 0]` prompt here would
+                // let the player "choose" an impossible option; fail the
+                // payment outright instead, exactly like any other
+                // unaffordable resolution-time cost.
+                None => {
+                    state.cost_payment_failed_flag = true;
+                }
+            }
         }
         // CR 107.1c + CR 107.14: "Pay any amount of {E}" — suspend the chain and
         // surface a `PayAmountChoice` prompt. The sub-ability continuation
@@ -292,12 +306,27 @@ fn resolve_ability_cost_payment(
     }
 }
 
-fn max_resolution_mana_x_value(
+/// CR 608.2d: while resolving, a player can't be offered an illegal or
+/// impossible choice. Returns `Some(max)` for the greatest affordable X —
+/// `Some(0)` covers both "a pure `{X}` cost with nothing to spend" (paying
+/// `{0}` is a trivial no-op, always legal) and "a fixed portion the player
+/// can just barely afford at X=0". Returns `None` only when the cost's
+/// fixed portion (any colored/generic pips alongside X, e.g. `{X}{W}` with
+/// no white available) can't be paid at ANY value of X, including 0 — the
+/// caller must treat that as an ordinary payment failure, never open a
+/// `[0, 0]` prompt (there is no legal amount to submit).
+///
+/// Monotonic by construction: `concretize_x` only ever ADDS generic mana as
+/// X grows while the fixed shards stay constant, so if some X = V is
+/// payable, X = 0 is payable too. The downward search below therefore never
+/// needs to re-check 0 separately — reaching `max == 0` and failing there is
+/// exactly the "not even 0 works" case.
+fn resolution_mana_x_max(
     state: &GameState,
     payer: PlayerId,
     source_id: crate::types::identifiers::ObjectId,
     cost: &ManaCost,
-) -> u32 {
+) -> Option<u32> {
     // Resolution-time X costs are not spell casts — convoke/improvise/waterbend
     // tap-payments do not apply, so no spell object is passed.
     let mut max = casting_costs::max_x_value(state, payer, cost, None);
@@ -305,10 +334,10 @@ fn max_resolution_mana_x_value(
         let mut concrete = cost.clone();
         concrete.concretize_x(max);
         if casting::can_pay_effect_mana_cost_after_auto_tap(state, payer, source_id, &concrete) {
-            return max;
+            return Some(max);
         }
         if max == 0 {
-            return 0;
+            return None;
         }
         max -= 1;
     }
@@ -1789,6 +1818,241 @@ mod tests {
             state.players[0].mana_pool.mana
         );
         assert_eq!(state.players[0].hand.len(), 4, "drew X=4 cards");
+    }
+
+    /// CR 608.2d + CR 118.12: a cost of `{X}{W}` with NO white mana available
+    /// can't be paid at any value of X, including 0 — there is no legal
+    /// amount to offer. Pre-fix, `max_resolution_mana_x_value` collapsed
+    /// "genuinely payable at X=0" and "not payable at all" into the same
+    /// `max = 0`, so this shape opened a `[0, 0]` `PayAmountChoice` that let
+    /// the player "choose" an impossible option, then failed with an
+    /// internal `InvalidAction` on submit instead of the ordinary
+    /// payment-failure path. Accepting the optional cost must instead fail
+    /// immediately: no `PayAmountChoice` ever appears, `cost_payment_failed_flag`
+    /// is set, and the `IfYouDo` Draw rider (gated on
+    /// `!cost_payment_failed_flag`) does not fire. Sibling control case:
+    /// `pay_x_plus_colored_mana_with_payable_fixed_pip_offers_zero_max_choice`
+    /// below covers the genuinely-payable `X=0` shape, which must still
+    /// present the prompt.
+    #[test]
+    fn pay_x_plus_colored_mana_with_unpayable_fixed_pip_fails_without_impossible_choice() {
+        use crate::game::effects::resolve_ability_chain;
+        use crate::game::engine_payment_choices::handle_optional_effect_choice;
+        use crate::game::zones::create_object;
+        use crate::types::ability::{AbilityCondition, SubAbilityLink};
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCostShard;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Elenda and Azor".to_string(),
+            Zone::Battlefield,
+        );
+        for n in 0..5 {
+            create_object(
+                &mut state,
+                CardId(100 + n),
+                PlayerId(0),
+                format!("Card {n}"),
+                Zone::Library,
+            );
+        }
+        assert!(
+            state.players[0].mana_pool.mana.is_empty(),
+            "controller must have no mana at all, so not even {{W}} at X=0 is payable"
+        );
+
+        let mut draw = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        draw.condition = Some(AbilityCondition::effect_performed());
+        draw.sub_link = SubAbilityLink::SequentialSibling;
+
+        let mut pay = ResolvedAbility::new(
+            Effect::PayCost {
+                cost: AbilityCost::Mana {
+                    cost: ManaCost::Cost {
+                        shards: vec![ManaCostShard::X, ManaCostShard::White],
+                        generic: 0,
+                    },
+                },
+                scale: None,
+                payer: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        pay.sub_ability = Some(Box::new(draw));
+        pay.optional = true;
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &pay, &mut events, 0).unwrap();
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ));
+
+        let waiting = handle_optional_effect_choice(&mut state, true, &mut events).unwrap();
+        assert!(
+            !matches!(waiting, WaitingFor::PayAmountChoice { .. }),
+            "an unpayable fixed pip must never open a PayAmountChoice prompt \
+             (CR 608.2d forbids offering an impossible choice), got {waiting:?}"
+        );
+        assert!(
+            state.cost_payment_failed_flag,
+            "PayCost with an unpayable fixed {{W}} pip must set cost_payment_failed_flag, \
+             exactly like any other unaffordable resolution-time cost"
+        );
+        assert_eq!(
+            state.players[0].hand.len(),
+            0,
+            "the IfYouDo Draw rider must not fire when the cost payment failed"
+        );
+        assert!(state.players[0].mana_pool.mana.is_empty());
+    }
+
+    /// Control case for the above: `{X}{W}` where the player has EXACTLY one
+    /// white mana and nothing else. X=0 (paying just `{W}`) IS genuinely
+    /// payable, so — unlike the unpayable-fixed-pip case — accepting the
+    /// optional cost MUST still present a `PayAmountChoice { min: 0, max: 0 }`
+    /// prompt, and submitting 0 must pay the `{W}` (not silently no-op).
+    #[test]
+    fn pay_x_plus_colored_mana_with_payable_fixed_pip_offers_zero_max_choice() {
+        use crate::game::effects::resolve_ability_chain;
+        use crate::game::engine_payment_choices::handle_optional_effect_choice;
+        use crate::game::engine_resolution_choices::handle_resolution_choice;
+        use crate::game::zones::create_object;
+        use crate::types::ability::{AbilityCondition, SubAbilityLink};
+        use crate::types::actions::GameAction;
+        use crate::types::identifiers::CardId;
+        use crate::types::mana::ManaCostShard;
+        use crate::types::zones::Zone;
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Elenda and Azor".to_string(),
+            Zone::Battlefield,
+        );
+        for n in 0..5 {
+            create_object(
+                &mut state,
+                CardId(100 + n),
+                PlayerId(0),
+                format!("Card {n}"),
+                Zone::Library,
+            );
+        }
+        // Exactly {W} — enough for X=0 ({W}), nothing left over for X>0.
+        state.players[0].mana_pool.add(ManaUnit {
+            color: ManaType::White,
+            source_id: ObjectId(0),
+            pip_id: crate::types::mana::ManaPipId(0),
+            supertype: None,
+            source_could_produce_two_or_more_colors: false,
+            restrictions: vec![],
+            grants: vec![],
+            expiry: None,
+        });
+
+        let mut draw = ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::Variable {
+                        name: "X".to_string(),
+                    },
+                },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        draw.condition = Some(AbilityCondition::effect_performed());
+        draw.sub_link = SubAbilityLink::SequentialSibling;
+
+        let mut pay = ResolvedAbility::new(
+            Effect::PayCost {
+                cost: AbilityCost::Mana {
+                    cost: ManaCost::Cost {
+                        shards: vec![ManaCostShard::X, ManaCostShard::White],
+                        generic: 0,
+                    },
+                },
+                scale: None,
+                payer: TargetFilter::Controller,
+            },
+            vec![],
+            source_id,
+            PlayerId(0),
+        );
+        pay.sub_ability = Some(Box::new(draw));
+        pay.optional = true;
+
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &pay, &mut events, 0).unwrap();
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ));
+
+        let waiting = handle_optional_effect_choice(&mut state, true, &mut events).unwrap();
+        match &waiting {
+            WaitingFor::PayAmountChoice {
+                resource, min, max, ..
+            } => {
+                assert_eq!(
+                    *resource,
+                    PayableResource::ManaGeneric {
+                        base_cost: ManaCost::Cost {
+                            shards: vec![ManaCostShard::X, ManaCostShard::White],
+                            generic: 0,
+                        },
+                    }
+                );
+                assert_eq!(*min, 0);
+                assert_eq!(*max, 0, "no spare mana beyond the {{W}} pip for X>0");
+            }
+            other => {
+                panic!("a genuinely payable X=0 cost must still present the choice, got {other:?}")
+            }
+        }
+
+        handle_resolution_choice(
+            &mut state,
+            waiting,
+            GameAction::SubmitPayAmount { amount: 0 },
+            &mut events,
+        )
+        .unwrap();
+
+        assert!(
+            state.players[0].mana_pool.mana.is_empty(),
+            "the {{W}} pip must be paid even though X=0"
+        );
+        assert_eq!(
+            state.players[0].hand.len(),
+            0,
+            "X=0 draws zero cards, but the IfYouDo rider still fires (payment succeeded)"
+        );
+        assert!(!state.cost_payment_failed_flag);
     }
 
     /// CR 603.2 + CR 603.5 + CR 107.3a + CR 608.2c + CR 119.3 + CR 121.1:

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -2456,12 +2456,13 @@ pub(super) fn handle_resolution_choice(
                     }
                 }
                 PayableResource::ManaGeneric { base_cost } => {
-                    // CR 107.1b + CR 118.1: concretize the chosen X into the
-                    // ORIGINAL cost — any colored/generic pips alongside the
-                    // X shard (e.g. Elenda and Azor's `{X}{W}{U}{B}`) survive
-                    // concretization and are paid here too. Paying a
-                    // synthetic all-generic `{N}` cost instead would silently
-                    // drop the colored requirements (#6410).
+                    // CR 107.3f + CR 118.1 + CR 118.12: concretize the chosen
+                    // X into the ORIGINAL cost — any colored/generic pips
+                    // alongside the X shard (e.g. Elenda and Azor's
+                    // `{X}{W}{U}{B}`) survive concretization and are paid
+                    // here too. Paying a synthetic all-generic `{N}` cost
+                    // instead would silently drop the colored requirements
+                    // (#6410).
                     let mut cost = base_cost.clone();
                     cost.concretize_x(amount);
                     if !casting::can_pay_effect_mana_cost_after_auto_tap(

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -12,7 +12,6 @@ use crate::types::game_state::{
     PendingPlayerScopeSacrificeCompletion, PersistentAxisMaterialization, WaitingFor,
 };
 use crate::types::identifiers::{ObjectId, TrackedSetId};
-use crate::types::mana::ManaCost;
 use crate::types::resolved_commands::{
     ResolvedInformationAudience, ResolvedInformationEdit, ResolvedInformationLifetime,
 };
@@ -2456,16 +2455,20 @@ pub(super) fn handle_resolution_choice(
                         });
                     }
                 }
-                PayableResource::ManaGeneric { per_x } => {
-                    let cost = ManaCost::Cost {
-                        shards: vec![],
-                        generic: amount.saturating_mul(per_x),
-                    };
+                PayableResource::ManaGeneric { base_cost } => {
+                    // CR 107.1b + CR 118.1: concretize the chosen X into the
+                    // ORIGINAL cost — any colored/generic pips alongside the
+                    // X shard (e.g. Elenda and Azor's `{X}{W}{U}{B}`) survive
+                    // concretization and are paid here too. Paying a
+                    // synthetic all-generic `{N}` cost instead would silently
+                    // drop the colored requirements (#6410).
+                    let mut cost = base_cost.clone();
+                    cost.concretize_x(amount);
                     if !casting::can_pay_effect_mana_cost_after_auto_tap(
                         state, player, source_id, &cost,
                     ) {
                         return Err(EngineError::InvalidAction(format!(
-                            "Player {:?} cannot pay {} generic mana",
+                            "Player {:?} cannot pay {}",
                             player,
                             cost.mana_value()
                         )));

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -9603,7 +9603,7 @@ pub enum DistributionUnit {
 pub enum PayableResource {
     /// CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.
     Energy,
-    /// CR 107.1b + CR 107.3 + CR 118.1: Pay a chosen X as part of a
+    /// CR 107.3f + CR 118.1 + CR 118.12: Pay a chosen X as part of a
     /// resolution-time mana cost. `base_cost` is the UNCONCRETIZED cost
     /// (still carrying `ManaCostShard::X` plus any colored/generic pips
     /// alongside it, e.g. `{X}{W}{U}{B}`); the submit handler concretizes X
@@ -9611,10 +9611,13 @@ pub enum PayableResource {
     /// the standard mana-payment authority, so colored requirements are
     /// enforced exactly like any other mana cost — never dropped in favor of
     /// a generic-only payment (Elenda and Azor, #6410).
-    ManaGeneric {
-        #[serde(default)]
-        base_cost: ManaCost,
-    },
+    ///
+    /// `base_cost` intentionally carries NO `#[serde(default)]`: a serialized
+    /// prompt missing this field must fail deserialization rather than
+    /// silently resolve to `ManaCost::zero()`, which would concretize to a
+    /// free payment (drops the fixed pips AND the X basis) instead of
+    /// visibly rejecting the incompatible/corrupt save.
+    ManaGeneric { base_cost: ManaCost },
     /// CR 107.1c + CR 122.1: Choose how many counters to remove.
     Counters,
     /// CR 119.4: Pay any amount of life — N is deducted as life loss via
@@ -21887,6 +21890,31 @@ mod tests {
                     source: CompanionChoiceSource::Sideboard { index: 2 },
                 }],
             }
+        );
+    }
+
+    /// #6410 review follow-up: `PayableResource::ManaGeneric::base_cost`
+    /// deliberately carries NO `#[serde(default)]`. A prior revision of this
+    /// fix defaulted the missing field to `ManaCost::zero()`, which would
+    /// have concretized a legacy/incomplete serialized prompt into a FREE
+    /// payment (drops both the fixed colored pips and the X basis) instead
+    /// of failing closed. A serialized prompt missing `base_cost` — whether
+    /// from the pre-fix `per_x`-only wire shape or any other truncation —
+    /// must be REJECTED at the deserialization boundary, never silently
+    /// downgraded to a zero-cost payment.
+    #[test]
+    fn pay_amount_choice_mana_generic_missing_base_cost_is_rejected() {
+        let empty_data = r#"{"type":"ManaGeneric","data":{}}"#;
+        assert!(
+            serde_json::from_str::<PayableResource>(empty_data).is_err(),
+            "a ManaGeneric prompt with no base_cost must fail to deserialize, \
+             not silently default to a zero-cost payment"
+        );
+
+        let legacy_per_x_shape = r#"{"type":"ManaGeneric","data":{"per_x":1}}"#;
+        assert!(
+            serde_json::from_str::<PayableResource>(legacy_per_x_shape).is_err(),
+            "the pre-fix per_x-only wire shape has no base_cost and must be rejected too"
         );
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -9598,15 +9598,22 @@ pub enum DistributionUnit {
 /// resource (energy, life, generic mana, counters); `LoopCollapse` is the one
 /// non-payment member — its N is the finite count an accepted CR 732.2a
 /// object-growth loop collapses into, deducting nothing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum PayableResource {
     /// CR 107.14: Pay any amount of `{E}` — removes N energy counters from the player.
     Energy,
-    /// CR 107.3 + CR 118.1: Pay a chosen X as generic mana while resolving an effect.
+    /// CR 107.1b + CR 107.3 + CR 118.1: Pay a chosen X as part of a
+    /// resolution-time mana cost. `base_cost` is the UNCONCRETIZED cost
+    /// (still carrying `ManaCostShard::X` plus any colored/generic pips
+    /// alongside it, e.g. `{X}{W}{U}{B}`); the submit handler concretizes X
+    /// into it (`ManaCost::concretize_x`) and pays the resulting cost through
+    /// the standard mana-payment authority, so colored requirements are
+    /// enforced exactly like any other mana cost — never dropped in favor of
+    /// a generic-only payment (Elenda and Azor, #6410).
     ManaGeneric {
-        #[serde(default = "default_one")]
-        per_x: u32,
+        #[serde(default)]
+        base_cost: ManaCost,
     },
     /// CR 107.1c + CR 122.1: Choose how many counters to remove.
     Counters,
@@ -9707,10 +9714,6 @@ impl LoopCollapseAxis {
             | ResourceAxis::Poison(_) => None,
         }
     }
-}
-
-fn default_one() -> u32 {
-    1
 }
 
 /// CR 115.7: Scope of retargeting — single target, all targets, or forced.

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -38,6 +38,12 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 23 — `PayableResource::ManaGeneric` changed from `{ per_x }` to
+///      `{ base_cost: ManaCost }` (#6410) — a `GameState` payload field type
+///      change, and `base_cost` intentionally carries no `#[serde(default)]`
+///      (a missing `base_cost` must fail deserialization, not silently
+///      resolve to a zero-cost payment), so old and new peers can't parse
+///      each other's serialized snapshots.
 /// 20 — Actor-scoped priority-passing settings and filtered per-player state.
 /// 19 — Connive's exact `EventObjectSnapshot` subject and resident paused
 ///      post-replacement drains changed serialized full-game state. Phase 4
@@ -52,7 +58,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 22;
+pub const PROTOCOL_VERSION: u32 = 23;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake. Lobby traffic has a one-version rollout window; full game servers
@@ -389,8 +395,8 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_priority_passing_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 22);
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 21);
+        assert_eq!(PROTOCOL_VERSION, 23);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 22);
     }
 
     #[test]

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2040,8 +2040,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_22() {
-        assert_eq!(PROTOCOL_VERSION, 22);
+    fn protocol_version_is_23() {
+        assert_eq!(PROTOCOL_VERSION, 23);
     }
 
     #[test]

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 22;
+const EXPECTED_PROTOCOL_VERSION = 23;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
## Summary

Fixes #6410 — Elenda and Azor's attack trigger (`Whenever Elenda and Azor attacks, you may pay {X}{W}{U}{B}. If you do, draw X cards.`) let players draw X cards without ever paying the `{W}{U}{B}` colored requirement.

**Root cause:** the resolution-time X-mana payment prompt (`WaitingFor::PayAmountChoice { resource: PayableResource::ManaGeneric }`) only ever charged the player's chosen amount as pure generic mana (`PayableResource::ManaGeneric { per_x: u32 }`). For a pure `{X}` cost this is correct, but for a mixed cost like `{X}{W}{U}{B}` it silently dropped the colored pips — the submit handler built a synthetic all-generic cost and paid *that* instead of the real cost. X-binding for the "draw X cards" rider was already correct (via `set_chosen_x_recursive`/`last_effect_count`), which is why the player still drew the right number of cards.

**Fix:** `PayableResource::ManaGeneric` now carries the full, unconcretized `base_cost` (the original `ManaCost`, X shard and all colored/generic pips included) instead of a bare shard count. The submit handler concretizes the chosen X into that cost (`ManaCost::concretize_x`, the same helper spell-casting X costs already use) and pays the *resulting* cost through the standard resolution-time mana authority (`casting::pay_unless_cost`) — so colored requirements are enforced exactly like any other mana cost, for the whole class of "pay {X}{colors...}" resolution-time abilities, not just this card.

This also removes the now-dead `mana_x_shard_count` helper and the `per_x`-only wire shape (updated the mirrored `PayableResource` TS type in `client/src/adapter/types.ts` to match).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p phase-engine --lib -- -D warnings` — clean
- [x] `cargo test -p phase-engine --lib` — 17,961 passed (one unrelated pre-existing flaky test, `bulk_treasure_activation_is_linear_not_factorial`, fails only under full-suite parallel load and passes in isolation — untouched by this change)
- [x] `cargo test -p phase-engine --test integration` — 4,182 passed, 0 failed
- [x] `pnpm run type-check` (frontend) — clean
- [x] New regression test `pay_x_plus_colored_mana_requires_the_colored_pips` reproduces the Elenda and Azor shape (`{X}{W}{U}{B}`) end-to-end: asserts the prompt carries the colored pips, asserts the correct affordability bound, and asserts the mana pool is fully drained (colors included) after submitting X

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “pay any amount of {X}” handling by preserving required colored mana in the chosen payment.
  * More accurately computes the maximum payable X and fails cleanly when the fixed (non‑X) portion can’t be paid, avoiding an incorrect prompt.
  * Corrected validation and payment calculation for generic mana requests.
* **Breaking Change**
  * Generic mana payment requests must now include the full base mana cost; missing/legacy requests are rejected instead of defaulting to an incorrect/free value.
  * Protocol version has been bumped to require matching clients/servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->