### PR TITLE
fix: parse coordinated damage targets

### DIFF
--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -995,6 +995,7 @@ pub fn parse_target_with_syntax<'a>(
         {
             if let Ok((object_tail, _)) = alt((
                 tag::<_, _, OracleError<'_>>(", and/or "),
+                tag(", and "),
                 tag(", or "),
                 tag(", "),
             ))
@@ -1003,12 +1004,17 @@ pub fn parse_target_with_syntax<'a>(
                 if starts_with_type_word(object_tail) {
                     let mut combined = player_filter.clone();
                     let mut leg_text = &text[lower.len() - object_tail.len()..];
+                    let mut merged_any = false;
                     loop {
                         let (leg, rest) = parse_type_phrase_with_ctx(leg_text, ctx);
                         if matches!(leg, TargetFilter::Any) {
+                            if merged_any {
+                                return (combined, leg_text, syntax);
+                            }
                             break;
                         }
                         combined = merge_or_filters(combined, leg);
+                        merged_any = true;
 
                         let rest_lower = rest.to_lowercase();
                         let Ok((next_leg, _)) = alt((
@@ -9651,6 +9657,23 @@ mod tests {
                     TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
                 ],
             }
+        );
+    }
+
+    #[test]
+    fn coordinated_player_and_object_target_accepts_and_connector() {
+        let (filter, rest) = parse_target("target player, and creature you control");
+
+        assert_eq!(rest, "");
+        assert_eq!(
+            filter,
+            TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Player,
+                    TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+                ],
+            },
+            "the ordinary `, and` connector must retain the object alternative"
         );
     }
 

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -976,19 +976,60 @@ pub fn parse_target_with_syntax<'a>(
                 syntax,
             );
         }
-        // "target opponent"
-        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("opponent").parse(after_target) {
-            return (
+        // CR 115.1: A coordinated target noun phrase may elide "target" after
+        // its first player leg: "target opponent, creature an opponent
+        // controls, or planeswalker an opponent controls." All coordinated
+        // nouns still describe one target slot, whose legal domain is the
+        // union of the player and object legs. Parse the player head and the
+        // separator compositionally, then delegate the complete object tail to
+        // the shared type-phrase grammar so controller/type qualifiers retain
+        // their ordinary semantics.
+        if let Ok((after_player, player_filter)) = alt((
+            value(
                 TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
-                &text[lower.len() - rest.len()..],
-                syntax,
-            );
-        }
-        // "target player"
-        if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("player").parse(after_target) {
+                tag::<_, _, OracleError<'_>>("opponent"),
+            ),
+            value(TargetFilter::Player, tag("player")),
+        ))
+        .parse(after_target)
+        {
+            if let Ok((object_tail, _)) = alt((
+                tag::<_, _, OracleError<'_>>(", and/or "),
+                tag(", or "),
+                tag(", "),
+            ))
+            .parse(after_player)
+            {
+                if starts_with_type_word(object_tail) {
+                    let mut combined = player_filter.clone();
+                    let mut leg_text = &text[lower.len() - object_tail.len()..];
+                    loop {
+                        let (leg, rest) = parse_type_phrase_with_ctx(leg_text, ctx);
+                        if matches!(leg, TargetFilter::Any) {
+                            break;
+                        }
+                        combined = merge_or_filters(combined, leg);
+
+                        let rest_lower = rest.to_lowercase();
+                        let Ok((next_leg, _)) = alt((
+                            tag::<_, _, OracleError<'_>>(", and/or "),
+                            tag(", and "),
+                            tag(", or "),
+                            tag(", "),
+                        ))
+                        .parse(rest_lower.as_str()) else {
+                            return (combined, rest, syntax);
+                        };
+                        if !starts_with_type_word(next_leg) {
+                            return (combined, rest, syntax);
+                        }
+                        leg_text = &rest[rest_lower.len() - next_leg.len()..];
+                    }
+                }
+            }
             return (
-                TargetFilter::Player,
-                &text[lower.len() - rest.len()..],
+                player_filter,
+                &text[lower.len() - after_player.len()..],
                 syntax,
             );
         }
@@ -9569,6 +9610,47 @@ mod tests {
         assert_eq!(
             f,
             TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent))
+        );
+    }
+
+    #[test]
+    fn target_opponent_with_elided_coordinated_object_alternatives() {
+        let (filter, rest) = parse_target(
+            "target opponent, creature an opponent controls, or planeswalker an opponent controls",
+        );
+
+        assert_eq!(rest, "");
+        assert_eq!(
+            filter,
+            TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+                    TargetFilter::Typed(
+                        TypedFilter::creature().controller(ControllerRef::Opponent)
+                    ),
+                    TargetFilter::Typed(
+                        TypedFilter::new(TypeFilter::Planeswalker)
+                            .controller(ControllerRef::Opponent)
+                    ),
+                ],
+            },
+            "the player and both opponent-controlled object alternatives share one target slot"
+        );
+    }
+
+    #[test]
+    fn coordinated_player_and_object_target_preserves_plain_player_behavior() {
+        let (filter, rest) = parse_target("target player, creature you control");
+
+        assert_eq!(rest, "");
+        assert_eq!(
+            filter,
+            TargetFilter::Or {
+                filters: vec![
+                    TargetFilter::Player,
+                    TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+                ],
+            }
         );
     }
 

--- a/crates/engine/tests/integration/l02_bbfu2_batched_counter_triggers.rs
+++ b/crates/engine/tests/integration/l02_bbfu2_batched_counter_triggers.rs
@@ -192,6 +192,66 @@ fn awbo_batched_multi_type_deals_total_single_firing() {
     );
 }
 
+/// Issue #5237: All Will Be One's coordinated target phrase denotes one target
+/// chosen from an opponent player, an opponent-controlled creature, or an
+/// opponent-controlled planeswalker. The parser used to stop after "target
+/// opponent", so the sole opponent was auto-selected even when object targets
+/// existed. Selecting the opponent's creature here drives the corrected union
+/// through trigger target discovery and damage resolution.
+#[test]
+fn awbo_can_target_opponent_controlled_creature_instead_of_opponent() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature_from_oracle(P0, "All Will Be One", 0, 3, ALL_WILL_BE_ONE)
+        .id();
+    let counter_recipient = scenario.add_creature(P0, "Grizzly Bear", 2, 2).id();
+    let damage_target = scenario.add_creature(P1, "Foe Giant", 5, 5).id();
+    let fangs = scenario
+        .add_spell_to_hand_from_oracle(P0, "Unexpected Fangs", true, UNEXPECTED_FANGS)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    let mut runner = scenario.build();
+
+    let out = runner
+        .cast(fangs)
+        .target_objects(&[counter_recipient, damage_target])
+        .resolve();
+
+    assert_eq!(
+        out.counters(counter_recipient, CounterType::Plus1Plus1),
+        1,
+        "reach-guard: the counter event that fires All Will Be One occurred"
+    );
+    assert_eq!(
+        out.counters(counter_recipient, lifelink_counter()),
+        1,
+        "reach-guard: the batched event placed both counter kinds"
+    );
+
+    let damage_to_creature: Vec<u32> = out
+        .events()
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::DamageDealt {
+                target: TargetRef::Object(object),
+                amount,
+                ..
+            } if *object == damage_target => Some(*amount),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        damage_to_creature,
+        vec![2],
+        "All Will Be One deals the batched counter amount to the selected creature"
+    );
+    assert!(
+        damage_to_p1(&out).is_empty(),
+        "the opponent is not silently auto-selected when its creature was chosen"
+    );
+}
+
 /// Batched AWBO single-KIND magnitude control: a single put-event placing TWO
 /// +1/+1 counters (one `CounterAdded` event, count == 2) makes AWBO deal 2 — the
 /// counter MAGNITUDE, not a subject headcount (which would be 1). This 1-event


### PR DESCRIPTION
## Summary

- parse coordinated target phrases that combine a player leg with object legs while eliding repeated `target`
- represent All Will Be One's damage target as one union of an opponent, an opponent-controlled creature, or an opponent-controlled planeswalker
- add parser and cast-pipeline regressions proving an opponent-controlled creature can be selected instead of silently targeting the opponent

Fixes #5237.

## Root cause

The target parser stopped after `target opponent` in:

> target opponent, creature an opponent controls, or planeswalker an opponent controls

The exported effect therefore contained only an empty-type opponent filter. The fix parses each coordinated object alternative independently, preserving its controller qualifier, and merges all alternatives into the existing `TargetFilter::Or` representation.

## Validation

- `cargo fmt --all`
- `./scripts/check-parser-combinators.sh`
- `./scripts/check-skill-doc.sh`
- `cargo test -p phase-engine target_opponent_with_elided_coordinated_object_alternatives -- --nocapture`
- `cargo test -p phase-engine coordinated_player_and_object_target_preserves_plain_player_behavior -- --nocapture`
- `cargo test -p phase-engine awbo_can_target_opponent_controlled_creature_instead_of_opponent -- --nocapture`
- `cargo run -p phase-engine --features cli --bin oracle-gen -- data --filter "All Will Be One"`
- `cargo clippy -p phase-engine --all-targets --features cli -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved target selection for coordinated options involving players and objects, such as opponent-controlled creatures or planeswalkers.
  * Ensured selecting an opponent-controlled object does not also incorrectly select the opponent.
  * Preserved correct handling of remaining input and syntax in complex target phrases.

* **Tests**
  * Added coverage confirming counter-triggered effects select the intended creature and apply damage correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->