### PR TITLE
fix(engine): honor controller choice for self tucks

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2845,7 +2845,6 @@ fn legacy_effect(x: &Effect) -> bool {
         | Effect::Exploit { target }
         | Effect::LoseAllPlayerCounters { target }
         | Effect::Heist { target, .. }
-        | Effect::PutOnTopOrBottom { target }
         | Effect::Goad { target }
         | Effect::GoadAll { target }
         | Effect::Detain { target }
@@ -2867,6 +2866,10 @@ fn legacy_effect(x: &Effect) -> bool {
         | Effect::AddTargetReplacement { target, .. }
         | Effect::DiscardCard { target, .. }
         | Effect::Animate { target, .. } => legacy_target_filter(target),
+
+        Effect::PutOnTopOrBottom { target, chooser } => {
+            legacy_target_filter(target) || legacy_target_filter(chooser)
+        }
 
         Effect::ForceBlock {
             target, duration, ..

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1548,9 +1548,10 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
             acc = acc.or(scan_target_filter(player, target_ctx, mode));
             acc
         }
-        Effect::PutOnTopOrBottom { target } => {
+        Effect::PutOnTopOrBottom { target, chooser } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target, target_ctx, mode));
+            acc = acc.or(scan_target_filter(chooser, target_ctx, mode));
             acc
         }
         Effect::GiftDelivery { kind: _ } => Axes::NONE,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3443,8 +3443,9 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             d.push(("count".into(), format!("{count:?}")));
             d.push(("position".into(), format!("{position:?}")));
         }
-        Effect::PutOnTopOrBottom { target } => {
+        Effect::PutOnTopOrBottom { target, chooser } => {
             d.push(("target".into(), fmt_target(target)));
+            d.push(("chooser".into(), fmt_target(chooser)));
         }
         Effect::Amass { subtype, count } => {
             d.push(("subtype".into(), subtype.clone()));

--- a/crates/engine/src/game/effects/put_on_top_or_bottom.rs
+++ b/crates/engine/src/game/effects/put_on_top_or_bottom.rs
@@ -1,4 +1,6 @@
-use crate::types::ability::{EffectError, EffectKind, ResolvedAbility, TargetRef};
+use crate::types::ability::{
+    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 /// CR 401.4: Target's owner puts it on top or bottom of their library.
@@ -8,8 +10,19 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let object_id = ability
-        .targets
+    // CR 608.2c + CR 603.10: Delegate target resolution to the unified 3-tier
+    // dispatch (`resolved_targets`) so this resolver picks up the same self-ref
+    // handling `Effect::Bounce` and the other zone-change resolvers use.
+    // `resolved_targets` short-circuits `SelfRef` to `ability.source_id`
+    // regardless of `ability.targets`, so a self-tuck (Arashin Sovereign: "When
+    // ~ dies, put it on your choice of the top or bottom of its owner's library")
+    // resolves to the source; a chosen/parent target is unchanged (tier 3
+    // returns the pre-selected targets satisfying the filter).
+    let target_filter = match &ability.effect {
+        Effect::PutOnTopOrBottom { target } => target,
+        _ => &TargetFilter::None,
+    };
+    let object_id = crate::game::targeting::resolved_targets(ability, target_filter, state)
         .iter()
         .find_map(|t| {
             if let TargetRef::Object(id) = t {

--- a/crates/engine/src/game/effects/put_on_top_or_bottom.rs
+++ b/crates/engine/src/game/effects/put_on_top_or_bottom.rs
@@ -1,10 +1,7 @@
-use crate::types::ability::{
-    Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter, TargetRef,
-};
+use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetRef};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
-/// CR 401.4: Target's owner puts it on top or bottom of their library.
-/// The owner (not the controller) makes the choice.
+/// Resolves a top-or-bottom choice and sends the object to its owner's library.
 pub fn resolve(
     state: &mut GameState,
     ability: &ResolvedAbility,
@@ -15,14 +12,15 @@ pub fn resolve(
     // handling `Effect::Bounce` and the other zone-change resolvers use.
     // `resolved_targets` short-circuits `SelfRef` to `ability.source_id`
     // regardless of `ability.targets`, so a self-tuck (Arashin Sovereign: "When
-    // ~ dies, put it on your choice of the top or bottom of its owner's library")
+    // ~ dies, you may put it on the top or bottom of its owner's library")
     // resolves to the source; a chosen/parent target is unchanged (tier 3
     // returns the pre-selected targets satisfying the filter).
-    let target_filter = match &ability.effect {
-        Effect::PutOnTopOrBottom { target } => target,
-        _ => &TargetFilter::None,
+    let Effect::PutOnTopOrBottom { target, chooser } = &ability.effect else {
+        return Err(EffectError::InvalidParam(
+            "PutOnTopOrBottom requires its matching effect".to_string(),
+        ));
     };
-    let object_id = crate::game::targeting::resolved_targets(ability, target_filter, state)
+    let object_id = crate::game::targeting::resolved_targets(ability, target, state)
         .iter()
         .find_map(|t| {
             if let TargetRef::Object(id) = t {
@@ -35,13 +33,12 @@ pub fn resolve(
             "PutOnTopOrBottom requires a target".to_string(),
         ))?;
 
-    let obj = state
-        .objects
-        .get(&object_id)
-        .ok_or(EffectError::ObjectNotFound(object_id))?;
+    if !state.objects.contains_key(&object_id) {
+        return Err(EffectError::ObjectNotFound(object_id));
+    }
 
-    // CR 401.4: The owner makes the choice, not the controller.
-    let owner = obj.owner;
+    // CR 608.2d: the Oracle text supplies the player who makes this choice.
+    let choice_player = super::resolve_player_for_context_ref(state, ability, chooser);
 
     events.push(GameEvent::EffectResolved {
         kind: EffectKind::from(&ability.effect),
@@ -49,9 +46,8 @@ pub fn resolve(
         subject: None,
     });
 
-    // CR 400.5: The order of objects in a library can't be changed except when effects allow it.
     state.waiting_for = WaitingFor::TopOrBottomChoice {
-        player: owner,
+        player: choice_player,
         object_id,
     };
 
@@ -68,7 +64,7 @@ mod tests {
     use crate::types::zones::Zone;
 
     #[test]
-    fn test_resolve_sets_waiting_for_owner() {
+    fn test_resolve_uses_chooser_not_destination_owner() {
         let mut state = GameState::new_two_player(42);
         // Create a creature owned by player 1 but controlled by player 0
         let obj_id = create_object(
@@ -84,6 +80,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::PutOnTopOrBottom {
                 target: TargetFilter::Any,
+                chooser: TargetFilter::Controller,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(100),
@@ -93,16 +90,16 @@ mod tests {
         let mut events = vec![];
         resolve(&mut state, &ability, &mut events).unwrap();
 
-        // Owner (player 1) should be the one choosing, not controller (player 0)
+        // P0 controls the effect and must choose; P1 still owns the destination library.
         assert!(
             matches!(
                 state.waiting_for,
                 WaitingFor::TopOrBottomChoice {
-                    player: PlayerId(1),
+                    player: PlayerId(0),
                     object_id: oid,
                 } if oid == obj_id
             ),
-            "Expected TopOrBottomChoice for owner (P1), got {:?}",
+            "Expected TopOrBottomChoice for chooser P0, got {:?}",
             state.waiting_for
         );
     }
@@ -110,7 +107,7 @@ mod tests {
     #[test]
     fn test_resolve_stack_spell_prompts_owner() {
         let mut state = GameState::new_two_player(42);
-        // CR 108.3 + CR 401.4: a stack spell is moved by its owner, and that owner chooses.
+        // The owner-framed form selects the stack spell's owner as the chooser.
         let obj_id = create_object(
             &mut state,
             CardId(2),
@@ -123,6 +120,7 @@ mod tests {
         let ability = ResolvedAbility::new(
             Effect::PutOnTopOrBottom {
                 target: TargetFilter::Any,
+                chooser: TargetFilter::ParentTargetOwner,
             },
             vec![TargetRef::Object(obj_id)],
             ObjectId(101),
@@ -143,5 +141,38 @@ mod tests {
             "Expected TopOrBottomChoice for stack spell owner (P1), got {:?}",
             state.waiting_for
         );
+    }
+
+    #[test]
+    fn chooser_serde_defaults_and_omits_owner_form() {
+        let legacy: Effect =
+            serde_json::from_str(r#"{"type":"PutOnTopOrBottom","target":{"type":"Any"}}"#)
+                .expect("legacy PutOnTopOrBottom without chooser must deserialize");
+        assert!(matches!(
+            legacy,
+            Effect::PutOnTopOrBottom {
+                chooser: TargetFilter::ParentTargetOwner,
+                ..
+            }
+        ));
+
+        let owner_chooser = Effect::PutOnTopOrBottom {
+            target: TargetFilter::Any,
+            chooser: TargetFilter::ParentTargetOwner,
+        };
+        let json = serde_json::to_string(&owner_chooser).unwrap();
+        assert!(
+            !json.contains("chooser"),
+            "default owner chooser must be omitted from JSON, got {json}"
+        );
+
+        let controller_chooser = Effect::PutOnTopOrBottom {
+            target: TargetFilter::SelfRef,
+            chooser: TargetFilter::Controller,
+        };
+        let json = serde_json::to_string(&controller_chooser).unwrap();
+        assert!(json.contains("chooser"));
+        let round_trip: Effect = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip, controller_chooser);
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -9073,6 +9073,14 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return clause;
     }
 
+    // CR 608.2k + CR 401.4: self/controller-framing sibling of the above —
+    // "[you may ]put it/~ on [your choice of ]the top or bottom of its owner's
+    // library" (Arashin Sovereign). Routes the SELF form to the same
+    // Effect::PutOnTopOrBottom the owner-framing patterns produce.
+    if let Some(clause) = try_parse_self_put_on_top_or_bottom(tp, ctx) {
+        return clause;
+    }
+
     // CR 701.24a + CR 400.3: "the owner of target [filter] shuffles it into their library"
     if let Some(clause) = try_parse_owner_of_target_shuffle(tp, ctx) {
         return clause;
@@ -11070,6 +11078,49 @@ fn try_parse_put_on_top_or_bottom(
     }
 
     None
+}
+
+/// CR 608.2k + CR 401.4: "put it/~ on [your choice of ]the top or bottom of its
+/// owner's library" — the self/controller-framing sibling of the owner-framing
+/// patterns in [`try_parse_put_on_top_or_bottom`]. Arashin Sovereign: "When this
+/// creature dies, you may put it on your choice of the top or bottom of its
+/// owner's library." The dying source's owner IS the controller the card tells to
+/// choose, so `Effect::PutOnTopOrBottom`'s owner-chooses resolution (CR 401.4)
+/// matches the "your choice" text with no new effect variant and no runtime path.
+///
+/// Scoped to the SELF reference via `resolve_it_pronoun` (CR 608.2k): a non-self
+/// "it" — a triggering object another player owns, where "your choice" is NOT the
+/// owner's choice (S.N.E.A.K. Dispatcher) — or a "that card" subject (Hinder) is
+/// declined so it stays an honest coverage gap rather than letting the wrong
+/// player choose the library position.
+fn try_parse_self_put_on_top_or_bottom(
+    tp: TextPair,
+    ctx: &mut ParseContext,
+) -> Option<ParsedEffectClause> {
+    let tp = tp.trim_end_matches('.');
+
+    let matched = super::oracle_nom::bridge::nom_on_lower(tp.original, tp.lower, |i| {
+        let (i, _) = tag("put ").parse(i)?;
+        let (i, _) = alt((tag("it"), tag("~"))).parse(i)?;
+        let (i, _) = tag(" on ").parse(i)?;
+        let (i, _) = opt(tag("your choice of ")).parse(i)?;
+        let (i, _) = tag("the top or bottom of its owner's library").parse(i)?;
+        value((), eof).parse(i)
+    })
+    .is_some();
+    if !matched {
+        return None;
+    }
+
+    // CR 608.2k: "it"/"~" names the source only in a self context. Restrict the
+    // owner-chooses `PutOnTopOrBottom` to that case so a non-self reference (whose
+    // owner is not the "your choice" controller) is never mis-modelled.
+    let target = resolve_it_pronoun(ctx);
+    if !matches!(target, TargetFilter::SelfRef) {
+        return None;
+    }
+
+    Some(parsed_clause(Effect::PutOnTopOrBottom { target }))
 }
 
 /// CR 701.57a: Parse "[player] discover[s] N/X" and return the discovering

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -9073,10 +9073,8 @@ fn parse_effect_clause_inner(text: &str, ctx: &mut ParseContext) -> ParsedEffect
         return clause;
     }
 
-    // CR 608.2k + CR 401.4: self/controller-framing sibling of the above —
-    // "[you may ]put it/~ on [your choice of ]the top or bottom of its owner's
-    // library" (Arashin Sovereign). Routes the SELF form to the same
-    // Effect::PutOnTopOrBottom the owner-framing patterns produce.
+    // Self/controller-framing sibling of the owner forms: "[you may ]put it/~
+    // on [your choice of ]the top or bottom of its owner's library".
     if let Some(clause) = try_parse_self_put_on_top_or_bottom(tp, ctx) {
         return clause;
     }
@@ -11001,6 +10999,7 @@ fn try_parse_put_on_top_or_bottom(
     {
         return Some(parsed_clause(Effect::PutOnTopOrBottom {
             target: TargetFilter::ParentTarget,
+            chooser: TargetFilter::ParentTargetOwner,
         }));
     }
 
@@ -11035,7 +11034,10 @@ fn try_parse_put_on_top_or_bottom(
                 line_index: 0,
             });
         }
-        return Some(parsed_clause(Effect::PutOnTopOrBottom { target: filter }));
+        return Some(parsed_clause(Effect::PutOnTopOrBottom {
+            target: filter,
+            chooser: TargetFilter::ParentTargetOwner,
+        }));
     }
 
     // Pattern 2: "the owner of target [filter] puts it ..."
@@ -11074,25 +11076,18 @@ fn try_parse_put_on_top_or_bottom(
                 line_index: 0,
             });
         }
-        return Some(parsed_clause(Effect::PutOnTopOrBottom { target: filter }));
+        return Some(parsed_clause(Effect::PutOnTopOrBottom {
+            target: filter,
+            chooser: TargetFilter::ParentTargetOwner,
+        }));
     }
 
     None
 }
 
-/// CR 608.2k + CR 401.4: "put it/~ on [your choice of ]the top or bottom of its
-/// owner's library" — the self/controller-framing sibling of the owner-framing
-/// patterns in [`try_parse_put_on_top_or_bottom`]. Arashin Sovereign: "When this
-/// creature dies, you may put it on your choice of the top or bottom of its
-/// owner's library." The dying source's owner IS the controller the card tells to
-/// choose, so `Effect::PutOnTopOrBottom`'s owner-chooses resolution (CR 401.4)
-/// matches the "your choice" text with no new effect variant and no runtime path.
-///
-/// Scoped to the SELF reference via `resolve_it_pronoun` (CR 608.2k): a non-self
-/// "it" — a triggering object another player owns, where "your choice" is NOT the
-/// owner's choice (S.N.E.A.K. Dispatcher) — or a "that card" subject (Hinder) is
-/// declined so it stays an honest coverage gap rather than letting the wrong
-/// player choose the library position.
+/// Parse self-reference top-or-bottom forms such as Arashin Sovereign's
+/// "put it on the top or bottom ...". The self guard keeps non-self `it` and
+/// Hinder's `that card` form excluded; the controller makes this choice.
 fn try_parse_self_put_on_top_or_bottom(
     tp: TextPair,
     ctx: &mut ParseContext,
@@ -11112,15 +11107,17 @@ fn try_parse_self_put_on_top_or_bottom(
         return None;
     }
 
-    // CR 608.2k: "it"/"~" names the source only in a self context. Restrict the
-    // owner-chooses `PutOnTopOrBottom` to that case so a non-self reference (whose
-    // owner is not the "your choice" controller) is never mis-modelled.
+    // `it`/`~` names the source only in a self context. Restrict this form so a
+    // non-self reference is never assigned the controller's choice.
     let target = resolve_it_pronoun(ctx);
     if !matches!(target, TargetFilter::SelfRef) {
         return None;
     }
 
-    Some(parsed_clause(Effect::PutOnTopOrBottom { target }))
+    Some(parsed_clause(Effect::PutOnTopOrBottom {
+        target,
+        chooser: TargetFilter::Controller,
+    }))
 }
 
 /// CR 701.57a: Parse "[player] discover[s] N/X" and return the discovering
@@ -11295,7 +11292,10 @@ fn try_parse_owner_of_target_put_second(
 
     let target = extract_owner_of_target(tp, ctx)?;
 
-    Some(parsed_clause(Effect::PutOnTopOrBottom { target }))
+    Some(parsed_clause(Effect::PutOnTopOrBottom {
+        target,
+        chooser: TargetFilter::ParentTargetOwner,
+    }))
 }
 
 /// Shared helper: extract the target filter from "the owner of target [filter] [verb]s it ..."

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -24234,8 +24234,14 @@ fn parse_put_on_top_or_bottom_possessive() {
         AbilityKind::Spell,
     );
     assert!(
-        matches!(*def.effect, Effect::PutOnTopOrBottom { .. }),
-        "Expected PutOnTopOrBottom, got {:?}",
+        matches!(
+            *def.effect,
+            Effect::PutOnTopOrBottom {
+                chooser: TargetFilter::ParentTargetOwner,
+                ..
+            }
+        ),
+        "Expected an owner-chosen PutOnTopOrBottom, got {:?}",
         def.effect
     );
 }
@@ -24311,6 +24317,7 @@ fn parse_aether_gust_effect_chain() {
             &*sub.effect,
             Effect::PutOnTopOrBottom {
                 target: TargetFilter::ParentTarget,
+                chooser: TargetFilter::ParentTargetOwner,
             }
         ),
         "Expected ParentTarget PutOnTopOrBottom continuation, got {:?}",

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -13090,9 +13090,18 @@ pub enum Effect {
         #[serde(default = "default_target_filter_controller")]
         player: TargetFilter,
     },
-    /// Target's owner puts it on top or bottom of their library (owner chooses).
+    /// Put a target on top or bottom of its owner's library.
     PutOnTopOrBottom {
         target: TargetFilter,
+        /// CR 608.2d: the player directed by the Oracle text chooses top or bottom.
+        ///
+        /// CR 400.3: the object is delivered to its owner's library regardless
+        /// of who makes that choice.
+        #[serde(
+            default = "default_target_filter_parent_target_owner",
+            skip_serializing_if = "is_target_filter_parent_target_owner"
+        )]
+        chooser: TargetFilter,
     },
     /// Deliver a gift to an opponent: draw a card, create a token, etc.
     /// Resolves for the opponent of the ability's controller (2-player: the single opponent).
@@ -13941,6 +13950,16 @@ fn default_target_filter_exiled_by_source() -> TargetFilter {
 /// the parent ability (e.g. `Effect::HideawayConceal`).
 fn default_target_filter_parent() -> TargetFilter {
     TargetFilter::ParentTarget
+}
+
+/// CR 608.2d: the owner-framed top-or-bottom forms choose relative to the
+/// referenced object rather than the resolving ability's controller.
+fn default_target_filter_parent_target_owner() -> TargetFilter {
+    TargetFilter::ParentTargetOwner
+}
+
+fn is_target_filter_parent_target_owner(filter: &TargetFilter) -> bool {
+    matches!(filter, TargetFilter::ParentTargetOwner)
 }
 
 fn target_filter_is_self_ref(filter: &TargetFilter) -> bool {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -9933,7 +9933,7 @@ pub enum WaitingFor {
         /// `repeat_until` is retained so the next iteration re-prompts.
         ability: Box<crate::types::ability::ResolvedAbility>,
     },
-    /// CR 401.4: Owner chooses to put a permanent on top or bottom of their library.
+    /// CR 608.2d: The effect-designated player chooses the library position.
     TopOrBottomChoice {
         player: PlayerId,
         object_id: ObjectId,

--- a/crates/engine/tests/integration/arashin_sovereign_self_tuck.rs
+++ b/crates/engine/tests/integration/arashin_sovereign_self_tuck.rs
@@ -1,0 +1,127 @@
+//! Surface parser near-miss: a SELF-reflexive library tuck — "you may put it on
+//! your choice of the top or bottom of its owner's library" (Arashin Sovereign's
+//! dies trigger) — was not routed to the existing `Effect::PutOnTopOrBottom`.
+//!
+//! The owner-framing patterns in `try_parse_put_on_top_or_bottom`
+//! (`oracle_effect/mod.rs`) recognize "its owner puts it on their choice of the
+//! top or bottom of their library" (Aether Gust, Subtlety, Aetherspouts). The
+//! controller-framing self form ("you may put it on your choice of the top or
+//! bottom of its owner's library") had no arm, so the effect body lowered to
+//! `Effect::Unimplemented` and nothing happened at resolution — Arashin stayed
+//! in the graveyard, and the whole card rendered unsupported.
+//!
+//! The one-arm fix (`try_parse_self_put_on_top_or_bottom`) routes the self form
+//! to the SAME `Effect::PutOnTopOrBottom` the owner-framing patterns produce. It
+//! is scoped to the SELF reference (`resolve_it_pronoun == SelfRef`): for the
+//! dying source's own library tuck the owner IS the controller, so the effect's
+//! owner-chooses resolution (CR 401.4) matches the card's "your choice" with no
+//! new runtime. A non-self "it" (S.N.E.A.K. Dispatcher, whose "it" is another
+//! player's card) or a "that card" subject (Hinder) is declined so the wrong
+//! player never chooses the position — those cards stay honest coverage gaps.
+//!
+//! This test drives the REAL dies-trigger -> resolve -> ChooseTopOrBottom
+//! pipeline and FAILS on `main`: the clause parses to `Unimplemented`, so no
+//! `TopOrBottomChoice` is ever offered and Arashin never leaves the graveyard.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::game::triggers::process_triggers;
+use engine::types::actions::GameAction;
+use engine::types::zones::Zone;
+
+// Arashin Sovereign's real Oracle text (verified against card-data.json).
+const ARASHIN_SOVEREIGN: &str = "Flying\nWhen this creature dies, you may put it on your \
+choice of the top or bottom of its owner's library.";
+
+/// After Arashin Sovereign dies and its optional dies trigger resolves with the
+/// controller choosing "top", the creature card must be on TOP of its owner's
+/// library. On `main` the effect body is `Unimplemented`, so no
+/// `TopOrBottomChoice` is ever offered and the card stays in the graveyard —
+/// both the "reached a choice" and the "now in library" assertions fail.
+#[test]
+fn arashin_sovereign_self_tuck_to_top_of_owner_library() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
+
+    // Two filler cards already on top, so "top" placement is observable: after the
+    // tuck Arashin must sit at library[0], ABOVE the fillers (proves the chosen
+    // position, not merely that the card landed somewhere in the library).
+    scenario.with_library_top(P0, &["Filler A", "Filler B"]);
+
+    let arashin = scenario
+        .add_creature_from_oracle(P0, "Arashin Sovereign", 5, 7, ARASHIN_SOVEREIGN)
+        .id();
+
+    let mut runner = scenario.build();
+
+    // Kill Arashin: move it to the graveyard as a game event so the dies trigger
+    // observes the death (mirrors issue_1332_bronzehide_lion).
+    let mut events = Vec::new();
+    engine::game::zones::move_to_zone(runner.state_mut(), arashin, Zone::Graveyard, &mut events);
+    process_triggers(runner.state_mut(), &events);
+
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "Arashin's dies trigger must be on the stack"
+    );
+
+    // Drive resolution: pass priority to resolve the trigger, accept the optional
+    // "you may", then choose the TOP of the library.
+    let mut guard = 0;
+    let reached_choice = loop {
+        guard += 1;
+        assert!(
+            guard < 64,
+            "resolution exceeded safety bound; waiting_for = {} stack = {}",
+            runner.waiting_for_kind(),
+            runner.state().stack.len()
+        );
+        match runner.waiting_for_kind() {
+            "OptionalEffectChoice" => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept the optional dies trigger");
+            }
+            "TopOrBottomChoice" => {
+                runner
+                    .act(GameAction::ChooseTopOrBottom { top: true })
+                    .expect("choose top of library");
+                break true;
+            }
+            "Priority" => {
+                if runner.state().stack.is_empty() {
+                    break false;
+                }
+                if runner.act(GameAction::PassPriority).is_err() {
+                    break false;
+                }
+            }
+            _ => break false,
+        }
+    };
+
+    assert!(
+        reached_choice,
+        "the self-tuck must reach a TopOrBottomChoice; on `main` the clause is \
+         Unimplemented so no choice is offered and Arashin never leaves the graveyard"
+    );
+
+    // End-to-end runtime delta: Arashin is now the TOP card of its owner's (P0's)
+    // library, not in the graveyard. On `main` it is still in the graveyard.
+    let arashin_obj = &runner.state().objects[&arashin];
+    assert_eq!(
+        arashin_obj.zone,
+        Zone::Library,
+        "Arashin must be in its owner's library after the self-tuck resolves; got {:?}",
+        arashin_obj.zone
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .library
+            .iter()
+            .next()
+            .copied(),
+        Some(arashin),
+        "Arashin must be on TOP of P0's library (the chosen position)"
+    );
+}

--- a/crates/engine/tests/integration/arashin_sovereign_self_tuck.rs
+++ b/crates/engine/tests/integration/arashin_sovereign_self_tuck.rs
@@ -1,57 +1,57 @@
 //! Surface parser near-miss: a SELF-reflexive library tuck — "you may put it on
-//! your choice of the top or bottom of its owner's library" (Arashin Sovereign's
+//! the top or bottom of its owner's library" (Arashin Sovereign's
 //! dies trigger) — was not routed to the existing `Effect::PutOnTopOrBottom`.
 //!
 //! The owner-framing patterns in `try_parse_put_on_top_or_bottom`
 //! (`oracle_effect/mod.rs`) recognize "its owner puts it on their choice of the
 //! top or bottom of their library" (Aether Gust, Subtlety, Aetherspouts). The
-//! controller-framing self form ("you may put it on your choice of the top or
+//! controller-framing self form ("you may put it on the top or
 //! bottom of its owner's library") had no arm, so the effect body lowered to
 //! `Effect::Unimplemented` and nothing happened at resolution — Arashin stayed
 //! in the graveyard, and the whole card rendered unsupported.
 //!
-//! The one-arm fix (`try_parse_self_put_on_top_or_bottom`) routes the self form
-//! to the SAME `Effect::PutOnTopOrBottom` the owner-framing patterns produce. It
-//! is scoped to the SELF reference (`resolve_it_pronoun == SelfRef`): for the
-//! dying source's own library tuck the owner IS the controller, so the effect's
-//! owner-chooses resolution (CR 401.4) matches the card's "your choice" with no
-//! new runtime. A non-self "it" (S.N.E.A.K. Dispatcher, whose "it" is another
-//! player's card) or a "that card" subject (Hinder) is declined so the wrong
-//! player never chooses the position — those cards stay honest coverage gaps.
+//! The self form carries `chooser: Controller`; owner-framed forms use
+//! `ParentTargetOwner`. A non-self "it" (S.N.E.A.K. Dispatcher) or a "that card"
+//! subject (Hinder) remains excluded, so it cannot be assigned the wrong chooser.
 //!
 //! This test drives the REAL dies-trigger -> resolve -> ChooseTopOrBottom
 //! pipeline and FAILS on `main`: the clause parses to `Unimplemented`, so no
 //! `TopOrBottomChoice` is ever offered and Arashin never leaves the graveyard.
 
-use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::triggers::process_triggers;
 use engine::types::actions::GameAction;
 use engine::types::zones::Zone;
 
 // Arashin Sovereign's real Oracle text (verified against card-data.json).
-const ARASHIN_SOVEREIGN: &str = "Flying\nWhen this creature dies, you may put it on your \
-choice of the top or bottom of its owner's library.";
+const ARASHIN_SOVEREIGN: &str =
+    "Flying\nWhen this creature dies, you may put it on the top or bottom of its owner's library.";
 
 /// After Arashin Sovereign dies and its optional dies trigger resolves with the
 /// controller choosing "top", the creature card must be on TOP of its owner's
-/// library. On `main` the effect body is `Unimplemented`, so no
-/// `TopOrBottomChoice` is ever offered and the card stays in the graveyard —
-/// both the "reached a choice" and the "now in library" assertions fail.
+/// library. This setup separates the controller (P0) from owner (P1), proving
+/// both that P0 receives the choice and that P1 receives the card.
 #[test]
-fn arashin_sovereign_self_tuck_to_top_of_owner_library() {
+fn stolen_arashin_sovereign_controller_chooses_owner_library_position() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(engine::types::phase::Phase::PreCombatMain);
 
     // Two filler cards already on top, so "top" placement is observable: after the
     // tuck Arashin must sit at library[0], ABOVE the fillers (proves the chosen
     // position, not merely that the card landed somewhere in the library).
-    scenario.with_library_top(P0, &["Filler A", "Filler B"]);
+    scenario.with_library_top(P1, &["Filler A", "Filler B"]);
 
     let arashin = scenario
-        .add_creature_from_oracle(P0, "Arashin Sovereign", 5, 7, ARASHIN_SOVEREIGN)
+        .add_creature_from_oracle(P1, "Arashin Sovereign", 5, 7, ARASHIN_SOVEREIGN)
         .id();
 
     let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&arashin)
+        .unwrap()
+        .controller = P0;
 
     // Kill Arashin: move it to the graveyard as a game event so the dies trigger
     // observes the death (mirrors issue_1332_bronzehide_lion).
@@ -83,6 +83,11 @@ fn arashin_sovereign_self_tuck_to_top_of_owner_library() {
                     .expect("accept the optional dies trigger");
             }
             "TopOrBottomChoice" => {
+                assert!(matches!(
+                    &runner.state().waiting_for,
+                    engine::types::game_state::WaitingFor::TopOrBottomChoice { player, .. }
+                        if *player == P0
+                ));
                 runner
                     .act(GameAction::ChooseTopOrBottom { top: true })
                     .expect("choose top of library");
@@ -106,7 +111,7 @@ fn arashin_sovereign_self_tuck_to_top_of_owner_library() {
          Unimplemented so no choice is offered and Arashin never leaves the graveyard"
     );
 
-    // End-to-end runtime delta: Arashin is now the TOP card of its owner's (P0's)
+    // End-to-end runtime delta: P0 made the choice, while Arashin is now the TOP card of P1's
     // library, not in the graveyard. On `main` it is still in the graveyard.
     let arashin_obj = &runner.state().objects[&arashin];
     assert_eq!(
@@ -116,12 +121,12 @@ fn arashin_sovereign_self_tuck_to_top_of_owner_library() {
         arashin_obj.zone
     );
     assert_eq!(
-        runner.state().players[P0.0 as usize]
+        runner.state().players[P1.0 as usize]
             .library
             .iter()
             .next()
             .copied(),
         Some(arashin),
-        "Arashin must be on TOP of P0's library (the chosen position)"
+        "Arashin must be on TOP of P1's library (the chosen position)"
     );
 }

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -8591,6 +8591,7 @@ fn put_on_top_or_bottom_redirect_pauses_before_continuation() {
     let mut ability = ResolvedAbility::new(
         Effect::PutOnTopOrBottom {
             target: TargetFilter::Any,
+            chooser: TargetFilter::ParentTargetOwner,
         },
         vec![TargetRef::Object(target)],
         source,
@@ -8774,6 +8775,7 @@ fn r2_effect_zone_moves_stay_synchronous_without_redirects() {
     let mut top_ability = ResolvedAbility::new(
         Effect::PutOnTopOrBottom {
             target: TargetFilter::Any,
+            chooser: TargetFilter::ParentTargetOwner,
         },
         vec![TargetRef::Object(top_target)],
         top_source,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -19,6 +19,7 @@ mod angels_grace_2hg;
 mod announce_locked_x_runtime;
 mod another_round_repeat;
 mod anya_merciless_angel_5920;
+mod arashin_sovereign_self_tuck;
 mod archmage_ascension_gated_draw_replacement;
 mod arcum_weathervane_supertype_removal;
 mod ark_of_hunger_play_from_graveyard_751;


### PR DESCRIPTION
Rescues the valuable self-tuck controller-choice semantics from #5889.\n\n- models the effect-designated chooser separately from the card owner whose library receives the object;\n- parses controller/owner choice forms and preserves the existing owner-default behavior;\n- covers serialization, parser, resolver, and stolen-permanent behavior.\n\nThe protected pre-push gate passed on the published tree (parser gates, engine/AI tests, card-data validation/coverage, frontend lint/type-check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting which player chooses whether an object goes on top or bottom of its owner’s library.
  * Improved handling of self-referential and controller-specific effects.
  * Preserved compatibility for existing effects and serialized data.

* **Bug Fixes**
  * Corrected chooser and target resolution when the affected object’s controller differs from its owner.
  * Added coverage for self-tuck behavior and related library placement choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->