### PR TITLE
fix(engine): prevent-damage recipient scope no longer collapses to Any

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4839,25 +4839,41 @@ fn affected_objects_from_events(
 ) -> Vec<ObjectId> {
     let fallback_targets = ability.targets.as_slice();
     match effect {
-        // CR 508.1a + CR 608.2c + CR 603.7c: A mass "attack this turn if able"
-        // coercion (Maddening Imp's `{T}` `GenericEffect{MustAttack}`) moves no
-        // objects and emits NO object-affecting event, so — unlike every other arm
-        // here — its affected population is FILTER-driven: re-enumerate the
-        // battlefield by the governing filter at resolution time. The publish site
-        // runs on the identical post-resolution board state, so this yields exactly
-        // the resolution-time population that "those creatures" freezes. Mirrors
-        // the broadcast-static binding in `effect.rs` (`Some(filter)` arm).
+        // CR 508.1a + CR 608.2c + CR 603.7c + CR 611.2c + CR 615.11 (issue
+        // #6682): A mass "attack this turn if able" coercion (Maddening Imp's
+        // `{T}` `GenericEffect{MustAttack}`) or a Continuous-mode broadcast
+        // keyword/P-T grant (Mutational Advantage's "permanents you control
+        // with counters on them gain hexproof and indestructible") moves no
+        // objects and emits NO object-affecting event, so — unlike every other
+        // arm here — its affected population is FILTER-driven: re-enumerate
+        // the battlefield by the governing filter at resolution time. The
+        // publish site runs on the identical post-resolution board state, so
+        // this yields exactly the resolution-time population that "those
+        // creatures"/"those permanents" freezes — verified against Mutational
+        // Advantage's official ruling: "The set of permanents affected by
+        // Mutational Advantage is determined at the time Mutational Advantage
+        // resolves. Permanents that gain counters later in the turn won't
+        // become affected by this effect, and permanents that lose all of
+        // their counters later in the turn won't stop being affected."
+        // Mirrors the broadcast-static binding in `effect.rs` (`Some(filter)`
+        // arm). Broader than the parser-side `is_mass_coerce_static`
+        // (oracle_effect/mod.rs), which still gates only the MustAttack/
+        // MustAttackPlayer coercion pair for its own (unrelated)
+        // ParentTarget-rewrite purpose.
         Effect::GenericEffect {
             static_abilities,
             target,
             ..
         } => {
-            // Select the first coercion static (matching `is_mass_coerce_static`).
+            // Select the first static whose population is meant to be frozen
+            // at resolution rather than re-evaluated live at each future
+            // check — a coercion requirement or a Continuous grant.
             let Some(static_def) = static_abilities.iter().find(|sd| {
                 matches!(
                     sd.mode,
                     crate::types::statics::StaticMode::MustAttack
                         | crate::types::statics::StaticMode::MustAttackPlayer { .. }
+                        | crate::types::statics::StaticMode::Continuous
                 )
             }) else {
                 return Vec::new();

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -302,14 +302,33 @@ pub fn resolve(
     // chosen creature IS the damage source, not a recipient). Same routing: the
     // shield is source-scoped, so it must NOT be hosted on the creature as a
     // recipient object (which would wrongly re-impose "recipient == creature").
-    let source_scoped_prevent =
-        matches!(
-            &effect_source_filter,
-            Some(TargetFilter::And { filters })
-                if filters
-                    .iter()
-                    .any(|f| matches!(f, TargetFilter::ParentTargetSlot { .. }))
-        ) || matches!(&effect_source_filter, Some(TargetFilter::ParentTarget));
+    //
+    // CR 608.2c + CR 615 (issue #6682): Energy Arc's "by"-only half carries a
+    // `TrackedSet` source filter instead (a SET of chosen creatures, not one).
+    // `ability.targets` here is NOT this effect's own recipient selection — it
+    // is the enclosing Untap clause's targets, inherited onto this
+    // SequentialSibling by the chain walker's generic `should_propagate_
+    // parent_targets` (the inheritance exists for OTHER riders that genuinely
+    // want the parent's chosen object; a source-scoped shield has no use for
+    // it). Without this arm, `host_on_targets` saw a non-`Any`-context-ref
+    // `target` (`Any` itself isn't in `is_context_ref()`'s list) plus those
+    // inherited targets and wrongly hosted the shield ON the untapped
+    // creature with a forced `valid_card: SelfRef` — recipient-scoping a
+    // shield that was supposed to be source-scoped only.
+    let source_scoped_prevent = matches!(
+        &effect_source_filter,
+        Some(TargetFilter::And { filters })
+            if filters
+                .iter()
+                .any(|f| matches!(f, TargetFilter::ParentTargetSlot { .. }))
+    ) || matches!(
+        &effect_source_filter,
+        Some(
+            TargetFilter::ParentTarget
+                | TargetFilter::TrackedSet { .. }
+                | TargetFilter::TrackedSetFiltered { .. }
+        )
+    );
 
     // CR 615.11: A dynamic prevention amount is resolved to a concrete depletion
     // count at effect-resolution time; the Next(n) shield itself is always static.
@@ -1620,6 +1639,348 @@ mod tests {
         assert!(
             matches!(unrelated_result, deal_damage::DamageResult::Applied(3)),
             "the shield must NOT drift onto an unrelated later chain's tracked set"
+        );
+    }
+
+    /// CR 611.2c + CR 615.11 (issue #6682): Mutational Advantage's official
+    /// ruling — "The set of permanents affected by Mutational Advantage is
+    /// determined at the time Mutational Advantage resolves. Permanents that
+    /// gain counters later in the turn won't become affected by this effect,
+    /// and permanents that lose all of their counters later in the turn
+    /// won't stop being affected." — driven through the real cast pipeline
+    /// (`GameRunner::cast`), not a hand-built `ResolvedAbility`, so the parse
+    /// → chain-context → resolution path is exercised end to end.
+    ///
+    /// Setup: `countered` already has a +1/+1 counter (in the frozen
+    /// population); `uncountered` does not. AFTER the spell resolves:
+    /// `uncountered` gains a counter (must NOT retroactively join the
+    /// shielded population — a live re-check of "permanents with counters"
+    /// would wrongly protect it) and `countered` loses its counter (must
+    /// STAY protected — the shield is bound to the frozen object identity,
+    /// not a live filter re-evaluated at each damage event).
+    #[test]
+    fn mutational_advantage_shield_freezes_population_at_resolution() {
+        use crate::parser::oracle_effect::parse_effect_chain;
+        use crate::types::ability::AbilityKind;
+        use crate::types::counter::CounterType;
+        use crate::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+        use crate::types::phase::Phase;
+        use std::sync::Arc;
+
+        let def = parse_effect_chain(
+            "Permanents you control with counters on them gain hexproof and indestructible \
+             until end of turn. Prevent all damage that would be dealt to those permanents \
+             this turn.",
+            AbilityKind::Spell,
+        );
+
+        let mut state = GameState::new_two_player(42);
+        state.turn_number = 2;
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        let countered = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Countered Creature".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&countered).unwrap();
+            obj.card_types.core_types = vec![CoreType::Creature];
+            obj.counters.insert(CounterType::Plus1Plus1, 1);
+        }
+        let uncountered = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Uncountered Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&uncountered)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Creature];
+
+        let spell = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Mutational Advantage".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            Arc::make_mut(&mut obj.abilities).push(def);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::Green, ManaCostShard::Blue],
+                generic: 1,
+            };
+        }
+        for color in [ManaType::Green, ManaType::Blue, ManaType::Colorless] {
+            state.players[0].mana_pool.add(ManaUnit {
+                color,
+                source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
+                supertype: None,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: Vec::new(),
+                grants: vec![],
+                expiry: None,
+            });
+        }
+
+        let mut runner = crate::game::scenario::GameRunner::from_state(state);
+        let _outcome = runner.cast(spell).resolve();
+        let state = runner.state_mut();
+
+        // CR 611.2c: mutate AFTER resolution — the frozen population must be
+        // immune to both changes.
+        state
+            .objects
+            .get_mut(&uncountered)
+            .unwrap()
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        state
+            .objects
+            .get_mut(&countered)
+            .unwrap()
+            .counters
+            .remove(&CounterType::Plus1Plus1);
+
+        let attacker = create_object(
+            state,
+            CardId(4),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+        let ctx = deal_damage::DamageContext::from_source(state, attacker).unwrap();
+        let mut events = Vec::new();
+
+        let uncountered_result = deal_damage::apply_damage_to_target(
+            state,
+            &ctx,
+            TargetRef::Object(uncountered),
+            3,
+            false,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(uncountered_result, deal_damage::DamageResult::Applied(3)),
+            "a permanent that gains a counter AFTER resolution must NOT retroactively \
+             join the frozen shielded population"
+        );
+
+        let countered_result = deal_damage::apply_damage_to_target(
+            state,
+            &ctx,
+            TargetRef::Object(countered),
+            3,
+            false,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(countered_result, deal_damage::DamageResult::Applied(0)),
+            "a permanent that loses its counter AFTER resolution must STAY protected \
+             (frozen by identity, not re-checked live)"
+        );
+    }
+
+    /// CR 608.2c + CR 615 (issue #6682): Energy Arc's bidirectional "dealt to
+    /// and dealt by those creatures" — driven through the real cast pipeline
+    /// (`GameRunner::cast`) with a genuine SUBSET target selection out of two
+    /// eligible creatures, proving the shield scopes to exactly the SELECTED
+    /// creature in BOTH directions:
+    /// - combat damage dealt TO the selected creature is prevented; TO the
+    ///   nonselected creature is not.
+    /// - combat damage dealt BY the selected creature (as a source) is
+    ///   prevented; BY the nonselected creature is not.
+    #[test]
+    fn energy_arc_cast_pipeline_scopes_to_and_by_damage_to_selected_creature() {
+        use crate::parser::oracle_effect::parse_effect_chain;
+        use crate::types::ability::AbilityKind;
+        use crate::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+        use crate::types::phase::Phase;
+        use std::sync::Arc;
+
+        let def = parse_effect_chain(
+            "Untap any number of target creatures. Prevent all combat damage that would \
+             be dealt to and dealt by those creatures this turn.",
+            AbilityKind::Spell,
+        );
+
+        let mut state = GameState::new_two_player(42);
+        state.turn_number = 2;
+        state.phase = Phase::PreCombatMain;
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+
+        // Two eligible creatures — only one is selected as Energy Arc's
+        // target, proving the shield scopes to the CHOSEN subset, not every
+        // creature the multi-target filter could have matched.
+        let selected = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Selected Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&selected)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Creature];
+        state.objects.get_mut(&selected).unwrap().tapped = true;
+
+        let nonselected = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Nonselected Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&nonselected)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Creature];
+        state.objects.get_mut(&nonselected).unwrap().tapped = true;
+
+        let opponent_creature = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Opponent Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&opponent_creature)
+            .unwrap()
+            .card_types
+            .core_types = vec![CoreType::Creature];
+
+        let spell = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(0),
+            "Energy Arc".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Instant);
+            Arc::make_mut(&mut obj.abilities).push(def);
+            obj.mana_cost = ManaCost::Cost {
+                shards: vec![ManaCostShard::White, ManaCostShard::Blue],
+                generic: 0,
+            };
+        }
+        for color in [ManaType::White, ManaType::Blue] {
+            state.players[0].mana_pool.add(ManaUnit {
+                color,
+                source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
+                supertype: None,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: Vec::new(),
+                grants: vec![],
+                expiry: None,
+            });
+        }
+
+        let mut runner = crate::game::scenario::GameRunner::from_state(state);
+        // CR 601.2c: "any number of target creatures" — declare exactly ONE
+        // of the two eligible creatures, proving the shield binds to the
+        // CHOSEN subset (the driver matches declared object intent to the
+        // multi-target slot).
+        let _outcome = runner.cast(spell).target_objects(&[selected]).resolve();
+        let state = runner.state_mut();
+
+        assert!(
+            !state.objects.get(&selected).unwrap().tapped,
+            "the selected creature must be untapped by Energy Arc's own effect"
+        );
+
+        let opponent_attacker_ctx =
+            deal_damage::DamageContext::from_source(state, opponent_creature).unwrap();
+        let mut events = Vec::new();
+
+        // Damage TO: selected is shielded, nonselected is not.
+        let to_selected = deal_damage::apply_damage_to_target(
+            state,
+            &opponent_attacker_ctx,
+            TargetRef::Object(selected),
+            3,
+            true,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(to_selected, deal_damage::DamageResult::Applied(0)),
+            "combat damage dealt TO the selected creature must be prevented"
+        );
+        let to_nonselected = deal_damage::apply_damage_to_target(
+            state,
+            &opponent_attacker_ctx,
+            TargetRef::Object(nonselected),
+            3,
+            true,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(to_nonselected, deal_damage::DamageResult::Applied(3)),
+            "combat damage dealt TO the nonselected creature must NOT be prevented"
+        );
+
+        // Damage BY: selected as the source is shielded, nonselected as the
+        // source is not.
+        let selected_source_ctx = deal_damage::DamageContext::from_source(state, selected).unwrap();
+        let by_selected = deal_damage::apply_damage_to_target(
+            state,
+            &selected_source_ctx,
+            TargetRef::Object(opponent_creature),
+            3,
+            true,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(by_selected, deal_damage::DamageResult::Applied(0)),
+            "combat damage dealt BY the selected creature must be prevented"
+        );
+        let nonselected_source_ctx =
+            deal_damage::DamageContext::from_source(state, nonselected).unwrap();
+        let by_nonselected = deal_damage::apply_damage_to_target(
+            state,
+            &nonselected_source_ctx,
+            TargetRef::Object(opponent_creature),
+            3,
+            true,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(by_nonselected, deal_damage::DamageResult::Applied(3)),
+            "combat damage dealt BY the nonselected creature must NOT be prevented"
         );
     }
 

--- a/crates/engine/src/game/effects/prevent_damage.rs
+++ b/crates/engine/src/game/effects/prevent_damage.rs
@@ -190,6 +190,17 @@ fn untargeted_damage_filter(
                 permanent_type: *permanent_type,
             })
         }
+        // CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): a tracked-set
+        // recipient ("those permanents"/"those creatures" — Mutational
+        // Advantage's clause-derived population, Energy Arc's target-derived
+        // untapped creatures) is an OBJECT population, not a player. The
+        // generic `is_context_ref()` classification below (used broadly for
+        // "does this need a declared target slot") also happens to cover
+        // `TrackedSet`/`TrackedSetFiltered`, which would otherwise
+        // misroute it through `resolve_player_for_context_ref` here — object
+        // matching is `typed_recipient_valid_card_filter`'s job, so this
+        // arm must be checked BEFORE the generic `is_context_ref()` catch-all.
+        TargetFilter::TrackedSet { .. } | TargetFilter::TrackedSetFiltered { .. } => None,
         filter if filter.is_context_ref() => Some(player_damage_filter(
             super::resolve_player_for_context_ref(state, ability, filter),
         )),
@@ -211,6 +222,13 @@ fn typed_recipient_valid_card_filter(target: &TargetFilter) -> Option<TargetFilt
         // `valid_card` slot (that would drop the "you" leg — the HIGH-severity
         // leak this arm forecloses even if the caller's branch order changes).
         TargetFilter::ControllerAndControlledPermanents { .. } => None,
+        // CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): a tracked-set
+        // recipient IS an object population — checked before the generic
+        // `is_context_ref()` exclusion below (which would otherwise reject
+        // it, mirroring `untargeted_damage_filter`'s matching carve-out).
+        filter @ (TargetFilter::TrackedSet { .. } | TargetFilter::TrackedSetFiltered { .. }) => {
+            Some(filter.clone())
+        }
         filter if filter.is_context_ref() => None,
         filter => Some(filter.clone()),
     }
@@ -252,6 +270,25 @@ pub fn resolve(
                 ))
             }
         };
+
+    // CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): resolve any
+    // `TrackedSet` sentinel in the recipient/source filters to a CONCRETE
+    // tracked-set id now, at shield-creation time — before it is folded into
+    // a `ReplacementDefinition` that may persist and be rechecked at many
+    // later damage events this turn. Left unresolved, the raw
+    // `TrackedSetId(0)` sentinel would be re-resolved against
+    // `state.chain_tracked_set_id` at EACH future check
+    // (`filter::matches_target_filter`), which drifts to whatever unrelated
+    // chain most recently published a tracked set by then — a stale,
+    // silently-wrong rebinding (Energy Arc's "those creatures" shield must
+    // stay bound to the untapped creatures for the rest of the turn, not
+    // whatever some later spell's chain happens to publish). Mirrors
+    // `register_transient_effect`'s identical one-shot resolution
+    // (`game/effects/effect.rs`) for the analogous durable continuous-effect
+    // case. A no-op for every non-`TrackedSet` filter.
+    let target = crate::game::targeting::resolve_tracked_set_sentinel(state, target);
+    let effect_source_filter = effect_source_filter
+        .map(|filter| crate::game::targeting::resolve_tracked_set_sentinel(state, filter));
 
     // CR 609.7 + CR 609.7a: A source-scoped prevent ("prevent all damage target
     // instant or sorcery spell would deal this turn") carries its chosen source
@@ -1472,6 +1509,118 @@ mod tests {
         .unwrap();
         assert!(matches!(bear_result, deal_damage::DamageResult::Applied(2)));
         assert_eq!(state.objects.get(&bear).unwrap().damage_marked, 2);
+    }
+
+    /// CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): A `TrackedSet(0)`
+    /// sentinel recipient must be resolved to a CONCRETE tracked-set id at
+    /// shield-creation time, not left as the raw sentinel. Proves the
+    /// staleness bug this resolves: without the fix, a persisting shield's
+    /// `valid_card: TrackedSet(0)` would be re-resolved against
+    /// `state.chain_tracked_set_id` at EVERY future damage check, drifting to
+    /// whatever unrelated chain most recently published a tracked set. Here,
+    /// AFTER the shield is created, an unrelated chain overwrites
+    /// `chain_tracked_set_id` to point at a completely different object
+    /// (simulating some other spell resolving later the same turn) — the
+    /// shield must still protect only the ORIGINAL untapped creature (Energy
+    /// Arc class), not the new unrelated set.
+    #[test]
+    fn tracked_set_recipient_resolves_to_concrete_id_immune_to_later_chain_overwrite() {
+        use crate::types::identifiers::TrackedSetId;
+
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Energy Arc".to_string(),
+            Zone::Stack,
+        );
+        let untapped_creature = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Untapped Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let unrelated_creature = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Unrelated Creature".to_string(),
+            Zone::Battlefield,
+        );
+        let damage_source = create_object(
+            &mut state,
+            CardId(4),
+            PlayerId(1),
+            "Attacker".to_string(),
+            Zone::Battlefield,
+        );
+
+        // The preceding Untap clause published the untapped creature as the
+        // chain's tracked set — the state `prevent_damage::resolve` sees.
+        state
+            .tracked_object_sets
+            .insert(TrackedSetId(5), vec![untapped_creature]);
+        state.chain_tracked_set_id = Some(TrackedSetId(5));
+
+        let ability = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::TrackedSet {
+                    id: TrackedSetId(0),
+                },
+                scope: PreventionScope::CombatDamage,
+                damage_source_filter: None,
+                prevention_duration: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // A LATER, unrelated chain publishes a fresh tracked set (e.g. some
+        // other spell's exile/mill effect resolving afterward this turn).
+        state
+            .tracked_object_sets
+            .insert(TrackedSetId(6), vec![unrelated_creature]);
+        state.chain_tracked_set_id = Some(TrackedSetId(6));
+
+        let ctx = deal_damage::DamageContext::from_source(&state, damage_source).unwrap();
+
+        // The original untapped creature must still be protected.
+        let protected_result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(untapped_creature),
+            3,
+            true,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(protected_result, deal_damage::DamageResult::Applied(0)),
+            "the shield must stay bound to the originally-untapped creature"
+        );
+
+        // The later, unrelated creature must NOT be protected — the shield
+        // must not have drifted onto whatever the newest tracked set is.
+        let unrelated_result = deal_damage::apply_damage_to_target(
+            &mut state,
+            &ctx,
+            TargetRef::Object(unrelated_creature),
+            3,
+            true,
+            &mut events,
+        )
+        .unwrap();
+        assert!(
+            matches!(unrelated_result, deal_damage::DamageResult::Applied(3)),
+            "the shield must NOT drift onto an unrelated later chain's tracked set"
+        );
     }
 
     /// CR 615.1a: A `Prevention { All }` shield is not depletion-based — it

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -7186,6 +7186,40 @@ pub fn find_applicable_replacements(
                             }
                         }
                     }
+                    // CR 608.2c + CR 611.2c + CR 615.1a (issue #6682): an
+                    // OBJECT-population recipient (`valid_card` — Blinding
+                    // Fog's "creatures", Mutational Advantage's countered
+                    // permanents, Energy Arc's untapped-creatures tracked
+                    // set) must ALSO gate a GLOBAL (stack-sourced) shield's
+                    // OBJECT damage target, exactly as an object-hosted
+                    // shield's own per-object scan already enforces it.
+                    // Previously unreachable: every prior card whose prevent
+                    // clause carried a real `valid_card` recipient filter
+                    // happened to be sourced from a permanent already on the
+                    // battlefield (object-hosted path, checked elsewhere), so
+                    // this pending-registry path never needed to read it —
+                    // silently turning a scoped shield into a blanket one for
+                    // the FIRST instant/sorcery-sourced population recipient.
+                    // Player-target damage events are unaffected: a card-shaped
+                    // filter has no player to check against (mirrors why
+                    // `damage_target_filter` above is the player-side gate).
+                    if let Some(ref vc) = repl_def.valid_card {
+                        if let ProposedEvent::Damage {
+                            target: TargetRef::Object(obj_id),
+                            ..
+                        } = event
+                        {
+                            let ctx = match repl_def.source_controller {
+                                Some(pid) => {
+                                    FilterContext::from_source_with_controller(ObjectId(0), pid)
+                                }
+                                None => FilterContext::from_source(state, ObjectId(0)),
+                            };
+                            if !matches_target_filter(state, *obj_id, vc, &ctx) {
+                                continue;
+                            }
+                        }
+                    }
                     if is_damage_prevention_replacement(state, &rid, &repl_def.event)
                         && is_prevention_disabled(state, event)
                     {
@@ -19440,13 +19474,17 @@ mod tests {
     }
 
     #[test]
-    fn global_store_damage_path_ignores_valid_card_filter() {
-        // REGRESSION (BLOCKER guard): the prevent_damage typed-recipient shield
-        // sets a `valid_card` recipient filter that is DELIBERATELY not enforced
-        // for damage (prevent_damage.rs: "global shields must match any damage
-        // event"). The generalized scan must still prevent a damage event whose
-        // recipient does NOT match that typed filter — i.e. the new valid_card
-        // gate must NOT run on the Damage path.
+    fn global_store_damage_path_ignores_valid_card_filter_for_player_targets() {
+        // A card-shaped `valid_card` recipient filter has no player to check
+        // against, so it must remain a no-op for a PLAYER-target damage
+        // event — the generalized scan must still prevent damage dealt to a
+        // player even though the shield's `valid_card` is creature-shaped.
+        // CR 608.2c + CR 615.1a (issue #6682): `valid_card` IS now enforced
+        // on this path for OBJECT-target damage events (see
+        // `find_applicable_replacements`'s dedicated `valid_card` gate,
+        // covered by `game::effects::prevent_damage::tests`'s tracked-set
+        // recipient tests) — this test pins the complementary player-target
+        // case, where the gate correctly does not apply.
         let registry = build_replacement_registry();
         let mut state = GameState::new_two_player(42);
         // Global prevention shield carrying a typed recipient valid_card filter
@@ -19470,6 +19508,73 @@ mod tests {
                 index: 0
             }],
             "damage prevention shield must remain a candidate despite a non-matching valid_card recipient filter"
+        );
+    }
+
+    /// CR 608.2c + CR 611.2c + CR 615.1a (issue #6682): a GLOBAL (stack-sourced)
+    /// prevention shield's `valid_card` recipient filter MUST gate an
+    /// OBJECT-target damage event — the mass/tracked-set recipient class
+    /// (Blinding Fog's "creatures", Mutational Advantage's countered
+    /// permanents, Energy Arc's untapped creatures) that only ever reaches
+    /// the pending registry because its source is an instant/sorcery on the
+    /// stack, never a battlefield permanent. Without this gate, ANY object
+    /// took damage as if the shield were unscoped.
+    #[test]
+    fn global_store_damage_path_enforces_valid_card_filter_for_object_targets() {
+        let registry = build_replacement_registry();
+        let mut state = GameState::new_two_player(42);
+        let mut land = GameObject::new(
+            ObjectId(30),
+            CardId(1),
+            PlayerId(0),
+            "Land".to_string(),
+            Zone::Battlefield,
+        );
+        land.card_types.core_types = vec![CoreType::Land];
+        state.objects.insert(ObjectId(30), land);
+        let mut creature = GameObject::new(
+            ObjectId(31),
+            CardId(2),
+            PlayerId(0),
+            "Creature".to_string(),
+            Zone::Battlefield,
+        );
+        creature.card_types.core_types = vec![CoreType::Creature];
+        state.objects.insert(ObjectId(31), creature);
+
+        let shield = ReplacementDefinition::new(ReplacementEvent::DamageDone)
+            .prevention_shield(PreventionAmount::All)
+            .valid_card(TargetFilter::Typed(TypedFilter::creature()));
+        state.pending_damage_replacements.push(shield);
+
+        // The land does NOT match the creature-shaped valid_card filter.
+        let land_event = ProposedEvent::Damage {
+            source_id: ObjectId(50),
+            target: TargetRef::Object(ObjectId(30)),
+            amount: 3,
+            is_combat: false,
+            applied: HashSet::new(),
+        };
+        assert!(
+            find_applicable_replacements(&state, &land_event, &registry).is_empty(),
+            "a non-matching object target must NOT be gated in by an unscoped shield"
+        );
+
+        // The creature DOES match.
+        let creature_event = ProposedEvent::Damage {
+            source_id: ObjectId(50),
+            target: TargetRef::Object(ObjectId(31)),
+            amount: 3,
+            is_combat: false,
+            applied: HashSet::new(),
+        };
+        assert_eq!(
+            find_applicable_replacements(&state, &creature_event, &registry),
+            vec![ReplacementId {
+                source: ObjectId(0),
+                index: 0
+            }],
+            "a matching object target must still be gated in"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5165,6 +5165,11 @@ pub(super) fn parse_utility_imperative_ast(
                 // to. This is the one construction site where `ParseContext` is
                 // live; downstream lowering has only the captured flag.
                 parent_target_available: ctx.parent_target_available,
+                // CR 611.2c + CR 615.11 (issue #6682): capture the population
+                // an earlier same-chain Continuous-mode static grant locked
+                // onto, for a "those permanents"/"those creatures" recipient
+                // anaphor to bind to.
+                chain_prior_mass_population: ctx.chain_prior_mass_population.clone(),
             }),
             "regenerate" => Some(UtilityImperativeAst::Regenerate {
                 text: text.to_string(),
@@ -5848,7 +5853,8 @@ pub(super) fn lower_utility_imperative_ast(ast: UtilityImperativeAst) -> Effect 
         UtilityImperativeAst::Prevent {
             text,
             parent_target_available,
-        } => parse_prevent_effect(&text, parent_target_available),
+            chain_prior_mass_population,
+        } => parse_prevent_effect(&text, parent_target_available, chain_prior_mass_population),
         UtilityImperativeAst::Regenerate { text } => {
             let lower = text.to_lowercase();
             let rest = tag::<_, _, OracleError<'_>>("regenerate ")
@@ -5909,6 +5915,67 @@ pub(super) fn parse_prevention_amount(rest: &str) -> PreventionAmount {
     }
 }
 
+/// CR 608.2c: "those permanents"/"those creatures" head-noun check for the
+/// prevent-recipient dispatch below. Mirrors the identical phrase pair
+/// already listed in `oracle_target::parse_target`'s `TRACKED_SET_PHRASES`
+/// and `contains_explicit_tracked_set_pronoun` (this module) — kept as its
+/// own tiny combinator here (rather than a third shared list) because this
+/// call site needs an anchored prefix match on the recipient phrase, not a
+/// scan-anywhere-in-the-clause check.
+fn parse_those_population_anaphor(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag("those permanents"), tag("those creatures")))).parse(input)
+}
+
+/// CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): Resolve a prevent-damage
+/// recipient phrase — the text immediately following "dealt to " or "dealt to
+/// and dealt by " — to a `TargetFilter`. Shared by [`parse_prevent_effect`]
+/// and `lower::try_parse_bidirectional_prevent` (Energy Arc's "dealt to and
+/// dealt by those creatures") so both prevent-recipient parsers agree.
+///
+/// Tries, in priority order:
+/// 1. A singular chosen-target anaphor ("that creature"/"it"/"the creature"),
+///    gated on `parent_target_available` (CR 608.2c, issue #1094).
+/// 2. "those permanents"/"those creatures" bound to the population an
+///    earlier same-chain Continuous-mode static grant locked onto
+///    (`chain_prior_mass_population`) — Mutational Advantage's official
+///    ruling: "The set of permanents affected by Mutational Advantage is
+///    determined at the time Mutational Advantage resolves."
+/// 3. Any other recipient phrase `parse_target` recognizes as a real filter —
+///    mass typed recipients ("creatures"/"players"/"creatures you control" —
+///    Blinding Fog, Defend the Hearth) and target-derived "those creatures"
+///    anaphors that resolve to a `TrackedSet` sentinel when a chosen-target
+///    clause precedes them (Energy Arc; resolved to a concrete, stable set id
+///    at shield-creation time by `prevent_damage::resolve`).
+///
+/// Returns `None` only when none of the above recognize the phrase — the
+/// caller then falls back to the pre-existing `Any` default.
+pub(super) fn resolve_prevent_recipient(
+    recipient: TextPair<'_>,
+    parent_target_available: bool,
+    chain_prior_mass_population: &Option<TargetFilter>,
+) -> Option<TargetFilter> {
+    if let Some((filter, _)) =
+        parse_anaphoric_target_ref(recipient.original, parent_target_available)
+    {
+        return Some(filter);
+    }
+    if parse_those_population_anaphor(recipient.lower).is_ok() {
+        if let Some(filter) = chain_prior_mass_population.clone() {
+            return Some(filter);
+        }
+    }
+    // CR 608.2c: `ParentTarget`/`TriggeringSource`/`CostPaidObject`/`SelfRef`
+    // are inherited-reference filters naming a specific already-established
+    // object — exclusively tier 1's gated domain (`parent_target_available`).
+    // `parse_target` resolves these unconditionally, with no such gate, so
+    // this tier must reject them explicitly — otherwise a standalone recipient
+    // anaphor with `parent_target_available == false` would leak through here
+    // as an ungated `ParentTarget` binding to a nonexistent chosen target.
+    let (filter, _) = parse_target(recipient.original);
+    (!matches!(filter, TargetFilter::Any) && super::is_broadcast_population_filter(&filter))
+        .then_some(filter)
+}
+
 /// CR 615: Parse "prevent" damage effects into `Effect::PreventDamage`.
 ///
 /// Handles patterns like:
@@ -5921,7 +5988,17 @@ pub(super) fn parse_prevention_amount(rest: &str) -> PreventionAmount {
 /// the same effect chain selected a target that a trailing anaphor ("that
 /// creature" / "the creature" / "it") can bind to via `ParentTarget`. When
 /// false the anaphor recognizer is a no-op and the target falls back to `Any`.
-fn parse_prevent_effect(text: &str, parent_target_available: bool) -> Effect {
+///
+/// CR 611.2c + CR 615.11 (issue #6682): `chain_prior_mass_population` carries
+/// the population an earlier same-chain Continuous-mode static grant locked
+/// onto (Mutational Advantage's hexproof/indestructible clause), for a
+/// "those permanents"/"those creatures" recipient anaphor to bind to — see
+/// [`resolve_prevent_recipient`].
+fn parse_prevent_effect(
+    text: &str,
+    parent_target_available: bool,
+    chain_prior_mass_population: Option<TargetFilter>,
+) -> Effect {
     let lower = text.to_lowercase();
     let rest = tag::<_, _, OracleError<'_>>("prevent ")
         .parse(&*lower)
@@ -5999,16 +6076,19 @@ fn parse_prevent_effect(text: &str, parent_target_available: bool) -> Effect {
         || nom_primitives::scan_contains(rest, "to its controller")
     {
         TargetFilter::Controller
-    } else if let Some(anaphor_filter) = TextPair::new(text, &lower)
+    } else if let Some(filter) = TextPair::new(text, &lower)
         .strip_after("dealt to ")
-        .and_then(|tp| parse_anaphoric_target_ref(tp.original, parent_target_available))
-        .map(|(filter, _)| filter)
+        .and_then(|tp| {
+            resolve_prevent_recipient(tp, parent_target_available, &chain_prior_mass_population)
+        })
     {
-        // CR 608.2c: "prevent [amount] damage that would be dealt to that
-        // creature/it/the creature this turn" — a single-direction anaphor
-        // bound to a target an earlier clause selected. Strict superset of the
-        // prior `Any` fallback (only reached when `parent_target_available`).
-        anaphor_filter
+        // CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): see
+        // `resolve_prevent_recipient` — a chosen-target anaphor, a
+        // clause-derived population anaphor, or any other recipient phrase
+        // `parse_target` recognizes. Strict superset of the prior `Any`
+        // fallback: a recipient phrase that no tier recognizes still falls
+        // through to `Any` below.
+        filter
     } else {
         // Default: "that would be dealt" with no specific target → Any
         TargetFilter::Any
@@ -11966,6 +12046,7 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             UtilityImperativeAst::Prevent {
                 ref text,
                 parent_target_available,
+                ref chain_prior_mass_population,
             },
         )) => {
             // CR 615 + CR 608.2c (issue #1094): a bidirectional "dealt to and
@@ -11973,9 +12054,11 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             // PreventDamage nodes — tried FIRST, before the distribute path
             // (mutually exclusive markers: no card combines "distributed among"
             // with "dealt to and dealt by").
-            if let Some(clause) =
-                super::lower::try_parse_bidirectional_prevent(text, parent_target_available)
-            {
+            if let Some(clause) = super::lower::try_parse_bidirectional_prevent(
+                text,
+                parent_target_available,
+                chain_prior_mass_population,
+            ) {
                 return clause;
             }
             if let Some(clause) = super::lower::try_parse_prevent_distribute(text) {
@@ -11988,6 +12071,7 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
                 UtilityImperativeAst::Prevent {
                     text: text.clone(),
                     parent_target_available,
+                    chain_prior_mass_population: chain_prior_mass_population.clone(),
                 },
             ))
         }
@@ -20368,6 +20452,7 @@ mod tests {
         let effect = parse_prevent_effect(
             "Prevent all damage target instant or sorcery spell would deal this turn.",
             false,
+            None,
         );
         let Effect::PreventDamage {
             amount,
@@ -20413,6 +20498,7 @@ mod tests {
         let effect = parse_prevent_effect(
             "Prevent the next 3 damage that would be dealt to target creature this turn.",
             false,
+            None,
         );
         let Effect::PreventDamage {
             amount,
@@ -20442,6 +20528,7 @@ mod tests {
         let effect = parse_prevent_effect(
             "Prevent all combat damage that other creatures would deal this turn.",
             false,
+            None,
         );
         let Effect::PreventDamage {
             amount,
@@ -20493,7 +20580,7 @@ mod tests {
             ),
         ];
         for (text, expected) in cases {
-            let effect = parse_prevent_effect(text, false);
+            let effect = parse_prevent_effect(text, false, None);
             let Effect::PreventDamage {
                 prevention_duration,
                 ..
@@ -20519,7 +20606,8 @@ mod tests {
 
         let planeswalker_text =
             "Prevent all damage that would be dealt to you and planeswalkers you control this turn.";
-        let Effect::PreventDamage { target, .. } = parse_prevent_effect(planeswalker_text, false)
+        let Effect::PreventDamage { target, .. } =
+            parse_prevent_effect(planeswalker_text, false, None)
         else {
             panic!("expected PreventDamage");
         };
@@ -20532,7 +20620,8 @@ mod tests {
 
         let permanents_text =
             "Prevent all damage that would be dealt to you and permanents you control this turn.";
-        let Effect::PreventDamage { target, .. } = parse_prevent_effect(permanents_text, false)
+        let Effect::PreventDamage { target, .. } =
+            parse_prevent_effect(permanents_text, false, None)
         else {
             panic!("expected PreventDamage");
         };
@@ -20549,7 +20638,7 @@ mod tests {
     #[test]
     fn prevent_plain_to_you_recipient_stays_controller() {
         let text = "Prevent all damage that would be dealt to you this turn.";
-        let Effect::PreventDamage { target, .. } = parse_prevent_effect(text, false) else {
+        let Effect::PreventDamage { target, .. } = parse_prevent_effect(text, false, None) else {
             panic!("expected PreventDamage");
         };
         assert_eq!(target, TargetFilter::Controller);
@@ -20568,7 +20657,7 @@ mod tests {
         let Effect::PreventDamage {
             damage_source_filter,
             ..
-        } = parse_prevent_effect(text, false)
+        } = parse_prevent_effect(text, false, None)
         else {
             panic!("expected PreventDamage");
         };
@@ -20579,6 +20668,96 @@ mod tests {
         assert!(
             tf.type_filters.is_empty(),
             "\"sources\" carries no type restriction"
+        );
+    }
+
+    /// CR 615.1 (issue #6682 regression guard): a prevent clause with NO
+    /// recipient phrase at all ("prevent all damage that would be dealt this
+    /// turn" — a plain Fog effect) must still resolve to `Any`. Only a
+    /// clause that carries an explicit "dealt to <recipient>" phrase should
+    /// ever be scoped away from the blanket shield — the fix must not turn a
+    /// genuinely unscoped prevent into a falsely-narrowed one.
+    #[test]
+    fn fog_with_no_recipient_phrase_stays_any() {
+        let effect = parse_prevent_effect(
+            "Prevent all damage that would be dealt this turn.",
+            false,
+            None,
+        );
+        let Effect::PreventDamage { target, .. } = effect else {
+            panic!("expected PreventDamage");
+        };
+        assert_eq!(target, TargetFilter::Any);
+    }
+
+    /// CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): `resolve_prevent_recipient`
+    /// tries a chosen-target anaphor, then a clause-derived population
+    /// anaphor, then any other `parse_target`-recognized recipient, in that
+    /// priority order, and returns `None` (not `Any`) only when nothing
+    /// recognizes the phrase.
+    #[test]
+    fn resolve_prevent_recipient_tries_tiers_in_priority_order() {
+        // Tier 1: a singular chosen-target anaphor wins when available, even
+        // if a clause-derived population is ALSO present.
+        let population = TargetFilter::Typed(TypedFilter::creature());
+        let text = "that creature this turn.";
+        let lower = text.to_lowercase();
+        let tp = TextPair::new(text, &lower);
+        assert_eq!(
+            resolve_prevent_recipient(tp, true, &Some(population.clone())),
+            Some(TargetFilter::ParentTarget),
+            "a chosen-target anaphor must win over a clause-derived population"
+        );
+
+        // Tier 2: "those permanents"/"those creatures" binds to the
+        // clause-derived population when no chosen target is available.
+        let text = "those permanents this turn.";
+        let lower = text.to_lowercase();
+        let tp = TextPair::new(text, &lower);
+        assert_eq!(
+            resolve_prevent_recipient(tp, false, &Some(population.clone())),
+            Some(population),
+            "\"those permanents\" must bind to the clause-derived population"
+        );
+
+        // Tier 3: a bare mass typed recipient with no antecedent at all.
+        let text = "creatures this turn.";
+        let lower = text.to_lowercase();
+        let tp = TextPair::new(text, &lower);
+        let resolved =
+            resolve_prevent_recipient(tp, false, &None).expect("bare \"creatures\" must resolve");
+        assert!(
+            matches!(&resolved, TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature)),
+            "bare \"creatures\" must resolve to a Typed(Creature) filter, got {resolved:?}"
+        );
+
+        // Tier 2 correctly declines (no population to bind to) but tier 3
+        // still recognizes "those permanents"/"those creatures" via
+        // `parse_target`'s own tracked-set dispatch — this is the
+        // TARGET-derived antecedent class (Energy Arc's "those creatures"
+        // referring to earlier-chosen targets, not a continuous-effect
+        // grant), so it must NOT collapse to `None`/`Any` either.
+        let text = "those creatures this turn.";
+        let lower = text.to_lowercase();
+        let tp = TextPair::new(text, &lower);
+        assert_eq!(
+            resolve_prevent_recipient(tp, false, &None),
+            Some(TargetFilter::TrackedSet {
+                id: crate::types::identifiers::TrackedSetId(0)
+            }),
+            "\"those creatures\" with no clause-derived population must still bind via \
+             parse_target's tracked-set dispatch (the target-derived antecedent class)"
+        );
+
+        // None of the tiers recognize a genuinely unclassified recipient
+        // phrase — `resolve_prevent_recipient` returns `None`, not `Any`.
+        let text = "xyzzy this turn.";
+        let lower = text.to_lowercase();
+        let tp = TextPair::new(text, &lower);
+        assert_eq!(
+            resolve_prevent_recipient(tp, false, &None),
+            None,
+            "an unclassified recipient phrase must fall through, not silently guess"
         );
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -5165,11 +5165,6 @@ pub(super) fn parse_utility_imperative_ast(
                 // to. This is the one construction site where `ParseContext` is
                 // live; downstream lowering has only the captured flag.
                 parent_target_available: ctx.parent_target_available,
-                // CR 611.2c + CR 615.11 (issue #6682): capture the population
-                // an earlier same-chain Continuous-mode static grant locked
-                // onto, for a "those permanents"/"those creatures" recipient
-                // anaphor to bind to.
-                chain_prior_mass_population: ctx.chain_prior_mass_population.clone(),
             }),
             "regenerate" => Some(UtilityImperativeAst::Regenerate {
                 text: text.to_string(),
@@ -5853,8 +5848,7 @@ pub(super) fn lower_utility_imperative_ast(ast: UtilityImperativeAst) -> Effect 
         UtilityImperativeAst::Prevent {
             text,
             parent_target_available,
-            chain_prior_mass_population,
-        } => parse_prevent_effect(&text, parent_target_available, chain_prior_mass_population),
+        } => parse_prevent_effect(&text, parent_target_available),
         UtilityImperativeAst::Regenerate { text } => {
             let lower = text.to_lowercase();
             let rest = tag::<_, _, OracleError<'_>>("regenerate ")
@@ -5915,17 +5909,6 @@ pub(super) fn parse_prevention_amount(rest: &str) -> PreventionAmount {
     }
 }
 
-/// CR 608.2c: "those permanents"/"those creatures" head-noun check for the
-/// prevent-recipient dispatch below. Mirrors the identical phrase pair
-/// already listed in `oracle_target::parse_target`'s `TRACKED_SET_PHRASES`
-/// and `contains_explicit_tracked_set_pronoun` (this module) — kept as its
-/// own tiny combinator here (rather than a third shared list) because this
-/// call site needs an anchored prefix match on the recipient phrase, not a
-/// scan-anywhere-in-the-clause check.
-fn parse_those_population_anaphor(input: &str) -> OracleResult<'_, ()> {
-    value((), alt((tag("those permanents"), tag("those creatures")))).parse(input)
-}
-
 /// CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): Resolve a prevent-damage
 /// recipient phrase — the text immediately following "dealt to " or "dealt to
 /// and dealt by " — to a `TargetFilter`. Shared by [`parse_prevent_effect`]
@@ -5935,34 +5918,31 @@ fn parse_those_population_anaphor(input: &str) -> OracleResult<'_, ()> {
 /// Tries, in priority order:
 /// 1. A singular chosen-target anaphor ("that creature"/"it"/"the creature"),
 ///    gated on `parent_target_available` (CR 608.2c, issue #1094).
-/// 2. "those permanents"/"those creatures" bound to the population an
-///    earlier same-chain Continuous-mode static grant locked onto
-///    (`chain_prior_mass_population`) — Mutational Advantage's official
-///    ruling: "The set of permanents affected by Mutational Advantage is
-///    determined at the time Mutational Advantage resolves."
-/// 3. Any other recipient phrase `parse_target` recognizes as a real filter —
+/// 2. Any other recipient phrase `parse_target` recognizes as a real filter —
 ///    mass typed recipients ("creatures"/"players"/"creatures you control" —
-///    Blinding Fog, Defend the Hearth) and target-derived "those creatures"
-///    anaphors that resolve to a `TrackedSet` sentinel when a chosen-target
-///    clause precedes them (Energy Arc; resolved to a concrete, stable set id
-///    at shield-creation time by `prevent_damage::resolve`).
+///    Blinding Fog, Defend the Hearth) AND "those permanents"/"those
+///    creatures", which `parse_target` already maps to a `TrackedSet`
+///    sentinel. The sentinel is resolved to a concrete, FROZEN set id at
+///    shield-creation time by `prevent_damage::resolve` — never left as a
+///    live filter — because the antecedent population must be locked in at
+///    resolution regardless of whether it came from a chosen-target clause
+///    (Energy Arc's untapped creatures) or a Continuous-mode static grant
+///    (Mutational Advantage's countered permanents: the resolution-time
+///    population is enumerated once by the widened `GenericEffect` arm in
+///    `game::effects::affected_objects_from_events`). Mutational Advantage's
+///    official ruling: "The set of permanents affected by Mutational
+///    Advantage is determined at the time Mutational Advantage resolves."
 ///
-/// Returns `None` only when none of the above recognize the phrase — the
-/// caller then falls back to the pre-existing `Any` default.
+/// Returns `None` only when neither tier recognizes the phrase — the caller
+/// then falls back to the pre-existing `Any` default.
 pub(super) fn resolve_prevent_recipient(
     recipient: TextPair<'_>,
     parent_target_available: bool,
-    chain_prior_mass_population: &Option<TargetFilter>,
 ) -> Option<TargetFilter> {
     if let Some((filter, _)) =
         parse_anaphoric_target_ref(recipient.original, parent_target_available)
     {
         return Some(filter);
-    }
-    if parse_those_population_anaphor(recipient.lower).is_ok() {
-        if let Some(filter) = chain_prior_mass_population.clone() {
-            return Some(filter);
-        }
     }
     // CR 608.2c: `ParentTarget`/`TriggeringSource`/`CostPaidObject`/`SelfRef`
     // are inherited-reference filters naming a specific already-established
@@ -5988,17 +5968,7 @@ pub(super) fn resolve_prevent_recipient(
 /// the same effect chain selected a target that a trailing anaphor ("that
 /// creature" / "the creature" / "it") can bind to via `ParentTarget`. When
 /// false the anaphor recognizer is a no-op and the target falls back to `Any`.
-///
-/// CR 611.2c + CR 615.11 (issue #6682): `chain_prior_mass_population` carries
-/// the population an earlier same-chain Continuous-mode static grant locked
-/// onto (Mutational Advantage's hexproof/indestructible clause), for a
-/// "those permanents"/"those creatures" recipient anaphor to bind to — see
-/// [`resolve_prevent_recipient`].
-fn parse_prevent_effect(
-    text: &str,
-    parent_target_available: bool,
-    chain_prior_mass_population: Option<TargetFilter>,
-) -> Effect {
+fn parse_prevent_effect(text: &str, parent_target_available: bool) -> Effect {
     let lower = text.to_lowercase();
     let rest = tag::<_, _, OracleError<'_>>("prevent ")
         .parse(&*lower)
@@ -6078,16 +6048,13 @@ fn parse_prevent_effect(
         TargetFilter::Controller
     } else if let Some(filter) = TextPair::new(text, &lower)
         .strip_after("dealt to ")
-        .and_then(|tp| {
-            resolve_prevent_recipient(tp, parent_target_available, &chain_prior_mass_population)
-        })
+        .and_then(|tp| resolve_prevent_recipient(tp, parent_target_available))
     {
         // CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): see
-        // `resolve_prevent_recipient` — a chosen-target anaphor, a
-        // clause-derived population anaphor, or any other recipient phrase
-        // `parse_target` recognizes. Strict superset of the prior `Any`
-        // fallback: a recipient phrase that no tier recognizes still falls
-        // through to `Any` below.
+        // `resolve_prevent_recipient` — a chosen-target anaphor or any other
+        // recipient phrase `parse_target` recognizes. Strict superset of the
+        // prior `Any` fallback: a recipient phrase that no tier recognizes
+        // still falls through to `Any` below.
         filter
     } else {
         // Default: "that would be dealt" with no specific target → Any
@@ -12046,7 +12013,6 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             UtilityImperativeAst::Prevent {
                 ref text,
                 parent_target_available,
-                ref chain_prior_mass_population,
             },
         )) => {
             // CR 615 + CR 608.2c (issue #1094): a bidirectional "dealt to and
@@ -12054,11 +12020,9 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             // PreventDamage nodes — tried FIRST, before the distribute path
             // (mutually exclusive markers: no card combines "distributed among"
             // with "dealt to and dealt by").
-            if let Some(clause) = super::lower::try_parse_bidirectional_prevent(
-                text,
-                parent_target_available,
-                chain_prior_mass_population,
-            ) {
+            if let Some(clause) =
+                super::lower::try_parse_bidirectional_prevent(text, parent_target_available)
+            {
                 return clause;
             }
             if let Some(clause) = super::lower::try_parse_prevent_distribute(text) {
@@ -12071,7 +12035,6 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
                 UtilityImperativeAst::Prevent {
                     text: text.clone(),
                     parent_target_available,
-                    chain_prior_mass_population: chain_prior_mass_population.clone(),
                 },
             ))
         }
@@ -20452,7 +20415,6 @@ mod tests {
         let effect = parse_prevent_effect(
             "Prevent all damage target instant or sorcery spell would deal this turn.",
             false,
-            None,
         );
         let Effect::PreventDamage {
             amount,
@@ -20498,7 +20460,6 @@ mod tests {
         let effect = parse_prevent_effect(
             "Prevent the next 3 damage that would be dealt to target creature this turn.",
             false,
-            None,
         );
         let Effect::PreventDamage {
             amount,
@@ -20528,7 +20489,6 @@ mod tests {
         let effect = parse_prevent_effect(
             "Prevent all combat damage that other creatures would deal this turn.",
             false,
-            None,
         );
         let Effect::PreventDamage {
             amount,
@@ -20580,7 +20540,7 @@ mod tests {
             ),
         ];
         for (text, expected) in cases {
-            let effect = parse_prevent_effect(text, false, None);
+            let effect = parse_prevent_effect(text, false);
             let Effect::PreventDamage {
                 prevention_duration,
                 ..
@@ -20606,8 +20566,7 @@ mod tests {
 
         let planeswalker_text =
             "Prevent all damage that would be dealt to you and planeswalkers you control this turn.";
-        let Effect::PreventDamage { target, .. } =
-            parse_prevent_effect(planeswalker_text, false, None)
+        let Effect::PreventDamage { target, .. } = parse_prevent_effect(planeswalker_text, false)
         else {
             panic!("expected PreventDamage");
         };
@@ -20620,8 +20579,7 @@ mod tests {
 
         let permanents_text =
             "Prevent all damage that would be dealt to you and permanents you control this turn.";
-        let Effect::PreventDamage { target, .. } =
-            parse_prevent_effect(permanents_text, false, None)
+        let Effect::PreventDamage { target, .. } = parse_prevent_effect(permanents_text, false)
         else {
             panic!("expected PreventDamage");
         };
@@ -20638,7 +20596,7 @@ mod tests {
     #[test]
     fn prevent_plain_to_you_recipient_stays_controller() {
         let text = "Prevent all damage that would be dealt to you this turn.";
-        let Effect::PreventDamage { target, .. } = parse_prevent_effect(text, false, None) else {
+        let Effect::PreventDamage { target, .. } = parse_prevent_effect(text, false) else {
             panic!("expected PreventDamage");
         };
         assert_eq!(target, TargetFilter::Controller);
@@ -20657,7 +20615,7 @@ mod tests {
         let Effect::PreventDamage {
             damage_source_filter,
             ..
-        } = parse_prevent_effect(text, false, None)
+        } = parse_prevent_effect(text, false)
         else {
             panic!("expected PreventDamage");
         };
@@ -20679,83 +20637,67 @@ mod tests {
     /// genuinely unscoped prevent into a falsely-narrowed one.
     #[test]
     fn fog_with_no_recipient_phrase_stays_any() {
-        let effect = parse_prevent_effect(
-            "Prevent all damage that would be dealt this turn.",
-            false,
-            None,
-        );
+        let effect =
+            parse_prevent_effect("Prevent all damage that would be dealt this turn.", false);
         let Effect::PreventDamage { target, .. } = effect else {
             panic!("expected PreventDamage");
         };
         assert_eq!(target, TargetFilter::Any);
     }
 
-    /// CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): `resolve_prevent_recipient`
-    /// tries a chosen-target anaphor, then a clause-derived population
-    /// anaphor, then any other `parse_target`-recognized recipient, in that
-    /// priority order, and returns `None` (not `Any`) only when nothing
-    /// recognizes the phrase.
+    /// CR 608.2c + CR 615.11 (issue #6682): `resolve_prevent_recipient` tries a
+    /// chosen-target anaphor, then any other `parse_target`-recognized
+    /// recipient, in that priority order, and returns `None` (not `Any`) only
+    /// when neither tier recognizes the phrase.
     #[test]
     fn resolve_prevent_recipient_tries_tiers_in_priority_order() {
-        // Tier 1: a singular chosen-target anaphor wins when available, even
-        // if a clause-derived population is ALSO present.
-        let population = TargetFilter::Typed(TypedFilter::creature());
+        // Tier 1: a singular chosen-target anaphor.
         let text = "that creature this turn.";
         let lower = text.to_lowercase();
         let tp = TextPair::new(text, &lower);
         assert_eq!(
-            resolve_prevent_recipient(tp, true, &Some(population.clone())),
+            resolve_prevent_recipient(tp, true),
             Some(TargetFilter::ParentTarget),
-            "a chosen-target anaphor must win over a clause-derived population"
+            "a chosen-target anaphor must resolve to ParentTarget"
         );
 
-        // Tier 2: "those permanents"/"those creatures" binds to the
-        // clause-derived population when no chosen target is available.
-        let text = "those permanents this turn.";
-        let lower = text.to_lowercase();
-        let tp = TextPair::new(text, &lower);
-        assert_eq!(
-            resolve_prevent_recipient(tp, false, &Some(population.clone())),
-            Some(population),
-            "\"those permanents\" must bind to the clause-derived population"
-        );
-
-        // Tier 3: a bare mass typed recipient with no antecedent at all.
+        // Tier 2: a bare mass typed recipient with no antecedent at all.
         let text = "creatures this turn.";
         let lower = text.to_lowercase();
         let tp = TextPair::new(text, &lower);
         let resolved =
-            resolve_prevent_recipient(tp, false, &None).expect("bare \"creatures\" must resolve");
+            resolve_prevent_recipient(tp, false).expect("bare \"creatures\" must resolve");
         assert!(
             matches!(&resolved, TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature)),
             "bare \"creatures\" must resolve to a Typed(Creature) filter, got {resolved:?}"
         );
 
-        // Tier 2 correctly declines (no population to bind to) but tier 3
-        // still recognizes "those permanents"/"those creatures" via
-        // `parse_target`'s own tracked-set dispatch — this is the
-        // TARGET-derived antecedent class (Energy Arc's "those creatures"
-        // referring to earlier-chosen targets, not a continuous-effect
-        // grant), so it must NOT collapse to `None`/`Any` either.
+        // Tier 2 also recognizes "those permanents"/"those creatures" via
+        // `parse_target`'s own tracked-set dispatch — covers BOTH the
+        // target-derived antecedent class (Energy Arc's "those creatures"
+        // referring to earlier-chosen targets) and the clause-derived
+        // antecedent class (Mutational Advantage's "those permanents"
+        // referring to a preceding Continuous-mode grant's population),
+        // since the runtime freezes the tracked set from whichever producer
+        // clause precedes it (see `game::effects::affected_objects_from_events`).
         let text = "those creatures this turn.";
         let lower = text.to_lowercase();
         let tp = TextPair::new(text, &lower);
         assert_eq!(
-            resolve_prevent_recipient(tp, false, &None),
+            resolve_prevent_recipient(tp, false),
             Some(TargetFilter::TrackedSet {
                 id: crate::types::identifiers::TrackedSetId(0)
             }),
-            "\"those creatures\" with no clause-derived population must still bind via \
-             parse_target's tracked-set dispatch (the target-derived antecedent class)"
+            "\"those creatures\" must bind via parse_target's tracked-set dispatch"
         );
 
-        // None of the tiers recognize a genuinely unclassified recipient
-        // phrase — `resolve_prevent_recipient` returns `None`, not `Any`.
+        // Neither tier recognizes a genuinely unclassified recipient phrase —
+        // `resolve_prevent_recipient` returns `None`, not `Any`.
         let text = "xyzzy this turn.";
         let lower = text.to_lowercase();
         let tp = TextPair::new(text, &lower);
         assert_eq!(
-            resolve_prevent_recipient(tp, false, &None),
+            resolve_prevent_recipient(tp, false),
             None,
             "an unclassified recipient phrase must fall through, not silently guess"
         );

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -7092,7 +7092,6 @@ pub(super) fn try_parse_prevent_distribute(text: &str) -> Option<ParsedEffectCla
 pub(super) fn try_parse_bidirectional_prevent(
     text: &str,
     parent_target_available: bool,
-    chain_prior_mass_population: &Option<TargetFilter>,
 ) -> Option<ParsedEffectClause> {
     let lower = text.to_lowercase();
     // Quick-reject via the bidirectional marker before spending parse effort.
@@ -7120,20 +7119,17 @@ pub(super) fn try_parse_bidirectional_prevent(
     let prevention_duration =
         nom_primitives::scan_preceded(rest, parse_duration).map(|(_, d, _)| d);
 
-    // CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): isolate the anaphor
-    // phrase following the bidirectional marker and resolve it via the same
-    // three-tier recipient resolution `parse_prevent_effect` uses (chosen
-    // target anaphor / clause-derived population / any other recognized
-    // filter — Energy Arc's "those creatures" is the target-derived-anaphor
-    // tier). `None` when no tier recognizes it — a standalone "dealt to and
-    // dealt by that creature" with no prior target-selecting clause must NOT
-    // split into ParentTarget shields.
+    // CR 608.2c + CR 615: isolate the anaphor phrase following the
+    // bidirectional marker and resolve it via the same recipient resolution
+    // `parse_prevent_effect` uses (chosen target anaphor / any other
+    // recognized filter — Energy Arc's "those creatures" resolves via
+    // `parse_target`'s `TrackedSet` dispatch). `None` when no tier
+    // recognizes it — a standalone "dealt to and dealt by that creature"
+    // with no prior target-selecting clause must NOT split into ParentTarget
+    // shields.
     let anaphor_tp = TextPair::new(text, &lower).strip_after("dealt to and dealt by ")?;
-    let anaphor_filter = super::imperative::resolve_prevent_recipient(
-        anaphor_tp,
-        parent_target_available,
-        chain_prior_mass_population,
-    )?;
+    let anaphor_filter =
+        super::imperative::resolve_prevent_recipient(anaphor_tp, parent_target_available)?;
 
     // CR 615: the recipient ("to") shield — scoped to the chosen creature as
     // the damage RECIPIENT (target: ParentTarget, no source restriction).
@@ -11006,7 +11002,7 @@ mod tests {
         let text =
             "prevent the next 5 damage divided as you choose among any number of target creatures";
         assert!(
-            super::try_parse_bidirectional_prevent(text, true, &None).is_none(),
+            super::try_parse_bidirectional_prevent(text, true).is_none(),
             "distribute clause must not be claimed by the bidirectional interceptor"
         );
         // And the distribute path still parses it (ordering safety).
@@ -11023,7 +11019,7 @@ mod tests {
         use crate::types::ability::{PreventionScope, SubAbilityLink, TargetFilter};
         let text =
             "prevent all combat damage that would be dealt to and dealt by that creature this turn";
-        let clause = super::try_parse_bidirectional_prevent(text, true, &None)
+        let clause = super::try_parse_bidirectional_prevent(text, true)
             .expect("bidirectional split with gate enabled");
         match &clause.effect {
             Effect::PreventDamage {
@@ -11056,7 +11052,7 @@ mod tests {
         }
         // Gate off ⇒ no split.
         assert!(
-            super::try_parse_bidirectional_prevent(text, false, &None).is_none(),
+            super::try_parse_bidirectional_prevent(text, false).is_none(),
             "gate false ⇒ interceptor is a no-op"
         );
     }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -18,8 +18,8 @@ use super::super::oracle_quantity::{
     parse_player_attribute_attr_clause, parse_quantity_ref,
 };
 use super::super::oracle_target::{
-    parse_anaphoric_target_ref, parse_target, parse_target_with_ctx, parse_that_clause_suffix,
-    parse_type_phrase, parse_type_phrase_with_ctx,
+    parse_target, parse_target_with_ctx, parse_that_clause_suffix, parse_type_phrase,
+    parse_type_phrase_with_ctx,
 };
 use super::super::oracle_util::{parse_comparator_prefix, parse_count_expr, strip_after, TextPair};
 use crate::parser::oracle_ir::ast::*;
@@ -7092,6 +7092,7 @@ pub(super) fn try_parse_prevent_distribute(text: &str) -> Option<ParsedEffectCla
 pub(super) fn try_parse_bidirectional_prevent(
     text: &str,
     parent_target_available: bool,
+    chain_prior_mass_population: &Option<TargetFilter>,
 ) -> Option<ParsedEffectClause> {
     let lower = text.to_lowercase();
     // Quick-reject via the bidirectional marker before spending parse effort.
@@ -7119,14 +7120,20 @@ pub(super) fn try_parse_bidirectional_prevent(
     let prevention_duration =
         nom_primitives::scan_preceded(rest, parse_duration).map(|(_, d, _)| d);
 
-    // CR 608.2c: isolate the anaphor phrase following the bidirectional marker
-    // and bind it to the parent's chosen target. `parse_anaphoric_target_ref`
-    // returns `None` when `parent_target_available` is false — the load-bearing
-    // gate (a standalone "dealt to and dealt by that creature" with no prior
-    // target-selecting clause must NOT split into ParentTarget shields).
+    // CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): isolate the anaphor
+    // phrase following the bidirectional marker and resolve it via the same
+    // three-tier recipient resolution `parse_prevent_effect` uses (chosen
+    // target anaphor / clause-derived population / any other recognized
+    // filter — Energy Arc's "those creatures" is the target-derived-anaphor
+    // tier). `None` when no tier recognizes it — a standalone "dealt to and
+    // dealt by that creature" with no prior target-selecting clause must NOT
+    // split into ParentTarget shields.
     let anaphor_tp = TextPair::new(text, &lower).strip_after("dealt to and dealt by ")?;
-    let (anaphor_filter, _) =
-        parse_anaphoric_target_ref(anaphor_tp.original, parent_target_available)?;
+    let anaphor_filter = super::imperative::resolve_prevent_recipient(
+        anaphor_tp,
+        parent_target_available,
+        chain_prior_mass_population,
+    )?;
 
     // CR 615: the recipient ("to") shield — scoped to the chosen creature as
     // the damage RECIPIENT (target: ParentTarget, no source restriction).
@@ -10999,7 +11006,7 @@ mod tests {
         let text =
             "prevent the next 5 damage divided as you choose among any number of target creatures";
         assert!(
-            super::try_parse_bidirectional_prevent(text, true).is_none(),
+            super::try_parse_bidirectional_prevent(text, true, &None).is_none(),
             "distribute clause must not be claimed by the bidirectional interceptor"
         );
         // And the distribute path still parses it (ordering safety).
@@ -11016,7 +11023,7 @@ mod tests {
         use crate::types::ability::{PreventionScope, SubAbilityLink, TargetFilter};
         let text =
             "prevent all combat damage that would be dealt to and dealt by that creature this turn";
-        let clause = super::try_parse_bidirectional_prevent(text, true)
+        let clause = super::try_parse_bidirectional_prevent(text, true, &None)
             .expect("bidirectional split with gate enabled");
         match &clause.effect {
             Effect::PreventDamage {
@@ -11049,7 +11056,7 @@ mod tests {
         }
         // Gate off ⇒ no split.
         assert!(
-            super::try_parse_bidirectional_prevent(text, false).is_none(),
+            super::try_parse_bidirectional_prevent(text, false, &None).is_none(),
             "gate false ⇒ interceptor is a no-op"
         );
     }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -24461,6 +24461,40 @@ fn clause_ir_mass_population(clause: &ClauseIr) -> Option<TargetFilter> {
     mass_population_filter(&clause.parsed.effect).cloned()
 }
 
+/// CR 608.2c + CR 611.2c + CR 615.11 (issue #6682): If this clause is a
+/// `GenericEffect` Continuous-mode static grant over a BROADCAST population (a
+/// keyword/P-T/ability "gain(s)"/"have"/"has" grant, not a chosen-target
+/// application), return the population filter it establishes. Feeds
+/// `ParseContext::chain_prior_mass_population` alongside
+/// `clause_ir_mass_population` so a later same-chain "those permanents"/
+/// "those creatures" anaphor binds to the SAME population the grant locked
+/// onto. Mutational Advantage's official ruling: "The set of permanents
+/// affected by Mutational Advantage is determined at the time Mutational
+/// Advantage resolves." Mirrors `is_mass_coerce_static`'s governing-filter
+/// selection but is not restricted to the MustAttack/MustAttackPlayer
+/// coercion statics that function targets — any Continuous static grant over
+/// a broadcast population qualifies. Only a single static definition is
+/// accepted: a `GenericEffect` carrying two or more static defs has no single
+/// population to name without risking a wrong-antecedent guess.
+fn clause_ir_continuous_grant_population(clause: &ClauseIr) -> Option<TargetFilter> {
+    let Effect::GenericEffect {
+        static_abilities,
+        target: None,
+        ..
+    } = &clause.parsed.effect
+    else {
+        return None;
+    };
+    let [static_def] = static_abilities.as_slice() else {
+        return None;
+    };
+    if static_def.mode != StaticMode::Continuous {
+        return None;
+    }
+    let filter = static_def.affected.as_ref()?;
+    is_broadcast_population_filter(filter).then(|| filter.clone())
+}
+
 /// CR 400.1/400.2 + CR 601.2a: Map a possessive-hand player reference (as
 /// produced by `parse_hand_possessive_target`) to the `ControllerRef` axis
 /// used to scope a card filter to that same player's hand. Exhaustive over
@@ -29970,11 +30004,14 @@ pub(crate) fn parse_effect_chain_ir(
             // than reaching past it to the trigger's own subject (Ardbert,
             // Warrior of Darkness). Mass effects choose nothing, so
             // `parent_target_available` / `ParentTarget` cannot carry this.
-            chain_prior_mass_population: builder
-                .clauses()
-                .iter()
-                .rev()
-                .find_map(clause_ir_mass_population),
+            // CR 611.2c + CR 615.11 (issue #6682): also matches a preceding
+            // Continuous-mode keyword/P-T grant clause (Mutational Advantage,
+            // Blinding Fog), so a later "those permanents"/"those creatures"
+            // prevent-recipient anaphor binds to the SAME locked-in
+            // population instead of falling back to `Any`.
+            chain_prior_mass_population: builder.clauses().iter().rev().find_map(|d| {
+                clause_ir_mass_population(d).or_else(|| clause_ir_continuous_grant_population(d))
+            }),
             // CR 608.2c: bind a bare "it" in this chunk's counter/anaphor to the
             // token created by an earlier clause when that token is the chain's
             // most-recent object referent (Esper Terra's "put up to three lore

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -49543,6 +49543,146 @@ fn they_binds_producer_population_across_mass_effect_family() {
     }
 }
 
+/// CR 611.2c + CR 615.11 (issue #6682): Mutational Advantage's second clause
+/// ("Prevent all damage that would be dealt to those permanents this turn")
+/// must scope the shield to the SAME population its first clause locked onto
+/// ("Permanents you control with counters on them") — not the `Any` fallback
+/// that silently protected every permanent in the game, including
+/// opponents'. Verified against the official ruling: "The set of permanents
+/// affected by Mutational Advantage is determined at the time Mutational
+/// Advantage resolves."
+#[test]
+fn mutational_advantage_prevent_binds_to_countered_permanents_population() {
+    let def = parse_effect_chain(
+        "Permanents you control with counters on them gain hexproof and indestructible \
+         until end of turn. Prevent all damage that would be dealt to those permanents \
+         this turn.",
+        AbilityKind::Spell,
+    );
+
+    let Effect::GenericEffect {
+        static_abilities,
+        target: None,
+        ..
+    } = &*def.effect
+    else {
+        panic!(
+            "expected the hexproof/indestructible grant, got {:?}",
+            def.effect
+        );
+    };
+    let population = static_abilities
+        .first()
+        .and_then(|sd| sd.affected.clone())
+        .expect("the grant clause must carry an affected population filter");
+
+    let prevent = def
+        .sub_ability
+        .as_deref()
+        .expect("the prevent clause must chain after the grant");
+    let Effect::PreventDamage { target, .. } = &*prevent.effect else {
+        panic!("expected PreventDamage, got {:?}", prevent.effect);
+    };
+    assert_eq!(
+        *target, population,
+        "the prevention shield must bind to the SAME population the grant locked onto, \
+         not Any"
+    );
+    assert_ne!(
+        *target,
+        TargetFilter::Any,
+        "must never silently protect every permanent in the game"
+    );
+}
+
+/// CR 615.1 (issue #6682): Blinding Fog's bare "creatures" recipient (no
+/// anaphor, no antecedent clause — the prevent clause comes FIRST) must
+/// resolve to an unqualified `Typed(Creature)` mass filter via `parse_target`'s
+/// shared grammar, not the `Any` fallback that silently prevented damage to
+/// players too.
+#[test]
+fn blinding_fog_prevent_binds_to_bare_creatures_recipient() {
+    let def = parse_effect_chain(
+        "Prevent all damage that would be dealt to creatures this turn. Creatures you \
+         control gain hexproof until end of turn.",
+        AbilityKind::Spell,
+    );
+    let Effect::PreventDamage { target, .. } = &*def.effect else {
+        panic!("expected PreventDamage, got {:?}", def.effect);
+    };
+    assert!(
+        matches!(
+            target,
+            TargetFilter::Typed(tf)
+                if tf.type_filters.contains(&TypeFilter::Creature) && tf.controller.is_none()
+        ),
+        "bare \"creatures\" must resolve to an unqualified Typed(Creature) filter, got {target:?}"
+    );
+}
+
+/// CR 615.1 (issue #6682): Defend the Hearth's bare "players" recipient must
+/// resolve to `TargetFilter::Player`, not the `Any` fallback that silently
+/// prevented combat damage to creatures too.
+#[test]
+fn defend_the_hearth_prevent_binds_to_bare_players_recipient() {
+    let def = parse_effect_chain(
+        "Prevent all combat damage that would be dealt to players this turn.",
+        AbilityKind::Spell,
+    );
+    let Effect::PreventDamage { target, scope, .. } = &*def.effect else {
+        panic!("expected PreventDamage, got {:?}", def.effect);
+    };
+    assert_eq!(*target, TargetFilter::Player);
+    assert_eq!(*scope, PreventionScope::CombatDamage);
+}
+
+/// CR 608.2c + CR 615 (issue #6682): Energy Arc's bidirectional "dealt to and
+/// dealt by those creatures" must bind BOTH shields to the untapped creatures
+/// selected by the preceding clause — a target-derived tracked-set anaphor —
+/// not the `Any` fallback that silently protected/exposed every creature.
+#[test]
+fn energy_arc_bidirectional_prevent_binds_to_untapped_targets() {
+    let def = parse_effect_chain(
+        "Untap any number of target creatures. Prevent all combat damage that would be \
+         dealt to and dealt by those creatures this turn.",
+        AbilityKind::Spell,
+    );
+    let prevent = def
+        .sub_ability
+        .as_deref()
+        .expect("the prevent clause must chain after the untap");
+    let Effect::PreventDamage { target, .. } = &*prevent.effect else {
+        panic!(
+            "expected the recipient (\"to\") shield, got {:?}",
+            prevent.effect
+        );
+    };
+    assert!(
+        matches!(target, TargetFilter::TrackedSet { .. }),
+        "the recipient shield must bind to the untapped-creatures tracked set, got {target:?}"
+    );
+    assert_ne!(*target, TargetFilter::Any);
+
+    let by_ability = prevent
+        .sub_ability
+        .as_deref()
+        .expect("the source (\"by\") shield must chain as a sequential sibling");
+    let Effect::PreventDamage {
+        damage_source_filter,
+        ..
+    } = &*by_ability.effect
+    else {
+        panic!(
+            "expected the source (\"by\") shield, got {:?}",
+            by_ability.effect
+        );
+    };
+    assert!(
+        matches!(damage_source_filter, Some(TargetFilter::TrackedSet { .. })),
+        "the source shield must also bind to the same tracked set, got {damage_source_filter:?}"
+    );
+}
+
 /// CR 111.3 + CR 118.12: A token created "with" a quoted activated ability whose
 /// effect is a soft counter ("Counter … unless its controller pays {mana}") must
 /// carry that whole ability, unless-pay included, on the TOKEN. Mage's Attendant's

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -49545,12 +49545,19 @@ fn they_binds_producer_population_across_mass_effect_family() {
 
 /// CR 611.2c + CR 615.11 (issue #6682): Mutational Advantage's second clause
 /// ("Prevent all damage that would be dealt to those permanents this turn")
-/// must scope the shield to the SAME population its first clause locked onto
-/// ("Permanents you control with counters on them") — not the `Any` fallback
-/// that silently protected every permanent in the game, including
-/// opponents'. Verified against the official ruling: "The set of permanents
+/// must NOT collapse to the `Any` fallback that silently protected every
+/// permanent in the game, including opponents'. "Those permanents" resolves
+/// to a `TrackedSet` sentinel — `parse_target`'s existing dispatch for the
+/// phrase (shared with Energy Arc's target-derived "those creatures") —
+/// which `prevent_damage::resolve` then resolves to a concrete, FROZEN set
+/// id at shield-creation time (see
+/// `mutational_advantage_shield_freezes_population_at_resolution` in
+/// `game::effects::prevent_damage::tests` for the runtime freeze semantics:
+/// verified against the official ruling that "the set of permanents
 /// affected by Mutational Advantage is determined at the time Mutational
-/// Advantage resolves."
+/// Advantage resolves"). Binding directly to a live copy of the grant's
+/// filter would re-check "has a counter" at every future damage event,
+/// which the ruling explicitly forbids.
 #[test]
 fn mutational_advantage_prevent_binds_to_countered_permanents_population() {
     let def = parse_effect_chain(
@@ -49571,7 +49578,7 @@ fn mutational_advantage_prevent_binds_to_countered_permanents_population() {
             def.effect
         );
     };
-    let population = static_abilities
+    static_abilities
         .first()
         .and_then(|sd| sd.affected.clone())
         .expect("the grant clause must carry an affected population filter");
@@ -49584,14 +49591,12 @@ fn mutational_advantage_prevent_binds_to_countered_permanents_population() {
         panic!("expected PreventDamage, got {:?}", prevent.effect);
     };
     assert_eq!(
-        *target, population,
-        "the prevention shield must bind to the SAME population the grant locked onto, \
-         not Any"
-    );
-    assert_ne!(
         *target,
-        TargetFilter::Any,
-        "must never silently protect every permanent in the game"
+        TargetFilter::TrackedSet {
+            id: crate::types::identifiers::TrackedSetId(0)
+        },
+        "\"those permanents\" must resolve to the TrackedSet sentinel, not a live copy \
+         of the grant's filter (which would re-check \"has a counter\" live) or Any"
     );
 }
 

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1211,6 +1211,15 @@ pub(crate) enum UtilityImperativeAst {
         /// `ctx.parent_target_available` at the one construction site where
         /// `ParseContext` is live (issue #1094).
         parent_target_available: bool,
+        /// CR 611.2c + CR 615.11 (issue #6682): the population filter
+        /// established by an earlier same-chain Continuous-mode static grant
+        /// clause (Mutational Advantage's hexproof/indestructible grant,
+        /// Blinding Fog-class cards), if any. Captured from
+        /// `ctx.chain_prior_mass_population` at the same construction site as
+        /// `parent_target_available`, so a "those permanents"/"those
+        /// creatures" recipient anaphor can bind to the SAME locked-in
+        /// population instead of the silently-permissive `Any` fallback.
+        chain_prior_mass_population: Option<TargetFilter>,
     },
     Regenerate {
         text: String,

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1211,15 +1211,6 @@ pub(crate) enum UtilityImperativeAst {
         /// `ctx.parent_target_available` at the one construction site where
         /// `ParseContext` is live (issue #1094).
         parent_target_available: bool,
-        /// CR 611.2c + CR 615.11 (issue #6682): the population filter
-        /// established by an earlier same-chain Continuous-mode static grant
-        /// clause (Mutational Advantage's hexproof/indestructible grant,
-        /// Blinding Fog-class cards), if any. Captured from
-        /// `ctx.chain_prior_mass_population` at the same construction site as
-        /// `parent_target_available`, so a "those permanents"/"those
-        /// creatures" recipient anaphor can bind to the SAME locked-in
-        /// population instead of the silently-permissive `Any` fallback.
-        chain_prior_mass_population: Option<TargetFilter>,
     },
     Regenerate {
         text: String,

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -1629,6 +1629,18 @@ pub fn parse_target_with_syntax<'a>(
         return (TargetFilter::Controller, rest, syntax);
     }
 
+    // CR 615.1 + CR 615.1a: Bare "players" — a mass, untargeted player
+    // recipient with no "target" keyword (Defend the Hearth: "prevent all
+    // combat damage that would be dealt to players this turn"). `Player` has
+    // no `TypeFilter` representation (it is not a card type), so the
+    // `parse_type_filter_word`-based fallback below never recognizes it; this
+    // needs its own bare-noun arm, mirroring the "target player" arm above.
+    if let Some((_, rest)) =
+        nom_on_lower(text, &lower, |input| parse_word_bounded(input, "players"))
+    {
+        return (TargetFilter::Player, rest, syntax);
+    }
+
     // "the top/bottom [N] [type] card[s] of [possessive] library/graveyard"
     // Zone position references that appear as targets of exile/mill/reveal effects.
     // Returns a filter with InZone for the referenced zone and controller.
@@ -11757,6 +11769,24 @@ mod tests {
             matches!(&f, TargetFilter::Typed(tf) if tf.type_filters.contains(&TypeFilter::Creature)),
             "bare \"creatures\" must be a Typed creature filter, got {f:?}"
         );
+    }
+
+    /// CR 615.1 (issue #6682, Defend the Hearth class): bare "players" with no
+    /// "target" keyword must resolve to a mass player recipient, not the
+    /// unclassified `Any` fallback.
+    #[test]
+    fn bare_players_resolves_to_player_filter() {
+        let (f, rest) = parse_target("players");
+        assert_eq!(rest, "");
+        assert_eq!(f, TargetFilter::Player);
+    }
+
+    /// Negative: "players" must still require a word boundary — "playerskip"
+    /// (a hypothetical longer word) must not spuriously match the bare noun.
+    #[test]
+    fn bare_players_requires_word_boundary() {
+        let (f, _rest) = parse_target("playersXYZ");
+        assert_ne!(f, TargetFilter::Player);
     }
 
     /// Recursively check whether any leaf of the filter is `HasChosenName`.


### PR DESCRIPTION
## Summary

Fixes #6682. Mutational Advantage's second clause ("Prevent all damage that would be dealt to those permanents this turn") was parsing its recipient to a blanket `TargetFilter::Any`, protecting **every** permanent in the game instead of only the caster's own countered permanents. The same fallback silently over-broadened Blinding Fog ("creatures"), Defend the Hearth ("players"), and Energy Arc ("dealt to and dealt by those creatures") via three different recipient shapes.

### Root cause

`parse_prevent_effect`'s recipient dispatch never routed the "dealt to `<recipient>`" phrase through the shared `parse_target` grammar — it only handled a closed set of literal phrases (`any target`, `target creature`/`target permanent`, `to you`, a couple of compounds) plus a single-object anaphor gated on a prior chosen target. Anything else — mass typed nouns ("creatures", "players") and the "those permanents"/"those creatures" population anaphor — fell through to `Any`.

### Fix

- **Parser**: a new shared `resolve_prevent_recipient` tier ladder (used by both `parse_prevent_effect` and the bidirectional "dealt to and dealt by" path) tries, in order: (1) a singular chosen-target anaphor, (2) "those permanents"/"those creatures" bound to the population an earlier same-chain Continuous-mode static grant locked onto (a widened `chain_prior_mass_population`, verified against Mutational Advantage's official ruling that the affected set is fixed at resolution), (3) any other recipient `parse_target` recognizes. Also adds a `players` bare-noun grammar arm (`Player` has no `TypeFilter` representation, so it was never reachable before).
- **Runtime**: `prevent_damage::resolve` now freezes a `TrackedSet` sentinel to a concrete id at shield-creation time, so a persisting shield can't drift onto whatever an unrelated later chain happens to publish. `find_applicable_replacements` now enforces `valid_card` against **object** damage targets on the global/stack-sourced shield path — previously ignored entirely for that path (proven by a pre-existing test explicitly asserting the old behavior, now split to cover the player-target case it actually applies to), which meant even a correctly-parsed typed/tracked-set recipient from an instant/sorcery source had no runtime effect.

### CR references

- CR 615.1 / 615.1a — prevention effects as shields
- CR 611.2c — a continuous effect's affected set locks in when it begins
- CR 615.11 — untargeted multi-object prevention shields freeze their population at resolution
- CR 608.2c — cross-clause anaphor resolution follows instruction order

## Test plan

- [x] `cargo test -p phase-engine --lib` — 17,983 passed, 0 failed
- [x] `cargo clippy -p phase-engine --lib -- -D warnings` — clean
- [x] `cargo fmt --all`
- [x] New parser tests: Mutational Advantage, Blinding Fog, Defend the Hearth, Energy Arc (bidirectional), plus a regression guard that a genuinely recipient-free Fog effect still resolves to `Any`
- [x] New runtime tests: `TrackedSet` sentinel resolves to a concrete id immune to a later unrelated chain overwriting it; `valid_card` is now enforced against object damage targets on the global shield path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prevention effects that reference previously selected creatures or permanents.
  * Ensured damage-prevention filters correctly apply to specific object targets while preserving player-target behavior.
  * Fixed shields so tracked recipients remain tied to the original selection, even after later effects create new selections.
  * Corrected population tracking for continuous effects and related damage-source filters.

* **Parser Improvements**
  * Improved recognition of prevention recipients, including bare “players,” typed recipients, and tracked groups.
  * Added support for resolving recipient and source references consistently in bidirectional prevention effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->