### PR TITLE
feat(engine): support Ozai conditional mana static

### DIFF
--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -4963,7 +4963,9 @@ fn apply_combat_assignment_rule_effects_filtered(
 
     for effect in effects {
         let scan_ids = effect_candidate_ids(state, &effect.affected_filter, &mut zone_cache);
-        let ctx = FilterContext::from_source(state, effect.source_id);
+        let condition_controller = combat_effect_condition_controller(state, &effect);
+        let ctx =
+            FilterContext::from_source_with_controller(effect.source_id, condition_controller);
         let affected_ids: Vec<ObjectId> = scan_ids
             .iter()
             .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
@@ -4973,7 +4975,7 @@ fn apply_combat_assignment_rule_effects_filtered(
                     evaluate_condition_with_recipient(
                         state,
                         condition,
-                        combat_effect_condition_controller(state, &effect),
+                        condition_controller,
                         effect.source_id,
                         id,
                     )
@@ -7127,11 +7129,15 @@ pub(crate) fn compute_current_copiable_values(
         gather_active_effects_for_layer(state, Layer::Copy)
             .into_iter()
             .filter(|effect| {
+                let condition_controller = active_effect_condition_controller(state, effect);
                 matches_target_filter(
                     state,
                     object_id,
                     &effect.affected_filter,
-                    &FilterContext::from_source(state, effect.source_id),
+                    &FilterContext::from_source_with_controller(
+                        effect.source_id,
+                        condition_controller,
+                    ),
                 )
             })
             .filter(|effect| {
@@ -8447,6 +8453,45 @@ mod tests {
         assert!(
             !source.assigns_damage_from_toughness,
             "a transient combat rule must remain gated by its captured P0 controller"
+        );
+    }
+
+    #[test]
+    fn transient_combat_rule_filter_uses_captured_controller_after_source_is_stolen() {
+        // CR 109.5 + CR 613.11: a transient combat-assignment effect's
+        // controller-relative recipient filter remains bound to its creator,
+        // even after a later layer-2 effect changes the source's controller.
+        let mut state = setup();
+        let source = make_creature(&mut state, "Transient Combat Source", 2, 2, P0);
+        let p0_recipient = make_creature(&mut state, "P0 Combat Recipient", 2, 2, P0);
+        let p1_recipient = make_creature(&mut state, "P1 Combat Recipient", 2, 2, P1);
+        state.add_transient_continuous_effect(
+            source,
+            P0,
+            Duration::Permanent,
+            creature_you_ctrl(),
+            vec![ContinuousModification::AssignDamageFromToughness],
+            None,
+        );
+        state.add_transient_continuous_effect(
+            source,
+            P1,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: source },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+
+        evaluate_layers(&mut state);
+
+        assert_eq!(state.objects[&source].controller, P1);
+        assert!(
+            state.objects[&p0_recipient].assigns_damage_from_toughness,
+            "the captured P0 controller determines the transient effect's recipients"
+        );
+        assert!(
+            !state.objects[&p1_recipient].assigns_damage_from_toughness,
+            "stealing the source must not retarget the transient effect to P1's creatures"
         );
     }
 

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -949,6 +949,8 @@ fn combat_effect_condition_controller(
 
 /// Resolves the player named by "you" for a condition on either a printed or
 /// resolution-created continuous effect.
+// CR 109.5: "you"/"your" on a static ability refers to the current controller
+// of its source, while a resolved spell or ability retains its controller.
 fn condition_controller(
     state: &GameState,
     transient_id: Option<u64>,
@@ -5990,7 +5992,7 @@ fn apply_continuous_effect_filtered(
         let condition_uses_recipient = effect
             .condition
             .as_ref()
-            .is_some_and(|condition| condition_uses_recipient_context(condition));
+            .is_some_and(condition_uses_recipient_context);
         let non_recipient_condition_passes = effect.condition.as_ref().is_none_or(|condition| {
             condition_uses_recipient
                 || evaluate_condition(state, condition, condition_controller, effect.source_id)

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -49,6 +49,7 @@ use crate::types::zones::Zone;
 struct ActiveCombatAssignmentRuleEffect {
     source_id: ObjectId,
     controller: PlayerId,
+    transient_id: Option<u64>,
     timestamp: u64,
     modification: ContinuousModification,
     affected_filter: TargetFilter,
@@ -916,6 +917,38 @@ pub(crate) fn evaluate_condition_with_recipient(
     recipient_id: ObjectId,
 ) -> bool {
     evaluate_condition_with_context(state, condition, controller, source_id, Some(recipient_id))
+}
+
+/// Selects the controller that supplies "you" for an active effect's
+/// condition. Printed and granted static abilities read their source's current
+/// controller; resolution-created transient continuous effects retain the
+/// controller that created them.
+pub(crate) fn active_effect_condition_controller(
+    state: &GameState,
+    effect: &ActiveContinuousEffect,
+) -> PlayerId {
+    if effect.transient_id.is_some() {
+        effect.controller
+    } else {
+        state
+            .objects
+            .get(&effect.source_id)
+            .map_or(effect.controller, |source| source.controller)
+    }
+}
+
+fn combat_effect_condition_controller(
+    state: &GameState,
+    effect: &ActiveCombatAssignmentRuleEffect,
+) -> PlayerId {
+    if effect.transient_id.is_some() {
+        effect.controller
+    } else {
+        state
+            .objects
+            .get(&effect.source_id)
+            .map_or(effect.controller, |source| source.controller)
+    }
 }
 
 fn condition_uses_recipient_context(condition: &StaticCondition) -> bool {
@@ -3470,15 +3503,10 @@ pub(crate) fn incremental_flush_must_escalate(
     }
 
     // Axis 2b — source-level enabling CONDITION over the EXISTING static-ability
-    // sources, NARROWED to entries that actually perturb the condition. The
-    // condition axis CANNOT be read off the collected `ActiveContinuousEffect`s:
-    // `active_continuous_effects_from_static_definitions` evaluates a
-    // non-recipient-context (source-level) condition as a gate at COLLECTION time
-    // and stores `condition: None` on the resulting effect (only recipient-context
-    // conditions are retained for per-recipient re-evaluation). So a board-
-    // population gate like "as long as you control N creatures" is already consumed
-    // and invisible on the active-effect set. We must inspect the intact
-    // `StaticDefinition.condition` on each live source instead.
+    // sources, NARROWED to entries that actually perturb the condition. Conditions
+    // remain attached to collected effects for application-time evaluation, while
+    // this source walk supplies the before/after truth comparison required for an
+    // incremental full-rebuild decision.
     //
     // CR 611.3a + CR 611.3b: when such a source-level enabling condition depends
     // on board population, an object entering can flip the condition for the
@@ -3530,7 +3558,7 @@ fn active_effects_force_incremental_escalation(
 /// whose enabling `condition` is board-population-dependent AND that one of the
 /// `entered_ids` actually perturbs. Walks the same source set as
 /// `collect_shared_active_continuous_effects` (`for_each_static_effect_source`)
-/// but reads the intact pre-collection `condition` field.
+/// and reads the source definition's `condition` field.
 /// O(active-source-count × entered-count); short-circuits on the first match.
 ///
 /// Three-stage test:
@@ -3545,8 +3573,7 @@ fn active_effects_force_incremental_escalation(
 ///     cannot be summarized by a single board-level boolean
 ///     (`source_condition_gate_passes` only over-approximates them). This
 ///     preserves the d9a40be71 behavior for that class.
-///  3. SOURCE-LEVEL gates (CR 611.3a — a single on/off switch consumed at
-///     collection): apply the truth-delta short-circuit. The static's BEFORE
+///  3. SOURCE-LEVEL gates: apply the truth-delta short-circuit. The static's BEFORE
 ///     truth was cached at the last full eval in `static_gate_truth`; recompute
 ///     AFTER against the live post-entry board. Escalate iff `before != after`.
 ///     Key absent (source not present / phased out at the last full eval) ->
@@ -4276,14 +4303,7 @@ fn active_continuous_effects_from_static_definitions(
             }
         }
 
-        let retained_condition = if let Some(condition) = &def.condition {
-            if !source_condition_gate_passes(state, condition, controller, source_id) {
-                continue;
-            }
-            condition_uses_recipient_context(condition).then(|| condition.clone())
-        } else {
-            None
-        };
+        let retained_condition = def.condition.clone();
 
         let affected_filter = def.affected.clone().unwrap_or(TargetFilter::Any);
         for (mod_index, modification) in def.modifications.iter().enumerate() {
@@ -4446,17 +4466,9 @@ fn expand_granted_static_effects(
             None => continue,
         };
         // CR 109.5 + CR 113.7: "You" inside the granted ability refers to the
-        // recipient's controller. Re-run any inner condition gate with the
-        // recipient as the source so that gating like "during your turn"
-        // resolves against the recipient's controller.
-        let retained_inner_condition = if let Some(condition) = &inner.condition {
-            if !source_condition_gate_passes(state, condition, recipient_controller, recipient_id) {
-                continue;
-            }
-            condition_uses_recipient_context(condition).then(|| condition.clone())
-        } else {
-            None
-        };
+        // recipient's controller. Keep its condition until application, after
+        // preceding layers have established that controller.
+        let retained_inner_condition = inner.condition.clone();
         for (mod_index, modification) in inner.modifications.iter().enumerate() {
             if is_combat_assignment_rule_modification(modification) {
                 continue;
@@ -4785,11 +4797,14 @@ pub(crate) fn gather_transient_continuous_effects(
             continue;
         }
 
-        let retained_condition = tce
-            .condition
-            .as_ref()
-            .filter(|condition| condition_uses_recipient_context(condition))
-            .cloned();
+        let retained_condition = if let Some(condition) = &tce.condition {
+            if !source_condition_gate_passes(state, condition, tce.controller, tce.source_id) {
+                continue;
+            }
+            condition_uses_recipient_context(condition).then(|| condition.clone())
+        } else {
+            None
+        };
 
         for (mod_index, modification) in tce.modifications.iter().enumerate() {
             if is_combat_assignment_rule_modification(modification) {
@@ -4942,7 +4957,7 @@ fn apply_combat_assignment_rule_effects_filtered(
                     evaluate_condition_with_recipient(
                         state,
                         condition,
-                        effect.controller,
+                        combat_effect_condition_controller(state, &effect),
                         effect.source_id,
                         id,
                     )
@@ -5074,14 +5089,7 @@ fn active_combat_assignment_rule_effects_from_static_definitions(
             continue;
         }
 
-        let retained_condition = if let Some(condition) = &def.condition {
-            if !source_condition_gate_passes(state, condition, controller, source_id) {
-                continue;
-            }
-            condition_uses_recipient_context(condition).then(|| condition.clone())
-        } else {
-            None
-        };
+        let retained_condition = def.condition.clone();
 
         let affected_filter = def.affected.clone().unwrap_or(TargetFilter::Any);
         effects.extend(
@@ -5091,6 +5099,7 @@ fn active_combat_assignment_rule_effects_from_static_definitions(
                 .map(|modification| ActiveCombatAssignmentRuleEffect {
                     source_id,
                     controller,
+                    transient_id: None,
                     timestamp,
                     modification: modification.clone(),
                     affected_filter: affected_filter.clone(),
@@ -5136,6 +5145,7 @@ fn collect_transient_combat_assignment_rule_effects(
                 .map(|modification| ActiveCombatAssignmentRuleEffect {
                     source_id: tce.source_id,
                     controller: tce.controller,
+                    transient_id: Some(tce.id),
                     timestamp: tce.timestamp,
                     modification: modification.clone(),
                     affected_filter: tce.affected.clone(),
@@ -5977,7 +5987,7 @@ fn apply_continuous_effect_filtered(
                     evaluate_condition_with_recipient(
                         state,
                         condition,
-                        effect.controller,
+                        active_effect_condition_controller(state, effect),
                         effect.source_id,
                         id,
                     )
@@ -7105,7 +7115,7 @@ pub(crate) fn compute_current_copiable_values(
                     evaluate_condition_with_recipient(
                         state,
                         condition,
-                        effect.controller,
+                        active_effect_condition_controller(state, effect),
                         effect.source_id,
                         object_id,
                     )
@@ -7261,7 +7271,7 @@ mod tests {
     use crate::types::game_state::{LayersDirty, StaticSourceIndex, TransientContinuousEffect};
     use crate::types::identifiers::CardId;
     use crate::types::keywords::Keyword;
-    use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
+    use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::player::PlayerId;
     use crate::types::replacements::ReplacementEvent;
     use crate::types::statics::StaticMode;
@@ -7329,6 +7339,46 @@ mod tests {
         obj.base_toughness = Some(toughness);
         obj.timestamp = ts;
         id
+    }
+
+    fn add_unspent_blue_mana(state: &mut GameState, player: PlayerId, count: usize) {
+        let player = state
+            .players
+            .iter_mut()
+            .find(|candidate| candidate.id == player)
+            .expect("test player must exist");
+        for _ in 0..count {
+            player.mana_pool.add(ManaUnit {
+                color: ManaType::Blue,
+                source_id: ObjectId(0),
+                pip_id: crate::types::mana::ManaPipId(0),
+                supertype: None,
+                source_could_produce_two_or_more_colors: false,
+                restrictions: Vec::new(),
+                grants: Vec::new(),
+                expiry: None,
+            });
+        }
+    }
+
+    fn six_unspent_mana_condition() -> StaticCondition {
+        StaticCondition::QuantityComparison {
+            lhs: QuantityExpr::Ref {
+                qty: QuantityRef::UnspentMana { color: None },
+            },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 6 },
+        }
+    }
+
+    fn install_static_definition(
+        state: &mut GameState,
+        object_id: ObjectId,
+        def: StaticDefinition,
+    ) {
+        let object = state.objects.get_mut(&object_id).unwrap();
+        Arc::make_mut(&mut object.base_static_definitions).push(def.clone());
+        object.static_definitions.push(def);
     }
 
     /// A bare non-creature Treasure token permanent (CR 111.1: `is_token`; CR 111.6:
@@ -8199,6 +8249,181 @@ mod tests {
 
         evaluate_layers(&mut state);
         assert!(!state.objects[&id].assigns_damage_as_though_unblocked);
+    }
+
+    #[test]
+    fn printed_static_condition_uses_controller_after_layer_two_in_one_pass() {
+        let mut state = setup();
+        let source = make_creature(&mut state, "Conditional Source", 2, 2, P0);
+        install_static_definition(
+            &mut state,
+            source,
+            StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AddKeyword {
+                    keyword: Keyword::Flying,
+                }])
+                .condition(six_unspent_mana_condition()),
+        );
+        add_unspent_blue_mana(&mut state, P0, 5);
+        add_unspent_blue_mana(&mut state, P1, 6);
+        state.add_transient_continuous_effect(
+            source,
+            P1,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: source },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+
+        evaluate_layers(&mut state);
+
+        let source = &state.objects[&source];
+        assert_eq!(source.controller, P1);
+        assert!(
+            source.has_keyword(&Keyword::Flying),
+            "a layer-6 printed static must read the layer-2 controller in the same pass"
+        );
+    }
+
+    #[test]
+    fn transient_static_condition_keeps_its_captured_controller() {
+        let mut state = setup();
+        let source = make_creature(&mut state, "Transient Source", 2, 2, P0);
+        let recipient = make_creature(&mut state, "Transient Recipient", 2, 2, P0);
+        add_unspent_blue_mana(&mut state, P0, 6);
+        state.add_transient_continuous_effect(
+            source,
+            P0,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: recipient },
+            vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying,
+            }],
+            Some(six_unspent_mana_condition()),
+        );
+        state.add_transient_continuous_effect(
+            source,
+            P1,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: source },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+
+        evaluate_layers(&mut state);
+
+        assert_eq!(state.objects[&source].controller, P1);
+        assert!(
+            state.objects[&recipient].has_keyword(&Keyword::Flying),
+            "a resolution-created effect must keep its captured P0 condition context"
+        );
+    }
+
+    #[test]
+    fn granted_static_condition_uses_its_recipient_controller_after_layer_two() {
+        let mut state = setup();
+        let grantor = make_creature(&mut state, "Grantor", 2, 2, P0);
+        let recipient = make_creature(&mut state, "Granted Static Source", 2, 2, P0);
+        let inner = StaticDefinition::continuous()
+            .affected(TargetFilter::SelfRef)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Flying,
+            }])
+            .condition(six_unspent_mana_condition());
+        install_static_definition(
+            &mut state,
+            grantor,
+            StaticDefinition::continuous()
+                .affected(TargetFilter::SpecificObject { id: recipient })
+                .modifications(vec![ContinuousModification::GrantStaticAbility {
+                    definition: Box::new(inner),
+                }]),
+        );
+        add_unspent_blue_mana(&mut state, P0, 5);
+        add_unspent_blue_mana(&mut state, P1, 6);
+        state.add_transient_continuous_effect(
+            grantor,
+            P1,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: recipient },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+
+        evaluate_layers(&mut state);
+
+        let recipient = &state.objects[&recipient];
+        assert_eq!(recipient.controller, P1);
+        assert!(
+            recipient.has_keyword(&Keyword::Flying),
+            "a granted static must bind its condition to the recipient's layer-2 controller"
+        );
+    }
+
+    #[test]
+    fn combat_assignment_static_condition_uses_controller_after_layer_two() {
+        let mut state = setup();
+        let source = make_creature(&mut state, "Combat Conditional Source", 2, 2, P0);
+        install_static_definition(
+            &mut state,
+            source,
+            StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AssignDamageFromToughness])
+                .condition(six_unspent_mana_condition()),
+        );
+        add_unspent_blue_mana(&mut state, P0, 5);
+        add_unspent_blue_mana(&mut state, P1, 6);
+        state.add_transient_continuous_effect(
+            source,
+            P1,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: source },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+
+        evaluate_layers(&mut state);
+
+        let source = &state.objects[&source];
+        assert_eq!(source.controller, P1);
+        assert!(
+            source.assigns_damage_from_toughness,
+            "post-layer combat rules must use the layer-2 controller for their condition"
+        );
+    }
+
+    #[test]
+    fn transient_combat_rule_condition_stays_off_when_captured_controller_fails() {
+        let mut state = setup();
+        let source = make_creature(&mut state, "Transient Combat Source", 2, 2, P0);
+        add_unspent_blue_mana(&mut state, P1, 6);
+        state.add_transient_continuous_effect(
+            source,
+            P0,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: source },
+            vec![ContinuousModification::AssignDamageFromToughness],
+            Some(six_unspent_mana_condition()),
+        );
+        state.add_transient_continuous_effect(
+            source,
+            P1,
+            Duration::Permanent,
+            TargetFilter::SpecificObject { id: source },
+            vec![ContinuousModification::ChangeController],
+            None,
+        );
+
+        evaluate_layers(&mut state);
+
+        let source = &state.objects[&source];
+        assert_eq!(source.controller, P1);
+        assert!(
+            !source.assigns_damage_from_toughness,
+            "a transient combat rule must remain gated by its captured P0 controller"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -927,27 +927,41 @@ pub(crate) fn active_effect_condition_controller(
     state: &GameState,
     effect: &ActiveContinuousEffect,
 ) -> PlayerId {
-    if effect.transient_id.is_some() {
-        effect.controller
-    } else {
-        state
-            .objects
-            .get(&effect.source_id)
-            .map_or(effect.controller, |source| source.controller)
-    }
+    condition_controller(
+        state,
+        effect.transient_id,
+        effect.controller,
+        effect.source_id,
+    )
 }
 
 fn combat_effect_condition_controller(
     state: &GameState,
     effect: &ActiveCombatAssignmentRuleEffect,
 ) -> PlayerId {
-    if effect.transient_id.is_some() {
-        effect.controller
+    condition_controller(
+        state,
+        effect.transient_id,
+        effect.controller,
+        effect.source_id,
+    )
+}
+
+/// Resolves the player named by "you" for a condition on either a printed or
+/// resolution-created continuous effect.
+fn condition_controller(
+    state: &GameState,
+    transient_id: Option<u64>,
+    controller: PlayerId,
+    source_id: ObjectId,
+) -> PlayerId {
+    if transient_id.is_some() {
+        controller
     } else {
         state
             .objects
-            .get(&effect.source_id)
-            .map_or(effect.controller, |source| source.controller)
+            .get(&source_id)
+            .map_or(controller, |source| source.controller)
     }
 }
 
@@ -5970,11 +5984,17 @@ fn apply_continuous_effect_filtered(
         // `MustAttackAwayFromSource` affected filter intact
         // (`effects/effect.rs`) — see the T13 regression
         // (`affected_population_does_not_follow_a_stolen_source`).
-        let ctx = if effect.transient_id.is_some() {
-            FilterContext::from_source_with_controller(effect.source_id, effect.controller)
-        } else {
-            FilterContext::from_source(state, effect.source_id)
-        };
+        let condition_controller = active_effect_condition_controller(state, effect);
+        let ctx =
+            FilterContext::from_source_with_controller(effect.source_id, condition_controller);
+        let condition_uses_recipient = effect
+            .condition
+            .as_ref()
+            .is_some_and(|condition| condition_uses_recipient_context(condition));
+        let non_recipient_condition_passes = effect.condition.as_ref().is_none_or(|condition| {
+            condition_uses_recipient
+                || evaluate_condition(state, condition, condition_controller, effect.source_id)
+        });
         newly_affected_ids = scan_ids
             .iter()
             // Incremental fast path: re-apply only to the freshly-entered objects.
@@ -5983,15 +6003,17 @@ fn apply_continuous_effect_filtered(
             .filter(|&&id| restrict_to.is_none_or(|ids| ids.contains(&id)))
             .filter(|&&id| matches_target_filter(state, id, &effect.affected_filter, &ctx))
             .filter(|&&id| {
-                effect.condition.as_ref().is_none_or(|condition| {
-                    evaluate_condition_with_recipient(
-                        state,
-                        condition,
-                        active_effect_condition_controller(state, effect),
-                        effect.source_id,
-                        id,
-                    )
-                })
+                non_recipient_condition_passes
+                    && effect.condition.as_ref().is_none_or(|condition| {
+                        !condition_uses_recipient
+                            || evaluate_condition_with_recipient(
+                                state,
+                                condition,
+                                condition_controller,
+                                effect.source_id,
+                                id,
+                            )
+                    })
             })
             .copied()
             .collect();

--- a/crates/engine/src/game/off_zone_characteristics.rs
+++ b/crates/engine/src/game/off_zone_characteristics.rs
@@ -173,8 +173,9 @@ pub(crate) fn collect_applicable_off_zone_keyword_effects(
     effects
         .into_iter()
         .filter(|effect| {
+            let condition_controller = active_effect_condition_controller(state, effect);
             let ctx =
-                FilterContext::from_source_with_controller(effect.source_id, effect.controller);
+                FilterContext::from_source_with_controller(effect.source_id, condition_controller);
             effect.layer == Layer::Ability
                 && supports_off_zone_keyword_query(&effect.modification)
                 && matches_off_zone_keyword_recipient(
@@ -188,7 +189,7 @@ pub(crate) fn collect_applicable_off_zone_keyword_effects(
                     evaluate_condition_with_recipient(
                         state,
                         condition,
-                        active_effect_condition_controller(state, effect),
+                        condition_controller,
                         effect.source_id,
                         object_id,
                     )

--- a/crates/engine/src/game/off_zone_characteristics.rs
+++ b/crates/engine/src/game/off_zone_characteristics.rs
@@ -2,8 +2,9 @@ use crate::game::filter::{
     matches_target_filter, matches_target_filter_in_owner_zone, FilterContext,
 };
 use crate::game::layers::{
-    active_continuous_effects_from_base_static_source, collect_shared_active_continuous_effects,
-    evaluate_condition_with_recipient, order_active_continuous_effects,
+    active_continuous_effects_from_base_static_source, active_effect_condition_controller,
+    collect_shared_active_continuous_effects, evaluate_condition_with_recipient,
+    order_active_continuous_effects,
 };
 use crate::game::quantity::resolve_quantity;
 use crate::types::ability::{ContinuousModification, TargetFilter, TriggerProducerOrigin};
@@ -187,7 +188,7 @@ pub(crate) fn collect_applicable_off_zone_keyword_effects(
                     evaluate_condition_with_recipient(
                         state,
                         condition,
-                        effect.controller,
+                        active_effect_condition_controller(state, effect),
                         effect.source_id,
                         object_id,
                     )

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1533,7 +1533,7 @@ fn world_acquisition_timestamp(
                     layers::evaluate_condition_with_recipient(
                         state,
                         condition,
-                        effect.controller,
+                        layers::active_effect_condition_controller(state, effect),
                         effect.source_id,
                         obj.id,
                     )

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1527,13 +1527,17 @@ fn world_acquisition_timestamp(
         .filter(|effect| {
             // Mirror apply_continuous_effect_filtered (layers.rs:4314-4332):
             // recipient must match affected_filter AND the effect's condition.
-            let ctx = crate::game::filter::FilterContext::from_source(state, effect.source_id);
+            let condition_controller = layers::active_effect_condition_controller(state, effect);
+            let ctx = crate::game::filter::FilterContext::from_source_with_controller(
+                effect.source_id,
+                condition_controller,
+            );
             crate::game::filter::matches_target_filter(state, obj.id, &effect.affected_filter, &ctx)
                 && effect.condition.as_ref().is_none_or(|condition| {
                     layers::evaluate_condition_with_recipient(
                         state,
                         condition,
-                        layers::active_effect_condition_controller(state, effect),
+                        condition_controller,
                         effect.source_id,
                         obj.id,
                     )

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -3333,6 +3333,12 @@ fn parse_you_have_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
     }
 
     if let Ok((after_or_more, _)) = tag::<_, _, OracleError<'_>>(" or more ").parse(rest) {
+        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("unspent mana").parse(after_or_more) {
+            return Ok((
+                rest,
+                make_quantity_ge(QuantityRef::UnspentMana { color: None }, n),
+            ));
+        }
         // CR 603.4 + CR 404.2: Oversold Cemetery's intervening-if predicate
         // counts face-up creature cards in its controller's graveyard.
         if let Ok((rest, type_filters)) =
@@ -14046,6 +14052,29 @@ mod tests {
                 rhs: QuantityExpr::Fixed { value: 5 },
             },
         );
+    }
+
+    #[test]
+    fn you_have_or_more_unspent_mana_parses_word_and_digit_thresholds() {
+        for (text, expected) in [
+            ("you have six or more unspent mana", 6),
+            ("you have 6 or more unspent mana", 6),
+            ("you have five or more unspent mana", 5),
+        ] {
+            let (rest, condition) = parse_inner_condition(text).unwrap();
+            assert_eq!(rest, "", "must fully consume {text:?}");
+            assert_eq!(
+                condition,
+                StaticCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::UnspentMana { color: None },
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: expected },
+                },
+                "expected total unspent mana threshold for {text:?}",
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -37,6 +37,82 @@ fn unsupported_ability_ir_lowering_preserves_generic_and_structural_payloads() {
 }
 
 #[test]
+fn ozai_document_ir_lowers_keyword_transform_and_unspent_mana_gate() {
+    const ORACLE: &str = "Trample, firebending 4, haste\nIf you would lose unspent mana, that mana becomes red instead.\nOzai has flying and indestructible as long as you have six or more unspent mana.";
+    let keyword_names = [
+        "trample".to_string(),
+        "firebending".to_string(),
+        "haste".to_string(),
+    ];
+    let types = ["Legendary".to_string(), "Creature".to_string()];
+    let subtypes = [
+        "Human".to_string(),
+        "Noble".to_string(),
+        "Wizard".to_string(),
+    ];
+
+    let mut ir = parse_oracle_ir(
+        ORACLE,
+        "Ozai, the Phoenix King",
+        &keyword_names,
+        &types,
+        &subtypes,
+    );
+    assert!(
+        ir.diagnostics.is_empty(),
+        "unexpected parse diagnostics: {ir:#?}"
+    );
+    assert!(
+        ir.items
+            .iter()
+            .all(|item| !matches!(item.node, OracleNodeIr::Unsupported { .. })),
+        "every printed Ozai line must have a typed IR node: {ir:#?}"
+    );
+    let parsed = lower_oracle_ir(&mut ir);
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "lowering must preserve a fully supported Ozai document: {:#?}",
+        parsed.parse_warnings
+    );
+    assert!(parsed.statics.iter().any(|definition| matches!(
+        definition.mode,
+        StaticMode::StepEndUnspentMana {
+            filter: None,
+            action: StepEndManaAction::Transform(ManaType::Red),
+        }
+    ) && definition.affected
+        == Some(TargetFilter::Controller)));
+
+    let gate = parsed
+        .statics
+        .iter()
+        .find(|definition| {
+            matches!(
+                definition.condition,
+                Some(StaticCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: QuantityRef::UnspentMana { color: None },
+                    },
+                    comparator: Comparator::GE,
+                    rhs: QuantityExpr::Fixed { value: 6 },
+                })
+            )
+        })
+        .expect("Ozai's six-unspent-mana conditional static");
+    assert_eq!(gate.affected, Some(TargetFilter::SelfRef));
+    assert!(gate
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Flying,
+        }));
+    assert!(gate
+        .modifications
+        .contains(&ContinuousModification::AddKeyword {
+            keyword: Keyword::Indestructible,
+        }));
+}
+
+#[test]
 fn nominal_dispatch_preserves_precomputed_x_floor_for_spells_and_residuals() {
     let types = ["Creature".to_string()];
     let spell = parse_oracle_text(
@@ -1193,8 +1269,8 @@ use crate::types::ability::{
     SacrificeCost, SacrificeRequirement, SharedQuality, SharedQualityRelation, ShieldKind,
     StaticCondition, TapStateChange, TargetFilter, TriggerCondition, TypeFilter, TypedFilter,
 };
-use crate::types::keywords::{FlashbackCost, KeywordKind, WardCost};
-use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use crate::types::keywords::{FlashbackCost, Keyword, KeywordKind, WardCost};
+use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, StepEndManaAction};
 use crate::types::replacements::ReplacementEvent;
 use crate::types::statics::{CostModifyMode, ProhibitionScope, StaticMode};
 use crate::types::triggers::{PlaneswalkRole, TriggerMode};

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1096,6 +1096,7 @@ mod otherwise_conditional_effects;
 mod outrageous_robbery_look_and_play;
 mod overlord_impending_offer_2859;
 mod owner_life_change_routing_3351;
+mod ozai_phoenix_king_unspent_mana;
 mod pact_of_negation_upkeep_payment;
 mod park_heights_pegasus_draw_condition_runtime;
 mod parker_luck;

--- a/crates/engine/tests/integration/ozai_phoenix_king_unspent_mana.rs
+++ b/crates/engine/tests/integration/ozai_phoenix_king_unspent_mana.rs
@@ -1,0 +1,125 @@
+use engine::game::keywords::has_keyword;
+use engine::game::layers::flush_layers;
+use engine::game::mana_payment;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{ContinuousModification, Duration, TargetFilter};
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType};
+use engine::types::phase::Phase;
+
+const OZAI_ORACLE: &str = "Trample, firebending 4, haste\nIf you would lose unspent mana, that mana becomes red instead.\nOzai has flying and indestructible as long as you have six or more unspent mana.";
+const OPT_ORACLE: &str = "Scry 1.\nDraw a card.";
+
+fn produce_blue(
+    runner: &mut GameRunner,
+    source: ObjectId,
+    player: engine::types::player::PlayerId,
+    count: usize,
+) {
+    for _ in 0..count {
+        let mut events = Vec::new();
+        mana_payment::produce_mana(
+            runner.state_mut(),
+            source,
+            ManaType::Blue,
+            player,
+            false,
+            &mut events,
+        );
+    }
+}
+
+fn has_keyword_after_layers(runner: &mut GameRunner, object: ObjectId, keyword: &Keyword) -> bool {
+    flush_layers(runner.state_mut());
+    has_keyword(&runner.state().objects[&object], keyword)
+}
+
+#[test]
+fn ozai_unspent_mana_gate_tracks_live_controller_and_cast_payment() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Drawn Card"]);
+
+    let ozai = scenario
+        .add_creature(P0, "Ozai, the Phoenix King", 4, 4)
+        .from_oracle_text_with_keywords(&["trample", "firebending", "haste"], OZAI_ORACLE)
+        .id();
+    let p1_mana_source = scenario.add_creature(P1, "P1 Mana Source", 1, 1).id();
+    let thief = scenario
+        .add_creature(P1, "Control Effect Source", 1, 1)
+        .id();
+    let opt = scenario
+        .add_spell_to_hand_from_oracle(P0, "Opt", true, OPT_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 0,
+        })
+        .id();
+    let mut runner = scenario.build();
+
+    produce_blue(&mut runner, p1_mana_source, P1, 6);
+    assert!(
+        !has_keyword_after_layers(&mut runner, ozai, &Keyword::Flying),
+        "P1's mana must not enable P0's Ozai"
+    );
+    assert!(
+        !has_keyword_after_layers(&mut runner, ozai, &Keyword::Indestructible),
+        "the negative controller fixture must reach Ozai's parsed gate"
+    );
+
+    produce_blue(&mut runner, ozai, P0, 6);
+    assert!(
+        has_keyword_after_layers(&mut runner, ozai, &Keyword::Flying),
+        "six unspent mana enables flying"
+    );
+    assert!(
+        has_keyword_after_layers(&mut runner, ozai, &Keyword::Indestructible),
+        "six unspent mana enables indestructible"
+    );
+    assert!(has_keyword_after_layers(
+        &mut runner,
+        ozai,
+        &Keyword::Trample
+    ));
+    assert!(has_keyword_after_layers(&mut runner, ozai, &Keyword::Haste));
+
+    let outcome = runner.cast(opt).resolve();
+    outcome.assert_hand_drawn(P0, 1);
+
+    assert!(
+        !has_keyword_after_layers(&mut runner, ozai, &Keyword::Flying),
+        "paying one mana through the casting pipeline drops Ozai below six"
+    );
+    assert!(
+        !has_keyword_after_layers(&mut runner, ozai, &Keyword::Indestructible),
+        "both conditional grants must be invalidated at five mana"
+    );
+    assert!(
+        has_keyword_after_layers(&mut runner, ozai, &Keyword::Trample),
+        "printed trample must survive conditional-grant invalidation"
+    );
+    assert!(
+        has_keyword_after_layers(&mut runner, ozai, &Keyword::Haste),
+        "printed haste must survive conditional-grant invalidation"
+    );
+
+    runner.state_mut().add_transient_continuous_effect(
+        thief,
+        P1,
+        Duration::Permanent,
+        TargetFilter::SpecificObject { id: ozai },
+        vec![ContinuousModification::ChangeController],
+        None,
+    );
+    flush_layers(runner.state_mut());
+    assert_eq!(runner.state().objects[&ozai].controller, P1);
+    assert!(
+        has_keyword(&runner.state().objects[&ozai], &Keyword::Flying),
+        "one layer flush must evaluate Ozai's layer-6 gate with P1 as controller"
+    );
+    assert!(
+        has_keyword(&runner.state().objects[&ozai], &Keyword::Indestructible,),
+        "P1's six mana enables the stolen Ozai"
+    );
+}

--- a/crates/engine/tests/integration/ozai_phoenix_king_unspent_mana.rs
+++ b/crates/engine/tests/integration/ozai_phoenix_king_unspent_mana.rs
@@ -2,6 +2,7 @@ use engine::game::keywords::has_keyword;
 use engine::game::layers::flush_layers;
 use engine::game::mana_payment;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::turns::advance_phase;
 use engine::types::ability::{ContinuousModification, Duration, TargetFilter};
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
@@ -122,4 +123,57 @@ fn ozai_unspent_mana_gate_tracks_live_controller_and_cast_payment() {
         has_keyword(&runner.state().objects[&ozai], &Keyword::Indestructible,),
         "P1's six mana enables the stolen Ozai"
     );
+}
+
+#[test]
+fn ozai_recolors_unspent_mana_when_entering_cleanup() {
+    // CR 500.5 + CR 614.1a: Ozai replaces the loss of its controller's
+    // unspent mana at the cleanup-step boundary, preserving the six-mana gate.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::End);
+    let ozai = scenario
+        .add_creature(P0, "Ozai, the Phoenix King", 4, 4)
+        .from_oracle_text_with_keywords(&["trample", "firebending", "haste"], OZAI_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    produce_blue(&mut runner, ozai, P0, 6);
+    assert!(has_keyword_after_layers(
+        &mut runner,
+        ozai,
+        &Keyword::Flying
+    ));
+    assert!(has_keyword_after_layers(
+        &mut runner,
+        ozai,
+        &Keyword::Indestructible
+    ));
+
+    advance_phase(runner.state_mut(), &mut Vec::new());
+
+    assert_eq!(runner.state().phase, Phase::Cleanup);
+    assert_eq!(runner.state().players[P0.0 as usize].mana_pool.total(), 6);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(ManaType::Red),
+        6,
+        "Ozai turns would-be-lost mana red rather than letting it empty"
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .count_color(ManaType::Blue),
+        0
+    );
+    assert!(has_keyword_after_layers(
+        &mut runner,
+        ozai,
+        &Keyword::Flying
+    ));
+    assert!(has_keyword_after_layers(
+        &mut runner,
+        ozai,
+        &Keyword::Indestructible
+    ));
 }


### PR DESCRIPTION
## Summary
- Parse total unspent-mana threshold conditions such as Ozai’s “six or more unspent mana.”
- Evaluate controller-relative printed and granted static conditions at their application layer, so they use the object’s effective controller after layer-2 control changes.
- Keep resolution-created continuous effects bound to their captured controller, including combat assignment rules.

## Validation
- Focused parser, layer, combat, and Ozai runtime regressions.
- Pre-push Rust lint, parser suite (608 tests), phase-AI suite (1,854 tests), card-data validation, and coverage regression check passed.
- Coverage adds Ozai, the Phoenix King as newly supported.

## Validation note
The local frontend lint could not start because pnpm requires build-script approval while bootstrapping dependencies. No client code is changed; GitHub CI remains authoritative for this check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oracle parsing for “unspent mana” in “or more” quantity conditions.
  * Enhanced controller-aware condition evaluation for active/continuous/combat effects and off-zone keyword effects.
* **Bug Fixes**
  * Fixed “you” resolution for conditions when effects originate from transient sources or combat-assignment effects, preserving the captured controller.
  * Corrected Ozai unspent-mana color replacement behavior at the Cleanup step after phase transitions.
* **Tests**
  * Added and extended unit/integration scenarios covering unspent-mana parsing and controller correctness across layer timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->