### PR TITLE
fix: prioritize selectable library search cards

### DIFF
--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -486,9 +486,15 @@ function SearchModal({ data }: { data: SearchChoice["data"] }) {
   // The engine records every card the searching player looked at. `cards`
   // remains the legal-selection subset; rendering the full engine-provided
   // look set lets a library-search modal show the remaining library while
-  // keeping non-matching cards unselectable.
+  // keeping non-matching cards unselectable. Put the legal candidates first
+  // so the cards the player can choose are immediately visible.
   const displayedCards = lookedAt
-    ? Array.from(new Set([...lookedAt.map(([, , identity]) => identity.object_id), ...data.cards]))
+    ? Array.from(
+        new Set([
+          ...data.cards,
+          ...lookedAt.map(([, , identity]) => identity.object_id),
+        ]),
+      )
     : data.cards;
   const selectableCards = new Set(data.cards);
   const countValid = searchChoiceAllowsPartialFind(data)
@@ -547,7 +553,7 @@ function SearchModal({ data }: { data: SearchChoice["data"] }) {
                   ? "z-10 ring-2 ring-emerald-400/80"
                   : isSelectable
                     ? "hover:shadow-[0_0_16px_rgba(200,200,255,0.3)]"
-                    : "cursor-not-allowed opacity-40"
+                    : "cursor-not-allowed opacity-40 grayscale"
               }`}
               initial={{ opacity: 0, y: 60, scale: 0.85 }}
               animate={{ opacity: isSelected ? 1 : isSelectable ? 0.7 : 0.4, y: 0, scale: 1 }}

--- a/client/src/components/modal/__tests__/SearchChoiceModal.test.tsx
+++ b/client/src/components/modal/__tests__/SearchChoiceModal.test.tsx
@@ -36,7 +36,7 @@ describe("SearchChoice modal", () => {
     cleanup();
   });
 
-  it("shows every card the engine exposed during a library search", () => {
+  it("shows selectable cards first and disables ineligible cards", () => {
     const waitingFor: WaitingFor = {
       type: "SearchChoice",
       data: { player: 0, cards: [42], count: 1 },
@@ -55,8 +55,8 @@ describe("SearchChoice modal", () => {
           effective_library_owner: 0,
           learned_audience: [0],
           looked_at: [
-            [0, "Library", { object_id: 42, incarnation: 0 }],
             [0, "Library", { object_id: 43, incarnation: 0 }],
+            [0, "Library", { object_id: 42, incarnation: 0 }],
           ],
         },
       },
@@ -65,8 +65,13 @@ describe("SearchChoice modal", () => {
 
     render(<CardChoiceModal />);
 
-    expect(screen.getByLabelText(/Eligible Card/)).toBeInTheDocument();
+    const eligibleCard = screen.getByLabelText(/Eligible Card/);
+    expect(eligibleCard).toBeInTheDocument();
     const ineligibleCard = screen.getByLabelText(/Ineligible Card/);
     expect(ineligibleCard.closest("button")).toBeDisabled();
+    expect(
+      eligibleCard.compareDocumentPosition(ineligibleCard) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Search results now show selectable cards before cards that cannot be selected.
  * Ineligible cards remain visible but are clearly marked as disabled with grayscale styling.
  * Duplicate cards continue to be removed from the results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->