### PR TITLE
fix(engine): stop search tutors double-firing landfall/ETB observers

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -616,9 +616,33 @@ fn park_search_observer_triggers(
     events: &[GameEvent],
     events_before_drain: usize,
 ) -> ResolutionChoiceOutcome {
+    // CR 603.2 + CR 603.3b + CR 701.23: park the search's post-put/shuffle
+    // observer events for the next priority checkpoint. The ZoneChanged events
+    // for cards put onto the battlefield by the search's ChangeZone delivery
+    // were ALREADY collected (once) by the zone-change pipeline's segment /
+    // settlement collections (`append_and_collect_logical_zone_trigger_segment`
+    // / `complete_logical_zone_trigger_collection`). Those same `ZoneChanged`
+    // occurrences sit in `events[events_before_drain..]`, so collecting this
+    // whole slice again would DOUBLE-fire every entrant's observer triggers
+    // (landfall, ETB observers) — a single land entry fires landfall twice.
+    //
+    // Mirror the generic post-priority scan's `deferred_logical_zone_events`
+    // guard (engine_priority.rs): drop any `ZoneChanged` occurrence whose event
+    // is already represented in `state.deferred_triggers`. Other event kinds
+    // (EffectResolved, Shuffle, PlayerPerformedAction, ...) remain eligible so
+    // their own observers are still parked.
+    let retained_zone_events: Vec<_> = state
+        .deferred_triggers
+        .iter()
+        .flat_map(|context| context.trigger_events.iter())
+        .filter(|event| matches!(event, GameEvent::ZoneChanged { .. }))
+        .collect();
     let trigger_events: Vec<GameEvent> = events[events_before_drain..]
         .iter()
         .filter(|ev| !matches!(ev, GameEvent::PhaseChanged { .. }))
+        .filter(|ev| {
+            !matches!(ev, GameEvent::ZoneChanged { .. }) || !retained_zone_events.contains(ev)
+        })
         .cloned()
         .collect();
     if !trigger_events.is_empty() {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1158,6 +1158,7 @@ mod sarkhan_dragon_ascendant_behold;
 mod scarblade_malice_delayed_dies_762;
 mod scry_choice_not_clobbered_by_triggers;
 mod scry_substituted_draw_per_card_replacement;
+mod search_landfall_double_fire_repro;
 mod secret_of_bloodbending_control_window;
 mod she_hulk_wallbreaker_becomes_blocked_4599;
 mod shelob_repro_token;

--- a/crates/engine/tests/integration/search_landfall_double_fire_repro.rs
+++ b/crates/engine/tests/integration/search_landfall_double_fire_repro.rs
@@ -1,0 +1,155 @@
+//! Repro for the reported double-fire: casting a search tutor that puts a land
+//! onto the battlefield (Prishe's Wanderings / Nature's Lore pattern) fires each
+//! landfall observer trigger twice for the single land entry.
+//!
+//! A landfall permanent ("Whenever a land enters the battlefield under your
+//! control, <effect>") must produce EXACTLY ONE trigger per land entry.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const LANDFALL_ORACLE: &str =
+    "Whenever a land enters the battlefield under your control, draw a card.";
+
+const NATURES_LORE_ORACLE: &str =
+    "Search your library for a Forest card, put that card onto the battlefield, then shuffle.";
+
+fn seed_forest_on_library_top(
+    runner: &mut engine::game::scenario::GameRunner,
+) -> engine::types::identifiers::ObjectId {
+    use engine::types::card_type::CoreType;
+    let card_id = engine::types::identifiers::CardId(runner.state().next_object_id);
+    let id = engine::game::zones::create_object(
+        runner.state_mut(),
+        card_id,
+        P0,
+        "Forest".to_string(),
+        Zone::Library,
+    );
+    let obj = runner.state_mut().objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Land);
+    obj.base_card_types = obj.card_types.clone();
+    obj.card_types.subtypes.push("Forest".to_string());
+    runner.state_mut().players[P0.0 as usize]
+        .library
+        .insert(0, id);
+    id
+}
+
+#[test]
+fn landfall_fires_once_per_land_etb_from_search_tutor() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::Green);
+
+    // A landfall permanent on the battlefield.
+    scenario
+        .add_creature_from_oracle(P0, "Landfall Scout", 1, 1, LANDFALL_ORACLE)
+        .id();
+
+    let natures_lore = scenario
+        .add_spell_to_hand_from_oracle(P0, "Nature's Lore", false, NATURES_LORE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let forest = seed_forest_on_library_top(&mut runner);
+    runner.cast(natures_lore).search_first_legal().resolve();
+
+    // The land entered the battlefield exactly once.
+    assert_eq!(
+        runner.state().objects[&forest].zone,
+        Zone::Battlefield,
+        "Nature's Lore must put the searched Forest onto the battlefield"
+    );
+
+    // Drain the search tutor to a priority window so deferred triggers settle.
+    runner.advance_until_stack_empty();
+
+    // Exactly ONE landfall trigger must have fired for the single land entry.
+    let landfall_count = runner
+        .state()
+        .deferred_triggers
+        .iter()
+        .filter(|ctx| {
+            ctx.pending
+                .description
+                .as_deref()
+                .unwrap_or("")
+                .contains("Whenever a land enters")
+        })
+        .count();
+    assert_eq!(
+        landfall_count,
+        1,
+        "landfall must fire exactly once per land ETB; deferred=[{:?}]",
+        runner
+            .state()
+            .deferred_triggers
+            .iter()
+            .map(|c| c.pending.description.clone().unwrap_or_default())
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The reported shape: TWO separate landfall permanents on the battlefield and
+/// one land entering via a search tutor. Each landfall permanent must fire
+/// exactly ONE trigger for the single land — two total, never four (the
+/// double-fire reported for Sazh's Chocobo + Bird token).
+#[test]
+fn two_landfall_sources_fire_once_each_for_single_search_land() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_basic_land(P0, ManaColor::Green);
+
+    scenario
+        .add_creature_from_oracle(P0, "Landfall Scout", 1, 1, LANDFALL_ORACLE)
+        .id();
+    scenario
+        .add_creature_from_oracle(P0, "Landfall Warden", 2, 2, LANDFALL_ORACLE)
+        .id();
+
+    let natures_lore = scenario
+        .add_spell_to_hand_from_oracle(P0, "Nature's Lore", false, NATURES_LORE_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let forest = seed_forest_on_library_top(&mut runner);
+    runner.cast(natures_lore).search_first_legal().resolve();
+    runner.advance_until_stack_empty();
+
+    // The land entered the battlefield exactly once.
+    assert_eq!(
+        runner.state().objects[&forest].zone,
+        Zone::Battlefield,
+        "Nature's Lore must put the searched Forest onto the battlefield"
+    );
+
+    let landfall_count = runner
+        .state()
+        .deferred_triggers
+        .iter()
+        .filter(|ctx| {
+            ctx.pending
+                .description
+                .as_deref()
+                .unwrap_or("")
+                .contains("Whenever a land enters")
+        })
+        .count();
+    assert_eq!(
+        landfall_count,
+        2,
+        "two landfall sources must fire exactly once each for the single land ETB; deferred=[{:?}]",
+        runner
+            .state()
+            .deferred_triggers
+            .iter()
+            .map(|c| (
+                c.pending.source_id,
+                c.pending.description.clone().unwrap_or_default()
+            ))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Human intro
See my response in the "Implementation method" section.

# LLM PR
## Summary

Search tutors that put a card into its destination zone (Nature's Lore, Cultivate, fetchlands) fired every observer triggered ability twice for a single zone change — a single land entry from a search fired each landfall/ETB observer twice. `park_search_observer_triggers` now drops `ZoneChanged` occurrences already collected (once) by the zone-change pipeline, mirroring the existing `deferred_logical_zone_events` guard.

## Files changed

- `crates/engine/src/game/engine_resolution_choices.rs`
- `crates/engine/tests/integration/main.rs`
- `crates/engine/tests/integration/search_landfall_double_fire_repro.rs` (new)

## Track

Developer

## LLM

Model: deepseek/deepseek-v4-flash-0731
Tier: Frontier
Thinking: high

<!-- Keep Model and Tier as exact, standalone canonical lines. AI-assisted PRs
must report their actual Frontier model, Tier: Frontier, and thinking level. -->

## Implementation method (required)
### Human response
This was not implemented with `/engine-implementer`; I failed to click the `/engine-implementer` link or I'd have immediately understood and basically created the equivalent and followed it with minion sessions! I absolutely will next time.

So this did NOT conform to that skill *EXCEPT* of course the review! Which absolutely was a separate fresh context window.

Sorry for this, I'm still getting used to it!
<!-- Or: Method: not-applicable — <specific non-engine reason> -->

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

- CR 603.2 — when a game event matches a triggered ability's trigger event, it automatically triggers.
- CR 603.3b — triggered abilities are placed on the stack the next time a player would receive priority.
- CR 701.23 — Search (keyword action); search/settle/shuffle protocol.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo clippy -p phase-engine --all-targets -- -D warnings` — clean, no warnings.
- `cargo nextest run -p phase-engine` — 22,606 integration + 18,229 unit tests pass (all pass; 8 + 6 skipped).
- New discriminating repro: reverting the dedup makes `landfall_fires_once_per_land_etb_from_search_tutor` and `two_landfall_sources_fire_once_each_for_single_search_land` fail (landfall fires 2 and 4 instead of 1 and 2).
- `cargo fmt --all` — no changes (already formatted).
- Reverted-dedup run confirmed the negative (`0 passed, 2 failed`), then fix restored and re-verified green.

## Gate A

Gate A PASS head=f69fc75fcdb4628a2df7ce4f0135a65d6d80b58f base=b9023330ef4b5d091f438eb27fbfbfe321983b85

## Anchored on

- crates/engine/src/game/engine_priority.rs:107 — `deferred_logical_zone_events` guard: drop `ZoneChanged` occurrences already represented in `state.deferred_triggers` so the generic post-priority scan doesn't double-fire; the exact idiom this fix mirrors.
- crates/engine/src/game/engine_resolution_choices.rs:570 — `batch_or_drain_observer_triggers` `zone_changes_are_logically_owned` guard: the sibling observer-parking path that already excludes pipeline-owned `ZoneChanged` events.

## Final review-impl

Final review-impl PASS head=f69fc75fcdb4628a2df7ce4f0135a65d6d80b58f

### Right seam — PASS

The fix sits at the correct architectural boundary. `park_search_observer_triggers`
(`engine_resolution_choices.rs`) is the function that takes a search tutor's
post-put/shuffle `events[events_before_drain..]` slice and parks its observers
into `state.deferred_triggers`. The double-fire bug lived precisely there: the
slice re-contains `ZoneChanged` occurrences that the zone-change pipeline had
**already collected once** (`append_and_collect_logical_zone_trigger_segment` /
`complete_logical_zone_trigger_collection`), so parking the whole slice
re-collected landfall/ETB observers a second time. This fixes the *class* of
"search that puts cards into their destination zone" (tutors, Cultivate,
fetchlands, etc.), not a single card.

### Idiomatic — PASS (with one refactor)

The fix mirrors the exact precedent guard `deferred_logical_zone_events` already
present in `engine_priority.rs:107`. `retained_zone_events` was aligned to that
precedent's reference-based `Vec<_>` form (dropping an unnecessary `.cloned()`
allocation) so the mirror is exact. `cargo clippy -p phase-engine --all-targets
-- -D warnings` is clean.

### Edge cases / MTG rules regressions — no regressions

- The dedup is **value-equality** on the full `ZoneChanged` event — it drops only
  an occurrence *identical* to one already collected. Two distinct lands entering
  from one search (distinct `object_id`) each fire once — preserved, not
  collapsed.
- Non-`ZoneChanged` events (`EffectResolved`, `Shuffle`, `PlayerPerformedAction`,
  ...) remain eligible, so their observers are still parked — no observer loss.
- Graveyard-/hand-destination search moves aren't battlefield-entrant
  pipeline-owned, so their `ZoneChanged` won't be in `deferred_triggers` and
  won't be wrongly swallowed.

### Verification

- **Discriminating test confirmed:** temporarily reverting the dedup made both
  new tests fail with landfall firing twice (2 and 4 instead of 1 and 2),
  proving the tests exercise the production path and are non-vacuous; fix then
  restored.
- `cargo nextest -p phase-engine`: all **22,606 integration + 18,229 unit** tests
  pass (including the 72-test search/landfall/ETB surface and the sibling
  issue_5336 Kodama path).
- `cargo clippy -p phase-engine --all-targets -- -D warnings`: clean.
- `cargo fmt --all`: no changes (already formatted).
- CR annotations verified against `docs/MagicCompRules.txt` (603.2 ✓, 603.3b ✓,
  701.23 ✓).

The anchors for the review are: crates/engine/src/game/engine_priority.rs:107 and
crates/engine/src/game/engine_resolution_choices.rs:570 (see "Anchored on").

## Claimed parse impact

None.
<!-- List exact card names only when the parse-diff changes cards. -->

## Scope Expansion

None.
<!-- Describe any change that crosses the issue/card's stated scope. -->

## Validation Failures

None.
<!-- Replace with the unresolved validation failure and its evidence. -->

## CI Failures

None.
<!-- Replace with the unresolved CI failure and its evidence. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where landfall and enter-the-battlefield triggers could be processed more than once after searching.
  * Ensured searched lands enter the battlefield once while preserving the correct number of triggers for multiple sources.

* **Tests**
  * Added regression coverage for search effects that put lands onto the battlefield and trigger landfall abilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->