### PR TITLE
fix(parser): parse external entry tap-state grammar

### DIFF
--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -733,6 +733,8 @@ const REPLACEMENT_CONTAINS_PATTERNS: &[&str] = &[
     "enters the battlefield tapped",
     "enters tapped",
     "enters untapped",
+    "enter the battlefield untapped",
+    "enters the battlefield untapped",
     "enters prepared",
     "enter as a copy of",
     "enter tapped as a copy of",
@@ -779,16 +781,6 @@ pub(crate) fn is_replacement_pattern(lower: &str) -> bool {
     }
 
     if lower.trim_end_matches('.').ends_with(" enter untapped") {
-        return true;
-    }
-
-    // CR 614.1c: the untapped-entry counterpart is templated the same short-vs-
-    // long way as the tapped form above (Vigorous Farming: "Lands you control
-    // enter the battlefield untapped.").
-    if lower
-        .trim_end_matches('.')
-        .ends_with(" enter the battlefield untapped")
-    {
         return true;
     }
 

--- a/crates/engine/src/parser/oracle_classifier.rs
+++ b/crates/engine/src/parser/oracle_classifier.rs
@@ -782,6 +782,16 @@ pub(crate) fn is_replacement_pattern(lower: &str) -> bool {
         return true;
     }
 
+    // CR 614.1c: the untapped-entry counterpart is templated the same short-vs-
+    // long way as the tapped form above (Vigorous Farming: "Lands you control
+    // enter the battlefield untapped.").
+    if lower
+        .trim_end_matches('.')
+        .ends_with(" enter the battlefield untapped")
+    {
+        return true;
+    }
+
     // CR 614.1e + CR 708.11: "As ~ is turned face up, [effect]"
     // is a replacement effect. The "When ~ is turned face up" form is a trigger
     // and stays out of this path, so the lead is required to be "As".

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5280,76 +5280,30 @@ fn parse_external_entry_suffix(stripped: &str) -> Option<(&str, ExternalEntryKin
                     )
                 })
         })
-        .or_else(|| {
-            // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
-            stripped.strip_suffix(" enter tapped").map(|subject| {
-                (
-                    subject,
-                    ExternalEntryKind::Plain {
-                        enters_tapped: true,
-                    },
-                )
-            })
-        })
-        .or_else(|| {
-            // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
-            stripped.strip_suffix(" enters tapped").map(|subject| {
-                (
-                    subject,
-                    ExternalEntryKind::Plain {
-                        enters_tapped: true,
-                    },
-                )
-            })
-        })
-        .or_else(|| parse_external_entry_untapped_long_suffix(stripped))
-        .or_else(|| {
-            // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
-            stripped.strip_suffix(" enter untapped").map(|subject| {
-                (
-                    subject,
-                    ExternalEntryKind::Plain {
-                        enters_tapped: false,
-                    },
-                )
-            })
-        })
-        .or_else(|| {
-            // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
-            stripped.strip_suffix(" enters untapped").map(|subject| {
-                (
-                    subject,
-                    ExternalEntryKind::Plain {
-                        enters_tapped: false,
-                    },
-                )
-            })
-        })
+        .or_else(|| parse_external_entry_plain_suffix(stripped))
 }
 
-/// CR 614.1c: Parse the long external-entry untapped form. The subject is a
-/// type phrase of arbitrary length, so capture it before a factored verb axis
-/// and require the suffix to consume the full line.
-fn parse_external_entry_untapped_long_suffix(input: &str) -> Option<(&str, ExternalEntryKind)> {
+/// CR 614.1c: Parse the external-entry tap-state grammar. The type-phrase
+/// subject is arbitrary, while verb number, battlefield wording, and tap state
+/// vary independently; parse those axes once rather than adding suffix arms.
+fn parse_external_entry_plain_suffix(input: &str) -> Option<(&str, ExternalEntryKind)> {
     type VE<'a> = OracleError<'a>;
-    let (_, subject) = terminated(
+    let (_, (subject, (_, enters_tapped))) = terminated(
         pair(
             take_until::<_, _, VE>(" enter"),
-            alt((
-                tag(" enter the battlefield untapped"),
-                tag(" enters the battlefield untapped"),
-            )),
+            preceded(
+                pair(tag(" enter"), opt(tag("s"))),
+                pair(
+                    opt(tag(" the battlefield")),
+                    alt((value(true, tag(" tapped")), value(false, tag(" untapped")))),
+                ),
+            ),
         ),
         eof::<&str, VE<'_>>,
     )
     .parse(input)
     .ok()?;
-    Some((
-        subject.0,
-        ExternalEntryKind::Plain {
-            enters_tapped: false,
-        },
-    ))
+    Some((subject, ExternalEntryKind::Plain { enters_tapped }))
 }
 
 fn build_external_entry_replacement(

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5302,35 +5302,7 @@ fn parse_external_entry_suffix(stripped: &str) -> Option<(&str, ExternalEntryKin
                 )
             })
         })
-        .or_else(|| {
-            // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
-            // CR 614.1c: the untapped-entry counterpart is templated the same
-            // short-vs-long way as the tapped form above (Vigorous Farming:
-            // "Lands you control enter the battlefield untapped.").
-            stripped
-                .strip_suffix(" enter the battlefield untapped")
-                .map(|subject| {
-                    (
-                        subject,
-                        ExternalEntryKind::Plain {
-                            enters_tapped: false,
-                        },
-                    )
-                })
-        })
-        .or_else(|| {
-            // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
-            stripped
-                .strip_suffix(" enters the battlefield untapped")
-                .map(|subject| {
-                    (
-                        subject,
-                        ExternalEntryKind::Plain {
-                            enters_tapped: false,
-                        },
-                    )
-                })
-        })
+        .or_else(|| parse_external_entry_untapped_long_suffix(stripped))
         .or_else(|| {
             // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
             stripped.strip_suffix(" enter untapped").map(|subject| {
@@ -5353,6 +5325,31 @@ fn parse_external_entry_suffix(stripped: &str) -> Option<(&str, ExternalEntryKin
                 )
             })
         })
+}
+
+/// CR 614.1c: Parse the long external-entry untapped form. The subject is a
+/// type phrase of arbitrary length, so capture it before a factored verb axis
+/// and require the suffix to consume the full line.
+fn parse_external_entry_untapped_long_suffix(input: &str) -> Option<(&str, ExternalEntryKind)> {
+    type VE<'a> = OracleError<'a>;
+    let (_, subject) = terminated(
+        pair(
+            take_until::<_, _, VE>(" enter"),
+            alt((
+                tag(" enter the battlefield untapped"),
+                tag(" enters the battlefield untapped"),
+            )),
+        ),
+        eof::<&str, VE<'_>>,
+    )
+    .parse(input)
+    .ok()?;
+    Some((
+        subject.0,
+        ExternalEntryKind::Plain {
+            enters_tapped: false,
+        },
+    ))
 }
 
 fn build_external_entry_replacement(

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -5304,6 +5304,35 @@ fn parse_external_entry_suffix(stripped: &str) -> Option<(&str, ExternalEntryKin
         })
         .or_else(|| {
             // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
+            // CR 614.1c: the untapped-entry counterpart is templated the same
+            // short-vs-long way as the tapped form above (Vigorous Farming:
+            // "Lands you control enter the battlefield untapped.").
+            stripped
+                .strip_suffix(" enter the battlefield untapped")
+                .map(|subject| {
+                    (
+                        subject,
+                        ExternalEntryKind::Plain {
+                            enters_tapped: false,
+                        },
+                    )
+                })
+        })
+        .or_else(|| {
+            // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
+            stripped
+                .strip_suffix(" enters the battlefield untapped")
+                .map(|subject| {
+                    (
+                        subject,
+                        ExternalEntryKind::Plain {
+                            enters_tapped: false,
+                        },
+                    )
+                })
+        })
+        .or_else(|| {
+            // allow-noncombinator: fixed external-entry suffix peel after type-phrase subject
             stripped.strip_suffix(" enter untapped").map(|subject| {
                 (
                     subject,
@@ -17035,6 +17064,55 @@ mod tests {
                 assert_eq!(tf.controller, Some(ControllerRef::You));
             }
             other => panic!("Expected Typed filter, got {other:?}"),
+        }
+    }
+
+    // CR 614.1c: the untapped-entry counterpart of the tapped-entry short-vs-long
+    // templating gap (see `frozen_aether_enters_the_battlefield_tapped_long_form`
+    // above) — Vigorous Farming prints "Lands you control enter the battlefield
+    // untapped." where the `spelunking_lands_you_control_enter_untapped` test
+    // above uses the short "enter untapped" simplification.
+    #[test]
+    fn vigorous_farming_enters_the_battlefield_untapped_long_form() {
+        let def = parse_replacement_line(
+            "Lands you control enter the battlefield untapped.",
+            "Vigorous Farming",
+        )
+        .expect("long-form 'enter the battlefield untapped' must parse");
+        assert_eq!(def.event, ReplacementEvent::ChangeZone);
+        assert_eq!(def.destination_zone, Some(Zone::Battlefield));
+        assert!(matches!(
+            *def.execute.as_ref().unwrap().effect,
+            Effect::SetTapState {
+                target: TargetFilter::SelfRef,
+                scope: EffectScope::Single,
+                state: TapStateChange::Untap,
+            }
+        ));
+        match &def.valid_card {
+            Some(TargetFilter::Typed(tf)) => {
+                assert!(tf.type_filters.contains(&TypeFilter::Land));
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+            }
+            other => panic!("Expected Typed filter, got {other:?}"),
+        }
+    }
+
+    // The controller-scoped Or-filter shape (mirroring
+    // `frozen_aether_enters_the_battlefield_tapped_long_form`) must also parse
+    // for the untapped long form.
+    #[test]
+    fn opponents_control_enters_the_battlefield_untapped_long_form() {
+        let def = parse_replacement_line(
+            "Artifacts, creatures, and lands your opponents control enter the battlefield untapped.",
+            "Untapped Aether",
+        )
+        .expect("long-form 'enter the battlefield untapped' with Or-filter subject must parse");
+        assert_eq!(def.event, ReplacementEvent::ChangeZone);
+        assert_eq!(def.destination_zone, Some(Zone::Battlefield));
+        match &def.valid_card {
+            Some(TargetFilter::Or { filters }) => assert_eq!(filters.len(), 3),
+            other => panic!("Expected Or filter with 3 elements, got {other:?}"),
         }
     }
 

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -536,6 +536,46 @@ fn spelunking_etb_put_cave_gains_life_conditionally() {
     );
 }
 
+/// CR 614.1c: the fully spelled external-entry untapped form must travel
+/// through document classification into a battlefield-entry replacement. This
+/// is intentionally a `parse_oracle_text` test rather than a direct suffix
+/// helper test: reverting the classifier route leaves Vigorous Farming as an
+/// unimplemented line and no replacement reaches the runtime card definition.
+#[test]
+fn vigorous_farming_long_untapped_entry_reaches_replacement_pipeline() {
+    let parsed = parse_oracle_text(
+        "Lands you control enter the battlefield untapped.",
+        "Vigorous Farming",
+        &[],
+        &["Enchantment".to_string()],
+        &[],
+    );
+
+    assert!(
+        parsed.abilities.is_empty(),
+        "the replacement line must not fall through as a spell ability: {:#?}",
+        parsed.abilities
+    );
+    let replacement = parsed
+        .replacements
+        .first()
+        .expect("long-form untapped entry must produce a replacement definition");
+    assert!(
+        matches!(
+            replacement
+                .execute
+                .as_deref()
+                .map(|definition| definition.effect.as_ref()),
+            Some(Effect::SetTapState {
+                state: TapStateChange::Untap,
+                target: TargetFilter::SelfRef,
+                scope: EffectScope::Single,
+            })
+        ),
+        "the replacement must install the normal entry-untap payload: {replacement:#?}"
+    );
+}
+
 /// CR 207.2c + CR 602.1: an activated ability may carry an italic ability-word
 /// label before its cost ("Mental Organism — Pay 3 life: ~ connives" —
 /// M.O.D.O.K.). The ability word has no rules meaning, so `find_activated_colon`

--- a/crates/engine/tests/integration/issue_4991_vigorous_farming.rs
+++ b/crates/engine/tests/integration/issue_4991_vigorous_farming.rs
@@ -1,0 +1,78 @@
+//! Vigorous Farming's long-form entry replacement must reach the real zone
+//! pipeline, not merely parse to a replacement definition.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, EffectScope, ReplacementDefinition, TapStateChange,
+    TargetFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::replacements::ReplacementEvent;
+use engine::types::zones::Zone;
+
+const VIGOROUS_FARMING: &str = "Lands you control enter the battlefield untapped.";
+
+/// CR 614.1c: a self replacement that makes the entering land tapped. Combined
+/// with Vigorous Farming's parsed untap replacement, this creates a material
+/// ordering choice whose selected order leaves the Farming effect last.
+fn enters_tapped_replacement() -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Moved)
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::SetTapState {
+                target: TargetFilter::SelfRef,
+                scope: EffectScope::Single,
+                state: TapStateChange::Tap,
+            },
+        ))
+        .valid_card(TargetFilter::SelfRef)
+        .destination_zone(Zone::Battlefield)
+        .description("This land enters tapped.".to_string())
+}
+
+#[test]
+fn vigorous_farming_long_form_untaps_a_land_through_the_entry_pipeline() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P0, "Vigorous Farming", VIGOROUS_FARMING);
+    let land = scenario
+        .add_land_to_hand(P0, "Tangled Field")
+        .with_replacement_definition(enters_tapped_replacement())
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&land].card_id;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: land,
+            card_id,
+        })
+        .expect("play land through the real entry pipeline");
+
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
+        panic!(
+            "the parsed Vigorous Farming replacement and the self-tap replacement \
+             must produce an ordering choice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    let self_tap_index = candidates
+        .iter()
+        .position(|candidate| candidate.source_id == land)
+        .expect("the self-tap replacement must be offered alongside Vigorous Farming");
+
+    runner
+        .act(GameAction::ChooseReplacement {
+            index: self_tap_index,
+        })
+        .expect("choose the self-tap replacement first");
+
+    let entered = &runner.state().objects[&land];
+    assert_eq!(entered.zone, Zone::Battlefield, "land must finish entering");
+    assert!(
+        !entered.tapped,
+        "CR 614.1c + CR 616.1: Vigorous Farming's parsed untap replacement must apply last"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -548,6 +548,7 @@ mod issue_4956_gift_of_immortality_reattach;
 mod issue_4960_nova_flame;
 mod issue_4962_volo_guide_to_monsters;
 mod issue_4966_waterbenders_ascension;
+mod issue_4991_vigorous_farming;
 mod issue_4999_treasure_cruise_delve_tokens;
 mod issue_5145_violent_eruption_choose_target_distribution;
 mod issue_5159_attacks_alone_investigate;


### PR DESCRIPTION
Rescues closed contributor PR #4991 for Vigorous Farming.

Parses the general external-entry tap-state grammar through the replacement pipeline and adds parser plus runtime coverage. Rebased onto current main and hardened after maintainer review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of effects that cause permanents to enter the battlefield tapped or untapped.
  - Supports both singular and plural wording, optional “the battlefield” phrasing, and more varied subjects.
  - Correctly handles replacement-effect ordering when multiple land-entry effects apply, ensuring the selected order produces the expected result.

- **Tests**
  - Added coverage for long-form untapped-entry text and real gameplay scenarios involving competing replacement effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->