### PR TITLE
fix(parser): keep the card-type gate on "from among them" casts (#6880)

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -22014,9 +22014,12 @@ fn parse_cast_type_disjunction(rest: &str) -> Option<TypedFilter> {
 ///
 /// Returns `None` when the clause names no card type — "cast a spell from among
 /// them" (Aetherworks Marvel, Svella, Apex of Power) grants an unrestricted
-/// permission, and synthesizing a gate there would silently narrow it.
-/// `TypeFilter::Card` / `TypeFilter::Any` are head nouns rather than
-/// restrictions, so they also yield `None`.
+/// permission, and synthesizing a gate there would silently narrow it. Only the
+/// *type* axis gates: `TypeFilter::Card` / `TypeFilter::Any` are head nouns
+/// rather than restrictions, and non-type restrictions carried as properties
+/// (Chandra's "red spells", Meeting of the Five's "spells with exactly three
+/// colors", Perception Bobblehead's mana-value bound) also yield `None` so this
+/// helper never invents a type gate the Oracle text did not state.
 fn parse_cast_type_gate(rest: &str) -> Option<TypedFilter> {
     let typed =
         parse_cast_type_disjunction(rest).or_else(

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21996,6 +21996,61 @@ fn parse_cast_type_disjunction(rest: &str) -> Option<TypedFilter> {
     })
 }
 
+/// CR 601.3 + CR 109.2b: the card-type gate carried by a
+/// "cast [a <type> spell] from among ..." clause subject.
+///
+/// CR 601.3 ("a player can begin to cast a spell only if a rule or effect
+/// allows that player to cast it") makes the clause's card-type restriction
+/// part of the cast-legality predicate, exactly as much as its mana-value
+/// bound is. The mana-value half already lowers to
+/// `CastPermissionConstraint::ManaValue`, but `CastPermissionConstraint` has no
+/// card-type arm — so the type half must ride on the cast `target` filter,
+/// AND-ed with whatever anaphor binds the candidate set.
+///
+/// Composes the two existing subject parsers in the same order the
+/// `has_from_among_cards_exiled_with_self` branch already uses:
+/// `parse_cast_type_disjunction` first (it handles " or " between bare core
+/// types, which `parse_type_phrase` does not), then `parse_type_phrase`.
+///
+/// Returns `None` when the clause names no card type — "cast a spell from among
+/// them" (Aetherworks Marvel, Svella, Apex of Power) grants an unrestricted
+/// permission, and synthesizing a gate there would silently narrow it.
+/// `TypeFilter::Card` / `TypeFilter::Any` are head nouns rather than
+/// restrictions, so they also yield `None`.
+fn parse_cast_type_gate(rest: &str) -> Option<TypedFilter> {
+    let typed =
+        parse_cast_type_disjunction(rest).or_else(
+            || match super::oracle_target::parse_type_phrase(rest).0 {
+                TargetFilter::Typed(tf) => Some(tf),
+                _ => None,
+            },
+        )?;
+    typed
+        .type_filters
+        .iter()
+        .any(|tf| !matches!(tf, TypeFilter::Card | TypeFilter::Any))
+        .then_some(typed)
+}
+
+/// CR 601.3: AND a parsed card-type gate onto an exile-set cast anaphor.
+///
+/// Deliberately adds no `FilterProp::InZone` leg, unlike the
+/// `from among cards exiled with [self]` branch: these anaphors also cover
+/// self-library peeks (`Dig { keep_count: 0 }` — Velomachus Lorehold, Kiora),
+/// whose candidate cards stay in the LIBRARY and are matched through
+/// `remap_exiled_by_source_for_looked_cards`. Pinning the filter to
+/// `Zone::Exile` would match nothing for those cards, converting a permissive
+/// bug into a total no-op. The exile-resident paths already restrict to
+/// `Zone::Exile` before applying this filter.
+fn exiled_cast_target_with_type_gate(rest: &str) -> TargetFilter {
+    match parse_cast_type_gate(rest) {
+        Some(typed) => TargetFilter::And {
+            filters: vec![TargetFilter::Typed(typed), TargetFilter::ExiledBySource],
+        },
+        None => TargetFilter::ExiledBySource,
+    }
+}
+
 fn strip_cast_target_prefix(rest: &str) -> &str {
     opt(tag::<_, _, OracleError<'_>>("target "))
         .parse(rest)
@@ -22842,6 +22897,15 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
                 .and_then(hand_reveal_target_to_controller_ref)
             {
                 let mut hand_filter = TypedFilter::new(TypeFilter::Card).controller(controller);
+                // CR 601.3: the hand binding supplies the zone and the revealed
+                // player's controller; the clause supplies the card type when
+                // it names one. Without this the hand-bound sibling drops the
+                // type gate exactly as the exile-bound anaphor below did
+                // (issue #6880) — "cast an instant or sorcery spell from among
+                // those cards" would reach any revealed card.
+                if let Some(typed) = parse_cast_type_gate(rest) {
+                    hand_filter.type_filters = typed.type_filters;
+                }
                 hand_filter
                     .properties
                     .push(FilterProp::InZone { zone: Zone::Hand });
@@ -22872,8 +22936,14 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
         } else {
             CastFromZoneDriver::LingeringPermission
         };
+        // CR 601.3: the clause's card-type restriction is part of the
+        // cast-legality predicate and must ride on the permission's target
+        // filter. Binding the anaphor alone permitted every card type, so
+        // Velomachus Lorehold's "an instant or sorcery spell with mana value
+        // less than or equal to [its] power" enforced only the mana-value
+        // ceiling and offered creatures inside it (issue #6880).
         return Some(Effect::CastFromZone {
-            target: TargetFilter::ExiledBySource,
+            target: exiled_cast_target_with_type_gate(rest),
             without_paying_mana_cost: without_paying,
             mode,
             cast_transformed: false,
@@ -22887,8 +22957,11 @@ fn try_parse_cast_effect(lower: &str, ctx: &ParseContext) -> Option<Effect> {
     if scan_contains_phrase(rest, "from among those exiled cards")
         || scan_contains_phrase(rest, "from among the exiled cards")
     {
+        // CR 601.3: same card-type gate as the bare anaphor above — this
+        // surface form carries type-restricted members too (Eager Flameguide's
+        // "creature spells", Kylox's "instant and/or sorcery spells").
         return Some(Effect::CastFromZone {
-            target: TargetFilter::ExiledBySource,
+            target: exiled_cast_target_with_type_gate(rest),
             without_paying_mana_cost: without_paying,
             mode,
             cast_transformed: false,

--- a/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
+++ b/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
@@ -9,8 +9,9 @@ use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::game::visibility::filter_state_for_viewer;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
-    AbilityDefinition, CastFromZoneDriver, CastPermissionConstraint, Comparator, Effect,
-    ObjectScope, QuantityExpr, QuantityRef, TargetFilter, TypeFilter,
+    AbilityDefinition, CastFromZoneDriver, CastPermissionConstraint, Comparator, ControllerRef,
+    Effect, FilterProp, ObjectScope, QuantityExpr, QuantityRef, TargetFilter, TypeFilter,
+    TypedFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::format::FormatConfig;
@@ -30,6 +31,8 @@ const APEX: &str = "Exile the top seven cards of your library. Until end of turn
 const TALENT: &str = "Target opponent reveals the top seven cards of their library. You may cast an instant or sorcery spell from among them without paying its mana cost. Then that player puts the rest into their graveyard.\nSpell mastery — If there are two or more instant and/or sorcery cards in your graveyard, you may cast up to two instant and/or sorcery spells from among the revealed cards instead of one.";
 const JACE: &str = "Flying\nWhen Jace's Mindseeker enters, target opponent mills five cards. You may cast an instant or sorcery spell from among them without paying its mana cost.";
 const SILENT_BLADE: &str = "Ninjutsu {4}{U}{B} ({4}{U}{B}, Return an unblocked attacker you control to hand: Put this card onto the battlefield from your hand tapped and attacking.)\nWhenever this creature deals combat damage to a player, look at that player's hand. You may cast a spell from among those cards without paying its mana cost.";
+const MINDCLAW_SHAMAN: &str = "When this creature enters, target opponent reveals their hand. You may cast an instant or sorcery spell from among those cards without paying its mana cost.";
+const MINDLEECH_MASS: &str = "Trample\nWhenever this creature deals combat damage to a player, you may look at that player's hand. If you do, you may cast a spell from among those cards without paying its mana cost.";
 const EPIC_EXPERIMENT: &str = "Exile the top X cards of your library. You may cast instant and sorcery spells with mana value X or less from among them without paying their mana costs. Then put all cards exiled this way that weren't cast into your graveyard.";
 const COLLECTED_CONJURING: &str = "Exile the top six cards of your library. You may cast up to two sorcery spells with mana value 3 or less from among them without paying their mana costs. Put the exiled cards not cast this way on the bottom of your library in a random order.";
 const HAZORET: &str = "Shuffle your library, then exile the top four cards. You may cast any number of spells with mana value 5 or less from among them without paying their mana costs. Lands you control don't untap during your next untap step.";
@@ -788,6 +791,103 @@ fn untyped_from_among_them_cast_stays_a_bare_exile_anaphor() {
             cast_target_of(oracle, name, types),
             TargetFilter::ExiledBySource,
             "{name} names no card type, so its cast permission must stay unrestricted"
+        );
+    }
+}
+
+/// Extracts the three legs of a hand-bound cast permission.
+///
+/// The hand-bound branch composes its filter from two independent sources: the
+/// prior `Effect::RevealHand` clause supplies the zone and the revealed player,
+/// and the cast clause supplies the card type. A test that read only one leg
+/// would pass while the branch silently dropped another, so every assertion
+/// below reads all three.
+fn hand_bound_cast_filter(oracle: &str, name: &str, types: &[&str]) -> TypedFilter {
+    match cast_target_of(oracle, name, types) {
+        TargetFilter::Typed(tf) => tf,
+        other => panic!(
+            "{name}: a hand-reveal chain must bind the cast to the revealed hand \
+             as a single typed filter, got {other:?}"
+        ),
+    }
+}
+
+/// The hand-bound half of issue #6880, which the exile-bound tests above do not
+/// reach: `chain_prior_hand_reveal_target` is set (no exile producer ever ran),
+/// so the anaphor resolves against the revealed player's hand rather than
+/// `ExiledBySource`, and the type gate has to be grafted onto that filter
+/// instead of AND-ed with an exile anaphor.
+///
+/// Mindclaw Shaman is the only type-gated card in that family. Pre-fix the
+/// branch emitted a bare `TypeFilter::Card`, so "an instant or sorcery spell"
+/// reached every card in the revealed hand — a creature or land was castable
+/// for free, contrary to CR 601.3.
+///
+/// The branch OVERWRITES `type_filters` rather than appending, so the bare
+/// `Card` head noun must be gone, not merely accompanied. Asserting equality on
+/// the whole vector (not `contains`) is what pins that.
+#[test]
+fn hand_bound_cast_retains_the_instant_or_sorcery_gate() {
+    let typed = hand_bound_cast_filter(MINDCLAW_SHAMAN, "Mindclaw Shaman", &["Creature"]);
+
+    assert_eq!(
+        typed.type_filters,
+        vec![TypeFilter::AnyOf(vec![
+            TypeFilter::Instant,
+            TypeFilter::Sorcery
+        ])],
+        "the clause restricts the cast to instant or sorcery spells, and replaces \
+         the bare `Card` head noun rather than joining it"
+    );
+    assert_eq!(
+        typed.controller,
+        Some(ControllerRef::Opponent),
+        "the candidate cards belong to the opponent who revealed, not the caster"
+    );
+    assert!(
+        typed
+            .properties
+            .contains(&FilterProp::InZone { zone: Zone::Hand }),
+        "the cards never left the revealed hand, so the zone leg must survive the \
+         type graft, got {:?}",
+        typed.properties
+    );
+}
+
+/// Sibling guard for the untyped majority of the hand-bound family.
+///
+/// Silent-Blade Oni and Mindleech Mass say "cast a spell from among those
+/// cards" — no card type is named, so the permission is unrestricted and the
+/// filter must keep its bare `Card` head noun. Synthesizing a type gate here
+/// would silently narrow both cards.
+///
+/// Their zone and controller legs are asserted for the same reason as above:
+/// this test also has to fail if the type graft is generalized in a way that
+/// clobbers the hand binding.
+#[test]
+fn untyped_hand_bound_cast_keeps_a_bare_card_filter() {
+    for (name, oracle) in [
+        ("Silent-Blade Oni", SILENT_BLADE),
+        ("Mindleech Mass", MINDLEECH_MASS),
+    ] {
+        let typed = hand_bound_cast_filter(oracle, name, &["Creature"]);
+
+        assert_eq!(
+            typed.type_filters,
+            vec![TypeFilter::Card],
+            "{name} names no card type, so its cast permission must stay unrestricted"
+        );
+        assert_eq!(
+            typed.controller,
+            Some(ControllerRef::TriggeringPlayer),
+            "{name} looks at the hand of the player it damaged"
+        );
+        assert!(
+            typed
+                .properties
+                .contains(&FilterProp::InZone { zone: Zone::Hand }),
+            "{name}: the cards stay in the looked-at hand, got {:?}",
+            typed.properties
         );
     }
 }

--- a/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
+++ b/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
@@ -778,7 +778,7 @@ fn from_among_them_cast_retains_the_instant_or_sorcery_gate() {
 }
 
 /// Sibling guard: an *untyped* "cast a spell from among them" clause (Svella,
-/// Aetherworks Marvel, Apex of Power, ... — the 25-card majority of this
+/// Aetherworks Marvel, Apex of Power, ... — the untyped majority of this
 /// anaphor family) must keep its bare `ExiledBySource` binding. A type gate
 /// synthesized where the Oracle text names no type would silently narrow every
 /// one of those cards.

--- a/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
+++ b/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
@@ -40,6 +40,8 @@ const PRIMEVAL_SPAWN: &str = "Vigilance, trample, lifelink\nWhen Primeval Spawn 
 const CAPSTONE: &str = "Exile cards from the top of your library until you exile cards with total mana value 4 or greater. You may cast any number of spells from among them without paying their mana costs.";
 const FOUNDING: &str = "Read ahead (Choose a chapter and start with that many lore counters. Add one after your draw step. Skipped chapters don't trigger. Sacrifice after III.)\nI — You may cast an instant or sorcery spell with mana value 1 or 2 from your hand without paying its mana cost.\nII — Target player mills four cards.\nIII — Exile target instant or sorcery card from your graveyard. Copy it. You may cast the copy.";
 
+const MEETING_OF_THE_FIVE: &str = "Exile the top ten cards of your library. You may cast spells with exactly three colors from among them this turn. Add {W}{W}{U}{U}{B}{B}{R}{R}{G}{G}. Spend this mana only to cast spells with exactly three colors.";
+
 fn parse(oracle: &str, name: &str, types: &[&str]) -> engine::parser::oracle::ParsedAbilities {
     parse_oracle_text(
         oracle,
@@ -780,12 +782,25 @@ fn from_among_them_cast_retains_the_instant_or_sorcery_gate() {
 /// anaphor family) must keep its bare `ExiledBySource` binding. A type gate
 /// synthesized where the Oracle text names no type would silently narrow every
 /// one of those cards.
+///
+/// The last three rows are the hostile cases, and they are the point of this
+/// test: Oracle text that carries a restrictive qualifier immediately next to
+/// "spell"/"spells" which is NOT a card type. CR 601.3 does restrict those
+/// casts, but along the color and mana-value axes — which this filter does not
+/// model, and which `parse_cast_type_gate` must therefore never mistake for a
+/// card type. Meeting of the Five ("spells with exactly three colors") probes
+/// the color axis; Perception Bobblehead and Kiora ("a spell with mana value
+/// N or less") probe the property axis that rides on
+/// `CastPermissionConstraint` instead.
 #[test]
 fn untyped_from_among_them_cast_stays_a_bare_exile_anaphor() {
     for (name, oracle, types) in [
         ("Svella, Ice Shaper", SVELLA, &["Creature"][..]),
         ("Aetherworks Marvel", AETHERWORKS_MARVEL, &["Artifact"][..]),
         ("Apex of Power", APEX, &["Sorcery"][..]),
+        ("Meeting of the Five", MEETING_OF_THE_FIVE, &["Sorcery"][..]),
+        ("Perception Bobblehead", BOBBLEHEAD, &["Artifact"][..]),
+        ("Kiora, Sovereign of the Deep", KIORA, &["Creature"][..]),
     ] {
         assert_eq!(
             cast_target_of(oracle, name, types),

--- a/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
+++ b/crates/engine/tests/integration/kiora_self_library_peek_cast.rs
@@ -10,7 +10,7 @@ use engine::game::visibility::filter_state_for_viewer;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
     AbilityDefinition, CastFromZoneDriver, CastPermissionConstraint, Comparator, Effect,
-    ObjectScope, QuantityExpr, QuantityRef, TargetFilter,
+    ObjectScope, QuantityExpr, QuantityRef, TargetFilter, TypeFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::format::FormatConfig;
@@ -712,6 +712,215 @@ fn epic_experiment_freezes_x_for_the_lingering_cast_permission() {
     assert_eq!(
         runner.state().objects[&mana_value_three].zone,
         Zone::Graveyard
+    );
+}
+
+/// Issue #6880: the "from among them" cast anaphor must carry the clause's
+/// card-type restriction, not just its mana-value constraint.
+///
+/// CR 601.3: "A player can begin to cast a spell only if a rule or effect
+/// allows that player to cast it." Velomachus Lorehold allows casting only *an
+/// instant or sorcery spell*, so the type gate is part of the cast-legality
+/// predicate exactly as much as the mana-value bound is. The parser bound the
+/// permission to a bare `TargetFilter::ExiledBySource`, dropping the type leg
+/// entirely — the mana-value ceiling survived as a `CastPermissionConstraint`
+/// while any card type at or below that ceiling became castable.
+///
+/// The composed shape mirrors the already-correct
+/// "from among cards exiled with [self]" sibling branch: the typed leg AND the
+/// exile-set anaphor.
+fn cast_target_of(oracle: &str, name: &str, types: &[&str]) -> TargetFilter {
+    let parsed = parse(oracle, name, types);
+    let Effect::CastFromZone { target, .. } = parsed_cast_from_zone(&parsed) else {
+        unreachable!("helper returns CastFromZone")
+    };
+    target.clone()
+}
+
+#[test]
+fn from_among_them_cast_retains_the_instant_or_sorcery_gate() {
+    let instant_or_sorcery = TypeFilter::AnyOf(vec![TypeFilter::Instant, TypeFilter::Sorcery]);
+
+    for (name, oracle, types) in [
+        ("Velomachus Lorehold", VELOMACHUS, &["Creature"][..]),
+        ("Jace's Mindseeker", JACE, &["Creature"][..]),
+        ("Talent of the Telepath", TALENT, &["Sorcery"][..]),
+    ] {
+        let target = cast_target_of(oracle, name, types);
+        let TargetFilter::And { filters } = &target else {
+            panic!(
+                "{name}: the cast permission must AND the card-type gate with the \
+                 exile-set anaphor, got {target:?}"
+            );
+        };
+        assert!(
+            filters.contains(&TargetFilter::ExiledBySource),
+            "{name}: the exile-set anaphor leg must survive the composition, got {filters:?}"
+        );
+        let typed = filters
+            .iter()
+            .find_map(|f| match f {
+                TargetFilter::Typed(tf) => Some(tf),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("{name}: expected a typed leg, got {filters:?}"));
+        assert_eq!(
+            typed.type_filters,
+            vec![instant_or_sorcery.clone()],
+            "{name}: the clause restricts the cast to instant or sorcery spells"
+        );
+    }
+}
+
+/// Sibling guard: an *untyped* "cast a spell from among them" clause (Svella,
+/// Aetherworks Marvel, Apex of Power, ... — the 25-card majority of this
+/// anaphor family) must keep its bare `ExiledBySource` binding. A type gate
+/// synthesized where the Oracle text names no type would silently narrow every
+/// one of those cards.
+#[test]
+fn untyped_from_among_them_cast_stays_a_bare_exile_anaphor() {
+    for (name, oracle, types) in [
+        ("Svella, Ice Shaper", SVELLA, &["Creature"][..]),
+        ("Aetherworks Marvel", AETHERWORKS_MARVEL, &["Artifact"][..]),
+        ("Apex of Power", APEX, &["Sorcery"][..]),
+    ] {
+        assert_eq!(
+            cast_target_of(oracle, name, types),
+            TargetFilter::ExiledBySource,
+            "{name} names no card type, so its cast permission must stay unrestricted"
+        );
+    }
+}
+
+/// The user-visible half of issue #6880, driven through the real attack-trigger
+/// resolution pipeline rather than asserted on the AST.
+///
+/// Velomachus has power 5. The looked-at cards include a mana-value 3 *creature*
+/// — comfortably inside the mana-value ceiling but outside the "instant or
+/// sorcery" permission. Pre-fix the engine offered it; CR 601.3 says it was
+/// never a legal choice.
+///
+/// Reach guard against a vacuous negative: the same assertion block requires the
+/// legal mana-value 4 sorcery to BE offered, proving the choice was actually
+/// opened and populated rather than short-circuited to an empty prompt.
+#[test]
+fn velomachus_does_not_offer_a_creature_inside_its_mana_value_ceiling() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::DeclareAttackers);
+    let velomachus = scenario
+        .add_creature(P0, "Velomachus Lorehold", 5, 5)
+        .from_oracle_text_with_keywords(&["flying", "vigilance", "haste"], VELOMACHUS)
+        .id();
+    let legal_sorcery = scenario
+        .add_spell_to_library_top(P0, "Velomachus Legal Sorcery", false)
+        .with_mana_cost(ManaCost::generic(4))
+        .from_oracle_text("You gain 1 life.")
+        .id();
+    // The trap: mana value 3 <= Velomachus's power 5, so only the card-type
+    // gate can exclude it.
+    let creature_inside_ceiling = scenario
+        .add_spell_to_library_top(P0, "Velomachus Trap Creature", false)
+        .with_mana_cost(ManaCost::generic(3))
+        .as_creature()
+        .id();
+    for index in 0..5 {
+        scenario
+            .add_spell_to_library_top(P0, &format!("Velomachus Filler {index}"), false)
+            .with_mana_cost(ManaCost::generic(6))
+            .from_oracle_text("You gain 1 life.");
+    }
+
+    let mut runner = scenario.build();
+    runner.state_mut().waiting_for = WaitingFor::DeclareAttackers {
+        player: P0,
+        valid_attacker_ids: vec![velomachus],
+        valid_attack_targets: vec![AttackTarget::Player(P1)],
+        valid_attack_targets_by_attacker: None,
+        attacker_constraints: Default::default(),
+    };
+    runner
+        .declare_attackers(&[(velomachus, AttackTarget::Player(P1))])
+        .expect("Velomachus must be able to attack");
+    runner.resolve_top();
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting Velomachus's optional cast must succeed");
+
+    let WaitingFor::EffectZoneChoice { cards, zone, .. } = runner.state().waiting_for.clone()
+    else {
+        panic!("Velomachus's attack trigger must reach the library cast choice")
+    };
+    assert_eq!(zone, Zone::Library);
+    assert!(
+        cards.contains(&legal_sorcery),
+        "reach guard: the legal instant-or-sorcery card must be offered, \
+         otherwise the negative assertion below is vacuous; offered = {cards:?}"
+    );
+    assert!(
+        !cards.contains(&creature_inside_ceiling),
+        "CR 601.3: Velomachus permits casting only an instant or sorcery spell — \
+         a creature within the mana-value ceiling must NEVER be offered \
+         (issue #6880); offered = {cards:?}"
+    );
+
+    // Observable outcome: taking the only legal card puts it on the stack and
+    // leaves the illegal creature in the library.
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![legal_sorcery],
+        })
+        .expect("choosing Velomachus's legal sorcery must succeed");
+    assert_eq!(runner.state().objects[&legal_sorcery].zone, Zone::Stack);
+    assert_eq!(
+        runner.state().objects[&creature_inside_ceiling].zone,
+        Zone::Library,
+        "the ineligible creature must stay in the library"
+    );
+    assert!(
+        runner.state().objects[&creature_inside_ceiling]
+            .casting_permissions
+            .is_empty(),
+        "the ineligible creature must not receive a casting permission"
+    );
+}
+
+/// Runtime sibling guard for the untyped majority: Svella says "cast a spell",
+/// so a creature in its looked-at set must STILL be offered. This is the
+/// runtime counterpart of `untyped_from_among_them_cast_stays_a_bare_exile_anaphor`
+/// and fails if the type gate is applied where no type was named.
+#[test]
+fn svella_untyped_peek_still_offers_a_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let svella = scenario
+        .add_creature(P0, "Svella, Ice Shaper", 2, 4)
+        .from_oracle_text(SVELLA)
+        .id();
+    let creature = scenario
+        .add_spell_to_library_top(P0, "Svella Creature", false)
+        .with_mana_cost(ManaCost::generic(2))
+        .as_creature()
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        (0..6)
+            .map(|_| ManaUnit::new(ManaType::Colorless, svella, false, vec![]))
+            .chain([
+                ManaUnit::new(ManaType::Red, svella, false, vec![]),
+                ManaUnit::new(ManaType::Green, svella, false, vec![]),
+            ])
+            .collect(),
+    );
+
+    let mut runner = scenario.build();
+    let outcome = runner.activate(svella, 0).accept_optional().resolve();
+    let WaitingFor::EffectZoneChoice { cards, .. } = outcome.final_waiting_for() else {
+        panic!("Svella's activated ability must reach the library cast choice")
+    };
+    assert!(
+        cards.contains(&creature),
+        "Svella's untyped \"cast a spell\" permission must still reach a creature; \
+         offered = {cards:?}"
     );
 }
 


### PR DESCRIPTION
Fixes #6880.

## The bug

Velomachus Lorehold: *"…you may cast **an instant or sorcery spell** with mana value less than or equal to Velomachus Lorehold's power from among them without paying its mana cost."*

The mana-value gate was enforced; the **instant-or-sorcery gate was not**, so any card type could be cast. The parsed `CastFromZone` carried the right `constraint: ManaValue{LE, Power(Source)}` but a bare `target: ExiledBySource` — an anaphor with no card-type leg.

The correct composition already existed in a sibling branch of the same function, which parses the type disjunction and ANDs it with the anaphor. The fix routes the bare-emitting branches through one shared helper.

## Three branches, not two

The survey that scoped this named two bare-emitting branches. There are **three**: `"from among them"`, the hand-bound sibling, and `"from among those/the exiled cards"`. The third has type-gated members (Eager Flameguide, Kylox), so fixing only the first two would have left the class half-covered.

## What is deliberately *not* copied from the sibling

The sibling composition includes `FilterProp::InZone { zone: Zone::Exile }`. **Copying that leg would have been worse than the bug.** Velomachus is `Dig { keep_count: 0 }` — the looked-at cards stay in the **library** and are published via `last_revealed_ids`. An exile-zone leg matches nothing there, converting a permissive filter into a **total no-op**: the card would become uncastable under a commit claiming a fix. The type gate is ANDed with `ExiledBySource` alone, and the reason is documented at the call site.

## No engine change

Confirmed with the mechanism, not by assertion:

- `TargetFilter::references_exiled_by_source` uses `any` over `And` legs, so the composed shape still enters the look-at fallback.
- `remap_exiled_by_source_for_looked_cards` recurses into `And`, so the library remap survives.

## Class — 37 anchor cards, 12 type-restricted, 10 fixed

The original scoping said 8 cards. That was wrong in both directions. Re-derived across all 35,657 entries: **41** cards carry the anchor with a bare `ExiledBySource`, of which **15** name a card type (10 fixed, 5 still bare) and **26** name none and are correctly bare. 10 + 5 + 26 = 41.

(An earlier revision of this description said 37/12/25. That was itself an undercount, caught by the same denominator discipline: the two anchor phrasings were censused separately, and a `"cast "` regex missed The Omenkeel, whose verb is "play lands". Corrected here.)

The original list also omitted four cards and was partly unverifiable by the method that produced it — **5 of its 8 have `abilities: []`**, because the `CastFromZone` lives under `.triggers`. A census walking only `.abilities` silently undercounts.

**Fixed (10 of the 15)** — each checked against its real Oracle text:

| card | gate now emitted |
|---|---|
| Velomachus Lorehold, Jace's Mindseeker, Muse Vortex, Summons of Saruman, Talent of the Telepath | `AnyOf[Instant, Sorcery]` |
| Chiss-Goria, Forge Tyrant | `Artifact` |
| Herald of Amity | `Subtype(Aura)` |
| Eager Flameguide | `Creature` |
| Narset, Enlightened Master | `Card + Non(Creature)` |
| The Omenkeel | `Land` — *"you may play lands from among those cards"* previously let **any** exiled card be played as a land |

Plus **one more card from outside this population** — see the follow-up section: **Mindclaw Shaman**, corrected on the **hand-bound** branch. It is not a missing member of the 41/15 set; that set is defined by a bare `ExiledBySource`, which the hand-bound branch never emits. **11 cards are corrected in total.**

**Still permissive (5 of the 15)** — pre-existing gap, **not** a regression, each blocked by a missing helper rather than by this change:

| card | clause | why it still fails |
|---|---|---|
| Epic Experiment, Ral, Leyline Prodigy | "instant **and** sorcery spells" | helper handles `" or "` only |
| Kylox | "any number of instant **and/or** sorcery spells" | same |
| Collected Conjuring | "**up to two** sorcery spells" | leading count blocks the article parse |
| Sanwell, Avenger Ace | "a **Vehicle** or artifact creature spell" | Vehicle is a subtype, not a core type |


Extending `parse_cast_type_disjunction` to `"and"` / `"and/or"` would reach three of them but changes two other call sites, so it is left for follow-up rather than widened here.

**On Elder Brain — checked, and it is correctly bare.** It reads *"You may play lands and cast spells from among the exiled cards"*, which looks like it should carry a `Land` gate. It does not, and should not: the clause reaching the cast parser is *"spells from among the exiled cards"*, which names no card type, so the bare binding is right. Verified against parsed card data — Elder Brain emits `CastFromZone` with a bare `ExiledBySource` and `mode: Cast`, whereas The Omenkeel's single *"play lands from among those cards"* emits `mode: Play` with `And[Typed[Land], ExiledBySource]`. Different clauses, correctly different results. Elder Brain is in the 26.

**Separately, Elder Brain does have a real defect, filed rather than fixed here.** It emits **only one** unit — the `Cast` half — with no `Play` unit and no `Typed[Land]` anywhere on the card. Its *"play lands"* permission is dropped outright, not merely under-restricted. That is a different defect in a different population and out of scope for this PR.

## Verification

- **Red → green, attributed by test name** rather than by resource colour, with the same 22,815 test count on both runs. At base: 22,813 passed / 2 failed (`from_among_them_cast_retains_the_instant_or_sorcery_gate`, `velomachus_does_not_offer_a_creature_inside_its_mana_value_ceiling`). After the fix: 22,815 / 22,815.
- **Two of the four tests are anti-swallow guards** for the 26 untyped cards — they pass before *and* after, pinning that a bare "cast a spell" clause still emits a bare anaphor rather than acquiring a spurious type leg. They are guards, not discrimination, and are labelled as such.
- `clippy`, `test-engine`, `card-data` all green. Parser combinator gate exit 0.
- CR 601.3 and CR 109.2b added — grep-verified **and read** to confirm they describe the code.

## Inertness — verified end to end

This is parser-side and therefore **inert until `card-data.json` is regenerated and redeployed**; it is invisible in the app on merge alone. Verified beyond the AST level: the card-data pipeline was rerun after the fix and the census re-taken against the regenerated file.

## Does not close #3267

Sanwell's reported symptom there is rest-to-bottom behaviour, which is untouched — and Sanwell is one of the five whose type gate still does not parse. Please do not auto-close it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed card-type restrictions in “cast from among” effects.
  * Typed permissions now correctly preserve instant/sorcery or other card-type limits when casting from exiled cards or cards in hand.
  * Unrestricted casting clauses remain unaffected.
  * Corrected gameplay behavior so ineligible card types are no longer offered as castable options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



---

## Follow-up commit: hand-bound coverage (`07163ac`)

CodeRabbit flagged that the **hand-bound** branch gained a genuinely new code path — it previously always used a bare `Card` filter — and that none of the four original tests exercised it; they all drive the exile-bound branches.

The right first question was whether the path is reachable at all, since unreachable code should be documented or removed rather than tested. It is reachable, by a real card: **Mindclaw Shaman** — *"target opponent reveals their hand. You may cast an instant or sorcery spell from among those cards without paying its mana cost."* Against regenerated card data it now parses to a `Typed` filter carrying `AnyOf[Instant, Sorcery]` alongside `InZone { Hand }` and `controller: Opponent`.

So it is an **11th corrected card**, not merely an untested branch — this PR was undercounting its own impact. Fittingly, Mindclaw Shaman is another `abilities: 0, triggers: 1` card, the same shape that made the original 8-card scoping unverifiable.

The new tests assert **all three legs** (type filter, zone, controller); a test pinning only the type filter would not catch a regression that dropped the zone or the controller. An untyped hand-bound guard is added alongside, as the hand-side counterpart of the exile-side guard.

The same commit sharpens `parse_cast_type_gate`'s doc to state why non-type restrictions carried as properties — Chandra's "red spells", Meeting of the Five's "spells with exactly three colors", Perception Bobblehead's mana-value bound — also yield `None`: only the type axis gates, so the helper never invents a restriction the Oracle text did not state.

CodeRabbit's other nit — that a sibling branch still hand-rolls the same composition rather than calling the shared helper — is a real single-authority point but changes AST shape for cards currently parsing that way, so it needs its own card-data census. Deferred to #6960.



### Why the 11th card was missed — the denominator, not the walk

Worth recording, because it is a different error from the `.abilities`-vs-`.triggers` one corrected above.

This description defines its population as *"cards carrying the anchor **with a bare `ExiledBySource`**"* — 41 cards, 15 type-restricted. But the defect lives in a function with **three** emitting branches, and the **hand-bound branch never emits `ExiledBySource` at all**; it emits a `Typed` hand filter. Mindclaw Shaman was therefore excluded **by construction**, not by an execution mistake. No amount of walking `.triggers` as well as `.abilities` would have surfaced it.

The tell is that the census predicate named a *concrete emitted value* rather than the *behaviour under test* (a cast permission that should carry a type gate). Whenever a population is defined by a value one code path emits, the question to ask is how many paths reach the defect and whether each emits that value.

### No other hand-bound card is newly corrected

Verified with its own denominator: 35,657 MTGJSON entries → **50** carrying `cast[^.]*from among (them|those cards)`. The hand-bound subset is **4**: Mindclaw Shaman (typed → now fixed), and Silent-Blade Oni, Mindleech Mass, Extract Brain (all "cast **a spell**", untyped → unchanged, and covered by the new untyped guard). The 350-card complement carrying the anaphor outside those 50 was checked for any hand-reveal-plus-cast combination: empty.

Incidental, pinned but not changed: Silent-Blade Oni and Mindleech Mass bind `controller: TriggeringPlayer` rather than `DefendingPlayer`. Pre-existing and untouched here.



