### PR TITLE
fix(scryfall): support JSON Lines bulk downloads

### DIFF
--- a/scripts/lib/scryfall-fetch.sh
+++ b/scripts/lib/scryfall-fetch.sh
@@ -77,16 +77,51 @@ def js_downcase:
   | implode;
 '
 
-# scryfall_fetch_bulk TYPE FILE — resolve a bulk-data download_uri by type
-# (e.g. oracle_cards, default_cards) and download it to FILE.
-scryfall_fetch_bulk() {
-  local type="$1" file="$2" uri
-  uri=$("${SCRYFALL_CURL[@]}" "https://api.scryfall.com/bulk-data" \
-    | jq -r --arg t "$type" '.data[] | select(.type == $t) | .download_uri') \
-    || return 1
-  if [ -z "$uri" ] || [ "$uri" = "null" ]; then
-    echo "scryfall: no download_uri for bulk-data type '$type'" >&2
+# scryfall_download_jsonl_gzip URL FILE — download Scryfall's gzip-compressed
+# JSON Lines bulk format, validate its card-object records, and stream it into
+# the JSON array the generators consume. The temp+rename has the same atomicity
+# guarantee as scryfall_download.
+scryfall_download_jsonl_gzip() {
+  local url="$1" file="$2" archive tmp
+  archive=$(mktemp "${file}.jsonl.gz.XXXXXX")
+  tmp=$(mktemp "${file}.XXXXXX")
+  if ! "${SCRYFALL_CURL[@]}" -o "$archive" "$url"; then
+    rm -f "$archive" "$tmp"
     return 1
   fi
-  scryfall_download "$uri" "$file"
+  if ! gzip -dc "$archive" \
+    | jq -ce 'if .object == "card" then . else error("Scryfall JSONL bulk data must contain card objects") end' \
+    | awk 'BEGIN { print "[" } NR > 1 { printf "," } { print } END { print "]" }' > "$tmp"; then
+    echo "scryfall: download of $url is not valid gzip-compressed JSON Lines" >&2
+    rm -f "$archive" "$tmp"
+    return 1
+  fi
+  rm -f "$archive"
+  mv -f "$tmp" "$file"
+}
+
+# scryfall_fetch_bulk TYPE FILE — resolve and download a bulk-data export by
+# type (e.g. oracle_cards, default_cards). Prefer Scryfall's legacy JSON array
+# download when present; otherwise normalize its JSON Lines export to that
+# same array shape for existing generators.
+scryfall_fetch_bulk() {
+  local type="$1" file="$2" metadata uri jsonl_uri
+  metadata=$("${SCRYFALL_CURL[@]}" "https://api.scryfall.com/bulk-data" \
+    | jq -cer --arg t "$type" '.data[] | select(.type == $t) | {
+      download_uri,
+      jsonl_download_uri
+    }') \
+    || return 1
+  uri=$(jq -r '.download_uri // empty' <<< "$metadata")
+  if [ -n "$uri" ]; then
+    scryfall_download "$uri" "$file"
+    return
+  fi
+  jsonl_uri=$(jq -r '.jsonl_download_uri // empty' <<< "$metadata")
+  if [ -n "$jsonl_uri" ]; then
+    scryfall_download_jsonl_gzip "$jsonl_uri" "$file"
+    return
+  fi
+  echo "scryfall: no bulk download URI for type '$type'" >&2
+  return 1
 }


### PR DESCRIPTION
## Root cause
Scryfall replaced the bulk-data `download_uri` field with `jsonl_download_uri`. The latter points to a gzip-compressed JSON Lines export, so the existing fetcher found no source and the staging Pages deployment failed.

## Change
Prefer the legacy JSON-array URL when present; otherwise download, validate, and stream Scryfall’s JSONL export into the existing JSON-array input expected by all generators.

## Validation
- Downloaded the live Oracle JSONL export and converted it under Bash
- Confirmed the result contains 38,416 card objects
- `bash -n scripts/lib/scryfall-fetch.sh`
- `git diff --check`