### PR TITLE
perf(engine): let a priority pass skip the legality clone

### DIFF
--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -232,9 +232,13 @@ impl SimulationFilter {
 ///
 /// Conservative by design, mirroring `structurally_valid_search_selection`: this
 /// returns `false` — costing one simulation, never a wrong verdict — for every
-/// shape it does not fully model. CR 117.4: the pass boundary's own post-reducer
-/// pipeline (stack resolution, continuation drains, trigger-target selection) is
-/// deliberately NOT modelled; that is the same boundary the four sibling hatches
+/// shape it does not fully model. CR 117.4 is what puts a boundary here at all:
+/// an all-pass succession resolves the top of the stack, or ends the phase or
+/// step when the stack is empty. What that boundary then runs is deliberately
+/// NOT modelled — the CR 608.2 resolution steps, the continuation drains hanging
+/// off them, and CR 603.3d target selection for any ability that triggers. Only
+/// the first of those is CR 117.4's own subject; the rest are consequences of
+/// the resolution it starts. That is the same boundary the four sibling hatches
 /// already draw.
 fn structurally_valid_pass_priority(state: &GameState, candidate: &CandidateAction) -> bool {
     let (WaitingFor::Priority { player }, GameAction::PassPriority) =
@@ -1527,9 +1531,19 @@ mod tests {
     }
 
     /// The authoritative oracle: `SimulationFilter::fallback_simulation`'s body,
-    /// with the same actor / semantic-owner resolution, minus the perf counter.
+    /// with the same actor / semantic-owner resolution and the same
+    /// `SimulationProbeGuard` window, minus the perf counter.
+    ///
+    /// The guard is load-bearing, not ceremony. It suppresses top-level loop
+    /// reconciliation (`reconcile_terminal_result` §3) and ring accumulation
+    /// (`pass_priority_once_with_pipeline` §2) for the duration of the probe, so
+    /// an oracle that omits it can return a verdict production legality
+    /// filtering never produces. Every soundness assertion below is a comparison
+    /// against this function; if it stops being `fallback_simulation`, those
+    /// assertions stop constraining the hatch, and they do so silently.
     fn pass_oracle_accepts(state: &GameState, candidate: &CandidateAction) -> bool {
         let mut sim = state.clone();
+        let _probe = SimulationProbeGuard::enter();
         let actor = candidate
             .metadata
             .actor

--- a/crates/engine/src/ai_support/filter.rs
+++ b/crates/engine/src/ai_support/filter.rs
@@ -139,6 +139,9 @@ impl CandidateFilter for SimulationFilter {
     }
 
     fn accept(&self, state: &GameState, candidate: &CandidateAction) -> bool {
+        if structurally_valid_pass_priority(state, candidate) {
+            return true;
+        }
         if super::structurally_valid_search_selection(state, &candidate.action) {
             return true;
         }
@@ -160,6 +163,9 @@ impl CandidateFilter for SimulationFilter {
         candidate: &CandidateAction,
         probe: Option<&casting::PriorityCastProbe>,
     ) -> bool {
+        if structurally_valid_pass_priority(state, candidate) {
+            return true;
+        }
         if super::structurally_valid_search_selection(state, &candidate.action) {
             return true;
         }
@@ -208,6 +214,49 @@ impl SimulationFilter {
             .is_ok()
         })
     }
+}
+
+/// CR 117.3d: the holder of a live priority window may always decline to act.
+/// The engine's `(Priority, PassPriority)` reducer arm rejects a pass on exactly
+/// two conditions (CR 723.5 submitter mismatch, CR 732.2c divergence obligation),
+/// both owned by `game::priority::pass_priority_legality`. This delegates to
+/// `game::priority::pass_priority_structurally_legal`, which is that authority
+/// plus the parked-continuation refusal — the same single predicate the
+/// `phase-ai` projection fast path calls, so neither can drift.
+///
+/// Skipping the clone-and-apply here is load-bearing: `PassPriority` is enumerated
+/// at every priority window (`candidates::priority_actions_with_probe`) and is never
+/// memoized (`legality_equivalence_key`'s catch-all), so before this hatch it paid a
+/// full `GameState` clone *per priority window* — plus the nested `boundary_snapshot`
+/// clone inside `apply_action_boundary_core` — to re-derive an O(1) answer.
+///
+/// Conservative by design, mirroring `structurally_valid_search_selection`: this
+/// returns `false` — costing one simulation, never a wrong verdict — for every
+/// shape it does not fully model. CR 117.4: the pass boundary's own post-reducer
+/// pipeline (stack resolution, continuation drains, trigger-target selection) is
+/// deliberately NOT modelled; that is the same boundary the four sibling hatches
+/// already draw.
+fn structurally_valid_pass_priority(state: &GameState, candidate: &CandidateAction) -> bool {
+    let (WaitingFor::Priority { player }, GameAction::PassPriority) =
+        (&state.waiting_for, &candidate.action)
+    else {
+        return false;
+    };
+
+    // CR 723.5: the simulation submits under `candidate.metadata.actor` when set.
+    // `PassPriority` carries no payload, so submitter identity IS half of its
+    // legality — accept only the actor the engine's own candidate stamping would
+    // produce (`candidates::authorize_candidate_actors`), and the `None` case that
+    // `fallback_simulation` resolves to that same value.
+    if candidate
+        .metadata
+        .actor
+        .is_some_and(|actor| actor != turn_control::authorized_submitter_for_player(state, *player))
+    {
+        return false;
+    }
+
+    crate::game::priority::pass_priority_structurally_legal(state, *player)
 }
 
 fn structurally_valid_priority_activation(state: &GameState, action: &GameAction) -> bool {
@@ -1295,7 +1344,8 @@ fn legality_equivalence_key(
             Some(LegalityKey::new(LegalityClass::ChooseTarget, fp))
         }
         // Everything else (empty/multi/banded DeclareAttackers, CastSpell,
-        // PassPriority, TapForConvoke [short-circuited in SimulationFilter],
+        // PassPriority [short-circuited in SimulationFilter],
+        // TapForConvoke [short-circuited in SimulationFilter],
         // non-object ChooseTarget): fresh per-candidate simulation.
         _ => None,
     }
@@ -1416,6 +1466,356 @@ mod tests {
             .expect("PassPriority should be a candidate in the opening state");
         assert!(SimulationFilter.accept(&state, &pass));
         assert!(BasicLegalityFilter.accept(&state, &pass));
+    }
+
+    // ------------------------------------------------------------------
+    // `structurally_valid_pass_priority` — the fifth structural hatch.
+    //
+    // Soundness condition (the converse of the module's `cheap ⊆ simulate`
+    // invariant, because a hatch lives INSIDE the oracle rather than before it):
+    //
+    //   structurally_valid_pass_priority(state, candidate) == true
+    //     ⇒ fallback_simulation(state, candidate) == true
+    //
+    // `pass_oracle_accepts` below is `fallback_simulation`'s body without the
+    // counter, so the implication is asserted against the real boundary.
+    // ------------------------------------------------------------------
+
+    /// A bare two-player `Priority` window on P0.
+    ///
+    /// The default phase of a fresh `GameState` is `Phase::Untap`, not a main
+    /// phase, and both hands are empty — so no `PlayLand` candidate can be
+    /// enumerated here. That matters only for the tests below that call
+    /// `legal_actions`; the ones that call the hatch directly never enumerate.
+    fn pass_priority_state() -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = PlayerId(0);
+        state.priority_player = PlayerId(0);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        state
+    }
+
+    /// A `Priority` window under CR 723.5 turn control: P1 holds the seat, P0 is
+    /// the authorized submitter. Mirrors the shipped
+    /// `turn_control_priority_softlock` integration setup.
+    fn turn_controlled_pass_priority_state() -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.active_player = PlayerId(1);
+        state.turn_decision_controller = Some(PlayerId(0));
+        state.priority_passes.clear();
+        crate::game::public_state::sync_waiting_for(
+            &mut state,
+            &WaitingFor::Priority {
+                player: PlayerId(1),
+            },
+        );
+        state
+    }
+
+    /// A `PassPriority` candidate stamped exactly as
+    /// `candidates::authorize_candidate_actors` would stamp it for `seat`.
+    fn authorized_pass_candidate(state: &GameState, seat: PlayerId) -> CandidateAction {
+        CandidateAction {
+            action: GameAction::PassPriority,
+            metadata: crate::ai_support::ActionMetadata::for_actor(
+                Some(turn_control::authorized_submitter_for_player(state, seat)),
+                crate::ai_support::TacticalClass::Pass,
+            ),
+        }
+    }
+
+    /// The authoritative oracle: `SimulationFilter::fallback_simulation`'s body,
+    /// with the same actor / semantic-owner resolution, minus the perf counter.
+    fn pass_oracle_accepts(state: &GameState, candidate: &CandidateAction) -> bool {
+        let mut sim = state.clone();
+        let actor = candidate
+            .metadata
+            .actor
+            .or_else(|| turn_control::authorized_submitters(state).first().copied());
+        actor.is_some_and(|actor| {
+            let semantic_owner = candidate.metadata.semantic_owner.unwrap_or(actor);
+            crate::game::engine::apply_interaction_for_simulation(
+                &mut sim,
+                actor,
+                semantic_owner,
+                candidate.action.clone(),
+            )
+            .is_ok()
+        })
+    }
+
+    /// T3. The hatch must be wired into BOTH `accept` and `accept_with_probe`.
+    ///
+    /// The two `assert!` calls on the verdict pass either way (the fallback
+    /// simulation also accepts this state) — they are reach-guards. The exact
+    /// zero counters, asserted separately per method, are the evidence: if a
+    /// future edit adds a hatch to only one of the two bodies, the other
+    /// method's counter regresses to non-zero here.
+    ///
+    /// No fixture pin is needed: this calls `SimulationFilter` directly on a
+    /// hand-built candidate, so nothing is enumerated and no `PlayLand`
+    /// candidate can exist.
+    #[test]
+    fn pass_priority_hatch_is_wired_into_both_simulation_filter_methods() {
+        let state = pass_priority_state();
+        let pass = authorized_pass_candidate(&state, PlayerId(0));
+
+        crate::game::perf_counters::reset();
+        assert!(SimulationFilter.accept(&state, &pass));
+        assert_eq!(
+            crate::game::perf_counters::snapshot().state_clone_for_legality,
+            0,
+            "`accept` must answer a bare pass without cloning the state"
+        );
+
+        crate::game::perf_counters::reset();
+        assert!(SimulationFilter.accept_with_probe(&state, &pass, None));
+        assert_eq!(
+            crate::game::perf_counters::snapshot().state_clone_for_legality,
+            0,
+            "`accept_with_probe` must answer a bare pass without cloning the state"
+        );
+    }
+
+    /// T4. The soundness property, executable, over pre-boundary shapes.
+    ///
+    /// Every fixture here perturbs only PRE-state fields; none makes the
+    /// accepted pass an all-players-passed pass, so this cannot say anything
+    /// about the CR 117.4 resolution seam. The seam-crossing companion is
+    /// `pass_priority_hatch_stays_sound_across_the_resolution_seam` in
+    /// `tests/integration/pass_priority_structural_legality.rs`.
+    ///
+    /// The accepted/rejected tallies are the non-vacuity guard: a predicate
+    /// stuck at `false` satisfies the implication trivially and must not report
+    /// green.
+    #[test]
+    fn pass_priority_hatch_accepts_only_what_the_simulation_accepts() {
+        use crate::types::game_state::{
+            DeferredLifeCostResume, ManaAbilityResume, PendingCostMoveResume,
+        };
+
+        let mut fixtures: Vec<(&'static str, GameState, PlayerId)> = Vec::new();
+
+        fixtures.push(("plain priority", pass_priority_state(), PlayerId(0)));
+        fixtures.push((
+            "turn-controlled priority",
+            turn_controlled_pass_priority_state(),
+            PlayerId(1),
+        ));
+
+        let mut latched_holder = pass_priority_state();
+        latched_holder.precast_shortcut_runtime.must_diverge = Some(PlayerId(0));
+        fixtures.push(("must_diverge on the holder", latched_holder, PlayerId(0)));
+
+        let mut latched_other = pass_priority_state();
+        latched_other.precast_shortcut_runtime.must_diverge = Some(PlayerId(1));
+        fixtures.push(("must_diverge on another player", latched_other, PlayerId(0)));
+
+        let mut desynced = pass_priority_state();
+        desynced.priority_player = PlayerId(1);
+        fixtures.push(("priority_player desynced", desynced, PlayerId(0)));
+
+        let mut parked_cost_move = pass_priority_state();
+        parked_cost_move.pending_cost_move_resume = Some(PendingCostMoveResume::Foretell {
+            player: PlayerId(0),
+            object_id: ObjectId(1),
+            cost: ManaCost::NoCost,
+            turn_foretold: 1,
+        });
+        fixtures.push(("parked cost-move root", parked_cost_move, PlayerId(0)));
+
+        let mut parked_deferred_life = pass_priority_state();
+        parked_deferred_life.pending_deferred_life_cost_resume =
+            Some(DeferredLifeCostResume::ManaRoot {
+                player: PlayerId(0),
+                resume: Box::new(ManaAbilityResume::Priority),
+                remaining_life_payments: vec![],
+                resume_at_resolution_depth: 0,
+            });
+        fixtures.push((
+            "parked deferred-life root",
+            parked_deferred_life,
+            PlayerId(0),
+        ));
+
+        let mut accepted = 0usize;
+        let mut rejected = 0usize;
+        for (label, state, seat) in &fixtures {
+            let candidate = authorized_pass_candidate(state, *seat);
+            if structurally_valid_pass_priority(state, &candidate) {
+                accepted += 1;
+                assert!(
+                    pass_oracle_accepts(state, &candidate),
+                    "[{label}] the hatch accepted a pass the authoritative simulation rejects"
+                );
+            } else {
+                rejected += 1;
+            }
+        }
+
+        assert!(
+            accepted > 0,
+            "non-vacuity: a predicate stuck at `false` must not report green"
+        );
+        assert!(
+            rejected > 0,
+            "non-vacuity: a predicate stuck at `true` must not report green"
+        );
+    }
+
+    /// T6. CR 732.2c: the divergence latch blocks only its own owner.
+    ///
+    /// The `Some(P0)` half is the load-bearing negative — a predicate that
+    /// omitted the latch entirely would over-accept and violate the soundness
+    /// condition. The `Some(P1)` half is its non-vacuity partner and catches the
+    /// opposite mistake, a predicate written as `must_diverge.is_some()`.
+    #[test]
+    fn pass_priority_hatch_honors_the_divergence_latch_owner() {
+        let mut blocked = pass_priority_state();
+        blocked.precast_shortcut_runtime.must_diverge = Some(PlayerId(0));
+        let blocked_candidate = authorized_pass_candidate(&blocked, PlayerId(0));
+        assert!(!structurally_valid_pass_priority(
+            &blocked,
+            &blocked_candidate
+        ));
+        assert!(
+            !pass_oracle_accepts(&blocked, &blocked_candidate),
+            "reach-guard: the reducer must actually reject this pass"
+        );
+
+        let mut unblocked = pass_priority_state();
+        unblocked.precast_shortcut_runtime.must_diverge = Some(PlayerId(1));
+        let unblocked_candidate = authorized_pass_candidate(&unblocked, PlayerId(0));
+        assert!(structurally_valid_pass_priority(
+            &unblocked,
+            &unblocked_candidate
+        ));
+        assert!(pass_oracle_accepts(&unblocked, &unblocked_candidate));
+    }
+
+    /// T6b. The over-accept direction, at the public `legal_actions` boundary.
+    ///
+    /// This passes on the unfixed tree — today the expensive clone is what
+    /// removes the pass — so it is a no-drift guard, and the most important one
+    /// in the set: it is what goes red if the hatch is written without gate
+    /// (d)'s `blocks_pass` component. That omission is invisible to every
+    /// latch-free fixture, and it would be a live over-accept: `legal_actions`
+    /// would start offering an action the reducer rejects.
+    ///
+    /// `must_diverge` is `pub(crate)`, so this cannot live in
+    /// `tests/integration/` and stays here beside T6.
+    #[test]
+    fn legal_actions_excludes_a_pass_blocked_by_the_divergence_latch() {
+        use crate::game::scenario::{GameScenario, P0};
+        use crate::types::phase::Phase;
+
+        let mut runner = {
+            let mut scenario = GameScenario::new();
+            scenario.at_phase(Phase::PreCombatMain);
+            scenario.build()
+        };
+        runner.state_mut().precast_shortcut_runtime.must_diverge = Some(P0);
+
+        assert!(
+            !crate::ai_support::legal_actions(runner.state()).contains(&GameAction::PassPriority),
+            "a pass the reducer rejects must never appear in legal_actions"
+        );
+        assert!(
+            matches!(
+                crate::game::engine::apply_as_current(runner.state_mut(), GameAction::PassPriority),
+                Err(crate::game::engine::EngineError::ActionNotAllowed(_))
+            ),
+            "reach-guard: the enumeration verdict and the reducer must agree"
+        );
+    }
+
+    /// T7. Gate (b) at the hatch: a parked payment root defers to the
+    /// simulation, because the pass boundary would then run a fallible
+    /// continuation drain this predicate does not model.
+    ///
+    /// The gate is `Option::is_some` on the two fields, so the variants below
+    /// are the cheapest constructible representatives rather than the specific
+    /// fallible roots. The both-`None` sibling is the reach-guard proving the
+    /// refusals came from the field gate.
+    #[test]
+    fn pass_priority_hatch_defers_when_a_payment_root_is_parked() {
+        use crate::types::game_state::{
+            DeferredLifeCostResume, ManaAbilityResume, PendingCostMoveResume,
+        };
+
+        let clean = pass_priority_state();
+        let clean_candidate = authorized_pass_candidate(&clean, PlayerId(0));
+        assert!(structurally_valid_pass_priority(&clean, &clean_candidate));
+
+        let mut parked_cost_move = pass_priority_state();
+        parked_cost_move.pending_cost_move_resume = Some(PendingCostMoveResume::Foretell {
+            player: PlayerId(0),
+            object_id: ObjectId(1),
+            cost: ManaCost::NoCost,
+            turn_foretold: 1,
+        });
+        assert!(!structurally_valid_pass_priority(
+            &parked_cost_move,
+            &authorized_pass_candidate(&parked_cost_move, PlayerId(0))
+        ));
+
+        let mut parked_deferred_life = pass_priority_state();
+        parked_deferred_life.pending_deferred_life_cost_resume =
+            Some(DeferredLifeCostResume::ManaRoot {
+                player: PlayerId(0),
+                resume: Box::new(ManaAbilityResume::Priority),
+                remaining_life_payments: vec![],
+                resume_at_resolution_depth: 0,
+            });
+        assert!(!structurally_valid_pass_priority(
+            &parked_deferred_life,
+            &authorized_pass_candidate(&parked_deferred_life, PlayerId(0))
+        ));
+    }
+
+    /// T8. Gate (c): candidate-actor identity. `PassPriority` carries no
+    /// payload, so submitter identity IS half of its legality.
+    ///
+    /// The `None` sibling is the reach-guard for `fallback_simulation`'s own
+    /// `.or_else(authorized_submitters(state).first())` resolution — the hatch
+    /// must accept exactly the case that resolves to the same actor the
+    /// authority derives.
+    #[test]
+    fn pass_priority_hatch_rejects_a_mismatched_candidate_actor() {
+        let state = pass_priority_state();
+
+        let mismatched = CandidateAction {
+            action: GameAction::PassPriority,
+            metadata: crate::ai_support::ActionMetadata::for_actor(
+                Some(PlayerId(1)),
+                crate::ai_support::TacticalClass::Pass,
+            ),
+        };
+        assert!(!structurally_valid_pass_priority(&state, &mismatched));
+        assert!(
+            matches!(
+                crate::game::engine::apply_interaction_for_simulation(
+                    &mut state.clone(),
+                    PlayerId(1),
+                    PlayerId(1),
+                    GameAction::PassPriority,
+                ),
+                Err(crate::game::engine::EngineError::WrongPlayer)
+            ),
+            "reach-guard: the hatch's refusal must match the oracle's rejection"
+        );
+
+        let unstamped = CandidateAction {
+            action: GameAction::PassPriority,
+            metadata: crate::ai_support::ActionMetadata::for_actor(
+                None,
+                crate::ai_support::TacticalClass::Pass,
+            ),
+        };
+        assert!(structurally_valid_pass_priority(&state, &unstamped));
+        assert!(pass_oracle_accepts(&state, &unstamped));
     }
 
     fn empty_search_state() -> GameState {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6795,17 +6795,10 @@ fn apply_action(
     // Validate and process action against current WaitingFor
     let waiting_for = match (&state.waiting_for.clone(), action) {
         (WaitingFor::Priority { player }, GameAction::PassPriority) => {
-            if state.priority_player
-                != turn_control::authorized_submitter_for_player(state, *player)
-            {
-                return Err(EngineError::NotYourPriority);
-            }
-            if super::precast_copy_shortcut::blocks_pass(state, *player) {
-                return Err(EngineError::ActionNotAllowed(
-                    "A shortened pre-cast shortcut requires a different meaningful action before passing"
-                        .to_string(),
-                ));
-            }
+            // CR 117.3d + CR 723.5 + CR 732.2a-c: single authority, shared with the
+            // AI candidate-legality hatch and the projection fast path so the
+            // three cannot drift.
+            super::priority::pass_priority_legality(state, *player)?;
             let wf = pass_priority_once_with_pipeline(state, &mut events, stack_resolution_limit)?;
             return Ok(ActionResult {
                 events,
@@ -15233,7 +15226,22 @@ mod stage2_injector_tests {
                 // is the producer this row NAMES below. The old coordinate now holds
                 // copy-target-slot code that mints nothing. The OTHER FOUR entries did not
                 // move, which is the same set-preservation evidence as the previous rebases.
-                "game/engine.rs:11427".to_string(),
+                //
+                // `PassPriority` structural-legality unit: `:11427 ⇒ :11420`, −7. UNLIKE every
+                // drift above, this one is LOCAL, not upstream — the CI-vs-local diagnosis in
+                // the header does not apply, because the shift originates in this same diff.
+                // The `(Priority, PassPriority)` reducer arm's two inline guards were extracted
+                // into `game::priority::pass_priority_legality`, replacing 11 lines with 4.
+                // That is engine.rs's only hunk ABOVE this producer — `@@ -6798,11 +6798,4 @@`,
+                // net -7, exactly accounting for the shift. The unit's only other engine.rs
+                // hunk is THIS drift-log comment, which sits below the producer and therefore
+                // cannot move it. Identity re-established at the new
+                // coordinate rather than assumed: the line is byte-identical by sha256 to
+                // `93da0ca15:engine.rs:11427`, and it is still inside
+                // `begin_pending_trigger_target_selection` (fn now opens at :11271, itself −7).
+                // The OTHER FOUR entries live in `game/effects/`, which this unit does not
+                // touch at all, and did not move — the same set-preservation evidence.
+                "game/engine.rs:11420".to_string(),
             ],
             "the five production producers, NAMED: the CR 603.5 gate in `resolve_chain_body` \
              plus the two repeated-optional-payment drivers, the per-player acceptance cursor \

--- a/crates/engine/src/game/priority.rs
+++ b/crates/engine/src/game/priority.rs
@@ -1,8 +1,11 @@
+use crate::game::engine::EngineError;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{AutoPassMode, GameState, WaitingFor};
 use crate::types::player::PlayerId;
 
 use super::players;
+use super::precast_copy_shortcut;
+use super::turn_control;
 use super::turns;
 
 /// Handle a priority pass from the current priority player (CR 117.4).
@@ -133,6 +136,90 @@ pub fn handle_priority_pass_with_limit(
 
         WaitingFor::Priority { player: next }
     }
+}
+
+/// CR 117.3d: "If a player has priority and chooses not to take any actions,
+/// that player passes." Passing is available to the holder of any live priority
+/// window; this is the single authority for the two conditions under which the
+/// engine nevertheless refuses one.
+///
+/// CR 723.5: under a turn-control effect the authorized submitter for the
+/// holder's seat is the controller, so the live `priority_player` must be
+/// compared against that mapped submitter, never against the seat itself.
+///
+/// CR 732.2a-c: a shortened pre-cast shortcut proposal (CR 732.2a-b) obliges the
+/// player who now has priority to "make a different game choice than what was
+/// originally proposed" (CR 732.2c). The runtime models that obligation as a
+/// divergence latch, and a bare pass can never discharge it.
+///
+/// Both the `(Priority, PassPriority)` reducer arm and
+/// `pass_priority_structurally_legal` below call this, so no fast path can drift
+/// from the reducer.
+pub fn pass_priority_legality(state: &GameState, player: PlayerId) -> Result<(), EngineError> {
+    if state.priority_player != turn_control::authorized_submitter_for_player(state, player) {
+        return Err(EngineError::NotYourPriority);
+    }
+    if precast_copy_shortcut::blocks_pass(state, player) {
+        return Err(EngineError::ActionNotAllowed(
+            "A shortened pre-cast shortcut requires a different meaningful action before passing"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// `true` iff a bare `PassPriority` by `player` is legal **and** the pass
+/// boundary is decidable without simulating it.
+///
+/// This is the single predicate shared by every structural fast path for a pass
+/// — the AI legality hatch (`ai_support::filter`) and the `phase-ai` forward
+/// projection. Both must ask exactly this question; a caller that re-derives a
+/// weaker approximation reintroduces the drift `pass_priority_legality` exists to
+/// prevent.
+///
+/// CR 118.3b + CR 119.4 + CR 616.1: a parked deferred-life or cost-move payment
+/// root makes the pass boundary drain a continuation
+/// (`engine::resume_pending_continuation_if_priority`, whose own annotation on
+/// that seam cites these same three rules), and that drain's failure modes are
+/// not modelled here. Both fallible `?` sites in the drain are gated on exactly
+/// these two fields being `Some`, so refusing on either is a sound, O(1)
+/// over-approximation for roots that are already parked when this runs.
+///
+/// **Scope limit — read before "simplifying" this.** This test is evaluated
+/// BEFORE the pass boundary. The drain reads these fields AFTER
+/// `handle_priority_pass_with_limit` has resolved the top of the stack (CR
+/// 117.4), so a root parked BY that resolution is not visible here. The
+/// mitigating argument is that parking such a root coincides with installing a
+/// live non-`Priority` prompt, and each fallible drain site re-tests
+/// `WaitingFor::Priority` immediately before firing, so it is skipped at that
+/// boundary and caught here at the next window. The local half of that argument
+/// is visible in `handle_priority_pass_with_limit` above: after a CR 117.4
+/// resolution it returns `state.waiting_for.clone()` untouched and only resets
+/// to `Priority` when the resolved effect requested no interaction. Two links
+/// are read rather than proved, though — the `PaidWithDeferredSubstitution`
+/// variant's doc contract in `game::life_costs`, and that the installed prompt
+/// still stands at the drain instant (the drains are not the first thing after
+/// the resolution: `engine::sync_waiting_for` and the Priority-gated infallible
+/// `effects::drain_pending_continuation` / `effects::resume_resolution_frames`
+/// run before them). So the remainder is a known, booked residual rather than a
+/// closed window.
+///
+/// **Note the direction**: this is a test on the *fields*, not on
+/// `ai_support::classify_payment_continuation`'s verdict — that verdict can be
+/// `NotAffiliated` while a field is still `Some` (see
+/// `ai_support::payment_continuation::classify_parked_cost_move_root` and
+/// `classify_deferred_life_root`), so a verdict test would be strictly weaker
+/// and would let a fallible drain through.
+///
+/// Conservative by design, mirroring `ai_support::structurally_valid_search_selection`:
+/// `false` only costs a simulation, so any shape this does not fully model returns
+/// `false` rather than guessing.
+pub fn pass_priority_structurally_legal(state: &GameState, player: PlayerId) -> bool {
+    if state.pending_deferred_life_cost_resume.is_some() || state.pending_cost_move_resume.is_some()
+    {
+        return false;
+    }
+    pass_priority_legality(state, player).is_ok()
 }
 
 /// Determine the next player to receive priority, using APNAP order (CR 101.4).
@@ -493,6 +580,99 @@ mod tests {
         );
         assert!(state.priority_passes.contains(&PlayerId(0)));
         assert!(!state.priority_passes.contains(&PlayerId(1)));
+    }
+
+    // --- pass legality authority (CR 117.3d / CR 723.5 / CR 732.2c) ---
+
+    /// T1. `pass_priority_legality` is the single expression of the reducer's two
+    /// pass guards. Each arm is asserted separately so a delegation that drops
+    /// one of them cannot pass on the strength of the other.
+    #[test]
+    fn pass_priority_legality_expresses_both_reducer_guards() {
+        // (a) A fresh two-player state: P0 holds priority and is its own
+        // authorized submitter, no divergence latch — the pass is legal.
+        let state = setup();
+        assert!(pass_priority_legality(&state, PlayerId(0)).is_ok());
+
+        // (b) CR 723.5: `priority_player` no longer maps to the seat's
+        // authorized submitter.
+        let mut desynced = setup();
+        desynced.priority_player = PlayerId(1);
+        assert!(matches!(
+            pass_priority_legality(&desynced, PlayerId(0)),
+            Err(EngineError::NotYourPriority)
+        ));
+
+        // (c) CR 732.2c: a shortened pre-cast shortcut obliges its owner to make
+        // a different game choice; a bare pass can never discharge it.
+        let mut latched = setup();
+        latched.precast_shortcut_runtime.must_diverge = Some(PlayerId(0));
+        let Err(EngineError::ActionNotAllowed(message)) =
+            pass_priority_legality(&latched, PlayerId(0))
+        else {
+            panic!("a latched divergence obligation must reject a bare pass");
+        };
+        assert!(
+            message.contains("shortened pre-cast shortcut"),
+            "the reducer's exact message must be preserved by the extraction, got {message:?}"
+        );
+    }
+
+    /// T1b. `pass_priority_structurally_legal` is the authority PLUS the
+    /// parked-continuation field gate — not an alias for
+    /// `pass_priority_legality(..).is_ok()`.
+    ///
+    /// Each `false` case re-asserts that `pass_priority_legality` is still `Ok`
+    /// in the same state. That paired positive is the non-vacuity partner: it
+    /// proves the refusal came from the field gate and not from the authority,
+    /// so collapsing the two functions into one goes red here.
+    ///
+    /// The gate is `Option::is_some` on the two fields, so it is deliberately
+    /// variant-agnostic; the variants below are the cheapest constructible
+    /// representatives. `DeferredLifeCostResume::ManaRoot` is one of the two
+    /// fallible deferred-life roots that motivate the gate.
+    #[test]
+    fn pass_priority_structurally_legal_adds_the_parked_continuation_gate() {
+        use crate::types::game_state::{
+            DeferredLifeCostResume, ManaAbilityResume, PendingCostMoveResume,
+        };
+
+        let clean = setup();
+        assert!(pass_priority_structurally_legal(&clean, PlayerId(0)));
+
+        let mut deferred_life = setup();
+        deferred_life.pending_deferred_life_cost_resume = Some(DeferredLifeCostResume::ManaRoot {
+            player: PlayerId(0),
+            resume: Box::new(ManaAbilityResume::Priority),
+            remaining_life_payments: vec![],
+            resume_at_resolution_depth: 0,
+        });
+        assert!(!pass_priority_structurally_legal(
+            &deferred_life,
+            PlayerId(0)
+        ));
+        assert!(
+            pass_priority_legality(&deferred_life, PlayerId(0)).is_ok(),
+            "the refusal must come from the field gate, not from the authority"
+        );
+
+        let mut cost_move = setup();
+        cost_move.pending_cost_move_resume = Some(PendingCostMoveResume::LoyaltyActivation {
+            player: PlayerId(0),
+            pw_id: crate::types::identifiers::ObjectId(1),
+            resolved: Box::new(ResolvedAbility::new(
+                crate::types::ability::Effect::NoOp,
+                vec![],
+                crate::types::identifiers::ObjectId(1),
+                PlayerId(0),
+            )),
+            ability_index: 0,
+        });
+        assert!(!pass_priority_structurally_legal(&cost_move, PlayerId(0)));
+        assert!(
+            pass_priority_legality(&cost_move, PlayerId(0)).is_ok(),
+            "the refusal must come from the field gate, not from the authority"
+        );
     }
 
     #[test]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -810,6 +810,7 @@ mod ozolith_leaves_battlefield_counters;
 mod painters_servant_multi_zone_additive_color;
 mod palisade_giant_redirect;
 mod panther_habit_equipped_prevention_scope;
+mod pass_priority_structural_legality;
 mod peer_into_the_abyss;
 mod peerless_recycling_gift_recipient;
 mod pendrell_flux_unless_pay_own_cost;

--- a/crates/engine/tests/integration/pass_priority_structural_legality.rs
+++ b/crates/engine/tests/integration/pass_priority_structural_legality.rs
@@ -1,0 +1,343 @@
+//! `PassPriority` structural legality at the public `legal_actions` boundary.
+//!
+//! CR 117.3d ("If a player has priority and chooses not to take any actions,
+//! that player passes") makes a bare pass an O(1) question, but before the
+//! fifth `SimulationFilter` structural hatch it was answered by cloning the
+//! whole `GameState` and performing the pass — at every priority window every
+//! consumer of `legal_actions` reached. These tests pin the clone away with
+//! exact `perf_counters` integers (never a timing assertion) and pin the hatch's
+//! soundness across the CR 117.4 resolution seam.
+
+use engine::ai_support::legal_actions;
+use engine::game::engine::apply_for_simulation;
+use engine::game::perf_counters;
+use engine::game::priority::pass_priority_structurally_legal;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::turn_control;
+use engine::game::zones::create_object;
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{
+    CastingVariant, GameState, PendingContinuation, StackEntry, StackEntryKind, WaitingFor,
+};
+use engine::types::identifiers::CardId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// T2. The hatch removes the clone at the exact call the projection makes.
+///
+/// **Fixture pin (i) + (ii):** both hands are empty AND the window is
+/// `Phase::Upkeep`, not a main phase. `candidates::priority_actions_with_probe`
+/// enumerates one `PlayLand` per playable land in hand whenever
+/// `is_main_phase && stack_empty && is_active` and the land-drop budget is
+/// unspent, and `PlayLand` has no structural hatch — so it would reach
+/// `fallback_simulation` and increment `state_clone_for_legality` even with a
+/// correct implementation. Do not relax the `assert_eq!` below to an
+/// inequality; repin the fixture instead.
+///
+/// `contains(PassPriority)` is the reach-guard: it passes either way by design
+/// and exists so the counter assertion cannot be satisfied vacuously by an
+/// empty action list.
+#[test]
+fn legal_actions_answers_a_bare_pass_without_cloning_the_state() {
+    let runner = {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::Upkeep);
+        scenario.build()
+    };
+    let state = runner.state();
+    assert!(state.players[P0.0 as usize].hand.is_empty());
+    assert!(state.stack.is_empty());
+
+    perf_counters::reset();
+    let actions = legal_actions(state);
+    let counters = perf_counters::snapshot();
+
+    assert!(
+        actions.contains(&GameAction::PassPriority),
+        "reach-guard: the pass must actually be enumerated at this window"
+    );
+    assert_eq!(
+        counters.state_clone_for_legality, 0,
+        "a bare pass must be decided structurally, with no legality clone"
+    );
+}
+
+/// T5. Hostile, multi-authority: CR 723.5 turn control, where the seat that
+/// holds priority (P1) is not the authorized submitter (P0).
+///
+/// **Fixture pin (ii):** the window is `Phase::Upkeep`, not a main phase, and
+/// both hands are empty — so no `PlayLand` candidate is enumerated for P1.
+///
+/// This is the fixture that catches a predicate comparing `state.priority_player`
+/// against the raw seat instead of `turn_control::authorized_submitter_for_player`
+/// — the exact bug `turn_control_priority_softlock` documents. The
+/// priority-movement assertion is the reach-guard proving this is a real,
+/// reducer-accepted pass rather than a degenerate state.
+#[test]
+fn legal_actions_answers_a_turn_controlled_pass_without_cloning_the_state() {
+    let mut runner = {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::Upkeep);
+        scenario.build()
+    };
+    {
+        let state = runner.state_mut();
+        // CR 723: P0 controls P1's turn.
+        state.active_player = P1;
+        state.turn_decision_controller = Some(P0);
+        state.priority_passes.clear();
+        engine::game::public_state::sync_waiting_for(state, &WaitingFor::Priority { player: P1 });
+    }
+    assert!(runner.state().players[P1.0 as usize].hand.is_empty());
+    assert_ne!(
+        runner.state().priority_player,
+        P1,
+        "reach-guard: under turn control the submitter must not be the seat"
+    );
+
+    perf_counters::reset();
+    let actions = legal_actions(runner.state());
+    let counters = perf_counters::snapshot();
+
+    assert!(
+        actions.contains(&GameAction::PassPriority),
+        "reach-guard: the controlled seat's pass must be enumerated"
+    );
+    assert_eq!(
+        counters.state_clone_for_legality, 0,
+        "a turn-controlled bare pass must be decided structurally too"
+    );
+
+    engine::game::engine::apply_as_current(runner.state_mut(), GameAction::PassPriority)
+        .expect("the enumerated pass must be reducer-accepted");
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P0),
+        "reach-guard: after the controlled seat passes, priority must move to P0's seat, got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+/// T4b. The soundness property across the CR 117.4 resolution seam.
+///
+/// The hatch is evaluated BEFORE the pass boundary, but `pass_priority_once_with_pipeline`
+/// runs `priority::handle_priority_pass_with_limit` FIRST — which, on the
+/// all-players-passed pass, resolves the top of the stack and executes arbitrary
+/// effect logic — and only then runs the continuation drains and
+/// `run_post_action_pipeline`. Every fixture here therefore makes the accepted
+/// pass the pass that actually resolves (or ends the phase), so a
+/// post-resolution error surface reachable from a state the hatch accepts
+/// surfaces here.
+///
+/// **Scope note — read before citing a green run here.**
+/// *"Fixture (ii) drains through `effects::drain_pending_continuation`
+/// (`engine.rs:5566`), which is called WITHOUT `?`. The only fallible drains are
+/// `engine.rs:5584` and `:5613-5617`. This test therefore cannot falsify §3.4
+/// residual 5, and a green run here is not evidence about it."*
+///
+/// Falsifying that residual needs a *fallible* root
+/// (`DeferredLifeCostResume::{Cast, ManaRoot}` or
+/// `PendingCostMoveResume::ManaAbilityPayment`) parked from INSIDE the
+/// resolution, which no fixture below does — and which reachability could not be
+/// established for this unit. This test is the standing falsifier for the
+/// `run_post_action_pipeline` / token-realization residuals only.
+///
+/// Note this asserts the shared engine predicate
+/// `game::priority::pass_priority_structurally_legal` rather than
+/// `ai_support::filter::structurally_valid_pass_priority`, which is private to
+/// its module and unreachable from an integration test. That predicate is the
+/// hatch's entire rules judgement; the hatch's remaining two gates (window shape
+/// and candidate-actor identity) hold by construction in every fixture here and
+/// are pinned directly in `filter.rs`'s own tests.
+#[test]
+fn pass_priority_hatch_stays_sound_across_the_resolution_seam() {
+    let mut accepted = 0usize;
+    let mut rejected = 0usize;
+
+    // (i) Baseline: the top of the stack is a plain no-choice spell. The seam
+    // runs and nothing parks.
+    {
+        let mut state = all_players_passed_window();
+        let spell = push_resolvable_spell(&mut state);
+        let before = state.stack.len();
+        assert_eq!(
+            before, 1,
+            "reach-guard: the fixture must have a stack object"
+        );
+        accept_tally(&state, &mut accepted, &mut rejected);
+        let after = pass_and_expect_ok(&state);
+        assert_resolved(&after, spell, before);
+    }
+
+    // (ii) The boundary additionally drains an ordinary ability continuation.
+    // This is the INFALLIBLE `effects::drain_pending_continuation` mechanism —
+    // see the scope note above.
+    {
+        let mut state = all_players_passed_window();
+        let spell = push_resolvable_spell(&mut state);
+        let continuation = ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            vec![],
+            engine::types::identifiers::ObjectId(9001),
+            P0,
+        );
+        let parked = PendingContinuation::new(Box::new(continuation), &state);
+        state.park_ability_continuation(parked);
+        let before = state.stack.len();
+        let life_before = state.players[P0.0 as usize].life;
+        accept_tally(&state, &mut accepted, &mut rejected);
+        let after = pass_and_expect_ok(&state);
+        assert_resolved(&after, spell, before);
+        assert_eq!(
+            after.players[P0.0 as usize].life,
+            life_before + 1,
+            "reach-guard: the parked continuation must ALSO have drained at this boundary. \
+             This is an additional guard on the drain, never a substitute for the \
+             resolution guard above."
+        );
+    }
+
+    // (iii) The all-passed pass ends the phase with an empty stack, so
+    // `run_post_action_pipeline` places any phase triggers. There is no stack
+    // object to resolve here, so the phase change is criterion 11a's equivalent
+    // reach-guard that the seam did real work.
+    {
+        let state = all_players_passed_window();
+        assert!(state.stack.is_empty());
+        accept_tally(&state, &mut accepted, &mut rejected);
+        let after = pass_and_expect_ok(&state);
+        assert_ne!(
+            after.phase, state.phase,
+            "reach-guard: the all-passed empty-stack pass must end the phase"
+        );
+    }
+
+    // Non-vacuity: one fixture the predicate must refuse, where the implication
+    // holds vacuously. `must_diverge` is `pub(crate)`, so the refusal is driven
+    // here by a CR 723.5 submitter desync instead; the latch half is pinned by
+    // `pass_priority_hatch_honors_the_divergence_latch_owner` in `filter.rs`.
+    {
+        let mut state = all_players_passed_window();
+        push_resolvable_spell(&mut state);
+        state.priority_player = P1;
+        accept_tally(&state, &mut accepted, &mut rejected);
+        assert!(
+            !pass_priority_structurally_legal(&state, P0),
+            "a desynced submitter must be refused"
+        );
+    }
+
+    assert!(
+        accepted >= 3,
+        "non-vacuity: a predicate stuck at `false` must not report green (accepted {accepted})"
+    );
+    assert!(
+        rejected > 0,
+        "non-vacuity: a predicate stuck at `true` must not report green"
+    );
+}
+
+/// A two-player `Priority` window on P0 where P1 has already passed, so P0's
+/// pass is the CR 117.4 all-players-passed pass.
+fn all_players_passed_window() -> GameState {
+    let mut runner = {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.build()
+    };
+    {
+        let state = runner.state_mut();
+        state.active_player = P0;
+        state.priority_passes.clear();
+        state.priority_passes.insert(P1);
+        state.priority_pass_count = 1;
+        engine::game::public_state::sync_waiting_for(state, &WaitingFor::Priority { player: P0 });
+    }
+    runner.state().clone()
+}
+
+/// Criterion 11(a): prove the accepted pass actually RESOLVED a stack object
+/// rather than merely handing priority along.
+///
+/// Two independent observables, because stack depth alone is the weaker signal:
+/// the stack shrank, AND the resolving spell reached its owner's graveyard,
+/// which per CR 608.2n is the final step of an instant's resolution and which
+/// nothing but a real resolution performs here. A fixture that silently degraded
+/// into a bare priority handoff fails both.
+fn assert_resolved(after: &GameState, spell: engine::types::identifiers::ObjectId, before: usize) {
+    assert!(
+        after.stack.len() < before,
+        "criterion 11a: the accepted pass must actually resolve a stack object \
+         (stack was {before}, is {})",
+        after.stack.len()
+    );
+    assert!(
+        after.players[P0.0 as usize].graveyard.contains(&spell),
+        "criterion 11a: CR 608.2n — the resolved instant must have reached its \
+         owner's graveyard, proving a real resolution and not a bare handoff"
+    );
+}
+
+/// Put one plain, no-choice instant on the stack so the all-passed pass has an
+/// object to resolve. Returns its `ObjectId` so the caller can prove it resolved.
+fn push_resolvable_spell(state: &mut GameState) -> engine::types::identifiers::ObjectId {
+    let id = create_object(
+        state,
+        CardId(9100),
+        P0,
+        "Structural Legality Test Instant".to_string(),
+        Zone::Stack,
+    );
+    state
+        .objects
+        .get_mut(&id)
+        .expect("just-created stack object")
+        .card_types
+        .core_types
+        .push(engine::types::card_type::CoreType::Instant);
+    state.stack.push_back(StackEntry {
+        id,
+        source_id: id,
+        controller: P0,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(9100),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 0,
+        },
+    });
+    id
+}
+
+/// Record whether the predicate accepted, and assert the soundness implication
+/// when it did: an accepted pass must be one the authoritative boundary runs
+/// without error.
+fn accept_tally(state: &GameState, accepted: &mut usize, rejected: &mut usize) {
+    if pass_priority_structurally_legal(state, P0) {
+        *accepted += 1;
+        let mut sim = state.clone();
+        let actor = turn_control::authorized_submitter_for_player(state, P0);
+        assert!(
+            apply_for_simulation(&mut sim, actor, GameAction::PassPriority).is_ok(),
+            "the predicate accepted a pass whose real boundary errors"
+        );
+        assert!(
+            legal_actions(state).contains(&GameAction::PassPriority),
+            "reach-guard: an accepted pass must reach the public legal_actions list"
+        );
+    } else {
+        *rejected += 1;
+    }
+}
+
+/// Perform the accepted pass for real and return the resulting state.
+fn pass_and_expect_ok(state: &GameState) -> GameState {
+    let mut applied = state.clone();
+    let actor = turn_control::authorized_submitter_for_player(state, P0);
+    apply_for_simulation(&mut applied, actor, GameAction::PassPriority)
+        .expect("an accepted pass must apply cleanly");
+    applied
+}

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -329,7 +329,11 @@ fn resolve_choice(
     // being `Some`, which is exactly when the pass boundary runs a fallible
     // continuation drain.
     //
-    // CR 601.2g-h ordering is preserved without hoisting
+    // Each parked field carries its own CR annotation on `GameState`, and they
+    // are not the same rule: `pending_cost_move_resume` is CR 601.2h (a cost
+    // that moves objects, paid in a defined order), `pending_deferred_life_cost_resume`
+    // is CR 118.3b + CR 119.4 (a life payment already committed). That ordering,
+    // together with CR 601.2g's mana-ability window, is preserved without hoisting
     // `classify_payment_continuation`: at a `Priority` window with both parked
     // fields `None`, that classifier necessarily returns `NotAffiliated`
     // (its deferred-life short-circuit needs a parked root, `Priority` matches

--- a/crates/phase-ai/src/projection.rs
+++ b/crates/phase-ai/src/projection.rs
@@ -17,6 +17,7 @@ use engine::ai_support::{
 };
 use engine::game::combat::AttackTarget;
 use engine::game::engine::{apply_for_simulation, EngineError};
+use engine::game::priority;
 use engine::types::game_state::{ManaChoice, ManaChoicePrompt};
 use engine::types::{
     CoreType, GameAction, GameState, ObjectId, PayCostKind, Phase, PlayerId, WaitingFor,
@@ -311,6 +312,35 @@ fn resolve_choice(
         .ok_or_else(|| BailReason::NoLegalAction {
             waiting_for: format!("{:?}", state.waiting_for),
         })?;
+
+    // CR 117.3d: at a priority window whose pass the engine can decide without
+    // simulating the boundary, the projection's only policy is "pass if you can"
+    // (`pick_pass_or_first`). That is an O(1) question the engine answers
+    // directly, so skip the full `legal_actions` enumeration — which builds a
+    // `PriorityCastProbe` (a `GameState` clone + `flush_layers` + auto-tap
+    // cache), validates every castable spell, activatable ability and land
+    // drop, and discards a grouped per-object map.
+    //
+    // `pass_priority_structurally_legal` is the SAME predicate the engine's
+    // `SimulationFilter` pass hatch uses. Do not substitute a local
+    // approximation: in particular a `classify_payment_continuation(state) ==
+    // NotAffiliated` test is strictly WEAKER — that verdict is compatible with
+    // `pending_deferred_life_cost_resume` / `pending_cost_move_resume` still
+    // being `Some`, which is exactly when the pass boundary runs a fallible
+    // continuation drain.
+    //
+    // CR 601.2g-h ordering is preserved without hoisting
+    // `classify_payment_continuation`: at a `Priority` window with both parked
+    // fields `None`, that classifier necessarily returns `NotAffiliated`
+    // (its deferred-life short-circuit needs a parked root, `Priority` matches
+    // none of its `waiting_for` arms, and its parked-cost-move fallback returns
+    // `NotAffiliated` when no root is parked), so this fast path can never steal
+    // a window the payment witness below owns.
+    if let WaitingFor::Priority { player } = state.waiting_for {
+        if priority::pass_priority_structurally_legal(state, player) {
+            return Ok((acting, GameAction::PassPriority, false, None));
+        }
+    }
 
     let actions = legal_actions(state);
     if actions.is_empty() {
@@ -630,8 +660,12 @@ pub fn threat_velocity(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use engine::game::scenario::{GameScenario, P0};
     use engine::game::zones::create_object;
+    use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+    use engine::types::game_state::{DeferredLifeCostResume, PendingCast, PendingCostMoveResume};
     use engine::types::identifiers::CardId;
+    use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
     use engine::types::zones::Zone;
 
     #[test]
@@ -721,6 +755,197 @@ mod tests {
             is_policy_choice,
             "declining an optional shortcut is a policy choice"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Priority fast path (CR 117.3d).
+    //
+    // Every assertion below is an exact `perf_counters` integer. Nothing here
+    // measures time: a wall-clock assertion is the defect class this change
+    // exists to remove.
+    // ------------------------------------------------------------------
+
+    /// A `Priority` window on P0 with a wide, fully-enumerable board: three
+    /// untapped lands and three castable instants. Mirrors the engine's own
+    /// `legal_actions_priority_cast_probe_reuses_one_flushed_state_and_one_auto_tap_cache`
+    /// fixture, so a full enumeration here demonstrably builds a
+    /// `PriorityCastProbe` and its auto-tap source cache.
+    fn wide_priority_board() -> GameState {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        for _ in 0..3 {
+            scenario.add_basic_land(P0, ManaColor::Blue);
+        }
+        for i in 0..3 {
+            scenario
+                .add_spell_to_hand(P0, &format!("Blue Spell {i}"), true)
+                .with_ability(Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                })
+                .with_mana_cost(ManaCost::Cost {
+                    shards: vec![ManaCostShard::Blue],
+                    generic: 0,
+                });
+        }
+        scenario.build().state().clone()
+    }
+
+    /// An empty `Priority` window on P0 outside a main phase.
+    ///
+    /// **Fixture pin (i) + (ii):** empty hand AND a non-main-phase window, so
+    /// `candidates::priority_actions_with_probe` cannot enumerate a `PlayLand`
+    /// candidate. `PlayLand` has no structural hatch, so each one would reach
+    /// `fallback_simulation` and inflate `state_clone_for_legality` even with a
+    /// correct implementation. Never relax the exact counter assertions below to
+    /// inequalities; repin the fixture instead.
+    fn bare_priority_window() -> GameState {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::Upkeep);
+        scenario.build().state().clone()
+    }
+
+    /// T9. The fast path removes both clones AND the whole enumeration.
+    ///
+    /// The three action assertions pass either way and are reach-guards; the
+    /// three exact zero counters are the evidence. No fixture pin is needed —
+    /// the fast path returns before enumeration, so the lands and spells on this
+    /// board only make the test stronger.
+    #[test]
+    fn priority_fast_path_skips_enumeration_entirely() {
+        let state = wide_priority_board();
+
+        engine::game::perf_counters::reset();
+        let (_actor, action, is_policy_choice, successor) =
+            resolve_choice(&state, PlayerId(0), PlayerId(1)).expect("a bare pass is available");
+        let counters = engine::game::perf_counters::snapshot();
+
+        assert_eq!(action, GameAction::PassPriority);
+        assert!(!is_policy_choice);
+        assert!(successor.is_none());
+        assert_eq!(
+            counters.priority_cast_probe_builds, 0,
+            "the fast path must not build a PriorityCastProbe"
+        );
+        assert_eq!(
+            counters.state_clone_for_legality, 0,
+            "the fast path must not pay a legality clone"
+        );
+        assert_eq!(
+            counters.auto_tap_source_cache_builds, 0,
+            "the fast path must not build the auto-tap source cache"
+        );
+    }
+
+    /// T7p. The fast path's gate is a test on the two parked-continuation
+    /// FIELDS, not on `classify_payment_continuation`'s verdict.
+    ///
+    /// `DeferredLifeCostResume::PayAmount` is exactly the divergence: the
+    /// classifier reports `NotAffiliated` while the field is still `Some`, which
+    /// is the state in which the pass boundary would run a fallible continuation
+    /// drain. The explicit `NotAffiliated` assertion is the non-vacuity guard —
+    /// without it the test would not be exercising the divergence at all.
+    ///
+    /// Both counters go to `0` if the fast path is gated on the classifier's
+    /// verdict instead of on `pass_priority_structurally_legal`. The returned
+    /// action is deliberately NOT asserted: a successful drain legitimately
+    /// yields `PassPriority` with `is_policy_choice == false` and no successor,
+    /// which is indistinguishable from a fast-path return by shape alone.
+    #[test]
+    fn priority_fast_path_declines_on_a_parked_deferred_life_root() {
+        let mut state = bare_priority_window();
+        state.pending_deferred_life_cost_resume = Some(DeferredLifeCostResume::PayAmount {
+            player: PlayerId(0),
+            total: 0,
+            resume_at_resolution_depth: 0,
+        });
+        assert_eq!(
+            classify_payment_continuation(&state),
+            PaymentContinuationState::NotAffiliated,
+            "non-vacuity: this fixture must be one where the verdict gate and the field gate disagree"
+        );
+
+        engine::game::perf_counters::reset();
+        let _ = resolve_choice(&state, PlayerId(0), PlayerId(1));
+        let counters = engine::game::perf_counters::snapshot();
+
+        assert_eq!(
+            counters.priority_cast_probe_builds, 1,
+            "the fast path must have declined, so the full enumeration ran"
+        );
+        assert_eq!(
+            counters.state_clone_for_legality, 1,
+            "the hatch must also have declined, deferring the pass to one simulation"
+        );
+    }
+
+    /// T10. The fallback path does not drift when the fast path declines.
+    ///
+    /// Passes either way by construction — a no-drift guard, not evidence of the
+    /// fix. Assertion (i) goes red if the fast path is made unconditional;
+    /// assertion (ii) goes red if the enumeration path is removed.
+    ///
+    /// Asserted on the whole `Result`: with `priority_player` desynced every
+    /// candidate is refused by the reducer, so `Err(NoLegalAction)` is a
+    /// legitimate outcome and must not be unwrapped.
+    #[test]
+    fn priority_fallback_path_runs_when_the_fast_path_declines() {
+        let mut state = wide_priority_board();
+        state.priority_player = PlayerId(1);
+
+        engine::game::perf_counters::reset();
+        let result = resolve_choice(&state, PlayerId(0), PlayerId(1));
+        let counters = engine::game::perf_counters::snapshot();
+
+        assert!(
+            !matches!(result, Ok((_, GameAction::PassPriority, ..))),
+            "the fast path must not fire when `pass_priority_legality` refuses"
+        );
+        assert_eq!(
+            counters.priority_cast_probe_builds, 1,
+            "the enumeration path must actually have run"
+        );
+    }
+
+    /// T11. A parked payment carrier at a `Priority` window still routes to the
+    /// payment witness, not to the fast path.
+    ///
+    /// Passes on the unfixed tree — a no-drift guard. It is what fails if the
+    /// `waiting_for` dispatch is hoisted above `classify_payment_continuation`.
+    /// Under this change it is doubly protected (the field gate refuses this
+    /// state before the classifier is consulted), but it stays because it pins
+    /// the observable contract rather than the implementation route.
+    #[test]
+    fn parked_payment_carrier_still_routes_to_the_payment_witness() {
+        let mut state = bare_priority_window();
+        let pending = PendingCast::new(
+            ObjectId(9200),
+            CardId(9200),
+            ResolvedAbility::new(Effect::NoOp, vec![], ObjectId(9200), PlayerId(0)),
+            ManaCost::NoCost,
+        );
+        state.pending_cost_move_resume = Some(PendingCostMoveResume::ActivationMillPayment {
+            player: PlayerId(0),
+            pending: Box::new(pending),
+        });
+        assert!(
+            matches!(
+                classify_payment_continuation(&state),
+                PaymentContinuationState::Affiliated(_)
+            ),
+            "non-vacuity: the fixture must actually reach the witness branch"
+        );
+
+        match resolve_choice(&state, PlayerId(0), PlayerId(1)) {
+            Ok((_, action, _, successor)) => {
+                assert!(
+                    successor.is_some(),
+                    "an affiliated payment window must return a witnessed successor, got {action:?}"
+                );
+            }
+            Err(BailReason::NoLegalManaPayment) => {}
+            other => panic!("expected the payment-witness branch, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Refs #6967 — the projection cost measured here is one input to that gate's wall-clock failures; this does not on its own close it.

## What

`SimulationFilter` validated `PassPriority` by cloning the whole `GameState` and running `apply_interaction_for_simulation` on it — a throwaway simulation of the very dispatch the caller was about to perform for real. At a priority window `legal_actions_full` also builds a `PriorityCastProbe`, which clones again and flushes layers even when they are clean. Two full state clones, to answer a question CR 117.3d makes near-constant: may this player pass?

This adds a fifth structural hatch alongside the four #6973 shipped, so a pass is decided without the clone.

## Why now

`phase-ai`'s forward projection pays that cost at every step. Measured in the AI gate (dev profile, Medium, `--games 3`):

| | base | cap lifted |
|---|---|---|
| projections exceeding the 15 ms cap | **371 / 371** | 0 |
| loop iterations | 840 | 48,019 |
| slowest single projection | — | 22.97 s |

371/371 means the evasion policy's velocity term produced **no signal at all** — `project_to` is not an anytime search, so a truncated projection returns `Err` and scores 0.0. The wall clock was not protecting a working feature; it had reduced the feature to pure overhead, and lifting it made the underlying cost visible rather than creating it.

## Design

One authority, three delegating call sites, none of which restates the judgement:

- `game::priority::pass_priority_legality` — the reducer's own two guards, extracted: CR 723.5 seat-vs-submitter, and the CR 732.2c divergence latch.
- `game::priority::pass_priority_structurally_legal` — that authority plus a refusal on the two parked-continuation fields.
- Call sites: the `(Priority, PassPriority)` reducer arm, the new `SimulationFilter` hatch, and a `resolve_choice` fast path that emits the pass without enumerating.

An earlier revision expressed the field gate separately in the hatch and the projection. That is exactly the drift this shape exists to prevent, and review caught it: the projection gated on `classify_payment_continuation`'s *verdict* while the hatch gated on the *fields*, and those are not equivalent — `classify` returns `NotAffiliated` at six sites where a field is still `Some`.

## Correctness

The hatch must never accept what the authoritative simulation would reject (`ai_support/filter.rs`). Every pre-boundary rejection path is closed: the reducer's two guards, actor authorization, and the two fallible continuation drains, each gated on a field the predicate refuses on.

**One residual is bounded but not closed, and ships documented.** The pass boundary uniquely runs the CR 117.4/608 resolution seam — no cast boundary does — so resolution can park a continuation that the fallible drains then read *after* the predicate ran. Every such park coincides with installing a live non-`Priority` prompt, and both drains re-test `waiting_for == Priority`, so the park is skipped and caught by the field gate at the next window. One link in that chain is read from documentation rather than proved, and **no test in this change can falsify it**. The scope note saying so is in the test's own doc comment, not only in the planning docs, so a green T4b is never misread as evidence about it. Follow-up unit is named in the plan.

Worth stating plainly: #6973 supplies the *shape* here, not the safety argument. `PassPriority` is the only hatched action that reaches the resolution seam.

## Tests

15 tests. Every discriminating one was watched go red against a deliberately broken copy rather than assumed to fail.

- All perf assertions are exact `assert_eq!` on `perf_counters` integers. **Nothing timing-based anywhere** — `grep` the diff for `Duration|Instant|elapsed|sleep` and the only hits are `CoreType::Instant` and a card name. A wall-clock assertion is the defect this change exists to fix.
- Counter fixtures pin away `PlayLand`, which has no structural hatch and would otherwise increment `state_clone_for_legality` and fail those tests *with a correct implementation*.
- `T4b`'s resolving fixtures assert two independent observables — stack depth decreasing **and** CR 608.2n graveyard arrival — so a fixture degrading into a bare priority handoff fails on both.

## Verification

- `cargo clippy -p phase-engine -p phase-ai --all-targets -- -D warnings`: 0 warnings
- 18,473 engine lib + 4,480 integration + 2,008 phase-ai tests: 0 failures
- Parser projection **run, not assumed** (the engine-source-hash key covers all of `crates/engine/src`, so three changed files flip it even though no parser file is touched): **0 clusters**, and base/candidate `card-data.json` are byte-identical from separately built binaries.

## Unplanned edit, flagged

`the_cr_603_5_prompt_census_is_pinned_so_a_sixth_producer_is_a_counted_event` pins five prompt-producer sites by absolute `file:line`. Extracting the reducer arm shortened the file by 7 lines above one of them, moving `engine.rs:11427` → `:11420`. Repaired via the procedure that test's own doc comment mandates, with a drift-log entry: the line is byte-identical by sha256 across the shift, the only hunk above it accounts for exactly −7, and the census's own producer-count partition asserts would have caught a real set change independently of the coordinate.

## Adjacent defect found, NOT fixed here

`coverage-parse-diff` has a latent masking channel. `coverage-report`'s `cards` array order is nondeterministic between runs, and 30 lowercased card-name keys are duplicated in the corpus; the comparator keys a `BTreeMap` by lowercased name, so last-wins resolves a colliding key to a different card per run. It surfaced here as a spurious `oracle_changed: 1`, disproved by the byte-identical normalized payloads. Pre-existing, present identically on both sides, not introduced by this change — but on a future change a real parse regression on a name-colliding card could be silently carved out the same way. Deserves its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster AI decisions during priority windows by recognizing valid pass actions without unnecessary action enumeration.
  * Reduced overhead while preserving fallback handling for complex continuation states.

* **Bug Fixes**
  * Improved validation for authorized players, turn-controlled states, and synchronized priority ownership.
  * Preserved correct behavior for payment, deferred-action, resolution, and phase-transition scenarios.

* **Tests**
  * Added comprehensive coverage for priority transitions, action acceptance, stack resolution, and continuation safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->