### PR TITLE
fix(ci): increase rust checks timeout to 30 minutes for #6886

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
   rust-test:
     name: Rust tests (shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Factored out increase of timeout for increased test length in #6886

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the automated Rust test workflow timeout to 30 minutes to accommodate longer-running test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->