### PR TITLE
refactor(parser): emit loyalty abilities as native ir

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4734,7 +4734,7 @@ pub(crate) fn parse_oracle_ir(
         }
         // Priority 11: Planeswalker loyalty abilities: +N:, −N:, 0:, [+N]:, [−N]:, [0]:
         if let Some(ability) = try_parse_loyalty_line(&line, &mut ctx) {
-            emitter.ability_at(item_line, ability);
+            emitter.ability_ir_at(item_line, ability);
             i += 1;
             continue;
         }
@@ -7293,7 +7293,7 @@ fn minus_x_loyalty_cost() -> AbilityCost {
 }
 
 /// Try to parse a planeswalker loyalty line: "+N:", "−N:", "0:", "[+N]:", "[−N]:", "[0]:", "[−X]:"
-fn try_parse_loyalty_line(line: &str, ctx: &mut ParseContext) -> Option<AbilityDefinition> {
+fn try_parse_loyalty_line(line: &str, ctx: &mut ParseContext) -> Option<AbilityIr> {
     let trimmed = line.trim();
 
     // Try bracket format first: [+2]: ..., [−1]: ..., [0]: ..., [−X]: ...
@@ -7305,26 +7305,20 @@ fn try_parse_loyalty_line(line: &str, ctx: &mut ParseContext) -> Option<AbilityD
                 // feeds the effect via `cost_x_paid`. Checked before
                 // `parse_loyalty_number`, which only handles fixed amounts.
                 if is_minus_x_loyalty(inner) {
-                    let effect_text = effect_text.trim();
-                    ctx.subject = None;
-                    ctx.actor = None;
-                    let mut def =
-                        parse_effect_chain_with_context(effect_text, AbilityKind::Activated, ctx);
-                    def.cost = Some(minus_x_loyalty_cost());
-                    def.description = Some(trimmed.to_string());
-                    apply_loyalty_restrictions(&mut def);
-                    return Some(def);
+                    return Some(parse_loyalty_ability_ir(
+                        effect_text.trim(),
+                        trimmed,
+                        minus_x_loyalty_cost(),
+                        ctx,
+                    ));
                 }
                 if let Some(amount) = parse_loyalty_number(inner) {
-                    let effect_text = effect_text.trim();
-                    ctx.subject = None;
-                    ctx.actor = None;
-                    let mut def =
-                        parse_effect_chain_with_context(effect_text, AbilityKind::Activated, ctx);
-                    def.cost = Some(AbilityCost::Loyalty { amount });
-                    def.description = Some(trimmed.to_string());
-                    apply_loyalty_restrictions(&mut def);
-                    return Some(def);
+                    return Some(parse_loyalty_ability_ir(
+                        effect_text.trim(),
+                        trimmed,
+                        AbilityCost::Loyalty { amount },
+                        ctx,
+                    ));
                 }
             }
         }
@@ -7336,14 +7330,12 @@ fn try_parse_loyalty_line(line: &str, ctx: &mut ParseContext) -> Option<AbilityD
         // bracket branch). `parse_loyalty_number` rejects "X", so this must be
         // checked first.
         if is_minus_x_loyalty(prefix) {
-            let effect_text = effect_text.trim();
-            ctx.subject = None;
-            ctx.actor = None;
-            let mut def = parse_effect_chain_with_context(effect_text, AbilityKind::Activated, ctx);
-            def.cost = Some(minus_x_loyalty_cost());
-            def.description = Some(trimmed.to_string());
-            apply_loyalty_restrictions(&mut def);
-            return Some(def);
+            return Some(parse_loyalty_ability_ir(
+                effect_text.trim(),
+                trimmed,
+                minus_x_loyalty_cost(),
+                ctx,
+            ));
         }
         if let Some(amount) = parse_loyalty_number(prefix) {
             // Verify it looks like a loyalty prefix (starts with +, −, –, -, or is "0")
@@ -7354,20 +7346,34 @@ fn try_parse_loyalty_line(line: &str, ctx: &mut ParseContext) -> Option<AbilityD
                 || first_char == '-'
                 || prefix.trim() == "0"
             {
-                let effect_text = effect_text.trim();
-                ctx.subject = None;
-                ctx.actor = None;
-                let mut def =
-                    parse_effect_chain_with_context(effect_text, AbilityKind::Activated, ctx);
-                def.cost = Some(AbilityCost::Loyalty { amount });
-                def.description = Some(trimmed.to_string());
-                apply_loyalty_restrictions(&mut def);
-                return Some(def);
+                return Some(parse_loyalty_ability_ir(
+                    effect_text.trim(),
+                    trimmed,
+                    AbilityCost::Loyalty { amount },
+                    ctx,
+                ));
             }
         }
     }
 
     None
+}
+
+/// Build native IR for an already-recognized loyalty header. The context reset
+/// remains immediately before body parsing, matching the prior lowered route.
+fn parse_loyalty_ability_ir(
+    effect_text: &str,
+    description: &str,
+    cost: AbilityCost,
+    ctx: &mut ParseContext,
+) -> AbilityIr {
+    ctx.subject = None;
+    ctx.actor = None;
+    let mut ir = parse_ability_ir_with_context(effect_text, AbilityKind::Activated, ctx);
+    ir.shell.cost = Some(cost);
+    ir.shell.description = Some(description.to_string());
+    apply_loyalty_restrictions(&mut ir.shell);
+    ir
 }
 
 /// CR 606.3: A player may activate a loyalty ability only during a main phase
@@ -7383,13 +7389,14 @@ fn try_parse_loyalty_line(line: &str, ctx: &mut ParseContext) -> Option<AbilityD
 /// a -1 on the same planeswalker in one turn and (b) block The Chain Veil's
 /// "as though none of its loyalty abilities have been activated this turn"
 /// cap-raise from ever taking effect.
-fn apply_loyalty_restrictions(def: &mut AbilityDefinition) {
+fn apply_loyalty_restrictions(shell: &mut AbilityShellIr) {
     // CR 606.3: "...only during a main phase of their turn when the stack is empty..."
-    if !def
+    if !shell
         .activation_restrictions
         .contains(&ActivationRestriction::AsSorcery)
     {
-        def.activation_restrictions
+        shell
+            .activation_restrictions
             .push(ActivationRestriction::AsSorcery);
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_ir/snapshot_tests.rs
@@ -9,7 +9,9 @@ use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::parser::oracle_ir::doc::{OracleDocIr, OracleNodeIr};
 use crate::parser::oracle_ir::trigger::TriggerNodeIr;
 use crate::types::ability::MultiTargetSpec;
-use crate::types::ability::{Effect, TargetChoiceTiming, TriggerCondition};
+use crate::types::ability::{
+    AbilityCost, ActivationRestriction, Effect, TargetChoiceTiming, TriggerCondition,
+};
 use crate::types::game_state::DistributionUnit;
 
 fn ability_has_unimplemented(def: &crate::types::ability::AbilityDefinition) -> bool {
@@ -930,6 +932,61 @@ fn jace_the_mind_sculptor() {
     );
     insta::assert_json_snapshot!("jace_the_mind_sculptor_ir", &ir);
     insta::assert_json_snapshot!("jace_the_mind_sculptor_lowered", &lowered);
+}
+
+/// CR 606.3 + CR 606.5 + CR 107.3a: a `[−X]` loyalty header remains native
+/// document IR, preserving its chosen-X loyalty-counter cost and sorcery-speed
+/// activation envelope until the sole lowering seam.
+#[test]
+fn chandra_nalaar_minus_x_loyalty_is_ir_native() {
+    let (ir, lowered) = parse_two_layer(
+        "[−X]: Chandra Nalaar deals X damage to target creature.",
+        "Chandra Nalaar",
+        &["Planeswalker"],
+        &["Chandra Nalaar", "Chandra"],
+    );
+
+    assert_eq!(ir.items.len(), 1);
+    let OracleNodeIr::Spell(ability) = &ir.items[0].node else {
+        panic!(
+            "expected native loyalty spell IR, got {:?}",
+            ir.items[0].node
+        );
+    };
+    assert!(matches!(
+        ability.shell.cost.as_ref(),
+        Some(AbilityCost::RemoveCounter {
+            count: crate::types::ability::REMOVE_COUNTER_COST_X,
+            counter_type: crate::types::counter::CounterMatch::OfType(
+                crate::types::counter::CounterType::Loyalty
+            ),
+            target: None,
+            ..
+        })
+    ));
+    assert_eq!(
+        ability.shell.description.as_deref(),
+        Some("[−X]: ~ deals X damage to target creature.")
+    );
+    assert_eq!(
+        ability.shell.activation_restrictions,
+        vec![ActivationRestriction::AsSorcery]
+    );
+    assert_eq!(lowered.abilities.len(), 1);
+    assert!(matches!(
+        lowered.abilities[0].cost.as_ref(),
+        Some(AbilityCost::RemoveCounter {
+            count: crate::types::ability::REMOVE_COUNTER_COST_X,
+            counter_type: crate::types::counter::CounterMatch::OfType(
+                crate::types::counter::CounterType::Loyalty
+            ),
+            target: None,
+            ..
+        })
+    ));
+
+    insta::assert_json_snapshot!("chandra_nalaar_minus_x_loyalty_ir", &ir);
+    insta::assert_json_snapshot!("chandra_nalaar_minus_x_loyalty_lowered", &lowered);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chandra_nalaar_minus_x_loyalty_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chandra_nalaar_minus_x_loyalty_ir.snap
@@ -1,0 +1,128 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&ir"
+---
+{
+  "items": [
+    {
+      "id": 0,
+      "source": {
+        "id": {
+          "item": 0,
+          "ordinal": 0
+        },
+        "span": {
+          "first_line": 0,
+          "last_line": 0,
+          "start_byte": 0,
+          "end_byte": 44,
+          "precision": "Exact",
+          "ordinal_within_span": 0
+        },
+        "fragment": "[−X]: ~ deals X damage to target creature."
+      },
+      "node": {
+        "Spell": {
+          "source_text": "~ deals X damage to target creature.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 35,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "~ deals X damage to target creature"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "DealDamage",
+                    "amount": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "Variable",
+                        "name": "X"
+                      }
+                    },
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "RemoveCounter",
+              "count": 4294967295,
+              "counter_type": {
+                "type": "OfType",
+                "data": "loyalty"
+              },
+              "target": null,
+              "selection": "SingleObject"
+            },
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "[−X]: ~ deals X damage to target creature."
+          },
+          "die_results": [],
+          "root_transforms": []
+        }
+      }
+    }
+  ],
+  "source_text": "[−X]: Chandra Nalaar deals X damage to target creature.",
+  "card_name": "Chandra Nalaar"
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chandra_nalaar_minus_x_loyalty_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__chandra_nalaar_minus_x_loyalty_lowered.snap
@@ -1,0 +1,56 @@
+---
+source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+expression: "&lowered"
+---
+{
+  "abilities": [
+    {
+      "kind": "Activated",
+      "effect": {
+        "type": "DealDamage",
+        "amount": {
+          "type": "Ref",
+          "qty": {
+            "type": "Variable",
+            "name": "X"
+          }
+        },
+        "target": {
+          "type": "Typed",
+          "type_filters": [
+            "Creature"
+          ],
+          "controller": null,
+          "properties": []
+        }
+      },
+      "cost": {
+        "type": "RemoveCounter",
+        "count": 4294967295,
+        "counter_type": {
+          "type": "OfType",
+          "data": "loyalty"
+        },
+        "target": null,
+        "selection": "SingleObject"
+      },
+      "sub_ability": null,
+      "duration": null,
+      "description": "[−X]: ~ deals X damage to target creature.",
+      "target_prompt": null,
+      "activation_restrictions": [
+        {
+          "type": "AsSorcery"
+        }
+      ],
+      "condition": null,
+      "optional_targeting": false,
+      "optional": false,
+      "forward_result": false
+    }
+  ],
+  "triggers": [],
+  "statics": [],
+  "replacements": [],
+  "extractedKeywords": []
+}

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__jace_the_mind_sculptor_ir.snap
@@ -22,69 +22,156 @@ expression: "&ir"
         "fragment": "[+2]: Look at the top card of target player's library. You may put that card on the bottom of that player's library."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Dig",
-            "player": {
-              "type": "Player"
-            },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            },
-            "destination": null,
-            "keep_count": 0,
-            "up_to": false,
-            "filter": {
-              "type": "Any"
-            },
-            "rest_destination": null,
-            "reveal": false,
-            "enter_tapped": false
-          },
-          "cost": {
-            "type": "Loyalty",
-            "amount": 2
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutAtLibraryPosition",
-              "target": {
-                "type": "ParentTarget"
+        "Spell": {
+          "source_text": "Look at the top card of target player's library. You may put that card on the bottom of that player's library.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 47,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Look at the top card of target player's library"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Dig",
+                    "player": {
+                      "type": "Player"
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "destination": null,
+                    "keep_count": null,
+                    "up_to": false,
+                    "filter": {
+                      "type": "Any"
+                    },
+                    "rest_destination": null,
+                    "reveal": false,
+                    "enter_tapped": false
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "count": {
-                "type": "Fixed",
-                "value": 1
-              },
-              "position": {
-                "type": "Bottom"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 49,
+                    "end_byte": 109,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "You may put that card on the bottom of that player's library"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "PutAtLibraryPosition",
+                    "target": {
+                      "type": "ParentTarget"
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "position": {
+                      "type": "Bottom"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": true,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": true,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "[+2]: Look at the top card of target player's library. You may put that card on the bottom of that player's library.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Loyalty",
+              "amount": 2
+            },
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "[+2]: Look at the top card of target player's library. You may put that card on the bottom of that player's library."
+          },
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -106,69 +193,157 @@ expression: "&ir"
         "fragment": "[0]: Draw three cards, then put two cards from your hand on top of your library in any order."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Draw",
-            "count": {
-              "type": "Fixed",
-              "value": 3
-            },
-            "target": {
-              "type": "Controller"
-            }
-          },
-          "cost": {
-            "type": "Loyalty",
-            "amount": 0
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "PutAtLibraryPosition",
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Card"
-                ],
-                "controller": "You",
-                "properties": [
-                  {
-                    "type": "InZone",
-                    "zone": "Hand"
+        "Spell": {
+          "source_text": "Draw three cards, then put two cards from your hand on top of your library in any order.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 16,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Draw three cards"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                ]
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Draw",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 3
+                    },
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Then",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "count": {
-                "type": "Fixed",
-                "value": 2
-              },
-              "position": {
-                "type": "Top"
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 23,
+                    "end_byte": 87,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "put two cards from your hand on top of your library in any order"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "PutAtLibraryPosition",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Card"
+                      ],
+                      "controller": "You",
+                      "properties": [
+                        {
+                          "type": "InZone",
+                          "zone": "Hand"
+                        }
+                      ]
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 2
+                    },
+                    "position": {
+                      "type": "Top"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "[0]: Draw three cards, then put two cards from your hand on top of your library in any order.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Loyalty",
+              "amount": 0
+            },
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "[0]: Draw three cards, then put two cards from your hand on top of your library in any order."
+          },
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -190,37 +365,91 @@ expression: "&ir"
         "fragment": "[−1]: Return target creature to its owner's hand."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Bounce",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": null,
-              "properties": []
+        "Spell": {
+          "source_text": "Return target creature to its owner's hand.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 42,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Return target creature to its owner's hand"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Bounce",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": null,
+                      "properties": []
+                    },
+                    "destination": null
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Loyalty",
+              "amount": -1
             },
-            "destination": null
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "[−1]: Return target creature to its owner's hand."
           },
-          "cost": {
-            "type": "Loyalty",
-            "amount": -1
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "[−1]: Return target creature to its owner's hand.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -242,83 +471,171 @@ expression: "&ir"
         "fragment": "[−12]: Exile all cards from target player's library, then that player shuffles their hand into their library."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "ChangeZoneAll",
-            "origin": "Library",
-            "destination": "Exile",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Card"
-              ],
-              "controller": null,
-              "properties": [
-                {
-                  "type": "Owned",
-                  "controller": "TargetPlayer"
+        "Spell": {
+          "source_text": "Exile all cards from target player's library, then that player shuffles their hand into their library.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 44,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Exile all cards from target player's library"
                 },
-                {
-                  "type": "InZone",
-                  "zone": "Library"
-                }
-              ]
-            }
-          },
-          "cost": {
-            "type": "Loyalty",
-            "amount": -12
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "ChangeZoneAll",
-              "origin": "Hand",
-              "destination": "Library",
-              "target": {
-                "type": "ParentTargetController"
-              }
-            },
-            "cost": null,
-            "sub_ability": {
-              "kind": "Spell",
-              "effect": {
-                "type": "Shuffle",
-                "target": {
-                  "type": "ParentTargetController"
-                }
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZoneAll",
+                    "origin": "Library",
+                    "destination": "Exile",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Card"
+                      ],
+                      "controller": null,
+                      "properties": [
+                        {
+                          "type": "Owned",
+                          "controller": "TargetPlayer"
+                        },
+                        {
+                          "type": "InZone",
+                          "zone": "Library"
+                        }
+                      ]
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Then",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               },
-              "cost": null,
-              "sub_ability": null,
-              "duration": null,
-              "description": null,
-              "target_prompt": null,
-              "condition": null,
-              "optional_targeting": false,
-              "optional": false,
-              "forward_result": false
-            },
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 51,
+                    "end_byte": 101,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "that player shuffles their hand into their library"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "ChangeZoneAll",
+                    "origin": "Hand",
+                    "destination": "Library",
+                    "target": {
+                      "type": "ParentTargetController"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": {
+                    "kind": "Spell",
+                    "effect": {
+                      "type": "Shuffle",
+                      "target": {
+                        "type": "ParentTargetController"
+                      }
+                    },
+                    "cost": null,
+                    "sub_ability": null,
+                    "duration": null,
+                    "description": null,
+                    "target_prompt": null,
+                    "condition": null,
+                    "optional_targeting": false,
+                    "optional": false,
+                    "forward_result": false
+                  },
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "[−12]: Exile all cards from target player's library, then that player shuffles their hand into their library.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Loyalty",
+              "amount": -12
+            },
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "[−12]: Exile all cards from target player's library, then that player shuffles their hand into their library."
+          },
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_of_the_veil_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__liliana_of_the_veil_ir.snap
@@ -22,38 +22,91 @@ expression: "&ir"
         "fragment": "[+1]: Each player discards a card."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Discard",
-            "count": {
-              "type": "Fixed",
-              "value": 1
+        "Spell": {
+          "source_text": "Each player discards a card.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 27,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Each player discards a card"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Discard",
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    },
+                    "target": {
+                      "type": "Controller"
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": {
+                  "type": "All"
+                },
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Loyalty",
+              "amount": 1
             },
-            "target": {
-              "type": "Controller"
-            }
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "[+1]: Each player discards a card."
           },
-          "cost": {
-            "type": "Loyalty",
-            "amount": 1
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "[+1]: Each player discards a card.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false,
-          "player_scope": {
-            "type": "All"
-          }
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -75,40 +128,94 @@ expression: "&ir"
         "fragment": "[−2]: Target player sacrifices a creature."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Sacrifice",
-            "target": {
-              "type": "Typed",
-              "type_filters": [
-                "Creature"
-              ],
-              "controller": "TargetPlayer",
-              "properties": []
+        "Spell": {
+          "source_text": "Target player sacrifices a creature.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 35,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Target player sacrifices a creature"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Sacrifice",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Creature"
+                      ],
+                      "controller": "TargetPlayer",
+                      "properties": []
+                    },
+                    "count": {
+                      "type": "Fixed",
+                      "value": 1
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              }
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
+          },
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Loyalty",
+              "amount": -2
             },
-            "count": {
-              "type": "Fixed",
-              "value": 1
-            }
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "[−2]: Target player sacrifices a creature."
           },
-          "cost": {
-            "type": "Loyalty",
-            "amount": -2
-          },
-          "sub_ability": null,
-          "duration": null,
-          "description": "[−2]: Target player sacrifices a creature.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "die_results": [],
+          "root_transforms": []
         }
       }
     },
@@ -130,67 +237,154 @@ expression: "&ir"
         "fragment": "[−6]: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice."
       },
       "node": {
-        "PreLoweredSpell": {
-          "kind": "Activated",
-          "effect": {
-            "type": "Unimplemented",
-            "name": "separate",
-            "description": "Separate all permanents target player controls into two piles"
-          },
-          "cost": {
-            "type": "Loyalty",
-            "amount": -6
-          },
-          "sub_ability": {
-            "kind": "Spell",
-            "effect": {
-              "type": "Sacrifice",
-              "target": {
-                "type": "Typed",
-                "type_filters": [
-                  "Permanent"
-                ],
-                "controller": "ParentTargetController",
-                "properties": []
-              },
-              "count": {
-                "type": "Ref",
-                "qty": {
-                  "type": "ObjectCount",
-                  "filter": {
-                    "type": "Typed",
-                    "type_filters": [
-                      "Permanent"
-                    ],
-                    "controller": null,
-                    "properties": []
+        "Spell": {
+          "source_text": "Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
+          "body": {
+            "clauses": [
+              {
+                "id": 0,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 1
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 0,
+                    "end_byte": 61,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 0
+                  },
+                  "fragment": "Separate all permanents target player controls into two piles"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
                   }
-                }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Unimplemented",
+                    "name": "separate",
+                    "description": "Separate all permanents target player controls into two piles"
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
+              },
+              {
+                "id": 1,
+                "source": {
+                  "id": {
+                    "item": 0,
+                    "ordinal": 2
+                  },
+                  "span": {
+                    "first_line": 0,
+                    "last_line": 0,
+                    "start_byte": 63,
+                    "end_byte": 128,
+                    "precision": "ChainRelative",
+                    "ordinal_within_span": 1
+                  },
+                  "fragment": "That player sacrifices all permanents in the pile of their choice"
+                },
+                "disposition": {
+                  "Emit": {
+                    "followup": null,
+                    "intrinsic": null
+                  }
+                },
+                "parsed": {
+                  "effect": {
+                    "type": "Sacrifice",
+                    "target": {
+                      "type": "Typed",
+                      "type_filters": [
+                        "Permanent"
+                      ],
+                      "controller": "ParentTargetController",
+                      "properties": []
+                    },
+                    "count": {
+                      "type": "Ref",
+                      "qty": {
+                        "type": "ObjectCount",
+                        "filter": {
+                          "type": "Typed",
+                          "type_filters": [
+                            "Permanent"
+                          ],
+                          "controller": null,
+                          "properties": []
+                        }
+                      }
+                    }
+                  },
+                  "duration": null,
+                  "sub_ability": null,
+                  "distribute": null,
+                  "multi_target": null,
+                  "condition": null,
+                  "optional": false,
+                  "unless_pay": null
+                },
+                "boundary": "Sentence",
+                "condition": null,
+                "is_optional": false,
+                "opponent_may_scope": null,
+                "repeat_for": null,
+                "player_scope": null,
+                "starting_with": null,
+                "delayed_condition": null,
+                "prefix_delayed_condition": null,
+                "multi_target": null,
+                "where_x_expression": null,
+                "unless_pay": null
               }
-            },
-            "cost": null,
-            "sub_ability": null,
-            "duration": null,
-            "description": null,
-            "target_prompt": null,
-            "condition": null,
-            "optional_targeting": false,
-            "optional": false,
-            "forward_result": false,
-            "sub_link": "SequentialSibling"
+            ],
+            "kind": "Activated",
+            "continuation_kind": null,
+            "player_scope_rewrite": "Apply",
+            "chain_rounding": null,
+            "actor": null,
+            "in_trigger": false,
+            "repeat_until": null
           },
-          "duration": null,
-          "description": "[−6]: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice.",
-          "target_prompt": null,
-          "activation_restrictions": [
-            {
-              "type": "AsSorcery"
-            }
-          ],
-          "condition": null,
-          "optional_targeting": false,
-          "optional": false,
-          "forward_result": false
+          "shell": {
+            "sub_link": null,
+            "cost": {
+              "type": "Loyalty",
+              "amount": -6
+            },
+            "activation_restrictions": [
+              {
+                "type": "AsSorcery"
+              }
+            ],
+            "description": "[−6]: Separate all permanents target player controls into two piles. That player sacrifices all permanents in the pile of their choice."
+          },
+          "die_results": [],
+          "root_transforms": []
         }
       }
     }


### PR DESCRIPTION
## Summary
- emit Priority 11 planeswalker loyalty abilities as native `AbilityIr`
- retain exact loyalty cost, source description, context-reset, and `AsSorcery` semantics
- add native chosen-X loyalty IR coverage while preserving lowered output

## Verification
- `cargo fmt --all`; parser Gates P/G/A; strict `cargo clippy --all-targets -- -D warnings`
- focused native/lowered Chandra, Jace, Liliana, and existing minus-X loyalty tests
- matched-input full-pool output byte-identical: `7e106986237ce3f41c0c23af6af867bcb3b7a0d99d4045a06309431d599f1cd1` (`cmp -s` pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of planeswalker loyalty abilities, including variable-cost (−X) abilities.
  * Preserved loyalty costs, descriptions, and sorcery-speed activation restrictions consistently through processing.

* **Tests**
  * Added regression coverage and snapshots for Chandra Nalaar’s −X loyalty ability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->