### PR TITLE
fix(server-core): report each forfeited game once, not once per seat

### DIFF
--- a/crates/server-core/src/reconnect.rs
+++ b/crates/server-core/src/reconnect.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use engine::types::player::PlayerId;
@@ -85,12 +85,11 @@ impl ReconnectManager {
     /// [`Self::check_expired_with_players`] stays per-seat: its entries are
     /// already distinct, and draft auto-pick acts on each seat individually.
     pub fn check_expired(&mut self) -> Vec<String> {
-        let mut expired: Vec<String> = Vec::new();
+        let mut expired = Vec::new();
+        let mut expired_game_codes = HashSet::new();
         self.disconnected.retain(|_key, info| {
             if info.disconnect_time.elapsed() > info.grace_period {
-                // Linear scan: bounded by the games lapsing within one sweep
-                // tick, so it stays cheaper than hashing.
-                if !expired.contains(&info.game_code) {
+                if expired_game_codes.insert(info.game_code.clone()) {
                     expired.push(info.game_code.clone());
                 }
                 false

--- a/crates/server-core/src/reconnect.rs
+++ b/crates/server-core/src/reconnect.rs
@@ -74,12 +74,25 @@ impl ReconnectManager {
         }
     }
 
-    /// Return game codes with expired grace periods (for forfeit processing).
+    /// Return the distinct game codes with expired grace periods (for forfeit
+    /// processing), in the order they were observed.
+    ///
+    /// Entries are keyed per `(game, seat)`, so a game whose seats lapse
+    /// together produced one element each. Callers treat a code as "one game to
+    /// tear down" — emitting it twice sends the terminal `GameOver` to every
+    /// player once per lapsed seat and repeats the session delete. Forfeit is a
+    /// per-game event, so collapse here rather than at each call site.
+    /// [`Self::check_expired_with_players`] stays per-seat: its entries are
+    /// already distinct, and draft auto-pick acts on each seat individually.
     pub fn check_expired(&mut self) -> Vec<String> {
-        let mut expired = Vec::new();
+        let mut expired: Vec<String> = Vec::new();
         self.disconnected.retain(|_key, info| {
             if info.disconnect_time.elapsed() > info.grace_period {
-                expired.push(info.game_code.clone());
+                // Linear scan: bounded by the games lapsing within one sweep
+                // tick, so it stays cheaper than hashing.
+                if !expired.contains(&info.game_code) {
+                    expired.push(info.game_code.clone());
+                }
                 false
             } else {
                 true
@@ -194,6 +207,44 @@ mod tests {
         assert_eq!(expired.len(), 2);
         assert!(expired.contains(&"GAME01".to_string()));
         assert!(expired.contains(&"GAME02".to_string()));
+    }
+
+    #[test]
+    fn check_expired_reports_a_multi_seat_game_once() {
+        // Records are keyed per (game, seat), so a pod whose seats lapse
+        // together yielded the same code once per seat. The forfeit sweep
+        // treats each element as a whole game to tear down, so duplicates sent
+        // GameOver to every player once per lapsed seat and repeated the
+        // session delete.
+        let mut mgr = ReconnectManager::new(Duration::from_millis(0));
+        for seat in 0..3 {
+            mgr.record_disconnect("GAME01", PlayerId(seat), Duration::from_millis(0));
+        }
+        mgr.record_disconnect("GAME02", PlayerId(0), Duration::from_millis(0));
+        std::thread::sleep(Duration::from_millis(2));
+
+        let expired = mgr.check_expired();
+
+        assert_eq!(expired.len(), 2, "one entry per game, got {expired:?}");
+        assert!(expired.contains(&"GAME01".to_string()));
+        assert!(expired.contains(&"GAME02".to_string()));
+        // Every record is still consumed, whether or not it was reported.
+        assert!(!mgr.is_disconnected("GAME01", PlayerId(1)));
+    }
+
+    #[test]
+    fn check_expired_with_players_stays_per_seat() {
+        // The per-seat sibling must keep one entry per lapsed seat — draft
+        // auto-pick acts on each seat individually.
+        let mut mgr = ReconnectManager::new(Duration::from_millis(0));
+        for seat in 0..3 {
+            mgr.record_disconnect("DRAFT1", PlayerId(seat), Duration::from_millis(0));
+        }
+        std::thread::sleep(Duration::from_millis(2));
+
+        let expired = mgr.check_expired_with_players();
+
+        assert_eq!(expired.len(), 3, "got {expired:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`check_expired` returns one bare game code per expired *record*, but records are keyed per `(game, seat)`. A pod whose seats lapse in the same sweep yields the same code once per seat, and the forfeit sweep treats each element as a whole game to tear down — so `GameOver` is broadcast to every connected player once per lapsed seat.

## Files changed

- `crates/server-core/src/reconnect.rs` — collapse to distinct game codes; two regression tests

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — `crates/server-core/` session bookkeeping. No `crates/engine/` game logic, parser, effect, resolver, or targeting code is touched; the diff is a de-duplication in the reconnect ledger's sweep. Per CONTRIBUTING's narrow exception for non-engine transport-layer code.

## CR references

None — the forfeit is a server policy (grace period), not a CR-defined action.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `./scripts/check-parser-combinators.sh` — `Gate A PASS head=144ebbbc5… base=a8766823c…` (full output below)
- `cargo test -p server-core` — `274 passed; 0 failed`, plus `22 passed` and `5 passed` in the sibling targets
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p server-core --all-targets` — 0 warnings

Same two disclosures as my previous PRs: I did not run `/review-impl` (in this environment the reviewer would share context with the author, which CONTRIBUTING is explicit is the failure mode the loop exists to prevent), and I ran cargo directly because Tilt is not up in this checkout.

## Gate A

```
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=144ebbbc5bfab9c27548ff03e6235f5001c241ff base=a8766823cd952ef280807ebb6e8af90b83d73588
```

## Anchored on

- `crates/server-core/src/reconnect.rs:92` — `check_expired_with_players`, the per-seat sibling whose entries are inherently distinct; it establishes that per-seat vs per-game is a deliberate split, and this change puts `check_expired` on the per-game side of it
- `crates/phase-server/src/main.rs:1252` — the forfeit sweep, which iterates the returned codes as whole games (`remove_game`, one `GameOver` fan-out, `delete_session`, spectator cleanup) and is the call site the duplicates multiply

## The bug

Keys are `"{game_code}:{player_id}"`, and the sweep pushes `info.game_code` per surviving-check:

```rust
self.disconnected.retain(|_key, info| {
    if info.disconnect_time.elapsed() > info.grace_period {
        expired.push(info.game_code.clone());   // once per seat
        false
    } else { true }
});
```

Three seats of one game lapsing together:

```
check_expired() -> ["GAME01", "GAME01", "GAME01"]
```

At `phase-server/src/main.rs:1252` each element drives a full teardown, so one forfeited game produces:

- `remove_game` three times
- the terminal `GameOver` sent to **every** connected player three times
- `delete_session` three times (three SQLite writes)
- `info!(reason = "disconnect_expired", "game over")` logged three times
- `specs.remove` three times

The duplicate `GameOver` is the client-visible one. This is reachable whenever more than one seat's grace period lapses inside the same 10-second tick — the common case when a pod's host drops and the room empties.

## The change

Collapse at the source. Forfeit is a per-game event, so a caller should never have to dedupe; pushing that to `main.rs` would leave the same trap for the next consumer.

`check_expired_with_players` is deliberately **not** changed — its entries are already distinct per `(game, seat)` and draft auto-pick acts on each seat individually. A test now pins that difference so the two cannot drift into each other.

The linear `contains` is bounded by the number of games lapsing within one sweep tick, which keeps it cheaper than hashing at these sizes.

Every expired record is still consumed whether or not it was reported, so the sweep-consumes-the-ledger contract from #6813 is unchanged.

## Tests

- `check_expired_reports_a_multi_seat_game_once` — three seats of one game plus a second game. Fails on `main` with:
  ```
  assertion `left == right` failed: one entry per game, got ["GAME01", "GAME01", "GAME02", "GAME01"]
  ```
  It also asserts the unreported records are still consumed.
- `check_expired_with_players_stays_per_seat` — pins the sibling at three entries, so a future "dedupe it too" change has to be deliberate.

The existing `check_expired_returns_expired_games` and `check_expired_retains_non_expired` are unchanged and still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expired games are now reported once per game code, avoiding duplicate entries when multiple seats expire at the same time.
  * Per-seat expiration details remain unchanged in the player-specific expiration path.
* **Tests**
  * Added coverage to confirm deduplication behavior for game-level reporting and one-entry-per-seat behavior for player-level reporting.
* **Documentation**
  * Updated related documentation to reflect the per-game collapsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->