### PR TITLE
fix(server-core): redact an object-shaped draftSessionJson too

### DIFF
--- a/crates/server-core/src/p2p_backup_guard.rs
+++ b/crates/server-core/src/p2p_backup_guard.rs
@@ -96,21 +96,30 @@ fn redact_secret_keys(obj: &mut Map<String, Value>) {
 }
 
 fn redact_nested_draft_session_json(obj: &mut Map<String, Value>) {
-    let Some(nested_raw) = obj.get(DRAFT_SESSION_JSON_KEY).and_then(|v| v.as_str()) else {
+    let Some(nested_value) = obj.get_mut(DRAFT_SESSION_JSON_KEY) else {
         return;
     };
-    let Ok(mut nested) = serde_json::from_str::<Value>(nested_raw) else {
-        return;
-    };
-    let Some(nested_obj) = nested.as_object_mut() else {
-        return;
-    };
-    redact_draft_session_object(nested_obj);
-    if let Ok(serialized) = serde_json::to_string(&nested) {
-        obj.insert(
-            DRAFT_SESSION_JSON_KEY.to_string(),
-            Value::String(serialized),
-        );
+    match nested_value {
+        // Canonical shape: the session serialized into a JSON string. Parse,
+        // redact, re-serialize so the field keeps its wire type.
+        Value::String(nested_raw) => {
+            let Ok(mut nested) = serde_json::from_str::<Value>(nested_raw) else {
+                return;
+            };
+            let Some(nested_obj) = nested.as_object_mut() else {
+                return;
+            };
+            redact_draft_session_object(nested_obj);
+            if let Ok(serialized) = serde_json::to_string(&nested) {
+                *nested_value = Value::String(serialized);
+            }
+        }
+        // The same payload sent inline as an object. `snapshot_json` is an
+        // opaque host-supplied blob, so nothing upstream pins the field to a
+        // string — matching only the string shape let a host keep unopened
+        // packs and the rng seed simply by not encoding them twice.
+        Value::Object(nested_obj) => redact_draft_session_object(nested_obj),
+        _ => {}
     }
 }
 
@@ -232,6 +241,49 @@ mod tests {
         assert_eq!(nested_out["config"]["rng_seed"], 0);
         assert!(nested_out.get("packs_by_seat").is_none());
         assert_eq!(nested_out["status"], "Drafting");
+    }
+
+    #[test]
+    fn redact_p2p_backup_snapshot_secrets_strips_object_shaped_draft_session() {
+        // `snapshot_json` is an opaque host-supplied blob, so nothing upstream
+        // pins `draftSessionJson` to a string. Sending the identical payload
+        // inline as an object used to skip redaction entirely, persisting the
+        // unopened packs and the rng seed and echoing both from
+        // `GET /p2p-draft-backup/{code}`.
+        let raw = serde_json::json!({
+            "draftCode": "ABC123",
+            "draftSessionJson": {
+                "draft_code": "ABC123",
+                "config": { "rng_seed": 42, "pod_size": 8 },
+                "packs_by_seat": [[{"card_id": "secret-pack"}]],
+                "status": "Drafting"
+            },
+            "seatTokens": { "0": "host-secret" }
+        });
+
+        let redacted =
+            redact_p2p_backup_snapshot_secrets(&raw.to_string()).expect("valid snapshot");
+
+        let parsed: Value = serde_json::from_str(&redacted).unwrap();
+        assert!(parsed.get("seatTokens").is_none());
+        let nested_out = &parsed["draftSessionJson"];
+        assert_eq!(nested_out["config"]["rng_seed"], 0);
+        assert!(nested_out.get("packs_by_seat").is_none());
+        // Untouched fields survive, and the field keeps the shape it arrived in.
+        assert_eq!(nested_out["status"], "Drafting");
+        assert_eq!(nested_out["config"]["pod_size"], 8);
+    }
+
+    #[test]
+    fn redact_p2p_backup_snapshot_secrets_leaves_non_session_shapes_alone() {
+        // A `draftSessionJson` that is neither a string nor an object carries no
+        // session to redact; it must pass through rather than error.
+        let raw = serde_json::json!({ "draftSessionJson": 7, "draftStarted": true });
+        let redacted =
+            redact_p2p_backup_snapshot_secrets(&raw.to_string()).expect("valid snapshot");
+        let parsed: Value = serde_json::from_str(&redacted).unwrap();
+        assert_eq!(parsed["draftSessionJson"], 7);
+        assert_eq!(parsed["draftStarted"], true);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`redact_nested_draft_session_json` only matched `draftSessionJson` when it was a JSON *string*. A host sending the identical session inline as an object skipped redaction entirely, so unopened `packs_by_seat` and `config.rng_seed` were persisted to SQLite and echoed from `GET /p2p-draft-backup/{code}` — the exact secrets the module exists to strip.

## Files changed

- `crates/server-core/src/p2p_backup_guard.rs` — redact both wire shapes; two regression tests

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — `crates/server-core/` wire validation. No `crates/engine/` game logic, parser, effect, resolver, or targeting code is touched; the diff is JSON shape handling in an HTTP-boundary guard. Per CONTRIBUTING's narrow exception for non-engine transport-layer code.

## CR references

None — HTTP payload redaction, no game rule involved.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `./scripts/check-parser-combinators.sh` — `Gate A PASS head=dbc8f44a7… base=a8766823c…` (full output below)
- `cargo test -p server-core` — `274 passed; 0 failed`, plus `22 passed` and `5 passed` in the sibling targets
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p server-core --all-targets` — 0 warnings

Same two disclosures as my previous PRs, restated rather than left implicit: I did not run `/review-impl` (in this environment the reviewer would share context with the author, which CONTRIBUTING is explicit is the failure mode the loop exists to prevent), and I ran cargo directly because Tilt is not up in this checkout.

## Gate A

```
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=dbc8f44a7fcfed26535f9545d3d36a55aaf60250 base=a8766823cd952ef280807ebb6e8af90b83d73588
```

## Anchored on

- `crates/server-core/src/p2p_backup_guard.rs:91` — `redact_secret_keys`, which already redacts the *top-level* object in place; this makes the nested payload follow the same in-place treatment when it arrives as an object
- `crates/server-core/src/p2p_backup_guard.rs:116` — `redact_draft_session_object`, the single authority for what a session must not carry; both wire shapes now route through it rather than only one

## The bug

```rust
let Some(nested_raw) = obj.get(DRAFT_SESSION_JSON_KEY).and_then(|v| v.as_str()) else {
    return;   // <- any non-string shape leaves the payload untouched
};
```

`snapshot_json` is an opaque host-supplied blob (`guard_p2p_backup` bounds its length and rejects control characters, but does not constrain its internal shape), so nothing upstream pins `draftSessionJson` to a string. Same payload, two encodings:

```
STRING form -> {"draftSessionJson":"{\"config\":{\"rng_seed\":0}}"}
OBJECT form -> {"draftSessionJson":{"config":{"rng_seed":42},"packs_by_seat":[["Black Lotus"]]}}
```

The module header states the contract this breaks:

> The host also embeds a full `draftSessionJson` blob (exported `DraftSession`). That nested payload can carry `config.rng_seed` and unopened `packs_by_seat`, which must be stripped before SQLite persistence or `GET` echo

and

> The backup row is keyed only by the 6-character draft code and is readable by any caller of `GET /p2p-draft-backup/{code}`

So the leak is unauthenticated: knowing a 6-character draft code is enough to read another pod's unopened packs and RNG seed, provided its host encoded the field as an object.

## The change

`match` on the field instead of demanding a string: `Value::String` keeps the parse → redact → re-serialize path (and preserves the string wire type), `Value::Object` redacts in place, anything else passes through untouched because it carries no session to redact.

I deliberately did not tighten `guard_p2p_backup` to reject non-string `draftSessionJson`. That would be a wire-contract change affecting existing hosts; redacting what arrives is the conservative fix and keeps the guard's stated job — strip secrets — independent of how the host encoded them.

## Tests

- `redact_p2p_backup_snapshot_secrets_strips_object_shaped_draft_session` — the leak above. Fails on `main` with `assertion left == right failed` on `rng_seed` (42 vs 0), with `packs_by_seat` still present.
- `redact_p2p_backup_snapshot_secrets_leaves_non_session_shapes_alone` — pins the pass-through arm so the new `match` cannot start erroring on shapes it previously ignored.

The existing `…_strips_nested_draft_session_secrets` (string form) is unchanged and still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction of nested draft session data when provided as either JSON text or an inline object.
  * Ensured sensitive nested values are removed and random seed settings are reset while preserving other data.
  * Added safe handling for unsupported value types without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->