### PR TITLE
refactor(parser): retain generic activated abilities as native IR

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -8485,7 +8485,11 @@ pub(crate) fn normalize_activated_mana_instead_delta(def: &mut AbilityDefinition
     let Some(sub) = def.sub_ability.as_mut() else {
         return;
     };
-    let Some(AbilityCondition::ConditionInstead { inner }) = sub.condition.take() else {
+    let Some(condition) = sub.condition.take() else {
+        return;
+    };
+    let AbilityCondition::ConditionInstead { inner } = condition else {
+        sub.condition = Some(condition);
         return;
     };
     let Effect::Mana {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -8462,7 +8462,7 @@ pub(super) fn parse_activated_with_self_ref_fallback(
     }
 }
 
-fn normalize_activated_mana_instead_delta(def: &mut AbilityDefinition) {
+pub(crate) fn normalize_activated_mana_instead_delta(def: &mut AbilityDefinition) {
     let Effect::Mana {
         produced:
             ManaProduction::Colorless {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -95,7 +95,7 @@ use super::oracle_replacement::{
 use super::oracle_saga::{is_saga_chapter, parse_saga_chapters};
 use super::oracle_spacecraft::parse_spacecraft_threshold_lines;
 use super::oracle_special::{
-    attach_die_result_branches_to_chain, normalize_self_refs_for_static,
+    attach_die_result_branches_to_chain, find_terminal_roll_die, normalize_self_refs_for_static,
     parse_cumulative_upkeep_keyword, parse_defiler_cost_reduction, parse_die_result_branches_ir,
     parse_harmonize_keyword, parse_mayhem_keyword, parse_solve_condition, try_parse_die_roll_table,
 };
@@ -5045,7 +5045,7 @@ pub(crate) fn parse_oracle_ir(
             // path serves both forms) to gate this ability.
             let aw_condition = strip_ability_word_with_name(cost_text)
                 .and_then(|(aw_name, _)| ability_word_to_condition(&aw_name));
-            let (mut def, effect_text) = parse_activated_ability_definition(
+            let (mut ir, effect_text) = parse_activated_ability_ir(
                 cost_text,
                 effect_text,
                 &line,
@@ -5059,23 +5059,31 @@ pub(crate) fn parse_oracle_ir(
             // `condition` (a resolution-time gate, CR 608.2c + Shelldock Isle
             // ruling, which the engine deliberately does not use for activation
             // legality). Applied AFTER the call because
-            // `parse_activated_ability_definition` overwrites
-            // `activation_restrictions` from the cost-text constraints.
+            // `parse_activated_ability_ir` captures the cost-text constraints in
+            // the activation shell before this outer router stamp is applied.
             if matches!(aw_condition, Some(StaticCondition::SourceIsHarnessed)) {
-                def.activation_restrictions
+                ir.shell
+                    .activation_restrictions
                     .push(ActivationRestriction::SourceIsHarnessed);
             }
             if ability_cant_be_copied {
-                def.cant_be_copied = true;
+                ir.shell.cant_be_copied = true;
             }
-            def.min_x_value = min_x_value;
+            ir.shell.min_x_value = ir.shell.min_x_value.max(min_x_value);
             i += 1;
-            // CR 706: If the activated ability ends with "roll a dN", consume
-            // subsequent d20 table lines and attach them as die result branches.
-            if has_roll_die_pattern(&effect_text.to_lowercase()) {
-                i = attach_die_result_branches_to_chain(&mut def, &lines, i);
+            // CR 706.3b: consume a following table only when the same native IR
+            // lowers to a terminal empty roll. Textual roll markers alone do not
+            // own subsequent lines.
+            let mut lowered_for_die_guard = lower_ability_ir(&ir);
+            if has_roll_die_pattern(&effect_text.to_lowercase())
+                && find_terminal_roll_die(&mut lowered_for_die_guard).is_some()
+            {
+                let (branches, next_line) =
+                    parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
+                ir.die_results = branches;
+                i = next_line;
             }
-            emitter.ability_at(item_line, def);
+            emitter.ability_ir_at(item_line, ir);
             continue;
         }
 
@@ -5179,7 +5187,7 @@ pub(crate) fn parse_oracle_ir(
                 if let Some(colon_pos) = find_activated_colon(&effect_text) {
                     let cost_text = effect_text[..colon_pos].trim();
                     let activated_effect_text = effect_text[colon_pos + 1..].trim();
-                    let (def, _) = parse_activated_ability_definition(
+                    let (ir, _) = parse_activated_ability_ir(
                         cost_text,
                         activated_effect_text,
                         &line,
@@ -5187,7 +5195,7 @@ pub(crate) fn parse_oracle_ir(
                         Some(PrintedAbilityIndex::placeholder()),
                         &mut ctx,
                     );
-                    emitter.ability_at(item_line, def);
+                    emitter.ability_ir_at(item_line, ir);
                     i += 1;
                     continue;
                 }
@@ -6751,14 +6759,14 @@ fn non_self_exile_cost_zone(cost: &AbilityCost) -> Option<Zone> {
     }
 }
 
-fn parse_activated_ability_definition(
+fn parse_activated_ability_ir(
     cost_text: &str,
     effect_text: &str,
     description: &str,
     card_name: &str,
     current_ability_index: Option<PrintedAbilityIndex>,
     ctx: &mut ParseContext,
-) -> (AbilityDefinition, String) {
+) -> (AbilityIr, String) {
     let (effect_text, activation_mana_payment_restriction) =
         strip_activated_mana_payment_restriction(effect_text);
     let (effect_text, constraints) = strip_activated_constraints(effect_text);
@@ -6784,34 +6792,35 @@ fn parse_activated_ability_definition(
 
     // Retry with `~` normalization if the first pass left an Unimplemented node
     // or emitted a target-fallback warning.
-    let mut def = parse_activated_with_self_ref_fallback(&effect_text, card_name, ctx);
+    let mut ir = parse_activated_ability_ir_with_self_ref_fallback(&effect_text, card_name, ctx);
 
     ctx.current_ability_exile_cost_zone = prev_exile_zone;
     ctx.current_ability_index = prev_ability_index;
-    normalize_activated_mana_instead_delta(&mut def);
-    if def.activation_zone.is_none() {
-        def.activation_zone = activation_zone_from_self_cost(&cost);
-    }
+    let lowered_for_activation_zone = lower_ability_ir(&ir);
     // CR 113.6m: fall back to the effect-side derivation — an ability whose
     // effect moves the source out of a non-battlefield zone functions only
     // from that zone. Cost-based derivation keeps priority.
-    if def.activation_zone.is_none() {
-        def.activation_zone = activation_zone_from_self_effect(&def);
-    }
-    def.cost = Some(cost);
-    def.description = Some(description.to_string());
+    ir.shell.activation_zone = lowered_for_activation_zone
+        .activation_zone
+        .or_else(|| activation_zone_from_self_cost(&cost))
+        .or_else(|| activation_zone_from_self_effect(&lowered_for_activation_zone));
+    ir.shell.cost = Some(cost);
+    ir.shell.description = Some(description.to_string());
     if !constraints.restrictions.is_empty() {
-        def.activation_restrictions = constraints.restrictions;
+        ir.shell.activation_restrictions = constraints.restrictions;
     }
-    def.activation_mana_payment_restriction = activation_mana_payment_restriction;
-    def.activator_filter = constraints.activator_filter.or_else(|| {
+    ir.shell.activation_mana_payment_restriction = activation_mana_payment_restriction;
+    ir.shell.activator_filter = constraints.activator_filter.or_else(|| {
         constraints
             .any_player_may_activate
             .then_some(PlayerFilter::All)
     });
-    extract_cost_reduction_from_chain(&mut def);
-    extract_mana_spend_trigger_from_chain(&mut def);
-    (def, effect_text)
+    ir.shell.stages = vec![
+        ShellStage::NormalizeActivatedManaInstead,
+        ShellStage::ExtractCostReduction,
+        ShellStage::ExtractManaSpendTrigger,
+    ];
+    (ir, effect_text)
 }
 
 /// CR 106.6: Strip the exact terminal rider "Spend only mana of the chosen
@@ -8409,31 +8418,31 @@ pub(super) fn has_unimplemented(def: &AbilityDefinition) -> bool {
 /// fell back to `TargetFilter::Any` because the bare card-name wasn't
 /// recognized as a self-reference. Warnings from the discarded pass are
 /// dropped so they don't pollute coverage output.
-pub(super) fn parse_activated_with_self_ref_fallback(
+pub(super) fn parse_activated_ability_ir_with_self_ref_fallback(
     effect_text: &str,
     card_name: &str,
     ctx: &mut ParseContext,
-) -> AbilityDefinition {
+) -> AbilityIr {
     // Pre-diagnostics stay in ctx naturally — only manage trial-parse diagnostics.
     let pre_snapshot = ctx.diagnostics.len();
 
     ctx.subject = None;
     ctx.actor = None;
-    let def = parse_effect_chain_with_context(effect_text, AbilityKind::Activated, ctx);
+    let ir = parse_ability_ir_with_context(effect_text, AbilityKind::Activated, ctx);
     let first_has_target_fallback = ctx.diagnostics[pre_snapshot..]
         .iter()
         .any(|d| matches!(d, OracleDiagnostic::TargetFallback { .. }));
-    let first_clean = !has_unimplemented(&def) && !first_has_target_fallback;
+    let first_clean = !has_unimplemented(&lower_ability_ir(&ir)) && !first_has_target_fallback;
 
     if first_clean {
         // First parse is clean — keep its diagnostics.
-        return def;
+        return ir;
     }
 
     let normalized = normalize_self_refs_for_static(effect_text, card_name);
     if normalized == effect_text {
         // No normalization change — keep first-pass diagnostics.
-        return def;
+        return ir;
     }
 
     // Save first-pass diagnostics for potential restoration.
@@ -8442,11 +8451,11 @@ pub(super) fn parse_activated_with_self_ref_fallback(
 
     ctx.subject = None;
     ctx.actor = None;
-    let alt = parse_effect_chain_with_context(&normalized, AbilityKind::Activated, ctx);
+    let alt = parse_ability_ir_with_context(&normalized, AbilityKind::Activated, ctx);
     let alt_has_target_fallback = ctx.diagnostics[pre_snapshot..]
         .iter()
         .any(|d| matches!(d, OracleDiagnostic::TargetFallback { .. }));
-    let alt_clean = !has_unimplemented(&alt) && !alt_has_target_fallback;
+    let alt_clean = !has_unimplemented(&lower_ability_ir(&alt)) && !alt_has_target_fallback;
 
     if alt_clean {
         // Normalized pass is strictly better — keep only its diagnostics (already in ctx).
@@ -8458,7 +8467,7 @@ pub(super) fn parse_activated_with_self_ref_fallback(
         ctx.diagnostics.truncate(pre_snapshot);
         ctx.diagnostics.extend(first_diagnostics);
         ctx.diagnostics.extend(alt_diagnostics);
-        def
+        ir
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26977,6 +26977,9 @@ pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
     apply_ability_shell_envelope(&mut def, &ir.shell);
     for stage in &ir.shell.stages {
         match stage {
+            ShellStage::NormalizeActivatedManaInstead => {
+                crate::parser::oracle::normalize_activated_mana_instead_delta(&mut def);
+            }
             ShellStage::ExtractCostReduction => {
                 crate::parser::oracle::extract_cost_reduction_from_chain(&mut def);
             }

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -133,7 +133,7 @@ pub(crate) struct ParseContext {
     /// clause state cannot leak across trigger lines.
     pub pending_trigger_subject_clause: Option<TargetFilter>,
     /// CR 608.2k: Source zone of the current ability's `AbilityCost::Exile`
-    /// component, if any. Set by `parse_activated_ability_definition` after the
+    /// component, if any. Set by `parse_activated_ability_ir` after the
     /// cost is parsed and before the effect text is parsed, then restored after
     /// the ability. Consumed by `parse_cost_paid_object_reference` to
     /// disambiguate "the exiled card" — a cost-paid-object reference

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -337,7 +337,7 @@ fn is_zero(v: &u32) -> bool {
 ///
 /// # Why an ordered `Vec` and not a set of booleans
 ///
-/// Both stages are folds that rewrite the `sub_ability` chain *and* write a root
+/// These stages are folds that rewrite the `sub_ability` chain *and* write a root
 /// field, so their position relative to the field stamps is behavior-load-bearing
 /// — a plain field bag cannot express "run these two, in this order, after the
 /// stamps":
@@ -353,10 +353,14 @@ fn is_zero(v: &u32) -> bool {
 ///
 /// Variants are named for the transform, not for a call site, so the list stays
 /// a description of *what runs* rather than of *who asked*.
-// Both variants are constructed by the T8-A2 recognizers (Channel, Boast,
-// Exhaust, Forecast), each of which lists them in this order.
+// The extraction variants are constructed by the T8-A2 recognizers (Channel,
+// Boast, Exhaust, Forecast), each of which lists them in this order.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub(crate) enum ShellStage {
+    /// CR 106.6: normalize an activated mana ability's `instead` alternative
+    /// into the additional-mana delta used by the existing mana authority.
+    /// Runs `oracle::normalize_activated_mana_instead_delta`.
+    NormalizeActivatedManaInstead,
     /// CR 601.2f: fold a trailing self-referential "this ability costs {X} less
     /// to activate" node out of the `sub_ability` chain into `cost_reduction`.
     /// Runs `oracle::extract_cost_reduction_from_chain`.

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -229,7 +229,7 @@ pub(crate) struct AbilityShellIr {
     /// this field by *reading the lowered def*
     /// (`activation_zone_from_self_cost` / `activation_zone_from_self_effect`),
     /// which a shell stamped before lowering cannot express. That is one of the
-    /// reasons `parse_activated_ability_definition` is scoped to its own unit
+    /// reasons `parse_activated_ability_ir` is scoped to its own unit
     /// rather than to T8 — this field is here for the recognizers that know
     /// their zone from the printed keyword (Channel, Forecast), not for that one.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -12,6 +12,18 @@ use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{Effect, TriggerCondition};
 use crate::types::game_state::DistributionUnit;
 
+fn ability_has_unimplemented(def: &crate::types::ability::AbilityDefinition) -> bool {
+    matches!(def.effect.as_ref(), Effect::Unimplemented { .. })
+        || def
+            .sub_ability
+            .as_deref()
+            .is_some_and(ability_has_unimplemented)
+        || def
+            .else_ability
+            .as_deref()
+            .is_some_and(ability_has_unimplemented)
+}
+
 /// Parse Oracle text through both IR and lowering layers.
 fn parse_two_layer(
     oracle_text: &str,
@@ -35,6 +47,152 @@ fn parse_two_layer_with_keywords(
     let mut ir = parse_oracle_ir(oracle_text, card_name, &keywords, &types, &subtypes);
     let lowered = lower_oracle_ir(&mut ir);
     (ir, lowered)
+}
+
+/// CR 707.9a + CR 602.1a: generic activated abilities are emitted as native
+/// spell IR, so the source-ordered lowerer can stamp the second printed ability
+/// before its self-retention copy effect is finalized.
+#[test]
+fn thespians_stage_generic_activated_router_is_ir_native() {
+    let (ir, lowered) = parse_two_layer(
+        "{T}: Add {C}.\n{2}, {T}: This land becomes a copy of target land, except it has this ability.",
+        "Thespian's Stage",
+        &["Land"],
+        &[],
+    );
+
+    assert_eq!(ir.items.len(), 2);
+    assert!(matches!(&ir.items[0].node, OracleNodeIr::Spell(_)));
+    assert!(matches!(&ir.items[1].node, OracleNodeIr::Spell(_)));
+    assert_eq!(lowered.abilities.len(), 2);
+    assert!(
+        !ability_has_unimplemented(&lowered.abilities[1]),
+        "the copy ability must lower without a residual fallback: {:?}",
+        lowered.abilities[1]
+    );
+    assert!(matches!(
+        lowered.abilities[1].effect.as_ref(),
+        Effect::BecomeCopy { additional_modifications, .. }
+            if additional_modifications.iter().any(|modification| matches!(
+                modification,
+                crate::types::ability::ContinuousModification::RetainPrintedAbilityFromSource {
+                    source_ability_index: 1
+                }
+            ))
+    ));
+
+    insta::assert_json_snapshot!("thespians_stage_generic_activated_ir", &ir);
+    insta::assert_json_snapshot!("thespians_stage_generic_activated_lowered", &lowered);
+}
+
+/// CR 207.2c + CR 602.1: an ability-word label on an activated ability does
+/// not impose a condition; the generic activation envelope is retained in IR.
+#[test]
+fn barbarian_ring_ability_word_activated_router_is_ir_native() {
+    let (ir, lowered) = parse_two_layer(
+        "{T}: Add {R}. This land deals 1 damage to you.\nThreshold — {R}, {T}, Sacrifice this land: It deals 2 damage to any target. Activate only if there are seven or more cards in your graveyard.",
+        "Barbarian Ring",
+        &["Land"],
+        &[],
+    );
+
+    assert_eq!(ir.items.len(), 2);
+    let OracleNodeIr::Spell(activated) = &ir.items[1].node else {
+        panic!(
+            "expected native activated spell IR, got {:?}",
+            ir.items[1].node
+        );
+    };
+    assert!(activated.shell.activation_restrictions.len() > 0);
+    assert_eq!(lowered.abilities.len(), 2);
+    let ability = &lowered.abilities[1];
+    assert!(
+        !ability_has_unimplemented(ability),
+        "ability-word activated route must not fall back: {ability:?}"
+    );
+    assert!(
+        ability.condition.is_none(),
+        "Threshold has no rules meaning here"
+    );
+    assert!(matches!(
+        ability.cost.as_ref(),
+        Some(crate::types::ability::AbilityCost::Composite { .. })
+    ));
+    assert!(matches!(ability.effect.as_ref(), Effect::DealDamage { .. }));
+    assert!(
+        !ability.activation_restrictions.is_empty(),
+        "explicit Activate only restriction must survive"
+    );
+
+    insta::assert_json_snapshot!("barbarian_ring_activated_ir", &ir);
+    insta::assert_json_snapshot!("barbarian_ring_activated_lowered", &lowered);
+}
+
+/// CR 706.3b: an activated terminal die roll owns only its contiguous result
+/// rows and preserves them as native branch IR until final lowering.
+#[test]
+fn component_pouch_activated_die_table_is_ir_native() {
+    let (ir, lowered) = parse_two_layer(
+        "{T}, Remove a component counter from this artifact: Add two mana of different colors.\n{T}: Roll a d20.\n1—9 | Put a component counter on this artifact.\n10—20 | Put two component counters on this artifact.",
+        "Component Pouch",
+        &["Artifact"],
+        &[],
+    );
+
+    assert_eq!(ir.items.len(), 2, "result rows must not become items");
+    let OracleNodeIr::Spell(roll) = &ir.items[1].node else {
+        panic!(
+            "expected native roll ability IR, got {:?}",
+            ir.items[1].node
+        );
+    };
+    assert_eq!(
+        roll.die_results
+            .iter()
+            .map(|branch| (branch.min, branch.max))
+            .collect::<Vec<_>>(),
+        vec![(1, 9), (10, 20)]
+    );
+    assert!(matches!(
+        lowered.abilities[1].effect.as_ref(),
+        Effect::RollDie { results, .. } if results.len() == 2
+    ));
+
+    insta::assert_json_snapshot!("component_pouch_activated_ir", &ir);
+    insta::assert_json_snapshot!("component_pouch_activated_lowered", &lowered);
+}
+
+/// CR 706.3b: the typed terminal-roll guard must leave the next line to the
+/// ordinary router when a die roll has a following non-roll instruction.
+#[test]
+fn nonterminal_activated_die_roll_does_not_consume_following_ability() {
+    let (ir, lowered) = parse_two_layer(
+        "{T}: Roll a d20, then draw a card.\n{T}: Add {C}.",
+        "Nonterminal Activated Die Fixture",
+        &["Artifact"],
+        &[],
+    );
+
+    assert_eq!(
+        ir.items.len(),
+        2,
+        "the following activation must remain routable"
+    );
+    assert!(matches!(&ir.items[0].node, OracleNodeIr::Spell(_)));
+    assert!(matches!(&ir.items[1].node, OracleNodeIr::Spell(_)));
+    assert_eq!(lowered.abilities.len(), 2);
+    assert!(
+        lowered
+            .abilities
+            .iter()
+            .all(|ability| !ability_has_unimplemented(ability)),
+        "both ordinary activations must parse after the nonterminal roll: {:?}",
+        lowered.abilities
+    );
+    assert!(matches!(
+        lowered.abilities[1].effect.as_ref(),
+        Effect::Mana { .. }
+    ));
 }
 
 /// CR 706.3b: ordinary trigger dispatch retains a die-result table in native

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -103,7 +103,7 @@ fn barbarian_ring_ability_word_activated_router_is_ir_native() {
             ir.items[1].node
         );
     };
-    assert!(activated.shell.activation_restrictions.len() > 0);
+    assert!(!activated.shell.activation_restrictions.is_empty());
     assert_eq!(lowered.abilities.len(), 2);
     let ability = &lowered.abilities[1];
     assert!(

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -181,6 +181,12 @@ fn nonterminal_activated_die_roll_does_not_consume_following_ability() {
     assert!(matches!(&ir.items[0].node, OracleNodeIr::Spell(_)));
     assert!(matches!(&ir.items[1].node, OracleNodeIr::Spell(_)));
     assert_eq!(lowered.abilities.len(), 2);
+    let first = &lowered.abilities[0];
+    assert!(matches!(first.effect.as_ref(), Effect::RollDie { .. }));
+    assert!(matches!(
+        first.sub_ability.as_deref().map(|sub| sub.effect.as_ref()),
+        Some(Effect::Draw { .. })
+    ));
     assert!(
         lowered
             .abilities

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
@@ -22,82 +22,156 @@ expression: "&ir"
         "fragment": "{U}: Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "ChangeZone",
-            "origin": null,
-            "destination": "Exile",
-            "target": {
-              "type": "SelfRef"
-            },
-            "owner_library": false,
-            "enter_transformed": false,
-            "enter_tapped": false,
-            "enters_attacking": false
-          },
-          "cost": {
-            "type": "Mana",
-            "cost": {
-              "type": "Cost",
-              "shards": [
-                "Blue"
-              ],
-              "generic": 0
-            }
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "CreateDelayedTrigger",
-              "condition": {
-                "type": "AtNextPhase",
-                "phase": "End"
-              },
-              "effect": {
-                "kind": "Activated",
-                "effect": {
-                  "type": "ChangeZone",
-                  "origin": "Exile",
-                  "destination": "Battlefield",
-                  "target": {
-                    "type": "ParentTarget"
+        "Spell": {
+          "source_text": "Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
                   },
-                  "owner_library": false,
-                  "enter_transformed": false,
-                  "enter_tapped": false,
-                  "enters_attacking": false
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 7,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Exile ~"
                 },
-                "cost": null,
-                "sub_ability": null,
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": null,
+                    "destination": "Exile",
+                    "target": {
+                      "type": "SelfRef"
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
                 "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "uses_tracked_set": true
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 9,
+                    "end_byte": 101,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "Return it to the battlefield under its owner's control at the beginning of the next end step"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": null,
+                    "destination": "Battlefield",
+                    "target": {
+                      "type": "ParentTarget"
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": {
+                  "type": "AtNextPhase",
+                  "phase": "End"
+                },
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "{U}: Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [
+                  "Blue"
+                ],
+                "generic": 0
+              }
+            },
+            "description": "{U}: Exile ~. Return it to the battlefield under its owner's control at the beginning of the next end step.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
+          },
+          "die_results": []
         }
       }
     },
@@ -119,51 +193,109 @@ expression: "&ir"
         "fragment": "{U}: ~ can't be blocked this turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
+        "Spell": {
+          "source_text": "~ can't be blocked this turn",
+          "body": {
+            "clauses": [
               {
-                "mode": "CantBeBlocked",
-                "affected": {
-                  "type": "SelfRef"
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 28,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "~ can't be blocked this turn"
                 },
-                "modifications": [
-                  {
-                    "type": "AddStaticMode",
-                    "mode": "CantBeBlocked"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ],
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "CantBeBlocked",
+                        "affected": {
+                          "type": "SelfRef"
+                        },
+                        "modifications": [
+                          {
+                            "type": "AddStaticMode",
+                            "mode": "CantBeBlocked"
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "can't be blocked"
+                      }
+                    ],
+                    "duration": "UntilEndOfTurn",
+                    "target": null
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
                 "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "can't be blocked"
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
             ],
-            "duration": "UntilEndOfTurn",
-            "target": null
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [
-                "Blue"
-              ],
-              "generic": 0
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [
+                  "Blue"
+                ],
+                "generic": 0
+              }
+            },
+            "description": "{U}: ~ can't be blocked this turn.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "{U}: ~ can't be blocked this turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     },
@@ -185,38 +317,96 @@ expression: "&ir"
         "fragment": "{1}: ~ gets +1/-1 until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Pump",
-            "power": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "toughness": {
-              "type": "Fixed",
-              "value": -1
-            },
-            "target": {
-              "type": "SelfRef"
-            }
+        "Spell": {
+          "source_text": "~ gets +1/-1 until end of turn",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 30,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "~ gets +1/-1 until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Pump",
+                    "power": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "toughness": {
+                      "type": "Fixed",
+                      "value": -1
+                    },
+                    "target": {
+                      "type": "SelfRef"
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 1
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [],
+                "generic": 1
+              }
+            },
+            "description": "{1}: ~ gets +1/-1 until end of turn.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "{1}: ~ gets +1/-1 until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     },
@@ -238,38 +428,96 @@ expression: "&ir"
         "fragment": "{1}: ~ gets -1/+1 until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Pump",
-            "power": {
-              "type": "Fixed",
-              "value": -1
-            },
-            "toughness": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "SelfRef"
-            }
+        "Spell": {
+          "source_text": "~ gets -1/+1 until end of turn",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 30,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "~ gets -1/+1 until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Pump",
+                    "power": {
+                      "type": "Fixed",
+                      "value": -1
+                    },
+                    "toughness": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "SelfRef"
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 1
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [],
+                "generic": 1
+              }
+            },
+            "description": "{1}: ~ gets -1/+1 until end of turn.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "{1}: ~ gets -1/+1 until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_ring_activated_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_ring_activated_ir.snap
@@ -15,15 +15,15 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 74,
+          "end_byte": 38,
           "precision": "Exact",
           "ordinal_within_span": 0
         },
-        "fragment": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery."
+        "fragment": "{T}: Add {R}. ~ deals 1 damage to you."
       },
       "node": {
         "Spell": {
-          "source_text": "Target player discards two cards",
+          "source_text": "Add {R}. ~ deals 1 damage to you",
           "body": {
             "clauses": [
               {
@@ -37,11 +37,11 @@ expression: "&ir"
                     "first_line": 0,
                     "last_line": 0,
                     "start_byte": 0,
-                    "end_byte": 32,
+                    "end_byte": 7,
                     "precision": "ChainRelative",
                     "ordinal_within_span": 0
                   },
-                  "fragment": "Target player discards two cards"
+                  "fragment": "Add {R}"
                 },
                 "disposition": {
                   "Emit": {
@@ -51,13 +51,67 @@ expression: "&ir"
                 },
                 "parsed": {
                   "effect": {
-                    "type": "Discard",
-                    "count": {
+                    "type": "Mana",
+                    "produced": {
                       "type": "Fixed",
-                      "value": 2
+                      "colors": [
+                        "Red"
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 9,
+                    "end_byte": 32,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "~ deals 1 damage to you"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                      "type": "Fixed",
+                      "value": 1
                     },
                     "target": {
-                      "type": "Player"
+                      "type": "Controller"
                     }
                   },
                   "duration": null,
@@ -93,29 +147,9 @@ expression: "&ir"
           "shell": {
             "sub_link": null,
             "cost": {
-              "type": "Composite",
-              "costs": [
-                {
-                  "type": "Mana",
-                  "cost": {
-                    "type": "Cost",
-                    "shards": [
-                      "Black"
-                    ],
-                    "generic": 4
-                  }
-                },
-                {
-                  "type": "Tap"
-                }
-              ]
+              "type": "Tap"
             },
-            "activation_restrictions": [
-              {
-                "type": "AsSorcery"
-              }
-            ],
-            "description": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery.",
+            "description": "{T}: Add {R}. ~ deals 1 damage to you.",
             "stages": [
               "NormalizeActivatedManaInstead",
               "ExtractCostReduction",
@@ -136,16 +170,16 @@ expression: "&ir"
         "span": {
           "first_line": 1,
           "last_line": 1,
-          "start_byte": 75,
-          "end_byte": 179,
+          "start_byte": 39,
+          "end_byte": 174,
           "precision": "Exact",
           "ordinal_within_span": 0
         },
-        "fragment": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery."
+        "fragment": "Threshold — {R}, {T}, Sacrifice ~: It deals 2 damage to any target. Activate only if there are seven or more cards in your graveyard."
       },
       "node": {
         "Spell": {
-          "source_text": "Target player discards four cards",
+          "source_text": "It deals 2 damage to any target",
           "body": {
             "clauses": [
               {
@@ -159,11 +193,11 @@ expression: "&ir"
                     "first_line": 0,
                     "last_line": 0,
                     "start_byte": 0,
-                    "end_byte": 33,
+                    "end_byte": 31,
                     "precision": "ChainRelative",
                     "ordinal_within_span": 0
                   },
-                  "fragment": "Target player discards four cards"
+                  "fragment": "It deals 2 damage to any target"
                 },
                 "disposition": {
                   "Emit": {
@@ -173,13 +207,13 @@ expression: "&ir"
                 },
                 "parsed": {
                   "effect": {
-                    "type": "Discard",
-                    "count": {
+                    "type": "DealDamage",
+                    "amount": {
                       "type": "Fixed",
-                      "value": 4
+                      "value": 2
                     },
                     "target": {
-                      "type": "Player"
+                      "type": "Any"
                     }
                   },
                   "duration": null,
@@ -222,32 +256,50 @@ expression: "&ir"
                   "cost": {
                     "type": "Cost",
                     "shards": [
-                      "Black",
-                      "Black"
+                      "Red"
                     ],
-                    "generic": 5
+                    "generic": 0
                   }
                 },
                 {
-                  "type": "Discard",
-                  "count": {
-                    "type": "Fixed",
-                    "value": 1
+                  "type": "Tap"
+                },
+                {
+                  "type": "Sacrifice",
+                  "target": {
+                    "type": "SelfRef"
                   },
-                  "filter": null,
-                  "random": false,
-                  "self_ref": true
+                  "count": 1
                 }
               ]
             },
             "activation_restrictions": [
               {
-                "type": "AsSorcery"
+                "type": "RequiresCondition",
+                "data": {
+                  "condition": {
+                    "type": "QuantityComparison",
+                    "lhs": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "GraveyardSize",
+                        "player": {
+                          "type": "Controller"
+                        }
+                      }
+                    },
+                    "comparator": "GE",
+                    "rhs": {
+                      "type": "Fixed",
+                      "value": 7
+                    }
+                  }
+                }
               }
             ],
-            "activation_zone": "Hand",
-            "description": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
+            "description": "Threshold — {R}, {T}, Sacrifice ~: It deals 2 damage to any target. Activate only if there are seven or more cards in your graveyard.",
             "stages": [
+              "NormalizeActivatedManaInstead",
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
@@ -257,6 +309,6 @@ expression: "&ir"
       }
     }
   ],
-  "source_text": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery.\nChannel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
-  "card_name": "Ghost-Lit Stalker"
+  "source_text": "{T}: Add {R}. This land deals 1 damage to you.\nThreshold — {R}, {T}, Sacrifice this land: It deals 2 damage to any target. Activate only if there are seven or more cards in your graveyard.",
+  "card_name": "Barbarian Ring"
 }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_ring_activated_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_ring_activated_lowered.snap
@@ -1,0 +1,128 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Mana",
+        "produced": {
+          "type": "Fixed",
+          "colors": [
+            "Red"
+          ]
+        }
+      },
+      "cost": {
+        "type": "Tap"
+      },
+      "sub_ability": {
+        "kind": "Spell",
+        "effect": {
+          "type": "DealDamage",
+          "amount": {
+            "type": "Fixed",
+            "value": 1
+          },
+          "target": {
+            "type": "Controller"
+          }
+        },
+        "cost": null,
+        "sub_ability": null,
+        "duration": null,
+        "description": null,
+        "target_prompt": null,
+        "condition": null,
+        "optional_targeting": false,
+        "optional": false,
+        "forward_result": false,
+        "sub_link": "SequentialSibling"
+      },
+      "duration": null,
+      "description": "{T}: Add {R}. ~ deals 1 damage to you.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false,
+      "is_mana_ability": true
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "DealDamage",
+        "amount": {
+          "type": "Fixed",
+          "value": 2
+        },
+        "target": {
+          "type": "Any"
+        }
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [
+                "Red"
+              ],
+              "generic": 0
+            }
+          },
+          {
+            "type": "Tap"
+          },
+          {
+            "type": "Sacrifice",
+            "target": {
+              "type": "SelfRef"
+            },
+            "count": 1
+          }
+        ]
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "Threshold — {R}, {T}, Sacrifice ~: It deals 2 damage to any target. Activate only if there are seven or more cards in your graveyard.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "RequiresCondition",
+          "data": {
+            "condition": {
+              "type": "QuantityComparison",
+              "lhs": {
+                "type": "Ref",
+                "qty": {
+                  "type": "GraveyardSize",
+                  "player": {
+                    "type": "Controller"
+                  }
+                }
+              },
+              "comparator": "GE",
+              "rhs": {
+                "type": "Fixed",
+                "value": 7
+              }
+            }
+          }
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
@@ -106,31 +106,89 @@ expression: "&ir"
         "fragment": "{3}: Return ~ to its owner's hand."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Bounce",
-            "target": {
-              "type": "SelfRef"
-            },
-            "destination": null
+        "Spell": {
+          "source_text": "Return ~ to its owner's hand",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 28,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Return ~ to its owner's hand"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Bounce",
+                    "target": {
+                      "type": "SelfRef"
+                    },
+                    "destination": null
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 3
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [],
+                "generic": 3
+              }
+            },
+            "description": "{3}: Return ~ to its owner's hand.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{3}: Return ~ to its owner's hand.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
@@ -50,37 +50,94 @@ expression: "&ir"
         "fragment": "{T}: Add one mana of any color."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Mana",
-            "produced": {
-              "type": "AnyOneColor",
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "color_options": [
-                "White",
-                "Blue",
-                "Black",
-                "Red",
-                "Green"
-              ]
-            }
+        "Spell": {
+          "source_text": "Add one mana of any color",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 25,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Add one mana of any color"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Mana",
+                    "produced": {
+                      "type": "AnyOneColor",
+                      "count": {
+                        "type": "Fixed",
+                        "value": 1
+                      },
+                      "color_options": [
+                        "White",
+                        "Blue",
+                        "Black",
+                        "Red",
+                        "Green"
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Tap"
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Tap"
+            },
+            "description": "{T}: Add one mana of any color.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{T}: Add one mana of any color.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false,
-          "is_mana_ability": true
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
@@ -184,61 +184,119 @@ expression: "&ir"
         "fragment": "{R}, Discard your hand, Sacrifice ~: Put all cards exiled with ~ into their owners' hands."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "ChangeZoneAll",
-            "origin": "Exile",
-            "destination": "Hand",
-            "target": {
-              "type": "ExiledBySource"
-            }
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
+        "Spell": {
+          "source_text": "Put all cards exiled with ~ into their owners' hands",
+          "body": {
+            "clauses": [
               {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "Red"
-                  ],
-                  "generic": 0
-                }
-              },
-              {
-                "type": "Discard",
-                "count": {
-                  "type": "Ref",
-                  "qty": {
-                    "type": "HandSize",
-                    "player": {
-                      "type": "Controller"
-                    }
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 52,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Put all cards exiled with ~ into their owners' hands"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
                 },
-                "filter": null,
-                "random": false,
-                "self_ref": false
-              },
-              {
-                "type": "Sacrifice",
-                "target": {
-                  "type": "SelfRef"
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZoneAll",
+                    "origin": "Exile",
+                    "destination": "Hand",
+                    "target": {
+                      "type": "ExiledBySource"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
                 },
-                "count": 1
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "Red"
+                    ],
+                    "generic": 0
+                  }
+                },
+                {
+                  "type": "Discard",
+                  "count": {
+                    "type": "Ref",
+                    "qty": {
+                      "type": "HandSize",
+                      "player": {
+                        "type": "Controller"
+                      }
+                    }
+                  },
+                  "filter": null,
+                  "random": false,
+                  "self_ref": false
+                },
+                {
+                  "type": "Sacrifice",
+                  "target": {
+                    "type": "SelfRef"
+                  },
+                  "count": 1
+                }
+              ]
+            },
+            "description": "{R}, Discard your hand, Sacrifice ~: Put all cards exiled with ~ into their owners' hands.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
             ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{R}, Discard your hand, Sacrifice ~: Put all cards exiled with ~ into their owners' hands.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
@@ -22,29 +22,86 @@ expression: "&ir"
         "fragment": "{T}: Add {G}."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Mana",
-            "produced": {
-              "type": "Fixed",
-              "colors": [
-                "Green"
-              ]
-            }
+        "Spell": {
+          "source_text": "Add {G}",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 7,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Add {G}"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Mana",
+                    "produced": {
+                      "type": "Fixed",
+                      "colors": [
+                        "Green"
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Tap"
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Tap"
+            },
+            "description": "{T}: Add {G}.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{T}: Add {G}.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false,
-          "is_mana_ability": true
+          "die_results": []
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__component_pouch_activated_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__component_pouch_activated_ir.snap
@@ -1,0 +1,423 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 73,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{T}, Remove a component counter from ~: Add two mana of different colors."
+      },
+      "node": {
+        "Spell": {
+          "source_text": "Add two mana of different colors",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 32,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Add two mana of different colors"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Mana",
+                    "produced": {
+                      "type": "ChoiceAmongCombinations",
+                      "options": [
+                        [
+                          "White",
+                          "Blue"
+                        ],
+                        [
+                          "White",
+                          "Black"
+                        ],
+                        [
+                          "White",
+                          "Red"
+                        ],
+                        [
+                          "White",
+                          "Green"
+                        ],
+                        [
+                          "Blue",
+                          "Black"
+                        ],
+                        [
+                          "Blue",
+                          "Red"
+                        ],
+                        [
+                          "Blue",
+                          "Green"
+                        ],
+                        [
+                          "Black",
+                          "Red"
+                        ],
+                        [
+                          "Black",
+                          "Green"
+                        ],
+                        [
+                          "Red",
+                          "Green"
+                        ]
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
+                {
+                  "type": "Tap"
+                },
+                {
+                  "type": "RemoveCounter",
+                  "count": 1,
+                  "counter_type": {
+                    "type": "OfType",
+                    "data": "component"
+                  },
+                  "target": null,
+                  "selection": "SingleObject"
+                }
+              ]
+            },
+            "description": "{T}, Remove a component counter from ~: Add two mana of different colors.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
+          },
+          "die_results": []
+        }
+      }
+    },
+    {
+      "id": 1,
+      "source": {
+        "id": {
+          "item": 1,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 1,
+          "last_line": 1,
+          "start_byte": 74,
+          "end_byte": 90,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "{T}: Roll a d20."
+      },
+      "node": {
+        "Spell": {
+          "source_text": "Roll a d20",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 10,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Roll a d20"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "RollDie",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "sides": 20,
+                    "results": []
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Tap"
+            },
+            "description": "{T}: Roll a d20.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
+          },
+          "die_results": [
+            {
+              "min": 1,
+              "max": 9,
+              "effect": {
+                "source_text": "Put a component counter on ~.",
+                "body": {
+                  "clauses": [
+                    {
+                      "id": 0,
+                      "source": {
+                        "id": {
+                          "item": 0,
+                          "ordinal": 1
+                        },
+                        "span": {
+                          "first_line": 0,
+                          "last_line": 0,
+                          "start_byte": 0,
+                          "end_byte": 28,
+                          "precision": "ChainRelative",
+                          "ordinal_within_span": 0
+                        },
+                        "fragment": "Put a component counter on ~"
+                      },
+                      "disposition": {
+                        "Emit": {
+                          "followup": null,
+                          "intrinsic": null
+                        }
+                      },
+                      "parsed": {
+                        "effect": {
+                          "type": "PutCounter",
+                          "counter_type": "component",
+                          "count": {
+                            "type": "Fixed",
+                            "value": 1
+                          },
+                          "target": {
+                            "type": "SelfRef"
+                          }
+                        },
+                        "duration": null,
+                        "sub_ability": null,
+                        "distribute": null,
+                        "multi_target": null,
+                        "condition": null,
+                        "optional": false,
+                        "unless_pay": null
+                      },
+                      "boundary": "Sentence",
+                      "condition": null,
+                      "is_optional": false,
+                      "opponent_may_scope": null,
+                      "repeat_for": null,
+                      "player_scope": null,
+                      "starting_with": null,
+                      "delayed_condition": null,
+                      "prefix_delayed_condition": null,
+                      "multi_target": null,
+                      "where_x_expression": null,
+                      "unless_pay": null
+                    }
+                  ],
+                  "kind": "Spell",
+                  "continuation_kind": null,
+                  "player_scope_rewrite": "Apply",
+                  "chain_rounding": null,
+                  "actor": null,
+                  "in_trigger": false,
+                  "repeat_until": null
+                },
+                "shell": {
+                  "sub_link": null
+                },
+                "die_results": []
+              }
+            },
+            {
+              "min": 10,
+              "max": 20,
+              "effect": {
+                "source_text": "Put two component counters on ~.",
+                "body": {
+                  "clauses": [
+                    {
+                      "id": 0,
+                      "source": {
+                        "id": {
+                          "item": 0,
+                          "ordinal": 1
+                        },
+                        "span": {
+                          "first_line": 0,
+                          "last_line": 0,
+                          "start_byte": 0,
+                          "end_byte": 31,
+                          "precision": "ChainRelative",
+                          "ordinal_within_span": 0
+                        },
+                        "fragment": "Put two component counters on ~"
+                      },
+                      "disposition": {
+                        "Emit": {
+                          "followup": null,
+                          "intrinsic": null
+                        }
+                      },
+                      "parsed": {
+                        "effect": {
+                          "type": "PutCounter",
+                          "counter_type": "component",
+                          "count": {
+                            "type": "Fixed",
+                            "value": 2
+                          },
+                          "target": {
+                            "type": "SelfRef"
+                          }
+                        },
+                        "duration": null,
+                        "sub_ability": null,
+                        "distribute": null,
+                        "multi_target": null,
+                        "condition": null,
+                        "optional": false,
+                        "unless_pay": null
+                      },
+                      "boundary": "Sentence",
+                      "condition": null,
+                      "is_optional": false,
+                      "opponent_may_scope": null,
+                      "repeat_for": null,
+                      "player_scope": null,
+                      "starting_with": null,
+                      "delayed_condition": null,
+                      "prefix_delayed_condition": null,
+                      "multi_target": null,
+                      "where_x_expression": null,
+                      "unless_pay": null
+                    }
+                  ],
+                  "kind": "Spell",
+                  "continuation_kind": null,
+                  "player_scope_rewrite": "Apply",
+                  "chain_rounding": null,
+                  "actor": null,
+                  "in_trigger": false,
+                  "repeat_until": null
+                },
+                "shell": {
+                  "sub_link": null
+                },
+                "die_results": []
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "source_text": "{T}, Remove a component counter from this artifact: Add two mana of different colors.\n{T}: Roll a d20.\n1—9 | Put a component counter on this artifact.\n10—20 | Put two component counters on this artifact.",
+  "card_name": "Component Pouch"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__component_pouch_activated_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__component_pouch_activated_lowered.snap
@@ -1,0 +1,168 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Mana",
+        "produced": {
+          "type": "ChoiceAmongCombinations",
+          "options": [
+            [
+              "White",
+              "Blue"
+            ],
+            [
+              "White",
+              "Black"
+            ],
+            [
+              "White",
+              "Red"
+            ],
+            [
+              "White",
+              "Green"
+            ],
+            [
+              "Blue",
+              "Black"
+            ],
+            [
+              "Blue",
+              "Red"
+            ],
+            [
+              "Blue",
+              "Green"
+            ],
+            [
+              "Black",
+              "Red"
+            ],
+            [
+              "Black",
+              "Green"
+            ],
+            [
+              "Red",
+              "Green"
+            ]
+          ]
+        }
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Tap"
+          },
+          {
+            "type": "RemoveCounter",
+            "count": 1,
+            "counter_type": {
+              "type": "OfType",
+              "data": "component"
+            },
+            "target": null,
+            "selection": "SingleObject"
+          }
+        ]
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{T}, Remove a component counter from ~: Add two mana of different colors.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false,
+      "is_mana_ability": true
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "RollDie",
+        "count": {
+          "type": "Fixed",
+          "value": 1
+        },
+        "sides": 20,
+        "results": [
+          {
+            "min": 1,
+            "max": 9,
+            "effect": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "component",
+                "count": {
+                  "type": "Fixed",
+                  "value": 1
+                },
+                "target": {
+                  "type": "SelfRef"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            }
+          },
+          {
+            "min": 10,
+            "max": 20,
+            "effect": {
+              "kind": "Spell",
+              "effect": {
+                "type": "PutCounter",
+                "counter_type": "component",
+                "count": {
+                  "type": "Fixed",
+                  "value": 2
+                },
+                "target": {
+                  "type": "SelfRef"
+                }
+              },
+              "cost": null,
+              "sub_ability": null,
+              "duration": null,
+              "description": null,
+              "target_prompt": null,
+              "condition": null,
+              "optional_targeting": false,
+              "optional": false,
+              "forward_result": false
+            }
+          }
+        ]
+      },
+      "cost": {
+        "type": "Tap"
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{T}: Roll a d20.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
@@ -50,32 +50,90 @@ expression: "&ir"
         "fragment": "Remove two +1/+1 counters from ~: Regenerate it. (The next time ~ would be destroyed this turn, instead tap it, remove it from combat, and heal all damage on it.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Regenerate",
-            "target": {
-              "type": "ParentTarget"
-            }
+        "Spell": {
+          "source_text": "Regenerate it",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 13,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Regenerate it"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Regenerate",
+                    "target": {
+                      "type": "ParentTarget"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "RemoveCounter",
-            "count": 2,
-            "counter_type": {
-              "type": "OfType",
-              "data": "P1P1"
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "RemoveCounter",
+              "count": 2,
+              "counter_type": {
+                "type": "OfType",
+                "data": "P1P1"
+              },
+              "target": null,
+              "selection": "SingleObject"
             },
-            "target": null,
-            "selection": "SingleObject"
+            "description": "Remove two +1/+1 counters from ~: Regenerate it.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "Remove two +1/+1 counters from ~: Regenerate it.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__figure_of_destiny_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__figure_of_destiny_ir.snap
@@ -22,71 +22,129 @@ expression: "&ir"
         "fragment": "{R/W}: ~ becomes a Kithkin Spirit with base power and toughness 2/2."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
+        "Spell": {
+          "source_text": "~ becomes a Kithkin Spirit with base power and toughness 2/2",
+          "body": {
+            "clauses": [
               {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "SelfRef"
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 60,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "~ becomes a Kithkin Spirit with base power and toughness 2/2"
                 },
-                "modifications": [
-                  {
-                    "type": "SetPower",
-                    "value": 2
-                  },
-                  {
-                    "type": "SetToughness",
-                    "value": 2
-                  },
-                  {
-                    "type": "AddType",
-                    "core_type": "Creature"
-                  },
-                  {
-                    "type": "RemoveAllSubtypes",
-                    "set": "Creature"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Kithkin"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Spirit"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ],
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "SelfRef"
+                        },
+                        "modifications": [
+                          {
+                            "type": "SetPower",
+                            "value": 2
+                          },
+                          {
+                            "type": "SetToughness",
+                            "value": 2
+                          },
+                          {
+                            "type": "AddType",
+                            "core_type": "Creature"
+                          },
+                          {
+                            "type": "RemoveAllSubtypes",
+                            "set": "Creature"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Kithkin"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Spirit"
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "become a Kithkin Spirit with base power and toughness 2/2"
+                      }
+                    ],
+                    "duration": "Permanent",
+                    "target": null
+                  },
+                  "duration": "Permanent",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
                 "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "become a Kithkin Spirit with base power and toughness 2/2"
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
             ],
-            "duration": "Permanent",
-            "target": null
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [
-                "RedWhite"
-              ],
-              "generic": 0
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [
+                  "RedWhite"
+                ],
+                "generic": 0
+              }
+            },
+            "description": "{R/W}: ~ becomes a Kithkin Spirit with base power and toughness 2/2.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": "Permanent",
-          "description": "{R/W}: ~ becomes a Kithkin Spirit with base power and toughness 2/2.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     },
@@ -108,89 +166,147 @@ expression: "&ir"
         "fragment": "{R/W}{R/W}{R/W}: If ~ is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
+        "Spell": {
+          "source_text": "If ~ is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4",
+          "body": {
+            "clauses": [
               {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "SelfRef"
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 87,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "If ~ is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4"
                 },
-                "modifications": [
-                  {
-                    "type": "SetPower",
-                    "value": 4
-                  },
-                  {
-                    "type": "SetToughness",
-                    "value": 4
-                  },
-                  {
-                    "type": "AddType",
-                    "core_type": "Creature"
-                  },
-                  {
-                    "type": "RemoveAllSubtypes",
-                    "set": "Creature"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Kithkin"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Spirit"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Warrior"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ],
-                "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "become a Kithkin Spirit Warrior with base power and toughness 4/4"
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "SelfRef"
+                        },
+                        "modifications": [
+                          {
+                            "type": "SetPower",
+                            "value": 4
+                          },
+                          {
+                            "type": "SetToughness",
+                            "value": 4
+                          },
+                          {
+                            "type": "AddType",
+                            "core_type": "Creature"
+                          },
+                          {
+                            "type": "RemoveAllSubtypes",
+                            "set": "Creature"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Kithkin"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Spirit"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Warrior"
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "become a Kithkin Spirit Warrior with base power and toughness 4/4"
+                      }
+                    ],
+                    "duration": "Permanent",
+                    "target": null
+                  },
+                  "duration": "Permanent",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": {
+                  "type": "SourceMatchesFilter",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      {
+                        "Subtype": "Spirit"
+                      }
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                },
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
             ],
-            "duration": "Permanent",
-            "target": null
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [
-                "RedWhite",
-                "RedWhite",
-                "RedWhite"
-              ],
-              "generic": 0
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [
+                  "RedWhite",
+                  "RedWhite",
+                  "RedWhite"
+                ],
+                "generic": 0
+              }
+            },
+            "description": "{R/W}{R/W}{R/W}: If ~ is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": "Permanent",
-          "description": "{R/W}{R/W}{R/W}: If ~ is a Spirit, it becomes a Kithkin Spirit Warrior with base power and toughness 4/4.",
-          "target_prompt": null,
-          "condition": {
-            "type": "SourceMatchesFilter",
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                {
-                  "Subtype": "Spirit"
-                }
-              ],
-              "controller": null,
-              "properties": []
-            }
-          },
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     },
@@ -212,100 +328,158 @@ expression: "&ir"
         "fragment": "{R/W}{R/W}{R/W}{R/W}{R/W}{R/W}: If ~ is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
+        "Spell": {
+          "source_text": "If ~ is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike",
+          "body": {
+            "clauses": [
               {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "SelfRef"
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 121,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "If ~ is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike"
                 },
-                "modifications": [
-                  {
-                    "type": "AddKeyword",
-                    "keyword": "Flying"
-                  },
-                  {
-                    "type": "AddKeyword",
-                    "keyword": "FirstStrike"
-                  },
-                  {
-                    "type": "RemoveAllSubtypes",
-                    "set": "Creature"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Kithkin"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Spirit"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Warrior"
-                  },
-                  {
-                    "type": "AddSubtype",
-                    "subtype": "Avatar"
-                  },
-                  {
-                    "type": "SetPower",
-                    "value": 8
-                  },
-                  {
-                    "type": "SetToughness",
-                    "value": 8
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ],
-                "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "become a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike"
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "SelfRef"
+                        },
+                        "modifications": [
+                          {
+                            "type": "AddKeyword",
+                            "keyword": "Flying"
+                          },
+                          {
+                            "type": "AddKeyword",
+                            "keyword": "FirstStrike"
+                          },
+                          {
+                            "type": "RemoveAllSubtypes",
+                            "set": "Creature"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Kithkin"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Spirit"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Warrior"
+                          },
+                          {
+                            "type": "AddSubtype",
+                            "subtype": "Avatar"
+                          },
+                          {
+                            "type": "SetPower",
+                            "value": 8
+                          },
+                          {
+                            "type": "SetToughness",
+                            "value": 8
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "become a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike"
+                      }
+                    ],
+                    "duration": "Permanent",
+                    "target": null
+                  },
+                  "duration": "Permanent",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": {
+                  "type": "SourceMatchesFilter",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [
+                      {
+                        "Subtype": "Warrior"
+                      }
+                    ],
+                    "controller": null,
+                    "properties": []
+                  }
+                },
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
             ],
-            "duration": "Permanent",
-            "target": null
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [
-                "RedWhite",
-                "RedWhite",
-                "RedWhite",
-                "RedWhite",
-                "RedWhite",
-                "RedWhite"
-              ],
-              "generic": 0
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [
+                  "RedWhite",
+                  "RedWhite",
+                  "RedWhite",
+                  "RedWhite",
+                  "RedWhite",
+                  "RedWhite"
+                ],
+                "generic": 0
+              }
+            },
+            "description": "{R/W}{R/W}{R/W}{R/W}{R/W}{R/W}: If ~ is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": "Permanent",
-          "description": "{R/W}{R/W}{R/W}{R/W}{R/W}{R/W}: If ~ is a Warrior, it becomes a Kithkin Spirit Warrior Avatar with base power and toughness 8/8, flying, and first strike.",
-          "target_prompt": null,
-          "condition": {
-            "type": "SourceMatchesFilter",
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                {
-                  "Subtype": "Warrior"
-                }
-              ],
-              "controller": null,
-              "properties": []
-            }
-          },
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jade_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jade_mage_ir.snap
@@ -22,55 +22,113 @@ expression: "&ir"
         "fragment": "{2}{G}: Create a 1/1 green Saproling creature token."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Token",
-            "name": "Saproling",
-            "power": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "toughness": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "types": [
-              "Creature",
-              "Saproling"
+        "Spell": {
+          "source_text": "Create a 1/1 green Saproling creature token",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 43,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Create a 1/1 green Saproling creature token"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Token",
+                    "name": "Saproling",
+                    "power": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "toughness": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "types": [
+                      "Creature",
+                      "Saproling"
+                    ],
+                    "colors": [
+                      "Green"
+                    ],
+                    "keywords": [],
+                    "tapped": false,
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "owner": {
+                      "type": "Controller"
+                    },
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
             ],
-            "colors": [
-              "Green"
-            ],
-            "keywords": [],
-            "tapped": false,
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "owner": {
-              "type": "Controller"
-            },
-            "enters_attacking": false
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [
-                "Green"
-              ],
-              "generic": 2
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [
+                  "Green"
+                ],
+                "generic": 2
+              }
+            },
+            "description": "{2}{G}: Create a 1/1 green Saproling creature token.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{2}{G}: Create a 1/1 green Saproling creature token.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
@@ -22,29 +22,86 @@ expression: "&ir"
         "fragment": "{T}: Add {G}."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Mana",
-            "produced": {
-              "type": "Fixed",
-              "colors": [
-                "Green"
-              ]
-            }
+        "Spell": {
+          "source_text": "Add {G}",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 7,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Add {G}"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Mana",
+                    "produced": {
+                      "type": "Fixed",
+                      "colors": [
+                        "Green"
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Tap"
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Tap"
+            },
+            "description": "{T}: Add {G}.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{T}: Add {G}.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false,
-          "is_mana_ability": true
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mother_of_runes_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mother_of_runes_ir.snap
@@ -22,69 +22,111 @@ expression: "&ir"
         "fragment": "{T}: Target creature you control gains protection from the color of your choice until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Choose",
-            "choice_type": "Color",
-            "persist": true
-          },
-          "cost": {
-            "type": "Tap"
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "Continuous",
-                  "affected": {
-                    "type": "ParentTarget"
+        "Spell": {
+          "source_text": "Target creature you control gains protection from the color of your choice until end of turn",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
                   },
-                  "modifications": [
-                    {
-                      "type": "AddKeyword",
-                      "keyword": {
-                        "Protection": "ChosenColor"
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 92,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target creature you control gains protection from the color of your choice until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "ParentTarget"
+                        },
+                        "modifications": [
+                          {
+                            "type": "AddKeyword",
+                            "keyword": {
+                              "Protection": "ChosenColor"
+                            }
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "gain protection from the color of your choice"
                       }
+                    ],
+                    "duration": "UntilEndOfTurn",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": []
                     }
-                  ],
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
                   "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": "gain protection from the color of your choice"
-                }
-              ],
-              "duration": "UntilEndOfTurn",
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": "You",
-                "properties": []
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": "UntilEndOfTurn",
-          "description": "{T}: Target creature you control gains protection from the color of your choice until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Tap"
+            },
+            "description": "{T}: Target creature you control gains protection from the color of your choice until end of turn.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
+          },
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__repeat_offender_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__repeat_offender_ir.snap
@@ -22,70 +22,177 @@ expression: "&ir"
         "fragment": "{2}{B}: If ~ is suspected, put a +1/+1 counter on it. Otherwise, suspect it. (A suspected creature has menace and can't block.)"
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "PutCounter",
-            "counter_type": "P1P1",
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "SelfRef"
-            }
-          },
-          "cost": {
-            "type": "Mana",
-            "cost": {
-              "type": "Cost",
-              "shards": [
-                "Black"
-              ],
-              "generic": 2
-            }
-          },
-          "sub_ability": null,
-          "else_ability": {
-            "kind": "Activated",
-            "effect": {
-              "type": "Suspect",
-              "target": {
-                "type": "SelfRef"
+        "Spell": {
+          "source_text": "If ~ is suspected, put a +1/+1 counter on it. Otherwise, suspect it",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 44,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "If ~ is suspected, put a +1/+1 counter on it"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "PutCounter",
+                    "counter_type": "P1P1",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "SelfRef"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": {
+                  "type": "SourceMatchesFilter",
+                  "filter": {
+                    "type": "Typed",
+                    "type_filters": [],
+                    "controller": null,
+                    "properties": [
+                      {
+                        "type": "Suspected"
+                      }
+                    ]
+                  }
+                },
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "scope": {
-                "type": "Single"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 46,
+                    "end_byte": 67,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "Otherwise, suspect it"
+                },
+                "disposition": {
+                  "BranchOtherwise": {
+                    "else_def": {
+                      "kind": "Activated",
+                      "effect": {
+                        "type": "Suspect",
+                        "target": {
+                          "type": "ParentTarget"
+                        },
+                        "scope": {
+                          "type": "Single"
+                        }
+                      },
+                      "cost": null,
+                      "sub_ability": null,
+                      "duration": null,
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": null,
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false
+                    },
+                    "kind": "Bound"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "otherwise_placeholder",
+                    "description": null
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [
+                  "Black"
+                ],
+                "generic": 2
               }
             },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            "description": "{2}{B}: If ~ is suspected, put a +1/+1 counter on it. Otherwise, suspect it.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "duration": null,
-          "description": "{2}{B}: If ~ is suspected, put a +1/+1 counter on it. Otherwise, suspect it.",
-          "target_prompt": null,
-          "condition": {
-            "type": "SourceMatchesFilter",
-            "filter": {
-              "type": "Typed",
-              "type_filters": [],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "Suspected"
-                }
-              ]
-            }
-          },
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
@@ -220,59 +220,116 @@ expression: "&ir"
         "fragment": "{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "ChangeZone",
-            "origin": "Hand",
-            "destination": "Battlefield",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
+        "Spell": {
+          "source_text": "You may put an Equipment card from your hand onto the battlefield",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 65,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "You may put an Equipment card from your hand onto the battlefield"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": "Hand",
+                    "destination": "Battlefield",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        {
+                          "Subtype": "Equipment"
+                        }
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "InZone",
+                          "zone": "Hand"
+                        }
+                      ]
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": true,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Composite",
+              "costs": [
                 {
-                  "Subtype": "Equipment"
-                }
-              ],
-              "controller": "You",
-              "properties": [
+                  "type": "Mana",
+                  "cost": {
+                    "type": "Cost",
+                    "shards": [
+                      "White"
+                    ],
+                    "generic": 1
+                  }
+                },
                 {
-                  "type": "InZone",
-                  "zone": "Hand"
+                  "type": "Tap"
                 }
               ]
             },
-            "owner_library": false,
-            "enter_transformed": false,
-            "enter_tapped": false,
-            "enters_attacking": false
-          },
-          "cost": {
-            "type": "Composite",
-            "costs": [
-              {
-                "type": "Mana",
-                "cost": {
-                  "type": "Cost",
-                  "shards": [
-                    "White"
-                  ],
-                  "generic": 1
-                }
-              },
-              {
-                "type": "Tap"
-              }
+            "description": "{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
             ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{1}{W}, {T}: You may put an Equipment card from your hand onto the battlefield.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": true,
-          "target_choice_timing": "Resolution",
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_safekeeper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_safekeeper_ir.snap
@@ -22,60 +22,118 @@ expression: "&ir"
         "fragment": "Sacrifice a land: Target creature you control gains shroud until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
+        "Spell": {
+          "source_text": "Target creature you control gains shroud until end of turn",
+          "body": {
+            "clauses": [
               {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "ParentTarget"
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 58,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target creature you control gains shroud until end of turn"
                 },
-                "modifications": [
-                  {
-                    "type": "AddKeyword",
-                    "keyword": "Shroud"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ],
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "ParentTarget"
+                        },
+                        "modifications": [
+                          {
+                            "type": "AddKeyword",
+                            "keyword": "Shroud"
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "gain shroud"
+                      }
+                    ],
+                    "duration": "UntilEndOfTurn",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "You",
+                      "properties": []
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
                 "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "gain shroud"
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
             ],
-            "duration": "UntilEndOfTurn",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": "You",
-              "properties": []
-            }
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Sacrifice",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Land"
-              ],
-              "controller": null,
-              "properties": []
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Sacrifice",
+              "target": {
+                "type": "Typed",
+                "type_filters": [
+                  "Land"
+                ],
+                "controller": null,
+                "properties": []
+              },
+              "count": 1
             },
-            "count": 1
+            "description": "Sacrifice a land: Target creature you control gains shroud until end of turn.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "Sacrifice a land: Target creature you control gains shroud until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thespians_stage_generic_activated_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thespians_stage_generic_activated_ir.snap
@@ -15,15 +15,15 @@ expression: "&ir"
           "first_line": 0,
           "last_line": 0,
           "start_byte": 0,
-          "end_byte": 74,
+          "end_byte": 13,
           "precision": "Exact",
           "ordinal_within_span": 0
         },
-        "fragment": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery."
+        "fragment": "{T}: Add {C}."
       },
       "node": {
         "Spell": {
-          "source_text": "Target player discards two cards",
+          "source_text": "Add {C}",
           "body": {
             "clauses": [
               {
@@ -37,11 +37,11 @@ expression: "&ir"
                     "first_line": 0,
                     "last_line": 0,
                     "start_byte": 0,
-                    "end_byte": 32,
+                    "end_byte": 7,
                     "precision": "ChainRelative",
                     "ordinal_within_span": 0
                   },
-                  "fragment": "Target player discards two cards"
+                  "fragment": "Add {C}"
                 },
                 "disposition": {
                   "Emit": {
@@ -51,13 +51,13 @@ expression: "&ir"
                 },
                 "parsed": {
                   "effect": {
-                    "type": "Discard",
-                    "count": {
-                      "type": "Fixed",
-                      "value": 2
-                    },
-                    "target": {
-                      "type": "Player"
+                    "type": "Mana",
+                    "produced": {
+                      "type": "Colorless",
+                      "count": {
+                        "type": "Fixed",
+                        "value": 1
+                      }
                     }
                   },
                   "duration": null,
@@ -93,29 +93,9 @@ expression: "&ir"
           "shell": {
             "sub_link": null,
             "cost": {
-              "type": "Composite",
-              "costs": [
-                {
-                  "type": "Mana",
-                  "cost": {
-                    "type": "Cost",
-                    "shards": [
-                      "Black"
-                    ],
-                    "generic": 4
-                  }
-                },
-                {
-                  "type": "Tap"
-                }
-              ]
+              "type": "Tap"
             },
-            "activation_restrictions": [
-              {
-                "type": "AsSorcery"
-              }
-            ],
-            "description": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery.",
+            "description": "{T}: Add {C}.",
             "stages": [
               "NormalizeActivatedManaInstead",
               "ExtractCostReduction",
@@ -136,16 +116,16 @@ expression: "&ir"
         "span": {
           "first_line": 1,
           "last_line": 1,
-          "start_byte": 75,
-          "end_byte": 179,
+          "start_byte": 14,
+          "end_byte": 84,
           "precision": "Exact",
           "ordinal_within_span": 0
         },
-        "fragment": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery."
+        "fragment": "{2}, {T}: ~ becomes a copy of target land, except it has this ability."
       },
       "node": {
         "Spell": {
-          "source_text": "Target player discards four cards",
+          "source_text": "~ becomes a copy of target land, except it has this ability",
           "body": {
             "clauses": [
               {
@@ -159,11 +139,11 @@ expression: "&ir"
                     "first_line": 0,
                     "last_line": 0,
                     "start_byte": 0,
-                    "end_byte": 33,
+                    "end_byte": 59,
                     "precision": "ChainRelative",
                     "ordinal_within_span": 0
                   },
-                  "fragment": "Target player discards four cards"
+                  "fragment": "~ becomes a copy of target land, except it has this ability"
                 },
                 "disposition": {
                   "Emit": {
@@ -173,16 +153,24 @@ expression: "&ir"
                 },
                 "parsed": {
                   "effect": {
-                    "type": "Discard",
-                    "count": {
-                      "type": "Fixed",
-                      "value": 4
-                    },
+                    "type": "BecomeCopy",
                     "target": {
-                      "type": "Player"
-                    }
+                      "type": "Typed",
+                      "type_filters": [
+                        "Land"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    },
+                    "duration": "Permanent",
+                    "additional_modifications": [
+                      {
+                        "type": "RetainPrintedAbilityFromSource",
+                        "source_ability_index": 0
+                      }
+                    ]
                   },
-                  "duration": null,
+                  "duration": "Permanent",
                   "sub_ability": null,
                   "distribute": null,
                   "multi_target": null,
@@ -221,33 +209,18 @@ expression: "&ir"
                   "type": "Mana",
                   "cost": {
                     "type": "Cost",
-                    "shards": [
-                      "Black",
-                      "Black"
-                    ],
-                    "generic": 5
+                    "shards": [],
+                    "generic": 2
                   }
                 },
                 {
-                  "type": "Discard",
-                  "count": {
-                    "type": "Fixed",
-                    "value": 1
-                  },
-                  "filter": null,
-                  "random": false,
-                  "self_ref": true
+                  "type": "Tap"
                 }
               ]
             },
-            "activation_restrictions": [
-              {
-                "type": "AsSorcery"
-              }
-            ],
-            "activation_zone": "Hand",
-            "description": "Channel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
+            "description": "{2}, {T}: ~ becomes a copy of target land, except it has this ability.",
             "stages": [
+              "NormalizeActivatedManaInstead",
               "ExtractCostReduction",
               "ExtractManaSpendTrigger"
             ]
@@ -257,6 +230,6 @@ expression: "&ir"
       }
     }
   ],
-  "source_text": "{4}{B}, {T}: Target player discards two cards. Activate only as a sorcery.\nChannel — {5}{B}{B}, Discard this card: Target player discards four cards. Activate only as a sorcery.",
-  "card_name": "Ghost-Lit Stalker"
+  "source_text": "{T}: Add {C}.\n{2}, {T}: This land becomes a copy of target land, except it has this ability.",
+  "card_name": "Thespian's Stage"
 }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thespians_stage_generic_activated_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thespians_stage_generic_activated_lowered.snap
@@ -1,0 +1,82 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "Mana",
+        "produced": {
+          "type": "Colorless",
+          "count": {
+            "type": "Fixed",
+            "value": 1
+          }
+        }
+      },
+      "cost": {
+        "type": "Tap"
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "{T}: Add {C}.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false,
+      "is_mana_ability": true
+    },
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "BecomeCopy",
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Land"
+          ],
+          "controller": null,
+          "properties": []
+        },
+        "duration": "Permanent",
+        "additional_modifications": [
+          {
+            "type": "RetainPrintedAbilityFromSource",
+            "source_ability_index": 1
+          }
+        ]
+      },
+      "cost": {
+        "type": "Composite",
+        "costs": [
+          {
+            "type": "Mana",
+            "cost": {
+              "type": "Cost",
+              "shards": [],
+              "generic": 2
+            }
+          },
+          {
+            "type": "Tap"
+          }
+        ]
+      },
+      "sub_ability": null,
+      "duration": "Permanent",
+      "description": "{2}, {T}: ~ becomes a copy of target land, except it has this ability.",
+      "target_prompt": null,
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 981
 expression: "&ir"
 ---
 {
@@ -84,35 +83,93 @@ expression: "&ir"
         "fragment": "{4}: Put a +1/+1 counter on ~."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "PutCounter",
-            "counter_type": "P1P1",
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "SelfRef"
-            }
+        "Spell": {
+          "source_text": "Put a +1/+1 counter on ~",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 24,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Put a +1/+1 counter on ~"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "PutCounter",
+                    "counter_type": "P1P1",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "SelfRef"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "Mana",
+          "shell": {
+            "sub_link": null,
             "cost": {
-              "type": "Cost",
-              "shards": [],
-              "generic": 4
-            }
+              "type": "Mana",
+              "cost": {
+                "type": "Cost",
+                "shards": [],
+                "generic": 4
+              }
+            },
+            "description": "{4}: Put a +1/+1 counter on ~.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "{4}: Put a +1/+1 counter on ~.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     },
@@ -134,36 +191,94 @@ expression: "&ir"
         "fragment": "Remove a +1/+1 counter from ~: It deals 1 damage to any target."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "target": {
-              "type": "Any"
-            }
+        "Spell": {
+          "source_text": "It deals 1 damage to any target",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 31,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "It deals 1 damage to any target"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "Any"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": null,
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": {
-            "type": "RemoveCounter",
-            "count": 1,
-            "counter_type": {
-              "type": "OfType",
-              "data": "P1P1"
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "RemoveCounter",
+              "count": 1,
+              "counter_type": {
+                "type": "OfType",
+                "data": "P1P1"
+              },
+              "target": null,
+              "selection": "SingleObject"
             },
-            "target": null,
-            "selection": "SingleObject"
+            "description": "Remove a +1/+1 counter from ~: It deals 1 damage to any target.",
+            "stages": [
+              "NormalizeActivatedManaInstead",
+              "ExtractCostReduction",
+              "ExtractManaSpendTrigger"
+            ]
           },
-          "sub_ability": null,
-          "duration": null,
-          "description": "Remove a +1/+1 counter from ~: It deals 1 damage to any target.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_pipeline_snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_pipeline_snapshot_tests.rs
@@ -544,7 +544,8 @@ fn zack_fair_activated_parses_counter_move_and_attach_sub_chain() {
 
     let effect = "Target creature you control gains indestructible until end of turn. Put Zack Fair's counters on that creature and attach an Equipment that was attached to Zack Fair to that creature.";
     let mut ctx = ParseContext::default();
-    let def = parse_activated_with_self_ref_fallback(effect, "Zack Fair", &mut ctx);
+    let ir = parse_activated_ability_ir_with_self_ref_fallback(effect, "Zack Fair", &mut ctx);
+    let def = lower_ability_ir(&ir);
 
     fn has_effect(def: &AbilityDefinition, pred: &dyn Fn(&Effect) -> bool) -> bool {
         if pred(&def.effect) {

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -8540,6 +8540,27 @@ fn parses_urza_tower_conditional_mana_as_delta() {
     }
 }
 
+#[test]
+fn activated_mana_instead_delta_preserves_non_instead_condition() {
+    let mut ability = parse(
+        "{T}: Add {C}. If you control an Urza's Mine and an Urza's Power-Plant, add {C}{C}{C} instead.",
+        "Urza's Tower",
+        &[],
+        &["Land"],
+        &["Urza's", "Tower"],
+    )
+    .abilities
+    .remove(0);
+    let before = ability.clone();
+
+    normalize_activated_mana_instead_delta(&mut ability);
+
+    assert_eq!(
+        ability, before,
+        "the normalizer must leave an already-lowered non-replacement condition intact"
+    );
+}
+
 /// CR 205.3i + CR 614.1a + CR 605.1a: All three Urza lands share a single
 /// parsed shape — an activated mana ability (`{T}: Add {C}.` per CR 605.1a)
 /// plus a conditional `Add {C}{C}{C} instead` sub-ability whose "instead"


### PR DESCRIPTION
## Summary
- adds an inert lowering-shell stage for activated mana-normalization before existing cost-reduction and mana-spend extraction
- routes generic and ability-word-prefixed activated abilities through native `AbilityIr`
- preserves activation envelopes, printed slots, fallback diagnostics, and terminal d20 result tables

## Verification
- `cargo fmt --all --check`
- parser combinator / classifier gates (G and A): PASS
- skill-doc and prelowered-ratchet gates: PASS
- focused IR snapshots: 118 passed
- `cargo clippy --all-targets -- -D warnings`: PASS
- full-pool card-data parity: identical SHA-256 and `cmp` exit 0

## Witnesses
- Thespian’s Stage preserves copied text and printed slot 1
- Barbarian Ring covers ability-word routing
- Component Pouch covers d20 table attachment and nonterminal-roll rejection

The full-pool exports used the same checked AtomicCards input; neither generated export is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activated-ability parsing and IR routing, including labeled abilities, self-references, die-roll handling, and copy/activation restrictions.
  * More reliable fallback behavior for ambiguous or unsupported text, with reduced chances of residual unimplemented effects.
  * Added consistent normalization for “activated mana instead” within the activated-ability shell pipeline.
* **Tests**
  * Added/expanded snapshot coverage for activated abilities across multiple complex scenarios.
  * Updated validation to follow the improved activated-ability parsing and lowering flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->