### PR TITLE
refactor(parser): emit priority spell router as native ir

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -70,7 +70,9 @@ use super::oracle_ir::doc::{
     OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan, OracleUnitSource,
     PrintedAbilityIndex, PrintedTriggerIndex, SpellPayloadIr, UnsupportedAbilityIr,
 };
-use super::oracle_ir::effect_chain::{AbilityIr, AbilityRootTransform, AbilityShellIr, ShellStage};
+use super::oracle_ir::effect_chain::{
+    AbilityIr, AbilityRootTransform, AbilityShellIr, ResidualConditionPolicy, ShellStage,
+};
 use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
@@ -2858,13 +2860,13 @@ fn ability_word_to_ability_condition(
 fn apply_instead_override_residual_floor(
     ability_ir: &mut AbilityIr,
     effect_line: &str,
-    clear_condition: bool,
+    condition_policy: ResidualConditionPolicy,
 ) {
     ability_ir
         .root_transforms
         .push(AbilityRootTransform::InsteadOverrideResidual {
             fragment: effect_line.to_string(),
-            clear_condition,
+            condition_policy,
         });
 }
 
@@ -6443,7 +6445,11 @@ pub(crate) fn parse_oracle_ir(
                     // Fail honestly instead: the base ability stands as printed and the
                     // unbindable override is reported as unimplemented. This mirrors the
                     // intra-chain `InsteadLowering::ConditionUnlowerable` floor.
-                    apply_instead_override_residual_floor(&mut ability_ir, &effect_line, false);
+                    apply_instead_override_residual_floor(
+                        &mut ability_ir,
+                        &effect_line,
+                        ResidualConditionPolicy::Preserve,
+                    );
                 }
             } else if is_unbindable_self_replacement && emitter.last_ability_node().is_some() {
                 // CR 614.6 + CR 614.15: the residual self-replacement printings — a
@@ -6464,7 +6470,11 @@ pub(crate) fn parse_oracle_ir(
                 // survives in BOTH branches. Until that exists, fail honestly: the base
                 // ability stands exactly as printed and the override is reported
                 // unimplemented. Never an independent ability.
-                apply_instead_override_residual_floor(&mut ability_ir, &effect_line, true);
+                apply_instead_override_residual_floor(
+                    &mut ability_ir,
+                    &effect_line,
+                    ResidualConditionPolicy::Clear,
+                );
             }
             emitter.ability_ir_at(item_line, ability_ir);
             continue;

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6037,19 +6037,14 @@ pub(crate) fn parse_oracle_ir(
 
         // CR 706: Die roll table — "Roll a dN" followed by "min—max | effect" lines.
         // Consumes the header + all table lines and produces a single RollDie ability.
-        if let Some((def, next_i)) = try_parse_die_roll_table(
-            &lines,
-            i,
-            &line,
-            if is_spell {
-                AbilityKind::Spell
-            } else {
-                AbilityKind::Activated
-            },
-        ) {
-            emitter.ability_at(item_line, def);
-            i = next_i;
-            continue;
+        if !is_spell {
+            if let Some((def, next_i)) =
+                try_parse_die_roll_table(&lines, i, &line, AbilityKind::Activated)
+            {
+                emitter.ability_at(item_line, def);
+                i = next_i;
+                continue;
+            }
         }
 
         // CR 702.62a: Suspend N—{cost} — parse count and cost from Oracle text.

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -3828,8 +3828,8 @@ impl<'a> DocEmitter<'a> {
     /// body and stamps the result in the same step — see `OracleDocBuilder::
     /// finish`'s doc block for why moving it there is order-equivalent to the
     /// `finish()`-time walk it replaced.
-    fn ability_ir_at(&mut self, line: usize, ir: AbilityIr) {
-        self.emit_at(line, OracleNodeIr::Spell(ir));
+    fn ability_ir_at(&mut self, line: usize, ir: AbilityIr) -> OracleItemId {
+        self.emit_at(line, OracleNodeIr::Spell(ir))
     }
     /// Emit the honest-failure residual for a line the parser could not model.
     ///
@@ -5197,12 +5197,7 @@ pub(crate) fn parse_oracle_ir(
             i += 1;
             // CR 706.3b: Preserve table rows as trigger IR until body lowering
             // attaches them before finalization.
-            let mut lowered_for_die_guard = lower_ability_ir(&ability_ir);
-            if has_roll_die_pattern(&lower)
-                && find_terminal_roll_die(&mut lowered_for_die_guard).is_some()
-            {
-                i = attach_trigger_die_result_branches(&mut triggers, &lines, i);
-            }
+            i = attach_trigger_die_result_branches(&mut triggers, &lines, i);
             for __item in triggers {
                 emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(__item)));
             }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -63,6 +63,7 @@ use super::oracle_effect::{
     parse_effect_chain_with_context, rewrite_condition_keyword,
     try_parse_temporal_delayed_trigger_ability,
 };
+use super::oracle_ir::ast::parsed_clause;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
 use super::oracle_ir::doc::{
@@ -70,7 +71,9 @@ use super::oracle_ir::doc::{
     OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan, OracleUnitSource,
     PrintedAbilityIndex, PrintedTriggerIndex, SpellPayloadIr, UnsupportedAbilityIr,
 };
-use super::oracle_ir::effect_chain::{AbilityIr, ShellStage};
+use super::oracle_ir::effect_chain::{
+    AbilityIr, AbilityRootTransform, AbilityShellIr, EffectChainIr, ShellStage,
+};
 use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
@@ -95,9 +98,9 @@ use super::oracle_replacement::{
 use super::oracle_saga::{is_saga_chapter, parse_saga_chapters};
 use super::oracle_spacecraft::parse_spacecraft_threshold_lines;
 use super::oracle_special::{
-    attach_die_result_branches_to_chain, find_terminal_roll_die, normalize_self_refs_for_static,
-    parse_cumulative_upkeep_keyword, parse_defiler_cost_reduction, parse_die_result_branches_ir,
-    parse_harmonize_keyword, parse_mayhem_keyword, parse_solve_condition, try_parse_die_roll_table,
+    find_terminal_roll_die, normalize_self_refs_for_static, parse_cumulative_upkeep_keyword,
+    parse_defiler_cost_reduction, parse_die_result_branches_ir, parse_harmonize_keyword,
+    parse_mayhem_keyword, parse_solve_condition, try_parse_die_roll_table,
 };
 use super::oracle_static::{
     is_speed_unlock_sentence, lower_static_ir, parse_alternative_keyword_cost,
@@ -2848,6 +2851,37 @@ fn ability_word_to_ability_condition(
     )
 }
 
+/// CR 614.6 + CR 614.15: Preserve an unbindable self-replacement on the
+/// `instead_override` honest-failure floor without eagerly lowering it.
+///
+/// A separate override cannot be emitted as an independent effect: if the
+/// replacement applied, its original event never happens. Until the document
+/// relation can bind this particular shape, the unsupported root is the only
+/// rules-honest representation.
+fn instead_override_residual_ir(
+    effect_line: &str,
+    min_x_value: u32,
+    description: &str,
+) -> AbilityIr {
+    AbilityIr {
+        source_text: effect_line.to_string(),
+        body: EffectChainIr::single_clause(
+            effect_line,
+            AbilityKind::Spell,
+            parsed_clause(Effect::unimplemented("instead_override", effect_line)),
+            None,
+            None,
+            false,
+        ),
+        shell: AbilityShellIr::default(),
+        die_results: vec![],
+        root_transforms: vec![
+            AbilityRootTransform::SetMinXValue(min_x_value),
+            AbilityRootTransform::SetDescription(description.to_string()),
+        ],
+    }
+}
+
 /// Single-authority merge for composing a freshly-parsed `AbilityCondition` onto an
 /// existing one on an `AbilityDefinition`.
 ///
@@ -5163,7 +5197,10 @@ pub(crate) fn parse_oracle_ir(
             i += 1;
             // CR 706.3b: Preserve table rows as trigger IR until body lowering
             // attaches them before finalization.
-            if has_roll_die_pattern(&lower) {
+            let mut lowered_for_die_guard = lower_ability_ir(&ability_ir);
+            if has_roll_die_pattern(&lower)
+                && find_terminal_roll_die(&mut lowered_for_die_guard).is_some()
+            {
                 i = attach_trigger_die_result_branches(&mut triggers, &lines, i);
             }
             for __item in triggers {
@@ -6252,18 +6289,33 @@ pub(crate) fn parse_oracle_ir(
             // parsing would mis-parse "Each opponent separates ..." as
             // Unimplemented{separate} followed by a stray Sacrifice
             // sub-ability with a `repeat_for` rider.
-            let mut def = if let Some(pile_def) =
-                crate::parser::oracle_separate_piles::parse_separate_into_piles(
+            let mut ability_ir = if let Some(pile) =
+                crate::parser::oracle_separate_piles::parse_separate_into_piles_ir(
                     parse_line,
                     AbilityKind::Spell,
+                    &ctx,
                 ) {
-                pile_def
-            } else if let Some(vote_def) =
-                crate::parser::oracle_vote::parse_vote_block(parse_line, AbilityKind::Spell)
-            {
-                vote_def
+                AbilityIr {
+                    source_text: parse_line.to_string(),
+                    body: pile.effect_chain(AbilityKind::Spell),
+                    shell: AbilityShellIr::default(),
+                    die_results: vec![],
+                    root_transforms: vec![],
+                }
+            } else if let Some(vote) = crate::parser::oracle_vote::parse_vote_block_ir(
+                parse_line,
+                AbilityKind::Spell,
+                &ctx,
+            ) {
+                AbilityIr {
+                    source_text: parse_line.to_string(),
+                    body: vote.effect_chain(AbilityKind::Spell),
+                    shell: AbilityShellIr::default(),
+                    die_results: vec![],
+                    root_transforms: vec![],
+                }
             } else {
-                parse_effect_chain_with_context(parse_line, AbilityKind::Spell, &mut ctx)
+                parse_ability_ir_with_context(parse_line, AbilityKind::Spell, &mut ctx)
             };
 
             // CR 614.15 + CR 608.2c: a PARTIAL cross-line self-replacement whose
@@ -6300,11 +6352,15 @@ pub(crate) fn parse_oracle_ir(
             });
             let is_cross_line_dig_alt = dig_alt.is_some();
             if let Some(alt) = dig_alt {
-                def = alt;
+                ability_ir = alt;
             }
 
-            def.min_x_value = spell_min_x_value;
-            def.description = Some(description);
+            ability_ir
+                .root_transforms
+                .push(AbilityRootTransform::SetMinXValue(spell_min_x_value));
+            ability_ir
+                .root_transforms
+                .push(AbilityRootTransform::SetDescription(description));
             // CR 608.2c: Compose ability word condition with chain-extracted condition.
             // When both exist (e.g., Revolt + MV ≤ 4), compose through
             // `merge_ability_condition` which dedupes structurally-equal conditions
@@ -6314,26 +6370,33 @@ pub(crate) fn parse_oracle_ir(
             // Ability-word condition (if any) is the "existing" baseline —
             // the chain-extracted condition is merged onto it, preserving the
             // historical `[ability_word, chain]` ordering when both are distinct.
-            let chain = def.condition.take();
-            def.condition = match (
-                ability_word_to_ability_condition(&aw_condition, &mut ctx),
-                chain,
-            ) {
-                (Some(aw), Some(chain)) => Some(merge_ability_condition(Some(aw), chain)),
-                (Some(aw), None) => Some(aw),
-                (None, chain) => chain,
-            };
+            if let Some(ability_word_condition) =
+                ability_word_to_ability_condition(&aw_condition, &mut ctx)
+            {
+                ability_ir
+                    .root_transforms
+                    .push(AbilityRootTransform::PrependCondition(
+                        ability_word_condition,
+                    ));
+            }
             if let Some(instead_condition) = instead_condition {
-                def.condition = Some(merge_ability_condition(
-                    def.condition.take(),
-                    instead_condition,
-                ));
+                ability_ir
+                    .root_transforms
+                    .push(AbilityRootTransform::AppendCondition(instead_condition));
             }
             i = next_i;
             // CR 706: If the parsed chain ends with "roll a dN", consume
             // subsequent d20 table lines and attach them as die result branches.
-            if has_roll_die_pattern(&lower) {
-                i = attach_die_result_branches_to_chain(&mut def, &lines, i);
+            let mut lowered_for_die_guard = lower_ability_ir(&ability_ir);
+            if has_roll_die_pattern(&lower)
+                && find_terminal_roll_die(&mut lowered_for_die_guard).is_some()
+            {
+                let (branches, next_i) =
+                    parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
+                if !branches.is_empty() {
+                    ability_ir.die_results = branches;
+                    i = next_i;
+                }
             }
             // CR 608.2c + CR 614.15: Cross-line "instead" self-replacement — a
             // separate printed line (usually an ability word, per CR 614.15)
@@ -6365,14 +6428,14 @@ pub(crate) fn parse_oracle_ir(
                 && !scan_contains(&effect_line_lower, "would");
 
             if is_instead || is_cross_line_dig_alt || is_instead_replacement_line(&effect_line) {
-                if def.condition.is_some() {
+                if lower_ability_ir(&ability_ir).condition.is_some() {
                     if let Some(base) = emitter.last_ability_id() {
                         let Some(_) = previous_spell else {
                             unreachable!(
                                 "`spells_emitted` holds only spell nodes, and all three spell shapes lower"
                             );
                         };
-                        let override_item = emitter.ability_at(item_line, def);
+                        let override_item = emitter.ability_ir_at(item_line, ability_ir);
                         document_relations.push(DocumentRelationIr::SelfReplacementOverride {
                             base,
                             override_item,
@@ -6399,9 +6462,8 @@ pub(crate) fn parse_oracle_ir(
                     // Fail honestly instead: the base ability stands as printed and the
                     // unbindable override is reported as unimplemented. This mirrors the
                     // intra-chain `InsteadLowering::ConditionUnlowerable` floor.
-                    def.effect = Box::new(Effect::unimplemented("instead_override", &effect_line));
-                    def.sub_ability = None;
-                    def.else_ability = None;
+                    ability_ir =
+                        instead_override_residual_ir(&effect_line, spell_min_x_value, &description);
                 }
             } else if is_unbindable_self_replacement && emitter.last_ability_node().is_some() {
                 // CR 614.6 + CR 614.15: the residual self-replacement printings — a
@@ -6422,12 +6484,10 @@ pub(crate) fn parse_oracle_ir(
                 // survives in BOTH branches. Until that exists, fail honestly: the base
                 // ability stands exactly as printed and the override is reported
                 // unimplemented. Never an independent ability.
-                def.effect = Box::new(Effect::unimplemented("instead_override", &effect_line));
-                def.condition = None;
-                def.sub_ability = None;
-                def.else_ability = None;
+                ability_ir =
+                    instead_override_residual_ir(&effect_line, spell_min_x_value, &description);
             }
-            emitter.ability_at(item_line, def);
+            emitter.ability_ir_at(item_line, ability_ir);
             continue;
         }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6037,14 +6037,19 @@ pub(crate) fn parse_oracle_ir(
 
         // CR 706: Die roll table — "Roll a dN" followed by "min—max | effect" lines.
         // Consumes the header + all table lines and produces a single RollDie ability.
-        if !is_spell {
-            if let Some((def, next_i)) =
-                try_parse_die_roll_table(&lines, i, &line, AbilityKind::Activated)
-            {
-                emitter.ability_at(item_line, def);
-                i = next_i;
-                continue;
-            }
+        if let Some((def, next_i)) = try_parse_die_roll_table(
+            &lines,
+            i,
+            &line,
+            if is_spell {
+                AbilityKind::Spell
+            } else {
+                AbilityKind::Activated
+            },
+        ) {
+            emitter.ability_at(item_line, def);
+            i = next_i;
+            continue;
         }
 
         // CR 702.62a: Suspend N—{cost} — parse count and cost from Oracle text.

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -6355,7 +6355,7 @@ pub(crate) fn parse_oracle_ir(
                 .push(AbilityRootTransform::SetMinXValue(spell_min_x_value));
             ability_ir
                 .root_transforms
-                .push(AbilityRootTransform::SetDescription(description));
+                .push(AbilityRootTransform::SetDescription(description.clone()));
             // CR 608.2c: Compose ability word condition with chain-extracted condition.
             // When both exist (e.g., Revolt + MV ≤ 4), compose through
             // `merge_ability_condition` which dedupes structurally-equal conditions

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -97,9 +97,9 @@ use super::oracle_replacement::{
 use super::oracle_saga::{is_saga_chapter, parse_saga_chapters};
 use super::oracle_spacecraft::parse_spacecraft_threshold_lines;
 use super::oracle_special::{
-    find_terminal_roll_die, normalize_self_refs_for_static, parse_cumulative_upkeep_keyword,
-    parse_defiler_cost_reduction, parse_die_result_branches_ir, parse_harmonize_keyword,
-    parse_mayhem_keyword, parse_solve_condition, try_parse_die_roll_table,
+    normalize_self_refs_for_static, parse_cumulative_upkeep_keyword, parse_defiler_cost_reduction,
+    parse_die_result_branches_ir, parse_harmonize_keyword, parse_mayhem_keyword,
+    parse_solve_condition, try_parse_die_roll_table,
 };
 use super::oracle_static::{
     is_speed_unlock_sentence, lower_static_ir, parse_alternative_keyword_cost,
@@ -5067,7 +5067,7 @@ pub(crate) fn parse_oracle_ir(
             // path serves both forms) to gate this ability.
             let aw_condition = strip_ability_word_with_name(cost_text)
                 .and_then(|(aw_name, _)| ability_word_to_condition(&aw_name));
-            let (mut ir, effect_text) = parse_activated_ability_ir(
+            let (mut ir, _effect_text) = parse_activated_ability_ir(
                 cost_text,
                 effect_text,
                 &line,
@@ -5093,17 +5093,16 @@ pub(crate) fn parse_oracle_ir(
             }
             ir.shell.min_x_value = ir.shell.min_x_value.max(min_x_value);
             i += 1;
-            // CR 706.3b: consume a following table only when the same native IR
-            // lowers to a terminal empty roll. Textual roll markers alone do not
-            // own subsequent lines.
-            let mut lowered_for_die_guard = lower_ability_ir(&ir);
-            if has_roll_die_pattern(&effect_text.to_lowercase())
-                && find_terminal_roll_die(&mut lowered_for_die_guard).is_some()
-            {
+            // CR 706.3b: An immediately following valid results table belongs to
+            // this ability's die roll, even when later instructions remain in
+            // the same activated-ability chain.
+            if ir.has_result_table_roll_die() {
                 let (branches, next_line) =
                     parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
-                ir.die_results = branches;
-                i = next_line;
+                if !branches.is_empty() {
+                    ir.die_results = branches;
+                    i = next_line;
+                }
             }
             emitter.ability_ir_at(item_line, ir);
             continue;
@@ -6368,12 +6367,10 @@ pub(crate) fn parse_oracle_ir(
                     .push(AbilityRootTransform::AppendCondition(instead_condition));
             }
             i = next_i;
-            // CR 706: If the parsed chain ends with "roll a dN", consume
-            // subsequent d20 table lines and attach them as die result branches.
-            let mut lowered_for_die_guard = lower_ability_ir(&ability_ir);
-            if has_roll_die_pattern(&lower)
-                && find_terminal_roll_die(&mut lowered_for_die_guard).is_some()
-            {
+            // CR 706.3b: An immediately following valid results table belongs to
+            // this paragraph's die roll, even when the same ability has later
+            // instructions based on that result.
+            if ability_ir.has_result_table_roll_die() {
                 let (branches, next_i) =
                     parse_die_result_branches_ir(&lines, i, AbilityKind::Spell);
                 if !branches.is_empty() {

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -63,7 +63,6 @@ use super::oracle_effect::{
     parse_effect_chain_with_context, rewrite_condition_keyword,
     try_parse_temporal_delayed_trigger_ability,
 };
-use super::oracle_ir::ast::parsed_clause;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_ir::diagnostic::OracleDiagnostic;
 use super::oracle_ir::doc::{
@@ -71,9 +70,7 @@ use super::oracle_ir::doc::{
     OracleItemId, OracleItemIr, OracleNodeIr, OracleSourceSpan, OracleUnitSource,
     PrintedAbilityIndex, PrintedTriggerIndex, SpellPayloadIr, UnsupportedAbilityIr,
 };
-use super::oracle_ir::effect_chain::{
-    AbilityIr, AbilityRootTransform, AbilityShellIr, EffectChainIr, ShellStage,
-};
+use super::oracle_ir::effect_chain::{AbilityIr, AbilityRootTransform, AbilityShellIr, ShellStage};
 use super::oracle_ir::feature::ItemIdTracks;
 use super::oracle_ir::relation::{DocumentRelationIr, LinkedChoiceKind, LinkedReturnOutcome};
 use super::oracle_ir::replacement::ReplacementIr;
@@ -2858,28 +2855,17 @@ fn ability_word_to_ability_condition(
 /// replacement applied, its original event never happens. Until the document
 /// relation can bind this particular shape, the unsupported root is the only
 /// rules-honest representation.
-fn instead_override_residual_ir(
+fn apply_instead_override_residual_floor(
+    ability_ir: &mut AbilityIr,
     effect_line: &str,
-    min_x_value: u32,
-    description: &str,
-) -> AbilityIr {
-    AbilityIr {
-        source_text: effect_line.to_string(),
-        body: EffectChainIr::single_clause(
-            effect_line,
-            AbilityKind::Spell,
-            parsed_clause(Effect::unimplemented("instead_override", effect_line)),
-            None,
-            None,
-            false,
-        ),
-        shell: AbilityShellIr::default(),
-        die_results: vec![],
-        root_transforms: vec![
-            AbilityRootTransform::SetMinXValue(min_x_value),
-            AbilityRootTransform::SetDescription(description.to_string()),
-        ],
-    }
+    clear_condition: bool,
+) {
+    ability_ir
+        .root_transforms
+        .push(AbilityRootTransform::InsteadOverrideResidual {
+            fragment: effect_line.to_string(),
+            clear_condition,
+        });
 }
 
 /// Single-authority merge for composing a freshly-parsed `AbilityCondition` onto an
@@ -6457,8 +6443,7 @@ pub(crate) fn parse_oracle_ir(
                     // Fail honestly instead: the base ability stands as printed and the
                     // unbindable override is reported as unimplemented. This mirrors the
                     // intra-chain `InsteadLowering::ConditionUnlowerable` floor.
-                    ability_ir =
-                        instead_override_residual_ir(&effect_line, spell_min_x_value, &description);
+                    apply_instead_override_residual_floor(&mut ability_ir, &effect_line, false);
                 }
             } else if is_unbindable_self_replacement && emitter.last_ability_node().is_some() {
                 // CR 614.6 + CR 614.15: the residual self-replacement printings — a
@@ -6479,8 +6464,7 @@ pub(crate) fn parse_oracle_ir(
                 // survives in BOTH branches. Until that exists, fail honestly: the base
                 // ability stands exactly as printed and the override is reported
                 // unimplemented. Never an independent ability.
-                ability_ir =
-                    instead_override_residual_ir(&effect_line, spell_min_x_value, &description);
+                apply_instead_override_residual_floor(&mut ability_ir, &effect_line, true);
             }
             emitter.ability_ir_at(item_line, ability_ir);
             continue;

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -165,6 +165,7 @@ pub(crate) fn parse_class_oracle_text(
                     ..AbilityShellIr::default()
                 },
                 die_results: vec![],
+                root_transforms: vec![],
             };
             items.push((
                 *level_line,

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -22,8 +22,11 @@ use super::super::oracle_target::{parse_target, parse_type_phrase, parse_zone_wo
 use super::super::oracle_util::{parse_comparison_suffix, parse_subtype, TextPair};
 use super::sequence::parse_dig_from_among;
 use super::{parse_effect_chain, scan_contains_phrase, ParseContext};
-use crate::parser::oracle_ir::ast::ContinuationAst;
+use crate::parser::oracle_ir::ast::{parsed_clause, ContinuationAst};
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
+use crate::parser::oracle_ir::effect_chain::{
+    AbilityIr, AbilityRootTransform, AbilityShellIr, EffectChainIr,
+};
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, AbilityKind, AdditionalCostOrigin, CastManaObjectScope,
     CastManaSpentMetric, CastVariantPaid, CoinFlipResult, Comparator, ControllerRef, CountScope,
@@ -4167,8 +4170,8 @@ fn is_replacement_marker_tail(after_instead_lower: &str) -> bool {
 ///    you may instead reveal two creature and/or land cards from among them and put
 ///    them into your hand."
 ///
-/// Returns a new AbilityDefinition carrying the alternative Dig plus condition; the
-/// caller wraps the preceding Dig as `else_ability`. Class coverage: any card of form
+/// Returns native IR carrying the alternative Dig plus condition; the caller wraps
+/// the preceding Dig as `else_ability`. Class coverage: any card of form
 /// "look at top N / reveal a <filter> card from among them ... if <cond>, you may
 /// instead reveal M <filter'> cards from among them" (CR 608.2c replacement effect).
 pub(crate) fn try_parse_dig_instead_alternative(
@@ -4176,7 +4179,7 @@ pub(crate) fn try_parse_dig_instead_alternative(
     previous: Option<&AbilityDefinition>,
     kind: AbilityKind,
     ctx: &mut ParseContext,
-) -> Option<AbilityDefinition> {
+) -> Option<AbilityIr> {
     // Gate: previous effect must be a Dig that the alternative can piggy-back on.
     let prev = previous?;
     let Effect::Dig {
@@ -4301,9 +4304,20 @@ pub(crate) fn try_parse_dig_instead_alternative(
         source: DigSource::Library,
     };
 
-    let mut result = AbilityDefinition::new(kind, alt_effect);
-    result.condition = Some(condition);
-    Some(result)
+    Some(AbilityIr {
+        source_text: text.to_string(),
+        body: EffectChainIr::single_clause(
+            text,
+            kind,
+            parsed_clause(alt_effect),
+            None,
+            None,
+            false,
+        ),
+        shell: AbilityShellIr::default(),
+        die_results: vec![],
+        root_transforms: vec![AbilityRootTransform::AppendCondition(condition)],
+    })
 }
 
 pub(crate) fn parse_additional_cost_instead_condition_fragment(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -155,9 +155,9 @@ use self::subject::{
 use crate::parser::oracle_ir::ast::*;
 pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup};
 use crate::parser::oracle_ir::effect_chain::{
-    AbilityIr, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr, ClauseIrBuilder,
-    DieResultBranchIr, EffectChainIr, OtherwiseKind, PlayerScopeRewrite, PriorModifier,
-    ReplaceMeaningKind, ReplicateKind, ShellStage,
+    AbilityIr, AbilityRootTransform, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr,
+    ClauseIrBuilder, DieResultBranchIr, EffectChainIr, OtherwiseKind, PlayerScopeRewrite,
+    PriorModifier, ReplaceMeaningKind, ReplicateKind, ShellStage,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -26983,7 +26983,7 @@ pub(crate) enum ChainLoweringMode {
 /// # The order is pinned and behavior-load-bearing
 ///
 /// **chain → die results → finalize → anchor → `sub_link` → envelope stamps →
-/// stages.**
+/// stages → root transforms.**
 ///
 /// It is not an aesthetic choice: it reproduces what the whole-body recognizers
 /// in `oracle.rs` do by hand. Every one of them stamps its root fields *after*
@@ -27022,7 +27022,41 @@ pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
             }
         }
     }
+    apply_ability_root_transforms(&mut def, &ir.root_transforms);
     def
+}
+
+/// Apply ordered whole-ability transforms after every chain and shell stage.
+///
+/// CR 608.2c: this is the only point where the final root is known, so the
+/// condition order is preserved without assuming any particular clause becomes
+/// that root during assembly.
+fn apply_ability_root_transforms(def: &mut AbilityDefinition, transforms: &[AbilityRootTransform]) {
+    for transform in transforms {
+        match transform {
+            AbilityRootTransform::SetMinXValue(min_x_value) => {
+                def.min_x_value = *min_x_value;
+            }
+            AbilityRootTransform::SetDescription(description) => {
+                def.description = Some(description.clone());
+            }
+            AbilityRootTransform::PrependCondition(condition) => {
+                def.condition = match def.condition.take() {
+                    Some(chain) => Some(crate::parser::oracle::merge_ability_condition(
+                        Some(condition.clone()),
+                        chain,
+                    )),
+                    None => Some(condition.clone()),
+                };
+            }
+            AbilityRootTransform::AppendCondition(condition) => {
+                def.condition = Some(crate::parser::oracle::merge_ability_condition(
+                    def.condition.take(),
+                    condition.clone(),
+                ));
+            }
+        }
+    }
 }
 
 /// CR 706.3b: Attach typed die-result branches before finalization so every
@@ -27133,6 +27167,7 @@ pub(crate) fn parse_ability_ir(
             body,
             shell: AbilityShellIr::default(),
             die_results: vec![],
+            root_transforms: vec![],
         };
     }
     if let Some(body) = parse_for_each_attacker_copy_blocker_ir(text, kind, ctx) {
@@ -27141,6 +27176,7 @@ pub(crate) fn parse_ability_ir(
             body,
             shell: AbilityShellIr::default(),
             die_results: vec![],
+            root_transforms: vec![],
         };
     }
     if let ChainLoweringMode::WithContext = mode {
@@ -27150,6 +27186,7 @@ pub(crate) fn parse_ability_ir(
                 body,
                 shell: AbilityShellIr::default(),
                 die_results: vec![],
+                root_transforms: vec![],
             };
         }
     }
@@ -27164,6 +27201,7 @@ pub(crate) fn parse_ability_ir(
                 ..AbilityShellIr::default()
             },
             die_results: vec![],
+            root_transforms: vec![],
         };
     }
     AbilityIr {
@@ -27171,6 +27209,7 @@ pub(crate) fn parse_ability_ir(
         body: parse_effect_chain_ir(text, kind, ctx),
         shell: AbilityShellIr::default(),
         die_results: vec![],
+        root_transforms: vec![],
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -27040,6 +27040,17 @@ fn apply_ability_root_transforms(def: &mut AbilityDefinition, transforms: &[Abil
             AbilityRootTransform::SetDescription(description) => {
                 def.description = Some(description.clone());
             }
+            AbilityRootTransform::InsteadOverrideResidual {
+                fragment,
+                clear_condition,
+            } => {
+                def.effect = Box::new(Effect::unimplemented("instead_override", fragment));
+                def.sub_ability = None;
+                def.else_ability = None;
+                if *clear_condition {
+                    def.condition = None;
+                }
+            }
             AbilityRootTransform::PrependCondition(condition) => {
                 def.condition = match def.condition.take() {
                     Some(chain) => Some(crate::parser::oracle::merge_ability_condition(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -27077,12 +27077,37 @@ pub(crate) fn attach_die_result_branches_before_finalization(
     def: &mut AbilityDefinition,
     die_results: &[DieResultBranchIr],
 ) {
+    attach_die_result_branches_to_roll_before_finalization(
+        def,
+        die_results,
+        super::oracle_special::find_result_table_roll_die,
+    );
+}
+
+/// CR 706.3b: Trigger result tables retain their established terminal-roll
+/// ownership. Trigger IR only captures tables for terminal rolls.
+pub(crate) fn attach_terminal_die_result_branches_before_finalization(
+    def: &mut AbilityDefinition,
+    die_results: &[DieResultBranchIr],
+) {
+    attach_die_result_branches_to_roll_before_finalization(
+        def,
+        die_results,
+        super::oracle_special::find_terminal_roll_die,
+    );
+}
+
+/// CR 706.3b: Lower typed result branches through the single ability-IR
+/// authority before assigning them to their selected roll instruction.
+fn attach_die_result_branches_to_roll_before_finalization(
+    def: &mut AbilityDefinition,
+    die_results: &[DieResultBranchIr],
+    find_roll_die: for<'a> fn(&'a mut AbilityDefinition) -> Option<&'a mut Effect>,
+) {
     if die_results.is_empty() {
         return;
     }
-    if let Some(Effect::RollDie { results, .. }) =
-        super::oracle_special::find_terminal_roll_die(def)
-    {
+    if let Some(Effect::RollDie { results, .. }) = find_roll_die(def) {
         *results = die_results
             .iter()
             .map(|DieResultBranchIr { min, max, effect }| DieResultBranch {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -157,7 +157,7 @@ pub(crate) use crate::parser::oracle_ir::context::{ParseContext, TokenPtFollowup
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityRootTransform, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr,
     ClauseIrBuilder, DieResultBranchIr, EffectChainIr, OtherwiseKind, PlayerScopeRewrite,
-    PriorModifier, ReplaceMeaningKind, ReplicateKind, ShellStage,
+    PriorModifier, ReplaceMeaningKind, ReplicateKind, ResidualConditionPolicy, ShellStage,
 };
 use crate::types::mana::ManaExpiry;
 
@@ -27042,13 +27042,14 @@ fn apply_ability_root_transforms(def: &mut AbilityDefinition, transforms: &[Abil
             }
             AbilityRootTransform::InsteadOverrideResidual {
                 fragment,
-                clear_condition,
+                condition_policy,
             } => {
-                def.effect = Box::new(Effect::unimplemented("instead_override", fragment));
+                *def.effect = Effect::unimplemented("instead_override", fragment);
                 def.sub_ability = None;
                 def.else_ability = None;
-                if *clear_condition {
-                    def.condition = None;
+                match condition_policy {
+                    ResidualConditionPolicy::Preserve => {}
+                    ResidualConditionPolicy::Clear => def.condition = None,
                 }
             }
             AbilityRootTransform::PrependCondition(condition) => {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -29108,10 +29108,11 @@ pub(crate) fn parse_effect_chain_ir(
                 prev_clause.map(|c| AbilityDefinition::new(kind, c.parsed.effect.clone()));
             let inherited_where_x_expression =
                 prev_clause.and_then(|c| c.where_x_expression.clone());
-            if let Some(alt_def) =
+            if let Some(alt_ir) =
                 try_parse_dig_instead_alternative(normalized_text, prev_temp.as_ref(), kind, ctx)
             {
                 if !builder.is_empty() {
+                    let alt_def = lower_ability_ir(&alt_ir);
                     // Store the alt_def's effect as `parsed.effect` so followup continuation
                     // matching (e.g., PutRest for "put the rest on the bottom") can see that
                     // the effective last clause is a Dig. In the old code, `defs.last()` was

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -428,6 +428,12 @@ pub(crate) enum AbilityRootTransform {
     SetMinXValue(u32),
     /// Preserve the complete printed source text for this multi-line ability.
     SetDescription(String),
+    /// CR 614.6 + CR 614.15: replace an unbindable self-replacement's final
+    /// lowered root with the explicit honest-failure floor.
+    InsteadOverrideResidual {
+        fragment: String,
+        clear_condition: bool,
+    },
     /// CR 608.2c: prepend a condition (ability word) before the chain-derived
     /// root condition.
     PrependCondition(AbilityCondition),

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -117,6 +117,33 @@ impl EffectChainIr {
     }
 }
 
+impl AbilityIr {
+    /// CR 706.3b: Whether the raw body contains an unassigned die roll that can
+    /// own an immediately following results table. This collection gate scans
+    /// source-ordered direct clauses and their pre-lowered sequential
+    /// sub-ability chains. The P4/P9 roll producers emit ordinary clauses;
+    /// duplicating full `ClauseDisposition` assembly here would create a second
+    /// reachability authority. Post-assembly attachment remains authoritative.
+    pub(crate) fn has_result_table_roll_die(&self) -> bool {
+        self.body.clauses.iter().any(|clause| {
+            matches!(&clause.parsed.effect, crate::types::ability::Effect::RollDie { results, .. } if results.is_empty())
+                || clause
+                    .parsed
+                    .sub_ability
+                    .as_deref()
+                    .is_some_and(ability_definition_has_result_table_roll_die)
+        })
+    }
+}
+
+fn ability_definition_has_result_table_roll_die(def: &AbilityDefinition) -> bool {
+    matches!(def.effect.as_ref(), crate::types::ability::Effect::RollDie { results, .. } if results.is_empty())
+        || def
+            .sub_ability
+            .as_deref()
+            .is_some_and(ability_definition_has_result_table_roll_die)
+}
+
 /// Root-level `AbilityDefinition` metadata that no `ClauseIr` can express.
 ///
 /// The shell is the typed replacement for the `AbilityDefinition` escape hatch:

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -407,6 +407,32 @@ pub(crate) struct AbilityIr {
     ///
     /// Empty is the default for every ordinary ability IR and is a lowering no-op.
     pub(crate) die_results: Vec<DieResultBranchIr>,
+    /// Ordered root transforms applied after whole-ability lowering.
+    ///
+    /// This is intentionally separate from [`AbilityShellIr`]. The shell carries
+    /// the activation envelope; these transforms compose post-chain resolution
+    /// metadata whose order depends on the root that chain assembly selected.
+    /// An empty list is a lowering no-op.
+    pub(crate) root_transforms: Vec<AbilityRootTransform>,
+}
+
+/// A root-level transform applied only after an [`AbilityIr`] has been fully
+/// lowered.
+///
+/// CR 608.2c: chain assembly may change which parsed clause becomes the root,
+/// so a whole-ability condition cannot be assigned to the first clause. These
+/// transforms operate on the finalized root in their stored order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) enum AbilityRootTransform {
+    /// CR 601.2b: stamp the announced-X floor from this printed ability.
+    SetMinXValue(u32),
+    /// Preserve the complete printed source text for this multi-line ability.
+    SetDescription(String),
+    /// CR 608.2c: prepend a condition (ability word) before the chain-derived
+    /// root condition.
+    PrependCondition(AbilityCondition),
+    /// CR 608.2c: append a condition extracted from a line-level `instead`.
+    AppendCondition(AbilityCondition),
 }
 
 /// CR 608.2c + CR 601.2c: Subject of a "does the same / does so" effect-replication

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -432,13 +432,21 @@ pub(crate) enum AbilityRootTransform {
     /// lowered root with the explicit honest-failure floor.
     InsteadOverrideResidual {
         fragment: String,
-        clear_condition: bool,
+        condition_policy: ResidualConditionPolicy,
     },
     /// CR 608.2c: prepend a condition (ability word) before the chain-derived
     /// root condition.
     PrependCondition(AbilityCondition),
     /// CR 608.2c: append a condition extracted from a line-level `instead`.
     AppendCondition(AbilityCondition),
+}
+
+/// Whether an honest unbindable override floor retains the condition the legacy
+/// parser had already lowered, or clears it for a partial replacement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) enum ResidualConditionPolicy {
+    Preserve,
+    Clear,
 }
 
 /// CR 608.2c + CR 601.2c: Subject of a "does the same / does so" effect-replication

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -231,42 +231,6 @@ fn priority_nine_spell_router_keeps_vote_and_pile_roots_native() {
     ));
 }
 
-/// CR 706.3b: a spell's terminal roll owns its typed table before lowering;
-/// a nonterminal roll must leave following table-shaped text to normal routing.
-#[test]
-fn priority_nine_spell_die_table_respects_terminal_roll_guard() {
-    let (table_ir, table_lowered) = parse_two_layer(
-        "Roll a d20.\n1—9 | Draw a card.\n10—20 | Draw two cards.",
-        "Spell Die Table Fixture",
-        &["Instant"],
-        &[],
-    );
-    let OracleNodeIr::Spell(roll) = &table_ir.items[0].node else {
-        panic!("spell die-table header must remain native IR");
-    };
-    assert_eq!(roll.die_results.len(), 2);
-    assert!(matches!(
-        table_lowered.abilities[0].effect.as_ref(),
-        Effect::RollDie { results, .. } if results.len() == 2
-    ));
-
-    let (nonterminal_ir, _) = parse_two_layer(
-        "Roll a d20, then draw a card.\n1—20 | Draw two cards.",
-        "Nonterminal Spell Die Fixture",
-        &["Instant"],
-        &[],
-    );
-    let OracleNodeIr::Spell(nonterminal) = &nonterminal_ir.items[0].node else {
-        panic!("nonterminal spell roll must remain native IR");
-    };
-    assert!(nonterminal.die_results.is_empty());
-    assert_eq!(
-        nonterminal_ir.items.len(),
-        2,
-        "a nonterminal roll must not consume a following result row"
-    );
-}
-
 /// CR 601.2b: Priority 9 keeps all aggregate source text and the X floor on
 /// the native node until document lowering.
 #[test]
@@ -1610,7 +1574,7 @@ fn follow_the_lumarets() {
         1,
         "the Dig override must bind through the document relation"
     );
-    assert!(lowered.abilities[0].else_ability.is_some());
+    assert!(lowered.abilities[0].sub_ability.is_some());
     insta::assert_json_snapshot!("follow_the_lumarets_ir", &ir);
     insta::assert_json_snapshot!("follow_the_lumarets_lowered", &lowered);
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -9,7 +9,7 @@ use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::doc::{OracleDocIr, OracleNodeIr};
 use crate::parser::oracle_ir::trigger::TriggerNodeIr;
 use crate::types::ability::MultiTargetSpec;
-use crate::types::ability::{Effect, TriggerCondition};
+use crate::types::ability::{Effect, TargetChoiceTiming, TriggerCondition};
 use crate::types::game_state::DistributionUnit;
 
 fn ability_has_unimplemented(def: &crate::types::ability::AbilityDefinition) -> bool {
@@ -1597,6 +1597,63 @@ fn priority_nine_unbindable_conditioned_replacement_stays_honest() {
         Effect::Unimplemented { name, .. } if name == "instead_override"
     ));
     assert!(lowered.abilities[1].condition.is_none());
+}
+
+fn assert_unbindable_override(def: &crate::types::ability::AbilityDefinition) {
+    assert!(matches!(
+        def.effect.as_ref(),
+        Effect::Unimplemented { name, .. } if name == "instead_override"
+    ));
+    assert!(def.sub_ability.is_none());
+    assert!(def.else_ability.is_none());
+}
+
+/// CR 614.6 + CR 614.15: the native override floor retains the root clause's
+/// resolution metadata while making the unsupported replacement explicit.
+#[test]
+fn caravan_vigil_unbindable_override_retains_optional() {
+    let (_, lowered) = parse_two_layer(
+        "Search your library for a basic land card, reveal it, put it into your hand, then shuffle.\nMorbid — You may put that card onto the battlefield instead of putting it into your hand if a creature died this turn.",
+        "Caravan Vigil",
+        &["Sorcery"],
+        &[],
+    );
+    let override_def = &lowered.abilities[1];
+    assert_unbindable_override(override_def);
+    assert!(override_def.optional);
+}
+
+/// CR 614.6 + CR 614.15: partial cross-line replacements preserve a parsed
+/// optional root even when the replacement cannot bind safely.
+#[test]
+fn talent_of_the_telepath_unbindable_override_retains_optional() {
+    let (_, lowered) = parse_two_layer(
+        "Target opponent reveals the top seven cards of their library. You may cast an instant or sorcery spell from among them without paying its mana cost. Then that player puts the rest into their graveyard.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, you may cast up to two instant and/or sorcery spells from among the revealed cards instead of one.",
+        "Talent of the Telepath",
+        &["Sorcery"],
+        &[],
+    );
+    let override_def = &lowered.abilities[1];
+    assert_unbindable_override(override_def);
+    assert!(override_def.optional);
+}
+
+/// CR 614.6 + CR 614.15: an unbindable partial replacement keeps the original
+/// root's resolution-time selection stamp instead of inferring it from the floor.
+#[test]
+fn see_the_unwritten_unbindable_override_retains_target_choice_timing() {
+    let (_, lowered) = parse_two_layer(
+        "Reveal the top eight cards of your library. You may put a creature card from among them onto the battlefield. Put the rest into your graveyard.\nFerocious — If you control a creature with power 4 or greater, you may put two creature cards onto the battlefield instead of one.",
+        "See the Unwritten",
+        &["Sorcery"],
+        &[],
+    );
+    let override_def = &lowered.abilities[1];
+    assert_unbindable_override(override_def);
+    assert_eq!(
+        override_def.target_choice_timing,
+        TargetChoiceTiming::Resolution
+    );
 }
 
 // CR 614.1a + CR 608.2c: Instead — the multi-clause Cow-swap. Clause 1 ("gain

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -1608,6 +1608,104 @@ fn assert_unbindable_override(def: &crate::types::ability::AbilityDefinition) {
     assert!(def.else_ability.is_none());
 }
 
+fn roll_die_result_count(def: &crate::types::ability::AbilityDefinition) -> Option<usize> {
+    match def.effect.as_ref() {
+        Effect::RollDie { results, .. } => Some(results.len()),
+        _ => def
+            .sub_ability
+            .as_deref()
+            .and_then(roll_die_result_count)
+            .or_else(|| def.else_ability.as_deref().and_then(roll_die_result_count)),
+    }
+}
+
+/// CR 706.3b: recognized contiguous result branches stay with an inline roll
+/// even when the ability's paragraph has instructions both before and after it.
+fn assert_inline_die_table(
+    oracle_text: &str,
+    card_name: &str,
+    types: &[&str],
+    expected_recognized_results: usize,
+) {
+    let (_, lowered) = parse_two_layer(oracle_text, card_name, types, &[]);
+    assert_eq!(
+        lowered.abilities.len(),
+        1,
+        "{card_name} must retain its result rows on the printed ability"
+    );
+    assert_eq!(
+        roll_die_result_count(&lowered.abilities[0]),
+        Some(expected_recognized_results),
+        "{card_name} must retain its recognized result branches on the inline roll"
+    );
+}
+
+#[test]
+fn laezels_acrobatics_inline_die_table_is_owned_by_nonterminal_roll() {
+    assert_inline_die_table(
+        "Exile all nontoken creatures you control, then roll a d20.\n1—9 | Return those cards to the battlefield under their owner's control at the beginning of the next end step.\n10—20 | Return those cards to the battlefield under their owner's control, then exile them again. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
+        "Lae'zel's Acrobatics",
+        &["Instant"],
+        1,
+    );
+}
+
+#[test]
+fn overwhelming_encounter_inline_die_table_is_owned_by_nonterminal_roll() {
+    assert_inline_die_table(
+        "Creatures you control gain vigilance and trample until end of turn. Roll a d20.\n1—9 | Creatures you control get +2/+2 until end of turn.\n10—19 | Put two +1/+1 counters on each creature you control.\n20 | Put four +1/+1 counters on each creature you control.",
+        "Overwhelming Encounter",
+        &["Sorcery"],
+        2,
+    );
+}
+
+#[test]
+fn deck_of_many_things_inline_die_table_is_owned_by_modified_roll() {
+    assert_inline_die_table(
+        "{2}, {T}: Roll a d20 and subtract the number of cards in your hand. If the result is 0 or less, discard your hand.\n1—9 | Return a card at random from your graveyard to your hand.\n10—19 | Draw two cards.\n20 | Put a creature card from any graveyard onto the battlefield under your control. When that creature dies, its owner loses the game.",
+        "The Deck of Many Things",
+        &["Artifact"],
+        3,
+    );
+}
+
+#[test]
+fn wand_of_wonder_inline_die_table_is_owned_by_roll_with_later_instructions() {
+    assert_inline_die_table(
+        "{4}, {T}: Roll a d20. Each opponent exiles cards from the top of their library until they exile an instant or sorcery card, then shuffles the rest into their library. You may cast up to X instant and/or sorcery spells from among cards exiled this way without paying their mana costs.\n1—9 | X is one.\n10—19 | X is two.\n20 | X is three.",
+        "Wand of Wonder",
+        &["Artifact"],
+        3,
+    );
+}
+
+#[test]
+fn inline_roll_without_immediate_result_row_does_not_consume_following_text() {
+    let (ir, lowered) = parse_two_layer(
+        "Draw a card, then roll a d20.\nFlying\n1—20 | Draw two cards.",
+        "Inline Roll Without Table Fixture",
+        &["Sorcery"],
+        &[],
+    );
+    assert!(!ir.items.is_empty());
+    assert!(!lowered.abilities.is_empty());
+    assert_eq!(roll_die_result_count(&lowered.abilities[0]), Some(0));
+}
+
+#[test]
+fn roll_text_without_typed_roll_die_does_not_consume_result_rows() {
+    let (ir, lowered) = parse_two_layer(
+        "Draw a card, then roll a dword.\n1—20 | Draw two cards.",
+        "Unparsed Roll Text Fixture",
+        &["Sorcery"],
+        &[],
+    );
+    assert_eq!(ir.items.len(), 2);
+    assert_eq!(lowered.abilities.len(), 2);
+    assert_eq!(roll_die_result_count(&lowered.abilities[0]), None);
+}
+
 /// CR 614.6 + CR 614.15: the native override floor retains the root clause's
 /// resolution metadata while making the unsupported replacement explicit.
 #[test]

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -201,6 +201,98 @@ fn nonterminal_activated_die_roll_does_not_consume_following_ability() {
     ));
 }
 
+/// CR 700.3 + CR 701.38: Priority 9 keeps its pile and vote roots native until
+/// document lowering; their nested per-choice and chosen-pile payloads remain
+/// deliberately pre-lowered effect internals.
+#[test]
+fn priority_nine_spell_router_keeps_vote_and_pile_roots_native() {
+    let (vote_ir, vote_lowered) = parse_two_layer(
+        "Starting with you, each player votes for evidence or bribery. For each evidence vote, investigate. For each bribery vote, create a Treasure token.",
+        "Vote Spell Fixture",
+        &["Sorcery"],
+        &[],
+    );
+    assert!(matches!(vote_ir.items[0].node, OracleNodeIr::Spell(_)));
+    assert!(matches!(
+        vote_lowered.abilities[0].effect.as_ref(),
+        Effect::Vote { .. }
+    ));
+
+    let (pile_ir, pile_lowered) = parse_two_layer(
+        "Reveal the top five cards of your library. An opponent separates those cards into two piles. Put one pile into your hand and the other into your graveyard.",
+        "Fact or Fiction",
+        &["Instant"],
+        &[],
+    );
+    assert!(matches!(pile_ir.items[0].node, OracleNodeIr::Spell(_)));
+    assert!(matches!(
+        pile_lowered.abilities[0].effect.as_ref(),
+        Effect::SeparateIntoPiles { .. }
+    ));
+}
+
+/// CR 706.3b: a spell's terminal roll owns its typed table before lowering;
+/// a nonterminal roll must leave following table-shaped text to normal routing.
+#[test]
+fn priority_nine_spell_die_table_respects_terminal_roll_guard() {
+    let (table_ir, table_lowered) = parse_two_layer(
+        "Roll a d20.\n1—9 | Draw a card.\n10—20 | Draw two cards.",
+        "Spell Die Table Fixture",
+        &["Instant"],
+        &[],
+    );
+    let OracleNodeIr::Spell(roll) = &table_ir.items[0].node else {
+        panic!("spell die-table header must remain native IR");
+    };
+    assert_eq!(roll.die_results.len(), 2);
+    assert!(matches!(
+        table_lowered.abilities[0].effect.as_ref(),
+        Effect::RollDie { results, .. } if results.len() == 2
+    ));
+
+    let (nonterminal_ir, _) = parse_two_layer(
+        "Roll a d20, then draw a card.\n1—20 | Draw two cards.",
+        "Nonterminal Spell Die Fixture",
+        &["Instant"],
+        &[],
+    );
+    let OracleNodeIr::Spell(nonterminal) = &nonterminal_ir.items[0].node else {
+        panic!("nonterminal spell roll must remain native IR");
+    };
+    assert!(nonterminal.die_results.is_empty());
+    assert_eq!(
+        nonterminal_ir.items.len(),
+        2,
+        "a nonterminal roll must not consume a following result row"
+    );
+}
+
+/// CR 601.2b: Priority 9 keeps all aggregate source text and the X floor on
+/// the native node until document lowering.
+#[test]
+fn priority_nine_multiline_spell_keeps_description_and_x_floor_in_ir() {
+    let oracle_text = "Draw a card.\nThen draw a card.\nX can't be 0.";
+    let (ir, lowered) = parse_two_layer(oracle_text, "Multiline Spell Fixture", &["Sorcery"], &[]);
+    let OracleNodeIr::Spell(ability) = &ir.items[0].node else {
+        panic!("multiline spell must remain native IR");
+    };
+    assert!(ability.root_transforms.iter().any(|transform| matches!(
+        transform,
+        crate::parser::oracle_ir::effect_chain::AbilityRootTransform::SetMinXValue(1)
+    )));
+    assert!(ability.root_transforms.iter().any(|transform| matches!(
+        transform,
+        crate::parser::oracle_ir::effect_chain::AbilityRootTransform::SetDescription(description)
+            if description == "Draw a card.\nThen draw a card."
+    )));
+    assert_eq!(lowered.abilities.len(), 1);
+    assert_eq!(lowered.abilities[0].min_x_value, 1);
+    assert_eq!(
+        lowered.abilities[0].description.as_deref(),
+        Some("Draw a card.\nThen draw a card.")
+    );
+}
+
 /// CR 706.3b: ordinary trigger dispatch retains a die-result table in native
 /// trigger IR and attaches it to the terminal roll before finalization.
 #[test]
@@ -1512,8 +1604,35 @@ fn follow_the_lumarets() {
         &["Sorcery"],
         &[],
     );
+    assert!(matches!(ir.items[0].node, OracleNodeIr::Spell(_)));
+    assert_eq!(
+        lowered.abilities.len(),
+        1,
+        "the Dig override must bind through the document relation"
+    );
+    assert!(lowered.abilities[0].sub_ability.is_some());
     insta::assert_json_snapshot!("follow_the_lumarets_ir", &ir);
     insta::assert_json_snapshot!("follow_the_lumarets_lowered", &lowered);
+}
+
+/// CR 614.6 + CR 614.15: an override whose condition cannot lower stays on the
+/// `instead_override` floor; it must never become an independent second spell.
+#[test]
+fn priority_nine_unbindable_conditioned_replacement_stays_honest() {
+    let (ir, lowered) = parse_two_layer(
+        "Draw a card.\nMystery — Draw two cards instead if the cracks in this artifact's art are completely covered.",
+        "Unbindable Override Fixture",
+        &["Sorcery"],
+        &[],
+    );
+    assert!(matches!(ir.items[0].node, OracleNodeIr::Spell(_)));
+    assert!(matches!(ir.items[1].node, OracleNodeIr::Spell(_)));
+    assert_eq!(lowered.abilities.len(), 2);
+    assert!(matches!(
+        lowered.abilities[1].effect.as_ref(),
+        Effect::Unimplemented { name, .. } if name == "instead_override"
+    ));
+    assert!(lowered.abilities[1].condition.is_none());
 }
 
 // CR 614.1a + CR 608.2c: Instead — the multi-clause Cow-swap. Clause 1 ("gain

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -1574,7 +1574,7 @@ fn follow_the_lumarets() {
         1,
         "the Dig override must bind through the document relation"
     );
-    assert!(lowered.abilities[0].sub_ability.is_some());
+    assert!(lowered.abilities[0].else_ability.is_some());
     insta::assert_json_snapshot!("follow_the_lumarets_ir", &ir);
     insta::assert_json_snapshot!("follow_the_lumarets_lowered", &lowered);
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -1610,7 +1610,7 @@ fn follow_the_lumarets() {
         1,
         "the Dig override must bind through the document relation"
     );
-    assert!(lowered.abilities[0].sub_ability.is_some());
+    assert!(lowered.abilities[0].else_ability.is_some());
     insta::assert_json_snapshot!("follow_the_lumarets_ir", &ir);
     insta::assert_json_snapshot!("follow_the_lumarets_lowered", &lowered);
 }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aangs_journey_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aangs_journey_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 763
 expression: "&ir"
 ---
 {
@@ -85,282 +84,435 @@ expression: "&ir"
         "fragment": "Search your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "SearchLibrary",
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                "Land"
-              ],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "HasSupertype",
-                  "value": "Basic"
-                }
-              ]
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "reveal": false
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "SearchLibrary",
-              "filter": {
-                "type": "Or",
-                "filters": [
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Land"
-                    ],
-                    "controller": null,
-                    "properties": [
-                      {
-                        "type": "HasSupertype",
-                        "value": "Basic"
-                      }
-                    ]
+        "Spell": {
+          "source_text": "Search your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle. You gain 2 life.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
                   },
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Enchantment",
-                      {
-                        "Subtype": "Shrine"
-                      }
-                    ],
-                    "controller": null,
-                    "properties": []
-                  }
-                ]
-              },
-              "count": {
-                "type": "Fixed",
-                "value": 2
-              },
-              "reveal": false,
-              "selection_constraint": {
-                "type": "MatchEachFilter",
-                "filters": [
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Land"
-                    ],
-                    "controller": null,
-                    "properties": [
-                      {
-                        "type": "HasSupertype",
-                        "value": "Basic"
-                      }
-                    ]
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 41,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
                   },
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Enchantment",
-                      {
-                        "Subtype": "Shrine"
+                  "fragment": "Search your library for a basic land card"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": {
+                      "SearchDestination": {
+                        "destination": "Hand",
+                        "enter_tapped": false,
+                        "enters_under": null,
+                        "reveal": false,
+                        "attach_host": null
                       }
-                    ],
-                    "controller": null,
-                    "properties": []
+                    }
                   }
-                ]
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "SearchLibrary",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Land"
+                      ],
+                      "controller": null,
+                      "properties": [
+                        {
+                          "type": "HasSupertype",
+                          "value": "Basic"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "reveal": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 43,
+                    "end_byte": 136,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "If this spell was kicked, instead search your library for a basic land card and a Shrine card"
+                },
+                "disposition": {
+                  "FoldSearchIntoElse": {
+                    "intrinsic": {
+                      "SearchDestination": {
+                        "destination": "Hand",
+                        "enter_tapped": false,
+                        "enters_under": null,
+                        "reveal": false,
+                        "attach_host": null
+                      }
+                    }
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "SearchLibrary",
+                    "filter": {
+                      "type": "Or",
+                      "filters": [
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Land"
+                          ],
+                          "controller": null,
+                          "properties": [
+                            {
+                              "type": "HasSupertype",
+                              "value": "Basic"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Enchantment",
+                            {
+                              "Subtype": "Shrine"
+                            }
+                          ],
+                          "controller": null,
+                          "properties": []
+                        }
+                      ]
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 2
+                    },
+                    "reveal": false,
+                    "selection_constraint": {
+                      "type": "MatchEachFilter",
+                      "filters": [
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Land"
+                          ],
+                          "controller": null,
+                          "properties": [
+                            {
+                              "type": "HasSupertype",
+                              "value": "Basic"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Enchantment",
+                            {
+                              "Subtype": "Shrine"
+                            }
+                          ],
+                          "controller": null,
+                          "properties": []
+                        }
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": {
+                  "type": "AdditionalCostPaidInstead"
+                },
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 2,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 3
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 138,
+                    "end_byte": 156,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 2
+                  },
+                  "fragment": "Reveal those cards"
+                },
+                "disposition": {
+                  "Continue": {
+                    "continuation": "SearchResultClauseHandled"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Reveal",
+                    "target": {
+                      "type": "ParentTarget"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Comma",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 3,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 4
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 158,
+                    "end_byte": 181,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 3
+                  },
+                  "fragment": "put them into your hand"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": null,
+                    "destination": "Hand",
+                    "target": {
+                      "type": "ParentTarget"
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Then",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 4,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 5
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 188,
+                    "end_byte": 195,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 4
+                  },
+                  "fragment": "shuffle"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Shuffle",
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 5,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 6
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 197,
+                    "end_byte": 212,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 5
+                  },
+                  "fragment": "You gain 2 life"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                      "type": "Fixed",
+                      "value": 2
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": "Library",
-                "destination": "Hand",
-                "target": {
-                  "type": "Any"
-                },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "ChangeZone",
-                  "origin": null,
-                  "destination": "Hand",
-                  "target": {
-                    "type": "ParentTarget"
-                  },
-                  "owner_library": false,
-                  "enter_transformed": false,
-                  "enter_tapped": false,
-                  "enters_attacking": false
-                },
-                "cost": null,
-                "sub_ability": {
-                  "kind": "Spell",
-                  "effect": {
-                    "type": "Shuffle",
-                    "target": {
-                      "type": "Controller"
-                    }
-                  },
-                  "cost": null,
-                  "sub_ability": {
-                    "kind": "Spell",
-                    "effect": {
-                      "type": "GainLife",
-                      "amount": {
-                        "type": "Fixed",
-                        "value": 2
-                      }
-                    },
-                    "cost": null,
-                    "sub_ability": null,
-                    "duration": null,
-                    "description": null,
-                    "target_prompt": null,
-                    "condition": null,
-                    "optional_targeting": false,
-                    "optional": false,
-                    "forward_result": false,
-                    "sub_link": "SequentialSibling"
-                  },
-                  "duration": null,
-                  "description": null,
-                  "target_prompt": null,
-                  "condition": null,
-                  "optional_targeting": false,
-                  "optional": false,
-                  "forward_result": false
-                },
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false
-              },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
-            },
-            "else_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": "Library",
-                "destination": "Hand",
-                "target": {
-                  "type": "Any"
-                },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "ChangeZone",
-                  "origin": null,
-                  "destination": "Hand",
-                  "target": {
-                    "type": "ParentTarget"
-                  },
-                  "owner_library": false,
-                  "enter_transformed": false,
-                  "enter_tapped": false,
-                  "enters_attacking": false
-                },
-                "cost": null,
-                "sub_ability": {
-                  "kind": "Spell",
-                  "effect": {
-                    "type": "Shuffle",
-                    "target": {
-                      "type": "Controller"
-                    }
-                  },
-                  "cost": null,
-                  "sub_ability": {
-                    "kind": "Spell",
-                    "effect": {
-                      "type": "GainLife",
-                      "amount": {
-                        "type": "Fixed",
-                        "value": 2
-                      }
-                    },
-                    "cost": null,
-                    "sub_ability": null,
-                    "duration": null,
-                    "description": null,
-                    "target_prompt": null,
-                    "condition": null,
-                    "optional_targeting": false,
-                    "optional": false,
-                    "forward_result": false,
-                    "sub_link": "SequentialSibling"
-                  },
-                  "duration": null,
-                  "description": null,
-                  "target_prompt": null,
-                  "condition": null,
-                  "optional_targeting": false,
-                  "optional": false,
-                  "forward_result": false
-                },
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false
-              },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
-            },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": {
-              "type": "AdditionalCostPaidInstead"
-            },
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "Search your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle.\nYou gain 2 life.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Search your library for a basic land card. If this spell was kicked, instead search your library for a basic land card and a Shrine card. Reveal those cards, put them into your hand, then shuffle.\nYou gain 2 life."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aerial_formation_ir.snap
@@ -49,61 +49,119 @@ expression: "&ir"
         "fragment": "Any number of target creatures each get +1/+1 and gain flying until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
+        "Spell": {
+          "source_text": "Any number of target creatures each get +1/+1 and gain flying until end of turn.",
+          "body": {
+            "clauses": [
               {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "ParentTarget"
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 79,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Any number of target creatures each get +1/+1 and gain flying until end of turn"
                 },
-                "modifications": [
-                  {
-                    "type": "AddPower",
-                    "value": 1
-                  },
-                  {
-                    "type": "AddToughness",
-                    "value": 1
-                  },
-                  {
-                    "type": "AddKeyword",
-                    "keyword": "Flying"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ],
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "ParentTarget"
+                        },
+                        "modifications": [
+                          {
+                            "type": "AddPower",
+                            "value": 1
+                          },
+                          {
+                            "type": "AddToughness",
+                            "value": 1
+                          },
+                          {
+                            "type": "AddKeyword",
+                            "keyword": "Flying"
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "get +1/+1 and gain flying"
+                      }
+                    ],
+                    "duration": "UntilEndOfTurn",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": {
+                    "min": 0,
+                    "max": null
+                  },
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
                 "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "get +1/+1 and gain flying"
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
             ],
-            "duration": "UntilEndOfTurn",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Any number of target creatures each get +1/+1 and gain flying until end of turn."
             }
-          },
-          "cost": null,
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "Any number of target creatures each get +1/+1 and gain flying until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "multi_target": {
-            "min": 0,
-            "max": null
-          },
-          "forward_result": false
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__aetherling_ir.snap
@@ -171,7 +171,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -295,7 +296,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -406,7 +408,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -517,7 +520,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__analyze_the_pollen_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__analyze_the_pollen_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 779
 expression: "&ir"
 ---
 {
@@ -52,161 +51,345 @@ expression: "&ir"
         "fragment": "Search your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "SearchLibrary",
-            "filter": {
-              "type": "Typed",
-              "type_filters": [
-                "Land"
-              ],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "HasSupertype",
-                  "value": "Basic"
-                }
-              ]
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "reveal": true
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "SearchLibrary",
-              "filter": {
-                "type": "Or",
-                "filters": [
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": null,
-                    "properties": []
+        "Spell": {
+          "source_text": "Search your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
                   },
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Land"
-                    ],
-                    "controller": null,
-                    "properties": []
-                  }
-                ]
-              },
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "reveal": true
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": "Library",
-                "destination": "Hand",
-                "target": {
-                  "type": "Any"
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 41,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Search your library for a basic land card"
                 },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "Shuffle",
-                  "target": {
-                    "type": "Controller"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": {
+                      "SearchDestination": {
+                        "destination": "Hand",
+                        "enter_tapped": false,
+                        "enters_under": null,
+                        "reveal": true,
+                        "attach_host": null
+                      }
+                    }
                   }
                 },
-                "cost": null,
-                "sub_ability": null,
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
+                "parsed": {
+                  "effect": {
+                    "type": "SearchLibrary",
+                    "filter": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Land"
+                      ],
+                      "controller": null,
+                      "properties": [
+                        {
+                          "type": "HasSupertype",
+                          "value": "Basic"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "reveal": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
                 "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
-            },
-            "else_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "ChangeZone",
-                "origin": "Library",
-                "destination": "Hand",
-                "target": {
-                  "type": "Any"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 43,
+                    "end_byte": 125,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "If evidence was collected, instead search your library for a creature or land card"
                 },
-                "owner_library": false,
-                "enter_transformed": false,
-                "enter_tapped": false,
-                "enters_attacking": false
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "Shuffle",
-                  "target": {
-                    "type": "Controller"
+                "disposition": {
+                  "FoldSearchIntoElse": {
+                    "intrinsic": {
+                      "SearchDestination": {
+                        "destination": "Hand",
+                        "enter_tapped": false,
+                        "enters_under": null,
+                        "reveal": true,
+                        "attach_host": null
+                      }
+                    }
                   }
                 },
-                "cost": null,
-                "sub_ability": null,
-                "duration": null,
-                "description": null,
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false
+                "parsed": {
+                  "effect": {
+                    "type": "SearchLibrary",
+                    "filter": {
+                      "type": "Or",
+                      "filters": [
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": null,
+                          "properties": []
+                        },
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Land"
+                          ],
+                          "controller": null,
+                          "properties": []
+                        }
+                      ]
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "reveal": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": {
+                  "type": "AdditionalCostPaidInstead"
+                },
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
-            },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": {
-              "type": "AdditionalCostPaidInstead"
-            },
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+              {
+                "id": 2,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 3
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 127,
+                    "end_byte": 143,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 2
+                  },
+                  "fragment": "Reveal that card"
+                },
+                "disposition": {
+                  "Continue": {
+                    "continuation": "SearchResultClauseHandled"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Reveal",
+                    "target": {
+                      "type": "ParentTarget"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Comma",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 3,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 4
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 145,
+                    "end_byte": 166,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 3
+                  },
+                  "fragment": "put it into your hand"
+                },
+                "disposition": {
+                  "Continue": {
+                    "continuation": "SearchResultClauseHandled"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": null,
+                    "destination": "Hand",
+                    "target": {
+                      "type": "ParentTarget"
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Then",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 4,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 5
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 173,
+                    "end_byte": 180,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 4
+                  },
+                  "fragment": "shuffle"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Shuffle",
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "Search your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Search your library for a basic land card. If evidence was collected, instead search your library for a creature or land card. Reveal that card, put it into your hand, then shuffle."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__arni_brokenbrow_ir.snap
@@ -145,7 +145,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_ring_activated_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__barbarian_ring_activated_ir.snap
@@ -156,7 +156,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -304,7 +305,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__batterskull_ir.snap
@@ -188,7 +188,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__birds_of_paradise_ir.snap
@@ -137,7 +137,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__blunt_the_assault_ir.snap
@@ -153,7 +153,8 @@ expression: "&ir"
           "shell": {
             "sub_link": null
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bomat_courier_ir.snap
@@ -296,7 +296,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bone_splinters_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bone_splinters_ir.snap
@@ -57,29 +57,88 @@ expression: "&ir"
         "fragment": "Destroy target creature."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Destroy",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            },
-            "cant_regenerate": false
+        "Spell": {
+          "source_text": "Destroy target creature.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 23,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Destroy target creature"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Destroy",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    },
+                    "cant_regenerate": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Destroy target creature.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Destroy target creature."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__boseiju_who_endures_ir.snap
@@ -101,7 +101,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -501,7 +502,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__browbeat_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__browbeat_ir.snap
@@ -22,55 +22,157 @@ expression: "&ir"
         "fragment": "Any player may have ~ deal 5 damage to them. If no one does, target player draws three cards."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Fixed",
-              "value": 5
-            },
-            "target": {
-              "type": "Player"
-            }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Draw",
-              "count": {
-                "type": "Fixed",
-                "value": 3
+        "Spell": {
+          "source_text": "Any player may have ~ deal 5 damage to them. If no one does, target player draws three cards.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 43,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Any player may have ~ deal 5 damage to them"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                      "type": "Fixed",
+                      "value": 5
+                    },
+                    "target": {
+                      "type": "Player"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": true,
+                "opponent_may_scope": "AnyPlayer",
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "target": {
-                "type": "Player"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 45,
+                    "end_byte": 92,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "If no one does, target player draws three cards"
+                },
+                "disposition": {
+                  "BranchOtherwise": {
+                    "else_def": {
+                      "kind": "Spell",
+                      "effect": {
+                        "type": "Draw",
+                        "count": {
+                          "type": "Fixed",
+                          "value": 3
+                        },
+                        "target": {
+                          "type": "Player"
+                        }
+                      },
+                      "cost": null,
+                      "sub_ability": null,
+                      "duration": null,
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": null,
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false
+                    },
+                    "kind": "Bound"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "otherwise_placeholder",
+                    "description": null
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": {
-              "type": "Not",
-              "condition": {
-                "type": "EffectOutcome",
-                "signal": "OptionalEffectPerformed"
-              }
-            },
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "Any player may have ~ deal 5 damage to them. If no one does, target player draws three cards.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": true,
-          "optional_for": "AnyPlayer",
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Any player may have ~ deal 5 damage to them. If no one does, target player draws three cards."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__carbonize_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__carbonize_ir.snap
@@ -22,145 +22,304 @@ expression: "&ir"
         "fragment": "~ deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Fixed",
-              "value": 3
-            },
-            "target": {
-              "type": "Any"
-            }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "CantBeRegenerated",
-                  "affected": {
-                    "type": "ParentTarget"
+        "Spell": {
+          "source_text": "~ deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
                   },
-                  "modifications": [
-                    {
-                      "type": "AddStaticMode",
-                      "mode": "CantBeRegenerated"
-                    }
-                  ],
-                  "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": null
-                }
-              ],
-              "duration": "UntilEndOfTurn",
-              "target": {
-                "type": "TrackedSet",
-                "id": 0
-              }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "AddTargetReplacement",
-                "replacement": {
-                  "event": "Moved",
-                  "execute": {
-                    "kind": "Spell",
-                    "effect": {
-                      "type": "ChangeZone",
-                      "origin": "Battlefield",
-                      "destination": "Exile",
-                      "target": {
-                        "type": "SelfRef"
-                      },
-                      "owner_library": false,
-                      "enter_transformed": false,
-                      "enter_tapped": false,
-                      "enters_attacking": false
-                    },
-                    "cost": null,
-                    "sub_ability": null,
-                    "duration": null,
-                    "description": null,
-                    "target_prompt": null,
-                    "condition": null,
-                    "optional_targeting": false,
-                    "optional": false,
-                    "forward_result": false
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 30,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
                   },
-                  "mode": {
-                    "type": "Mandatory"
-                  },
-                  "valid_card": {
-                    "type": "SelfRef"
-                  },
-                  "description": null,
-                  "condition": null,
-                  "destination_zone": "Graveyard",
-                  "consume_on_apply": true,
-                  "expiry": {
-                    "type": "EndOfTurn"
+                  "fragment": "~ deals 3 damage to any target"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
                 },
-                "target": {
-                  "type": "Any"
-                }
-              },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": {
-                "type": "TargetMatchesFilter",
-                "filter": {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": null,
-                  "properties": []
+                "parsed": {
+                  "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                      "type": "Fixed",
+                      "value": 3
+                    },
+                    "target": {
+                      "type": "Any"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
                 },
-                "use_lki": true
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
-            },
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": {
-              "type": "TargetMatchesFilter",
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Creature"
-                ],
-                "controller": null,
-                "properties": []
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 32,
+                    "end_byte": 134,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead"
+                },
+                "disposition": {
+                  "Absorb": {
+                    "rider": {
+                      "kind": "Spell",
+                      "effect": {
+                        "type": "GenericEffect",
+                        "static_abilities": [
+                          {
+                            "mode": "CantBeRegenerated",
+                            "affected": {
+                              "type": "ParentTarget"
+                            },
+                            "modifications": [
+                              {
+                                "type": "AddStaticMode",
+                                "mode": "CantBeRegenerated"
+                              }
+                            ],
+                            "condition": null,
+                            "affected_zone": null,
+                            "effect_zone": null,
+                            "active_zones": [],
+                            "characteristic_defining": false,
+                            "description": null
+                          }
+                        ],
+                        "duration": "UntilEndOfTurn",
+                        "target": {
+                          "type": "TrackedSet",
+                          "id": 0
+                        }
+                      },
+                      "cost": null,
+                      "sub_ability": null,
+                      "duration": "UntilEndOfTurn",
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": {
+                        "type": "TargetMatchesFilter",
+                        "filter": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": null,
+                          "properties": []
+                        },
+                        "use_lki": true
+                      },
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false
+                    },
+                    "kind": "CantBeRegenerated"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "cant_be_regenerated_rider_placeholder",
+                    "description": ""
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "use_lki": true
-            },
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+              {
+                "id": 2,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 3
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 134,
+                    "end_byte": 134,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 2
+                  },
+                  "fragment": "If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead"
+                },
+                "disposition": {
+                  "Absorb": {
+                    "rider": {
+                      "kind": "Spell",
+                      "effect": {
+                        "type": "AddTargetReplacement",
+                        "replacement": {
+                          "event": "Moved",
+                          "execute": {
+                            "kind": "Spell",
+                            "effect": {
+                              "type": "ChangeZone",
+                              "origin": "Battlefield",
+                              "destination": "Exile",
+                              "target": {
+                                "type": "SelfRef"
+                              },
+                              "owner_library": false,
+                              "enter_transformed": false,
+                              "enter_tapped": false,
+                              "enters_attacking": false
+                            },
+                            "cost": null,
+                            "sub_ability": null,
+                            "duration": null,
+                            "description": null,
+                            "target_prompt": null,
+                            "condition": null,
+                            "optional_targeting": false,
+                            "optional": false,
+                            "forward_result": false
+                          },
+                          "mode": {
+                            "type": "Mandatory"
+                          },
+                          "valid_card": {
+                            "type": "SelfRef"
+                          },
+                          "description": null,
+                          "condition": null,
+                          "destination_zone": "Graveyard",
+                          "consume_on_apply": true,
+                          "expiry": {
+                            "type": "EndOfTurn"
+                          }
+                        },
+                        "target": {
+                          "type": "Any"
+                        }
+                      },
+                      "cost": null,
+                      "sub_ability": null,
+                      "duration": null,
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": {
+                        "type": "TargetMatchesFilter",
+                        "filter": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": null,
+                          "properties": []
+                        },
+                        "use_lki": true
+                      },
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false
+                    },
+                    "kind": "DieExile"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "die_exile_rider_placeholder",
+                    "description": ""
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "~ deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "~ deals 3 damage to any target. If it's a creature, it can't be regenerated this turn, and if it would die this turn, exile it instead."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__case_of_the_stashed_skeleton_ir.snap
@@ -378,7 +378,8 @@ expression: "&ir"
             ],
             "description": "Solved — {1}{B}, Sacrifice this ~: Search your library for a card, put it into your hand, then shuffle. Activate only as a sorcery."
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__champions_victory_ir.snap
@@ -73,33 +73,92 @@ expression: "&ir"
         "fragment": "Return target attacking creature to its owner's hand."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Bounce",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "Attacking"
-                }
-              ]
-            },
-            "destination": null
+        "Spell": {
+          "source_text": "Return target attacking creature to its owner's hand.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 52,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Return target attacking creature to its owner's hand"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Bounce",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": [
+                        {
+                          "type": "Attacking"
+                        }
+                      ]
+                    },
+                    "destination": null
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Return target attacking creature to its owner's hand.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Return target attacking creature to its owner's hand."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__component_pouch_activated_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__component_pouch_activated_ir.snap
@@ -155,7 +155,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -332,7 +333,8 @@ expression: "&ir"
                 "shell": {
                   "sub_link": null
                 },
-                "die_results": []
+                "die_results": [],
+                "root_transforms": []
               }
             },
             {
@@ -410,10 +412,12 @@ expression: "&ir"
                 "shell": {
                   "sub_link": null
                 },
-                "die_results": []
+                "die_results": [],
+                "root_transforms": []
               }
             }
-          ]
+          ],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__deadly_rollick_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__deadly_rollick_ir.snap
@@ -69,34 +69,93 @@ expression: "&ir"
         "fragment": "Exile target creature."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "ChangeZone",
-            "origin": null,
-            "destination": "Exile",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            },
-            "owner_library": false,
-            "enter_transformed": false,
-            "enter_tapped": false,
-            "enters_attacking": false
+        "Spell": {
+          "source_text": "Exile target creature.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 21,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Exile target creature"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": null,
+                    "destination": "Exile",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Exile target creature.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Exile target creature."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dismember_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__dismember_ir.snap
@@ -22,36 +22,95 @@ expression: "&ir"
         "fragment": "Target creature gets -5/-5 until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Pump",
-            "power": {
-              "type": "Fixed",
-              "value": -5
-            },
-            "toughness": {
-              "type": "Fixed",
-              "value": -5
-            },
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            }
+        "Spell": {
+          "source_text": "Target creature gets -5/-5 until end of turn.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 44,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target creature gets -5/-5 until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Pump",
+                    "power": {
+                      "type": "Fixed",
+                      "value": -5
+                    },
+                    "toughness": {
+                      "type": "Fixed",
+                      "value": -5
+                    },
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": "UntilEndOfTurn",
-          "description": "Target creature gets -5/-5 until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Target creature gets -5/-5 until end of turn."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__evils_thrall_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__evils_thrall_ir.snap
@@ -22,156 +22,332 @@ expression: "&ir"
         "fragment": "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "GainControl",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GainControl",
-              "target": {
-                "type": "ParentTarget"
-              }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "SetTapState",
-                "target": {
-                  "type": "ParentTarget"
+        "Spell": {
+          "source_text": "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 49,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Gain control of target creature until end of turn"
                 },
-                "scope": {
-                  "type": "Single"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
                 },
-                "state": {
-                  "type": "Untap"
-                }
-              },
-              "cost": null,
-              "sub_ability": {
-                "kind": "Spell",
-                "effect": {
-                  "type": "GenericEffect",
-                  "static_abilities": [
-                    {
-                      "mode": "Continuous",
-                      "affected": {
-                        "type": "SelfRef"
-                      },
-                      "modifications": [
-                        {
-                          "type": "AddKeyword",
-                          "keyword": "Haste"
-                        }
-                      ],
-                      "condition": null,
-                      "affected_zone": null,
-                      "effect_zone": null,
-                      "active_zones": [],
-                      "characteristic_defining": false,
-                      "description": "gain haste"
-                    }
-                  ],
-                  "duration": "UntilEndOfTurn",
-                  "target": null
-                },
-                "cost": null,
-                "sub_ability": null,
-                "duration": "UntilEndOfTurn",
-                "description": null,
-                "target_prompt": null,
-                "condition": null,
-                "optional_targeting": false,
-                "optional": false,
-                "forward_result": false,
-                "sub_link": "SequentialSibling"
-              },
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false,
-              "sub_link": "SequentialSibling"
-            },
-            "duration": {
-              "UntilEndOfNextTurnOf": {
-                "player": {
-                  "type": "Controller"
-                }
-              }
-            },
-            "description": null,
-            "target_prompt": null,
-            "condition": {
-              "type": "ConditionInstead",
-              "inner": {
-                "type": "QuantityCheck",
-                "lhs": {
-                  "type": "Ref",
-                  "qty": {
-                    "type": "ObjectCount",
-                    "filter": {
+                "parsed": {
+                  "effect": {
+                    "type": "GainControl",
+                    "target": {
                       "type": "Typed",
                       "type_filters": [
-                        {
-                          "Subtype": "Villain"
-                        }
+                        "Creature"
                       ],
-                      "controller": "You",
-                      "properties": [
-                        {
-                          "type": "Cmc",
-                          "comparator": "GT",
-                          "value": {
-                            "type": "Ref",
-                            "qty": {
-                              "type": "ObjectManaValue",
-                              "scope": {
-                                "type": "Target"
-                              }
+                      "controller": null,
+                      "properties": []
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 51,
+                    "end_byte": 189,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead"
+                },
+                "disposition": {
+                  "ReplaceMeaning": {
+                    "kind": {
+                      "Instead": {
+                        "kind": "Spell",
+                        "effect": {
+                          "type": "GainControl",
+                          "target": {
+                            "type": "ParentTarget"
+                          }
+                        },
+                        "cost": null,
+                        "sub_ability": null,
+                        "duration": {
+                          "UntilEndOfNextTurnOf": {
+                            "player": {
+                              "type": "Controller"
                             }
                           }
                         },
-                        {
-                          "type": "InZone",
-                          "zone": "Battlefield"
-                        }
-                      ]
+                        "description": null,
+                        "target_prompt": null,
+                        "condition": {
+                          "type": "ConditionInstead",
+                          "inner": {
+                            "type": "QuantityCheck",
+                            "lhs": {
+                              "type": "Ref",
+                              "qty": {
+                                "type": "ObjectCount",
+                                "filter": {
+                                  "type": "Typed",
+                                  "type_filters": [
+                                    {
+                                      "Subtype": "Villain"
+                                    }
+                                  ],
+                                  "controller": "You",
+                                  "properties": [
+                                    {
+                                      "type": "Cmc",
+                                      "comparator": "GT",
+                                      "value": {
+                                        "type": "Ref",
+                                        "qty": {
+                                          "type": "ObjectManaValue",
+                                          "scope": {
+                                            "type": "Target"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "type": "InZone",
+                                      "zone": "Battlefield"
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "comparator": "GE",
+                            "rhs": {
+                              "type": "Fixed",
+                              "value": 1
+                            }
+                          }
+                        },
+                        "optional_targeting": false,
+                        "optional": false,
+                        "forward_result": false
+                      }
                     }
                   }
                 },
-                "comparator": "GE",
-                "rhs": {
-                  "type": "Fixed",
-                  "value": 1
-                }
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "instead_clause_placeholder",
+                    "description": null
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 2,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 3
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 191,
+                    "end_byte": 210,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 2
+                  },
+                  "fragment": "Untap that creature"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "SetTapState",
+                    "target": {
+                      "type": "ParentTarget"
+                    },
+                    "scope": {
+                      "type": "Single"
+                    },
+                    "state": {
+                      "type": "Untap"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 3,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 4
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 212,
+                    "end_byte": 244,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 3
+                  },
+                  "fragment": "It gains haste until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "SelfRef"
+                        },
+                        "modifications": [
+                          {
+                            "type": "AddKeyword",
+                            "keyword": "Haste"
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "gain haste"
+                      }
+                    ],
+                    "duration": "UntilEndOfTurn",
+                    "target": null
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": "UntilEndOfTurn",
-          "description": "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Gain control of target creature until end of turn. If you control a Villain with greater mana value than that creature, gain control of that creature until the end of your next turn instead. Untap that creature. It gains haste until end of turn."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__experiment_one_ir.snap
@@ -133,7 +133,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__figure_of_destiny_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__figure_of_destiny_ir.snap
@@ -144,7 +144,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -306,7 +307,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -479,7 +481,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__fog_ir.snap
@@ -91,7 +91,8 @@ expression: "&ir"
           "shell": {
             "sub_link": null
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__follow_the_lumarets_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__follow_the_lumarets_ir.snap
@@ -22,119 +22,394 @@ expression: "&ir"
         "fragment": "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Dig",
-            "player": {
-              "type": "Controller"
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 4
-            },
-            "destination": "Hand",
-            "keep_count": 2,
-            "up_to": false,
-            "filter": {
-              "type": "Or",
-              "filters": [
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Creature"
-                  ],
-                  "controller": null,
-                  "properties": []
-                },
-                {
-                  "type": "Typed",
-                  "type_filters": [
-                    "Land"
-                  ],
-                  "controller": null,
-                  "properties": []
-                }
-              ]
-            },
-            "rest_destination": "Library",
-            "reveal": false,
-            "enter_tapped": false
-          },
-          "cost": null,
-          "sub_ability": null,
-          "else_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Dig",
-              "player": {
-                "type": "Controller"
-              },
-              "count": {
-                "type": "Fixed",
-                "value": 4
-              },
-              "destination": "Hand",
-              "keep_count": 1,
-              "up_to": true,
-              "filter": {
-                "type": "Or",
-                "filters": [
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Creature"
-                    ],
-                    "controller": null,
-                    "properties": []
+        "Spell": {
+          "source_text": "Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
                   },
-                  {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Land"
-                    ],
-                    "controller": null,
-                    "properties": []
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 42,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Look at the top four cards of your library"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ]
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Dig",
+                    "player": {
+                      "type": "Controller"
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 4
+                    },
+                    "destination": null,
+                    "keep_count": null,
+                    "up_to": false,
+                    "filter": {
+                      "type": "Any"
+                    },
+                    "rest_destination": null,
+                    "reveal": false,
+                    "enter_tapped": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "rest_destination": "Library",
-              "reveal": true,
-              "enter_tapped": false
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
-          },
-          "duration": null,
-          "description": "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order.",
-          "target_prompt": null,
-          "condition": {
-            "type": "QuantityCheck",
-            "lhs": {
-              "type": "Ref",
-              "qty": {
-                "type": "LifeGainedThisTurn",
-                "player": {
-                  "type": "Controller"
-                }
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 44,
+                    "end_byte": 124,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "You may reveal a creature or land card from among them and put it into your hand"
+                },
+                "disposition": {
+                  "Continue": {
+                    "continuation": {
+                      "DigFromAmong": {
+                        "quantity": {
+                          "Up": {
+                            "type": "Fixed",
+                            "value": 1
+                          }
+                        },
+                        "filter": {
+                          "type": "Or",
+                          "filters": [
+                            {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Creature"
+                              ],
+                              "controller": null,
+                              "properties": []
+                            },
+                            {
+                              "type": "Typed",
+                              "type_filters": [
+                                "Land"
+                              ],
+                              "controller": null,
+                              "properties": []
+                            }
+                          ]
+                        },
+                        "destination": "Hand",
+                        "rest_destination": null,
+                        "enter_tapped": false,
+                        "reveal_verb": true
+                      }
+                    }
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "RevealHand",
+                    "target": {
+                      "type": "Any"
+                    },
+                    "card_filter": {
+                      "type": "None"
+                    },
+                    "count": null,
+                    "reveal": true
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": true,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 2,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 3
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 126,
+                    "end_byte": 253,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 2
+                  },
+                  "fragment": "If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand"
+                },
+                "disposition": {
+                  "ReplaceMeaning": {
+                    "kind": {
+                      "DigAlt": {
+                        "kind": "Spell",
+                        "effect": {
+                          "type": "Dig",
+                          "player": {
+                            "type": "Controller"
+                          },
+                          "count": {
+                            "type": "Fixed",
+                            "value": 4
+                          },
+                          "destination": "Hand",
+                          "keep_count": 2,
+                          "up_to": false,
+                          "filter": {
+                            "type": "Or",
+                            "filters": [
+                              {
+                                "type": "Typed",
+                                "type_filters": [
+                                  "Creature"
+                                ],
+                                "controller": null,
+                                "properties": []
+                              },
+                              {
+                                "type": "Typed",
+                                "type_filters": [
+                                  "Land"
+                                ],
+                                "controller": null,
+                                "properties": []
+                              }
+                            ]
+                          },
+                          "rest_destination": null,
+                          "reveal": false,
+                          "enter_tapped": false
+                        },
+                        "cost": null,
+                        "sub_ability": null,
+                        "duration": null,
+                        "description": null,
+                        "target_prompt": null,
+                        "condition": {
+                          "type": "QuantityCheck",
+                          "lhs": {
+                            "type": "Ref",
+                            "qty": {
+                              "type": "LifeGainedThisTurn",
+                              "player": {
+                                "type": "Controller"
+                              }
+                            }
+                          },
+                          "comparator": "GE",
+                          "rhs": {
+                            "type": "Fixed",
+                            "value": 1
+                          }
+                        },
+                        "optional_targeting": false,
+                        "optional": false,
+                        "forward_result": false
+                      }
+                    }
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Dig",
+                    "player": {
+                      "type": "Controller"
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 4
+                    },
+                    "destination": "Hand",
+                    "keep_count": 2,
+                    "up_to": false,
+                    "filter": {
+                      "type": "Or",
+                      "filters": [
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Creature"
+                          ],
+                          "controller": null,
+                          "properties": []
+                        },
+                        {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Land"
+                          ],
+                          "controller": null,
+                          "properties": []
+                        }
+                      ]
+                    },
+                    "rest_destination": null,
+                    "reveal": false,
+                    "enter_tapped": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 3,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 4
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 255,
+                    "end_byte": 315,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 3
+                  },
+                  "fragment": "Put the rest on the bottom of your library in a random order"
+                },
+                "disposition": {
+                  "Continue": {
+                    "continuation": {
+                      "PutRest": {
+                        "destination": "Library",
+                        "reorder_all": false
+                      }
+                    }
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "PutAtLibraryPosition",
+                    "target": {
+                      "type": "TrackedSet",
+                      "id": 0
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "position": {
+                      "type": "Bottom"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "comparator": "GE",
-            "rhs": {
-              "type": "Fixed",
-              "value": 1
-            }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Infusion — Look at the top four cards of your library. You may reveal a creature or land card from among them and put it into your hand. If you gained life this turn, you may instead reveal two creature and/or land cards from among them and put them into your hand. Put the rest on the bottom of your library in a random order."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__ghost_lit_stalker_ir.snap
@@ -122,7 +122,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -252,7 +253,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__govern_the_guildless_ir.snap
@@ -22,34 +22,93 @@ expression: "&ir"
         "fragment": "Gain control of target monocolored creature."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "GainControl",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "ColorCount",
-                  "comparator": "EQ",
-                  "count": 1
-                }
-              ]
-            }
+        "Spell": {
+          "source_text": "Gain control of target monocolored creature.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 43,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Gain control of target monocolored creature"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GainControl",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": [
+                        {
+                          "type": "ColorCount",
+                          "comparator": "EQ",
+                          "count": 1
+                        }
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Gain control of target monocolored creature.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Gain control of target monocolored creature."
+            }
+          ]
         }
       }
     },
@@ -213,7 +272,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__guul_draz_assassin_ir.snap
@@ -217,7 +217,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -403,7 +404,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__incinerate_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__incinerate_ir.snap
@@ -22,66 +22,175 @@ expression: "&ir"
         "fragment": "~ deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Fixed",
-              "value": 3
-            },
-            "target": {
-              "type": "Any"
-            }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GenericEffect",
-              "static_abilities": [
-                {
-                  "mode": "CantBeRegenerated",
-                  "affected": {
-                    "type": "ParentTarget"
+        "Spell": {
+          "source_text": "~ deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
                   },
-                  "modifications": [
-                    {
-                      "type": "AddStaticMode",
-                      "mode": "CantBeRegenerated"
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 30,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "~ deals 3 damage to any target"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                      "type": "Fixed",
+                      "value": 3
+                    },
+                    "target": {
+                      "type": "Any"
                     }
-                  ],
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
                   "condition": null,
-                  "affected_zone": null,
-                  "effect_zone": null,
-                  "active_zones": [],
-                  "characteristic_defining": false,
-                  "description": null
-                }
-              ],
-              "duration": "UntilEndOfTurn",
-              "target": {
-                "type": "TrackedSet",
-                "id": 0
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 32,
+                    "end_byte": 95,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "A creature dealt damage this way can't be regenerated this turn"
+                },
+                "disposition": {
+                  "Absorb": {
+                    "rider": {
+                      "kind": "Spell",
+                      "effect": {
+                        "type": "GenericEffect",
+                        "static_abilities": [
+                          {
+                            "mode": "CantBeRegenerated",
+                            "affected": {
+                              "type": "ParentTarget"
+                            },
+                            "modifications": [
+                              {
+                                "type": "AddStaticMode",
+                                "mode": "CantBeRegenerated"
+                              }
+                            ],
+                            "condition": null,
+                            "affected_zone": null,
+                            "effect_zone": null,
+                            "active_zones": [],
+                            "characteristic_defining": false,
+                            "description": null
+                          }
+                        ],
+                        "duration": "UntilEndOfTurn",
+                        "target": {
+                          "type": "TrackedSet",
+                          "id": 0
+                        }
+                      },
+                      "cost": null,
+                      "sub_ability": null,
+                      "duration": "UntilEndOfTurn",
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": null,
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false
+                    },
+                    "kind": "CantBeRegenerated"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "cant_be_regenerated_rider_placeholder",
+                    "description": ""
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "~ deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "~ deals 3 damage to any target. A creature dealt damage this way can't be regenerated this turn."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jade_mage_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jade_mage_ir.snap
@@ -128,7 +128,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__joraga_treespeaker_ir.snap
@@ -193,7 +193,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_the_repentant_ir.snap
@@ -395,7 +395,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__llanowar_elves_ir.snap
@@ -101,7 +101,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__manamorphose_ir.snap
@@ -22,57 +22,148 @@ expression: "&ir"
         "fragment": "Add two mana in any combination of colors."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Mana",
-            "produced": {
-              "type": "AnyCombination",
-              "count": {
-                "type": "Fixed",
-                "value": 2
+        "Spell": {
+          "source_text": "Add two mana in any combination of colors. Draw a card.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 41,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Add two mana in any combination of colors"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Mana",
+                    "produced": {
+                      "type": "AnyCombination",
+                      "count": {
+                        "type": "Fixed",
+                        "value": 2
+                      },
+                      "color_options": [
+                        "White",
+                        "Blue",
+                        "Black",
+                        "Red",
+                        "Green"
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "color_options": [
-                "White",
-                "Blue",
-                "Black",
-                "Red",
-                "Green"
-              ]
-            }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Draw",
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "target": {
-                "type": "Controller"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 43,
+                    "end_byte": 54,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "Draw a card"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Draw",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "Add two mana in any combination of colors.\nDraw a card.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false,
-          "is_mana_ability": true
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Add two mana in any combination of colors.\nDraw a card."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mother_of_runes_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__mother_of_runes_ir.snap
@@ -126,7 +126,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__questing_beast_ir.snap
@@ -184,7 +184,8 @@ expression: "&ir"
           "shell": {
             "sub_link": null
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__repeat_offender_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__repeat_offender_ir.snap
@@ -192,7 +192,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__stoneforge_mystic_ir.snap
@@ -329,7 +329,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__swords_to_plowshares_ir.snap
@@ -22,61 +22,153 @@ expression: "&ir"
         "fragment": "Exile target creature. Its controller gains life equal to its power."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "ChangeZone",
-            "origin": null,
-            "destination": "Exile",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            },
-            "owner_library": false,
-            "enter_transformed": false,
-            "enter_tapped": false,
-            "enters_attacking": false
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "GainLife",
-              "amount": {
-                "type": "Ref",
-                "qty": {
-                  "type": "Power",
-                  "scope": {
-                    "type": "Target"
+        "Spell": {
+          "source_text": "Exile target creature. Its controller gains life equal to its power.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 21,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Exile target creature"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZone",
+                    "origin": null,
+                    "destination": "Exile",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    },
+                    "owner_library": false,
+                    "enter_transformed": false,
+                    "enter_tapped": false,
+                    "enters_attacking": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "player": {
-                "type": "ParentTargetController"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 23,
+                    "end_byte": 67,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "Its controller gains life equal to its power"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GainLife",
+                    "amount": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "Power",
+                        "scope": {
+                          "type": "Target"
+                        }
+                      }
+                    },
+                    "player": {
+                      "type": "ParentTargetController"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "Exile target creature. Its controller gains life equal to its power.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Exile target creature. Its controller gains life equal to its power."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_safekeeper_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__sylvan_safekeeper_ir.snap
@@ -133,7 +133,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thespians_stage_generic_activated_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__thespians_stage_generic_activated_ir.snap
@@ -102,7 +102,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -225,7 +226,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__touch_of_the_void_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__touch_of_the_void_ir.snap
@@ -43,84 +43,193 @@ expression: "&ir"
         "fragment": "~ deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "DealDamage",
-            "amount": {
-              "type": "Fixed",
-              "value": 3
-            },
-            "target": {
-              "type": "Any"
-            }
-          },
-          "cost": null,
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "AddTargetReplacement",
-              "replacement": {
-                "event": "Moved",
-                "execute": {
-                  "kind": "Spell",
-                  "effect": {
-                    "type": "ChangeZone",
-                    "origin": "Battlefield",
-                    "destination": "Exile",
-                    "target": {
-                      "type": "SelfRef"
-                    },
-                    "owner_library": false,
-                    "enter_transformed": false,
-                    "enter_tapped": false,
-                    "enters_attacking": false
+        "Spell": {
+          "source_text": "~ deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
                   },
-                  "cost": null,
-                  "sub_ability": null,
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 30,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "~ deals 3 damage to any target"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                      "type": "Fixed",
+                      "value": 3
+                    },
+                    "target": {
+                      "type": "Any"
+                    }
+                  },
                   "duration": null,
-                  "description": null,
-                  "target_prompt": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
                   "condition": null,
-                  "optional_targeting": false,
                   "optional": false,
-                  "forward_result": false
+                  "unless_pay": null
                 },
-                "mode": {
-                  "type": "Mandatory"
-                },
-                "valid_card": {
-                  "type": "SelfRef"
-                },
-                "description": null,
+                "boundary": "Sentence",
                 "condition": null,
-                "destination_zone": "Graveyard",
-                "consume_on_apply": true,
-                "expiry": {
-                  "type": "EndOfTurn"
-                }
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "target": {
-                "type": "Any"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 32,
+                    "end_byte": 105,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "If a creature dealt damage this way would die this turn, exile it instead"
+                },
+                "disposition": {
+                  "Absorb": {
+                    "rider": {
+                      "kind": "Spell",
+                      "effect": {
+                        "type": "AddTargetReplacement",
+                        "replacement": {
+                          "event": "Moved",
+                          "execute": {
+                            "kind": "Spell",
+                            "effect": {
+                              "type": "ChangeZone",
+                              "origin": "Battlefield",
+                              "destination": "Exile",
+                              "target": {
+                                "type": "SelfRef"
+                              },
+                              "owner_library": false,
+                              "enter_transformed": false,
+                              "enter_tapped": false,
+                              "enters_attacking": false
+                            },
+                            "cost": null,
+                            "sub_ability": null,
+                            "duration": null,
+                            "description": null,
+                            "target_prompt": null,
+                            "condition": null,
+                            "optional_targeting": false,
+                            "optional": false,
+                            "forward_result": false
+                          },
+                          "mode": {
+                            "type": "Mandatory"
+                          },
+                          "valid_card": {
+                            "type": "SelfRef"
+                          },
+                          "description": null,
+                          "condition": null,
+                          "destination_zone": "Graveyard",
+                          "consume_on_apply": true,
+                          "expiry": {
+                            "type": "EndOfTurn"
+                          }
+                        },
+                        "target": {
+                          "type": "Any"
+                        }
+                      },
+                      "cost": null,
+                      "sub_ability": null,
+                      "duration": null,
+                      "description": null,
+                      "target_prompt": null,
+                      "condition": null,
+                      "optional_targeting": false,
+                      "optional": false,
+                      "forward_result": false
+                    },
+                    "kind": "DieExile"
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "die_exile_rider_placeholder",
+                    "description": null
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "~ deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "~ deals 3 damage to any target. If a creature dealt damage this way would die this turn, exile it instead."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__village_rites_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__village_rites_ir.snap
@@ -57,27 +57,86 @@ expression: "&ir"
         "fragment": "Draw two cards."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "Draw",
-            "count": {
-              "type": "Fixed",
-              "value": 2
-            },
-            "target": {
-              "type": "Controller"
-            }
+        "Spell": {
+          "source_text": "Draw two cards.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 14,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Draw two cards"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Draw",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 2
+                    },
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Spell",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "cost": null,
-          "sub_ability": null,
-          "duration": null,
-          "description": "Draw two cards.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Draw two cards."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__vines_of_vastwood_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__vines_of_vastwood_ir.snap
@@ -88,77 +88,169 @@ expression: "&ir"
         "fragment": "Target creature can't be the target of spells or abilities your opponents control this turn. If this spell was kicked, that creature gets +4/+4 until end of turn."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Spell",
-          "effect": {
-            "type": "GenericEffect",
-            "static_abilities": [
+        "Spell": {
+          "source_text": "Target creature can't be the target of spells or abilities your opponents control this turn. If this spell was kicked, that creature gets +4/+4 until end of turn.",
+          "body": {
+            "clauses": [
               {
-                "mode": "Continuous",
-                "affected": {
-                  "type": "ParentTarget"
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 91,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target creature can't be the target of spells or abilities your opponents control this turn"
                 },
-                "modifications": [
-                  {
-                    "type": "AddKeyword",
-                    "keyword": "Hexproof"
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ],
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "GenericEffect",
+                    "static_abilities": [
+                      {
+                        "mode": "Continuous",
+                        "affected": {
+                          "type": "ParentTarget"
+                        },
+                        "modifications": [
+                          {
+                            "type": "AddKeyword",
+                            "keyword": "Hexproof"
+                          }
+                        ],
+                        "condition": null,
+                        "affected_zone": null,
+                        "effect_zone": null,
+                        "active_zones": [],
+                        "characteristic_defining": false,
+                        "description": "can't be the target of spells or abilities your opponents control"
+                      }
+                    ],
+                    "duration": "UntilEndOfTurn",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
                 "condition": null,
-                "affected_zone": null,
-                "effect_zone": null,
-                "active_zones": [],
-                "characteristic_defining": false,
-                "description": "can't be the target of spells or abilities your opponents control"
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 93,
+                    "end_byte": 161,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "If this spell was kicked, that creature gets +4/+4 until end of turn"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Pump",
+                    "power": {
+                      "type": "Fixed",
+                      "value": 4
+                    },
+                    "toughness": {
+                      "type": "Fixed",
+                      "value": 4
+                    },
+                    "target": {
+                      "type": "ParentTarget"
+                    }
+                  },
+                  "duration": "UntilEndOfTurn",
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": {
+                  "type": "AdditionalCostPaid"
+                },
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
             ],
-            "duration": "UntilEndOfTurn",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
-            }
-          },
-          "cost": null,
-          "sub_ability": {
             "kind": "Spell",
-            "effect": {
-              "type": "Pump",
-              "power": {
-                "type": "Fixed",
-                "value": 4
-              },
-              "toughness": {
-                "type": "Fixed",
-                "value": 4
-              },
-              "target": {
-                "type": "ParentTarget"
-              }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": "UntilEndOfTurn",
-            "description": null,
-            "target_prompt": null,
-            "condition": {
-              "type": "AdditionalCostPaid"
-            },
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": "UntilEndOfTurn",
-          "description": "Target creature can't be the target of spells or abilities your opponents control this turn. If this spell was kicked, that creature gets +4/+4 until end of turn.",
-          "target_prompt": null,
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null
+          },
+          "die_results": [],
+          "root_transforms": [
+            {
+              "SetMinXValue": 0
+            },
+            {
+              "SetDescription": "Target creature can't be the target of spells or abilities your opponents control this turn. If this spell was kicked, that creature gets +4/+4 until end of turn."
+            }
+          ]
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__walking_ballista_ir.snap
@@ -169,7 +169,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -278,7 +279,8 @@ expression: "&ir"
               "ExtractManaSpendTrigger"
             ]
           },
-          "die_results": []
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -207,24 +207,6 @@ impl VoteIr {
             self.in_trigger,
         )
     }
-
-    /// Compatibility lowering for non-trigger callers that have not yet moved
-    /// to trigger-body IR. Trigger parsing uses [`Self::effect_chain`] instead.
-    pub(crate) fn into_ability(self, kind: AbilityKind) -> AbilityDefinition {
-        let vote = AbilityDefinition::new(kind, self.vote);
-        match self.pre_vote_choose {
-            Some(choice_type) => AbilityDefinition::new(
-                kind,
-                Effect::Choose {
-                    choice_type,
-                    persist: true,
-                    selection: TargetSelectionMode::Random,
-                },
-            )
-            .sub_ability(vote),
-            None => vote,
-        }
-    }
 }
 
 /// CR 700.3: Typed pile-separation trigger body.
@@ -273,12 +255,6 @@ impl PileIr {
             self.actor.clone(),
             self.in_trigger,
         )
-    }
-
-    /// Compatibility lowering for non-trigger callers that still consume a
-    /// lowered definition. Trigger parsing uses [`Self::effect_chain`] instead.
-    pub(crate) fn into_ability(self, kind: AbilityKind) -> AbilityDefinition {
-        AbilityDefinition::new(kind, self.effect)
     }
 }
 

--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -207,6 +207,23 @@ impl VoteIr {
             self.in_trigger,
         )
     }
+
+    /// Compatibility lowering for callers outside the native spell router.
+    pub(crate) fn into_ability(self, kind: AbilityKind) -> AbilityDefinition {
+        let vote = AbilityDefinition::new(kind, self.vote);
+        match self.pre_vote_choose {
+            Some(choice_type) => AbilityDefinition::new(
+                kind,
+                Effect::Choose {
+                    choice_type,
+                    persist: true,
+                    selection: TargetSelectionMode::Random,
+                },
+            )
+            .sub_ability(vote),
+            None => vote,
+        }
+    }
 }
 
 /// CR 700.3: Typed pile-separation trigger body.

--- a/crates/engine/src/parser/oracle_separate_piles.rs
+++ b/crates/engine/src/parser/oracle_separate_piles.rs
@@ -107,17 +107,6 @@ pub(crate) fn parse_separate_into_piles_ir(
     Some(PileIr::new(effect).with_source(text).with_context(ctx))
 }
 
-/// Compatibility entry point for non-trigger callers that still consume a
-/// lowered definition. Trigger parsing uses [`parse_separate_into_piles_ir`]
-/// so the root flows through ordinary trigger lowering.
-pub(crate) fn parse_separate_into_piles(
-    text: &str,
-    kind: AbilityKind,
-) -> Option<AbilityDefinition> {
-    parse_separate_into_piles_ir(text, kind, &ParseContext::default())
-        .map(|pile| pile.into_ability(kind))
-}
-
 /// CR 700.3 + CR 700.3a: Consume the "Each opponent separates the creatures
 /// they control into two piles." opener. Returns the remainder and the
 /// `VoterScope` for the partitioning subject. Currently supports the
@@ -515,9 +504,10 @@ mod tests {
         let text = "Each opponent separates the creatures they control into two piles. \
                     For each opponent, you choose one of their piles. \
                     Each opponent sacrifices the creatures in their chosen pile.";
-        let def = parse_separate_into_piles(text, AbilityKind::Spell)
+        let pile = parse_separate_into_piles_ir(text, AbilityKind::Spell, &ParseContext::default())
             .expect("Make an Example body parses");
-        match &*def.effect {
+        let chain = pile.effect_chain(AbilityKind::Spell);
+        match &*chain.clauses[0].parsed.effect {
             Effect::SeparateIntoPiles {
                 partition_subject,
                 chooser,
@@ -545,9 +535,10 @@ mod tests {
         let text = "Reveal the top five cards of your library. \
                     An opponent separates those cards into two piles. \
                     Put one pile into your hand and the other into your graveyard.";
-        let def = parse_separate_into_piles(text, AbilityKind::Spell)
+        let pile = parse_separate_into_piles_ir(text, AbilityKind::Spell, &ParseContext::default())
             .expect("Fact or Fiction body parses");
-        match &*def.effect {
+        let chain = pile.effect_chain(AbilityKind::Spell);
+        match &*chain.clauses[0].parsed.effect {
             Effect::SeparateIntoPiles {
                 partition_subject,
                 chooser,
@@ -623,7 +614,10 @@ mod tests {
     #[test]
     fn rejects_non_pile_body() {
         let text = "Destroy target creature. Draw a card.";
-        assert!(parse_separate_into_piles(text, AbilityKind::Spell).is_none());
+        assert!(
+            parse_separate_into_piles_ir(text, AbilityKind::Spell, &ParseContext::default())
+                .is_none()
+        );
     }
 
     /// CR 700.3 + CR 608.2c: Boneyard Parley mid-chain shape parses to

--- a/crates/engine/src/parser/oracle_separate_piles.rs
+++ b/crates/engine/src/parser/oracle_separate_piles.rs
@@ -507,7 +507,7 @@ mod tests {
         let pile = parse_separate_into_piles_ir(text, AbilityKind::Spell, &ParseContext::default())
             .expect("Make an Example body parses");
         let chain = pile.effect_chain(AbilityKind::Spell);
-        match &*chain.clauses[0].parsed.effect {
+        match &chain.clauses[0].parsed.effect {
             Effect::SeparateIntoPiles {
                 partition_subject,
                 chooser,
@@ -538,7 +538,7 @@ mod tests {
         let pile = parse_separate_into_piles_ir(text, AbilityKind::Spell, &ParseContext::default())
             .expect("Fact or Fiction body parses");
         let chain = pile.effect_chain(AbilityKind::Spell);
-        match &*chain.clauses[0].parsed.effect {
+        match &chain.clauses[0].parsed.effect {
             Effect::SeparateIntoPiles {
                 partition_subject,
                 chooser,

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -219,6 +219,17 @@ pub(crate) fn find_terminal_roll_die(def: &mut AbilityDefinition) -> Option<&mut
     None
 }
 
+/// CR 706.3b: A results table belongs to the first die-roll instruction in its
+/// paragraph even when later instructions remain in that ability's chain.
+pub(crate) fn find_result_table_roll_die(def: &mut AbilityDefinition) -> Option<&mut Effect> {
+    if matches!(&*def.effect, Effect::RollDie { results, .. } if results.is_empty()) {
+        return Some(&mut *def.effect);
+    }
+    def.sub_ability
+        .as_deref_mut()
+        .and_then(find_result_table_roll_die)
+}
+
 /// CR 706.3b: Parse contiguous result-table rows into typed branch IR.
 ///
 /// A non-table first line is not consumed, so the ordinary document dispatcher

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -340,6 +340,7 @@ pub(super) fn try_parse_die_roll_table(
             ..AbilityShellIr::default()
         },
         die_results: branches,
+        root_transforms: vec![],
     };
     Some((lower_ability_ir(&ir), next_line))
 }

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -260,11 +260,11 @@ pub(super) fn attach_die_result_branches_to_chain(
 }
 
 pub(crate) fn find_terminal_roll_die(def: &mut AbilityDefinition) -> Option<&mut Effect> {
-    if matches!(&*def.effect, Effect::RollDie { results, .. } if results.is_empty()) {
-        return Some(&mut *def.effect);
-    }
     if let Some(ref mut sub) = def.sub_ability {
         return find_terminal_roll_die(sub);
+    }
+    if matches!(&*def.effect, Effect::RollDie { results, .. } if results.is_empty()) {
+        return Some(&mut *def.effect);
     }
     None
 }

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -8,8 +8,8 @@ use nom::sequence::delimited;
 use nom::Parser;
 
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, Comparator, DieResultBranch, Effect,
-    SolveCondition, StaticDefinition, TargetFilter, TypedFilter,
+    AbilityCost, AbilityDefinition, AbilityKind, Comparator, Effect, SolveCondition,
+    StaticDefinition, TargetFilter, TypedFilter,
 };
 use crate::types::keywords::{EscapeCost, Keyword};
 use crate::types::mana::{ManaColor, ManaCost, ManaCostShard};
@@ -17,9 +17,7 @@ use crate::types::statics::StaticMode;
 
 use super::oracle_cost::{parse_or_separated_mana_costs, parse_single_cost};
 use super::oracle_effect::imperative::try_parse_die_result_line;
-use super::oracle_effect::{
-    capitalize, lower_ability_ir, parse_ability_ir_standalone, parse_effect_chain,
-};
+use super::oracle_effect::{capitalize, lower_ability_ir, parse_ability_ir_standalone};
 use super::oracle_ir::ast::parsed_clause;
 use super::oracle_ir::effect_chain::{AbilityIr, AbilityShellIr, DieResultBranchIr, EffectChainIr};
 use super::oracle_nom::bridge::nom_on_lower;
@@ -209,54 +207,6 @@ fn defiler_color_word(color: ManaColor) -> &'static str {
 /// Normalize self-references in a line for static ability parsing.
 pub(crate) fn normalize_self_refs_for_static(text: &str, card_name: &str) -> String {
     normalize_card_name_refs(text, card_name)
-}
-
-/// CR 706: Walk the sub_ability chain of a parsed trigger/ability to find the
-/// terminal `RollDie { results: [] }` node and attach die result branches
-/// from subsequent oracle text lines.
-pub(super) fn attach_die_result_branches_to_chain(
-    def: &mut AbilityDefinition,
-    lines: &[&str],
-    start_line: usize,
-) -> usize {
-    let roll_die = find_terminal_roll_die(def);
-    let roll_die = match roll_die {
-        Some(roll_die) => roll_die,
-        None => return start_line,
-    };
-
-    let mut branches = Vec::new();
-    let mut j = start_line;
-    while j < lines.len() {
-        let table_line = strip_reminder_text(lines[j].trim());
-        if table_line.is_empty() {
-            j += 1;
-            continue;
-        }
-        if let Some((min, max, effect_text)) = try_parse_die_result_line(&table_line) {
-            let effect_text = strip_die_table_flavor_label(effect_text);
-            let branch_def = parse_effect_chain(effect_text, AbilityKind::Spell);
-            branches.push(DieResultBranch {
-                min,
-                max,
-                effect: Box::new(branch_def),
-            });
-            j += 1;
-        } else {
-            break;
-        }
-    }
-
-    if !branches.is_empty() {
-        if let Effect::RollDie {
-            ref mut results, ..
-        } = roll_die
-        {
-            *results = branches;
-        }
-    }
-
-    j
 }
 
 pub(crate) fn find_terminal_roll_die(def: &mut AbilityDefinition) -> Option<&mut Effect> {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -9,7 +9,7 @@ use nom::Parser;
 
 use super::oracle_effect::conditions::source_saddled_filter;
 use super::oracle_effect::{
-    attach_die_result_branches_before_finalization, condition_text_is_rehomeable,
+    attach_terminal_die_result_branches_before_finalization, condition_text_is_rehomeable,
     lower_effect_chain_ir, parse_effect_chain_ir, try_parse_reanimator_aura_etb_effect_ir,
     try_parse_reanimator_aura_grant_etb_effect_ir,
 };
@@ -1540,7 +1540,7 @@ fn lower_trigger_effect_chain(
     die_results: &[DieResultBranchIr],
 ) -> AbilityDefinition {
     let mut ability = lower_effect_chain_ir(chain_ir);
-    attach_die_result_branches_before_finalization(&mut ability, die_results);
+    attach_terminal_die_result_branches_before_finalization(&mut ability, die_results);
     crate::parser::oracle_effect::finalize_effect_chain(&mut ability);
     if effect_adds_mana_to_triggering_player(&modifiers.effect_lower)
         && matches!(


### PR DESCRIPTION
## Summary
- migrate priority spell routing to native `AbilityIr` with ordered root transforms
- retain inline spell and activated die-result tables without changing trigger terminal-roll behavior
- preserve compatibility lowerings while removing obsolete spell-router shims

## Verification
- parser focused snapshots: 130 passed
- strict clippy: `cargo clippy -p phase-engine --all-targets -- -D warnings`
- Gates P/G/A passed
- independent review completed
- full-pool export: byte-identical to base and C1 (`b24bc943a3b1…`, 99,208,311 bytes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oracle rules parsing for “instead” effects, replacements, and overrides, including complex multiline and unbindable conditions.
  * Corrected die-result table association so results attach to the appropriate roll and are not consumed by unrelated text.
  * Improved handling of Priority 9 spell text, including voting, separate piles, descriptions, and minimum-value rules.
  * Improved parsing of Dig alternatives and trigger-based abilities.
* **Tests**
  * Added coverage for replacement behavior, spell structures, and die-result table edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->