### PR TITLE
fix(client): one authority for object activation, and make the attachment fan use it

### DIFF
--- a/client/src/components/board/AttachmentFan.tsx
+++ b/client/src/components/board/AttachmentFan.tsx
@@ -164,16 +164,35 @@ export function AttachmentFan() {
       const verdict = resolveObjectActivation(
         collectObjectActions(store.legalActionsByObject, id),
         store.gameState?.objects[id],
-        affordances.manaTappableObjectIds.has(id),
+        affordances,
+        id,
       );
-      if (verdict.kind === "none") return;
-      // MUST precede opening the modal: the fan is a `fixed inset-0 z-[120]`
-      // backdrop with an `onClick={close}` catcher and DialogHost anchors at z-40,
-      // so a fan left mounted would both paint over and swallow clicks for the
-      // modal it just opened.
-      close();
-      if (verdict.kind === "dispatch") void dispatchAction(verdict.action).catch(notifyFailure);
-      else setPendingAbilityChoice({ objectId: id, actions: verdict.actions });
+      // `close()` MUST precede opening the modal: the fan is a `fixed inset-0
+      // z-[120]` backdrop with an `onClick={close}` catcher and DialogHost anchors
+      // at z-40, so a fan left mounted would both paint over and swallow clicks for
+      // the modal it just opened. It stays inside the two acting arms because
+      // `kind: "none"` must leave the fan exactly as it was.
+      switch (verdict.kind) {
+        case "dispatch":
+          close();
+          void dispatchAction(verdict.action).catch(notifyFailure);
+          return;
+        case "choose":
+          close();
+          setPendingAbilityChoice({ objectId: id, actions: verdict.actions });
+          return;
+        case "none":
+          // Reachable only through the render→click staleness window: the ring was
+          // painted from a bucket this click no longer sees. Doing nothing (and
+          // leaving the fan open) is correct.
+          return;
+        default: {
+          // CLAUDE.md "exhaustive match without wildcard fallbacks": a new
+          // ObjectActivation variant is a compile error here, never a silent drop.
+          const _exhaustive: never = verdict;
+          return _exhaustive;
+        }
+      }
     },
     [
       affordances,

--- a/client/src/components/board/AttachmentFan.tsx
+++ b/client/src/components/board/AttachmentFan.tsx
@@ -4,11 +4,17 @@ import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 
 import type { ObjectId } from "../../adapter/types.ts";
-import { dispatchInteraction } from "../../game/dispatch.ts";
+import { dispatchAction, dispatchInteraction } from "../../game/dispatch.ts";
+import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import { useAppNotificationStore } from "../../stores/appToastStore.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
+import {
+  collectObjectActions,
+  deriveActivationAffordances,
+  resolveObjectActivation,
+} from "../../viewmodel/cardActionChoice.ts";
 import { CardImage } from "../card/CardImage.tsx";
 import { fanGeometry, spreadFactor } from "../card/fanGeometry.ts";
 
@@ -52,8 +58,11 @@ function fanCardSizingStyle(cardCount: number): CSSProperties {
  * independent object), and the fan lets the player choose which one without
  * hunting the peek.
  *
- * The fan NEVER invents a choice — each card lights up (cyan) and dispatches
- * only what the engine's live prompt actually offers for that object. Terminal
+ * The fan NEVER invents a choice. It has exactly two engine-owned sources: an
+ * open interaction's projection (mode 1), and — when no prompt is open — the
+ * permanent's own legal-action bucket read through `deriveActivationAffordances`
+ * (mode 2, the same authority the battlefield ring uses). Each card lights up
+ * (cyan) and dispatches only what one of those two offers for that object. Terminal
  * One-step picks close the fan. Multi-step decisions stay in their dedicated
  * engine-authored interaction surfaces instead of asking this display to build
  * a response payload.
@@ -69,6 +78,24 @@ export function AttachmentFan() {
 
   const objects = useGameStore((s) => s.gameState?.objects);
   const viewerInteraction = useGameStore((s) => s.viewerInteraction);
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
+  const canActForWaitingState = useCanActForWaitingState();
+  const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
+  // Mode 2's gate: THE same affordance sets the battlefield ring uses, so the fan
+  // can never offer what the board would not. `AttachmentFan` is a single portaled
+  // overlay (GamePage.tsx:1885), not a per-permanent component — one subscription,
+  // not an O(board) cost.
+  const affordances = useMemo(
+    () =>
+      deriveActivationAffordances(waitingFor, canActForWaitingState, legalActionsByObject, objects),
+    [waitingFor, canActForWaitingState, legalActionsByObject, objects],
+  );
+  const canActivate = useCallback(
+    (id: ObjectId) =>
+      affordances.activatableObjectIds.has(id) || affordances.manaTappableObjectIds.has(id),
+    [affordances],
+  );
   const host = hostId != null ? objects?.[hostId] : undefined;
   const interactionFan = useMemo(
     () =>
@@ -108,18 +135,55 @@ export function AttachmentFan() {
     return () => window.removeEventListener("keydown", onKey);
   }, [hostId, close]);
 
-  const handlePick = useCallback(
-    (id: ObjectId) => {
-      const child = interactionFan?.children.find((candidate) => candidate.objectId === id);
-      if (!child || !viewerInteraction?.canSubmit) return;
-      void dispatchInteraction(child.submission).then(close).catch((error: unknown) => {
-        showNotification({
-          title: t("actionError.title", { action: t("permanent.fanPick") }),
-          description: error instanceof Error ? error.message : t("actionError.unknownEngineError"),
-        });
+  const notifyFailure = useCallback(
+    (error: unknown) => {
+      showNotification({
+        title: t("actionError.title", { action: t("permanent.fanPick") }),
+        description: error instanceof Error ? error.message : t("actionError.unknownEngineError"),
       });
     },
-    [close, interactionFan, showNotification, t, viewerInteraction?.canSubmit],
+    [showNotification, t],
+  );
+
+  const handlePick = useCallback(
+    (id: ObjectId) => {
+      // Mode 1 — an engine interaction owns the prompt: the projection is the sole
+      // authority and the fan only forwards its opaque submission. UNCHANGED.
+      if (interactionFan !== null) {
+        const child = interactionFan.children.find((candidate) => candidate.objectId === id);
+        if (!child || !viewerInteraction?.canSubmit) return;
+        void dispatchInteraction(child.submission).then(close).catch(notifyFailure);
+        return;
+      }
+      // Mode 2 — no prompt is open, so the fan is a reachability surface for the
+      // permanent's OWN legal actions. Gate and dispatch both come from the shared
+      // authority the battlefield uses. CR 301.5 / CR 303.4: an attached permanent
+      // is its own object.
+      if (!canActivate(id)) return;
+      const store = useGameStore.getState();
+      const verdict = resolveObjectActivation(
+        collectObjectActions(store.legalActionsByObject, id),
+        store.gameState?.objects[id],
+        affordances.manaTappableObjectIds.has(id),
+      );
+      if (verdict.kind === "none") return;
+      // MUST precede opening the modal: the fan is a `fixed inset-0 z-[120]`
+      // backdrop with an `onClick={close}` catcher and DialogHost anchors at z-40,
+      // so a fan left mounted would both paint over and swallow clicks for the
+      // modal it just opened.
+      close();
+      if (verdict.kind === "dispatch") void dispatchAction(verdict.action).catch(notifyFailure);
+      else setPendingAbilityChoice({ objectId: id, actions: verdict.actions });
+    },
+    [
+      affordances,
+      canActivate,
+      close,
+      interactionFan,
+      notifyFailure,
+      setPendingAbilityChoice,
+      viewerInteraction?.canSubmit,
+    ],
   );
 
   if (hostId == null || !host || cardIds.length === 0) return null;
@@ -155,7 +219,7 @@ export function AttachmentFan() {
             rotation={fan.rotation(i)}
             arcOffset={fan.arc(i)}
             zIndex={i}
-            selectable={interactionFan !== null && id !== host.id}
+            selectable={id !== host.id && (interactionFan !== null || canActivate(id))}
             onPick={handlePick}
           />
         ))}

--- a/client/src/components/board/GameBoard.tsx
+++ b/client/src/components/board/GameBoard.tsx
@@ -7,7 +7,7 @@ import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { useCanActForWaitingState, usePerspectivePlayerId, usePlayerId } from "../../hooks/usePlayerId.ts";
 import { sortCreaturesForBlockers } from "../../viewmodel/blockerSorting.ts";
-import { isManaObjectAction } from "../../viewmodel/cardActionChoice.ts";
+import { deriveActivationAffordances } from "../../viewmodel/cardActionChoice.ts";
 import {
   buildPlayerBattlefieldView,
   getBoardChoiceView,
@@ -89,11 +89,19 @@ export const GameBoard = memo(function GameBoard({
   }, [splitBoardActive, playerBattlefieldView, focusedBattlefieldView, blockerAssignments]);
 
   const boardInteractionState = useMemo(() => {
+    // THE single authority (viewmodel/cardActionChoice.ts). Computed BEFORE the
+    // `!gameState?.objects` early return so both returns spread the same value and
+    // no local shadow can exist: deleting the locals makes a stale shorthand key a
+    // compile error (TS18004) instead of a silent board-wide regression.
+    const affordances = deriveActivationAffordances(
+      waitingFor,
+      canActForWaitingState,
+      legalActionsByObject,
+      gameState?.objects,
+    );
     const validTargetObjectIds = new Set<number>();
     const validAttackerIds = new Set<number>();
-    const activatableObjectIds = new Set<number>();
     const boardChoiceObjectIds = new Set<number>();
-    const manaTappableObjectIds = new Set<number>();
     const selectableSacrificeObjectIds = new Set<number>();
     const selectableManaCostCreatureIds = new Set<number>();
     const undoableTapObjectIds = new Set<number>();
@@ -171,11 +179,10 @@ export const GameBoard = memo(function GameBoard({
 
     if (!gameState?.objects) {
       return {
-        activatableObjectIds,
+        ...affordances,
         boardChoiceObjectIds,
         committedAttackerIds,
         incomingAttackerCounts,
-        manaTappableObjectIds,
         selectableSacrificeObjectIds,
         selectableManaCostCreatureIds,
         undoableTapObjectIds,
@@ -184,52 +191,11 @@ export const GameBoard = memo(function GameBoard({
       };
     }
 
-    const playerCanAct =
-      waitingFor != null
-      && (
-        (waitingFor.type === "Priority" && canActForWaitingState)
-        || (waitingFor.type === "ManaPayment" && canActForWaitingState)
-        || (waitingFor.type === "UnlessPayment" && canActForWaitingState)
-        // CR 118.12a: Disjunctive unless-cost — same input enablement as
-        // UnlessPayment (player chooses among sub-costs).
-        || (waitingFor.type === "UnlessPaymentChooseCost" && canActForWaitingState)
-      );
-
-    if (waitingFor?.type === "Priority" && canActForWaitingState) {
-      // The engine owns the "which permanent does this action act on" mapping
-      // via GameAction::source_object(), exposed as `legalActionsByObject`.
-      // The cyan activatable ring surfaces battlefield permanents with at
-      // least one non-mana action; mana abilities are handled by the separate
-      // mana-tappable ring below. This iteration is variant-agnostic — adding
-      // a future keyword activation requires zero frontend changes.
-      for (const [idStr, actions] of Object.entries(legalActionsByObject)) {
-        const objectId = Number(idStr);
-        const object = gameState.objects[objectId];
-        if (!object) continue;
-        const hasNonManaAction = actions.some((action) => !isManaObjectAction(action, object));
-        if (hasNonManaAction) {
-          activatableObjectIds.add(objectId);
-        }
-      }
-    }
-
-    if (playerCanAct) {
-      for (const [idStr, actions] of Object.entries(legalActionsByObject)) {
-        const objectId = Number(idStr);
-        const object = gameState.objects[objectId];
-        if (!object) continue;
-        if (actions.some((action) => isManaObjectAction(action, object))) {
-          manaTappableObjectIds.add(objectId);
-        }
-      }
-    }
-
     return {
-      activatableObjectIds,
+      ...affordances,
       boardChoiceObjectIds,
       committedAttackerIds,
       incomingAttackerCounts,
-      manaTappableObjectIds,
       selectableSacrificeObjectIds,
       selectableManaCostCreatureIds,
       undoableTapObjectIds,

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -693,12 +693,28 @@ export const PermanentCard = memo(function PermanentCard({
       const verdict = resolveObjectActivation(
         collectObjectActions(store.legalActionsByObject, objectId),
         store.gameState?.objects[objectId],
-        canTapForMana,
+        { activatableObjectIds, manaTappableObjectIds },
+        objectId,
       );
-      if (verdict.kind === "dispatch") {
-        dispatchAction(verdict.action);
-      } else if (verdict.kind === "choose") {
-        setPendingAbilityChoice({ objectId, actions: verdict.actions });
+      switch (verdict.kind) {
+        case "dispatch":
+          dispatchAction(verdict.action);
+          return;
+        case "choose":
+          setPendingAbilityChoice({ objectId, actions: verdict.actions });
+          return;
+        case "none":
+          // Reachable only through the render→click staleness window: the ring
+          // was painted from a bucket this click no longer sees. Doing nothing
+          // is correct — and, as before, this branch does NOT fall through to
+          // select/inspect, because the chain already committed to it.
+          return;
+        default: {
+          // CLAUDE.md "exhaustive match without wildcard fallbacks": a new
+          // ObjectActivation variant is a compile error here, never a silent drop.
+          const _exhaustive: never = verdict;
+          return _exhaustive;
+        }
       }
     } else if (isUndoableTap) {
       dispatchAction({ type: "UntapLandForMana", data: { object_id: objectId } });

--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -3,7 +3,7 @@ import type React from "react";
 import { memo, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { AbilityBlockKind, GameAction, GameObject, Keyword } from "../../adapter/types.ts";
+import type { AbilityBlockKind, GameObject, Keyword } from "../../adapter/types.ts";
 import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
 import { dispatchAction } from "../../game/dispatch.ts";
@@ -37,8 +37,7 @@ import {
 } from "../../viewmodel/gameStateView.ts";
 import {
   collectObjectActions,
-  isManaObjectAction,
-  resolveSingleActionDispatch,
+  resolveObjectActivation,
 } from "../../viewmodel/cardActionChoice.ts";
 
 interface PermanentCardProps {
@@ -687,61 +686,42 @@ export const PermanentCard = memo(function PermanentCard({
       // from the engine's current legal-target set.
       showAttachmentFan();
     } else if (isActivatable) {
-      const o = useGameStore.getState().gameState?.objects[objectId];
-      // Read the engine-provided action list for this permanent — the mapping
-      // from GameAction variant to source permanent is owned by the engine
-      // (GameAction::source_object), not reconstructed here. Partitioning by
-      // effect type (Mana vs other) is a display concern: mana abilities route
-      // through the mana-tap UI; everything else routes through the ability
-      // choice modal or auto-dispatches.
-      const objectActions = collectObjectActions(
-        useGameStore.getState().legalActionsByObject,
-        objectId,
+      // THE single authority for "what does a click on this bucket do"
+      // (viewmodel/cardActionChoice.ts). Owns the CR 605.1a mana/non-mana
+      // partition and the #506 confirmation gate; this site never re-derives it.
+      const store = useGameStore.getState();
+      const verdict = resolveObjectActivation(
+        collectObjectActions(store.legalActionsByObject, objectId),
+        store.gameState?.objects[objectId],
+        canTapForMana,
       );
-      const abilityActions: Array<Extract<GameAction, { type: "ActivateAbility" }>> = [];
-      const manaActions: GameAction[] = [];
-      const keywordActions: GameAction[] = [];
-      for (const action of objectActions) {
-        if (isManaObjectAction(action, o)) {
-          manaActions.push(action);
-        } else if (action.type === "ActivateAbility") {
-          abilityActions.push(action);
-        } else {
-          // CR 113.3b keyword activations (Crew/Station/Equip/Saddle) and any
-          // future per-permanent action are surfaced alongside activated
-          // abilities in the choice modal.
-          keywordActions.push(action);
-        }
-      }
-      const manaChoiceNeeded = manaActions.length > 1;
-
-      const nonManaActions: GameAction[] = [...abilityActions, ...keywordActions];
-      if (nonManaActions.length === 0 && canTapForMana) {
-        if (manaChoiceNeeded) {
-          setPendingAbilityChoice({ objectId, actions: manaActions });
-        } else if (manaActions.length === 1) {
-          dispatchAction(manaActions[0]);
-        }
-      } else {
-        // #506: lone-action auto-dispatch is gated through
-        // resolveSingleActionDispatch so a card-consuming ActivateAbility
-        // surfaces the choice modal instead of auto-firing. This merges the
-        // former `nonManaActions.length === 1 && !canTapForMana` branch — when
-        // canTapForMana is false, allActions === nonManaActions, so a lone
-        // non-mana action reproduces that branch exactly.
-        const allActions: GameAction[] = [...nonManaActions];
-        if (canTapForMana) {
-          allActions.push(...manaActions);
-        }
-        const auto = resolveSingleActionDispatch(allActions, o);
-        if (auto) {
-          dispatchAction(auto);
-        } else {
-          setPendingAbilityChoice({ objectId, actions: allActions });
-        }
+      if (verdict.kind === "dispatch") {
+        dispatchAction(verdict.action);
+      } else if (verdict.kind === "choose") {
+        setPendingAbilityChoice({ objectId, actions: verdict.actions });
       }
     } else if (isUndoableTap) {
       dispatchAction({ type: "UntapLandForMana", data: { object_id: objectId } });
+    } else if (
+      obj.attachments.some(
+        (attachId) => activatableObjectIds.has(attachId) || manaTappableObjectIds.has(attachId),
+      )
+    ) {
+      // The host offers nothing, but an attached Aura/Equipment/Fortification does
+      // (CR 301.5 / CR 303.4 — it is its own object). Its only in-place affordance is
+      // a ~22px peek deliberately rendered BELOW the host (ATTACHMENT_PEEK_PX, zIndex
+      // 5 - i), under the 44px touch-target floor. Fall through to the full-card
+      // chooser. Same affordance sets the host's own ring uses, so this can never
+      // offer what the board would not; placed LAST so it can never pre-empt the
+      // host's target / activation / undo intent.
+      //
+      // Selection is set UNCONDITIONALLY, deliberately unlike the plain-click
+      // fallback below which TOGGLES (`selectObject(isSelected ? null : objectId)`).
+      // This branch always opens the fan, so a toggle would strand the fan open over
+      // a host that just lost its white ring, its attachment expansion and its
+      // exile-link expansion.
+      selectObject(objectId);
+      showAttachmentFan();
     } else if (isMobile) {
       inspectObject(objectId);
       setPreviewSticky(true);

--- a/client/src/components/board/__tests__/AttachmentFan.test.tsx
+++ b/client/src/components/board/__tests__/AttachmentFan.test.tsx
@@ -1,0 +1,387 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameAction, GameObject, GameState, WaitingFor } from "../../../adapter/types.ts";
+import type {
+  InteractionChoiceId,
+  InteractionId,
+  ViewerInteraction,
+} from "../../../adapter/generated/interaction";
+import { dispatchAction, dispatchInteraction } from "../../../game/dispatch.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
+import {
+  buildGameState,
+  buildPlayers,
+  buildPriorityWaitingFor,
+} from "../../../test/factories/gameStateFactory.ts";
+import { AttachmentFan } from "../AttachmentFan.tsx";
+
+/**
+ * `AttachmentFan` mode 2 — the fan as a reachability surface for an attached
+ * permanent's OWN legal actions (plan §6.9). Rows V1–V9.
+ *
+ * THE BUG THIS MODULE COVERS: with Kilo (401) enchanted by Freed from the Real
+ * (408), the engine published `legalActionsByObject["408"] = [#0, #1]` and the
+ * fan was inert — no ring, and clicking Freed did nothing. Before this change
+ * the fan had exactly one source (an open interaction's projection), so a
+ * populated bucket with no prompt open reached nothing.
+ *
+ * ---------------------------------------------------------------------------
+ * EVIDENCE-LABEL CONVENTION (plan §7.2, binding on this module).
+ * Every comment in this file that carries a mutant/coverage claim is tagged,
+ * and the tag says what KIND of statement it is — an in-file label is
+ * otherwise ambiguous between an instruction and a report:
+ *
+ *   MEASURED   a PAST-TENSE REPORT: this PR ran that arm and the quoted line
+ *              is the failing assertion it produced.
+ *   QUOTED     a past-tense report copied verbatim from a named harness log.
+ *   POINTER    names a sweep row / mutant id whose measurement lives in the
+ *              plan's evidence logs, not here.
+ *   PAIR-ONLY / DROP-ONLY   the row carries ONE side by construction (§7.1)
+ *              and is counted as coverage for that side only.
+ *
+ * An untagged comment is prose and is evidence for nothing.
+ *
+ * NAMED UNMEASURED ANCHOR IN THIS FILE: none. Every row below carries at least
+ * one measured side; the rows that carry only one are labelled above.
+ * ---------------------------------------------------------------------------
+ */
+
+vi.mock("../../../game/dispatch.ts", () => ({
+  dispatchAction: vi.fn(),
+  dispatchInteraction: vi.fn(),
+}));
+
+// Deliberately NOT re-emitting the object name: `FanCard` owns the
+// `aria-label`, so a mock that also emitted it would label every card twice and
+// silently break the per-card queries below.
+vi.mock("../../card/CardImage.tsx", () => ({
+  CardImage: ({ cardName }: { cardName: string }) => <div data-card-image={cardName} />,
+}));
+
+const HOST_ID = 401;
+const FREED_ID = 408;
+const BOOTS_ID = 409;
+
+/** Freed from the Real — `{U}: Tap enchanted creature.` / `{U}: Untap …`. */
+const FREED_TAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: FREED_ID, ability_index: 0 },
+};
+const FREED_UNTAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: FREED_ID, ability_index: 1 },
+};
+
+function makeObject(overrides: Partial<GameObject>): GameObject {
+  return buildGameObject({
+    zone: "Battlefield",
+    owner: 0,
+    controller: 0,
+    entered_battlefield_turn: null,
+    ...overrides,
+  });
+}
+
+function makeState(options: { attachments?: number[]; freedAbilities?: unknown[] } = {}): GameState {
+  const attachments = options.attachments ?? [FREED_ID];
+  const host = makeObject({
+    id: HOST_ID,
+    card_id: 4010,
+    name: "Kilo, Apogee Mind",
+    attachments,
+    card_types: { supertypes: ["Legendary"], core_types: ["Creature"], subtypes: ["Robot"] },
+  });
+  const freed = makeObject({
+    id: FREED_ID,
+    card_id: 4080,
+    name: "Freed from the Real",
+    attached_to: { type: "Object", data: HOST_ID },
+    card_types: { supertypes: [], core_types: ["Enchantment"], subtypes: ["Aura"] },
+    abilities: (options.freedAbilities ?? [
+      { effect: { type: "Tap" } },
+      { effect: { type: "Untap" } },
+    ]) as GameObject["abilities"],
+  });
+  const boots = makeObject({
+    id: BOOTS_ID,
+    card_id: 4090,
+    name: "Swiftfoot Boots",
+    attached_to: { type: "Object", data: HOST_ID },
+    card_types: { supertypes: [], core_types: ["Artifact"], subtypes: ["Equipment"] },
+  });
+
+  return buildGameState({
+    players: buildPlayers([0, 1]),
+    objects: buildObjectMap(host, freed, boots),
+    battlefield: [HOST_ID, FREED_ID, BOOTS_ID],
+    exile: [],
+    stack: [],
+    waiting_for: buildPriorityWaitingFor(),
+  });
+}
+
+function seed(options: {
+  legalActionsByObject?: Record<string, GameAction[]>;
+  waitingFor?: WaitingFor;
+  attachments?: number[];
+  freedAbilities?: unknown[];
+  viewerInteraction?: ViewerInteraction | null;
+} = {}) {
+  const gameState = makeState({
+    attachments: options.attachments,
+    freedAbilities: options.freedAbilities,
+  });
+  const waitingFor = options.waitingFor ?? gameState.waiting_for;
+  gameState.waiting_for = waitingFor;
+  useGameStore.setState({
+    gameMode: "local",
+    gameState,
+    waitingFor,
+    legalActions: [],
+    legalActionsByObject: options.legalActionsByObject ?? {},
+    viewerInteraction: options.viewerInteraction ?? null,
+  });
+  useUiStore.setState({ attachmentFanHostId: HOST_ID, pendingAbilityChoice: null });
+  return render(<AttachmentFan />);
+}
+
+/** The rendered fan card for one object, by the `aria-label` `FanCard` owns. */
+function fanCard(name: string): HTMLElement {
+  const fan = document.querySelector("[data-attachment-fan]");
+  expect(fan).not.toBeNull();
+  const card = fan?.querySelector(`[aria-label="${name}"]`);
+  expect(card).not.toBeNull();
+  return card as HTMLElement;
+}
+
+/** Cyan ring + `cursor-pointer` is `FanCard`'s rendering of `selectable`. */
+function isSelectable(name: string): boolean {
+  const card = fanCard(name);
+  const ringed = card.querySelector(".ring-cyan-400") != null;
+  const pointer = card.className.includes("cursor-pointer");
+  // The two must agree — they are two renderings of one prop, so a disagreement
+  // means the query, not the component, is wrong.
+  expect(ringed).toBe(pointer);
+  return ringed;
+}
+
+function interactionOver(objectIds: number[]): ViewerInteraction {
+  const interactionId = "fan-interaction" as InteractionId;
+  const choiceId = (objectId: number) => `fan-${objectId}` as InteractionChoiceId;
+  return {
+    waitingForKind: { simultaneous: null, terminal: false, code: "choose" },
+    authorizedSubmitters: [0],
+    canSubmit: true,
+    autoPassRecommended: false,
+    opportunities: [{
+      interactionId,
+      response: {
+        type: "exactChoices",
+        data: {
+          choices: objectIds.map((objectId) => ({
+            id: choiceId(objectId),
+            status: { type: "available" },
+            surfaces: [],
+          })),
+        },
+      },
+      surfaces: [],
+      progress: { selected: 0, minimum: 1, maximum: 1, aggregate: null, confirmable: false },
+    }],
+    attachmentFans: {
+      [HOST_ID]: {
+        hostId: HOST_ID,
+        children: objectIds.map((objectId) => ({
+          objectId,
+          submission: {
+            interactionId,
+            response: { type: "choose", data: { choiceId: choiceId(objectId) } },
+          },
+        })),
+      },
+    },
+    availability: { type: "inputRequired" },
+  };
+}
+
+describe("AttachmentFan mode 2 — the permanent's own legal actions", () => {
+  beforeEach(() => {
+    vi.mocked(dispatchAction).mockReset();
+    vi.mocked(dispatchAction).mockResolvedValue(undefined);
+    vi.mocked(dispatchInteraction).mockReset();
+    vi.mocked(dispatchInteraction).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useUiStore.setState({ attachmentFanHostId: null, pendingAbilityChoice: null });
+  });
+
+  // V1 — THE USER'S BUG. Both abilities reach the chooser, in engine order, and
+  // the fan is closed FIRST so the modal it opens is neither painted over nor
+  // click-swallowed by the fan's `fixed inset-0 z-[120]` backdrop.
+  //
+  // MEASURED (drop side, whole-change): this row on the un-patched tree reports
+  //   `AssertionError: expected null to deeply equal { objectId: 408, actions: [ …(2) }`
+  // MEASURED (always side): with `canActivate` forced constant-true and the
+  //   `id !== host.id` host invariant dropped, the V5 host arm below flips.
+  it("opens the ability chooser with both of the Aura's abilities and closes the fan first", () => {
+    seed({ legalActionsByObject: { [String(FREED_ID)]: [FREED_TAP, FREED_UNTAP] } });
+
+    expect(isSelectable("Freed from the Real")).toBe(true);
+    fireEvent.click(fanCard("Freed from the Real"));
+
+    expect(useUiStore.getState().pendingAbilityChoice).toEqual({
+      objectId: FREED_ID,
+      actions: [FREED_TAP, FREED_UNTAP],
+    });
+    expect(useUiStore.getState().attachmentFanHostId).toBeNull();
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  // V2 — a lone benign action auto-dispatches rather than opening a one-option
+  // modal. PAIR-ONLY (§7.1): POINTER sweep row `C4 lone benign ability`; its
+  // always-side mutant is `alwaysChoose`.
+  it("auto-dispatches a lone benign ability instead of opening a one-option modal", () => {
+    seed({ legalActionsByObject: { [String(FREED_ID)]: [FREED_TAP] } });
+
+    fireEvent.click(fanCard("Freed from the Real"));
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(FREED_TAP);
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+    expect(useUiStore.getState().attachmentFanHostId).toBeNull();
+  });
+
+  // V3 (#506) — a lone card-consuming ability must NOT auto-fire from the fan.
+  // POINTER: sweep row `C3 lone consumes_source`, mutant `noGate506`; the
+  // always side is `alwaysDispatch`. The fan delegates the decision rather than
+  // re-implementing it, which is the whole point of the shared authority.
+  it("routes a lone card-consuming ability through the modal, never auto-firing it", () => {
+    seed({
+      legalActionsByObject: { [String(FREED_ID)]: [FREED_TAP] },
+      freedAbilities: [{ effect: { type: "Tap" }, consumes_source: true }],
+    });
+
+    fireEvent.click(fanCard("Freed from the Real"));
+
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingAbilityChoice).toEqual({
+      objectId: FREED_ID,
+      actions: [FREED_TAP],
+    });
+  });
+
+  // V4 — the timing gate. The bucket is populated exactly as in V1, but the
+  // engine is not at Priority, so the fan must offer nothing at all.
+  // POINTER: `REV5SWEEP[V4 DeclareBlockers canAct=T] act=[] mana=[]` versus
+  // `REV5SWEEP[V4 Priority canAct=T] act=[408] mana=[]` — the same bucket, the
+  // two timing arms.
+  it("offers nothing at DeclareBlockers even though the bucket is populated", () => {
+    seed({
+      legalActionsByObject: { [String(FREED_ID)]: [FREED_TAP, FREED_UNTAP] },
+      waitingFor: {
+        type: "DeclareBlockers",
+        data: { player: 0, valid_blocker_ids: [], valid_block_targets: {} },
+      },
+    });
+
+    expect(isSelectable("Freed from the Real")).toBe(false);
+    fireEvent.click(fanCard("Freed from the Real"));
+
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+    // Still open: an inert click must not dismiss the fan either.
+    expect(useUiStore.getState().attachmentFanHostId).toBe(HOST_ID);
+  });
+
+  // V5 — the host invariant. The fan is opened FROM the host, so the host card
+  // is the fan's anchor and never one of its picks, even when the engine
+  // publishes actions for the host too. Assertion order: host first, then
+  // attachment — the attachment assert is the control proving the fixture is
+  // live rather than uniformly inert.
+  //
+  // MEASURED (drop side): dropping `id !== host.id` from `selectable` flips the
+  //   host assert to `AssertionError: expected true to be false`.
+  it("never makes the host itself a pick, while its attachment stays one", () => {
+    seed({
+      legalActionsByObject: {
+        [String(HOST_ID)]: [{ type: "ActivateAbility", data: { source_id: HOST_ID, ability_index: 0 } }],
+        [String(FREED_ID)]: [FREED_TAP, FREED_UNTAP],
+      },
+    });
+
+    expect(isSelectable("Kilo, Apogee Mind")).toBe(false);
+    expect(isSelectable("Freed from the Real")).toBe(true);
+
+    fireEvent.click(fanCard("Kilo, Apogee Mind"));
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+  });
+
+  // V7 — the ring is per-object, not per-fan. One attachment has a bucket and
+  // the other does not, so exactly one lights up.
+  // QUOTED (`.review3r2-probe1.log:115`):
+  //   `A6 FIX freed=true boots=false host=false | MUTANT(drop priority arm)
+  //    freed=false boots=false | MUTANT(always) freed=true boots=true`
+  it("rings only the attachment the engine published actions for", () => {
+    seed({
+      attachments: [FREED_ID, BOOTS_ID],
+      legalActionsByObject: { [String(FREED_ID)]: [FREED_TAP, FREED_UNTAP] },
+    });
+
+    expect(isSelectable("Freed from the Real")).toBe(true);
+    expect(isSelectable("Swiftfoot Boots")).toBe(false);
+    expect(isSelectable("Kilo, Apogee Mind")).toBe(false);
+
+    fireEvent.click(fanCard("Swiftfoot Boots"));
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+  });
+
+  // V8 — mode 1 is byte-unchanged: with an interaction open the fan forwards
+  // the engine's opaque submission and nothing else. PAIR-ONLY (§7.1): this row
+  // claims the change altered NOTHING on its fixture, so no drop-the-fix mutant
+  // can be visible on it by construction, and it is counted as always-side
+  // coverage only. Its drop-side partner is V9.
+  it("still forwards the engine's own submission when an interaction owns the prompt", () => {
+    seed({
+      legalActionsByObject: {},
+      viewerInteraction: interactionOver([FREED_ID]),
+    });
+
+    fireEvent.click(fanCard("Freed from the Real"));
+
+    expect(dispatchInteraction).toHaveBeenCalledTimes(1);
+    expect(dispatchInteraction).toHaveBeenCalledWith({
+      interactionId: "fan-interaction",
+      response: { type: "choose", data: { choiceId: "fan-408" } },
+    });
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+  });
+
+  // V9 — MULTI-AUTHORITY HOSTILE FIXTURE. Both sources are live at once: an
+  // interaction owns the prompt AND the same object has a populated bucket.
+  // Exactly one authority may win, and it must be the engine's prompt.
+  // Assertion order: interaction count, then action count, then the store.
+  // QUOTED: `PD1[interaction + populated bucket] dispatchInteraction calls: 1,
+  //          dispatchAction calls: 0, pending=null`
+  // MEASURED (drop side): removing mode 1's early `return` makes mode 2 also
+  //   fire, flipping `expected "spy" to not be called at all, but it was called
+  //   1 times`.
+  it("lets the engine interaction win when a prompt and a bucket are both live", () => {
+    seed({
+      legalActionsByObject: { [String(FREED_ID)]: [FREED_TAP, FREED_UNTAP] },
+      viewerInteraction: interactionOver([FREED_ID]),
+    });
+
+    fireEvent.click(fanCard("Freed from the Real"));
+
+    expect(dispatchInteraction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+  });
+});

--- a/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
+++ b/client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx
@@ -73,6 +73,7 @@ function renderOverflow(options: {
   groups?: GroupedPermanentType[];
   includePreview?: boolean;
   objects?: Record<string, GameObject>;
+  activatableObjectIds?: Set<number>;
   boardChoiceObjectIds?: Set<number>;
   selectableSacrificeObjectIds?: Set<number>;
   validTargetObjectIds?: Set<number>;
@@ -87,7 +88,7 @@ function renderOverflow(options: {
   return render(
     <BoardInteractionContext.Provider
       value={{
-        activatableObjectIds: new Set(),
+        activatableObjectIds: options.activatableObjectIds ?? new Set(),
         boardChoiceObjectIds: options.boardChoiceObjectIds ?? new Set(),
         committedAttackerIds: options.committedAttackerIds ?? new Set(),
         incomingAttackerCounts: new Map(),
@@ -199,6 +200,28 @@ describe("BattlefieldZoneOverflow", () => {
 
     expect(screen.getByText(/target 1/i)).toBeInTheDocument();
     expect(screen.getByText(/mana 1/i)).toBeInTheDocument();
+  });
+
+  // V24 — this component is the SECOND consumer of the affordance pair this PR
+  // re-plumbs (`:378`/`:382` destructured from `useBoardInteractionState()`,
+  // read at `:407`/`:410`), and its `activatableObjectIds` read was unaudited:
+  // the sibling `manaTappableObjectIds` read is already load-bearing (the stub
+  // seeds `new Set([1])` and the badge test above asserts `/mana 1/i`), but the
+  // activatable read could be DELETED with the whole board suite still green.
+  // QUOTED (plan §7.0, the two arms of one recipe — the sibling is the control
+  // that makes the silent arm readable):
+  //   `R8BZO[mutant-DELETE-activatable-read@407]  Tests 130 passed (130) `
+  //   `R8BZO[mutant-DELETE-mana-read@410] Tests 1 failed | 129 passed (130) `
+  // MEASURED (drop side — the `:407` read deleted): `Unable to find an element
+  //   with the text: /^act 2$/i`.
+  // MEASURED (always side — `activatable++` made unconditional, i.e. count the
+  //   whole group instead of the set): `act 9` renders and the anchored matcher
+  //   fails. The count is asserted against the SEEDED SET, never the group size,
+  //   which is what makes "count everything" visible.
+  it("counts only the activatable ids the board published, not the whole group", () => {
+    renderOverflow({ activatableObjectIds: new Set([2, 5]) });
+
+    expect(screen.getByText(/^act 2$/i)).toBeInTheDocument();
   });
 
   it("surfaces hidden board-choice permanents as interactive", () => {

--- a/client/src/components/board/__tests__/GameBoardInteractionWiring.test.tsx
+++ b/client/src/components/board/__tests__/GameBoardInteractionWiring.test.tsx
@@ -1,0 +1,209 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameAction, GameObject } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
+import {
+  buildGameState,
+  buildPlayers,
+  buildPriorityWaitingFor,
+} from "../../../test/factories/gameStateFactory.ts";
+import { GameBoard } from "../GameBoard.tsx";
+import { useBoardInteractionState } from "../BoardInteractionContext.tsx";
+
+/**
+ * V14w — WIRING, not parity (plan §7.0/§7.3).
+ *
+ * `deriveActivationAffordances` being correct as a function proves nothing
+ * about the board: the value has to REACH the consumer. `GameBoard` publishes
+ * it through `BoardInteractionContext`, and this row renders the real
+ * `<GameBoard/>` with a child that reads `useBoardInteractionState()` under the
+ * real provider, then asserts both sets BY CONTENT.
+ *
+ * Content, not size, is what makes the always-true side fail: a `.size` assert
+ * passes under an "add every object" mutant.
+ *
+ * ---------------------------------------------------------------------------
+ * EVIDENCE-LABEL CONVENTION (plan §7.2, binding on this module). Every comment
+ * carrying a mutant/coverage claim is tagged, because an in-file label is
+ * otherwise ambiguous between an INSTRUCTION and a PAST-TENSE REPORT:
+ *
+ *   MEASURED   past-tense report: this PR ran that arm; the quoted text is the
+ *              assertion that flipped.
+ *   QUOTED     past-tense report copied verbatim from a named harness log.
+ *   POINTER    names a row/mutant whose measurement lives in the plan's
+ *              evidence logs, not here.
+ *
+ * An untagged comment is prose and is evidence for nothing.
+ *
+ * NAMED UNMEASURED ANCHOR IN THIS FILE: this row observes the context boundary
+ * only. The two OTHER consumers of the affordance pair are covered elsewhere —
+ * `PermanentCard` by the V10–V13 rows in `PermanentCard.test.tsx`, and
+ * `BattlefieldZoneOverflow` by the V24 row in its own file (claimed for
+ * `activatableObjectIds` only; its `manaTappableObjectIds` read was already
+ * guarded).
+ * ---------------------------------------------------------------------------
+ */
+
+const AURA_ID = 408;
+const LAND_ID = 500;
+
+/** A child under the real provider — the consumer whose read is being proved. */
+function AffordanceProbe() {
+  const { activatableObjectIds, manaTappableObjectIds } = useBoardInteractionState();
+  return (
+    <div
+      data-testid="affordance-probe"
+      data-activatable={[...activatableObjectIds].sort((a, b) => a - b).join(",")}
+      data-mana={[...manaTappableObjectIds].sort((a, b) => a - b).join(",")}
+    />
+  );
+}
+
+vi.mock("../PlayerArea.tsx", () => ({
+  PlayerArea: ({ playerId }: { playerId: number }) =>
+    playerId === 0 ? <AffordanceProbe /> : <div data-testid={`player-area-${playerId}`} />,
+}));
+
+vi.mock("../ArchenemyPanel.tsx", () => ({ ArchenemyPanel: () => null }));
+vi.mock("../CombatLine.tsx", () => ({ CombatLine: () => null }));
+vi.mock("../PlanechasePanel.tsx", () => ({ PlanechasePanel: () => null }));
+vi.mock("../OpponentSeatHeader.tsx", () => ({ OpponentSeatHeader: () => null }));
+vi.mock("../../flexlayout/DraggableWidget.tsx", () => ({
+  DraggableWidget: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("../../hand/OpponentHand.tsx", () => ({ OpponentHand: () => null }));
+vi.mock("../../zone/ExilePile.tsx", () => ({ ExilePile: () => null }));
+vi.mock("../../zone/GraveyardPile.tsx", () => ({ GraveyardPile: () => null }));
+vi.mock("../../zone/LibraryPile.tsx", () => ({ LibraryPile: () => null }));
+
+const AURA_TAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: AURA_ID, ability_index: 0 },
+};
+const AURA_UNTAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: AURA_ID, ability_index: 1 },
+};
+const TAP_LAND: GameAction = {
+  type: "TapLandForMana",
+  data: {
+    selection: {
+      source: { object_id: LAND_ID, incarnation: 1 },
+      ability_index: null,
+      mana_type: "Blue",
+      output: { type: "Concrete", data: "Blue" },
+      atomic_combination: null,
+      restrictions: [],
+      penalty: "None",
+      taps_for_mana: [],
+    },
+  },
+};
+
+function battlefieldObject(overrides: Partial<GameObject>): GameObject {
+  return buildGameObject({
+    zone: "Battlefield",
+    owner: 0,
+    controller: 0,
+    entered_battlefield_turn: null,
+    ...overrides,
+  });
+}
+
+describe("GameBoard publishes the shared activation affordances to its consumers", () => {
+  beforeEach(() => {
+    const aura = battlefieldObject({
+      id: AURA_ID,
+      card_id: 4080,
+      name: "Freed from the Real",
+      card_types: { supertypes: [], core_types: ["Enchantment"], subtypes: ["Aura"] },
+      abilities: [
+        { effect: { type: "Tap" } },
+        { effect: { type: "Untap" } },
+      ] as GameObject["abilities"],
+    });
+    const land = battlefieldObject({
+      id: LAND_ID,
+      card_id: 5000,
+      name: "Island",
+      card_types: { supertypes: ["Basic"], core_types: ["Land"], subtypes: ["Island"] },
+      abilities: [
+        { is_mana_ability: true, effect: { type: "Mana" } },
+      ] as GameObject["abilities"],
+    });
+    const waitingFor = buildPriorityWaitingFor();
+    useGameStore.setState({
+      gameMode: "local",
+      gameState: buildGameState({
+        players: buildPlayers([0, 1]),
+        objects: buildObjectMap(aura, land),
+        battlefield: [AURA_ID, LAND_ID],
+        exile: [],
+        stack: [],
+        seat_order: [0, 1],
+        eliminated_players: [],
+        waiting_for: waitingFor,
+      }),
+      waitingFor,
+      legalActions: [],
+      legalActionsByObject: {
+        [String(AURA_ID)]: [AURA_TAP, AURA_UNTAP],
+        [String(LAND_ID)]: [TAP_LAND],
+      },
+      viewerInteraction: null,
+    });
+    useUiStore.setState({ focusedOpponent: 1, blockerAssignments: new Map() });
+    usePreferencesStore.setState({ multiplayerBoardLayout: "focused" });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // V14w — WIRING, not parity: the affordance pair reaches a real child consumer
+  // NON-EMPTY, through the real provider.
+  // Assertion ORDER: `data-activatable` first, then `data-mana`.
+  //
+  // QUOTED (drop side — deleting the Priority arm inside the authority):
+  //   `REV6WIRE[A2_dropPriorityArm] activatable="" mana="500"` ⇒
+  //   `REV6ARM[A2_dropPriorityArm] AssertionError: expected '' to be '408'`
+  // QUOTED (always side): `REV6WIRE[A3_alwaysTrue] activatable="408,500"
+  //   mana="408,500"` ⇒ `REV6ARM[A3_alwaysTrue] AssertionError: expected
+  //   '408,500' to be '408'` — the activatable assert fails first.
+  // QUOTED (non-domination of the SECOND assert, so it is not merely dominated
+  //   by the first): `REV6WIRE[A7_dropManaArm] activatable="408" mana=""` —
+  //   that mutant is invisible to the activatable assert and kills on the mana
+  //   assert alone.
+  it("reaches a child consumer with both sets populated by content at Priority", () => {
+    render(
+      <GameBoard effectiveMultiplayerBoardLayout="focused" oppHud={<div />} playerHud={<div />} />,
+    );
+
+    const probe = screen.getByTestId("affordance-probe");
+    expect(probe.getAttribute("data-activatable")).toBe("408");
+    expect(probe.getAttribute("data-mana")).toBe("500");
+  });
+
+  // V14w (negative arm) — the board's own timing gate, observed at the same
+  // boundary: this proves the assertion above reads a live value, not a constant.
+  it("reaches the same consumer with both sets EMPTY when the viewer cannot act", () => {
+    const waitingFor = { type: "Priority", data: { player: 1 } } as const;
+    useGameStore.setState({
+      gameState: { ...useGameStore.getState().gameState!, waiting_for: waitingFor },
+      waitingFor,
+    });
+
+    render(
+      <GameBoard effectiveMultiplayerBoardLayout="focused" oppHud={<div />} playerHud={<div />} />,
+    );
+
+    const probe = screen.getByTestId("affordance-probe");
+    expect(probe.getAttribute("data-activatable")).toBe("");
+    expect(probe.getAttribute("data-mana")).toBe("");
+  });
+});

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -124,6 +124,7 @@ function renderPermanent(
   boardChoiceObjectIds = new Set<number>(),
   activatableObjectIds = new Set<number>(),
   undoableTapObjectIds = new Set<number>(),
+  manaTappableObjectIds = new Set<number>(),
 ) {
   return render(
     <BoardInteractionContext.Provider
@@ -132,7 +133,7 @@ function renderPermanent(
         boardChoiceObjectIds,
         committedAttackerIds: new Set(),
         incomingAttackerCounts: new Map(),
-        manaTappableObjectIds: new Set(),
+        manaTappableObjectIds,
         selectableSacrificeObjectIds,
         selectableManaCostCreatureIds: new Set(),
         undoableTapObjectIds,
@@ -509,6 +510,207 @@ describe("PermanentCard", () => {
       height: "clamp(20px, calc(var(--card-w) * 0.22), 28px)",
       fontSize: "clamp(12px, calc(var(--card-w) * 0.12), 15px)",
     });
+  });
+
+  /**
+   * Plan rows V10–V13 + V10c — hunk B: a host whose OWN click offers nothing,
+   * over an attachment the engine published affordances for, falls through to
+   * the full-card chooser instead of demanding a pixel-accurate click on a
+   * ~22px peek rendered BELOW the host (CR 301.5 / CR 303.4 — an attachment is
+   * its own object).
+   *
+   * EVIDENCE LABELS (plan §7.2): MEASURED = this PR ran that mutant arm and the
+   * quoted line is what flipped. QUOTED = verbatim from a named plan log.
+   * An untagged comment is prose and is evidence for nothing.
+   */
+  function clickHost(container: HTMLElement) {
+    fireEvent.click(container.querySelector('[data-object-id="1"]') as HTMLElement);
+  }
+
+  // V10 — the positive control for hunk B firing at all: an inert host over an
+  // actionable attachment opens the fan AND selects the host.
+  // QUOTED (plan §6.10, `.review3r4-v13.log`):
+  //   `PV13d[inert host + actionable attachment] dispatch=none fanHostId=1 selectedObjectId=1`
+  // MEASURED (drop side — hunk B deleted): `expected null to be 1`.
+  // MEASURED (always side — the `.some(...)` predicate forced constant-true):
+  //   V11's `expected 1 to be null` flips instead; on THIS fixture an
+  //   always-true predicate agrees, which is exactly why V11 exists.
+  it("opens the fan from an inert host when an attachment is actionable", () => {
+    act(() => {
+      useUiStore.setState({ attachmentFanHostId: null, selectedObjectId: null });
+    });
+
+    const { container } = renderPermanent(new Set(), new Set(), new Set(), new Set([2]));
+    clickHost(container);
+
+    expect(useUiStore.getState().attachmentFanHostId).toBe(1);
+    expect(useUiStore.getState().selectedObjectId).toBe(1);
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  // V10 (mana arm) — the predicate's SECOND disjunct. `activatableObjectIds` and
+  // `manaTappableObjectIds` are two independent affordance sets and hunk B reads
+  // both; without this arm the `|| manaTappableObjectIds.has(attachId)` half
+  // could be deleted and every other row here would stay green.
+  // MEASURED (drop side — the mana disjunct deleted): `expected null to be 1`.
+  it("opens the fan when the attachment is mana-tappable rather than activatable", () => {
+    act(() => {
+      useUiStore.setState({ attachmentFanHostId: null, selectedObjectId: null });
+    });
+
+    const { container } = renderPermanent(
+      new Set(), new Set(), new Set(), new Set(), new Set(), new Set([2]),
+    );
+    clickHost(container);
+
+    expect(useUiStore.getState().attachmentFanHostId).toBe(1);
+  });
+
+  // V10c — hunk B's selection is UNCONDITIONAL, deliberately unlike the plain
+  // click fallback which TOGGLES. Only a fixture whose host is ALREADY selected
+  // can see the difference; V10 above passes under both implementations.
+  // QUOTED (plan §6.10):
+  //   `PC1[before=null]  unconditional=401 toggle=401 DISCRIMINATES=false`
+  //   `PC1[before=401] unconditional=401 toggle=null  DISCRIMINATES=true`
+  // MEASURED (drop side — `selectObject(objectId)` replaced by the toggle form
+  //   `selectObject(isSelected ? null : objectId)`): `expected null to be 1`.
+  it("keeps the host selected when the fan is re-opened from an already-selected host", () => {
+    act(() => {
+      useUiStore.setState({ attachmentFanHostId: null, selectedObjectId: 1 });
+    });
+
+    const { container } = renderPermanent(new Set(), new Set(), new Set(), new Set([2]));
+    clickHost(container);
+
+    // A toggle would strand the fan open over a host that just lost its ring,
+    // its attachment expansion and its exile-link expansion.
+    expect(useUiStore.getState().selectedObjectId).toBe(1);
+    expect(useUiStore.getState().attachmentFanHostId).toBe(1);
+  });
+
+  // V11 — the negative side: no actionable attachment ⇒ the pre-existing
+  // fallback still owns the click. PAIR-ONLY (§7.1) — the row claims the change
+  // did NOTHING on this fixture, so no drop-the-fix mutant can be visible on it
+  // by construction; it is counted as always-side coverage only.
+  // QUOTED (plan §6.10): `PV13e[inert host + inert attachment] fanHostId=null selectedObjectId=1`
+  // MEASURED (always side — predicate forced constant-true): `expected 1 to be null`.
+  it("leaves the plain-click fallback alone when no attachment is actionable", () => {
+    act(() => {
+      useUiStore.setState({ attachmentFanHostId: null, selectedObjectId: null });
+    });
+
+    const { container } = renderPermanent();
+    clickHost(container);
+
+    expect(useUiStore.getState().attachmentFanHostId).toBeNull();
+    expect(useUiStore.getState().selectedObjectId).toBe(1);
+  });
+
+  // V12 — the predicate's SOURCE. Hunk B reads the shared affordance sets, never
+  // the raw `legalActionsByObject` bucket, so it can never offer what the board
+  // itself would not (the sets already carry the timing/seat gates). The bucket
+  // here is populated exactly as in V10; only the affordance set is empty.
+  // MEASURED (drop side — `activatableObjectIds.has(attachId)` swapped for a raw
+  //   `collectObjectActions(legalActionsByObject, attachId).length > 0` check):
+  //   `expected 1 to be null` — the fan opens at a state the board gates off.
+  it("ignores a populated action bucket that the affordance sets exclude", () => {
+    act(() => {
+      useUiStore.setState({ attachmentFanHostId: null, selectedObjectId: null });
+    });
+    useGameStore.setState({
+      legalActionsByObject: {
+        "2": [{ type: "ActivateAbility", data: { source_id: 2, ability_index: 0 } }],
+      },
+    });
+
+    const { container } = renderPermanent();
+    clickHost(container);
+
+    expect(useUiStore.getState().attachmentFanHostId).toBeNull();
+    // REACH GUARD, paired with the negative above: a bare "no fan" assertion
+    // would also pass if the click never landed at all. Selection proves the
+    // handler ran and fell through to the plain-click fallback.
+    expect(useUiStore.getState().selectedObjectId).toBe(1);
+  });
+
+  // V13 (mobile arm) — hunk B sits ABOVE the `isMobile` branch, so on a narrow
+  // viewport a host whose attachment is actionable opens the fan instead of the
+  // sticky preview. That is a deliberate trade (long-press still inspects, and
+  // the fan renders large legible cards), and it is pinned here so a future
+  // reorder cannot revert it silently.
+  // MEASURED (drop side — hunk B deleted): `expected null to be 1`, and the
+  //   preview arm takes the click instead.
+  it("prefers the fan over the mobile sticky preview when an attachment is actionable", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 800 });
+    act(() => {
+      useUiStore.setState({
+        attachmentFanHostId: null,
+        selectedObjectId: null,
+        inspectedObjectId: null,
+      });
+    });
+
+    try {
+      const { container } = renderPermanent(new Set(), new Set(), new Set(), new Set([2]));
+      clickHost(container);
+
+      expect(useUiStore.getState().attachmentFanHostId).toBe(1);
+      // The arm hunk B pre-empts, asserted as the pair: no sticky preview.
+      expect(useUiStore.getState().inspectedObjectId).toBeNull();
+    } finally {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value: 1024 });
+    }
+  });
+
+  // V13 — hunk B is placed LAST, so it can never pre-empt the host's own
+  // target / activation / undo intent. Every arm below holds the actionable
+  // attachment FIXED and varies only the host's own affordance, so a passing
+  // arm is a statement about branch ORDER and nothing else.
+  // QUOTED (plan §6.10, `.review3r4-v13.log`):
+  //   `PV13a[valid target + actionable attachment]      dispatch=ChooseTarget      fanHostId=null`
+  //   `PV13b[activatable host + actionable attachment]  dispatch=ActivateAbility   fanHostId=null`
+  //   `PV13c[undoable tap + actionable attachment]      dispatch=UntapLandForMana  fanHostId=null`
+  // MEASURED (drop side — hunk B moved ABOVE `isValidTarget`): the PV13a arm
+  //   flips to `expected "spy" to be called with ... ChooseTarget`, and
+  //   `fanHostId` reads 1 instead of null.
+  // V10 is the positive control proving these arms are not uniformly inert.
+  it("never pre-empts the host's own target, activation or undo intent", () => {
+    const actionableAttachment = new Set([2]);
+
+    act(() => {
+      useUiStore.setState({ attachmentFanHostId: null, selectedObjectId: null });
+    });
+    const targetArm = renderPermanent(new Set([1]), new Set(), new Set(), actionableAttachment);
+    clickHost(targetArm.container);
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: "ChooseTarget",
+      data: { target: { Object: 1 } },
+    });
+    expect(useUiStore.getState().attachmentFanHostId).toBeNull();
+    cleanup();
+    vi.mocked(dispatchAction).mockClear();
+
+    const hostAbility = { type: "ActivateAbility", data: { source_id: 1, ability_index: 0 } } as const;
+    useGameStore.setState({ legalActionsByObject: { "1": [hostAbility] } });
+    const activateArm = renderPermanent(
+      new Set(), new Set(), new Set(), new Set([1, 2]),
+    );
+    clickHost(activateArm.container);
+    expect(dispatchAction).toHaveBeenCalledWith(hostAbility);
+    expect(useUiStore.getState().attachmentFanHostId).toBeNull();
+    cleanup();
+    vi.mocked(dispatchAction).mockClear();
+    useGameStore.setState({ legalActionsByObject: {} });
+
+    const undoArm = renderPermanent(
+      new Set(), new Set(), new Set(), actionableAttachment, new Set([1]),
+    );
+    clickHost(undoArm.container);
+    expect(dispatchAction).toHaveBeenCalledWith({
+      type: "UntapLandForMana",
+      data: { object_id: 1 },
+    });
+    expect(useUiStore.getState().attachmentFanHostId).toBeNull();
   });
 
   it("refreshes the attachment fan when the engine clears host attachments", () => {

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -1454,9 +1454,16 @@ describe("PermanentCard", () => {
       mana_cost: { type: "NoCost" },
       color: [],
       base_color: [],
+      // `is_mana_ability` is the engine-derived key (CR 605.1a) that BOTH
+      // `deriveActivationAffordances` and `resolveObjectActivation` classify
+      // with, so in production the affordance sets and the resolver's partition
+      // can never disagree. This fixture asserts the mana-only affordance pair
+      // below, so the abilities must carry the flag that produces it; without it
+      // the fixture describes a state the engine cannot emit.
       abilities: [
         {
           kind: "Activated",
+          is_mana_ability: true,
           cost: { type: "Tap" },
           description: "{T}: Add {C}.",
           effect: {
@@ -1466,6 +1473,7 @@ describe("PermanentCard", () => {
         },
         {
           kind: "Activated",
+          is_mana_ability: true,
           cost: {
             type: "Composite",
             costs: [

--- a/client/src/components/board/__tests__/abilityChoiceConsumerWiring.test.tsx
+++ b/client/src/components/board/__tests__/abilityChoiceConsumerWiring.test.tsx
@@ -1,0 +1,252 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameAction, GameObject, GameState } from "../../../adapter/types.ts";
+import { dispatchAction, dispatchInteraction } from "../../../game/dispatch.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
+import {
+  buildGameState,
+  buildPlayers,
+  buildPriorityWaitingFor,
+} from "../../../test/factories/gameStateFactory.ts";
+import { DialogHost } from "../../modal/DialogHost.tsx";
+import { AttachmentFan } from "../AttachmentFan.tsx";
+
+/**
+ * Plan row V25 — THE USER'S BUG, END TO END, THROUGH A REAL CONSUMER.
+ *
+ * Every other row in this matrix asserts "opens the modal" on the store,
+ * because `AbilityChoiceModal` is module-private inside `GamePage.tsx:3074`.
+ * `pendingAbilityChoice` IS that modal's input contract, and `DialogHost`
+ * (`:118-120` sets `hasUiDialog` from it, `:131-132` turns that into
+ * `dialogVisible`, `:199` anchors `fixed inset-0 z-40`) is the consumer that
+ * decides whether anything is painted at all. This row drives the PRODUCER
+ * (`AttachmentFan` mode 2) and observes the real CONSUMER, so the wiring
+ * between them is measured rather than assumed.
+ *
+ * ---------------------------------------------------------------------------
+ * EVIDENCE-LABEL CONVENTION (plan §7.2, binding on this module):
+ *   MEASURED  a PAST-TENSE REPORT — this PR ran that mutant arm and the quoted
+ *             line is the assertion that flipped.
+ *   QUOTED    a past-tense report copied verbatim from a named plan log.
+ * An untagged comment is prose and is evidence for nothing.
+ *
+ * ASSERTION ORDER: none. Both observations use `expect.soft`, so neither can
+ * pre-empt the other. That is not a style choice — with hard asserts the
+ * payload assert throws first on BOTH mutant arms and the overlay assert (the
+ * only assertion in this matrix that observes a `pendingAbilityChoice`
+ * CONSUMER) is never reached, i.e. unmeasured.
+ * QUOTED (`.plan3r10-v25soft.log`, the three trees the applier built out of §6):
+ *   `R10V25[BASE]      FAILINGASSERT| ASSERT=overlay: expected +0 to be 1`
+ *   `R10V25[BASE]      FAILINGASSERT| ASSERT=payload: expected null to deeply equal { objectId: 408, actions: [ …(2) `
+ *   `R10V25[ADOPTED]   CARDINALITY|      Tests  3 passed (3)`
+ *   `R10V25[ALWAYSMUT] FAILINGASSERT| ASSERT=overlay: expected 1 to be +0`
+ *   `R10V25[ALWAYSMUT] FAILINGASSERT| ASSERT=payload: expected { objectId: 401, actions: [ …(2)`
+ *
+ * NAMED UNMEASURED ANCHOR: the `GamePage.tsx:3122` options map. It is the other
+ * consumer of `pendingAbilityChoice` and this module does NOT observe it — plan
+ * §7.3 row V26 registers it as an audited absence. It is coverage for nothing.
+ * ---------------------------------------------------------------------------
+ */
+
+vi.mock("../../../game/dispatch.ts", () => ({
+  dispatchAction: vi.fn(),
+  dispatchInteraction: vi.fn(),
+}));
+
+// `FanCard` owns the `aria-label`; a mock that re-emitted it would label every
+// card twice and silently break the precondition assert below. That is not
+// hypothetical — QUOTED (`.plan3r10-v25fixture.log`), with the mock mutated to
+// re-emit it: `R10V25FX[ADOPTED+brokenfixture] AssertionError: expected [ <div
+// …(3)>…(1)</div>, …(3) ] to have a length of 2 but got 4`, on EVERY arm of an
+// otherwise-passing tree — which is what a broken FIXTURE looks like as
+// against a broken FIX.
+vi.mock("../../card/CardImage.tsx", () => ({
+  CardImage: ({ cardName }: { cardName: string }) => <div data-card-image={cardName} />,
+}));
+
+const HOST_ID = 401;
+const FREED_ID = 408;
+
+/** Freed from the Real — `{U}: Tap enchanted creature.` / `{U}: Untap …`. */
+const FREED_TAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: FREED_ID, ability_index: 0 },
+};
+const FREED_UNTAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: FREED_ID, ability_index: 1 },
+};
+const HOST_ABILITY_A: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: HOST_ID, ability_index: 0 },
+};
+const HOST_ABILITY_B: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: HOST_ID, ability_index: 1 },
+};
+
+function battlefieldObject(overrides: Partial<GameObject>): GameObject {
+  return buildGameObject({
+    zone: "Battlefield",
+    owner: 0,
+    controller: 0,
+    entered_battlefield_turn: null,
+    ...overrides,
+  });
+}
+
+function makeState(): GameState {
+  const host = battlefieldObject({
+    id: HOST_ID,
+    card_id: 4010,
+    name: "Kilo, Apogee Mind",
+    attachments: [FREED_ID],
+    card_types: { supertypes: ["Legendary"], core_types: ["Creature"], subtypes: ["Robot"] },
+    abilities: [
+      { effect: { type: "Tap" } },
+      { effect: { type: "Untap" } },
+    ] as GameObject["abilities"],
+  });
+  const freed = battlefieldObject({
+    id: FREED_ID,
+    card_id: 4080,
+    name: "Freed from the Real",
+    attached_to: { type: "Object", data: HOST_ID },
+    card_types: { supertypes: [], core_types: ["Enchantment"], subtypes: ["Aura"] },
+    abilities: [
+      { effect: { type: "Tap" } },
+      { effect: { type: "Untap" } },
+    ] as GameObject["abilities"],
+  });
+
+  return buildGameState({
+    players: buildPlayers([0, 1]),
+    objects: buildObjectMap(host, freed),
+    battlefield: [HOST_ID, FREED_ID],
+    exile: [],
+    stack: [],
+    waiting_for: buildPriorityWaitingFor(),
+  });
+}
+
+function seed(legalActionsByObject: Record<string, GameAction[]>) {
+  const gameState = makeState();
+  useGameStore.setState({
+    gameMode: "local",
+    gameState,
+    waitingFor: gameState.waiting_for,
+    legalActions: [],
+    legalActionsByObject,
+    viewerInteraction: null,
+  });
+  // `enchantmentsDialogPlayer` is the OTHER input to `hasUiDialog`. Left
+  // non-null it would raise the overlay on its own and the overlay assert
+  // would be vacuous on every arm.
+  useUiStore.setState({
+    attachmentFanHostId: HOST_ID,
+    pendingAbilityChoice: null,
+    enchantmentsDialogPlayer: null,
+  });
+  return render(
+    <>
+      <DialogHost>
+        <div />
+      </DialogHost>
+      <AttachmentFan />
+    </>,
+  );
+}
+
+/** `DialogHost.tsx:199` — `fixed inset-0 ${GAME_Z_LAYER.dialogHost}`, z-40. */
+function hostOverlayCount(): number {
+  return document.querySelectorAll(".fixed.inset-0.z-40").length;
+}
+
+function fanCards(): HTMLElement[] {
+  const fan = document.querySelector("[data-attachment-fan]");
+  return Array.from(fan?.querySelectorAll("[aria-label]") ?? []) as HTMLElement[];
+}
+
+function clickFanCard(name: string) {
+  const card = fanCards().find((el) => el.getAttribute("aria-label") === name);
+  expect(card, `fan card ${name} must be rendered`).toBeTruthy();
+  fireEvent.click(card as HTMLElement);
+}
+
+describe("pendingAbilityChoice reaches its DialogHost consumer", () => {
+  beforeEach(() => {
+    vi.mocked(dispatchAction).mockReset();
+    vi.mocked(dispatchAction).mockResolvedValue(undefined);
+    vi.mocked(dispatchInteraction).mockReset();
+    vi.mocked(dispatchInteraction).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useUiStore.setState({ attachmentFanHostId: null, pendingAbilityChoice: null });
+  });
+
+  // V25 (a) — the bug itself. Clicking the Aura in the fan must publish BOTH of
+  // its abilities, in engine order, AND raise the host overlay that paints the
+  // chooser. Before this change the fan had exactly one source (an open
+  // interaction's projection), so a populated bucket with no prompt open
+  // reached nothing at all.
+  // MEASURED (drop side, whole change reverted): both asserts flip —
+  //   `ASSERT=payload: expected null to deeply equal { objectId: 408, actions: [ …(2) `
+  //   `ASSERT=overlay: expected +0 to be 1`
+  it("publishes the clicked attachment's abilities and raises the dialog overlay", () => {
+    seed({ [String(FREED_ID)]: [FREED_TAP, FREED_UNTAP] });
+
+    // Non-soft PRECONDITION, and its own control: if the fixture ever stops
+    // rendering both cards the arms below would agree for the wrong reason.
+    expect(fanCards()).toHaveLength(2);
+    expect(hostOverlayCount(), "no overlay before the click").toBe(0);
+
+    clickFanCard("Freed from the Real");
+
+    expect.soft(useUiStore.getState().pendingAbilityChoice, "ASSERT=payload").toEqual({
+      objectId: FREED_ID,
+      actions: [FREED_TAP, FREED_UNTAP],
+    });
+    expect.soft(hostOverlayCount(), "ASSERT=overlay").toBe(1);
+  });
+
+  // V25 (b) — the fan is opened FROM the host, so the host card is the fan's
+  // anchor and never one of its picks. Same bucket as (a); only the clicked
+  // card differs.
+  it("publishes nothing when the fan's own host is clicked", () => {
+    seed({ [String(FREED_ID)]: [FREED_TAP, FREED_UNTAP] });
+
+    expect(fanCards()).toHaveLength(2);
+
+    clickFanCard("Kilo, Apogee Mind");
+
+    expect.soft(useUiStore.getState().pendingAbilityChoice, "ASSERT=payload").toBeNull();
+    expect.soft(hostOverlayCount(), "ASSERT=overlay").toBe(0);
+  });
+
+  // V25 (c) — THE ARM THAT SEPARATES THE ALWAYS-TRUE MUTANT. With an EMPTY host
+  // bucket, (a) and (b) cannot tell a correct implementation from one whose
+  // `selectable` predicate is constant-true with the `id !== host.id` host
+  // invariant dropped: both agree on every arm. Populating the host's OWN
+  // bucket is what makes that mutant visible.
+  // MEASURED (always side, on THIS arm only): both asserts flip —
+  //   `ASSERT=payload: expected { objectId: 401, actions: [ …(2)`
+  //   `ASSERT=overlay: expected 1 to be +0`
+  it("still publishes nothing when the host's own bucket is populated too", () => {
+    seed({
+      [String(HOST_ID)]: [HOST_ABILITY_A, HOST_ABILITY_B],
+      [String(FREED_ID)]: [FREED_TAP, FREED_UNTAP],
+    });
+
+    expect(fanCards()).toHaveLength(2);
+
+    clickFanCard("Kilo, Apogee Mind");
+
+    expect.soft(useUiStore.getState().pendingAbilityChoice, "ASSERT=payload").toBeNull();
+    expect.soft(hostOverlayCount(), "ASSERT=overlay").toBe(0);
+  });
+});

--- a/client/src/components/hud/DialogAttachmentCard.tsx
+++ b/client/src/components/hud/DialogAttachmentCard.tsx
@@ -4,11 +4,15 @@ import { useTranslation } from "react-i18next";
 import type { ObjectId } from "../../adapter/types.ts";
 import { dispatchAction } from "../../game/dispatch.ts";
 import { useCardHover } from "../../hooks/useCardHover.ts";
-import { usePlayerId, waitingPlayer } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState, usePlayerId, waitingPlayer } from "../../hooks/usePlayerId.ts";
 import { cardImageLookup } from "../../services/cardImageLookup.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
-import { collectObjectActions } from "../../viewmodel/cardActionChoice.ts";
+import {
+  collectObjectActions,
+  deriveActivationAffordances,
+  resolveObjectActivation,
+} from "../../viewmodel/cardActionChoice.ts";
 import { COUNTER_COLORS, formatCounterType } from "../../viewmodel/cardProps.ts";
 import { getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
 import { CardImage } from "../card/CardImage.tsx";
@@ -80,11 +84,25 @@ export function DialogAttachmentCard({ objectId, widthPx, onDismiss }: Props) {
   // triggered) but the engine surfaces them through the same per-object
   // legal-action map that PermanentCard consumes on the battlefield.
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const objects = useGameStore((s) => s.gameState?.objects);
+  const canActForWaitingState = useCanActForWaitingState();
   const objectActions = useMemo(
     () => (legalActionsByObject ? collectObjectActions(legalActionsByObject, objectId) : []),
     [legalActionsByObject, objectId],
   );
-  const isActivatable = objectActions.length > 0;
+  // THE single authority — the same affordance sets the battlefield ring reads,
+  // so this dialog can never offer an activation the board would refuse. It
+  // replaces an `objectActions.length > 0` test that had no WaitingFor gate and
+  // no seat gate.
+  const affordances = useMemo(
+    () =>
+      deriveActivationAffordances(waitingFor, canActForWaitingState, legalActionsByObject, objects),
+    [waitingFor, canActForWaitingState, legalActionsByObject, objects],
+  );
+  const isActivatable =
+    affordances.activatableObjectIds.has(objectId)
+    || affordances.manaTappableObjectIds.has(objectId);
 
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
 
@@ -118,18 +136,21 @@ export function DialogAttachmentCard({ objectId, widthPx, onDismiss }: Props) {
       return;
     }
     if (isActivatable) {
-      if (objectActions.length === 1) {
-        dispatchAction(objectActions[0]);
-        // Close so the board is reachable for whatever the activation asks
-        // next — e.g. Equip transitions to `EquipTarget`, whose creature
-        // target is picked on the battlefield, not in this dialog.
+      // #506: the lone-action auto-dispatch decision belongs to the shared
+      // authority, never re-implemented here. `onDismiss` fires on both outcomes
+      // exactly as before — the board must be reachable for whatever the
+      // activation asks next (Equip → `EquipTarget`), and the multi-ability
+      // picker floats independently above this dialog.
+      const verdict = resolveObjectActivation(
+        objectActions,
+        obj,
+        affordances.manaTappableObjectIds.has(objectId),
+      );
+      if (verdict.kind === "dispatch") {
+        dispatchAction(verdict.action);
         onDismiss?.();
-      } else {
-        // Multi-ability picker takes over. Hand off to it and close this
-        // dialog: the picker floats independently (DialogHost z-ordering)
-        // and its own dispatch will drive the next board prompt, so keeping
-        // the attachments dialog mounted behind it only obscures the board.
-        setPendingAbilityChoice({ objectId, actions: objectActions });
+      } else if (verdict.kind === "choose") {
+        setPendingAbilityChoice({ objectId, actions: verdict.actions });
         onDismiss?.();
       }
     }

--- a/client/src/components/hud/DialogAttachmentCard.tsx
+++ b/client/src/components/hud/DialogAttachmentCard.tsx
@@ -141,17 +141,28 @@ export function DialogAttachmentCard({ objectId, widthPx, onDismiss }: Props) {
       // exactly as before — the board must be reachable for whatever the
       // activation asks next (Equip → `EquipTarget`), and the multi-ability
       // picker floats independently above this dialog.
-      const verdict = resolveObjectActivation(
-        objectActions,
-        obj,
-        affordances.manaTappableObjectIds.has(objectId),
-      );
-      if (verdict.kind === "dispatch") {
-        dispatchAction(verdict.action);
-        onDismiss?.();
-      } else if (verdict.kind === "choose") {
-        setPendingAbilityChoice({ objectId, actions: verdict.actions });
-        onDismiss?.();
+      const verdict = resolveObjectActivation(objectActions, obj, affordances, objectId);
+      switch (verdict.kind) {
+        case "dispatch":
+          dispatchAction(verdict.action);
+          onDismiss?.();
+          return;
+        case "choose":
+          setPendingAbilityChoice({ objectId, actions: verdict.actions });
+          onDismiss?.();
+          return;
+        case "none":
+          // Reachable only through the render→click staleness window: the cyan
+          // ring was painted from a bucket this click no longer sees. Doing
+          // nothing — and NOT dismissing — is correct, and is what the old
+          // if/else chain did.
+          return;
+        default: {
+          // CLAUDE.md "exhaustive match without wildcard fallbacks": a new
+          // ObjectActivation variant is a compile error here, never a silent drop.
+          const _exhaustive: never = verdict;
+          return _exhaustive;
+        }
       }
     }
   };

--- a/client/src/components/hud/__tests__/DialogAttachmentCard.test.tsx
+++ b/client/src/components/hud/__tests__/DialogAttachmentCard.test.tsx
@@ -1,0 +1,212 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameAction, GameObject, GameState, WaitingFor } from "../../../adapter/types.ts";
+import { dispatchAction } from "../../../game/dispatch.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
+import {
+  buildGameState,
+  buildPlayers,
+  buildPriorityWaitingFor,
+} from "../../../test/factories/gameStateFactory.ts";
+import { DialogAttachmentCard } from "../DialogAttachmentCard.tsx";
+
+/**
+ * `DialogAttachmentCard` adoption of the shared activation authority
+ * (plan §6.4). Rows V16 (D2 — the gate the dialog never had) and V16b (the
+ * LIVE #506 bypass this site was shipping).
+ *
+ * Before this change the dialog decided activation with
+ * `objectActions.length > 0` — no `WaitingFor` gate and no seat gate — and then
+ * re-implemented the lone-action dispatch decision inline, so a lone
+ * card-consuming ability auto-fired here while the battlefield correctly asked
+ * for confirmation.
+ *
+ * ---------------------------------------------------------------------------
+ * EVIDENCE-LABEL CONVENTION (plan §7.2, binding on this module). Every comment
+ * carrying a mutant/coverage claim is tagged, because an in-file label is
+ * otherwise ambiguous between an INSTRUCTION and a PAST-TENSE REPORT:
+ *
+ *   MEASURED   past-tense report: this PR ran that arm; the quoted text is the
+ *              assertion that flipped.
+ *   QUOTED     past-tense report copied verbatim from a named harness log.
+ *   POINTER    names a row/mutant whose measurement lives in the plan's
+ *              evidence logs, not here.
+ *   PAIR-ONLY / DROP-ONLY   the row carries ONE side by construction (§7.1).
+ *
+ * An untagged comment is prose and is evidence for nothing.
+ *
+ * NAMED UNMEASURED ANCHOR IN THIS FILE: none.
+ * ---------------------------------------------------------------------------
+ */
+
+vi.mock("../../../game/dispatch.ts", () => ({
+  dispatchAction: vi.fn(),
+  dispatchInteraction: vi.fn(),
+}));
+
+vi.mock("../../card/CardImage.tsx", () => ({
+  CardImage: ({ cardName }: { cardName: string }) => <div data-card-image={cardName} />,
+}));
+
+const CURSE_ID = 408;
+
+/** A Curse-cycle Aura: attached to a PLAYER, so it renders only in this dialog. */
+const CURSE_TAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: CURSE_ID, ability_index: 0 },
+};
+
+function makeCurse(abilities: unknown[]): GameObject {
+  return buildGameObject({
+    id: CURSE_ID,
+    card_id: 4080,
+    zone: "Battlefield",
+    owner: 0,
+    controller: 0,
+    name: "Cruel Reality",
+    attached_to: { type: "Player", data: 1 },
+    entered_battlefield_turn: null,
+    card_types: { supertypes: [], core_types: ["Enchantment"], subtypes: ["Aura", "Curse"] },
+    abilities: abilities as GameObject["abilities"],
+  });
+}
+
+function makeState(curse: GameObject, waitingFor: WaitingFor): GameState {
+  return buildGameState({
+    players: buildPlayers([0, 1]),
+    objects: buildObjectMap(curse),
+    battlefield: [CURSE_ID],
+    exile: [],
+    stack: [],
+    waiting_for: waitingFor,
+  });
+}
+
+const DECLARE_BLOCKERS: WaitingFor = {
+  type: "DeclareBlockers",
+  data: { player: 0, valid_blocker_ids: [], valid_block_targets: {} },
+};
+
+function seed(options: {
+  abilities?: unknown[];
+  legalActionsByObject?: Record<string, GameAction[]>;
+  waitingFor?: WaitingFor;
+}) {
+  const curse = makeCurse(options.abilities ?? [{ effect: { type: "Tap" } }]);
+  const waitingFor = options.waitingFor ?? buildPriorityWaitingFor();
+  useGameStore.setState({
+    gameMode: "local",
+    gameState: makeState(curse, waitingFor),
+    waitingFor,
+    legalActions: [],
+    legalActionsByObject: options.legalActionsByObject ?? {},
+    viewerInteraction: null,
+  });
+  useUiStore.setState({ pendingAbilityChoice: null });
+  const onDismiss = vi.fn();
+  render(<DialogAttachmentCard objectId={CURSE_ID} widthPx={200} onDismiss={onDismiss} />);
+  return { onDismiss };
+}
+
+/** `role="button"` is the component's rendering of `interactive`. */
+function interactiveCard(): HTMLElement | null {
+  return screen.queryByRole("button");
+}
+
+describe("DialogAttachmentCard activation gate", () => {
+  beforeEach(() => {
+    window.matchMedia = ((query: string) => ({
+      matches: query === "(hover: hover)" || query === "(any-hover: hover)",
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })) as unknown as typeof window.matchMedia;
+    vi.mocked(dispatchAction).mockReset();
+    vi.mocked(dispatchAction).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useUiStore.setState({ pendingAbilityChoice: null });
+  });
+
+  // V16 (D2) — the timing gate the dialog never had. IDENTICAL bucket on both
+  // arms; only the engine's `WaitingFor` differs. Assertion order: the
+  // DeclareBlockers arm (which both the drop and the always mutant fail), then
+  // the Priority arm, which is the control proving this fixture can be
+  // interactive at all — without it "never interactive" would pass.
+  //
+  // QUOTED (`.plan-item3-r4.md:651`, the pre/post pair for this fixture):
+  //   `D-2 interactive at DeclareBlockers(opponent): true`
+  //   → `D2 interactive at DeclareBlockers: false`
+  // MEASURED (drop side): restoring `isActivatable = objectActions.length > 0`
+  //   flips the first assert to `expected <div /> to be null`.
+  it("is inert at DeclareBlockers and interactive at Priority with the same bucket", () => {
+    const bucket = { [String(CURSE_ID)]: [CURSE_TAP] };
+
+    seed({ legalActionsByObject: bucket, waitingFor: DECLARE_BLOCKERS });
+    expect(interactiveCard()).toBeNull();
+    cleanup();
+
+    seed({ legalActionsByObject: bucket });
+    expect(interactiveCard()).not.toBeNull();
+  });
+
+  // The seat axis of the same gate: at a Priority prompt this viewer cannot act
+  // on, the dialog must not offer the activation either. `legalActionsByObject`
+  // in local/AI mode is computed for the STATE's priority player, not the
+  // viewer, so a populated bucket alone is not authorization.
+  it("is inert at an opponent's Priority even with a populated bucket", () => {
+    seed({
+      legalActionsByObject: { [String(CURSE_ID)]: [CURSE_TAP] },
+      waitingFor: { type: "Priority", data: { player: 1 } },
+    });
+
+    expect(interactiveCard()).toBeNull();
+  });
+
+  // V16b — the LIVE #506 bypass. Same lone action on both arms; only
+  // `consumes_source` differs, so neither arm can pass by "always modal" or
+  // "always dispatch".
+  //
+  // QUOTED (`.plan-item3-r4.md:652`, pre-fix behaviour of this exact fixture):
+  //   `D-1 consumes_source=true dispatchAction calls: 1 pendingAbilityChoice: null`
+  // MEASURED (drop side): restoring `objectActions.length === 1 ⇒ dispatchAction`
+  //   flips the consuming arm to
+  //   `expected "dispatchAction" to not be called at all, but it was called 1 times`.
+  it("sends a lone card-consuming ability to the modal, and a benign one straight through", () => {
+    const consuming = seed({
+      abilities: [{ effect: { type: "Tap" }, consumes_source: true }],
+      legalActionsByObject: { [String(CURSE_ID)]: [CURSE_TAP] },
+    });
+
+    fireEvent.click(interactiveCard() as HTMLElement);
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(useUiStore.getState().pendingAbilityChoice).toEqual({
+      objectId: CURSE_ID,
+      actions: [CURSE_TAP],
+    });
+    // `onDismiss` fires on BOTH outcomes, exactly as before this change: the
+    // picker floats independently above this dialog.
+    expect(consuming.onDismiss).toHaveBeenCalledTimes(1);
+    cleanup();
+
+    const benign = seed({
+      abilities: [{ effect: { type: "Tap" }, consumes_source: false }],
+      legalActionsByObject: { [String(CURSE_ID)]: [CURSE_TAP] },
+    });
+
+    fireEvent.click(interactiveCard() as HTMLElement);
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(CURSE_TAP);
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+    expect(benign.onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/zone/CommandZone.tsx
+++ b/client/src/components/zone/CommandZone.tsx
@@ -28,8 +28,19 @@ interface CommandZoneProps {
 interface GroupedEmblem {
   description: string;
   sourceName: string | null;
-  count: number;
-  representative: GameObject;
+  /**
+   * EVERY emblem in the group, in command-zone order — never a lone
+   * representative plus a tally.
+   *
+   * CR 114.1: an emblem is a marker representing its OWN object; CR 114.4: its
+   * abilities function in the command zone. `legalActionsByObject` is keyed by
+   * exact object id, so a group that remembered only a representative could ask
+   * the activation authority about one id while the engine had published the
+   * legal action against a sibling — the chip rendered inert and the action was
+   * unreachable. The stack is a DISPLAY grouping; activation identity stays
+   * per-object. `.length` is the display count.
+   */
+  members: GameObject[];
 }
 
 /** The emblem's granted rules text ("what it does"). The engine attaches it to
@@ -82,9 +93,11 @@ export function CommandZone({ playerId }: CommandZoneProps) {
       const key = `${sourceName ?? ""}|${desc}`;
       const existing = byKey.get(key);
       if (existing) {
-        existing.count++;
+        // Retain the member, never just a tally — the chip needs its id to reach
+        // an action the engine published against this exact emblem.
+        existing.members.push(emblem);
       } else {
-        byKey.set(key, { description: desc, sourceName, count: 1, representative: emblem });
+        byKey.set(key, { description: desc, sourceName, members: [emblem] });
       }
     }
 
@@ -96,7 +109,7 @@ export function CommandZone({ playerId }: CommandZoneProps) {
   return (
     <div className="flex items-center gap-1.5">
       {groups.map((group) => (
-        <EmblemCard key={group.representative.id} group={group} label={t("zone.emblem")} />
+        <EmblemCard key={group.members[0].id} group={group} label={t("zone.emblem")} />
       ))}
     </div>
   );
@@ -114,7 +127,11 @@ export function CommandZone({ playerId }: CommandZoneProps) {
  */
 function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
   const isCompactHeight = useIsCompactHeight();
-  const emblem = group.representative;
+  // DISPLAY identity only. Art, source and rules text are group-invariant by
+  // construction of the grouping key (`source | description`), so any member
+  // renders the same chip — but activation identity is resolved per-object
+  // below, never from this one.
+  const emblem = group.members[0];
   const printedRef = emblem.emblem_source?.printed_ref ?? null;
   const { src: artSrc } = useCardImage(group.sourceName ?? "", {
     size: "art_crop",
@@ -143,24 +160,53 @@ function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
       deriveActivationAffordances(waitingFor, canActForWaitingState, legalActionsByObject, objects),
     [waitingFor, canActForWaitingState, legalActionsByObject, objects],
   );
-  const isActivatable =
-    affordances.activatableObjectIds.has(emblem.id)
-    || affordances.manaTappableObjectIds.has(emblem.id);
+  // WHICH id the authority is asked about — not a second decision site. CR
+  // 114.1: each emblem is its own object, and `legalActionsByObject` is keyed by
+  // exact id, so a display group must offer whichever MEMBER the shared sets
+  // name. Asking about the representative alone hid a legal action whenever the
+  // engine published it against a sibling. `find` takes the first offered
+  // member, so one chip can never dispatch twice; class-general for any group
+  // size and any member position.
+  const activeMember =
+    group.members.find(
+      (member) =>
+        affordances.activatableObjectIds.has(member.id)
+        || affordances.manaTappableObjectIds.has(member.id),
+    ) ?? null;
+  const isActivatable = activeMember !== null;
 
   const handleActivate = useCallback(() => {
+    // Re-checked rather than assumed: the DOM only wires this when a member is
+    // offered, and `activeMember` is the one id this chip may act on.
+    if (!activeMember) return;
     // #506 stays where it always was — inside the authority. The bucket is read
     // at click, so this chip keeps no per-render projection of its own.
     const verdict = resolveObjectActivation(
-      collectObjectActions(useGameStore.getState().legalActionsByObject, emblem.id),
-      emblem,
-      affordances.manaTappableObjectIds.has(emblem.id),
+      collectObjectActions(useGameStore.getState().legalActionsByObject, activeMember.id),
+      activeMember,
+      affordances,
+      activeMember.id,
     );
-    if (verdict.kind === "dispatch") {
-      dispatchAction(verdict.action);
-    } else if (verdict.kind === "choose") {
-      setPendingAbilityChoice({ objectId: emblem.id, actions: verdict.actions });
+    switch (verdict.kind) {
+      case "dispatch":
+        dispatchAction(verdict.action);
+        return;
+      case "choose":
+        setPendingAbilityChoice({ objectId: activeMember.id, actions: verdict.actions });
+        return;
+      case "none":
+        // Reachable only through the render→click staleness window: the chip's
+        // ring was painted from a bucket this click no longer sees. Doing
+        // nothing is correct, and is exactly what the old if/else chain did.
+        return;
+      default: {
+        // CLAUDE.md "exhaustive match without wildcard fallbacks": a new
+        // ObjectActivation variant is a compile error here, never a silent drop.
+        const _exhaustive: never = verdict;
+        return _exhaustive;
+      }
     }
-  }, [affordances, emblem, setPendingAbilityChoice]);
+  }, [activeMember, affordances, setPendingAbilityChoice]);
 
   return (
     <div
@@ -253,14 +299,16 @@ function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
         </div>
       </div>
 
-      {/* Count badge (CR 114: identical emblems stacked) */}
-      {group.count > 1 && (
+      {/* Count badge (CR 114: identical emblems stacked). The count is now the
+          retained member list's length rather than a separate tally, so it
+          cannot drift from the ids the chip can actually act on. */}
+      {group.members.length > 1 && (
         <div
           className={`absolute -bottom-[3px] -right-[3px] z-20 inline-flex items-center justify-center rounded-full border border-black/80 bg-amber-600 px-1 font-bold text-black shadow-[0_2px_4px_rgba(0,0,0,0.8)] ${
             isCompactHeight ? "h-3.5 min-w-3.5 text-[8px]" : "h-4 min-w-4 text-[9px]"
           }`}
         >
-          ×{group.count}
+          ×{group.members.length}
         </div>
       )}
     </div>

--- a/client/src/components/zone/CommandZone.tsx
+++ b/client/src/components/zone/CommandZone.tsx
@@ -5,11 +5,13 @@ import type { GameObject, PlayerId } from "../../adapter/types.ts";
 import { dispatchAction } from "../../game/dispatch.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
+import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import {
   collectObjectActions,
-  resolveSingleActionDispatch,
+  deriveActivationAffordances,
+  resolveObjectActivation,
 } from "../../viewmodel/cardActionChoice.ts";
 import { RichLabel } from "../mana/RichLabel.tsx";
 import { GameplayTooltip } from "../ui/GameplayTooltip.tsx";
@@ -129,25 +131,36 @@ function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
   // no client-side legality inference. Static/triggered emblems never report
   // actions here, so they stay display-only as before.
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const objects = useGameStore((s) => s.gameState?.objects);
+  const canActForWaitingState = useCanActForWaitingState();
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
-  const emblemActions = useMemo(
-    () => collectObjectActions(legalActionsByObject, emblem.id),
-    [legalActionsByObject, emblem.id],
+  // THE single authority. `emblemActions.length > 0` had NEITHER a WaitingFor
+  // gate nor a seat gate, so an opponent's chip was clickable from this viewer's
+  // seat (D4); membership in the shared sets closes both at once.
+  const affordances = useMemo(
+    () =>
+      deriveActivationAffordances(waitingFor, canActForWaitingState, legalActionsByObject, objects),
+    [waitingFor, canActForWaitingState, legalActionsByObject, objects],
   );
-  const isActivatable = emblemActions.length > 0;
+  const isActivatable =
+    affordances.activatableObjectIds.has(emblem.id)
+    || affordances.manaTappableObjectIds.has(emblem.id);
 
   const handleActivate = useCallback(() => {
-    if (emblemActions.length === 0) return;
-    // Reuse the shared single-authority dispatch helper (issue #506): a
-    // card-consuming ability surfaces the confirmation modal; otherwise the
-    // lone action auto-fires, kicking off the engine's X / discard prompts.
-    const auto = resolveSingleActionDispatch(emblemActions, emblem);
-    if (auto) {
-      dispatchAction(auto);
-    } else {
-      setPendingAbilityChoice({ objectId: emblem.id, actions: emblemActions });
+    // #506 stays where it always was — inside the authority. The bucket is read
+    // at click, so this chip keeps no per-render projection of its own.
+    const verdict = resolveObjectActivation(
+      collectObjectActions(useGameStore.getState().legalActionsByObject, emblem.id),
+      emblem,
+      affordances.manaTappableObjectIds.has(emblem.id),
+    );
+    if (verdict.kind === "dispatch") {
+      dispatchAction(verdict.action);
+    } else if (verdict.kind === "choose") {
+      setPendingAbilityChoice({ objectId: emblem.id, actions: verdict.actions });
     }
-  }, [emblemActions, emblem, setPendingAbilityChoice]);
+  }, [affordances, emblem, setPendingAbilityChoice]);
 
   return (
     <div

--- a/client/src/components/zone/CommanderCardZone.tsx
+++ b/client/src/components/zone/CommanderCardZone.tsx
@@ -9,12 +9,13 @@ import { previewAutomaticManaPayment } from "../../game/manaPaymentPreview.ts";
 import { useCardHover } from "../../hooks/useCardHover.ts";
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
-import { getPlayerId } from "../../hooks/usePlayerId.ts";
+import { getPlayerId, useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { useDragToCast } from "../../hooks/useDragToCast.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import {
   collectObjectActions,
+  deriveActivationAffordances,
   resolveSingleActionDispatch,
 } from "../../viewmodel/cardActionChoice.ts";
 import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
@@ -96,8 +97,31 @@ function CommanderCard({
     [commanderActions],
   );
 
-  const canCast = castAction !== null;
-  const canNinjutsu = ninjutsuActions.length > 0;
+  // THE single authority — the same one the emblem chip adopts one file over.
+  // `castAction !== null` / `ninjutsuActions.length > 0` were raw-bucket tests
+  // with NEITHER a `WaitingFor` gate NOR a seat gate, and `PlayerArea` renders a
+  // `<CommanderCardZone playerId={opponentId}/>` from the same `CommandDock`
+  // subtree for every seat. In local/AI mode `legalActionsByObject` is computed
+  // for the STATE's priority player rather than the viewer, so an opponent's
+  // commander chip was clickable — and dispatched — from this seat.
+  //
+  // Only the non-mana ring is consulted: CastSpell and ActivateNinjutsu are both
+  // non-mana, so CR 113.3b ("whenever they have priority") is the whole gate.
+  // The mana ring would be dead weight here — a command-zone card publishes no
+  // mana action — and consulting it would re-open the cast affordance during a
+  // cost-payment prompt.
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const objects = useGameStore((s) => s.gameState?.objects);
+  const canActForWaitingState = useCanActForWaitingState();
+  const affordances = useMemo(
+    () =>
+      deriveActivationAffordances(waitingFor, canActForWaitingState, legalActionsByObject, objects),
+    [waitingFor, canActForWaitingState, legalActionsByObject, objects],
+  );
+  const activationOffered = affordances.activatableObjectIds.has(commander.id);
+
+  const canCast = activationOffered && castAction !== null;
+  const canNinjutsu = activationOffered && ninjutsuActions.length > 0;
 
   // CR 702.49d: commander ninjutsu returns an unblocked attacker and puts this
   // commander onto the battlefield tapped and attacking. The engine emits one

--- a/client/src/components/zone/LibraryPile.tsx
+++ b/client/src/components/zone/LibraryPile.tsx
@@ -10,7 +10,10 @@ import { CARD_BACK_URL } from "../../services/scryfall.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { CASTABLE_AFFORDANCE_IDLE } from "../../viewmodel/castableAffordance.ts";
-import { playOrCastActionsForObject } from "../../viewmodel/cardActionChoice.ts";
+import {
+  playOrCastActionsForObject,
+  resolveSingleActionDispatch,
+} from "../../viewmodel/cardActionChoice.ts";
 import { isLibraryCardRevealedToViewer } from "../../viewmodel/gameStateView.ts";
 
 interface LibraryPileProps {
@@ -108,13 +111,14 @@ export function LibraryPile({ playerId, size, onView }: LibraryPileProps) {
 
   const handlePlay = useCallback(() => {
     if (playActions.length === 0 || topObjectId == null) return;
-    if (playActions.length === 1) {
-      void dispatchAction(playActions[0]);
-    } else {
-      // Multiple options (e.g., cast normal + alt-cost) — defer to the shared
-      // ability-choice modal so the player can pick.
-      setPendingAbilityChoice({ objectId: topObjectId as ObjectId, actions: playActions });
-    }
+    // #506: one authority for the lone-action decision. Multiple options (e.g.
+    // cast normal + alt-cost) defer to the shared ability-choice modal.
+    const auto = resolveSingleActionDispatch(
+      playActions,
+      useGameStore.getState().gameState?.objects[topObjectId],
+    );
+    if (auto) void dispatchAction(auto);
+    else setPendingAbilityChoice({ objectId: topObjectId as ObjectId, actions: playActions });
   }, [playActions, topObjectId, dispatchAction, setPendingAbilityChoice]);
 
   if (count === 0) return null;

--- a/client/src/components/zone/__tests__/CommandZone.test.tsx
+++ b/client/src/components/zone/__tests__/CommandZone.test.tsx
@@ -1,0 +1,216 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GameAction, GameObject, GameState, WaitingFor } from "../../../adapter/types.ts";
+import { dispatchAction } from "../../../game/dispatch.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
+import {
+  buildGameState,
+  buildPlayers,
+  buildPriorityWaitingFor,
+} from "../../../test/factories/gameStateFactory.ts";
+import { CommandZone } from "../CommandZone.tsx";
+
+/**
+ * The emblem chip adopting the shared activation authority (plan §6.5).
+ * Rows V20 (timing axis), V20b (seat axis — a LIVE cross-seat bug), and
+ * V20c (D5: modal action order on the reachable emblem shape).
+ *
+ * Before this change the chip decided with `emblemActions.length > 0`: no
+ * `WaitingFor` gate and no seat gate. `PlayerArea` renders a `<CommandZone
+ * playerId={opponentId}/>`, and in local/AI mode `legalActionsByObject` is
+ * computed for the STATE's priority player rather than the viewer — so an
+ * opponent's emblem chip was clickable, and dispatched, from this seat.
+ *
+ * ---------------------------------------------------------------------------
+ * EVIDENCE-LABEL CONVENTION (plan §7.2, binding on this module). Every comment
+ * carrying a mutant/coverage claim is tagged, because an in-file label is
+ * otherwise ambiguous between an INSTRUCTION and a PAST-TENSE REPORT:
+ *
+ *   MEASURED   past-tense report: this PR ran that arm; the quoted text is the
+ *              assertion that flipped.
+ *   QUOTED     past-tense report copied verbatim from a named harness log.
+ *   POINTER    names a row/mutant whose measurement lives in the plan's
+ *              evidence logs, not here.
+ *   PAIR-ONLY / DROP-ONLY   the row carries ONE side by construction (§7.1).
+ *
+ * An untagged comment is prose and is evidence for nothing.
+ *
+ * NAMED UNMEASURED ANCHOR IN THIS FILE: D5's order claim is asserted on the
+ * STORE payload (`pendingAbilityChoice.actions`), NOT on rendered option
+ * labels. `AbilityChoiceModal` is module-private inside `GamePage.tsx`, so no
+ * component-level row here can observe its labels; that consumer is registered
+ * as an audited absence (plan §7.3 row V26) and is coverage for nothing.
+ * ---------------------------------------------------------------------------
+ */
+
+vi.mock("../../../game/dispatch.ts", () => ({
+  dispatchAction: vi.fn(),
+  dispatchInteraction: vi.fn(),
+}));
+
+vi.mock("../../../hooks/useCardImage.ts", () => ({
+  useCardImage: () => ({ src: null, isLoading: false, isRotated: false, isFlip: false }),
+}));
+
+const EMBLEM_ID = 700;
+
+/** CR 114.4 + CR 602.1: an emblem can carry an activated ability. */
+const EMBLEM_ABILITY_0: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: EMBLEM_ID, ability_index: 0 },
+};
+const EMBLEM_ABILITY_1: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: EMBLEM_ID, ability_index: 1 },
+};
+
+function makeEmblem(options: { controller?: number; abilities?: unknown[] } = {}): GameObject {
+  return buildGameObject({
+    id: EMBLEM_ID,
+    card_id: 7000,
+    zone: "Command",
+    owner: options.controller ?? 0,
+    controller: options.controller ?? 0,
+    name: "Emblem",
+    is_emblem: true,
+    entered_battlefield_turn: null,
+    card_types: { supertypes: [], core_types: [], subtypes: [] },
+    abilities: (options.abilities ?? [
+      { description: "{X}, Discard a card: Create a token.", effect: { type: "CreateToken" } },
+    ]) as GameObject["abilities"],
+  });
+}
+
+function makeState(emblem: GameObject, waitingFor: WaitingFor): GameState {
+  return buildGameState({
+    players: buildPlayers([0, 1]),
+    objects: buildObjectMap(emblem),
+    battlefield: [],
+    exile: [],
+    stack: [],
+    command_zone: [EMBLEM_ID],
+    waiting_for: waitingFor,
+  });
+}
+
+const DECLARE_BLOCKERS: WaitingFor = {
+  type: "DeclareBlockers",
+  data: { player: 0, valid_blocker_ids: [], valid_block_targets: {} },
+};
+
+function seed(options: {
+  abilities?: unknown[];
+  controller?: number;
+  legalActionsByObject?: Record<string, GameAction[]>;
+  waitingFor?: WaitingFor;
+  viewerSeat?: number;
+} = {}) {
+  const emblem = makeEmblem({ controller: options.controller, abilities: options.abilities });
+  const waitingFor = options.waitingFor ?? buildPriorityWaitingFor();
+  useGameStore.setState({
+    gameMode: "local",
+    gameState: makeState(emblem, waitingFor),
+    waitingFor,
+    legalActions: [],
+    legalActionsByObject: options.legalActionsByObject ?? {},
+    viewerInteraction: null,
+  });
+  useUiStore.setState({ pendingAbilityChoice: null });
+  return render(<CommandZone playerId={options.controller ?? 0} />);
+}
+
+/** `data-activatable` is the chip's own rendering of the affordance verdict. */
+function chipIsActivatable(): boolean {
+  const chip = screen.getByTestId("emblem-card");
+  return chip.getAttribute("data-activatable") === "true";
+}
+
+describe("CommandZone emblem chip activation gate", () => {
+  beforeEach(() => {
+    vi.mocked(dispatchAction).mockReset();
+    vi.mocked(dispatchAction).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useUiStore.setState({ pendingAbilityChoice: null });
+  });
+
+  // V20 — the TIMING axis. Identical bucket on both arms; only the engine's
+  // `WaitingFor` differs. Assertion order: the DeclareBlockers arm (the one a
+  // restored `emblemActions.length > 0` fails), then the Priority arm, which is
+  // the control proving this fixture can be activatable at all.
+  //
+  // MEASURED (drop side): restoring `isActivatable = emblemActions.length > 0`
+  //   flips the first assert to `expected true to be false`.
+  it("is inert at DeclareBlockers and activatable at Priority with the same bucket", () => {
+    const bucket = { [String(EMBLEM_ID)]: [EMBLEM_ABILITY_0] };
+
+    seed({ legalActionsByObject: bucket, waitingFor: DECLARE_BLOCKERS });
+    expect(chipIsActivatable()).toBe(false);
+    expect(screen.queryByRole("button")).toBeNull();
+    cleanup();
+
+    seed({ legalActionsByObject: bucket });
+    expect(chipIsActivatable()).toBe(true);
+    fireEvent.click(screen.getByTestId("emblem-card"));
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(EMBLEM_ABILITY_0);
+  });
+
+  // V20b — the SEAT axis, and a LIVE bug: `PlayerArea` → `CommandDock` renders
+  // this component for the opponent's seat too.
+  // QUOTED (`.plan3r4-transcript.log:30-31`):
+  //   `PF1[opponent emblem @ OPPONENT Priority, viewer=P0] measuredCanAct=false
+  //    today data-activatable=true dispatches=1 | adopted activatable=false mana=false`
+  //   `PF1b[own emblem @ own Priority] measuredCanAct=true today
+  //    data-activatable=true dispatches=1 | adopted activatable=true`
+  it("does not offer an opponent's emblem chip from this viewer's seat", () => {
+    // The engine is waiting on player 1; the local viewer is player 0. The
+    // bucket is populated exactly as in the own-seat arm below.
+    seed({
+      controller: 1,
+      legalActionsByObject: { [String(EMBLEM_ID)]: [EMBLEM_ABILITY_0] },
+      waitingFor: { type: "Priority", data: { player: 1 } },
+    });
+
+    expect(chipIsActivatable()).toBe(false);
+    fireEvent.click(screen.getByTestId("emblem-card"));
+    expect(dispatchAction).not.toHaveBeenCalled();
+    cleanup();
+
+    // Control: the same chip, on this viewer's own turn, IS offered — so the
+    // arm above cannot pass by "the chip is never activatable".
+    seed({ legalActionsByObject: { [String(EMBLEM_ID)]: [EMBLEM_ABILITY_0] } });
+    expect(chipIsActivatable()).toBe(true);
+  });
+
+  // V20c (D5) — action ORDER is preserved on the reachable emblem shape. CR
+  // 114.5: an emblem cannot tap for mana, so its bucket never interleaves the
+  // mana and non-mana groups and the partitioned list equals the raw one.
+  // QUOTED: `PE1[E1 two NON-mana activated abilities (the reachable emblem
+  //          shape)] today order=[0,1] adopted order=[0,1] SAME=true`
+  // POINTER: sweep row `E1 two NON-mana abilities`, mutants `allReverse` and
+  //   `withinGroupReverse`. The expectation is a LITERAL pair, not a list the
+  //   test re-derives from `legalActionsByObject`.
+  it("opens the chooser with both emblem abilities in engine order", () => {
+    seed({
+      abilities: [
+        { description: "{X}: Create a token.", effect: { type: "CreateToken" } },
+        { description: "{2}: Draw a card.", effect: { type: "Draw" } },
+      ],
+      legalActionsByObject: { [String(EMBLEM_ID)]: [EMBLEM_ABILITY_0, EMBLEM_ABILITY_1] },
+    });
+
+    fireEvent.click(screen.getByTestId("emblem-card"));
+
+    expect(useUiStore.getState().pendingAbilityChoice).toEqual({
+      objectId: EMBLEM_ID,
+      actions: [EMBLEM_ABILITY_0, EMBLEM_ABILITY_1],
+    });
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/zone/__tests__/CommandZone.test.tsx
+++ b/client/src/components/zone/__tests__/CommandZone.test.tsx
@@ -56,6 +56,8 @@ vi.mock("../../../hooks/useCardImage.ts", () => ({
 }));
 
 const EMBLEM_ID = 700;
+/** A SECOND emblem that groups with EMBLEM_ID — the non-representative member. */
+const SIBLING_EMBLEM_ID = 701;
 
 /** CR 114.4 + CR 602.1: an emblem can carry an activated ability. */
 const EMBLEM_ABILITY_0: GameAction = {
@@ -67,9 +69,11 @@ const EMBLEM_ABILITY_1: GameAction = {
   data: { source_id: EMBLEM_ID, ability_index: 1 },
 };
 
-function makeEmblem(options: { controller?: number; abilities?: unknown[] } = {}): GameObject {
+function makeEmblem(
+  options: { controller?: number; abilities?: unknown[]; id?: number } = {},
+): GameObject {
   return buildGameObject({
-    id: EMBLEM_ID,
+    id: options.id ?? EMBLEM_ID,
     card_id: 7000,
     zone: "Command",
     owner: options.controller ?? 0,
@@ -211,6 +215,166 @@ describe("CommandZone emblem chip activation gate", () => {
       objectId: EMBLEM_ID,
       actions: [EMBLEM_ABILITY_0, EMBLEM_ABILITY_1],
     });
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * GROUPED-EMBLEM ACTIVATION IDENTITY.
+ *
+ * Maintainer review (matthewevans, CHANGES_REQUESTED, 2026-08-04) `[MED]
+ * Grouped emblem actions can make legal nonrepresentative emblems unreachable`,
+ * independently reported by CodeRabbit as `Preserve activation identity for
+ * every grouped emblem`. CR 114.1: each emblem is its own object and
+ * `legalActionsByObject` is keyed by exact object id, so a chip that asked the
+ * activation authority about `representative.id` alone rendered inert whenever
+ * the engine had published the action against a sibling — the command-zone UI
+ * could hide a legal action.
+ *
+ * The grouping itself is unchanged (display stacking by `source | description`,
+ * CR 114); what changed is WHICH id the same authority is asked about.
+ */
+describe("CommandZone grouped-emblem activation identity", () => {
+  beforeEach(() => {
+    vi.mocked(dispatchAction).mockReset();
+    vi.mocked(dispatchAction).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    useUiStore.setState({ pendingAbilityChoice: null });
+  });
+
+  function abilityAction(sourceId: number, abilityIndex = 0): GameAction {
+    return { type: "ActivateAbility", data: { source_id: sourceId, ability_index: abilityIndex } };
+  }
+
+  /**
+   * Two emblems that GROUP: no `emblem_source`, identical granted text, so the
+   * key `source | description` collides and `CommandZone` renders exactly one
+   * chip. `command_zone` order fixes EMBLEM_ID as the representative and
+   * SIBLING_EMBLEM_ID as the non-representative member.
+   */
+  function seedGroupedPair(legalActionsByObject: Record<string, GameAction[]>) {
+    const representative = makeEmblem({ id: EMBLEM_ID });
+    const sibling = makeEmblem({ id: SIBLING_EMBLEM_ID });
+    const waitingFor = buildPriorityWaitingFor();
+    useGameStore.setState({
+      gameMode: "local",
+      gameState: buildGameState({
+        players: buildPlayers([0, 1]),
+        objects: buildObjectMap(representative, sibling),
+        battlefield: [],
+        exile: [],
+        stack: [],
+        command_zone: [EMBLEM_ID, SIBLING_EMBLEM_ID],
+        waiting_for: waitingFor,
+      }),
+      waitingFor,
+      legalActions: [],
+      legalActionsByObject,
+      viewerInteraction: null,
+    });
+    useUiStore.setState({ pendingAbilityChoice: null });
+    return render(<CommandZone playerId={0} />);
+  }
+
+  /** Structural precondition every row below depends on: the two emblems really
+   *  did collapse into ONE chip carrying a ×2 badge. Without this, a row could
+   *  pass because the sibling rendered its own separate chip. */
+  function expectOneChipOfTwo() {
+    expect(screen.getAllByTestId("emblem-card")).toHaveLength(1);
+    expect(screen.getByText("×2")).toBeInTheDocument();
+  }
+
+  // THE discriminating row both reviewers asked for.
+  //
+  // MEASURED (drop side): restoring the representative-only derivation
+  //   (`isActivatable` from `emblem.id`, `handleActivate` resolving on
+  //   `emblem.id`) flips this row with
+  //   `AssertionError: expected false to be true // Object.is equality`
+  //   on `chipIsActivatable()` — the group renders inert and the legal action
+  //   is unreachable. The chooser row below flips in the same arm with
+  //   `AssertionError: expected null to deeply equal { objectId: 701, actions:
+  //   [ …(2) ] }`.
+  // MEASURED (trivialize side): replacing the affordance-driven `find` with
+  //   "always the last member" fails five rows — the two controls below, the
+  //   negative control, and the timing/seat rows in the describe above.
+  it("reaches an action published against a non-representative group member", () => {
+    const action = abilityAction(SIBLING_EMBLEM_ID);
+    seedGroupedPair({ [String(SIBLING_EMBLEM_ID)]: [action] });
+
+    expectOneChipOfTwo();
+    expect(chipIsActivatable()).toBe(true);
+
+    fireEvent.click(screen.getByTestId("emblem-card"));
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    // The SIBLING's own action, dispatched under the sibling's own id.
+    expect(dispatchAction).toHaveBeenCalledWith(action);
+  });
+
+  // The dispatch axis is not the only one the maintainer named: the pending
+  // choice must also carry the member's EXACT id, or the chooser would resolve
+  // against an object the engine never offered.
+  it("opens the chooser against the non-representative member's own id", () => {
+    const first = abilityAction(SIBLING_EMBLEM_ID, 0);
+    const second = abilityAction(SIBLING_EMBLEM_ID, 1);
+    seedGroupedPair({ [String(SIBLING_EMBLEM_ID)]: [first, second] });
+
+    expectOneChipOfTwo();
+    fireEvent.click(screen.getByTestId("emblem-card"));
+
+    expect(useUiStore.getState().pendingAbilityChoice).toEqual({
+      objectId: SIBLING_EMBLEM_ID,
+      actions: [first, second],
+    });
+    expect(dispatchAction).not.toHaveBeenCalled();
+  });
+
+  // CONTROL — the representative-live case must keep working, so the row above
+  // cannot pass by "the chip now always picks the last member".
+  it("still reaches an action published against the representative member", () => {
+    const action = abilityAction(EMBLEM_ID);
+    seedGroupedPair({ [String(EMBLEM_ID)]: [action] });
+
+    expectOneChipOfTwo();
+    expect(chipIsActivatable()).toBe(true);
+
+    fireEvent.click(screen.getByTestId("emblem-card"));
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(action);
+  });
+
+  // CONTROL — every member live: ONE chip is ONE click, so exactly one dispatch
+  // (the first member in command-zone order), and the display count is intact.
+  it("dispatches exactly once when every group member is live", () => {
+    const representativeAction = abilityAction(EMBLEM_ID);
+    const siblingAction = abilityAction(SIBLING_EMBLEM_ID);
+    seedGroupedPair({
+      [String(EMBLEM_ID)]: [representativeAction],
+      [String(SIBLING_EMBLEM_ID)]: [siblingAction],
+    });
+
+    expectOneChipOfTwo();
+    fireEvent.click(screen.getByTestId("emblem-card"));
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(representativeAction);
+    expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
+  });
+
+  // NEGATIVE CONTROL — no member live: inert. Its reach guard is the first row
+  // above, which shows this same fixture DOES light up when a member is offered.
+  it("stays inert when no group member has a legal action", () => {
+    seedGroupedPair({});
+
+    expectOneChipOfTwo();
+    expect(chipIsActivatable()).toBe(false);
+    expect(screen.queryByRole("button")).toBeNull();
+
+    fireEvent.click(screen.getByTestId("emblem-card"));
     expect(dispatchAction).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/zone/__tests__/CommanderCardZone.test.tsx
+++ b/client/src/components/zone/__tests__/CommanderCardZone.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { GameAction, GameObject } from "../../../adapter/types.ts";
+import type { GameAction, GameObject, PlayerId, WaitingFor } from "../../../adapter/types.ts";
 import { dispatchAction } from "../../../game/dispatch.ts";
 import { useGameStore } from "../../../stores/gameStore.ts";
 import { useUiStore } from "../../../stores/uiStore.ts";
@@ -29,19 +29,32 @@ vi.mock("../../../hooks/useCardImage.ts", () => ({
 
 const COMMANDER_ID = 101;
 
-function makeState(commander: GameObject) {
+function makeState(
+  commander: GameObject,
+  options: { waitingFor?: WaitingFor; activeSeat?: PlayerId } = {},
+) {
+  const seat = options.activeSeat ?? 0;
   return buildGameState({
-    active_player: 0,
-    priority_player: 0,
+    active_player: seat,
+    priority_player: seat,
+    // Nobody controls another player's turn decisions here, so
+    // `useCanActForWaitingState` reduces to "is the waiting seat my seat" —
+    // the escape hatch cannot silently rescue the opponent-seat arm below.
+    turn_decision_controller: null,
     players: buildPlayers([0, 1]),
     objects: buildObjectMap(commander),
     command_zone: [commander.id],
     battlefield: [],
     exile: [],
     stack: [],
-    waiting_for: buildPriorityWaitingFor(),
+    waiting_for: options.waitingFor ?? buildPriorityWaitingFor({ data: { player: seat } }),
   });
 }
+
+const DECLARE_BLOCKERS: WaitingFor = {
+  type: "DeclareBlockers",
+  data: { player: 0, valid_blocker_ids: [], valid_block_targets: {} },
+};
 
 function ninjutsuAction(creatureToReturn: number): GameAction {
   return {
@@ -67,10 +80,19 @@ function signatureSpell() {
 }
 
 /** Seed both stores for a command-zone commander with the given legal actions. */
-function seedStores(actions: GameAction[]) {
-  const commander = buildCommanderGameObject({ id: COMMANDER_ID });
-  const gameState = makeState(commander);
+function seedStores(
+  actions: GameAction[],
+  options: { seat?: PlayerId; waitingFor?: WaitingFor } = {},
+) {
+  const seat = options.seat ?? 0;
+  const commander = buildCommanderGameObject({
+    id: COMMANDER_ID,
+    owner: seat,
+    controller: seat,
+  });
+  const gameState = makeState(commander, { waitingFor: options.waitingFor, activeSeat: seat });
   useGameStore.setState({
+    gameMode: "local",
     gameState,
     waitingFor: gameState.waiting_for,
     legalActions: actions,
@@ -141,6 +163,7 @@ describe("CommanderCardZone commander ninjutsu (issue #5239)", () => {
     const spell = signatureSpell();
     const gameState = makeState(spell);
     useGameStore.setState({
+      gameMode: "local",
       gameState,
       waitingFor: gameState.waiting_for,
       legalActions: [castAction()],
@@ -155,5 +178,94 @@ describe("CommanderCardZone commander ninjutsu (issue #5239)", () => {
       "title",
       "Cast Scheming Symmetry — double-click or drag to play",
     );
+  });
+});
+
+/**
+ * Sibling sweep of the `CommandZone.EmblemCard` hunk in this PR: the same
+ * raw-bucket predicate (`castAction !== null` / `ninjutsuActions.length > 0`,
+ * with NEITHER a `WaitingFor` gate NOR a seat gate) survived one file over, in
+ * a component `PlayerArea` → `CommandDock` renders for every seat. Pre-existing
+ * rather than introduced by this PR, and disclosed as such.
+ *
+ * EVIDENCE-LABEL CONVENTION (same as `CommandZone.test.tsx`):
+ *   MEASURED — past-tense report: this PR ran that arm; the quoted text is the
+ *              assertion that flipped.
+ * An untagged comment is prose and is evidence for nothing.
+ */
+describe("CommanderCardZone activation gate", () => {
+  beforeEach(() => {
+    vi.mocked(dispatchAction).mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    useUiStore.setState({ inspectedObjectId: null, pendingAbilityChoice: null });
+  });
+
+  // The SEAT axis. In local/AI mode `legalActionsByObject` is computed for the
+  // STATE's priority player, not the viewer, so an opponent's commander chip
+  // dispatched from this seat.
+  //
+  // MEASURED (drop side): restoring `const canNinjutsu = ninjutsuActions.length
+  //   > 0` flips the first assertion to `AssertionError: expected "vi.fn()" to
+  //   not be called at all, but actually been called 1 times`.
+  // MEASURED (always side): forcing both flags false fails this row's control
+  //   arm plus three pre-existing rows in the describe above.
+  it("does not offer an opponent's commander ninjutsu from this viewer's seat", () => {
+    const action = ninjutsuAction(9);
+    // The engine is waiting on player 1; the local viewer is player 0.
+    seedStores([action], { seat: 1 });
+
+    render(<CommanderCardZone playerId={1} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(dispatchAction).not.toHaveBeenCalled();
+    // REACH GUARD — without it the negative above is vacuous. The click WAS
+    // delivered and DID take a branch: it fell through to inspect.
+    expect(useUiStore.getState().inspectedObjectId).toBe(COMMANDER_ID);
+    cleanup();
+
+    // Control: the identical bucket on this viewer's own seat IS offered, so
+    // the arm above cannot pass by "this fixture never activates".
+    vi.mocked(dispatchAction).mockClear();
+    seedStores([action]);
+    render(<CommanderCardZone playerId={0} />);
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
+    expect(dispatchAction).toHaveBeenCalledWith(action);
+  });
+
+  // The TIMING axis, both flags at once. Identical bucket on both arms; only
+  // the engine's `WaitingFor` differs. `title` is the component's own rendering
+  // of `canCast`, the click outcome is its rendering of `canNinjutsu`.
+  //
+  // MEASURED (drop side): restoring the two raw-bucket predicates flips this
+  //   row with `expect(element).toHaveAttribute("title", "Commander: Mock
+  //   Commander")` — the chip renders the cast title at DeclareBlockers.
+  // MEASURED (always side): forcing both flags false fails this row's control
+  //   arm (the Priority half).
+  it("is inert at DeclareBlockers and live at Priority with the same bucket", () => {
+    const bucket = [castAction(), ninjutsuAction(9)];
+
+    seedStores(bucket, { waitingFor: DECLARE_BLOCKERS });
+    render(<CommanderCardZone playerId={0} />);
+    const inert = screen.getByRole("button");
+    expect(inert).toHaveAttribute("title", "Commander: Mock Commander");
+    fireEvent.click(inert);
+    expect(dispatchAction).not.toHaveBeenCalled();
+    // REACH GUARD, as above.
+    expect(useUiStore.getState().inspectedObjectId).toBe(COMMANDER_ID);
+    cleanup();
+
+    // Control: the same bucket at Priority advertises the cast and activates.
+    vi.mocked(dispatchAction).mockClear();
+    seedStores(bucket);
+    render(<CommanderCardZone playerId={0} />);
+    const live = screen.getByRole("button");
+    expect(live).toHaveAttribute("title", "Cast Mock Commander — double-click or drag to play");
+    fireEvent.click(live);
+    expect(dispatchAction).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/viewmodel/__tests__/cardActionChoice.test.ts
+++ b/client/src/viewmodel/__tests__/cardActionChoice.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { GameAction, GameObject, WaitingFor } from "../../adapter/types.ts";
+import type { ActivationAffordances, ObjectActivation } from "../cardActionChoice.ts";
 import {
   collectObjectActions,
   deriveActivationAffordances,
@@ -496,6 +497,27 @@ function sorted(ids: Set<number>): number[] {
   return [...ids].sort((a, b) => a - b);
 }
 
+/**
+ * Calls the activation authority the way a consumer does: the object's own id
+ * drives BOTH the affordance lookup and the resolver argument.
+ *
+ * Every row declares both rings. The resolver's earlier signature carried only
+ * the mana half, so the non-mana partition was merged unconditionally and a
+ * cost-payment prompt offered activations the board itself refuses; rows that
+ * pass `activate: false` are the ones that fail against that signature.
+ */
+function resolveFor(
+  actions: GameAction[],
+  object: GameObject,
+  open: { activate: boolean; mana: boolean },
+): ObjectActivation {
+  const affordances: ActivationAffordances = {
+    activatableObjectIds: new Set(open.activate ? [object.id] : []),
+    manaTappableObjectIds: new Set(open.mana ? [object.id] : []),
+  };
+  return resolveObjectActivation(actions, object, affordances, object.id);
+}
+
 describe("deriveActivationAffordances", () => {
   // Two buckets the engine publishes: an Aura with two non-mana activations and
   // a land with a mana tap. Contents are asserted, never sizes — a size assert
@@ -596,14 +618,14 @@ describe("resolveObjectActivation", () => {
   // so no always-mutant can be visible on this row and it is counted as
   // drop-side coverage only. Its consumer-side pair is the V25 module.
   it("returns none for an empty bucket instead of opening an empty modal", () => {
-    expect(resolveObjectActivation([], freedFromTheReal(), false)).toEqual({ kind: "none" });
+    expect(resolveFor([], freedFromTheReal(), { activate: true, mana: false })).toEqual({ kind: "none" });
   });
 
   // POINTER: sweep row `C10 mana-only canTap=F`, also DROP-ONLY. Dropping the
   // mana action when the mana ring is closed must yield `none`, not a modal
   // offering an action the player cannot pay with.
   it("returns none when the only action is mana and the mana ring is closed", () => {
-    expect(resolveObjectActivation([tapLandAction(500)], island(), false)).toEqual({
+    expect(resolveFor([tapLandAction(500)], island(), { activate: true, mana: false })).toEqual({
       kind: "none",
     });
   });
@@ -620,7 +642,7 @@ describe("resolveObjectActivation", () => {
         { is_mana_ability: true, consumes_source: true, effect: { type: "Mana" } },
       ],
     });
-    expect(resolveObjectActivation([MANA_ABILITY], object, true)).toEqual({
+    expect(resolveFor([MANA_ABILITY], object, { activate: true, mana: true })).toEqual({
       kind: "choose",
       actions: [MANA_ABILITY],
     });
@@ -630,24 +652,24 @@ describe("resolveObjectActivation", () => {
   // modal". POINTER: sweep row `C4b`; PAIR-ONLY per §7.1 (its always-side
   // mutant is `alwaysChoose`; no drop-the-fix mutant is visible on it).
   it("still auto-dispatches a lone non-consuming mana ability", () => {
-    expect(resolveObjectActivation([MANA_ABILITY], freedFromTheReal(), true)).toEqual({
+    expect(resolveFor([MANA_ABILITY], freedFromTheReal(), { activate: true, mana: true })).toEqual({
       kind: "dispatch",
       action: MANA_ABILITY,
     });
   });
 
-  // V19 (CR 605.1a) — the mana/non-mana partition is driven by canTapForMana.
+  // V19 (CR 605.1a) — the mana/non-mana partition is driven by the mana ring.
   // POINTER: sweep rows `C6 mana+nonmana canTap=T` / `C8 mana+nonmana canTap=F`,
   // mutant `M2`.
   it("merges mana actions after the non-mana ones only when the mana ring is open", () => {
     const object = freedFromTheReal();
-    expect(resolveObjectActivation([FREED_TAP, MANA_ABILITY], object, true)).toEqual({
+    expect(resolveFor([FREED_TAP, MANA_ABILITY], object, { activate: true, mana: true })).toEqual({
       kind: "choose",
       actions: [FREED_TAP, MANA_ABILITY],
     });
-    // canTapForMana=false drops the mana action entirely, leaving a lone benign
+    // A closed mana ring drops the mana action entirely, leaving a lone benign
     // non-mana action — which auto-dispatches.
-    expect(resolveObjectActivation([FREED_TAP, MANA_ABILITY], object, false)).toEqual({
+    expect(resolveFor([FREED_TAP, MANA_ABILITY], object, { activate: true, mana: false })).toEqual({
       kind: "dispatch",
       action: FREED_TAP,
     });
@@ -660,8 +682,8 @@ describe("resolveObjectActivation", () => {
   it("classifies TapLandForMana and TapForConvoke by action type", () => {
     const land = island();
     const tapLand = tapLandAction(500);
-    expect(resolveObjectActivation([tapLand], land, false)).toEqual({ kind: "none" });
-    expect(resolveObjectActivation([tapLand], land, true)).toEqual({
+    expect(resolveFor([tapLand], land, { activate: true, mana: false })).toEqual({ kind: "none" });
+    expect(resolveFor([tapLand], land, { activate: true, mana: true })).toEqual({
       kind: "dispatch",
       action: tapLand,
     });
@@ -670,14 +692,14 @@ describe("resolveObjectActivation", () => {
       type: "TapForConvoke",
       data: { object_id: 500, mana_type: "Blue" },
     };
-    expect(resolveObjectActivation([convoke], land, false)).toEqual({ kind: "none" });
+    expect(resolveFor([convoke], land, { activate: true, mana: false })).toEqual({ kind: "none" });
   });
 
   // V19c (CR 113.3b) — the `keywords` partition arm is load-bearing: an Equip
   // is neither mana nor `ActivateAbility`, so without that arm it vanishes from
   // the merged list. POINTER: sweep row `C11 lone Equip`, mutant `M1`.
   it("surfaces a keyword activation that is neither mana nor ActivateAbility", () => {
-    expect(resolveObjectActivation([EQUIP_ACTION], freedFromTheReal(), false)).toEqual({
+    expect(resolveFor([EQUIP_ACTION], freedFromTheReal(), { activate: true, mana: false })).toEqual({
       kind: "dispatch",
       action: EQUIP_ACTION,
     });
@@ -688,7 +710,7 @@ describe("resolveObjectActivation", () => {
   // `allReverse`. Order is asserted, so "any two actions" fails.
   it("keeps [ability, keyword] order in a mixed bucket", () => {
     expect(
-      resolveObjectActivation([FREED_TAP, EQUIP_ACTION], freedFromTheReal(), false),
+      resolveFor([FREED_TAP, EQUIP_ACTION], freedFromTheReal(), { activate: true, mana: false }),
     ).toEqual({ kind: "choose", actions: [FREED_TAP, EQUIP_ACTION] });
   });
 
@@ -696,7 +718,7 @@ describe("resolveObjectActivation", () => {
   // `C14 Equip+mana canTap=T`, mutants `M1` AND `M2`.
   it("orders [keyword, mana] when both partitions fire", () => {
     expect(
-      resolveObjectActivation([MANA_ABILITY, EQUIP_ACTION], freedFromTheReal(), true),
+      resolveFor([MANA_ABILITY, EQUIP_ACTION], freedFromTheReal(), { activate: true, mana: true }),
     ).toEqual({ kind: "choose", actions: [EQUIP_ACTION, MANA_ABILITY] });
   });
 
@@ -704,7 +726,7 @@ describe("resolveObjectActivation", () => {
   // lone prepared copy is offered explicitly instead of firing on one click.
   // POINTER: sweep row `C15 lone CastPreparedCopy`, mutants `M1` + `noGate506`.
   it("offers a lone CastPreparedCopy through the modal rather than auto-casting", () => {
-    expect(resolveObjectActivation([PREPARED_COPY], freedFromTheReal(), false)).toEqual({
+    expect(resolveFor([PREPARED_COPY], freedFromTheReal(), { activate: true, mana: false })).toEqual({
       kind: "choose",
       actions: [PREPARED_COPY],
     });
@@ -716,7 +738,7 @@ describe("resolveObjectActivation", () => {
   // `rawBucket` / `allReverse`.
   it("deliberately reorders a mana-first bucket to [non-mana, mana]", () => {
     const rawBucket: GameAction[] = [MANA_ABILITY, FREED_TAP];
-    expect(resolveObjectActivation(rawBucket, freedFromTheReal(), true)).toEqual({
+    expect(resolveFor(rawBucket, freedFromTheReal(), { activate: true, mana: true })).toEqual({
       kind: "choose",
       actions: [FREED_TAP, MANA_ABILITY],
     });
@@ -730,7 +752,74 @@ describe("resolveObjectActivation", () => {
   // both, in engine order.
   it("offers both of an Aura's activated abilities in engine order", () => {
     expect(
-      resolveObjectActivation([FREED_TAP, FREED_UNTAP], freedFromTheReal(), false),
+      resolveFor([FREED_TAP, FREED_UNTAP], freedFromTheReal(), { activate: true, mana: false }),
     ).toEqual({ kind: "choose", actions: [FREED_TAP, FREED_UNTAP] });
+  });
+
+  // ------------------------------------------------------------------------
+  // The non-mana ring is a GATE, not decoration (CR 113.3b).
+  //
+  // MEASURED (two-sided, this PR). DROP side — restoring the unconditional
+  // merge the previous 3-argument signature had (`if (true)` in place of the
+  // ring test) fails the three rows below; the first flips with
+  // `AssertionError: expected { kind: 'choose', …(1) } to deeply equal
+  // { kind: 'none' }` — the exact `[P4 ManaPayment] verdict=choose[NON-mana,
+  // mana]` the review measured, byte-identical to the `[P4 Priority]` verdict
+  // at a state where `deriveActivationAffordances` had already closed the
+  // non-mana ring. ALWAYS side — forcing the ring closed (`if (false)`) fails
+  // ten rows, including every positive control below.
+  // ------------------------------------------------------------------------
+  it("drops the non-mana partition when the activation ring is closed", () => {
+    const aura = freedFromTheReal();
+    // A cost-payment prompt: `deriveActivationAffordances` opens the mana ring
+    // only. The two non-mana abilities must not be offered.
+    expect(resolveFor([FREED_TAP, FREED_UNTAP], aura, { activate: false, mana: true })).toEqual({
+      kind: "none",
+    });
+    // …and neither ring open is `none` too — the object is simply not offered.
+    expect(resolveFor([FREED_TAP, FREED_UNTAP], aura, { activate: false, mana: false })).toEqual({
+      kind: "none",
+    });
+    // POSITIVE CONTROL (reach guard): the identical bucket with the non-mana
+    // ring OPEN is offered, so the two assertions above cannot pass by "this
+    // fixture is never offered".
+    expect(resolveFor([FREED_TAP, FREED_UNTAP], aura, { activate: true, mana: true })).toEqual({
+      kind: "choose",
+      actions: [FREED_TAP, FREED_UNTAP],
+    });
+  });
+
+  // The mixed bucket at a cost-payment prompt — the shape the review measured.
+  // Only the mana action survives, and being alone and benign it auto-fires
+  // instead of opening a modal that offers a non-mana activation.
+  it("offers only the mana action at a cost-payment prompt", () => {
+    const aura = freedFromTheReal();
+    expect(
+      resolveFor([FREED_TAP, MANA_ABILITY, EQUIP_ACTION], aura, { activate: false, mana: true }),
+    ).toEqual({ kind: "dispatch", action: MANA_ABILITY });
+    // Positive control: with the non-mana ring open the same bucket offers all
+    // three, in `[ability, keyword, mana]` order.
+    expect(
+      resolveFor([FREED_TAP, MANA_ABILITY, EQUIP_ACTION], aura, { activate: true, mana: true }),
+    ).toEqual({ kind: "choose", actions: [FREED_TAP, EQUIP_ACTION, MANA_ABILITY] });
+  });
+
+  // HOSTILE FIXTURE — membership is keyed by the id passed in, never by "the
+  // set is non-empty". Calls the real 4-argument signature directly (not via
+  // `resolveFor`), with both rings populated for a DIFFERENT object.
+  it("reads both rings by object id, not by set emptiness", () => {
+    const aura = freedFromTheReal();
+    const otherId = aura.id + 1;
+    const affordances: ActivationAffordances = {
+      activatableObjectIds: new Set([otherId]),
+      manaTappableObjectIds: new Set([otherId]),
+    };
+    expect(
+      resolveObjectActivation([FREED_TAP, MANA_ABILITY], aura, affordances, aura.id),
+    ).toEqual({ kind: "none" });
+    // Positive control: the same non-empty sets, queried for the id they name.
+    expect(
+      resolveObjectActivation([FREED_TAP, MANA_ABILITY], aura, affordances, otherId),
+    ).toEqual({ kind: "choose", actions: [FREED_TAP, MANA_ABILITY] });
   });
 });

--- a/client/src/viewmodel/__tests__/cardActionChoice.test.ts
+++ b/client/src/viewmodel/__tests__/cardActionChoice.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import type { GameAction, GameObject } from "../../adapter/types.ts";
+import type { GameAction, GameObject, WaitingFor } from "../../adapter/types.ts";
 import {
   collectObjectActions,
+  deriveActivationAffordances,
   isManaObjectAction,
   requiresConfirmation,
   resolveDirectPlayOrCastAction,
+  resolveObjectActivation,
   resolveSingleActionDispatch,
 } from "../cardActionChoice.ts";
 import { abilityChoiceLabel } from "../costLabel.ts";
@@ -417,5 +419,318 @@ describe("abilityChoiceLabel", () => {
       label: "Play Bala Ged Sanctuary",
       description: "Play this card as a land",
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rows below cover the two authorities extracted in this change.
+//
+// EVIDENCE-LABEL CONVENTION (plan §7.2). A comment carrying a mutant claim is
+// tagged, and the tag says what KIND of statement it is:
+//   QUOTED    past-tense report — harness output copied verbatim from a run.
+//   POINTER   names a sweep row / mutant id whose measurement lives in the
+//             plan's evidence logs, not here.
+//   MEASURED  a two-sided arm this PR ran at its own tip.
+// An untagged comment is prose and is NOT evidence for anything.
+//
+// Expected payloads below are LITERALS. No row rebuilds its expectation by
+// calling the function under test (or `collectObjectActions`) on the same
+// source the implementation reads — a re-derived expectation co-varies with
+// the implementation and cannot fail.
+// ---------------------------------------------------------------------------
+
+/** Freed from the Real: two NON-mana activated abilities on the Aura itself. */
+const FREED_TAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: 408, ability_index: 0 },
+};
+const FREED_UNTAP: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: 408, ability_index: 1 },
+};
+const EQUIP_ACTION: GameAction = {
+  type: "Equip",
+  data: { equipment_id: 408, target_id: 401 },
+};
+const PREPARED_COPY: GameAction = { type: "CastPreparedCopy", data: { source: 408 } };
+
+/** The Aura carries two non-mana abilities; index 2 is a mana ability. */
+function freedFromTheReal(overrides: Partial<GameObject> = {}): GameObject {
+  return makeGameObject({
+    id: 408,
+    zone: "Battlefield",
+    name: "Freed from the Real",
+    card_types: { supertypes: [], core_types: ["Enchantment"], subtypes: ["Aura"] },
+    abilities: [
+      { effect: { type: "Tap" } },
+      { effect: { type: "Untap" } },
+      { is_mana_ability: true, effect: { type: "Mana" } },
+    ],
+    ...overrides,
+  });
+}
+
+const MANA_ABILITY: GameAction = {
+  type: "ActivateAbility",
+  data: { source_id: 408, ability_index: 2 },
+};
+
+function island(): GameObject {
+  return makeGameObject({
+    id: 500,
+    zone: "Battlefield",
+    name: "Island",
+    card_types: { supertypes: ["Basic"], core_types: ["Land"], subtypes: ["Island"] },
+    abilities: [{ is_mana_ability: true, effect: { type: "Mana" } }],
+  });
+}
+
+const PRIORITY: WaitingFor = { type: "Priority", data: { player: 0 } };
+const MANA_PAYMENT: WaitingFor = { type: "ManaPayment", data: { player: 0 } };
+const DECLARE_BLOCKERS: WaitingFor = {
+  type: "DeclareBlockers",
+  data: { player: 0, valid_blocker_ids: [], valid_block_targets: {} },
+};
+
+function sorted(ids: Set<number>): number[] {
+  return [...ids].sort((a, b) => a - b);
+}
+
+describe("deriveActivationAffordances", () => {
+  // Two buckets the engine publishes: an Aura with two non-mana activations and
+  // a land with a mana tap. Contents are asserted, never sizes — a size assert
+  // passes under an "add every object" mutant.
+  const objects: Record<string, GameObject> = {
+    "408": freedFromTheReal(),
+    "500": island(),
+  };
+  const legalActionsByObject: Record<string, GameAction[]> = {
+    "408": [FREED_TAP, FREED_UNTAP],
+    "500": [tapLandAction(500)],
+  };
+
+  // V14 — extraction parity. CR 113.3b: a non-mana activated ability is offered
+  // only where the player has priority; the mana ring additionally opens during
+  // the cost-payment states.
+  it("offers the non-mana ring only at Priority, and the mana ring at every payment state", () => {
+    const atPriority = deriveActivationAffordances(
+      PRIORITY,
+      true,
+      legalActionsByObject,
+      objects,
+    );
+    expect(sorted(atPriority.activatableObjectIds)).toEqual([408]);
+    expect(sorted(atPriority.manaTappableObjectIds)).toEqual([500]);
+
+    // POINTER: sweep row `V14 ManaPayment mana bucket` — the non-mana set must
+    // stay EMPTY here, which is what the dropped-Priority-arm mutant flips.
+    const atManaPayment = deriveActivationAffordances(
+      MANA_PAYMENT,
+      true,
+      legalActionsByObject,
+      objects,
+    );
+    expect(sorted(atManaPayment.activatableObjectIds)).toEqual([]);
+    expect(sorted(atManaPayment.manaTappableObjectIds)).toEqual([500]);
+
+    // CR 118.12a: a disjunctive unless-cost enables the same mana input as a
+    // plain UnlessPayment.
+    for (const waitingFor of [
+      { type: "UnlessPayment", data: { player: 0, cost: {}, pending_effect: null } },
+      { type: "UnlessPaymentChooseCost", data: { player: 0, costs: [], pending_effect: null } },
+    ] as unknown as WaitingFor[]) {
+      const derived = deriveActivationAffordances(waitingFor, true, legalActionsByObject, objects);
+      expect(sorted(derived.activatableObjectIds)).toEqual([]);
+      expect(sorted(derived.manaTappableObjectIds)).toEqual([500]);
+    }
+  });
+
+  // V4's viewmodel half — the timing axis. A non-Priority combat state offers
+  // neither ring even though both buckets are populated.
+  it("offers nothing at DeclareBlockers even with both buckets populated", () => {
+    const derived = deriveActivationAffordances(
+      DECLARE_BLOCKERS,
+      true,
+      legalActionsByObject,
+      objects,
+    );
+    expect(sorted(derived.activatableObjectIds)).toEqual([]);
+    expect(sorted(derived.manaTappableObjectIds)).toEqual([]);
+  });
+
+  // The seat axis, independent of timing: same Priority prompt, but this viewer
+  // is not the player the engine is waiting on.
+  it("offers nothing at Priority when the viewer cannot act for the waiting state", () => {
+    const derived = deriveActivationAffordances(
+      PRIORITY,
+      false,
+      legalActionsByObject,
+      objects,
+    );
+    expect(sorted(derived.activatableObjectIds)).toEqual([]);
+    expect(sorted(derived.manaTappableObjectIds)).toEqual([]);
+  });
+
+  // NEGATIVE CONTROL. Pre-init (`objects` undefined) and an id present in the
+  // bucket but absent from the objects map must both drop out — never crash,
+  // never admit an unknown id.
+  it("drops ids with no object, and returns empty sets before the state loads", () => {
+    const noObjects = deriveActivationAffordances(PRIORITY, true, legalActionsByObject, undefined);
+    expect(sorted(noObjects.activatableObjectIds)).toEqual([]);
+    expect(sorted(noObjects.manaTappableObjectIds)).toEqual([]);
+
+    const staleBucket = deriveActivationAffordances(
+      PRIORITY,
+      true,
+      { ...legalActionsByObject, "999": [FREED_TAP] },
+      objects,
+    );
+    expect(sorted(staleBucket.activatableObjectIds)).toEqual([408]);
+  });
+});
+
+describe("resolveObjectActivation", () => {
+  // V15 (D1) — an empty merged list is `none`, NOT an empty choice modal.
+  // POINTER: sweep row `C9 empty bucket`, mutant `emptyModal`. Labelled
+  // DROP-ONLY in the plan (§7.1): the expected verdict IS the degenerate value,
+  // so no always-mutant can be visible on this row and it is counted as
+  // drop-side coverage only. Its consumer-side pair is the V25 module.
+  it("returns none for an empty bucket instead of opening an empty modal", () => {
+    expect(resolveObjectActivation([], freedFromTheReal(), false)).toEqual({ kind: "none" });
+  });
+
+  // POINTER: sweep row `C10 mana-only canTap=F`, also DROP-ONLY. Dropping the
+  // mana action when the mana ring is closed must yield `none`, not a modal
+  // offering an action the player cannot pay with.
+  it("returns none when the only action is mana and the mana ring is closed", () => {
+    expect(resolveObjectActivation([tapLandAction(500)], island(), false)).toEqual({
+      kind: "none",
+    });
+  });
+
+  // V18 (D3) — a lone MANA action that consumes its source must NOT auto-fire.
+  // POINTER: sweep row `C7 lone MANA consumes canTap=T`, mutants `noGate506`
+  // and `manaCarveOut`. This is a contract fix, not a live bug: a battlefield
+  // permanent cannot carry `consumes_source` today.
+  it("routes a lone consuming mana ability through the confirmation modal", () => {
+    const object = freedFromTheReal({
+      abilities: [
+        { effect: { type: "Tap" } },
+        { effect: { type: "Untap" } },
+        { is_mana_ability: true, consumes_source: true, effect: { type: "Mana" } },
+      ],
+    });
+    expect(resolveObjectActivation([MANA_ABILITY], object, true)).toEqual({
+      kind: "choose",
+      actions: [MANA_ABILITY],
+    });
+  });
+
+  // V18b — the benign sibling, so V18 cannot pass by "mana always opens the
+  // modal". POINTER: sweep row `C4b`; PAIR-ONLY per §7.1 (its always-side
+  // mutant is `alwaysChoose`; no drop-the-fix mutant is visible on it).
+  it("still auto-dispatches a lone non-consuming mana ability", () => {
+    expect(resolveObjectActivation([MANA_ABILITY], freedFromTheReal(), true)).toEqual({
+      kind: "dispatch",
+      action: MANA_ABILITY,
+    });
+  });
+
+  // V19 (CR 605.1a) — the mana/non-mana partition is driven by canTapForMana.
+  // POINTER: sweep rows `C6 mana+nonmana canTap=T` / `C8 mana+nonmana canTap=F`,
+  // mutant `M2`.
+  it("merges mana actions after the non-mana ones only when the mana ring is open", () => {
+    const object = freedFromTheReal();
+    expect(resolveObjectActivation([FREED_TAP, MANA_ABILITY], object, true)).toEqual({
+      kind: "choose",
+      actions: [FREED_TAP, MANA_ABILITY],
+    });
+    // canTapForMana=false drops the mana action entirely, leaving a lone benign
+    // non-mana action — which auto-dispatches.
+    expect(resolveObjectActivation([FREED_TAP, MANA_ABILITY], object, false)).toEqual({
+      kind: "dispatch",
+      action: FREED_TAP,
+    });
+  });
+
+  // V19b — the TYPE-based mana branch (`TapLandForMana` / `TapForConvoke`) is
+  // honored, not just the `is_mana_ability` flag. POINTER: sweep row
+  // `C13b lone TapLandForMana canTap=F` (DROP-ONLY), mutant `M2`; the canTap=T
+  // half is sweep row `C13`, PAIR-ONLY.
+  it("classifies TapLandForMana and TapForConvoke by action type", () => {
+    const land = island();
+    const tapLand = tapLandAction(500);
+    expect(resolveObjectActivation([tapLand], land, false)).toEqual({ kind: "none" });
+    expect(resolveObjectActivation([tapLand], land, true)).toEqual({
+      kind: "dispatch",
+      action: tapLand,
+    });
+
+    const convoke: GameAction = {
+      type: "TapForConvoke",
+      data: { object_id: 500, mana_type: "Blue" },
+    };
+    expect(resolveObjectActivation([convoke], land, false)).toEqual({ kind: "none" });
+  });
+
+  // V19c (CR 113.3b) — the `keywords` partition arm is load-bearing: an Equip
+  // is neither mana nor `ActivateAbility`, so without that arm it vanishes from
+  // the merged list. POINTER: sweep row `C11 lone Equip`, mutant `M1`.
+  it("surfaces a keyword activation that is neither mana nor ActivateAbility", () => {
+    expect(resolveObjectActivation([EQUIP_ACTION], freedFromTheReal(), false)).toEqual({
+      kind: "dispatch",
+      action: EQUIP_ACTION,
+    });
+  });
+
+  // V20c2 — a mixed-group bucket keeps `[ability, keyword]` order. POINTER:
+  // sweep row `E1c ability+Equip (mixed groups)`, mutants `M1` / `revConcat` /
+  // `allReverse`. Order is asserted, so "any two actions" fails.
+  it("keeps [ability, keyword] order in a mixed bucket", () => {
+    expect(
+      resolveObjectActivation([FREED_TAP, EQUIP_ACTION], freedFromTheReal(), false),
+    ).toEqual({ kind: "choose", actions: [FREED_TAP, EQUIP_ACTION] });
+  });
+
+  // V19d — both partition arms at once. POINTER: sweep row
+  // `C14 Equip+mana canTap=T`, mutants `M1` AND `M2`.
+  it("orders [keyword, mana] when both partitions fire", () => {
+    expect(
+      resolveObjectActivation([MANA_ABILITY, EQUIP_ACTION], freedFromTheReal(), true),
+    ).toEqual({ kind: "choose", actions: [EQUIP_ACTION, MANA_ABILITY] });
+  });
+
+  // V19e — `CastPreparedCopy` reaches the keyword arm AND the #506 gate, so a
+  // lone prepared copy is offered explicitly instead of firing on one click.
+  // POINTER: sweep row `C15 lone CastPreparedCopy`, mutants `M1` + `noGate506`.
+  it("offers a lone CastPreparedCopy through the modal rather than auto-casting", () => {
+    expect(resolveObjectActivation([PREPARED_COPY], freedFromTheReal(), false)).toEqual({
+      kind: "choose",
+      actions: [PREPARED_COPY],
+    });
+  });
+
+  // V20d (D5) — DISCLOSED order change. A bucket the engine publishes
+  // mana-first comes back non-mana-first after partitioning. POINTER: sweep row
+  // `E2 mana-first + non-mana canTap=T`, mutants `M2` / `revConcat` /
+  // `rawBucket` / `allReverse`.
+  it("deliberately reorders a mana-first bucket to [non-mana, mana]", () => {
+    const rawBucket: GameAction[] = [MANA_ABILITY, FREED_TAP];
+    expect(resolveObjectActivation(rawBucket, freedFromTheReal(), true)).toEqual({
+      kind: "choose",
+      actions: [FREED_TAP, MANA_ABILITY],
+    });
+    // The raw engine order is the thing that changed — assert it explicitly so
+    // this row cannot be read as "order happens to be preserved".
+    expect(rawBucket).toEqual([MANA_ABILITY, FREED_TAP]);
+  });
+
+  // The user's bucket, at the viewmodel layer: Freed from the Real publishes
+  // TWO non-mana activated abilities, so the click must open the chooser with
+  // both, in engine order.
+  it("offers both of an Aura's activated abilities in engine order", () => {
+    expect(
+      resolveObjectActivation([FREED_TAP, FREED_UNTAP], freedFromTheReal(), false),
+    ).toEqual({ kind: "choose", actions: [FREED_TAP, FREED_UNTAP] });
   });
 });

--- a/client/src/viewmodel/cardActionChoice.ts
+++ b/client/src/viewmodel/cardActionChoice.ts
@@ -1,4 +1,4 @@
-import type { GameAction, GameObject, ObjectId } from "../adapter/types.ts";
+import type { GameAction, GameObject, ObjectId, WaitingFor } from "../adapter/types.ts";
 
 /**
  * Look up the legal actions whose `source_object()` is `objectId`.
@@ -126,4 +126,114 @@ export function resolveDirectPlayOrCastAction(
   return playOrCastActionsForObject(legalActionsByObject, object.id).includes(directAction)
     ? directAction
     : null;
+}
+
+export interface ActivationAffordances {
+  /** Objects with >=1 NON-mana action, offered only where the engine accepts an
+   *  activation: CR 113.3b — "A player may activate such an ability whenever they
+   *  have priority". Membership-queried by id; NOT zone-scoped (a hand card with a
+   *  CastSpell is a member) — never enumerate this set to build a zone listing. */
+  activatableObjectIds: Set<number>;
+  /** Objects with >=1 mana action (CR 605.1a), additionally offered during the
+   *  cost-payment states whose `apply` arms accept a mana activation. */
+  manaTappableObjectIds: Set<number>;
+}
+
+/**
+ * THE single authority for "which objects may be activated right now, and through
+ * which ring". Every deciding activation surface consumes this — none re-derives it.
+ *
+ * Lifted verbatim from `GameBoard`'s `boardInteractionState` memo, with the three
+ * `gameState.objects[objectId]` reads rewritten to `objects[objectId]` because the
+ * parameter is the objects map, not the game state.
+ */
+export function deriveActivationAffordances(
+  waitingFor: WaitingFor | null,
+  canActForWaitingState: boolean,
+  legalActionsByObject: Record<string, GameAction[]>,
+  objects: Record<string, GameObject> | undefined,
+): ActivationAffordances {
+  const activatableObjectIds = new Set<number>();
+  const manaTappableObjectIds = new Set<number>();
+  if (!objects) return { activatableObjectIds, manaTappableObjectIds };
+
+  const playerCanAct =
+    waitingFor != null
+    && (
+      (waitingFor.type === "Priority" && canActForWaitingState)
+      || (waitingFor.type === "ManaPayment" && canActForWaitingState)
+      || (waitingFor.type === "UnlessPayment" && canActForWaitingState)
+      // CR 118.12a: Disjunctive unless-cost — same input enablement as
+      // UnlessPayment (player chooses among sub-costs).
+      || (waitingFor.type === "UnlessPaymentChooseCost" && canActForWaitingState)
+    );
+
+  if (waitingFor?.type === "Priority" && canActForWaitingState) {
+    // The engine owns the "which permanent does this action act on" mapping
+    // via GameAction::source_object(), exposed as `legalActionsByObject`.
+    // The cyan activatable ring surfaces permanents with at least one non-mana
+    // action; mana abilities are handled by the separate mana ring below. This
+    // iteration is variant-agnostic — a future keyword activation needs zero
+    // frontend changes.
+    for (const [idStr, actions] of Object.entries(legalActionsByObject)) {
+      const objectId = Number(idStr);
+      const object = objects[objectId];
+      if (!object) continue;
+      if (actions.some((action) => !isManaObjectAction(action, object))) {
+        activatableObjectIds.add(objectId);
+      }
+    }
+  }
+
+  if (playerCanAct) {
+    for (const [idStr, actions] of Object.entries(legalActionsByObject)) {
+      const objectId = Number(idStr);
+      const object = objects[objectId];
+      if (!object) continue;
+      if (actions.some((action) => isManaObjectAction(action, object))) {
+        manaTappableObjectIds.add(objectId);
+      }
+    }
+  }
+
+  return { activatableObjectIds, manaTappableObjectIds };
+}
+
+export type ObjectActivation =
+  | { kind: "dispatch"; action: GameAction }
+  | { kind: "choose"; actions: GameAction[] }
+  | { kind: "none" };
+
+/**
+ * THE single authority for "given one object's engine bucket, what does a click do".
+ *
+ * Owns the CR 605.1a mana/non-mana partition; EVERY dispatch decision — mana and
+ * non-mana alike — goes through resolveSingleActionDispatch (#506). CR 113.3b
+ * keyword activations (Crew/Station/Equip/Saddle) are surfaced alongside activated
+ * abilities. The merged order is [abilities, keywords, mana].
+ */
+export function resolveObjectActivation(
+  actions: GameAction[],
+  object: GameObject | undefined,
+  canTapForMana: boolean,
+): ObjectActivation {
+  const abilityActions: GameAction[] = [];
+  const manaActions: GameAction[] = [];
+  const keywordActions: GameAction[] = [];
+  for (const action of actions) {
+    if (isManaObjectAction(action, object)) {
+      manaActions.push(action);
+    } else if (action.type === "ActivateAbility") {
+      abilityActions.push(action);
+    } else {
+      keywordActions.push(action);
+    }
+  }
+
+  const merged: GameAction[] = [...abilityActions, ...keywordActions];
+  if (canTapForMana) merged.push(...manaActions);
+  if (merged.length === 0) return { kind: "none" };
+
+  const auto = resolveSingleActionDispatch(merged, object);
+  return auto ? { kind: "dispatch", action: auto } : { kind: "choose", actions: merged };
 }

--- a/client/src/viewmodel/cardActionChoice.ts
+++ b/client/src/viewmodel/cardActionChoice.ts
@@ -211,11 +211,18 @@ export type ObjectActivation =
  * non-mana alike — goes through resolveSingleActionDispatch (#506). CR 113.3b
  * keyword activations (Crew/Station/Equip/Saddle) are surfaced alongside activated
  * abilities. The merged order is [abilities, keywords, mana].
+ *
+ * Takes the WHOLE `ActivationAffordances` pair rather than a loose boolean per
+ * ring: each ring is dropped by the same authority that painted it, so a caller
+ * cannot hand this function half of its own gate. An earlier signature took only
+ * the mana bit, which merged the non-mana partition unconditionally and let a
+ * cost-payment prompt offer an activation the board itself refuses.
  */
 export function resolveObjectActivation(
   actions: GameAction[],
   object: GameObject | undefined,
-  canTapForMana: boolean,
+  affordances: ActivationAffordances,
+  objectId: ObjectId,
 ): ObjectActivation {
   const abilityActions: GameAction[] = [];
   const manaActions: GameAction[] = [];
@@ -230,8 +237,18 @@ export function resolveObjectActivation(
     }
   }
 
-  const merged: GameAction[] = [...abilityActions, ...keywordActions];
-  if (canTapForMana) merged.push(...manaActions);
+  const merged: GameAction[] = [];
+  // CR 113.3b: an activated ability that isn't a mana ability may be activated
+  // only when its controller has priority. `activatableObjectIds` is populated
+  // for exactly that state, so a cost-payment prompt (ManaPayment /
+  // UnlessPayment / UnlessPaymentChooseCost) drops the non-mana partition
+  // instead of offering an activation the engine would refuse.
+  if (affordances.activatableObjectIds.has(objectId)) {
+    merged.push(...abilityActions, ...keywordActions);
+  }
+  // CR 605.1a: mana abilities are additionally offered during those payment
+  // states, whose `apply` arms accept a mana activation.
+  if (affordances.manaTappableObjectIds.has(objectId)) merged.push(...manaActions);
   if (merged.length === 0) return { kind: "none" };
 
   const auto = resolveSingleActionDispatch(merged, object);


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

An attached permanent's own activated abilities were unreachable. With Kilo, Apogee Mind enchanted by Freed from the Real the engine published `legalActionsByObject["408"] = [#0, #1]`, and the attachment fan was inert — no ring, and clicking the Aura did nothing. Root cause is that four call sites each re-derived "may I activate this object, and what does a click do" from a different premise; this extracts the two authorities into `viewmodel/cardActionChoice.ts`, adopts them at every deciding site, and gives the fan and the host click a path to them.

Three of the adopting sites were measurably wrong before the change: the attachments dialog, the command-zone emblem chip, and the command-zone commander chip gated on a raw `<x>Actions.length > 0` bucket check with **neither** a `WaitingFor` gate **nor** a seat gate, so an opponent's emblem/commander chip was clickable from this viewer's seat and the attachments dialog stayed interactive at `DeclareBlockers`.

### Review round (head `5ea5dc100`)

Five follow-up fixes from the independent `/review-impl` (GO, 3 findings, 0 blocking) and from @matthewevans' `CHANGES_REQUESTED`:

1. **Exhaustive `switch` + `never` at all four `resolveObjectActivation` consumers.** Only `AttachmentFan`'s bare `else` failed to compile against a new union variant; `PermanentCard`, `DialogAttachmentCard` and `CommandZone` compiled clean and **silently dropped it**. Today's `kind: "none"` behaviour is preserved exactly (it is reachable only through the render→click staleness window, where doing nothing is right) — this makes a future variant a compile error, per CLAUDE.md "exhaustive `match` without wildcard fallbacks".
2. **The authority was receiving half its own gate.** `deriveActivationAffordances` emits two bits; `resolveObjectActivation` took only the mana one, so the non-mana partition was merged unconditionally. Measured: `[P4 ManaPayment] activatableSet=false manaSet=true clickOffered=true verdict=choose[NON-mana, mana]` — byte-identical to the `[P4 Priority]` arm, at a state where the gate had already closed the non-mana ring (CR 113.3b). It now takes the whole `ActivationAffordances` plus the object id and drops the non-mana partition when that ring is closed, mirroring the existing mana drop. Taking the pair rather than two loose booleans makes "half the gate" unrepresentable at a call site, which is the actual defect class.
3. **Same-mechanism sibling swept: `CommanderCardZone`.** It still gated `canCast`/`canNinjutsu` on the raw bucket with neither a `WaitingFor` nor a seat gate — the exact predicate this PR replaced at `CommandZone.EmblemCard`, rendered from the same `PlayerArea → CommandDock` subtree for every seat. Measured at the un-fixed site: `[P3 opponent commander @ opponent priority, viewer=P0] renderedAsButton=true dispatches=1 | sharedAuthorityWouldSay activatable=false`, with an own-seat control reporting `activatable=true`. **Pre-existing rather than introduced by this PR, and swept here because it is the same mechanism.**
4. **Grouped-emblem activation identity** — @matthewevans' `[MED]` finding, independently reported by CodeRabbit. `GroupedEmblem` kept a lone `representative` plus a `count`, and `legalActionsByObject` is keyed by exact object id, so an action the engine published against a **non-representative** member was unreachable and the chip rendered inert. It now retains every member; the chip acts on the member the shared affordance sets name, and the count badge is that list's length so it cannot drift from the actionable ids. This changes **which id the authority is asked about, not who decides** — no second decision site, and it is class-general for any group size and any member position. (His evidence cites `client/src/components/game/CommandZone.tsx`; that path does not exist — `find client/src -name "CommandZone*.tsx"` returns only `client/src/components/zone/CommandZone.tsx`. His line numbers and substance match the real file, so we read it as `components/zone/` and fixed it there.)
5. **A pre-existing vacuous fixture that fix 2 unmasked.** `PermanentCard.test.tsx > opens the ability picker when a land has multiple mana abilities` seeded `manaTappableObjectIds={40}` with `activatableObjectIds={}` but omitted `is_mana_ability` on both abilities, so the resolver classified them NON-mana — **a state the engine cannot emit**, since the deriver and the resolver classify through the same `isManaObjectAction`. The row only passed because the old code never consulted the activation bit. Adding the flags makes it actually exercise the mana partition.

## Files changed

- `client/src/viewmodel/cardActionChoice.ts` — the two authorities: `deriveActivationAffordances` (timing + seat gate → the activatable / mana-tappable id pair) and `resolveObjectActivation` (typed `none` / `dispatch` / `choose` verdict; owns the CR 605.1a mana partition, the CR 113.3b non-mana gate, and the #506 confirmation gate)
- `client/src/components/board/GameBoard.tsx` — derives the affordance pair from the authority instead of an inline copy
- `client/src/components/board/AttachmentFan.tsx` — mode 2: the fan as a reachability surface for the permanent's own legal actions; mode 1 (engine interaction) unchanged and still returns early; exhaustive verdict handling
- `client/src/components/board/PermanentCard.tsx` — adopts the authority; adds the last-placed host-click fall-through to the fan; exhaustive verdict handling
- `client/src/components/hud/DialogAttachmentCard.tsx` — adopts the shared gate (gains the missing timing + seat gates); exhaustive verdict handling
- `client/src/components/zone/CommandZone.tsx` — same, for the emblem chip; plus grouped-emblem activation identity (`members: GameObject[]` replaces `count` + `representative`)
- `client/src/components/zone/CommanderCardZone.tsx` — **swept sibling**: adopts `deriveActivationAffordances` for `canCast` / `canNinjutsu`
- `client/src/components/zone/LibraryPile.tsx` — refactor only
- `client/src/viewmodel/__tests__/cardActionChoice.test.ts` — authority-level rows, incl. the closed-ring rows and a hostile fixture proving membership is keyed by the id passed in, not by set emptiness
- `client/src/components/board/__tests__/GameBoardInteractionWiring.test.tsx` (new) — real `<GameBoard/>` + real provider, read back from a child consumer
- `client/src/components/board/__tests__/AttachmentFan.test.tsx` (new) — mode 2, incl. a multi-authority hostile fixture
- `client/src/components/board/__tests__/abilityChoiceConsumerWiring.test.tsx` (new) — producer → store → real `DialogHost` consumer
- `client/src/components/hud/__tests__/DialogAttachmentCard.test.tsx` (new) — timing + seat arms
- `client/src/components/zone/__tests__/CommandZone.test.tsx` (new) — timing + seat + order arms, plus the grouped-emblem identity block (non-representative live; chooser id; representative-live control; all-live single-dispatch control; none-live negative control)
- `client/src/components/zone/__tests__/CommanderCardZone.test.tsx` — seat and timing arms for the swept sibling
- `client/src/components/board/__tests__/PermanentCard.test.tsx` — host-click branch-order rows; the mana-ability fixture repair above
- `client/src/components/board/__tests__/BattlefieldZoneOverflow.test.tsx` — turns a previously silent `activatableObjectIds` read red

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — frontend-only change; no `crates/engine/` game logic is touched (17 files, all under `client/src/`).

## CR references

`CR 113.3b` (a non-mana activated ability may be activated only when its controller has priority), `CR 114`, `CR 114.1` (an emblem is a marker representing its own object), `CR 114.4` (abilities of emblems function in the command zone), `CR 118.12a`, `CR 301.5`, `CR 303.4` (an attachment is its own object), `CR 602.1`, `CR 605.1a` (mana-ability partition). Every number added in the diff was grepped against `docs/MagicCompRules.txt`: `0 UNVERIFIED`, and the instrument's negative control (`702.808`) correctly reports absent, so that zero is not vacuous.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

All results below are from the pushed head `5ea5dc100` (built on `38c0dc1ae` in a detached worktree, since this checkout hosts a concurrent agent's uncommitted `crates/**` work).

- `npx tsc -b --noEmit --force` — **EXIT=0, 0 error lines.** Instrument control: with a `TS2322` injected, the repo's vacuous `tsc --noEmit -p tsconfig.json` still reports `EXIT=0 errorLines=0` while `-b --noEmit --force` reports `EXIT=2 errorLines=2`.
- `npx eslint .` — **EXIT=0**, `✖ 27 problems (0 errors, 27 warnings)`. `eslint .` cannot gate `react-hooks/exhaustive-deps` (severity `warn`), so the gate is the warning **set**: `onlyInBASE=0 onlyInPOST=0`, exhaustive-deps 2 on both arms. Instrument positive control for that zero-diff: dropping `objects` from `CommanderCardZone`'s new memo dep array keeps `EXIT=0` but moves the set to 28 warnings / 3 exhaustive-deps, with the added line naming `CommanderCardZone.tsx`.
- `npx vitest run` (full configured suite) — **EXIT=0**, `Test Files 285 passed | 3 skipped (288)`, `Tests 2518 passed | 12 todo (2530)`.
- **Test-count attribution, corrected.** The earlier body said "42 new `it(`" and that figure was wrong twice over. Measured on this branch: merge base `a970e5548` → `Test Files 280 passed | 3 skipped (283)` / `Tests 2465 passed | 12 todo (2477)`; the previous head `38c0dc1ae` → `288` / `2520` (i.e. **+43**, not 42); this head → `288` / `2530`. **The PR's true delta is +5 files and +53 tests, −0 removed** (`2530 − 2477 = 53`). A second, independent instrument agrees: a structural grep census of `^\s*(it|test)(\.(only|skip|todo|concurrent))?\(` over `client/src/**/*.test.ts{,x}` gives `2249` at the merge base and `2302` here — **delta +53**. (The absolute counts differ from vitest's because vitest also counts `.each`/dynamic rows; the delta is the claim and both instruments give 53.)
- **Two-sided controls for the review round**, each flipping its own named assertion rather than a suite delta:
  - fix 1 — ARM A (synthetic 4th `ObjectActivation` variant, consumers unfixed): `EXIT=2`, **exactly 1** error, `AttachmentFan.tsx(176,69) TS2339`. ARM B (4th variant + the new switches): `EXIT=2`, **exactly 4** errors, `TS2322 … not assignable to type 'never'` at `AttachmentFan(192,17)`, `PermanentCard(715,17)`, `DialogAttachmentCard(163,17)`, `CommandZone(174,15)`. ARM C (real 3-variant union + switches): `EXIT=0`; the synthetic variant is grep-verified removed (0 hits).
  - fix 2 — DROP (`if (true)` for the activation ring) fails the 3 new authority rows, first flip `expected { kind: 'choose', …(1) } to deeply equal { kind: 'none' }`; TRIVIALIZE (`if (false)`) fails 10 rows including every positive control.
  - fix 3 — DROP (restore the raw-bucket predicates) fails both new rows, first flip `expected "vi.fn()" to not be called at all, but actually been called 1 times`; TRIVIALIZE (both flags constant-false) fails 5 rows.
  - fix 4 — DROP (representative-only on both the gate and the dispatch axis, i.e. the pre-fix code) fails 2 rows: `expected false to be true` on the chip's own `data-activatable`, and `expected null to deeply equal { objectId: 701, actions: [ …(2) ] }` on the chooser id; TRIVIALIZE ("always the last member") fails 5 rows — both controls, the negative control, and the timing + seat rows.
- Original round: 17 mutants, each flipping its own named assertion — hunk-B drop / constant-true / mana-disjunct-drop / toggle-selection / branch-reorder / raw-bucket; the overflow read's drop vs count-everything (verified to fail by *different* mechanisms — count-everything renders `act 9`, drop renders no badge); the fan's mode-2 drop, never-close, host-invariant drop, early-return drop, never-selectable; and both gates forced constant-true and constant-false.

## Gate A

Gate A PASS head=5ea5dc100cb04e7eff820f8026e8ef5d2fba8f66 base=4b34e5465eafa94bcd49dfe1a9275968be4300dc

## Anchored on

- `client/src/viewmodel/cardActionChoice.ts:73` — `resolveSingleActionDispatch`, the existing single-authority-for-a-click pattern this extends rather than replaces
- `client/src/components/board/PermanentCard.tsx:688` — the existing `isActivatable` branch that already routed through the shared authority; the new sites adopt exactly this shape

## Final review-impl

Final review-impl PASS head=38c0dc1aeb23420604ced0b13431dbd3270f47cd — an independent `/review-impl` returned **GO, 3 findings, 0 blocking** at that head. Head `5ea5dc100` is the fix round for those findings plus @matthewevans' `CHANGES_REQUESTED`; **no independent review has run at `5ea5dc100` yet**, and the evidence for it is the gate battery and the two-sided controls above.

## Claimed parse impact

None.

## Scope Expansion

The swept sibling `client/src/components/zone/CommanderCardZone.tsx` (fix 3) is **pre-existing, not introduced by this PR**. It is included because it is the same mechanism as the `CommandZone.EmblemCard` hunk already here, and leaving one copy of a defect the PR is removing everywhere else would be worse than the extra 30 lines.

## Named follow-ups (deliberately not fixed here)

1. **Five components each memoize the identical pure `deriveActivationAffordances` call** — `GameBoard`, `AttachmentFan`, `DialogAttachmentCard`, `CommandZone.EmblemCard`, `CommanderCardZone.CommanderCard` — rather than sharing a `useActivationAffordances()` hook, and the last two run **per chip / per commander**, not once per component. "One authority" in code, several computations at runtime. Rated **LOW**: it is a shape/perf refactor with no correctness content, and folding it in would widen this diff across five files for no behavioural change.
2. **Engine-side reachability of fix 2 is UNMEASURED.** Whether a payment-state bucket can actually carry a non-mana `ActivateAbility` needs `crates/**` plus a cargo run, and the cargo token belongs to a concurrent agent on this checkout. The fix is fail-closed either way: if the engine never emits that shape, fix 2 is a no-op; if it does, fix 2 stops the UI offering what the board refuses.

## Validation Failures

The original round's `/review-impl` was a **self**-review; that has since been **superseded** by an independent `/review-impl` at `38c0dc1ae` (**GO, 3 findings, 0 blocking**) and by @matthewevans' `CHANGES_REQUESTED`. All four findings are fixed at `5ea5dc100`. The self-review's own two findings (a negative assertion with no reach guard, and an untested arm of the host-click branch on mobile viewports) were fixed before `38c0dc1ae`.

**Browser verification was not performed**; the evidence is the component-level suite plus the mutant controls above.

**Not fixed, because it was measured unreachable — CodeRabbit's first inline comment** (`AttachmentFan.tsx:222`, Minor): "during an engine interaction `selectable` ignores `viewerInteraction.canSubmit`, so an unsubmittable card still paints the pick affordance while the click does nothing." The premise is that `can_submit: false` can co-occur with a populated `attachment_fans`. **It cannot, in the engine as written:**

- `derive_viewer_interaction` (`crates/engine/src/game/interaction.rs:7273-7436`) is the **sole producer**. Repo-wide `grep -rn "ViewerInteraction {" crates/` returns 10 hits: **7 struct literals, all inside that one function**, plus the struct definition and two return-type annotations in `tests/integration/interaction_contract.rs`.
- Scripted census over those 7 literals: **`VIOLATIONS(can_submit=false AND populated attachment_fans) = 0`.** Both `can_submit: false` literals (`:7286`, `:7302`) pair with `attachment_fans: BTreeMap::new()` (`:7289`, `:7305`). The **only** populated construction (`:7425`, the field-init shorthand bound at `:7373` and filled at `:7392`) sets `can_submit: true`. The one post-construction mutation, `view.attachment_fans.clear()` at `:7430`, is the payload-too-large path and never sets `can_submit: false`.
- **Positive control for that zero** (a zero census is worthless without one): injecting a synthetic populated map into the first `can_submit: false` literal makes the same census report `VIOLATIONS = 1`. The instrument is not stuck at zero.
- The engine file is **byte-unchanged by this PR**.

So the affordance and the click already agree on every reachable state, and CodeRabbit's proposed diff would guard against a state the producer cannot emit. If this is ever tidied, the architecturally correct move is the **inverse** of that diff — delete the now-redundant `canSubmit` re-check inside `handlePick`, since a paint/click asymmetry that cannot occur is the smell, not the paint. Recorded as a named follow-up, deliberately not taken while a maintainer `CHANGES_REQUESTED` is open: adding an unrequested cosmetic change to this diff at this moment is scope creep.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved activation interactions for permanents, attachments, emblems, and other cards.
  * Cards are now selectable only when a legal action is available.
  * Direct actions execute immediately, while multiple available abilities open a choice dialog.
  * Added support for activating attachments through their host card, including mobile interactions.

* **Bug Fixes**
  * Prevented activation during unavailable game phases or when another player has priority.
  * Improved handling of mana abilities and source-consuming actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
