### PR TITLE
refactor(parser): emit modal blocks as native ir

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4513,13 +4513,14 @@ pub(crate) fn parse_oracle_ir(
                     for (line, children) in children {
                         for child in children {
                             match child {
-                                AnchorModeIr::Trigger(trigger) => emitter
-                                    .trigger_ir_at(line, TriggerNodeIr::Parsed(Box::new(trigger))),
+                                AnchorModeIr::Trigger(trigger) => {
+                                    emitter.trigger_ir_at(line, TriggerNodeIr::Parsed(trigger))
+                                }
                                 AnchorModeIr::Static(static_ir) => {
-                                    emitter.static_ir_at(line, static_ir)
+                                    emitter.static_ir_at(line, *static_ir)
                                 }
                                 AnchorModeIr::Unsupported(ability) => {
-                                    emitter.ability_ir_at(line, ability);
+                                    emitter.ability_ir_at(line, *ability);
                                 }
                             }
                         }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4538,7 +4538,9 @@ pub(crate) fn parse_oracle_ir(
         if let Some((block, next_i)) = parse_oracle_block(&lines, i) {
             match lower_oracle_block_ir(block, card_name, ctx.host_self_reference.clone(), &mut ctx)
             {
-                OracleBlockIr::Activated(ability) => emitter.ability_ir_at(item_line, ability),
+                OracleBlockIr::Activated(ability) => {
+                    emitter.ability_ir_at(item_line, ability);
+                }
                 OracleBlockIr::Modal { choice, modes } => {
                     for mode in modes {
                         emitter.ability_ir_at(
@@ -4568,7 +4570,7 @@ pub(crate) fn parse_oracle_ir(
                                     emitter.static_ir_at(line, static_ir)
                                 }
                                 AnchorModeIr::Unsupported(ability) => {
-                                    emitter.ability_ir_at(line, ability)
+                                    emitter.ability_ir_at(line, ability);
                                 }
                             }
                         }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1195,7 +1195,6 @@ fn try_split_and_cant_become_untapped(
 fn item_replacement(item: &OracleItemIr) -> Option<&ReplacementDefinition> {
     match &item.node {
         OracleNodeIr::Replacement(replacement_ir) => Some(&replacement_ir.definition),
-        OracleNodeIr::PreLoweredReplacement(def) => Some(def),
         _ => None,
     }
 }
@@ -1266,7 +1265,6 @@ fn item_trigger(item: &OracleItemIr) -> Option<Cow<'_, TriggerDefinition>> {
 fn item_static(item: &OracleItemIr) -> Option<&StaticDefinition> {
     match &item.node {
         OracleNodeIr::Static(ir) => Some(&ir.definition),
-        OracleNodeIr::PreLoweredStatic(def) => Some(def),
         _ => None,
     }
 }
@@ -3129,14 +3127,6 @@ pub(crate) fn lower_oracle_ir(ir: &mut OracleDocIr) -> ParsedAbilities {
                 result.triggers.push(def);
                 trigger_ids.push(item.id);
             }
-            OracleNodeIr::PreLoweredStatic(def) => {
-                result.statics.push(def.clone());
-                static_ids.push(item.id);
-            }
-            OracleNodeIr::PreLoweredReplacement(def) => {
-                result.replacements.push(def.clone());
-                replacement_ids.push(item.id);
-            }
             OracleNodeIr::PreLoweredSpell(def) => {
                 let mut def = def.clone();
                 stamp_printed_ability_slot(&mut def, result.abilities.len());
@@ -3851,10 +3841,6 @@ impl<'a> DocEmitter<'a> {
             },
         );
     }
-    fn trigger_at(&mut self, line: usize, def: TriggerDefinition) {
-        self.last_trigger = Some(def.clone());
-        self.emit_at(line, OracleNodeIr::PreLoweredTrigger(def));
-    }
     /// Mirrors `static_ir_at`: the peek mirror stores the LOWERED definition, so
     /// the peek reader is unchanged and no `source_text` is invented for a slot
     /// nothing reads it from. Lowering here is a clone (`lower_trigger_node_ir`
@@ -3862,10 +3848,6 @@ impl<'a> DocEmitter<'a> {
     fn trigger_ir_at(&mut self, line: usize, ir: TriggerNodeIr) {
         self.last_trigger = Some(lower_trigger_node_ir(&ir));
         self.emit_at(line, OracleNodeIr::Trigger(ir));
-    }
-    fn static_at(&mut self, line: usize, def: StaticDefinition) {
-        self.last_static = Some(def.clone());
-        self.emit_at(line, OracleNodeIr::PreLoweredStatic(def));
     }
     fn static_ir_at(&mut self, line: usize, ir: StaticIr) {
         self.last_static = Some(lower_static_ir(&ir));
@@ -3922,39 +3904,6 @@ impl<'a> DocEmitter<'a> {
         }
     }
 
-    /// Move every vector item a `&mut ParsedAbilities`-taking mutator just pushed
-    /// into the builder at `item_line`, then clear them. Used for the complex
-    /// cross-file mutators (modal / enters-replacement lowering) that the (B)
-    /// tuple-return design does NOT rewrite internally: they still push into a
-    /// scratch `ParsedAbilities`, and this drains that scratch into source-ordered
-    /// emission. `result`'s SINGLETON fields (modal/additional_cost/…) are left
-    /// untouched — the caller handles those.
-    fn drain_result_vectors(&mut self, item_line: usize, result: &mut ParsedAbilities) {
-        for def in std::mem::take(&mut result.abilities) {
-            self.ability_at(item_line, def);
-        }
-        for def in std::mem::take(&mut result.triggers) {
-            self.trigger_at(item_line, def);
-        }
-        for def in std::mem::take(&mut result.statics) {
-            self.static_at(item_line, def);
-        }
-        for def in std::mem::take(&mut result.replacements) {
-            self.replacement_at(item_line, def);
-        }
-        for kw in std::mem::take(&mut result.extracted_keywords) {
-            self.keyword_at(item_line, kw);
-        }
-        for r in std::mem::take(&mut result.casting_restrictions) {
-            self.casting_restriction_at(item_line, r);
-        }
-        for o in std::mem::take(&mut result.casting_options) {
-            self.casting_option_at(item_line, o);
-        }
-    }
-    fn replacement_at(&mut self, line: usize, def: ReplacementDefinition) {
-        self.emit_at(line, OracleNodeIr::PreLoweredReplacement(def));
-    }
     fn keyword_at(&mut self, line: usize, kw: Keyword) {
         self.emit_at(line, OracleNodeIr::Keyword(kw));
     }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -4453,35 +4453,7 @@ pub(crate) fn parse_oracle_ir(
             continue;
         }
 
-        // Priority 0: Semicolon-separated keyword lines (e.g., "Defender; reach").
-        // Oracle text uses semicolons exclusively to separate keywords on a single line.
-        // The colon guard prevents splitting activated ability lines like "{T}: Draw a card".
-        if line.contains(';') && !line.contains(':') {
-            let parts: Vec<&str> = line
-                .split(';')
-                .map(|s| s.trim())
-                .filter(|s| !s.is_empty())
-                .collect();
-            // Consume-on-success: EVERY part must parse completely as keywords. The
-            // permissive form accepted a part carrying a semantic clause ("cycling
-            // {2} if you control an artifact"), consumed the whole line, and dropped
-            // that clause with no keyword and no diagnostic.
-            if parts.len() > 1 {
-                let routed: Option<Vec<Vec<Keyword>>> = parts
-                    .iter()
-                    .map(|part| parse_router_keyword_list(part, mtgjson_keyword_names))
-                    .collect();
-                if let Some(routed) = routed {
-                    for keyword in routed.into_iter().flatten() {
-                        emitter.keyword_at(item_line, keyword);
-                    }
-                    i += 1;
-                    continue;
-                }
-            }
-        }
-
-        // Priority 1: Modal block (standard "Choose one —" + modes, or Spree + modes).
+        // Priority 0: Modal block (standard "Choose one —" + modes, or Spree + modes).
         // Must run before keyword extraction so "Spree" header + follow-on `+` lines
         // are consumed as a modal block, not swallowed as a keyword-only line.
         if let Some((block, next_i)) = parse_oracle_block(&lines, i) {
@@ -4529,6 +4501,34 @@ pub(crate) fn parse_oracle_ir(
             }
             i = next_i;
             continue;
+        }
+
+        // Priority 1: Semicolon-separated keyword lines (e.g., "Defender; reach").
+        // Oracle text uses semicolons exclusively to separate keywords on a single line.
+        // The colon guard prevents splitting activated ability lines like "{T}: Draw a card".
+        if line.contains(';') && !line.contains(':') {
+            let parts: Vec<&str> = line
+                .split(';')
+                .map(|s| s.trim())
+                .filter(|s| !s.is_empty())
+                .collect();
+            // Consume-on-success: EVERY part must parse completely as keywords. The
+            // permissive form accepted a part carrying a semantic clause ("cycling
+            // {2} if you control an artifact"), consumed the whole line, and dropped
+            // that clause with no keyword and no diagnostic.
+            if parts.len() > 1 {
+                let routed: Option<Vec<Vec<Keyword>>> = parts
+                    .iter()
+                    .map(|part| parse_router_keyword_list(part, mtgjson_keyword_names))
+                    .collect();
+                if let Some(routed) = routed {
+                    for keyword in routed.into_iter().flatten() {
+                        emitter.keyword_at(item_line, keyword);
+                    }
+                    i += 1;
+                    continue;
+                }
+            }
         }
 
         // Pre-keyword activated ability: "Equip {cost}" / "Equip — {cost}"

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -87,9 +87,9 @@ use super::oracle_keyword::{
 };
 use super::oracle_level::parse_level_blocks;
 use super::oracle_modal::{
-    extract_ability_word_reminder_body, lower_oracle_block, parse_oracle_block,
+    extract_ability_word_reminder_body, lower_oracle_block_ir, parse_oracle_block,
     split_short_label_prefix, strip_ability_word, strip_ability_word_with_name,
-    strip_flavor_word_with_name, FLAVOR_WORD_COST_LABEL_MAX_WORDS,
+    strip_flavor_word_with_name, AnchorModeIr, OracleBlockIr, FLAVOR_WORD_COST_LABEL_MAX_WORDS,
 };
 use super::oracle_replacement::{
     find_copy_verb_present, lower_as_enters_becomes_choice_modal,
@@ -4536,18 +4536,44 @@ pub(crate) fn parse_oracle_ir(
         // Must run before keyword extraction so "Spree" header + follow-on `+` lines
         // are consumed as a modal block, not swallowed as a keyword-only line.
         if let Some((block, next_i)) = parse_oracle_block(&lines, i) {
-            // Modal lowering still pushes into a scratch `ParsedAbilities`; drain
-            // its vector output into source-ordered emission at the block's line,
-            // and capture the `modal` singleton's line for post-loop emission.
-            lower_oracle_block(
-                block,
-                card_name,
-                ctx.host_self_reference.clone(),
-                &mut result,
-            );
-            emitter.drain_result_vectors(item_line, &mut result);
-            if result.modal.is_some() {
-                modal_line.get_or_insert(item_line);
+            match lower_oracle_block_ir(block, card_name, ctx.host_self_reference.clone(), &mut ctx)
+            {
+                OracleBlockIr::Activated(ability) => emitter.ability_ir_at(item_line, ability),
+                OracleBlockIr::Modal { choice, modes } => {
+                    for mode in modes {
+                        emitter.ability_ir_at(
+                            mode.source_line
+                                .expect("collected modal bullets have source lines"),
+                            *mode.ability,
+                        );
+                    }
+                    emitter.modal_at(item_line, choice);
+                }
+                OracleBlockIr::Triggered(triggers) => {
+                    for trigger in triggers {
+                        emitter.trigger_ir_at(item_line, TriggerNodeIr::Parsed(Box::new(trigger)));
+                    }
+                }
+                OracleBlockIr::AsEnters {
+                    replacement,
+                    children,
+                } => {
+                    emitter.replacement_ir_at(item_line, replacement);
+                    for (line, children) in children {
+                        for child in children {
+                            match child {
+                                AnchorModeIr::Trigger(trigger) => emitter
+                                    .trigger_ir_at(line, TriggerNodeIr::Parsed(Box::new(trigger))),
+                                AnchorModeIr::Static(static_ir) => {
+                                    emitter.static_ir_at(line, static_ir)
+                                }
+                                AnchorModeIr::Unsupported(ability) => {
+                                    emitter.ability_ir_at(line, ability)
+                                }
+                            }
+                        }
+                    }
+                }
             }
             i = next_i;
             continue;
@@ -6286,6 +6312,7 @@ pub(crate) fn parse_oracle_ir(
                     shell: AbilityShellIr::default(),
                     die_results: vec![],
                     root_transforms: vec![],
+                    modal: None,
                 }
             } else if let Some(vote) = crate::parser::oracle_vote::parse_vote_block_ir(
                 parse_line,
@@ -6298,6 +6325,7 @@ pub(crate) fn parse_oracle_ir(
                     shell: AbilityShellIr::default(),
                     die_results: vec![],
                     root_transforms: vec![],
+                    modal: None,
                 }
             } else {
                 parse_ability_ir_with_context(parse_line, AbilityKind::Spell, &mut ctx)
@@ -7127,6 +7155,7 @@ pub(crate) fn try_parse_equip(line: &str) -> Option<AbilityIr> {
             ..AbilityShellIr::default()
         },
         die_results: vec![],
+        modal: None,
         root_transforms: vec![],
     })
 }

--- a/crates/engine/src/parser/oracle_class.rs
+++ b/crates/engine/src/parser/oracle_class.rs
@@ -165,6 +165,7 @@ pub(crate) fn parse_class_oracle_text(
                     ..AbilityShellIr::default()
                 },
                 die_results: vec![],
+                modal: None,
                 root_transforms: vec![],
             };
             items.push((

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -4317,6 +4317,7 @@ pub(crate) fn try_parse_dig_instead_alternative(
         shell: AbilityShellIr::default(),
         die_results: vec![],
         root_transforms: vec![AbilityRootTransform::AppendCondition(condition)],
+        modal: None,
     })
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -1666,6 +1666,7 @@ pub(crate) fn try_parse_temporal_delayed_trigger_ability(
         shell: AbilityShellIr::default(),
         die_results: vec![],
         root_transforms: vec![],
+        modal: None,
     })
 }
 
@@ -27029,6 +27030,16 @@ pub(crate) fn lower_ability_ir(ir: &AbilityIr) -> AbilityDefinition {
         }
     }
     apply_ability_root_transforms(&mut def, &ir.root_transforms);
+    if let Some(modal) = &ir.modal {
+        def = def.with_modal(
+            modal.choice.clone(),
+            modal
+                .modes
+                .iter()
+                .map(|mode| lower_ability_ir(&mode.ability))
+                .collect(),
+        );
+    }
     def
 }
 
@@ -27211,6 +27222,7 @@ pub(crate) fn parse_ability_ir(
             shell: AbilityShellIr::default(),
             die_results: vec![],
             root_transforms: vec![],
+            modal: None,
         };
     }
     if let Some(body) = parse_for_each_attacker_copy_blocker_ir(text, kind, ctx) {
@@ -27220,6 +27232,7 @@ pub(crate) fn parse_ability_ir(
             shell: AbilityShellIr::default(),
             die_results: vec![],
             root_transforms: vec![],
+            modal: None,
         };
     }
     if let ChainLoweringMode::WithContext = mode {
@@ -27230,6 +27243,7 @@ pub(crate) fn parse_ability_ir(
                 shell: AbilityShellIr::default(),
                 die_results: vec![],
                 root_transforms: vec![],
+                modal: None,
             };
         }
     }
@@ -27245,6 +27259,7 @@ pub(crate) fn parse_ability_ir(
             },
             die_results: vec![],
             root_transforms: vec![],
+            modal: None,
         };
     }
     AbilityIr {
@@ -27253,6 +27268,7 @@ pub(crate) fn parse_ability_ir(
         shell: AbilityShellIr::default(),
         die_results: vec![],
         root_transforms: vec![],
+        modal: None,
     }
 }
 

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1872,6 +1872,11 @@ pub(crate) enum OracleBlockAst {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct ModeAst {
     pub(crate) raw: String,
+    /// Verbatim mode text before any structural distribution rewrite.
+    pub(crate) source_text: String,
+    /// Absolute Oracle line for a collected block bullet. Inline `; or` modes
+    /// have no independent printed line.
+    pub(crate) source_line: Option<usize>,
     pub(crate) label: Option<String>,
     pub(crate) body: String,
     /// Per-mode additional cost (Spree). None for standard `\u{2022}` modes.

--- a/crates/engine/src/parser/oracle_ir/context.rs
+++ b/crates/engine/src/parser/oracle_ir/context.rs
@@ -20,7 +20,7 @@ pub(crate) enum TokenPtFollowup {
 /// pronoun/reference resolution ("it", "that creature", "that many").
 ///
 /// Callers set only the fields they need; all fields are Default-able (D-02).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ParseContext {
     /// The current subject (resolved target — "it", "that creature").
     pub subject: Option<TargetFilter>,

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -31,8 +31,8 @@ use super::static_ir::StaticIr;
 use super::trigger::TriggerNodeIr;
 use crate::types::ability::{
     AbilityDefinition, AdditionalCost, CastingPermission, CastingRestriction,
-    ContinuousModification, Effect, ModalChoice, ReplacementDefinition, SolveCondition,
-    SpellCastingOption, StaticDefinition, TriggerDefinition, VoteSubject,
+    ContinuousModification, Effect, ModalChoice, SolveCondition, SpellCastingOption,
+    StaticDefinition, TriggerDefinition, VoteSubject,
 };
 use crate::types::keywords::Keyword;
 use crate::types::mana::ManaCost;

--- a/crates/engine/src/parser/oracle_ir/doc.rs
+++ b/crates/engine/src/parser/oracle_ir/doc.rs
@@ -452,10 +452,6 @@ pub(crate) enum OracleNodeIr {
     // -----------------------------------------------------------------------
     /// Pre-lowered trigger from a preprocessor. UNIT-4 DEBT.
     PreLoweredTrigger(TriggerDefinition),
-    /// Pre-lowered static from a preprocessor. UNIT-4 DEBT.
-    PreLoweredStatic(StaticDefinition),
-    /// Pre-lowered replacement from a preprocessor. UNIT-4 DEBT.
-    PreLoweredReplacement(ReplacementDefinition),
     /// Pre-lowered spell/activated ability from a preprocessor or dispatch path
     /// that constructs an `AbilityDefinition` directly. UNIT-4 DEBT.
     PreLoweredSpell(AbilityDefinition),
@@ -500,9 +496,7 @@ impl OracleNodeIr {
             | OracleNodeIr::CastingOption(_)
             | OracleNodeIr::SolveCondition(_)
             | OracleNodeIr::StriveCost(_)
-            | OracleNodeIr::PreLoweredTrigger(_)
-            | OracleNodeIr::PreLoweredStatic(_)
-            | OracleNodeIr::PreLoweredReplacement(_) => None,
+            | OracleNodeIr::PreLoweredTrigger(_) => None,
         }
     }
 
@@ -548,9 +542,7 @@ impl OracleNodeIr {
             | OracleNodeIr::CastingOption(_)
             | OracleNodeIr::SolveCondition(_)
             | OracleNodeIr::StriveCost(_)
-            | OracleNodeIr::PreLoweredTrigger(_)
-            | OracleNodeIr::PreLoweredStatic(_)
-            | OracleNodeIr::PreLoweredReplacement(_) => None,
+            | OracleNodeIr::PreLoweredTrigger(_) => None,
         }
     }
 }
@@ -1021,9 +1013,7 @@ impl OracleDocBuilder {
                 self.trigger_index += 1
             }
             OracleNodeIr::Static(_)
-            | OracleNodeIr::PreLoweredStatic(_)
             | OracleNodeIr::Replacement(_)
-            | OracleNodeIr::PreLoweredReplacement(_)
             | OracleNodeIr::Keyword(_)
             | OracleNodeIr::Modal(_)
             | OracleNodeIr::AdditionalCost(_)

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -442,6 +442,7 @@ pub(crate) struct AbilityIr {
     /// An empty list is a lowering no-op.
     pub(crate) root_transforms: Vec<AbilityRootTransform>,
     /// Modal metadata attached to this ability root and lowered with it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) modal: Option<ModalPayloadIr>,
 }
 

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -441,6 +441,23 @@ pub(crate) struct AbilityIr {
     /// metadata whose order depends on the root that chain assembly selected.
     /// An empty list is a lowering no-op.
     pub(crate) root_transforms: Vec<AbilityRootTransform>,
+    /// Modal metadata attached to this ability root and lowered with it.
+    pub(crate) modal: Option<ModalPayloadIr>,
+}
+
+/// Native modal payload. Its modes retain parser provenance until their
+/// ordinary `AbilityIr` lowering runs at the owning root's lowering seam.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ModalPayloadIr {
+    pub(crate) choice: crate::types::ability::ModalChoice,
+    pub(crate) modes: Vec<ModalModeIr>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ModalModeIr {
+    pub(crate) source_text: String,
+    pub(crate) source_line: Option<usize>,
+    pub(crate) ability: Box<AbilityIr>,
 }
 
 /// A root-level transform applied only after an [`AbilityIr`] has been fully

--- a/crates/engine/src/parser/oracle_ir/feature.rs
+++ b/crates/engine/src/parser/oracle_ir/feature.rs
@@ -475,9 +475,7 @@ pub(crate) fn scope_to_unit(
             | OracleNodeIr::Static(_)
             | OracleNodeIr::Replacement(_)
             | OracleNodeIr::PreLoweredSpell(_)
-            | OracleNodeIr::PreLoweredTrigger(_)
-            | OracleNodeIr::PreLoweredStatic(_)
-            | OracleNodeIr::PreLoweredReplacement(_) => {}
+            | OracleNodeIr::PreLoweredTrigger(_) => {}
         }
     }
     scoped

--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use super::ast::parsed_clause;
 use super::context::ParseContext;
-use super::effect_chain::{DieResultBranchIr, EffectChainIr};
+use super::effect_chain::{DieResultBranchIr, EffectChainIr, ModalModeIr};
 use crate::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, ChoiceType, ControllerRef, Effect, ModalChoice,
     TargetFilter, TargetSelectionMode, TriggerCondition, TriggerConstraint, TriggerDefinition,
@@ -85,6 +85,11 @@ pub(crate) struct TriggerIr {
     /// CR 706.3b result-table rows for the terminal die roll in this trigger.
     /// They remain IR until trigger-body lowering attaches them before finalization.
     pub(crate) die_results: Vec<DieResultBranchIr>,
+    /// Complete context established from the trigger condition before its body
+    /// is parsed. Nested modal modes must start from this same seed so event
+    /// anaphora (notably spell-cast "it") keep their trigger-body meaning.
+    #[serde(skip)]
+    pub(crate) body_context: ParseContext,
 }
 
 impl TriggerIr {
@@ -129,6 +134,8 @@ pub(crate) enum TriggerBody {
 pub(crate) struct ReflexivePaymentIr {
     pub(crate) cost: AbilityCost,
     pub(crate) effect_chain: EffectChainIr,
+    pub(crate) payment_chain: Option<EffectChainIr>,
+    pub(crate) modal: Option<ModalIr>,
 }
 
 /// CR 700.2: Typed inline-modal trigger body.
@@ -141,7 +148,7 @@ pub(crate) struct ReflexivePaymentIr {
 pub(crate) struct ModalIr {
     pub(crate) marker: EffectChainIr,
     pub(crate) choice: ModalChoice,
-    pub(crate) mode_abilities: Vec<AbilityDefinition>,
+    pub(crate) modes: Vec<ModalModeIr>,
 }
 
 /// CR 701.38: Typed vote trigger body.

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3112,7 +3112,7 @@ mod tests {
                 name
             };
             let mut ir = parse_oracle_ir(oracle, card_name, &[], &types, &[]);
-            let span_source = oracle;
+            let span_source = oracle.replacen("Spree", "~", 1);
 
             assert_eq!(
                 ir.items.len(),
@@ -3127,7 +3127,10 @@ mod tests {
                     (*expected_line, *expected_line),
                     "{name}: source-order slot drift"
                 );
-                let expected_fragment = oracle.lines().nth(*expected_line).unwrap();
+                let expected_fragment = match (name, *expected_line) {
+                    ("Spree", 0) => "~ (Choose one or more additional costs.)",
+                    _ => oracle.lines().nth(*expected_line).unwrap(),
+                };
                 assert_eq!(
                     item.source.fragment(),
                     Some(expected_fragment),

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3149,7 +3149,14 @@ mod tests {
                     "{name}: migrated modal route may emit only native modal or spell IR"
                 );
             }
-            assert!(matches!(&ir.items[0].node, OracleNodeIr::Modal(_)));
+            assert!(
+                matches!(&ir.items[0].node, OracleNodeIr::Modal(_))
+                    || matches!(
+                        &ir.items[0].node,
+                        OracleNodeIr::Spell(ability) if ability.modal.is_some()
+                    ),
+                "{name}: header must retain native modal metadata"
+            );
             assert!(
                 ir.items.iter().skip(1).all(|item| matches!(
                     &item.node,

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3831,6 +3831,11 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             &non_self_trigger.partial_def.valid_source,
             Some(TargetFilter::Typed(_))
         ));
+        assert_eq!(
+            modal_relative_player_scope_for_trigger(non_self_trigger),
+            None,
+            "non-self damage triggers keep their established context"
+        );
         let Some(TriggerBody::Modal(non_self_modal)) = non_self_trigger.body.as_ref() else {
             panic!("non-self damage modal must retain nested mode payload");
         };

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -9,8 +9,8 @@ use nom::Parser;
 
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, AdditionalCostOrigin, AdditionalCostPaymentSource, ChoiceType,
-    Effect, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint, PlayerFilter,
-    QuantityExpr, QuantityRef, ReplacementDefinition, StaticCondition, TargetFilter,
+    ControllerRef, Effect, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
+    PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition, StaticCondition, TargetFilter,
     TargetSelectionMode, TriggerCondition,
 };
 use crate::types::replacements::ReplacementEvent;
@@ -1052,6 +1052,31 @@ pub(crate) enum AnchorModeIr {
     Unsupported(Box<AbilityIr>),
 }
 
+/// CR 603.2c + CR 608.2c: A self-source combat-damage trigger establishes the
+/// damaged player as the referent for a nested modal mode's "that player".
+/// The ordinary trigger classifier retains its historical `TargetPlayer`
+/// treatment of this normalized `~` surface; modal modes instead require the
+/// event-player context to parse their independent effect chains correctly.
+fn modal_relative_player_scope_for_condition(condition: &str) -> Option<ControllerRef> {
+    let lower = condition.to_lowercase();
+    let self_damage_to_player = value(
+        ControllerRef::TriggeringPlayer,
+        (
+            alt((tag::<_, _, OracleError<'_>>("when "), tag("whenever "))),
+            tag("~ deals "),
+            opt(tag("combat ")),
+            tag("damage to "),
+            alt((tag("a player"), tag("an opponent"))),
+        ),
+    )
+    .parse(lower.as_str())
+    .ok()
+    .and_then(|(rest, scope)| rest.trim().is_empty().then_some(scope));
+
+    self_damage_to_player
+        .or_else(|| super::oracle_trigger::relative_player_scope_for_condition(&lower))
+}
+
 pub(crate) fn lower_oracle_block_ir(
     block: OracleBlockAst,
     card_name: &str,
@@ -1099,6 +1124,9 @@ pub(crate) fn lower_oracle_block_ir(
                 // facts, but no mode can leak chain-local state into another.
                 let mut mode_ctx = trigger.body_context.clone();
                 mode_ctx.diagnostics.clear();
+                if let Some(scope) = modal_relative_player_scope_for_condition(&trigger_line) {
+                    mode_ctx.relative_player_scope = Some(scope);
+                }
                 let payload = ModalIr {
                     marker: EffectChainIr::single_clause(
                         &header.raw,
@@ -1972,16 +2000,15 @@ fn guard_unsupported_mode_qualifiers(
 }
 
 /// IR-native qualifier guard for the modal migration. It inspects every parsed
-/// clause and its own source fragment; it never lowers an `AbilityIr` merely to
-/// decide whether a restrictive qualifier was swallowed.
+/// clause against its enclosing mode source; it never lowers an `AbilityIr`
+/// merely to decide whether a restrictive qualifier was swallowed.
 fn guard_unsupported_mode_qualifiers_ir(
     ability: &mut AbilityIr,
     kind: AbilityKind,
     ctx: &ParseContext,
 ) {
+    let lower = ability.source_text.to_lowercase();
     let has_unsupported_qualifier = ability.body.clauses.iter().any(|clause| {
-        let source = clause.source.fragment().unwrap_or(&ability.source_text);
-        let lower = source.to_lowercase();
         let dig_with_total_mv = matches!(&clause.parsed.effect, Effect::Dig { .. })
             && nom_primitives::scan_contains(&lower, "with total mana value");
         let put_counter_with_thats_a = matches!(
@@ -3073,8 +3100,7 @@ mod tests {
 
         for (name, oracle, expected_lines, expected_mode_count) in cases {
             let types = vec!["Instant".to_string()];
-            let card_name = format!("Test {name} Modal");
-            let mut ir = parse_oracle_ir(oracle, &card_name, &[], &types, &[]);
+            let mut ir = parse_oracle_ir(oracle, name, &[], &types, &[]);
 
             assert_eq!(
                 ir.items.len(),
@@ -3091,7 +3117,10 @@ mod tests {
                 );
                 assert_eq!(
                     item.source.fragment(),
-                    oracle.lines().nth(*expected_line),
+                    Some(match (name, *expected_line) {
+                        ("Spree", 0) => "~ (Choose one or more additional costs.)",
+                        _ => oracle.lines().nth(*expected_line).unwrap(),
+                    }),
                     "{name}: slot must retain its verbatim printed source"
                 );
                 let expected_start_byte = oracle

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -2432,6 +2432,8 @@ fn scan_modal_count_override(text: &str) -> Option<ModalCountSpec> {
 
 #[cfg(test)]
 mod tests {
+    use crate::parser::oracle_util::normalize_card_name_refs;
+
     use super::*;
 
     #[test]
@@ -3079,25 +3081,19 @@ mod tests {
             ),
             (
                 "Spree",
-                "Spree\n+\
-+ {1} — Draw a card.\n+\
-+ {2} — Gain 3 life.",
+                "Spree\n+ {1} — Draw a card.\n+ {2} — Gain 3 life.",
                 &[0, 1, 2][..],
                 2,
             ),
             (
                 "pawprint",
-                "Choose up to five {P} worth of modes. You may choose the same mode more than once.\n+\
-{P} — Draw a card.\n+\
-{P}{P} — Gain 3 life.",
+                "Choose up to five {P} worth of modes. You may choose the same mode more than once.\n{P} — Draw a card.\n{P}{P} — Gain 3 life.",
                 &[0, 1, 2][..],
                 2,
             ),
             (
                 "ordinary Tiered",
-                "Tiered (Choose one additional cost.)\n+\
-• Cure — {0} — Draw a card.\n+\
-• Cura — {1} — Gain 3 life.",
+                "Tiered (Choose one additional cost.)\n• Cure — {0} — Draw a card.\n• Cura — {1} — Gain 3 life.",
                 &[0, 1, 2][..],
                 2,
             ),
@@ -3107,12 +3103,12 @@ mod tests {
         for (name, oracle, expected_lines, expected_mode_count) in cases {
             let types = vec!["Instant".to_string()];
             let card_name = if name == "Spree" {
-                "Spree Slot Witness"
+                "Modal Slot Witness"
             } else {
                 name
             };
             let mut ir = parse_oracle_ir(oracle, card_name, &[], &types, &[]);
-            let span_source = oracle.replacen("Spree", "~", 1);
+            let span_source = normalize_card_name_refs(oracle, card_name);
 
             assert_eq!(
                 ir.items.len(),
@@ -3127,10 +3123,7 @@ mod tests {
                     (*expected_line, *expected_line),
                     "{name}: source-order slot drift"
                 );
-                let expected_fragment = match (name, *expected_line) {
-                    ("Spree", 0) => "~",
-                    _ => oracle.lines().nth(*expected_line).unwrap(),
-                };
+                let expected_fragment = oracle.lines().nth(*expected_line).unwrap();
                 assert_eq!(
                     item.source.fragment(),
                     Some(expected_fragment),

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3112,7 +3112,7 @@ mod tests {
                 name
             };
             let mut ir = parse_oracle_ir(oracle, card_name, &[], &types, &[]);
-            let span_source = oracle;
+            let span_source = oracle.replacen("Spree", "~", 1);
 
             assert_eq!(
                 ir.items.len(),
@@ -3127,7 +3127,10 @@ mod tests {
                     (*expected_line, *expected_line),
                     "{name}: source-order slot drift"
                 );
-                let expected_fragment = oracle.lines().nth(*expected_line).unwrap();
+                let expected_fragment = match (name, *expected_line) {
+                    ("Spree", 0) => "~",
+                    _ => oracle.lines().nth(*expected_line).unwrap(),
+                };
                 assert_eq!(
                     item.source.fragment(),
                     Some(expected_fragment),

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -1062,25 +1062,25 @@ pub(crate) enum AnchorModeIr {
 /// second, narrower Oracle grammar here. In particular, the trigger parser
 /// already accounts for combat/noncombat, plural damage verbs, and thresholds.
 fn modal_relative_player_scope_for_trigger(trigger: &TriggerIr) -> Option<ControllerRef> {
-    matches!(
-        (
-            &trigger.condition,
-            &trigger.partial_def.valid_source,
-            &trigger.partial_def.valid_target
-        ),
+    match (
+        &trigger.condition,
+        &trigger.partial_def.valid_source,
+        &trigger.partial_def.valid_target,
+    ) {
+        (TriggerMode::DamageDone, Some(TargetFilter::SelfRef), Some(TargetFilter::Player)) => {
+            Some(ControllerRef::TriggeringPlayer)
+        }
         (
             TriggerMode::DamageDone,
             Some(TargetFilter::SelfRef),
-            Some(
-                TargetFilter::Player
-                    | TargetFilter::Typed(TypedFilter {
-                        controller: Some(ControllerRef::Opponent),
-                        ..
-                    }),
-            ),
-        )
-    )
-    .then_some(ControllerRef::TriggeringPlayer)
+            Some(TargetFilter::Typed(TypedFilter {
+                type_filters,
+                controller: Some(ControllerRef::Opponent),
+                ..
+            })),
+        ) if type_filters.is_empty() => Some(ControllerRef::TriggeringPlayer),
+        _ => None,
+    }
 }
 
 pub(crate) fn lower_oracle_block_ir(
@@ -3748,6 +3748,15 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
         let Some(TriggerBody::Modal(modal)) = trigger.body.as_ref() else {
             panic!("damage modal must retain nested mode payload");
         };
+        let mut opponent_controlled_object_trigger = trigger.clone();
+        opponent_controlled_object_trigger.partial_def.valid_target = Some(TargetFilter::Typed(
+            TypedFilter::creature().controller(ControllerRef::Opponent),
+        ));
+        assert_eq!(
+            modal_relative_player_scope_for_trigger(&opponent_controlled_object_trigger),
+            None,
+            "an opponent-controlled object is not the damaged player"
+        );
         assert!(matches!(
             &modal.modes[0].ability.body.clauses[0].parsed.effect,
             Effect::Draw {

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -36,7 +36,7 @@ use super::oracle_quantity::parse_cda_quantity;
 #[cfg(test)]
 use super::oracle_static::parse_static_line;
 use super::oracle_static::{parse_pt_mod, parse_static_line_ir};
-use super::oracle_trigger::parse_trigger_lines_at_index_ir;
+use super::oracle_trigger::{parse_trigger_lines, parse_trigger_lines_at_index_ir};
 use super::oracle_util::{parse_mana_symbols, strip_reminder_text, TextPair};
 use crate::parser::oracle_ir::ast::{
     parsed_clause, ModalHeaderAst, ModalOptionality, ModeAst, OracleBlockAst,
@@ -3116,7 +3116,7 @@ mod tests {
                     OracleNodeIr::Spell(ability)
                         if ability.modal.is_none()
                             && !matches!(
-                                ability.body.clauses[0].parsed.effect.as_ref(),
+                                &ability.body.clauses[0].parsed.effect,
                                 Effect::Unimplemented { .. }
                             )
                 )),
@@ -3608,7 +3608,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             panic!("unsupported anchor bullet must not disappear or pre-lower");
         };
         assert!(matches!(
-            residual.body.clauses[0].parsed.effect.as_ref(),
+            &residual.body.clauses[0].parsed.effect,
             Effect::Unimplemented { .. }
         ));
         assert_eq!(
@@ -3664,10 +3664,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             panic!("completed-scry modal must retain its nested mode payload");
         };
         assert!(matches!(
-            modal.modes[0].ability.body.clauses[0]
-                .parsed
-                .effect
-                .as_ref(),
+            &modal.modes[0].ability.body.clauses[0].parsed.effect,
             Effect::ExileTop {
                 count: QuantityExpr::Ref {
                     qty: QuantityRef::TriggeringScryBottomCount,
@@ -3676,10 +3673,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             }
         ));
         assert!(matches!(
-            modal.modes[1].ability.body.clauses[0]
-                .parsed
-                .effect
-                .as_ref(),
+            &modal.modes[1].ability.body.clauses[0].parsed.effect,
             Effect::Draw {
                 count: QuantityExpr::Fixed { value: 1 },
                 target: TargetFilter::Controller,
@@ -3714,17 +3708,14 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             panic!("damage modal must retain nested mode payload");
         };
         assert!(matches!(
-            modal.modes[0].ability.body.clauses[0]
-                .parsed
-                .effect
-                .as_ref(),
+            &modal.modes[0].ability.body.clauses[0].parsed.effect,
             Effect::Draw {
                 target: TargetFilter::Controller,
                 ..
             }
         ));
         assert!(matches!(
-            modal.modes[1].ability.body.clauses[0].parsed.effect.as_ref(),
+            &modal.modes[1].ability.body.clauses[0].parsed.effect,
             Effect::Destroy {
                 target: TargetFilter::Typed(filter),
                 ..
@@ -3775,7 +3766,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             &actor_ir.items[1].node,
             OracleNodeIr::Spell(ability)
                 if matches!(
-                    ability.body.clauses[0].parsed.effect.as_ref(),
+                    &ability.body.clauses[0].parsed.effect,
                     Effect::Sacrifice {
                         target: TargetFilter::Typed(filter),
                         ..
@@ -3786,7 +3777,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             &actor_ir.items[2].node,
             OracleNodeIr::Spell(ability)
                 if matches!(
-                    ability.body.clauses[0].parsed.effect.as_ref(),
+                    &ability.body.clauses[0].parsed.effect,
                     Effect::Sacrifice {
                         target: TargetFilter::Typed(filter),
                         ..
@@ -4163,7 +4154,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
         );
         assert!(
             modal.modes.iter().all(|mode| !matches!(
-                mode.ability.body.clauses[0].parsed.effect.as_ref(),
+                &mode.ability.body.clauses[0].parsed.effect,
                 Effect::Unimplemented { .. }
             )),
             "every native Caesar mode must remain lowerable"

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3106,8 +3106,13 @@ mod tests {
 
         for (name, oracle, expected_lines, expected_mode_count) in cases {
             let types = vec!["Instant".to_string()];
-            let mut ir = parse_oracle_ir(oracle, name, &[], &types, &[]);
-            let span_source = oracle.replacen(name, "~", 1);
+            let card_name = if name == "Spree" {
+                "Spree Slot Witness"
+            } else {
+                name
+            };
+            let mut ir = parse_oracle_ir(oracle, card_name, &[], &types, &[]);
+            let span_source = oracle;
 
             assert_eq!(
                 ir.items.len(),
@@ -3122,10 +3127,7 @@ mod tests {
                     (*expected_line, *expected_line),
                     "{name}: source-order slot drift"
                 );
-                let expected_fragment = match (name, *expected_line) {
-                    ("Spree", 0) => "~ (Choose one or more additional costs.)",
-                    _ => oracle.lines().nth(*expected_line).unwrap(),
-                };
+                let expected_fragment = oracle.lines().nth(*expected_line).unwrap();
                 assert_eq!(
                     item.source.fragment(),
                     Some(expected_fragment),
@@ -3149,14 +3151,7 @@ mod tests {
                     "{name}: migrated modal route may emit only native modal or spell IR"
                 );
             }
-            assert!(
-                matches!(&ir.items[0].node, OracleNodeIr::Modal(_))
-                    || matches!(
-                        &ir.items[0].node,
-                        OracleNodeIr::Spell(ability) if ability.modal.is_some()
-                    ),
-                "{name}: header must retain native modal metadata"
-            );
+            assert!(matches!(&ir.items[0].node, OracleNodeIr::Modal(_)));
             assert!(
                 ir.items.iter().skip(1).all(|item| matches!(
                     &item.node,

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -1253,7 +1253,7 @@ fn anchor_mode_irs(
     {
         let mut mode_ctx = base_ctx.clone();
         mode_ctx.diagnostics.clear();
-        let mut triggers = parse_trigger_lines_at_index_ir(body, card_name, None, &mut mode_ctx);
+        let triggers = parse_trigger_lines_at_index_ir(body, card_name, None, &mut mode_ctx);
         base_ctx.diagnostics.extend(mode_ctx.diagnostics);
         let children = triggers
             .into_iter()
@@ -1982,10 +1982,10 @@ fn guard_unsupported_mode_qualifiers_ir(
     };
     let source = clause.source.fragment().unwrap_or(&ability.source_text);
     let lower = source.to_lowercase();
-    let dig_with_total_mv = matches!(&*clause.parsed.effect, Effect::Dig { .. })
+    let dig_with_total_mv = matches!(&clause.parsed.effect, Effect::Dig { .. })
         && nom_primitives::scan_contains(&lower, "with total mana value");
     let put_counter_with_thats_a = matches!(
-        &*clause.parsed.effect,
+        &clause.parsed.effect,
         Effect::PutCounterAll { .. } | Effect::PutCounter { .. }
     ) && nom_primitives::scan_contains(&lower, "that's a ");
 

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -8,29 +8,41 @@ use nom::sequence::{delimited, preceded, terminated};
 use nom::Parser;
 
 use crate::types::ability::{
-    AbilityCondition, AbilityDefinition, AbilityKind, AdditionalCostOrigin,
-    AdditionalCostPaymentSource, ChoiceType, Effect, ModalChoice, ModalSelectionCondition,
-    ModalSelectionConstraint, PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition,
-    StaticCondition, TargetFilter, TargetSelectionMode, TriggerCondition,
+    AbilityDefinition, AbilityKind, AdditionalCostOrigin, AdditionalCostPaymentSource, ChoiceType,
+    Effect, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint, PlayerFilter,
+    QuantityExpr, QuantityRef, ReplacementDefinition, StaticCondition, TargetFilter,
+    TargetSelectionMode, TriggerCondition,
 };
 use crate::types::replacements::ReplacementEvent;
+use crate::types::triggers::TriggerMode;
 
 use super::oracle::{find_activated_colon, strip_activated_constraints};
 use super::oracle_cost::parse_oracle_cost;
-use super::oracle_effect::{parse_effect_chain_with_context, try_parse_named_choice};
+#[cfg(test)]
+use super::oracle_effect::lower_ability_ir;
+use super::oracle_effect::{parse_ability_ir_with_context, try_parse_named_choice};
 use super::oracle_ir::context::ParseContext;
-use super::oracle_ir::effect_chain::EffectChainIr;
-use super::oracle_ir::trigger::ModalIr;
+use super::oracle_ir::doc::PrintedTriggerIndex;
+use super::oracle_ir::effect_chain::{
+    AbilityIr, AbilityShellIr, EffectChainIr, ModalModeIr, ModalPayloadIr,
+};
+use super::oracle_ir::replacement::ReplacementIr;
+use super::oracle_ir::static_ir::StaticIr;
+use super::oracle_ir::trigger::{ModalIr, ReflexivePaymentIr, TriggerBody, TriggerIr};
 use super::oracle_nom::bridge::nom_on_lower;
 use super::oracle_nom::condition as nom_condition;
 use super::oracle_nom::primitives::{self as nom_primitives, scan_preceded};
 use super::oracle_quantity::parse_cda_quantity;
-use super::oracle_static::{parse_pt_mod, parse_static_line};
-use super::oracle_trigger::parse_trigger_lines;
+#[cfg(test)]
+use super::oracle_static::parse_static_line;
+use super::oracle_static::{parse_pt_mod, parse_static_line_ir};
+use super::oracle_trigger::parse_trigger_lines_at_index_ir;
 use super::oracle_util::{parse_mana_symbols, strip_reminder_text, TextPair};
 use crate::parser::oracle_ir::ast::{
     parsed_clause, ModalHeaderAst, ModalOptionality, ModeAst, OracleBlockAst,
 };
+#[cfg(test)]
+use crate::types::ability::AbilityCondition;
 use crate::types::mana::ManaCost;
 
 pub(crate) fn parse_oracle_block(lines: &[&str], start: usize) -> Option<(OracleBlockAst, usize)> {
@@ -195,10 +207,14 @@ fn parse_pawprint_run(input: &str) -> OracleResult<'_, u8> {
 pub(crate) fn collect_mode_asts(lines: &[&str], start: usize) -> Vec<ModeAst> {
     let mut modes = Vec::new();
 
-    for raw in lines.iter().skip(start) {
+    for (line_index, raw) in lines.iter().enumerate().skip(start) {
         let line = strip_reminder_text(raw.trim());
         if let Some(stripped) = line.strip_prefix('•') {
-            modes.push(parse_mode_ast(stripped.trim()));
+            modes.push(parse_mode_ast(
+                stripped.trim(),
+                line.as_str(),
+                Some(line_index),
+            ));
         } else if let Some(stripped) = line.strip_prefix('+') {
             // CR 702.172: Spree mode lines use `+ {cost} — effect` format
             let stripped = stripped.trim();
@@ -207,6 +223,8 @@ pub(crate) fn collect_mode_asts(lines: &[&str], start: usize) -> Vec<ModeAst> {
                 let body = strip_mode_separator(rest);
                 modes.push(ModeAst {
                     raw: body.to_string(),
+                    source_text: line.to_string(),
+                    source_line: Some(line_index),
                     label: None,
                     body: body.to_string(),
                     mode_cost: Some(cost),
@@ -220,6 +238,8 @@ pub(crate) fn collect_mode_asts(lines: &[&str], start: usize) -> Vec<ModeAst> {
             let body = strip_mode_separator(rest);
             modes.push(ModeAst {
                 raw: body.to_string(),
+                source_text: line.to_string(),
+                source_line: Some(line_index),
                 label: None,
                 body: body.to_string(),
                 mode_cost: None,
@@ -233,12 +253,14 @@ pub(crate) fn collect_mode_asts(lines: &[&str], start: usize) -> Vec<ModeAst> {
     modes
 }
 
-fn parse_mode_ast(text: &str) -> ModeAst {
+fn parse_mode_ast(text: &str, source_text: &str, source_line: Option<usize>) -> ModeAst {
     if let Some((label, body)) = split_short_label_prefix(text, 4) {
         if let Some((cost, rest)) = parse_mana_symbols(body) {
             let body = strip_mode_separator(rest);
             return ModeAst {
                 raw: text.to_string(),
+                source_text: source_text.to_string(),
+                source_line,
                 label: Some(label.to_string()),
                 body: body.to_string(),
                 mode_cost: Some(cost),
@@ -248,6 +270,8 @@ fn parse_mode_ast(text: &str) -> ModeAst {
 
         return ModeAst {
             raw: text.to_string(),
+            source_text: source_text.to_string(),
+            source_line,
             label: Some(label.to_string()),
             body: body.to_string(),
             mode_cost: None,
@@ -265,6 +289,8 @@ fn parse_mode_ast(text: &str) -> ModeAst {
     if let Some((label, body)) = split_mode_flavor_label(text) {
         return ModeAst {
             raw: text.to_string(),
+            source_text: source_text.to_string(),
+            source_line,
             label: Some(label.to_string()),
             body: body.to_string(),
             mode_cost: None,
@@ -274,6 +300,8 @@ fn parse_mode_ast(text: &str) -> ModeAst {
 
     ModeAst {
         raw: text.to_string(),
+        source_text: source_text.to_string(),
+        source_line,
         label: None,
         body: text.to_string(),
         mode_cost: None,
@@ -362,6 +390,8 @@ fn distribute_shared_mode_effect(header_full_text: &str, modes: Vec<ModeAst>) ->
             let distributed = format!("{prefix}{target_phrase}{suffix}");
             ModeAst {
                 raw: mode.raw,
+                source_text: mode.source_text,
+                source_line: mode.source_line,
                 label: mode.label,
                 body: distributed,
                 mode_cost: mode.mode_cost,
@@ -546,13 +576,13 @@ fn anchor_modes_match_labels(modes: &[ModeAst], labels: &[String]) -> bool {
     if modes.len() != labels.len() {
         return false;
     }
-    let mode_labels: Vec<String> = modes
+    let Some(mode_labels): Option<Vec<String>> = modes
         .iter()
-        .filter_map(|m| m.label.as_ref().map(|s| s.to_lowercase()))
-        .collect();
-    if mode_labels.len() != modes.len() {
+        .map(|mode| mode.label.as_ref().map(|label| label.to_lowercase()))
+        .collect()
+    else {
         return false;
-    }
+    };
     let mut wanted: Vec<String> = labels.iter().map(|s| s.to_lowercase()).collect();
     for actual in &mode_labels {
         match wanted.iter().position(|w| w == actual) {
@@ -996,6 +1026,278 @@ fn split_reflexive_optional_cost(trigger_line: &str) -> Option<(String, String)>
     Some((trigger_orig.to_string(), cost_cased))
 }
 
+/// Native document payload for a Priority-1 modal block.  The document router
+/// owns all source spans; this type deliberately carries only nested parser IR.
+pub(crate) enum OracleBlockIr {
+    Activated(AbilityIr),
+    Modal {
+        choice: ModalChoice,
+        modes: Vec<ModalModeIr>,
+    },
+    Triggered(Vec<TriggerIr>),
+    AsEnters {
+        replacement: ReplacementIr,
+        children: Vec<(usize, Vec<AnchorModeIr>)>,
+    },
+}
+
+pub(crate) enum AnchorModeIr {
+    Trigger(TriggerIr),
+    Static(StaticIr),
+    /// The bullet is still a first-class document item when no native trigger
+    /// or static grammar accepts it. This preserves its printed slot and exact
+    /// source line instead of silently dropping the label's semantics.
+    Unsupported(AbilityIr),
+}
+
+pub(crate) fn lower_oracle_block_ir(
+    block: OracleBlockAst,
+    card_name: &str,
+    host_self_reference: Option<TargetFilter>,
+    ctx: &mut ParseContext,
+) -> OracleBlockIr {
+    match block {
+        OracleBlockAst::ActivatedModal {
+            cost_text,
+            header,
+            modes,
+            constraints,
+        } => {
+            let payload = ModalPayloadIr {
+                choice: build_modal_choice(&header, &modes),
+                modes: parse_modal_mode_irs(&modes, AbilityKind::Activated, ctx),
+            };
+            let mut ability = modal_marker_ir(&header, AbilityKind::Activated, payload, ctx);
+            ability.shell.cost = Some(parse_oracle_cost(&cost_text));
+            ability.shell.activation_restrictions = constraints.restrictions;
+            OracleBlockIr::Activated(ability)
+        }
+        OracleBlockAst::Modal { header, modes } => OracleBlockIr::Modal {
+            choice: build_modal_choice(&header, &modes),
+            modes: parse_modal_mode_irs(&modes, AbilityKind::Spell, ctx),
+        },
+        OracleBlockAst::TriggeredModal {
+            trigger_line,
+            header,
+            modes,
+            optional_cost,
+        } => {
+            let mut trigger_ctx = ctx.clone();
+            trigger_ctx.host_self_reference = host_self_reference;
+            let mut triggers = parse_trigger_lines_at_index_ir(
+                &trigger_line,
+                card_name,
+                Some(PrintedTriggerIndex::placeholder()),
+                &mut trigger_ctx,
+            );
+            ctx.diagnostics.extend(trigger_ctx.diagnostics);
+            for trigger in &mut triggers {
+                // `body_context` is captured before normal trigger-body parsing.
+                // Clone it per sibling: each mode receives all trigger-established
+                // facts, but no mode can leak chain-local state into another.
+                let mut mode_ctx = trigger.body_context.clone();
+                mode_ctx.diagnostics.clear();
+                let payload = ModalIr {
+                    marker: EffectChainIr::single_clause(
+                        &header.raw,
+                        AbilityKind::Spell,
+                        parsed_clause(modal_marker_effect(&header)),
+                        None,
+                        mode_ctx.actor.clone(),
+                        true,
+                    ),
+                    choice: build_modal_choice(&header, &modes),
+                    modes: parse_modal_mode_irs(&modes, AbilityKind::Spell, &mut mode_ctx),
+                };
+                ctx.diagnostics.extend(mode_ctx.diagnostics);
+                trigger.body = Some(match &optional_cost {
+                    Some(cost_text) => {
+                        TriggerBody::ReflexivePayment(Box::new(ReflexivePaymentIr {
+                            cost: parse_oracle_cost(cost_text),
+                            effect_chain: EffectChainIr::single_clause(
+                                cost_text,
+                                AbilityKind::Spell,
+                                parsed_clause(Effect::PayCost {
+                                    cost: parse_oracle_cost(cost_text),
+                                    scale: None,
+                                    payer: TargetFilter::Controller,
+                                }),
+                                None,
+                                None,
+                                true,
+                            ),
+                            payment_chain: Some(
+                                parse_ability_ir_with_context(
+                                    cost_text,
+                                    AbilityKind::Spell,
+                                    &mut ParseContext {
+                                        actor: ctx.actor.clone(),
+                                        in_trigger: true,
+                                        ..Default::default()
+                                    },
+                                )
+                                .body,
+                            ),
+                            modal: Some(payload.clone()),
+                        }))
+                    }
+                    None => TriggerBody::Modal(Box::new(payload.clone())),
+                });
+                if matches!(header.optionality, ModalOptionality::MayDecline) {
+                    trigger.modifiers.optional = true;
+                }
+            }
+            OracleBlockIr::Triggered(triggers)
+        }
+        OracleBlockAst::AsEntersAnchorWordModal {
+            header_text,
+            labels,
+            modes,
+        } => {
+            // `ReplacementIr` is the bounded wrapper permitted for the native
+            // as-enters header. The execute choice is a typed replacement payload,
+            // never a document-level pre-lowered node.
+            let replacement = ReplacementIr {
+                definition: ReplacementDefinition::new(ReplacementEvent::Moved)
+                    .execute(AbilityDefinition::new(
+                        AbilityKind::Spell,
+                        Effect::Choose {
+                            choice_type: ChoiceType::Labeled { options: labels },
+                            persist: true,
+                            selection: TargetSelectionMode::Chosen,
+                        },
+                    ))
+                    .valid_card(TargetFilter::SelfRef)
+                    .destination_zone(crate::types::zones::Zone::Battlefield)
+                    .description(header_text.trim().to_string()),
+                source_text: header_text,
+                execute_ir: None,
+            };
+            let children = modes
+                .iter()
+                .map(|mode| anchor_mode_irs(mode, card_name, ctx))
+                .collect();
+            OracleBlockIr::AsEnters {
+                replacement,
+                children,
+            }
+        }
+    }
+}
+
+fn modal_marker_ir(
+    header: &ModalHeaderAst,
+    kind: AbilityKind,
+    modal: ModalPayloadIr,
+    ctx: &ParseContext,
+) -> AbilityIr {
+    AbilityIr {
+        source_text: header.raw.clone(),
+        body: EffectChainIr::single_clause(
+            &header.raw,
+            kind,
+            parsed_clause(modal_marker_effect(header)),
+            None,
+            ctx.actor.clone(),
+            ctx.in_trigger,
+        ),
+        shell: AbilityShellIr::default(),
+        die_results: vec![],
+        root_transforms: vec![],
+        modal: Some(modal),
+    }
+}
+
+fn parse_modal_mode_irs(
+    modes: &[ModeAst],
+    kind: AbilityKind,
+    base_ctx: &mut ParseContext,
+) -> Vec<ModalModeIr> {
+    modes
+        .iter()
+        .map(|mode| {
+            let mut mode_ctx = base_ctx.clone();
+            mode_ctx.diagnostics.clear();
+            let mut ability = parse_ability_ir_with_context(&mode.body, kind, &mut mode_ctx);
+            guard_unsupported_mode_qualifiers_ir(&mut ability, kind, &mode_ctx);
+            base_ctx.diagnostics.extend(mode_ctx.diagnostics);
+            ModalModeIr {
+                source_text: mode.source_text.clone(),
+                source_line: mode.source_line,
+                ability: Box::new(ability),
+            }
+        })
+        .collect()
+}
+
+fn anchor_mode_irs(
+    mode: &ModeAst,
+    card_name: &str,
+    base_ctx: &mut ParseContext,
+) -> (usize, Vec<AnchorModeIr>) {
+    let line = mode
+        .source_line
+        .expect("collected as-enters anchor modes have independent bullet lines");
+    let Some(label) = mode.label.as_ref() else {
+        return (line, vec![unsupported_anchor_mode_ir(mode, base_ctx)]);
+    };
+    let body = mode.body.trim();
+    let lower = body.to_lowercase();
+    if alt((
+        tag::<_, _, OracleError<'_>>("when "),
+        tag("whenever "),
+        tag("at "),
+    ))
+    .parse(lower.as_str())
+    .is_ok()
+    {
+        let mut mode_ctx = base_ctx.clone();
+        mode_ctx.diagnostics.clear();
+        let mut triggers = parse_trigger_lines_at_index_ir(body, card_name, None, &mut mode_ctx);
+        base_ctx.diagnostics.extend(mode_ctx.diagnostics);
+        let children = triggers
+            .into_iter()
+            .map(|mut trigger| {
+                if matches!(&trigger.condition, TriggerMode::Unknown(_)) || trigger.body.is_none() {
+                    unsupported_anchor_mode_ir(mode, base_ctx)
+                } else {
+                    attach_chosen_label_to_trigger_ir(&mut trigger, label);
+                    AnchorModeIr::Trigger(trigger)
+                }
+            })
+            .collect();
+        return (line, children);
+    }
+    match parse_static_line_ir(body) {
+        Some(mut static_ir) => {
+            attach_chosen_label_to_static_ir(&mut static_ir, label);
+            (line, vec![AnchorModeIr::Static(static_ir)])
+        }
+        None => (line, vec![unsupported_anchor_mode_ir(mode, base_ctx)]),
+    }
+}
+
+fn unsupported_anchor_mode_ir(mode: &ModeAst, ctx: &ParseContext) -> AnchorModeIr {
+    let source = mode.source_text.clone();
+    AnchorModeIr::Unsupported(AbilityIr {
+        source_text: source.clone(),
+        body: EffectChainIr::single_clause(
+            &source,
+            AbilityKind::Spell,
+            parsed_clause(Effect::unimplemented("as_enters_anchor_mode", &source)),
+            None,
+            ctx.actor.clone(),
+            ctx.in_trigger,
+        ),
+        shell: AbilityShellIr::default(),
+        die_results: vec![],
+        root_transforms: vec![],
+        modal: None,
+    })
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
 pub(crate) fn lower_oracle_block(
     block: OracleBlockAst,
     card_name: &str,
@@ -1123,6 +1425,7 @@ pub(crate) fn lower_oracle_block(
 /// Falls back to a no-op placeholder static with an `Unrecognized` condition
 /// when a mode body parses to neither a trigger nor a static — preserves the
 /// choice shape for the coverage report instead of silently dropping a mode.
+#[cfg(test)]
 fn lower_as_enters_anchor_word_modal(
     header_text: String,
     labels: Vec<String>,
@@ -1241,10 +1544,38 @@ fn lower_as_enters_anchor_word_modal(
     }
 }
 
-/// Attach a `ChosenLabelIs` intervening-if to a parsed trigger. Composes with
-/// any pre-existing condition via `TriggerCondition::And` so the linked
-/// ability remains rule-correct even if the body itself carries an "if"
-/// clause (none in current corpus, future-safe).
+/// Attach the anchor gate before trigger lowering. Composes through the same
+/// `intervening_if` field ordinary trigger parsing uses, so lowering remains
+/// the sole definition-assembly seam.
+fn attach_chosen_label_to_trigger_ir(trigger: &mut TriggerIr, label: &str) {
+    let gate = TriggerCondition::ChosenLabelIs {
+        label: label.to_string(),
+    };
+    trigger.modifiers.intervening_if = Some(match trigger.modifiers.intervening_if.take() {
+        None => gate,
+        Some(existing) => TriggerCondition::And {
+            conditions: vec![gate, existing],
+        },
+    });
+}
+
+/// Attach the anchor gate before static lowering. `StaticIr` is the permitted
+/// bounded static wrapper for this whole-line grammar.
+fn attach_chosen_label_to_static_ir(static_ir: &mut StaticIr, label: &str) {
+    let gate = StaticCondition::ChosenLabelIs {
+        label: label.to_string(),
+    };
+    static_ir.definition.condition = Some(match static_ir.definition.condition.take() {
+        None => gate,
+        Some(existing) => StaticCondition::And {
+            conditions: vec![gate, existing],
+        },
+    });
+}
+
+/// Attach a `ChosenLabelIs` intervening-if to a parsed trigger. Kept only for
+/// the legacy lowering compatibility tests below.
+#[cfg(test)]
 fn attach_chosen_label_to_trigger(
     trigger: &mut crate::types::ability::TriggerDefinition,
     label: &str,
@@ -1264,8 +1595,8 @@ fn attach_chosen_label_to_trigger(
     // battlefield-only behavior is correct.
 }
 
-/// Attach a `ChosenLabelIs` gate to a parsed static. Composes with any
-/// pre-existing condition via `StaticCondition::And`.
+/// Attach a `ChosenLabelIs` gate to a parsed static for legacy tests.
+#[cfg(test)]
 fn attach_chosen_label_to_static(
     static_def: &mut crate::types::ability::StaticDefinition,
     label: &str,
@@ -1281,6 +1612,7 @@ fn attach_chosen_label_to_static(
     });
 }
 
+#[cfg(test)]
 pub(crate) fn build_modal_ability(
     kind: AbilityKind,
     header: &ModalHeaderAst,
@@ -1307,6 +1639,7 @@ pub(crate) fn build_modal_ability(
 /// caster (`ControllerRef::You`). This mirrors the inline `"; or"` modal path
 /// (`try_parse_inline_modal_ir`); both must thread the same scope so bullet-line
 /// and inline modal forms of the same trigger agree (issue #2346).
+#[cfg(test)]
 fn build_modal_ability_with_subject(
     kind: AbilityKind,
     header: &ModalHeaderAst,
@@ -1334,6 +1667,7 @@ fn build_modal_ability_with_subject(
 /// `resolve_it_pronoun`'s gating: only non-self, non-Any subjects route mode-
 /// body "that creature" to `TriggeringSource`; self-triggers (like Saga
 /// chapters that name themselves) keep the legacy `ParentTarget` semantics.
+#[cfg(test)]
 fn derive_modal_subject(
     triggers: &[crate::types::ability::TriggerDefinition],
 ) -> Option<TargetFilter> {
@@ -1465,6 +1799,7 @@ fn cap_modal_constraints(
         .collect()
 }
 
+#[cfg(test)]
 fn lower_mode_abilities(
     modes: &[ModeAst],
     kind: AbilityKind,
@@ -1482,6 +1817,7 @@ fn lower_mode_abilities(
 /// typed attachment-host self-reference so a `"that creature"` copy-token
 /// anaphor inside a modal mode body of an Aura/bestow card remaps to the
 /// enchanted host. `None` for non-Aura cards.
+#[cfg(test)]
 fn lower_mode_abilities_with_subject(
     modes: &[ModeAst],
     kind: AbilityKind,
@@ -1499,6 +1835,7 @@ fn lower_mode_abilities_with_subject(
 /// For DamageDone triggers the damaged player is the triggering
 /// player; "that player" in each modal branch must resolve to them, not the
 /// caster or `ParentTargetController`.
+#[cfg(test)]
 pub(crate) fn lower_mode_abilities_with_scope(
     modes: &[ModeAst],
     kind: AbilityKind,
@@ -1512,12 +1849,9 @@ pub(crate) fn lower_mode_abilities_with_scope(
         relative_player_scope,
         ..Default::default()
     };
-    modes
-        .iter()
-        .map(|mode| {
-            let parsed = parse_effect_chain_with_context(&mode.body, kind, &mut ctx);
-            guard_unsupported_mode_qualifiers(&mode.body, parsed, kind)
-        })
+    parse_modal_mode_irs(modes, kind, &mut ctx)
+        .into_iter()
+        .map(|mode| lower_ability_ir(&mode.ability))
         .collect()
 }
 
@@ -1555,6 +1889,8 @@ pub(crate) fn try_parse_inline_modal_ir(effect_body: &str, ctx: &ParseContext) -
             let body = body.trim_end_matches('.');
             ModeAst {
                 raw: body.to_string(),
+                source_text: body.to_string(),
+                source_line: None,
                 label: None,
                 body: body.to_string(),
                 mode_cost: None,
@@ -1563,13 +1899,7 @@ pub(crate) fn try_parse_inline_modal_ir(effect_body: &str, ctx: &ParseContext) -
         })
         .collect();
 
-    let mode_abilities = lower_mode_abilities_with_scope(
-        &modes,
-        AbilityKind::Spell,
-        None,
-        ctx.relative_player_scope.clone(),
-        None,
-    );
+    let mut mode_ctx = ctx.clone();
     Some(ModalIr {
         marker: EffectChainIr::single_clause(
             effect_body,
@@ -1580,7 +1910,7 @@ pub(crate) fn try_parse_inline_modal_ir(effect_body: &str, ctx: &ParseContext) -
             ctx.in_trigger,
         ),
         choice: build_modal_choice(&header, &modes),
-        mode_abilities,
+        modes: parse_modal_mode_irs(&modes, AbilityKind::Spell, &mut mode_ctx),
     })
 }
 
@@ -1603,6 +1933,8 @@ pub(crate) fn try_parse_inline_modal_ir(effect_body: &str, ctx: &ParseContext) -
 /// (e.g. `TotalManaValueAtMost`) or filter extensions (core-type + subtype
 /// disjunction in `that's a X or Y`) are introduced, this guard will be
 /// tightened to only fire on the residual unsupported forms.
+#[cfg(test)]
+#[allow(dead_code)]
 fn guard_unsupported_mode_qualifiers(
     body: &str,
     parsed: AbilityDefinition,
@@ -1629,15 +1961,50 @@ fn guard_unsupported_mode_qualifiers(
     if dig_with_total_mv || put_counter_with_thats_a {
         return AbilityDefinition::new(
             kind,
-            Effect::Unimplemented {
-                name: "modal_mode_unsupported_qualifier".into(),
-                description: Some(body.to_string()),
-            },
+            Effect::unimplemented("modal_mode_unsupported_qualifier", body),
         )
         .description(body.to_string());
     }
 
     parsed
+}
+
+/// IR-native qualifier guard for the modal migration.  It inspects exactly one
+/// parsed clause and its own source fragment; it never lowers an `AbilityIr`
+/// merely to decide whether a restrictive qualifier was swallowed.
+fn guard_unsupported_mode_qualifiers_ir(
+    ability: &mut AbilityIr,
+    kind: AbilityKind,
+    ctx: &ParseContext,
+) {
+    let [clause] = ability.body.clauses.as_slice() else {
+        return;
+    };
+    let source = clause.source.fragment().unwrap_or(&ability.source_text);
+    let lower = source.to_lowercase();
+    let dig_with_total_mv = matches!(&*clause.parsed.effect, Effect::Dig { .. })
+        && nom_primitives::scan_contains(&lower, "with total mana value");
+    let put_counter_with_thats_a = matches!(
+        &*clause.parsed.effect,
+        Effect::PutCounterAll { .. } | Effect::PutCounter { .. }
+    ) && nom_primitives::scan_contains(&lower, "that's a ");
+
+    if !(dig_with_total_mv || put_counter_with_thats_a) {
+        return;
+    }
+
+    let source = source.to_string();
+    ability.body = EffectChainIr::single_clause(
+        &source,
+        kind,
+        parsed_clause(Effect::unimplemented(
+            "modal_mode_unsupported_qualifier",
+            &source,
+        )),
+        None,
+        ctx.actor.clone(),
+        ctx.in_trigger,
+    );
 }
 
 /// Parse the "choose N" count from the modal header line.
@@ -2046,11 +2413,13 @@ mod tests {
             Effect::GenericEffect { .. }
         ));
         assert_eq!(modal.choice.mode_count, 2);
-        assert_eq!(modal.mode_abilities.len(), 2);
-        assert!(modal
-            .mode_abilities
-            .iter()
-            .all(|mode| { !matches!(mode.effect.as_ref(), Effect::Unimplemented { .. }) }));
+        assert_eq!(modal.modes.len(), 2);
+        assert!(modal.modes.iter().all(|mode| {
+            !matches!(
+                mode.ability.body.clauses[0].parsed.effect,
+                Effect::Unimplemented { .. }
+            )
+        }));
     }
 
     #[test]
@@ -2131,6 +2500,8 @@ mod tests {
     fn bare_target_mode(body: &str) -> ModeAst {
         ModeAst {
             raw: format!("{body}."),
+            source_text: format!("{body}."),
+            source_line: None,
             label: None,
             body: body.to_string(),
             mode_cost: None,
@@ -2597,10 +2968,262 @@ mod tests {
     }
 
     #[test]
+    fn block_mode_ir_preserves_independent_bullet_provenance() {
+        let lines = ["Choose one —", "• Draw a card.", "• Gain 3 life."];
+        let (block, _) = parse_oracle_block(&lines, 0).expect("modal block");
+        let ir = lower_oracle_block_ir(
+            block,
+            "Provenance Witness",
+            None,
+            &mut ParseContext::default(),
+        );
+        let OracleBlockIr::Modal { choice, modes } = ir else {
+            panic!("plain modal must remain independent document items");
+        };
+
+        assert_eq!(choice.mode_count, 2);
+        assert_eq!(modes[0].source_line, Some(1));
+        assert_eq!(modes[1].source_line, Some(2));
+        assert!(matches!(
+            modes[0].ability.body.clauses[0].parsed.effect,
+            Effect::Draw { .. }
+        ));
+        assert!(matches!(
+            modes[1].ability.body.clauses[0].parsed.effect,
+            Effect::GainLife { .. }
+        ));
+    }
+
+    #[test]
+    fn plain_modal_document_ir_keeps_each_bullet_in_its_exact_printed_slot() {
+        const ORACLE: &str = "Choose one —\n• Draw a card.\n• Gain 3 life.";
+        let mut ir = parse_oracle_ir(ORACLE, "Slot Witness", &[], &[], &[]);
+
+        assert_eq!(
+            ir.items.len(),
+            3,
+            "header plus two independently emitted modes"
+        );
+        assert!(matches!(&ir.items[0].node, OracleNodeIr::Modal(_)));
+        assert!(matches!(&ir.items[1].node, OracleNodeIr::Spell(_)));
+        assert!(matches!(&ir.items[2].node, OracleNodeIr::Spell(_)));
+        for (line, item) in ir.items.iter().enumerate() {
+            let span = item.source.span();
+            assert!(span.is_exact());
+            assert_eq!((span.first_line, span.last_line), (line, line));
+            assert_eq!(
+                item.source.fragment(),
+                Some(ORACLE.lines().nth(line).unwrap())
+            );
+        }
+
+        let lowered = lower_oracle_ir(&mut ir);
+        assert_eq!(
+            lowered.modal.as_ref().map(|choice| choice.mode_count),
+            Some(2)
+        );
+        assert_eq!(lowered.abilities.len(), 2);
+        assert!(matches!(
+            lowered.abilities[0].effect.as_ref(),
+            Effect::Draw { .. }
+        ));
+        assert!(matches!(
+            lowered.abilities[1].effect.as_ref(),
+            Effect::GainLife { .. }
+        ));
+    }
+
+    #[test]
+    fn modal_document_items_keep_exact_slots_for_every_non_nested_modal_surface() {
+        let cases = [
+            (
+                "plain",
+                "Choose one —\n• Draw a card.\n• Gain 3 life.",
+                &[0, 1, 2][..],
+                2,
+            ),
+            (
+                "Spree",
+                "Spree (Choose one or more additional costs.)\n+\
++ {1} — Draw a card.\n+\
++ {2} — Gain 3 life.",
+                &[0, 1, 2][..],
+                2,
+            ),
+            (
+                "pawprint",
+                "Choose up to five {P} worth of modes. You may choose the same mode more than once.\n+\
+{P} — Draw a card.\n+\
+{P}{P} — Gain 3 life.",
+                &[0, 1, 2][..],
+                2,
+            ),
+            (
+                "ordinary Tiered",
+                "Tiered (Choose one additional cost.)\n+\
+• Cure — {0} — Draw a card.\n+\
+• Cura — {1} — Gain 3 life.",
+                &[0, 1, 2][..],
+                2,
+            ),
+            ("shared-effect Tiered", VINCENTS_ORACLE, &[0, 2, 3, 4][..], 3),
+        ];
+
+        for (name, oracle, expected_lines, expected_mode_count) in cases {
+            let types = vec!["Instant".to_string()];
+            let mut ir = parse_oracle_ir(oracle, name, &[], &types, &[]);
+
+            assert_eq!(
+                ir.items.len(),
+                expected_lines.len(),
+                "{name}: header and every printed bullet must retain its own document slot"
+            );
+            for (item, expected_line) in ir.items.iter().zip(expected_lines) {
+                let span = item.source.span();
+                assert!(span.is_exact(), "{name}: slot must have an exact span");
+                assert_eq!(
+                    (span.first_line, span.last_line),
+                    (*expected_line, *expected_line),
+                    "{name}: source-order slot drift"
+                );
+                assert_eq!(
+                    item.source.fragment(),
+                    oracle.lines().nth(*expected_line),
+                    "{name}: slot must retain its verbatim printed source"
+                );
+                let expected_start_byte = oracle
+                    .lines()
+                    .take(*expected_line)
+                    .map(|line| line.len() + 1)
+                    .sum::<usize>();
+                assert_eq!(
+                    (span.start_byte, span.end_byte),
+                    (
+                        expected_start_byte,
+                        expected_start_byte + oracle.lines().nth(*expected_line).unwrap().len()
+                    ),
+                    "{name}: exact source span must bound this header or bullet only"
+                );
+                assert!(
+                    matches!(&item.node, OracleNodeIr::Modal(_) | OracleNodeIr::Spell(_)),
+                    "{name}: migrated modal route may emit only native modal or spell IR"
+                );
+            }
+            assert!(matches!(&ir.items[0].node, OracleNodeIr::Modal(_)));
+            assert!(
+                ir.items.iter().skip(1).all(|item| matches!(
+                    &item.node,
+                    OracleNodeIr::Spell(ability)
+                        if ability.modal.is_none()
+                            && !matches!(
+                                ability.body.clauses[0].parsed.effect.as_ref(),
+                                Effect::Unimplemented { .. }
+                            )
+                )),
+                "{name}: every bullet must remain a native, independently lowerable ability"
+            );
+
+            let lowered = lower_oracle_ir(&mut ir);
+            assert_eq!(
+                lowered.modal.as_ref().map(|choice| choice.mode_count),
+                Some(expected_mode_count),
+                "{name}: all source modes must reach modal metadata"
+            );
+            assert_eq!(
+                lowered.abilities.len(),
+                expected_mode_count,
+                "{name}: every source mode must lower exactly once"
+            );
+            assert!(
+                lowered.abilities.iter().all(|ability| !matches!(
+                    ability.effect.as_ref(),
+                    Effect::Unimplemented { .. }
+                )),
+                "{name}: a source-preserving route must still lower each mode"
+            );
+        }
+    }
+
+    #[test]
+    fn activated_and_triggered_modal_modes_remain_nested_with_native_provenance() {
+        const ACTIVATED: &str = "{1}: Choose one —\n• Draw a card.\n• Gain 3 life.";
+        let mut activated_ir = parse_oracle_ir(ACTIVATED, "Nested Activated", &[], &[], &[]);
+        assert_eq!(activated_ir.items.len(), 1);
+        let OracleNodeIr::Spell(activated_item) = &activated_ir.items[0].node else {
+            panic!("activated modal must stay native spell IR, not pre-lowered");
+        };
+        let activated_modes = &activated_item
+            .modal
+            .as_ref()
+            .expect("activated header owns native modal payload")
+            .modes;
+        assert_eq!(
+            activated_modes
+                .iter()
+                .map(|mode| (mode.source_line, mode.source_text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(Some(1), "• Draw a card."), (Some(2), "• Gain 3 life."),],
+            "nested activated modes retain bullet provenance without independent slots"
+        );
+        assert_eq!(activated_ir.items[0].source.span().first_line, 0);
+        assert_eq!(
+            activated_ir.items[0].source.fragment(),
+            Some("{1}: Choose one —")
+        );
+        let activated = lower_oracle_ir(&mut activated_ir);
+        assert_eq!(activated.abilities.len(), 1);
+        assert!(matches!(
+            activated.abilities[0].mode_abilities.as_slice(),
+            [first, second]
+                if matches!(first.effect.as_ref(), Effect::Draw { .. })
+                    && matches!(second.effect.as_ref(), Effect::GainLife { .. })
+        ));
+
+        const TRIGGERED: &str =
+            "Whenever Nested Trigger enters, choose one —\n• Draw a card.\n• Gain 3 life.";
+        let mut triggered_ir = parse_oracle_ir(TRIGGERED, "Nested Trigger", &[], &[], &[]);
+        assert_eq!(triggered_ir.items.len(), 1);
+        let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &triggered_ir.items[0].node
+        else {
+            panic!("triggered modal must stay parsed trigger IR, not Assembled");
+        };
+        let Some(TriggerBody::Modal(modal)) = trigger.body.as_ref() else {
+            panic!("plain triggered modal must retain its native modal body");
+        };
+        assert_eq!(
+            modal
+                .modes
+                .iter()
+                .map(|mode| (mode.source_line, mode.source_text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(Some(1), "• Draw a card."), (Some(2), "• Gain 3 life."),],
+            "nested trigger modes retain provenance without independent document slots"
+        );
+        assert_eq!(triggered_ir.items[0].source.span().first_line, 0);
+        assert_eq!(
+            triggered_ir.items[0].source.fragment(),
+            Some("Whenever Nested Trigger enters, choose one —")
+        );
+        let triggered = lower_oracle_ir(&mut triggered_ir);
+        assert_eq!(triggered.triggers.len(), 1);
+        assert!(matches!(
+            triggered.triggers[0]
+                .execute
+                .as_deref()
+                .map(|execute| execute.mode_abilities.as_slice()),
+            Some([first, second])
+                if matches!(first.effect.as_ref(), Effect::Draw { .. })
+                    && matches!(second.effect.as_ref(), Effect::GainLife { .. })
+        ));
+    }
+
+    #[test]
     fn build_modal_choice_preserves_positional_mode_costs_with_zero_for_costless_modes() {
         let modes = vec![
             ModeAst {
                 raw: "Draw a card.".to_string(),
+                source_text: "Draw a card.".to_string(),
+                source_line: None,
                 label: None,
                 body: "Draw a card.".to_string(),
                 mode_cost: None,
@@ -2608,6 +3231,8 @@ mod tests {
             },
             ModeAst {
                 raw: "Gain 3 life.".to_string(),
+                source_text: "Gain 3 life.".to_string(),
+                source_line: None,
                 label: None,
                 body: "Gain 3 life.".to_string(),
                 mode_cost: Some(ManaCost::generic(1)),
@@ -2615,6 +3240,8 @@ mod tests {
             },
             ModeAst {
                 raw: "Deal 3 damage.".to_string(),
+                source_text: "Deal 3 damage.".to_string(),
+                source_line: None,
                 label: None,
                 body: "Deal 3 damage.".to_string(),
                 mode_cost: Some(ManaCost::generic(2)),
@@ -2748,9 +3375,12 @@ mod tests {
 
     // ---- Ao, the Dawn Sky (SOC) — modal dies trigger integration ----
 
-    use crate::parser::oracle::parse_oracle_text;
+    use crate::parser::oracle::{lower_oracle_ir, parse_oracle_ir, parse_oracle_text};
+    use crate::parser::oracle_ir::doc::OracleNodeIr;
+    use crate::parser::oracle_ir::trigger::TriggerNodeIr;
     use crate::types::ability::{
-        ChoiceType, Effect, StaticCondition, TargetFilter, TriggerCondition,
+        ChoiceType, ControllerRef, Effect, QuantityExpr, QuantityRef, StaticCondition,
+        TargetFilter, TriggerCondition,
     };
     use crate::types::replacements::ReplacementEvent;
     use crate::types::triggers::TriggerMode;
@@ -2916,6 +3546,266 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             Some(StaticCondition::ChosenLabelIs { label }) if label == "Temur"
         ));
         assert_eq!(parsed.statics[0].modifications.len(), 4);
+    }
+
+    #[test]
+    fn frostcliff_siege_document_ir_is_native_and_preserves_all_bullet_lines() {
+        let mut ir = parse_oracle_ir(FROSTCLIFF_SIEGE_ORACLE, "Frostcliff Siege", &[], &[], &[]);
+        assert_eq!(
+            ir.items.len(),
+            3,
+            "header replacement plus both anchor modes"
+        );
+        assert!(matches!(&ir.items[0].node, OracleNodeIr::Replacement(_)));
+        assert!(matches!(
+            &ir.items[1].node,
+            OracleNodeIr::Trigger(TriggerNodeIr::Parsed(_))
+        ));
+        assert!(matches!(&ir.items[2].node, OracleNodeIr::Static(_)));
+        for (line, item) in ir.items.iter().enumerate() {
+            assert!(item.source.span().is_exact());
+            assert_eq!(
+                (item.source.span().first_line, item.source.span().last_line),
+                (line, line)
+            );
+            assert_eq!(
+                item.source.fragment(),
+                Some(FROSTCLIFF_SIEGE_ORACLE.lines().nth(line).unwrap())
+            );
+        }
+
+        let lowered = lower_oracle_ir(&mut ir);
+        assert_eq!(lowered.replacements.len(), 1);
+        assert_eq!(lowered.triggers.len(), 1);
+        assert_eq!(lowered.statics.len(), 1);
+        assert!(matches!(
+            lowered.triggers[0].condition.as_ref(),
+            Some(TriggerCondition::ChosenLabelIs { label }) if label == "Jeskai"
+        ));
+        assert!(matches!(
+            lowered.statics[0].condition.as_ref(),
+            Some(StaticCondition::ChosenLabelIs { label }) if label == "Temur"
+        ));
+    }
+
+    #[test]
+    fn as_enters_anchor_mode_that_has_no_native_grammar_is_an_honest_residual() {
+        const ORACLE: &str = "As this enchantment enters, choose A or B.\n\
+• A — Whenever Anchor Residual enters, draw a card.\n\
+• B — This deliberately unsupported anchor body.";
+        let mut ir = parse_oracle_ir(ORACLE, "Anchor Residual", &[], &[], &[]);
+        assert_eq!(
+            ir.items.len(),
+            3,
+            "unsupported labeled bullet still owns a slot"
+        );
+        assert!(matches!(&ir.items[0].node, OracleNodeIr::Replacement(_)));
+        assert!(matches!(
+            &ir.items[1].node,
+            OracleNodeIr::Trigger(TriggerNodeIr::Parsed(_))
+        ));
+        let OracleNodeIr::Spell(residual) = &ir.items[2].node else {
+            panic!("unsupported anchor bullet must not disappear or pre-lower");
+        };
+        assert!(matches!(
+            residual.body.clauses[0].parsed.effect.as_ref(),
+            Effect::Unimplemented { .. }
+        ));
+        assert_eq!(
+            ir.items[2].source.fragment(),
+            Some("• B — This deliberately unsupported anchor body.")
+        );
+
+        let lowered = lower_oracle_ir(&mut ir);
+        assert_eq!(lowered.abilities.len(), 1);
+        assert!(matches!(
+            lowered.abilities[0].effect.as_ref(),
+            Effect::Unimplemented { .. }
+        ));
+    }
+
+    #[test]
+    fn triggered_modal_spell_pronoun_uses_complete_trigger_body_context() {
+        const ORACLE: &str = "Whenever you cast a spell, choose one —\n\
+• Return it to its owner's hand.\n\
+• Draw a card.";
+        let mut ir = parse_oracle_ir(ORACLE, "Spell Context Witness", &[], &[], &[]);
+        assert!(matches!(
+            ir.items.as_slice(),
+            [item] if matches!(&item.node, OracleNodeIr::Trigger(TriggerNodeIr::Parsed(_)))
+        ));
+
+        let lowered = lower_oracle_ir(&mut ir);
+        let first_mode = &lowered.triggers[0]
+            .execute
+            .as_ref()
+            .expect("triggered modal execute")
+            .mode_abilities[0];
+        match first_mode.effect.as_ref() {
+            Effect::ChangeZone { target, .. } => assert_eq!(
+                target,
+                &TargetFilter::TriggeringSource,
+                "spell-cast 'it' must remain the triggering spell, not a parent target"
+            ),
+            other => panic!("expected spell-return mode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn modal_siblings_start_from_a_complete_fresh_context() {
+        const SCRY_ORACLE: &str = "When you choose to put two or more cards on the bottom of your library while scrying, choose one —\n\
+• Exile that many cards from the bottom of your library.\n\
+• Draw a card.";
+        let mut scry_ir = parse_oracle_ir(SCRY_ORACLE, "Scry Context Witness", &[], &[], &[]);
+        let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &scry_ir.items[0].node else {
+            panic!("completed-scry modal must retain parsed trigger IR");
+        };
+        let Some(TriggerBody::Modal(modal)) = trigger.body.as_ref() else {
+            panic!("completed-scry modal must retain its nested mode payload");
+        };
+        assert!(matches!(
+            modal.modes[0].ability.body.clauses[0]
+                .parsed
+                .effect
+                .as_ref(),
+            Effect::ExileTop {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::TriggeringScryBottomCount,
+                },
+                ..
+            }
+        ));
+        assert!(matches!(
+            modal.modes[1].ability.body.clauses[0]
+                .parsed
+                .effect
+                .as_ref(),
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            }
+        ));
+        let scry_lowered = lower_oracle_ir(&mut scry_ir);
+        assert!(matches!(
+            scry_lowered.triggers[0]
+                .execute
+                .as_ref()
+                .expect("completed-scry modal execute")
+                .mode_abilities[0]
+                .effect
+                .as_ref(),
+            Effect::ExileTop {
+                count: QuantityExpr::Ref {
+                    qty: QuantityRef::TriggeringScryBottomCount,
+                },
+                ..
+            }
+        ));
+
+        const DAMAGE_ORACLE: &str =
+            "Whenever Context Witness deals combat damage to a player, choose one —\n\
+• Draw a card.\n\
+• Destroy target creature that player controls.";
+        let mut damage_ir = parse_oracle_ir(DAMAGE_ORACLE, "Context Witness", &[], &[], &[]);
+        let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &damage_ir.items[0].node else {
+            panic!("damage modal must retain parsed trigger IR");
+        };
+        let Some(TriggerBody::Modal(modal)) = trigger.body.as_ref() else {
+            panic!("damage modal must retain nested mode payload");
+        };
+        assert!(matches!(
+            modal.modes[0].ability.body.clauses[0]
+                .parsed
+                .effect
+                .as_ref(),
+            Effect::Draw {
+                target: TargetFilter::Controller,
+                ..
+            }
+        ));
+        assert!(matches!(
+            modal.modes[1].ability.body.clauses[0].parsed.effect.as_ref(),
+            Effect::Destroy {
+                target: TargetFilter::Typed(filter),
+                ..
+            } if filter.controller == Some(ControllerRef::TriggeringPlayer)
+        ));
+        let damage_lowered = lower_oracle_ir(&mut damage_ir);
+        assert!(matches!(
+            damage_lowered.triggers[0]
+                .execute
+                .as_ref()
+                .expect("damage modal execute")
+                .mode_abilities[1]
+                .effect
+                .as_ref(),
+            Effect::Destroy {
+                target: TargetFilter::Typed(filter),
+                ..
+            } if filter.controller == Some(ControllerRef::TriggeringPlayer)
+        ));
+
+        const CAST_ORACLE: &str = "Whenever you cast a spell, choose one —\n\
+• Return it to its owner's hand.\n\
+• Exile it.";
+        let mut cast_ir = parse_oracle_ir(CAST_ORACLE, "Cast Context Witness", &[], &[], &[]);
+        let cast_lowered = lower_oracle_ir(&mut cast_ir);
+        let cast_modes = &cast_lowered.triggers[0]
+            .execute
+            .as_ref()
+            .expect("spell-cast modal execute")
+            .mode_abilities;
+        assert!(matches!(
+            cast_modes.as_slice(),
+            [first, second]
+                if matches!(first.effect.as_ref(), Effect::ChangeZone {
+                    target: TargetFilter::TriggeringSource,
+                    ..
+                }) && matches!(second.effect.as_ref(), Effect::ChangeZone {
+                    target: TargetFilter::TriggeringSource,
+                    ..
+                })
+        ));
+
+        const ACTOR_ORACLE: &str = "Choose one —\n\
+• You may sacrifice a creature.\n\
+• Any opponent may sacrifice a creature of their choice.";
+        let mut actor_ir = parse_oracle_ir(ACTOR_ORACLE, "Actor Context Witness", &[], &[], &[]);
+        assert!(matches!(
+            &actor_ir.items[1].node,
+            OracleNodeIr::Spell(ability)
+                if matches!(
+                    ability.body.clauses[0].parsed.effect.as_ref(),
+                    Effect::Sacrifice {
+                        target: TargetFilter::Typed(filter),
+                        ..
+                    } if filter.controller == Some(ControllerRef::You)
+                )
+        ));
+        assert!(matches!(
+            &actor_ir.items[2].node,
+            OracleNodeIr::Spell(ability)
+                if matches!(
+                    ability.body.clauses[0].parsed.effect.as_ref(),
+                    Effect::Sacrifice {
+                        target: TargetFilter::Typed(filter),
+                        ..
+                    } if filter.controller == Some(ControllerRef::Opponent)
+                )
+        ));
+        let actor_lowered = lower_oracle_ir(&mut actor_ir);
+        assert!(matches!(
+            actor_lowered.abilities.as_slice(),
+            [first, second]
+                if matches!(first.effect.as_ref(), Effect::Sacrifice {
+                    target: TargetFilter::Typed(filter),
+                    ..
+                } if filter.controller == Some(ControllerRef::You))
+                    && matches!(second.effect.as_ref(), Effect::Sacrifice {
+                        target: TargetFilter::Typed(filter),
+                        ..
+                    } if filter.controller == Some(ControllerRef::Opponent))
+        ));
     }
 
     // ---- Final Act (SOC / M3C) — "Choose one or more —" modal spell ----
@@ -3220,6 +4110,88 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             3,
             "one AbilityDefinition per mode"
         );
+    }
+
+    #[test]
+    fn caesar_reflexive_modal_is_native_before_lowering() {
+        let mut ir = parse_oracle_ir(
+            CAESAR_ORACLE,
+            "Caesar, Legion's Emperor",
+            &[],
+            &["Legendary".to_string(), "Creature".to_string()],
+            &["Human".to_string(), "Soldier".to_string()],
+        );
+        let [item] = ir.items.as_slice() else {
+            panic!("Caesar's block must remain one nested trigger document item");
+        };
+        let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &item.node else {
+            panic!("Caesar must not escape through a pre-lowered trigger node");
+        };
+        assert_eq!(item.source.span().first_line, 0);
+        assert_eq!(
+            item.source.fragment(),
+            Some("Whenever you attack, you may sacrifice another creature. When you do, choose two —")
+        );
+        let Some(TriggerBody::ReflexivePayment(reflexive)) = trigger.body.as_ref() else {
+            panic!("Caesar must retain its native reflexive-payment trigger body");
+        };
+        let modal = reflexive
+            .modal
+            .as_ref()
+            .expect("Caesar's reflexive payment owns the native modal payload");
+        assert_eq!(
+            (
+                modal.choice.min_choices,
+                modal.choice.max_choices,
+                modal.choice.mode_count
+            ),
+            (2, 2, 3),
+            "Caesar preserves its choose-two-of-three gate before lowering"
+        );
+        assert_eq!(
+            modal
+                .modes
+                .iter()
+                .map(|mode| (mode.source_line, mode.source_text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (Some(1), "• Create two 1/1 red and white Soldier creature tokens with haste that are tapped and attacking."),
+                (Some(2), "• You draw a card and you lose 1 life."),
+                (Some(3), "• Caesar deals damage equal to the number of creature tokens you control to target opponent."),
+            ],
+            "Caesar's bullet provenance stays nested under the sole trigger item"
+        );
+        assert!(
+            modal.modes.iter().all(|mode| !matches!(
+                mode.ability.body.clauses[0].parsed.effect.as_ref(),
+                Effect::Unimplemented { .. }
+            )),
+            "every native Caesar mode must remain lowerable"
+        );
+
+        let lowered = lower_oracle_ir(&mut ir);
+        assert!(
+            lowered.abilities.is_empty(),
+            "nested Caesar bullets must not become standalone spell abilities"
+        );
+        let payment = lowered.triggers[0]
+            .execute
+            .as_deref()
+            .expect("Caesar trigger has its optional payment");
+        assert!(payment.optional, "Caesar's sacrifice payment is optional");
+        assert!(matches!(payment.effect.as_ref(), Effect::Sacrifice { .. }));
+        let gated_modal = payment
+            .sub_ability
+            .as_deref()
+            .expect("payment must gate the modal under its result");
+        assert_eq!(gated_modal.condition, Some(AbilityCondition::WhenYouDo));
+        assert!(matches!(
+            gated_modal.mode_abilities.as_slice(),
+            [first, second, third]
+                if matches!(first.effect.as_ref(), Effect::Token { .. })
+                    && matches!(second.effect.as_ref(), Effect::Draw { .. })
+                    && matches!(third.effect.as_ref(), Effect::DealDamage { .. })
+        ));
     }
 
     // ---- Vincent's Limit Break (FIN) — Tiered shared-effect chosen-P/T ----

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -36,7 +36,9 @@ use super::oracle_quantity::parse_cda_quantity;
 #[cfg(test)]
 use super::oracle_static::parse_static_line;
 use super::oracle_static::{parse_pt_mod, parse_static_line_ir};
-use super::oracle_trigger::{parse_trigger_lines, parse_trigger_lines_at_index_ir};
+#[cfg(test)]
+use super::oracle_trigger::parse_trigger_lines;
+use super::oracle_trigger::parse_trigger_lines_at_index_ir;
 use super::oracle_util::{parse_mana_symbols, strip_reminder_text, TextPair};
 use crate::parser::oracle_ir::ast::{
     parsed_clause, ModalHeaderAst, ModalOptionality, ModeAst, OracleBlockAst,
@@ -1042,12 +1044,12 @@ pub(crate) enum OracleBlockIr {
 }
 
 pub(crate) enum AnchorModeIr {
-    Trigger(TriggerIr),
-    Static(StaticIr),
+    Trigger(Box<TriggerIr>),
+    Static(Box<StaticIr>),
     /// The bullet is still a first-class document item when no native trigger
     /// or static grammar accepts it. This preserves its printed slot and exact
     /// source line instead of silently dropping the label's semantics.
-    Unsupported(AbilityIr),
+    Unsupported(Box<AbilityIr>),
 }
 
 pub(crate) fn lower_oracle_block_ir(
@@ -1262,7 +1264,7 @@ fn anchor_mode_irs(
                     unsupported_anchor_mode_ir(mode, base_ctx)
                 } else {
                     attach_chosen_label_to_trigger_ir(&mut trigger, label);
-                    AnchorModeIr::Trigger(trigger)
+                    AnchorModeIr::Trigger(Box::new(trigger))
                 }
             })
             .collect();
@@ -1271,7 +1273,7 @@ fn anchor_mode_irs(
     match parse_static_line_ir(body) {
         Some(mut static_ir) => {
             attach_chosen_label_to_static_ir(&mut static_ir, label);
-            (line, vec![AnchorModeIr::Static(static_ir)])
+            (line, vec![AnchorModeIr::Static(Box::new(static_ir))])
         }
         None => (line, vec![unsupported_anchor_mode_ir(mode, base_ctx)]),
     }
@@ -1279,7 +1281,7 @@ fn anchor_mode_irs(
 
 fn unsupported_anchor_mode_ir(mode: &ModeAst, ctx: &ParseContext) -> AnchorModeIr {
     let source = mode.source_text.clone();
-    AnchorModeIr::Unsupported(AbilityIr {
+    AnchorModeIr::Unsupported(Box::new(AbilityIr {
         source_text: source.clone(),
         body: EffectChainIr::single_clause(
             &source,
@@ -1293,7 +1295,7 @@ fn unsupported_anchor_mode_ir(mode: &ModeAst, ctx: &ParseContext) -> AnchorModeI
         die_results: vec![],
         root_transforms: vec![],
         modal: None,
-    })
+    }))
 }
 
 #[cfg(test)]

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -11,7 +11,7 @@ use crate::types::ability::{
     AbilityDefinition, AbilityKind, AdditionalCostOrigin, AdditionalCostPaymentSource, ChoiceType,
     ControllerRef, Effect, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
     PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition, StaticCondition, TargetFilter,
-    TargetSelectionMode, TriggerCondition,
+    TargetSelectionMode, TriggerCondition, TypedFilter,
 };
 use crate::types::replacements::ReplacementEvent;
 use crate::types::triggers::TriggerMode;
@@ -1052,29 +1052,35 @@ pub(crate) enum AnchorModeIr {
     Unsupported(Box<AbilityIr>),
 }
 
-/// CR 603.2c + CR 608.2c: A self-source combat-damage trigger establishes the
+/// CR 603.2c + CR 608.2c: A self-source damage trigger establishes the
 /// damaged player as the referent for a nested modal mode's "that player".
 /// The ordinary trigger classifier retains its historical `TargetPlayer`
-/// treatment of this normalized `~` surface; modal modes instead require the
+/// treatment of the normalized `~` surface; modal modes instead require the
 /// event-player context to parse their independent effect chains correctly.
-fn modal_relative_player_scope_for_condition(condition: &str) -> Option<ControllerRef> {
-    let lower = condition.to_lowercase();
-    let self_damage_to_player = value(
-        ControllerRef::TriggeringPlayer,
+///
+/// This consumes the trigger parser's typed output instead of recognizing a
+/// second, narrower Oracle grammar here. In particular, the trigger parser
+/// already accounts for combat/noncombat, plural damage verbs, and thresholds.
+fn modal_relative_player_scope_for_trigger(trigger: &TriggerIr) -> Option<ControllerRef> {
+    matches!(
         (
-            alt((tag::<_, _, OracleError<'_>>("when "), tag("whenever "))),
-            tag("~ deals "),
-            opt(tag("combat ")),
-            tag("damage to "),
-            alt((tag("a player"), tag("an opponent"))),
+            &trigger.condition,
+            &trigger.partial_def.valid_source,
+            &trigger.partial_def.valid_target
         ),
+        (
+            TriggerMode::DamageDone,
+            Some(TargetFilter::SelfRef),
+            Some(
+                TargetFilter::Player
+                    | TargetFilter::Typed(TypedFilter {
+                        controller: Some(ControllerRef::Opponent),
+                        ..
+                    }),
+            ),
+        )
     )
-    .parse(lower.as_str())
-    .ok()
-    .and_then(|(rest, scope)| rest.trim().is_empty().then_some(scope));
-
-    self_damage_to_player
-        .or_else(|| super::oracle_trigger::relative_player_scope_for_condition(&lower))
+    .then_some(ControllerRef::TriggeringPlayer)
 }
 
 pub(crate) fn lower_oracle_block_ir(
@@ -1124,7 +1130,7 @@ pub(crate) fn lower_oracle_block_ir(
                 // facts, but no mode can leak chain-local state into another.
                 let mut mode_ctx = trigger.body_context.clone();
                 mode_ctx.diagnostics.clear();
-                if let Some(scope) = modal_relative_player_scope_for_condition(&trigger_line) {
+                if let Some(scope) = modal_relative_player_scope_for_trigger(trigger) {
                     mode_ctx.relative_player_scope = Some(scope);
                 }
                 let payload = ModalIr {
@@ -3762,6 +3768,85 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
                 .execute
                 .as_ref()
                 .expect("damage modal execute")
+                .mode_abilities[1]
+                .effect
+                .as_ref(),
+            Effect::Destroy {
+                target: TargetFilter::Typed(filter),
+                ..
+            } if filter.controller == Some(ControllerRef::TriggeringPlayer)
+        ));
+
+        const NONCOMBAT_DAMAGE_ORACLE: &str =
+            "Whenever Context Witness deals noncombat damage to an opponent, choose one —\n\
+• Draw a card.\n\
+• Destroy target creature that player controls.";
+        const THRESHOLD_DAMAGE_ORACLE: &str =
+            "Whenever Context Witness deals combat 3 or more damage to a player, choose one —\n\
+• Draw a card.\n\
+• Destroy target creature that player controls.";
+        for oracle in [NONCOMBAT_DAMAGE_ORACLE, THRESHOLD_DAMAGE_ORACLE] {
+            let mut ir = parse_oracle_ir(oracle, "Context Witness", &[], &[], &[]);
+            let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(trigger)) = &ir.items[0].node else {
+                panic!("damage modal sibling must retain parsed trigger IR");
+            };
+            let Some(TriggerBody::Modal(modal)) = trigger.body.as_ref() else {
+                panic!("damage modal sibling must retain nested mode payload");
+            };
+            assert!(matches!(
+                &modal.modes[1].ability.body.clauses[0].parsed.effect,
+                Effect::Destroy {
+                    target: TargetFilter::Typed(filter),
+                    ..
+                } if filter.controller == Some(ControllerRef::TriggeringPlayer)
+            ));
+            let lowered = lower_oracle_ir(&mut ir);
+            assert!(matches!(
+                lowered.triggers[0]
+                    .execute
+                    .as_ref()
+                    .expect("damage modal sibling execute")
+                    .mode_abilities[1]
+                    .effect
+                    .as_ref(),
+                Effect::Destroy {
+                    target: TargetFilter::Typed(filter),
+                    ..
+                } if filter.controller == Some(ControllerRef::TriggeringPlayer)
+            ));
+        }
+
+        const NON_SELF_DAMAGE_ORACLE: &str =
+            "Whenever a creature deals combat damage to a player, choose one —\n\
+• Draw a card.\n\
+• Destroy target creature that player controls.";
+        let mut non_self_damage_ir =
+            parse_oracle_ir(NON_SELF_DAMAGE_ORACLE, "Context Witness", &[], &[], &[]);
+        let OracleNodeIr::Trigger(TriggerNodeIr::Parsed(non_self_trigger)) =
+            &non_self_damage_ir.items[0].node
+        else {
+            panic!("non-self damage modal must retain parsed trigger IR");
+        };
+        assert!(matches!(
+            &non_self_trigger.partial_def.valid_source,
+            Some(TargetFilter::Typed(_))
+        ));
+        let Some(TriggerBody::Modal(non_self_modal)) = non_self_trigger.body.as_ref() else {
+            panic!("non-self damage modal must retain nested mode payload");
+        };
+        assert!(matches!(
+            &non_self_modal.modes[1].ability.body.clauses[0].parsed.effect,
+            Effect::Destroy {
+                target: TargetFilter::Typed(filter),
+                ..
+            } if filter.controller == Some(ControllerRef::TriggeringPlayer)
+        ));
+        let non_self_lowered = lower_oracle_ir(&mut non_self_damage_ir);
+        assert!(matches!(
+            non_self_lowered.triggers[0]
+                .execute
+                .as_ref()
+                .expect("non-self damage modal execute")
                 .mode_abilities[1]
                 .effect
                 .as_ref(),

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3154,7 +3154,10 @@ mod tests {
                     "{name}: migrated modal route may emit only native modal or spell IR"
                 );
             }
-            assert!(matches!(&ir.items[0].node, OracleNodeIr::Modal(_)));
+            assert!(
+                matches!(&ir.items[0].node, OracleNodeIr::Modal(_)),
+                "{name}: root must retain standalone modal metadata"
+            );
             assert!(
                 ir.items.iter().skip(1).all(|item| matches!(
                     &item.node,

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3107,6 +3107,7 @@ mod tests {
         for (name, oracle, expected_lines, expected_mode_count) in cases {
             let types = vec!["Instant".to_string()];
             let mut ir = parse_oracle_ir(oracle, name, &[], &types, &[]);
+            let span_source = oracle.replacen(name, "~", 1);
 
             assert_eq!(
                 ir.items.len(),
@@ -3130,7 +3131,7 @@ mod tests {
                     Some(expected_fragment),
                     "{name}: slot must retain its verbatim printed source"
                 );
-                let expected_start_byte = oracle
+                let expected_start_byte = span_source
                     .lines()
                     .take(*expected_line)
                     .map(|line| line.len() + 1)

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3121,12 +3121,13 @@ mod tests {
                     (*expected_line, *expected_line),
                     "{name}: source-order slot drift"
                 );
+                let expected_fragment = match (name, *expected_line) {
+                    ("Spree", 0) => "~ (Choose one or more additional costs.)",
+                    _ => oracle.lines().nth(*expected_line).unwrap(),
+                };
                 assert_eq!(
                     item.source.fragment(),
-                    Some(match (name, *expected_line) {
-                        ("Spree", 0) => "~ (Choose one or more additional costs.)",
-                        _ => oracle.lines().nth(*expected_line).unwrap(),
-                    }),
+                    Some(expected_fragment),
                     "{name}: slot must retain its verbatim printed source"
                 );
                 let expected_start_byte = oracle
@@ -3138,7 +3139,7 @@ mod tests {
                     (span.start_byte, span.end_byte),
                     (
                         expected_start_byte,
-                        expected_start_byte + oracle.lines().nth(*expected_line).unwrap().len()
+                        expected_start_byte + expected_fragment.len()
                     ),
                     "{name}: exact source span must bound this header or bullet only"
                 );

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -1971,31 +1971,31 @@ fn guard_unsupported_mode_qualifiers(
     parsed
 }
 
-/// IR-native qualifier guard for the modal migration.  It inspects exactly one
-/// parsed clause and its own source fragment; it never lowers an `AbilityIr`
-/// merely to decide whether a restrictive qualifier was swallowed.
+/// IR-native qualifier guard for the modal migration. It inspects every parsed
+/// clause and its own source fragment; it never lowers an `AbilityIr` merely to
+/// decide whether a restrictive qualifier was swallowed.
 fn guard_unsupported_mode_qualifiers_ir(
     ability: &mut AbilityIr,
     kind: AbilityKind,
     ctx: &ParseContext,
 ) {
-    let [clause] = ability.body.clauses.as_slice() else {
-        return;
-    };
-    let source = clause.source.fragment().unwrap_or(&ability.source_text);
-    let lower = source.to_lowercase();
-    let dig_with_total_mv = matches!(&clause.parsed.effect, Effect::Dig { .. })
-        && nom_primitives::scan_contains(&lower, "with total mana value");
-    let put_counter_with_thats_a = matches!(
-        &clause.parsed.effect,
-        Effect::PutCounterAll { .. } | Effect::PutCounter { .. }
-    ) && nom_primitives::scan_contains(&lower, "that's a ");
+    let has_unsupported_qualifier = ability.body.clauses.iter().any(|clause| {
+        let source = clause.source.fragment().unwrap_or(&ability.source_text);
+        let lower = source.to_lowercase();
+        let dig_with_total_mv = matches!(&clause.parsed.effect, Effect::Dig { .. })
+            && nom_primitives::scan_contains(&lower, "with total mana value");
+        let put_counter_with_thats_a = matches!(
+            &clause.parsed.effect,
+            Effect::PutCounterAll { .. } | Effect::PutCounter { .. }
+        ) && nom_primitives::scan_contains(&lower, "that's a ");
+        dig_with_total_mv || put_counter_with_thats_a
+    });
 
-    if !(dig_with_total_mv || put_counter_with_thats_a) {
+    if !has_unsupported_qualifier {
         return;
     }
 
-    let source = source.to_string();
+    let source = ability.source_text.clone();
     ability.body = EffectChainIr::single_clause(
         &source,
         kind,
@@ -3073,7 +3073,8 @@ mod tests {
 
         for (name, oracle, expected_lines, expected_mode_count) in cases {
             let types = vec!["Instant".to_string()];
-            let mut ir = parse_oracle_ir(oracle, name, &[], &types, &[]);
+            let card_name = format!("Test {name} Modal");
+            let mut ir = parse_oracle_ir(oracle, &card_name, &[], &types, &[]);
 
             assert_eq!(
                 ir.items.len(),
@@ -3204,7 +3205,7 @@ mod tests {
         assert_eq!(triggered_ir.items[0].source.span().first_line, 0);
         assert_eq!(
             triggered_ir.items[0].source.fragment(),
-            Some("Whenever Nested Trigger enters, choose one —")
+            Some("Whenever ~ enters, choose one —")
         );
         let triggered = lower_oracle_ir(&mut triggered_ir);
         assert_eq!(triggered.triggers.len(), 1);
@@ -3572,7 +3573,10 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             );
             assert_eq!(
                 item.source.fragment(),
-                Some(FROSTCLIFF_SIEGE_ORACLE.lines().nth(line).unwrap())
+                Some(match line {
+                    0 => "As ~ enters, choose Jeskai or Temur.",
+                    _ => FROSTCLIFF_SIEGE_ORACLE.lines().nth(line).unwrap(),
+                })
             );
         }
 
@@ -3644,7 +3648,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             .expect("triggered modal execute")
             .mode_abilities[0];
         match first_mode.effect.as_ref() {
-            Effect::ChangeZone { target, .. } => assert_eq!(
+            Effect::Bounce { target, .. } => assert_eq!(
                 target,
                 &TargetFilter::TriggeringSource,
                 "spell-cast 'it' must remain the triggering spell, not a parent target"
@@ -3751,7 +3755,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
         assert!(matches!(
             cast_modes.as_slice(),
             [first, second]
-                if matches!(first.effect.as_ref(), Effect::ChangeZone {
+                if matches!(first.effect.as_ref(), Effect::Bounce {
                     target: TargetFilter::TriggeringSource,
                     ..
                 }) && matches!(second.effect.as_ref(), Effect::ChangeZone {
@@ -4150,7 +4154,7 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
             vec![
                 (Some(1), "• Create two 1/1 red and white Soldier creature tokens with haste that are tapped and attacking."),
                 (Some(2), "• You draw a card and you lose 1 life."),
-                (Some(3), "• Caesar deals damage equal to the number of creature tokens you control to target opponent."),
+                (Some(3), "• ~ deals damage equal to the number of creature tokens you control to target opponent."),
             ],
             "Caesar's bullet provenance stays nested under the sole trigger item"
         );

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -3079,7 +3079,7 @@ mod tests {
             ),
             (
                 "Spree",
-                "Spree (Choose one or more additional costs.)\n+\
+                "Spree\n+\
 + {1} — Draw a card.\n+\
 + {2} — Gain 3 life.",
                 &[0, 1, 2][..],
@@ -3112,7 +3112,7 @@ mod tests {
                 name
             };
             let mut ir = parse_oracle_ir(oracle, card_name, &[], &types, &[]);
-            let span_source = oracle.replacen("Spree", "~", 1);
+            let span_source = oracle;
 
             assert_eq!(
                 ir.items.len(),
@@ -3127,10 +3127,7 @@ mod tests {
                     (*expected_line, *expected_line),
                     "{name}: source-order slot drift"
                 );
-                let expected_fragment = match (name, *expected_line) {
-                    ("Spree", 0) => "~ (Choose one or more additional costs.)",
-                    _ => oracle.lines().nth(*expected_line).unwrap(),
-                };
+                let expected_fragment = oracle.lines().nth(*expected_line).unwrap();
                 assert_eq!(
                     item.source.fragment(),
                     Some(expected_fragment),

--- a/crates/engine/src/parser/oracle_special.rs
+++ b/crates/engine/src/parser/oracle_special.rs
@@ -301,6 +301,7 @@ pub(super) fn try_parse_die_roll_table(
             ..AbilityShellIr::default()
         },
         die_results: branches,
+        modal: None,
         root_transforms: vec![],
     };
     Some((lower_ability_ir(&ir), next_line))

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11711,7 +11711,6 @@ fn parse_damage_source_subject(input: &str) -> OracleResult<'_, TargetFilter> {
     // Each branch consumes the trailing space so the caller can chain into
     // `tag("deals ")`, mirroring the article path's own trailing-space consume.
     if let Ok((rest, filter)) = alt((
-        value(TargetFilter::SelfRef, tag::<_, _, OracleError<'_>>("~ ")),
         value(
             TargetFilter::AttachedTo,
             tag::<_, _, OracleError<'_>>("enchanted creature "),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -1314,6 +1314,7 @@ pub(crate) fn parse_trigger_line_with_index_ir(
         // source name; the gate carried the partner name).
         pending_meld_partner: meld_partner,
         pending_mana_symbol_count_color,
+        actor: ctx.actor.clone(),
         object_pronoun_ref: trigger_object_pronoun_ref_for_condition(condition_text)
             .or_else(|| trigger_object_pronoun_ref_for_intervening_if(&if_condition)),
         in_trigger: true,
@@ -1335,6 +1336,10 @@ pub(crate) fn parse_trigger_line_with_index_ir(
     if parse_completed_scry_bottom_condition(&cond_lower).is_some() {
         effect_ctx.quantity_ref = Some(QuantityRef::TriggeringScryBottomCount);
     }
+    // Keep the condition-established context intact for nested parser payloads.
+    // The body parser mutates its working context while it walks clauses, whereas
+    // each nested modal mode must begin from the same trigger-level facts.
+    let body_context = effect_ctx.clone();
     // Snapshot the condition-established scope before body parsing (which may
     // temporarily rebind it via `with_player_scope`) so lowering sees the scope
     // the condition introduced, not a transient nested-clause value.
@@ -1355,7 +1360,12 @@ pub(crate) fn parse_trigger_line_with_index_ir(
             let effect_chain =
                 parse_effect_chain_ir(&reflexive_effect_text, AbilityKind::Spell, &mut effect_ctx);
             Some(TriggerBody::ReflexivePayment(Box::new(
-                ReflexivePaymentIr { cost, effect_chain },
+                ReflexivePaymentIr {
+                    cost,
+                    effect_chain,
+                    payment_chain: None,
+                    modal: None,
+                },
             )))
         } else if is_unsupported_disjunctive_reflexive_optional_payment(&effect_for_parse) {
             Some(TriggerBody::EffectChain(EffectChainIr::single_clause(
@@ -1478,6 +1488,7 @@ pub(crate) fn parse_trigger_line_with_index_ir(
         },
         source_text: text.to_string(),
         die_results: Vec::new(),
+        body_context,
     }
 }
 
@@ -1610,21 +1621,41 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
                 lower_trigger_effect_chain(&reflexive.effect_chain, modifiers, &ir.die_results);
             reflexive_ability.condition = Some(AbilityCondition::WhenYouDo);
 
-            let mut pay_ability = AbilityDefinition::new(
-                AbilityKind::Spell,
-                Effect::PayCost {
-                    cost: reflexive.cost.clone(),
-                    scale: None,
-                    payer: TargetFilter::Controller,
-                },
-            );
+            if let Some(modal) = &reflexive.modal {
+                reflexive_ability = reflexive_ability.with_modal(
+                    modal.choice.clone(),
+                    modal
+                        .modes
+                        .iter()
+                        .map(|mode| crate::parser::oracle_effect::lower_ability_ir(&mode.ability))
+                        .collect(),
+                );
+            }
+
+            let mut pay_ability = match &reflexive.payment_chain {
+                Some(chain) => lower_trigger_effect_chain(chain, modifiers, &[]),
+                None => AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::PayCost {
+                        cost: reflexive.cost.clone(),
+                        scale: None,
+                        payer: TargetFilter::Controller,
+                    },
+                ),
+            };
             pay_ability.optional = true;
             pay_ability.sub_ability = Some(Box::new(reflexive_ability));
             Some(Box::new(pay_ability))
         }
         Some(TriggerBody::Modal(modal)) => Some(Box::new(
-            lower_trigger_effect_chain(&modal.marker, modifiers, &[])
-                .with_modal(modal.choice.clone(), modal.mode_abilities.clone()),
+            lower_trigger_effect_chain(&modal.marker, modifiers, &[]).with_modal(
+                modal.choice.clone(),
+                modal
+                    .modes
+                    .iter()
+                    .map(|mode| crate::parser::oracle_effect::lower_ability_ir(&mode.ability))
+                    .collect(),
+            ),
         )),
         Some(TriggerBody::Vote(vote)) => Some(Box::new(lower_trigger_effect_chain(
             &vote.effect_chain(AbilityKind::Spell),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -11711,6 +11711,7 @@ fn parse_damage_source_subject(input: &str) -> OracleResult<'_, TargetFilter> {
     // Each branch consumes the trailing space so the caller can chain into
     // `tag("deals ")`, mirroring the article path's own trailing-space consume.
     if let Ok((rest, filter)) = alt((
+        value(TargetFilter::SelfRef, tag::<_, _, OracleError<'_>>("~ ")),
         value(
             TargetFilter::AttachedTo,
             tag::<_, _, OracleError<'_>>("enchanted creature "),

--- a/scripts/prelowered-ratchet.txt
+++ b/scripts/prelowered-ratchet.txt
@@ -12,16 +12,16 @@
 # real IR nodes. Every tranche that converts a producer must lower its number
 # in the same commit, which is what makes the burn-down visible in `git log`
 # on this one file.
-crates/engine/src/parser/oracle.rs         12
+crates/engine/src/parser/oracle.rs          5
 crates/engine/src/parser/oracle_class.rs    3
 
 # --- infrastructure: NOT burn-down targets ----------------------------------
 # The variant declarations and their consumers. These legitimately survive
 # until the last producer is gone and the variants themselves are deleted, so
 # they are ceilings only — they are not expected to reach 0 before then.
-# 20 includes spell_payload's exhaustive consumer arms, not producers.
-crates/engine/src/parser/oracle_ir/doc.rs      20
-crates/engine/src/parser/oracle_ir/feature.rs   9
+# 12 includes spell_payload's exhaustive consumer arms, not producers.
+crates/engine/src/parser/oracle_ir/doc.rs      12
+crates/engine/src/parser/oracle_ir/feature.rs   7
 
 # Prose references in the T1 witness-corpus comment.
 crates/engine/src/parser/oracle_ir/snapshot_tests.rs   2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modal ability handling across “choose one”, “as enters”, reflexive optional-cost modes, and triggered effects.
  - Modal options now reliably nest and render in the correct document slots, with more consistent modal choice and anchor wiring.
  - Refined shared-effect and unsupported-qualifier behavior inside modal options, including correct handling of static/unsupported anchors.
  - Removed legacy pre-lowered static/replacement handling to avoid inconsistent emission.

- **Enhancements**
  - Modal options now carry more accurate per-mode source provenance (text and line) for references and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->