### PR TITLE
fix(engine): serialize game-state hash collections deterministically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,6 +2102,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "strum",
+ "syn 2.0.117",
  "tempfile",
  "thiserror 2.0.18",
  "toml",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -115,3 +115,4 @@ tempfile = "3"
 insta = { version = "1", features = ["json"] }
 assert_matches = "1.5"
 pretty_assertions = "1"
+syn = { version = "2", features = ["full"] }

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -205,8 +205,10 @@ impl<'de> Deserialize<'de> for BlockRequirement {
 pub struct CombatState {
     pub attackers: Vec<AttackerInfo>,
     /// attacker_id -> list of blocker ids
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub blocker_assignments: HashMap<ObjectId, Vec<ObjectId>>,
     /// blocker_id -> attacker_ids (reverse lookup; Vec supports multi-blocking via ExtraBlockers)
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub blocker_to_attacker: HashMap<ObjectId, Vec<ObjectId>>,
     /// Defending players who have declared blockers this step.
     #[serde(default)]
@@ -219,23 +221,36 @@ pub struct CombatState {
     /// they attacked in this combat. Declaration history, not live attacker
     /// membership, so Melee counts remain stable if attackers leave combat
     /// before the trigger resolves.
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "crate::types::deterministic_serde::hash_map_of_hash_set"
+    )]
     pub attacked_defenders_this_combat: HashMap<PlayerId, HashSet<PlayerId>>,
     /// CR 508.6 + CR 702.121a: Source-specific current-combat counterpart to
     /// `attacked_defenders_this_combat`.
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "crate::types::deterministic_serde::hash_map_of_hash_set"
+    )]
     pub creature_attacked_defenders_this_combat: HashMap<ObjectId, HashSet<PlayerId>>,
     /// CR 400.7 + CR 508.1: exact current-combat attack ledger for source
     /// intervening-if conditions. The raw-id defender map remains a display
     /// history; this identity ledger must not match a re-entered object.
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub attacking_incarnations_this_combat: HashSet<ObjectIncarnationRef>,
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub damage_assignments: HashMap<ObjectId, Vec<DamageAssignment>>,
     pub first_strike_done: bool,
     /// CR 510.4: Combatants that had first strike or double strike as the first
     /// combat-damage step began. `None` means the step has not been snapshotted;
     /// `Some(empty)` means combat has only a regular damage step.
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "crate::types::deterministic_serde::option_hash_set"
+    )]
     pub first_strike_participants: Option<HashSet<ObjectId>>,
     /// Index into attacker list for resumable damage assignment iteration.
     pub damage_step_index: Option<usize>,

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -515,7 +515,11 @@ pub struct GameObject {
     pub back_face: Option<BackFaceData>,
 
     /// Digital-only Specialize: specialized faces keyed by added color pip.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::types::deterministic_serde::option_hash_map"
+    )]
     pub specialize_faces: Option<super::specialize::SpecializeFaceMap>,
 
     /// Digital-only Specialize: set after specializing; prevents re-specializing.
@@ -932,13 +936,21 @@ pub struct GameObject {
     /// CR 701.15c: Which players have goaded this creature. A goaded creature must attack
     /// each combat if able and must attack a player other than the goading player(s) if able.
     /// Multiple players can goad the same creature, creating additional combat requirements.
-    #[serde(default, skip_serializing_if = "std::collections::HashSet::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "std::collections::HashSet::is_empty",
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub goaded_by: std::collections::HashSet<PlayerId>,
 
     /// CR 701.35a: Which players have detained this permanent. A detained permanent
     /// can't attack or block and its activated abilities can't be activated until the
     /// detaining player's next turn. Cleared during layer evaluation like goaded_by.
-    #[serde(default, skip_serializing_if = "std::collections::HashSet::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "std::collections::HashSet::is_empty",
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub detained_by: std::collections::HashSet<PlayerId>,
 
     /// CR 701.60a: Whether this creature is currently suspected.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -23242,7 +23242,11 @@ pub struct ResolvedAbility {
     /// interactive continuation later proposes a follow-up event (for example a
     /// replacement's ChooseOneOf branch creates the substitute token), that event
     /// must inherit this set so the same replacement cannot apply to itself again.
-    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashSet::is_empty",
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub replacement_applied: HashSet<AppliedReplacementKey>,
     /// CR 608.2c: How this ability links to its parent when present as a
     /// `sub_ability`. Copied through from the originating `AbilityDefinition`.

--- a/crates/engine/src/types/counter.rs
+++ b/crates/engine/src/types/counter.rs
@@ -212,7 +212,6 @@ impl<'de> serde::Deserialize<'de> for CounterType {
 pub(crate) mod counter_map_serde {
     use super::*;
     use serde::de::{self, MapAccess, Visitor};
-    use serde::ser::SerializeMap;
     use serde::{Deserializer, Serializer};
     use std::fmt;
 
@@ -223,14 +222,11 @@ pub(crate) mod counter_map_serde {
     where
         S: Serializer,
     {
-        let mut entries: Vec<_> = map.iter().collect();
-        entries.sort_unstable_by_key(|(key, _)| *key);
-
-        let mut ser_map = serializer.serialize_map(Some(entries.len()))?;
-        for (counter_type, count) in entries {
-            ser_map.serialize_entry(counter_type.as_str().as_ref(), count)?;
-        }
-        ser_map.end()
+        crate::types::deterministic_serde::serialize_sorted_map_entries(
+            map.iter(),
+            std::convert::identity,
+            serializer,
+        )
     }
 
     pub(crate) fn deserialize<'de, D>(

--- a/crates/engine/src/types/counter.rs
+++ b/crates/engine/src/types/counter.rs
@@ -216,15 +216,18 @@ pub(crate) mod counter_map_serde {
     use serde::{Deserializer, Serializer};
     use std::fmt;
 
-    pub(crate) fn serialize<S>(
-        map: &HashMap<CounterType, u32>,
+    pub(crate) fn serialize<S, H>(
+        map: &HashMap<CounterType, u32, H>,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut ser_map = serializer.serialize_map(Some(map.len()))?;
-        for (counter_type, count) in map {
+        let mut entries: Vec<_> = map.iter().collect();
+        entries.sort_unstable_by_key(|(key, _)| *key);
+
+        let mut ser_map = serializer.serialize_map(Some(entries.len()))?;
+        for (counter_type, count) in entries {
             ser_map.serialize_entry(counter_type.as_str().as_ref(), count)?;
         }
         ser_map.end()
@@ -434,10 +437,58 @@ pub fn prune_zero_counters(counters: &mut HashMap<CounterType, u32>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        has_positive_counters, parse_counter_type, positive_counter_entries,
+        counter_map_serde, has_positive_counters, parse_counter_type, positive_counter_entries,
         positive_counter_types, prune_zero_counters, try_parse_counter_type, CounterType,
     };
+    use crate::types::deterministic_serde::test_support::ReverseBuildHasher;
+    use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
+
+    #[derive(Serialize)]
+    struct AdversarialCounterMapFixture<'a> {
+        #[serde(serialize_with = "counter_map_serde::serialize")]
+        counters: &'a HashMap<CounterType, u32, ReverseBuildHasher>,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct CounterMapFixture {
+        #[serde(with = "counter_map_serde")]
+        counters: HashMap<CounterType, u32>,
+    }
+
+    #[test]
+    fn counter_map_serializer_sorts_typed_keys_without_changing_its_object_shape() {
+        let counters = HashMap::with_hasher(ReverseBuildHasher);
+        let mut counters = counters;
+        counters.insert(CounterType::Loyalty, 3);
+        counters.insert(CounterType::Minus1Minus1, 2);
+        counters.insert(CounterType::Plus1Plus1, 1);
+
+        assert_eq!(
+            counters.keys().cloned().collect::<Vec<_>>(),
+            vec![
+                CounterType::Loyalty,
+                CounterType::Minus1Minus1,
+                CounterType::Plus1Plus1,
+            ],
+            "hostile hasher must expose descending native iteration"
+        );
+        assert_eq!(
+            serde_json::to_string(&AdversarialCounterMapFixture {
+                counters: &counters
+            })
+            .expect("counter fixture should serialize"),
+            r#"{"counters":{"P1P1":1,"M1M1":2,"loyalty":3}}"#
+        );
+
+        let restored: CounterMapFixture =
+            serde_json::from_str(r#"{"counters":{"loyalty":3,"M1M1":2,"P1P1":1}}"#)
+                .expect("current counter object shape should deserialize");
+        assert_eq!(
+            serde_json::to_string(&restored).expect("restored counter map should serialize"),
+            r#"{"counters":{"P1P1":1,"M1M1":2,"loyalty":3}}"#
+        );
+    }
 
     #[test]
     fn parses_legacy_power_toughness_counter_deltas() {
@@ -480,12 +531,6 @@ mod tests {
 
     #[test]
     fn sums_legacy_duplicate_counter_keys_on_deserialize() {
-        #[derive(serde::Deserialize)]
-        struct CounterMapFixture {
-            #[serde(with = "super::counter_map_serde")]
-            counters: HashMap<CounterType, u32>,
-        }
-
         let fixture: CounterMapFixture =
             serde_json::from_str(r#"{"counters":{"P1P1":2,"p1p1":3,"M1M1":1,"m1m1":4}}"#).unwrap();
 

--- a/crates/engine/src/types/deterministic_serde.rs
+++ b/crates/engine/src/types/deterministic_serde.rs
@@ -137,6 +137,15 @@ where
 
 struct NumericHashMapVisitor<K, V>(PhantomData<(K, V)>);
 
+fn cautious_map_capacity<K, V>(hint: Option<usize>) -> usize {
+    const MAX_PREALLOC_BYTES: usize = 1024 * 1024;
+
+    let max_entries = MAX_PREALLOC_BYTES
+        .checked_div(std::mem::size_of::<(K, V)>())
+        .unwrap_or(0);
+    hint.unwrap_or(0).min(max_entries)
+}
+
 impl<'de, K, V> Visitor<'de> for NumericHashMapVisitor<K, V>
 where
     K: Eq + Hash + NumericMapKey,
@@ -152,7 +161,9 @@ where
     where
         A: MapAccess<'de>,
     {
-        let mut values = HashMap::with_capacity(access.size_hint().unwrap_or(0));
+        // A wire-provided size hint is only an optimization. Cap it like Serde's
+        // cautious collection allocation; the map grows normally past this cap.
+        let mut values = HashMap::with_capacity(cautious_map_capacity::<K, V>(access.size_hint()));
         while let Some((NumericKey(key), value)) = access.next_entry()? {
             values.insert(key, value);
         }
@@ -472,10 +483,13 @@ pub(crate) mod test_support {
 mod tests {
     use std::collections::{HashMap, HashSet};
 
+    use serde::de::value::{Error as ValueError, MapAccessDeserializer};
+    use serde::de::{DeserializeSeed, IntoDeserializer, MapAccess};
     use serde::{Deserialize, Serialize};
 
     use super::test_support::ReverseBuildHasher;
     use crate::types::identifiers::ObjectId;
+    use crate::types::player::PlayerId;
 
     type Set = HashSet<u64, ReverseBuildHasher>;
     type Map<V> = HashMap<u64, V, ReverseBuildHasher>;
@@ -643,6 +657,13 @@ mod tests {
             )]
             values: Option<HashMap<ObjectId, String>>,
         },
+        Player {
+            #[serde(
+                serialize_with = "super::hash_map",
+                deserialize_with = "super::deserialize_numeric_hash_map"
+            )]
+            values: HashMap<PlayerId, String>,
+        },
     }
 
     #[test]
@@ -705,6 +726,75 @@ mod tests {
             serde_json::from_str::<ObjectId>(r#""1""#).is_err(),
             "ObjectId values must not become string-permissive"
         );
+
+        let players = BufferedNumericMap::Player {
+            values: HashMap::from([(PlayerId(7), "seven".to_string())]),
+        };
+        let players_value = serde_json::to_value(&players).unwrap();
+        assert_eq!(
+            serde_json::from_value::<BufferedNumericMap>(players_value).unwrap(),
+            players,
+            "a valid PlayerId key must reach the strict numeric-key adapter"
+        );
+
+        let error = serde_json::from_value::<BufferedNumericMap>(serde_json::json!({
+            "type": "Player",
+            "data": {"values": {"256": "out of range"}}
+        }))
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "numeric map key 256 is out of range for engine::types::player::PlayerId"
+        );
+    }
+
+    struct EnormousHintMapAccess {
+        entry: Option<(u64, String)>,
+        value: Option<String>,
+    }
+
+    impl<'de> MapAccess<'de> for EnormousHintMapAccess {
+        type Error = ValueError;
+
+        fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+        where
+            K: DeserializeSeed<'de>,
+        {
+            let Some((key, value)) = self.entry.take() else {
+                return Ok(None);
+            };
+            self.value = Some(value);
+            seed.deserialize(key.into_deserializer()).map(Some)
+        }
+
+        fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+        where
+            V: DeserializeSeed<'de>,
+        {
+            seed.deserialize(
+                self.value
+                    .take()
+                    .expect("next_value_seed must follow next_key_seed")
+                    .into_deserializer(),
+            )
+        }
+
+        fn size_hint(&self) -> Option<usize> {
+            Some(usize::MAX)
+        }
+    }
+
+    #[test]
+    fn numeric_map_deserializer_caps_untrusted_size_hints() {
+        let access = EnormousHintMapAccess {
+            entry: Some((7, "seven".to_string())),
+            value: None,
+        };
+
+        let values: HashMap<ObjectId, String> =
+            super::deserialize_numeric_hash_map(MapAccessDeserializer::new(access)).unwrap();
+
+        assert_eq!(values, HashMap::from([(ObjectId(7), "seven".to_string())]));
     }
 
     #[derive(Serialize)]

--- a/crates/engine/src/types/deterministic_serde.rs
+++ b/crates/engine/src/types/deterministic_serde.rs
@@ -1,0 +1,748 @@
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::hash::{BuildHasher, Hash};
+use std::marker::PhantomData;
+
+use serde::de::{MapAccess, Visitor};
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::identifiers::{ObjectId, TrackedSetId};
+use super::player::PlayerId;
+
+pub(crate) trait NumericMapKey: Sized {
+    fn from_u64(value: u64) -> Option<Self>;
+}
+
+impl NumericMapKey for u64 {
+    fn from_u64(value: u64) -> Option<Self> {
+        Some(value)
+    }
+}
+
+impl NumericMapKey for ObjectId {
+    fn from_u64(value: u64) -> Option<Self> {
+        Some(Self(value))
+    }
+}
+
+impl NumericMapKey for PlayerId {
+    fn from_u64(value: u64) -> Option<Self> {
+        u8::try_from(value).ok().map(Self)
+    }
+}
+
+impl NumericMapKey for TrackedSetId {
+    fn from_u64(value: u64) -> Option<Self> {
+        Some(Self(value))
+    }
+}
+
+struct NumericKey<K>(K);
+
+impl<'de, K> Deserialize<'de> for NumericKey<K>
+where
+    K: NumericMapKey,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct NumericKeyVisitor<K>(PhantomData<K>);
+
+        impl<K> NumericKeyVisitor<K>
+        where
+            K: NumericMapKey,
+        {
+            fn convert<E>(value: u64) -> Result<NumericKey<K>, E>
+            where
+                E: serde::de::Error,
+            {
+                K::from_u64(value).map(NumericKey).ok_or_else(|| {
+                    E::custom(format_args!(
+                        "numeric map key {value} is out of range for {}",
+                        std::any::type_name::<K>()
+                    ))
+                })
+            }
+        }
+
+        impl<'de, K> Visitor<'de> for NumericKeyVisitor<K>
+        where
+            K: NumericMapKey,
+        {
+            type Value = NumericKey<K>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a canonical unsigned decimal map key")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Self::convert(value)
+            }
+
+            fn visit_u8<E>(self, value: u8) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Self::convert(u64::from(value))
+            }
+
+            fn visit_u16<E>(self, value: u16) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Self::convert(u64::from(value))
+            }
+
+            fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Self::convert(u64::from(value))
+            }
+
+            fn visit_u128<E>(self, value: u128) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                u64::try_from(value)
+                    .map_err(|_| E::invalid_value(serde::de::Unexpected::Other("u128"), &self))
+                    .and_then(Self::convert)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                if value.is_empty()
+                    || (value.len() > 1 && value.starts_with('0'))
+                    || !value.bytes().all(|byte| byte.is_ascii_digit())
+                {
+                    return Err(E::invalid_value(serde::de::Unexpected::Str(value), &self));
+                }
+                let value = value
+                    .parse::<u64>()
+                    .map_err(|_| E::invalid_value(serde::de::Unexpected::Str(value), &self))?;
+                Self::convert(value)
+            }
+        }
+
+        deserializer.deserialize_any(NumericKeyVisitor(PhantomData))
+    }
+}
+
+struct NumericHashMapVisitor<K, V>(PhantomData<(K, V)>);
+
+impl<'de, K, V> Visitor<'de> for NumericHashMapVisitor<K, V>
+where
+    K: Eq + Hash + NumericMapKey,
+    V: Deserialize<'de>,
+{
+    type Value = HashMap<K, V>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("a map with canonical unsigned numeric keys")
+    }
+
+    fn visit_map<A>(self, mut access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = HashMap::with_capacity(access.size_hint().unwrap_or(0));
+        while let Some((NumericKey(key), value)) = access.next_entry()? {
+            values.insert(key, value);
+        }
+        Ok(values)
+    }
+}
+
+pub(crate) fn deserialize_numeric_hash_map<'de, K, V, D>(
+    deserializer: D,
+) -> Result<HashMap<K, V>, D::Error>
+where
+    K: Eq + Hash + NumericMapKey,
+    V: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    deserializer.deserialize_map(NumericHashMapVisitor(PhantomData))
+}
+
+pub(crate) fn deserialize_option_numeric_hash_map<'de, K, V, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<K, V>>, D::Error>
+where
+    K: Eq + Hash + NumericMapKey,
+    V: Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    struct OptionalNumericHashMapVisitor<K, V>(PhantomData<(K, V)>);
+
+    impl<'de, K, V> Visitor<'de> for OptionalNumericHashMapVisitor<K, V>
+    where
+        K: Eq + Hash + NumericMapKey,
+        V: Deserialize<'de>,
+    {
+        type Value = Option<HashMap<K, V>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("null or a map with canonical unsigned numeric keys")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            deserialize_numeric_hash_map(deserializer).map(Some)
+        }
+    }
+
+    deserializer.deserialize_option(OptionalNumericHashMapVisitor(PhantomData))
+}
+
+pub(crate) fn hash_set<T, H, S>(values: &HashSet<T, H>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    T: Ord + Serialize,
+    S: Serializer,
+{
+    SortedHashSet(values).serialize(serializer)
+}
+
+pub(crate) fn option_hash_set<T, H, S>(
+    values: &Option<HashSet<T, H>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    T: Ord + Serialize,
+    S: Serializer,
+{
+    values.as_ref().map(SortedHashSet).serialize(serializer)
+}
+
+pub(crate) fn hash_map<K, V, H, S>(
+    values: &HashMap<K, V, H>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K: Ord + Serialize,
+    V: Serialize,
+    S: Serializer,
+{
+    SortedHashMap(values).serialize(serializer)
+}
+
+pub(crate) fn option_hash_map<K, V, H, S>(
+    values: &Option<HashMap<K, V, H>>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K: Ord + Serialize,
+    V: Serialize,
+    S: Serializer,
+{
+    values.as_ref().map(SortedHashMap).serialize(serializer)
+}
+
+pub(crate) fn vec_hash_map<K, V, H, S>(
+    values: &[HashMap<K, V, H>],
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K: Ord + Serialize,
+    V: Serialize,
+    S: Serializer,
+{
+    let mut sequence = serializer.serialize_seq(Some(values.len()))?;
+    for value in values {
+        sequence.serialize_element(&SortedHashMap(value))?;
+    }
+    sequence.end()
+}
+
+pub(crate) fn hash_map_of_hash_set<K, V, H1, H2, S>(
+    values: &HashMap<K, HashSet<V, H2>, H1>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K: Ord + Serialize,
+    V: Ord + Serialize,
+    S: Serializer,
+{
+    let mut entries: Vec<_> = values.iter().collect();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+
+    let mut map = serializer.serialize_map(Some(entries.len()))?;
+    for (key, value) in entries {
+        map.serialize_entry(key, &SortedHashSet(value))?;
+    }
+    map.end()
+}
+
+pub(crate) fn hash_map_of_hash_map<K1, K2, V, H1, H2, S>(
+    values: &HashMap<K1, HashMap<K2, V, H2>, H1>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K1: Ord + Serialize,
+    K2: Ord + Serialize,
+    V: Serialize,
+    S: Serializer,
+{
+    let mut entries: Vec<_> = values.iter().collect();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+
+    let mut map = serializer.serialize_map(Some(entries.len()))?;
+    for (key, value) in entries {
+        map.serialize_entry(key, &SortedHashMap(value))?;
+    }
+    map.end()
+}
+
+pub(crate) fn im_hash_set<T, H, S>(
+    values: &im::HashSet<T, H>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    T: Clone + Eq + Hash + Ord + Serialize,
+    H: BuildHasher,
+    S: Serializer,
+{
+    let mut values: Vec<_> = values.iter().collect();
+    values.sort_unstable();
+    values.serialize(serializer)
+}
+
+pub(crate) fn im_hash_map<K, V, H, S>(
+    values: &im::HashMap<K, V, H>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K: Clone + Eq + Hash + Ord + Serialize,
+    V: Clone + Serialize,
+    H: BuildHasher,
+    S: Serializer,
+{
+    let mut entries: Vec<_> = values.iter().collect();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+
+    let mut map = serializer.serialize_map(Some(entries.len()))?;
+    for (key, value) in entries {
+        map.serialize_entry(key, value)?;
+    }
+    map.end()
+}
+
+pub(crate) fn im_hash_map_of_im_hash_map<K1, K2, V, H1, H2, S>(
+    values: &im::HashMap<K1, im::HashMap<K2, V, H2>, H1>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K1: Clone + Eq + Hash + Ord + Serialize,
+    K2: Clone + Eq + Hash + Ord + Serialize,
+    V: Clone + Serialize,
+    H1: BuildHasher,
+    H2: BuildHasher,
+    S: Serializer,
+{
+    let mut entries: Vec<_> = values.iter().collect();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+
+    let mut map = serializer.serialize_map(Some(entries.len()))?;
+    for (key, value) in entries {
+        map.serialize_entry(key, &SortedImHashMap(value))?;
+    }
+    map.end()
+}
+
+struct SortedHashSet<'a, T, H>(&'a HashSet<T, H>);
+
+impl<T, H> Serialize for SortedHashSet<'_, T, H>
+where
+    T: Ord + Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut values: Vec<_> = self.0.iter().collect();
+        values.sort_unstable();
+        values.serialize(serializer)
+    }
+}
+
+struct SortedHashMap<'a, K, V, H>(&'a HashMap<K, V, H>);
+
+impl<K, V, H> Serialize for SortedHashMap<'_, K, V, H>
+where
+    K: Ord + Serialize,
+    V: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut entries: Vec<_> = self.0.iter().collect();
+        entries.sort_unstable_by_key(|(key, _)| *key);
+
+        let mut map = serializer.serialize_map(Some(entries.len()))?;
+        for (key, value) in entries {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+}
+
+struct SortedImHashMap<'a, K, V, H>(&'a im::HashMap<K, V, H>);
+
+impl<K, V, H> Serialize for SortedImHashMap<'_, K, V, H>
+where
+    K: Clone + Eq + Hash + Ord + Serialize,
+    V: Clone + Serialize,
+    H: BuildHasher,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut entries: Vec<_> = self.0.iter().collect();
+        entries.sort_unstable_by_key(|(key, _)| *key);
+
+        let mut map = serializer.serialize_map(Some(entries.len()))?;
+        for (key, value) in entries {
+            map.serialize_entry(key, value)?;
+        }
+        map.end()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::hash::{BuildHasher, Hasher};
+
+    #[derive(Clone, Default)]
+    pub(crate) struct ReverseBuildHasher;
+
+    pub(crate) struct ReverseHasher(u64);
+
+    impl BuildHasher for ReverseBuildHasher {
+        type Hasher = ReverseHasher;
+
+        fn build_hasher(&self) -> Self::Hasher {
+            ReverseHasher(0)
+        }
+    }
+
+    impl Hasher for ReverseHasher {
+        fn finish(&self) -> u64 {
+            u64::MAX - self.0
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            self.0 = bytes
+                .iter()
+                .fold(0_u64, |value, byte| (value << 8) | u64::from(*byte));
+        }
+
+        fn write_u64(&mut self, value: u64) {
+            self.0 = value;
+        }
+
+        fn write_usize(&mut self, value: usize) {
+            self.0 = value as u64;
+        }
+
+        fn write_isize(&mut self, value: isize) {
+            self.0 = value as u64;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use serde::{Deserialize, Serialize};
+
+    use super::test_support::ReverseBuildHasher;
+    use crate::types::identifiers::ObjectId;
+
+    type Set = HashSet<u64, ReverseBuildHasher>;
+    type Map<V> = HashMap<u64, V, ReverseBuildHasher>;
+
+    #[derive(Serialize)]
+    struct StandardFixture<'a> {
+        #[serde(serialize_with = "super::hash_set")]
+        set: &'a Set,
+        #[serde(serialize_with = "super::option_hash_set")]
+        optional_set: &'a Option<Set>,
+        #[serde(serialize_with = "super::hash_map")]
+        map: &'a Map<&'static str>,
+        #[serde(serialize_with = "super::option_hash_map")]
+        optional_map: &'a Option<Map<&'static str>>,
+        #[serde(serialize_with = "super::vec_hash_map")]
+        maps: &'a Vec<Map<&'static str>>,
+        #[serde(serialize_with = "super::hash_map_of_hash_set")]
+        map_of_sets: &'a Map<Set>,
+        #[serde(serialize_with = "super::hash_map_of_hash_map")]
+        map_of_maps: &'a Map<Map<&'static str>>,
+    }
+
+    #[test]
+    fn standard_hash_adapters_sort_every_unordered_level_and_preserve_vector_order() {
+        let set = Set::from_iter([1, 2, 3]);
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![3, 2, 1]);
+
+        let map = Map::from_iter([(1, "one"), (2, "two"), (3, "three")]);
+        assert_eq!(map.keys().copied().collect::<Vec<_>>(), vec![3, 2, 1]);
+
+        let optional_set = Some(set.clone());
+        let optional_map = Some(map.clone());
+        let maps = vec![
+            Map::from_iter([(2, "two"), (1, "one")]),
+            Map::from_iter([(3, "three"), (2, "two")]),
+        ];
+        let map_of_sets =
+            Map::from_iter([(2, Set::from_iter([3, 1])), (1, Set::from_iter([2, 1]))]);
+        let map_of_maps = Map::from_iter([
+            (2, Map::from_iter([(3, "three"), (1, "one")])),
+            (1, Map::from_iter([(2, "two"), (1, "one")])),
+        ]);
+
+        let serialized = serde_json::to_string(&StandardFixture {
+            set: &set,
+            optional_set: &optional_set,
+            map: &map,
+            optional_map: &optional_map,
+            maps: &maps,
+            map_of_sets: &map_of_sets,
+            map_of_maps: &map_of_maps,
+        })
+        .expect("fixture should serialize");
+
+        assert_eq!(
+            serialized,
+            r#"{"set":[1,2,3],"optional_set":[1,2,3],"map":{"1":"one","2":"two","3":"three"},"optional_map":{"1":"one","2":"two","3":"three"},"maps":[{"1":"one","2":"two"},{"2":"two","3":"three"}],"map_of_sets":{"1":[1,2],"2":[1,3]},"map_of_maps":{"1":{"1":"one","2":"two"},"2":{"1":"one","3":"three"}}}"#
+        );
+    }
+
+    #[test]
+    fn standard_hash_adapters_cover_empty_singleton_and_none() {
+        let empty_set = Set::default();
+        let singleton_set = Set::from_iter([7]);
+        let empty_map = Map::default();
+        let singleton_map = Map::from_iter([(7, "seven")]);
+
+        #[derive(Serialize)]
+        struct BoundaryFixture<'a> {
+            #[serde(serialize_with = "super::hash_set")]
+            empty_set: &'a Set,
+            #[serde(serialize_with = "super::hash_set")]
+            singleton_set: &'a Set,
+            #[serde(serialize_with = "super::hash_map")]
+            empty_map: &'a Map<&'static str>,
+            #[serde(serialize_with = "super::hash_map")]
+            singleton_map: &'a Map<&'static str>,
+            #[serde(serialize_with = "super::option_hash_set")]
+            no_set: &'a Option<Set>,
+            #[serde(serialize_with = "super::option_hash_map")]
+            no_map: &'a Option<Map<&'static str>>,
+        }
+
+        assert_eq!(
+            serde_json::to_string(&BoundaryFixture {
+                empty_set: &empty_set,
+                singleton_set: &singleton_set,
+                empty_map: &empty_map,
+                singleton_map: &singleton_map,
+                no_set: &None,
+                no_map: &None,
+            })
+            .expect("fixture should serialize"),
+            r#"{"empty_set":[],"singleton_set":[7],"empty_map":{},"singleton_map":{"7":"seven"},"no_set":null,"no_map":null}"#
+        );
+    }
+
+    #[test]
+    fn sorted_map_serialization_is_default_transparent_except_for_order() {
+        #[derive(Serialize)]
+        struct DefaultMap<'a> {
+            map: &'a HashMap<ObjectId, &'static str, ReverseBuildHasher>,
+        }
+
+        #[derive(Serialize)]
+        struct SortedMap<'a> {
+            #[serde(serialize_with = "super::hash_map")]
+            map: &'a HashMap<ObjectId, &'static str, ReverseBuildHasher>,
+        }
+
+        let map = HashMap::from_iter([
+            (ObjectId(1), "one"),
+            (ObjectId(2), "two"),
+            (ObjectId(3), "three"),
+        ]);
+        assert_eq!(
+            map.keys().copied().collect::<Vec<_>>(),
+            vec![ObjectId(3), ObjectId(2), ObjectId(1)]
+        );
+
+        let default_json = serde_json::to_string(&DefaultMap { map: &map }).unwrap();
+        let sorted_json = serde_json::to_string(&SortedMap { map: &map }).unwrap();
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&default_json).unwrap(),
+            serde_json::from_str::<serde_json::Value>(&sorted_json).unwrap(),
+            "sorting must not change the parsed key/value representation"
+        );
+        assert_eq!(sorted_json, r#"{"map":{"1":"one","2":"two","3":"three"}}"#);
+
+        let singleton = HashMap::from_iter([(ObjectId(7), "seven")]);
+        assert_eq!(
+            serde_json::to_string(&DefaultMap { map: &singleton }).unwrap(),
+            serde_json::to_string(&SortedMap { map: &singleton }).unwrap(),
+            "a singleton has no ordering difference and must be byte-identical"
+        );
+
+        let restored_default: HashMap<ObjectId, String> =
+            serde_json::from_str(r#"{"1":"one","2":"two","3":"three"}"#).unwrap();
+        let restored_sorted: HashMap<ObjectId, String> = serde_json::from_str(
+            serde_json::to_value(&SortedMap { map: &map })
+                .unwrap()
+                .get("map")
+                .unwrap()
+                .to_string()
+                .as_str(),
+        )
+        .unwrap();
+        assert_eq!(restored_default, restored_sorted);
+    }
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(tag = "type", content = "data")]
+    enum BufferedNumericMap {
+        Required {
+            #[serde(
+                serialize_with = "super::hash_map",
+                deserialize_with = "super::deserialize_numeric_hash_map"
+            )]
+            values: HashMap<ObjectId, String>,
+        },
+        Optional {
+            #[serde(
+                serialize_with = "super::option_hash_map",
+                deserialize_with = "super::deserialize_option_numeric_hash_map"
+            )]
+            values: Option<HashMap<ObjectId, String>>,
+        },
+    }
+
+    #[test]
+    fn buffered_numeric_map_keys_are_field_local_round_trippable_and_strict() {
+        let required = BufferedNumericMap::Required {
+            values: HashMap::from([
+                (ObjectId(2), "two".to_string()),
+                (ObjectId(1), "one".to_string()),
+            ]),
+        };
+        let required_value = serde_json::to_value(&required).unwrap();
+        assert_eq!(
+            required_value["data"]["values"],
+            serde_json::json!({"1": "one", "2": "two"})
+        );
+        assert_eq!(
+            serde_json::from_value::<BufferedNumericMap>(required_value).unwrap(),
+            required
+        );
+
+        for optional in [
+            BufferedNumericMap::Optional {
+                values: Some(HashMap::from([
+                    (ObjectId(2), "two".to_string()),
+                    (ObjectId(1), "one".to_string()),
+                ])),
+            },
+            BufferedNumericMap::Optional {
+                values: Some(HashMap::new()),
+            },
+            BufferedNumericMap::Optional { values: None },
+        ] {
+            let value = serde_json::to_value(&optional).unwrap();
+            assert_eq!(
+                serde_json::from_value::<BufferedNumericMap>(value).unwrap(),
+                optional
+            );
+        }
+
+        for malformed in [
+            "-1",
+            "1.0",
+            "01",
+            " 1",
+            "1 ",
+            "text",
+            "18446744073709551616",
+        ] {
+            let value = serde_json::json!({
+                "type": "Required",
+                "data": {"values": {(malformed): "bad"}}
+            });
+            assert!(
+                serde_json::from_value::<BufferedNumericMap>(value).is_err(),
+                "malformed key {malformed:?} must be rejected"
+            );
+        }
+
+        assert!(
+            serde_json::from_str::<ObjectId>(r#""1""#).is_err(),
+            "ObjectId values must not become string-permissive"
+        );
+    }
+
+    #[derive(Serialize)]
+    struct ImFixture<'a> {
+        #[serde(serialize_with = "super::im_hash_set")]
+        set: &'a im::HashSet<u64, ReverseBuildHasher>,
+        #[serde(serialize_with = "super::im_hash_map")]
+        map: &'a im::HashMap<u64, &'static str, ReverseBuildHasher>,
+        #[serde(serialize_with = "super::im_hash_map_of_im_hash_map")]
+        map_of_maps: &'a im::HashMap<
+            u64,
+            im::HashMap<u64, &'static str, ReverseBuildHasher>,
+            ReverseBuildHasher,
+        >,
+    }
+
+    #[test]
+    fn im_hash_adapters_sort_plain_and_nested_collections() {
+        let set = im::HashSet::from_iter([1_u64, 2, 3]);
+        assert_eq!(set.iter().copied().collect::<Vec<_>>(), vec![3, 2, 1]);
+        let map = im::HashMap::from_iter([(1_u64, "one"), (2, "two"), (3, "three")]);
+        assert_eq!(map.keys().copied().collect::<Vec<_>>(), vec![3, 2, 1]);
+        let map_of_maps = im::HashMap::from_iter([
+            (
+                2_u64,
+                im::HashMap::from_iter([(3_u64, "three"), (1, "one")]),
+            ),
+            (1, im::HashMap::from_iter([(2_u64, "two"), (1, "one")])),
+        ]);
+
+        assert_eq!(
+            serde_json::to_string(&ImFixture {
+                set: &set,
+                map: &map,
+                map_of_maps: &map_of_maps,
+            })
+            .expect("fixture should serialize"),
+            r#"{"set":[1,2,3],"map":{"1":"one","2":"two","3":"three"},"map_of_maps":{"1":{"1":"one","2":"two"},"2":{"1":"one","3":"three"}}}"#
+        );
+    }
+}

--- a/crates/engine/src/types/deterministic_serde.rs
+++ b/crates/engine/src/types/deterministic_serde.rs
@@ -281,6 +281,28 @@ where
     sequence.end()
 }
 
+pub(crate) fn serialize_sorted_map_entries<'a, K, V, W, F, S>(
+    entries: impl Iterator<Item = (&'a K, &'a V)>,
+    wrap_value: F,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    K: Ord + Serialize + 'a,
+    V: 'a,
+    W: Serialize,
+    F: Fn(&'a V) -> W,
+    S: Serializer,
+{
+    let mut entries: Vec<_> = entries.collect();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+
+    let mut map = serializer.serialize_map(Some(entries.len()))?;
+    for (key, value) in entries {
+        map.serialize_entry(key, &wrap_value(value))?;
+    }
+    map.end()
+}
+
 pub(crate) fn hash_map_of_hash_set<K, V, H1, H2, S>(
     values: &HashMap<K, HashSet<V, H2>, H1>,
     serializer: S,
@@ -290,14 +312,7 @@ where
     V: Ord + Serialize,
     S: Serializer,
 {
-    let mut entries: Vec<_> = values.iter().collect();
-    entries.sort_unstable_by_key(|(key, _)| *key);
-
-    let mut map = serializer.serialize_map(Some(entries.len()))?;
-    for (key, value) in entries {
-        map.serialize_entry(key, &SortedHashSet(value))?;
-    }
-    map.end()
+    serialize_sorted_map_entries(values.iter(), SortedHashSet, serializer)
 }
 
 pub(crate) fn hash_map_of_hash_map<K1, K2, V, H1, H2, S>(
@@ -310,14 +325,7 @@ where
     V: Serialize,
     S: Serializer,
 {
-    let mut entries: Vec<_> = values.iter().collect();
-    entries.sort_unstable_by_key(|(key, _)| *key);
-
-    let mut map = serializer.serialize_map(Some(entries.len()))?;
-    for (key, value) in entries {
-        map.serialize_entry(key, &SortedHashMap(value))?;
-    }
-    map.end()
+    serialize_sorted_map_entries(values.iter(), SortedHashMap, serializer)
 }
 
 pub(crate) fn im_hash_set<T, H, S>(
@@ -344,14 +352,7 @@ where
     H: BuildHasher,
     S: Serializer,
 {
-    let mut entries: Vec<_> = values.iter().collect();
-    entries.sort_unstable_by_key(|(key, _)| *key);
-
-    let mut map = serializer.serialize_map(Some(entries.len()))?;
-    for (key, value) in entries {
-        map.serialize_entry(key, value)?;
-    }
-    map.end()
+    SortedImHashMap(values).serialize(serializer)
 }
 
 pub(crate) fn im_hash_map_of_im_hash_map<K1, K2, V, H1, H2, S>(
@@ -366,14 +367,7 @@ where
     H2: BuildHasher,
     S: Serializer,
 {
-    let mut entries: Vec<_> = values.iter().collect();
-    entries.sort_unstable_by_key(|(key, _)| *key);
-
-    let mut map = serializer.serialize_map(Some(entries.len()))?;
-    for (key, value) in entries {
-        map.serialize_entry(key, &SortedImHashMap(value))?;
-    }
-    map.end()
+    serialize_sorted_map_entries(values.iter(), SortedImHashMap, serializer)
 }
 
 struct SortedHashSet<'a, T, H>(&'a HashSet<T, H>);
@@ -403,14 +397,7 @@ where
     where
         S: Serializer,
     {
-        let mut entries: Vec<_> = self.0.iter().collect();
-        entries.sort_unstable_by_key(|(key, _)| *key);
-
-        let mut map = serializer.serialize_map(Some(entries.len()))?;
-        for (key, value) in entries {
-            map.serialize_entry(key, value)?;
-        }
-        map.end()
+        serialize_sorted_map_entries(self.0.iter(), std::convert::identity, serializer)
     }
 }
 
@@ -426,14 +413,7 @@ where
     where
         S: Serializer,
     {
-        let mut entries: Vec<_> = self.0.iter().collect();
-        entries.sort_unstable_by_key(|(key, _)| *key);
-
-        let mut map = serializer.serialize_map(Some(entries.len()))?;
-        for (key, value) in entries {
-            map.serialize_entry(key, value)?;
-        }
-        map.end()
+        serialize_sorted_map_entries(self.0.iter(), std::convert::identity, serializer)
     }
 }
 
@@ -532,6 +512,20 @@ mod tests {
             (2, Map::from_iter([(3, "three"), (1, "one")])),
             (1, Map::from_iter([(2, "two"), (1, "one")])),
         ]);
+        for inner in map_of_sets.values() {
+            let values = inner.iter().copied().collect::<Vec<_>>();
+            assert!(
+                values.windows(2).all(|pair| pair[0] > pair[1]),
+                "nested set must expose descending native iteration: {values:?}"
+            );
+        }
+        for inner in map_of_maps.values() {
+            let keys = inner.keys().copied().collect::<Vec<_>>();
+            assert!(
+                keys.windows(2).all(|pair| pair[0] > pair[1]),
+                "nested map must expose descending native iteration: {keys:?}"
+            );
+        }
 
         let serialized = serde_json::to_string(&StandardFixture {
             set: &set,
@@ -824,6 +818,13 @@ mod tests {
             ),
             (1, im::HashMap::from_iter([(2_u64, "two"), (1, "one")])),
         ]);
+        for inner in map_of_maps.values() {
+            let keys = inner.keys().copied().collect::<Vec<_>>();
+            assert!(
+                keys.windows(2).all(|pair| pair[0] > pair[1]),
+                "nested map must expose descending native iteration: {keys:?}"
+            );
+        }
 
         assert_eq!(
             serde_json::to_string(&ImFixture {

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -123,7 +123,7 @@ impl ManaTapState {
 }
 
 /// Avatar crossover: The four elemental bending types, tracked per-turn on each player.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum BendingType {
     Fire,
     Air,
@@ -131,7 +131,7 @@ pub enum BendingType {
     Water,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum PlayerActionKind {
     /// A player accepted a resolution-time optional effect.
     AcceptedOptionalEffect,
@@ -321,6 +321,7 @@ pub struct EventObjectSnapshot {
     /// CR 202.3: effective mana value as of capture.
     pub mana_value: u32,
     /// CR 122.1: counters on the subject as of capture.
+    #[serde(with = "crate::types::counter::counter_map_serde")]
     pub counters: HashMap<CounterType, u32>,
 
     pub is_token: bool,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -138,15 +138,18 @@ mod tuple_key_map {
     use serde::{Deserializer, Serializer};
     use std::fmt;
 
-    pub fn serialize<S>(
-        map: &HashMap<(ObjectId, usize), u32>,
+    pub fn serialize<S, H>(
+        map: &HashMap<(ObjectId, usize), u32, H>,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut ser_map = serializer.serialize_map(Some(map.len()))?;
-        for ((oid, idx), val) in map {
+        let mut entries: Vec<_> = map.iter().collect();
+        entries.sort_unstable_by_key(|(key, _)| *key);
+
+        let mut ser_map = serializer.serialize_map(Some(entries.len()))?;
+        for ((oid, idx), val) in entries {
             ser_map.serialize_entry(&format!("{}_{}", oid.0, idx), val)?;
         }
         ser_map.end()
@@ -195,14 +198,16 @@ mod tuple_key_map {
 mod trigger_definition_ref_map {
     use super::*;
 
-    pub fn serialize<S>(
-        map: &HashMap<TriggerDefinitionRef, u32>,
+    pub fn serialize<S, H>(
+        map: &HashMap<TriggerDefinitionRef, u32, H>,
         serializer: S,
     ) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        map.iter().collect::<Vec<_>>().serialize(serializer)
+        let mut entries: Vec<_> = map.iter().collect();
+        entries.sort_unstable_by_key(|(key, _)| *key);
+        entries.serialize(serializer)
     }
 
     pub fn deserialize<'de, D>(
@@ -3684,7 +3689,11 @@ pub struct PendingChooseOneOf {
     pub context: super::ability::SpellContext,
     /// CR 614.5 + CR 616.1f: replacement effects already applied to the event
     /// that produced this queued branch choice.
-    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashSet::is_empty",
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub replacement_applied: HashSet<AppliedReplacementKey>,
     pub remaining_players: Vec<PlayerId>,
 }
@@ -4584,7 +4593,11 @@ pub struct PendingBatchDeliveries {
     /// physical-card delivery is being resumed. Meld result redirects reuse
     /// this set for each component move so the redirect cannot apply again to
     /// either modified event.
-    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashSet::is_empty",
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub replacement_applied: HashSet<AppliedReplacementKey>,
     /// Exact heterogeneous undelivered suffix. New saves use this authority;
     /// the uniform fields above remain as a compatibility projection for older
@@ -4618,7 +4631,11 @@ pub enum PendingBatchZoneChangeCause {
     StateBasedAction,
     CommanderRuleReturn,
     Draw {
-        #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+        #[serde(
+            default,
+            skip_serializing_if = "HashSet::is_empty",
+            serialize_with = "crate::types::deterministic_serde::hash_set"
+        )]
         seed_applied: HashSet<AppliedReplacementKey>,
     },
     CastingToStack {
@@ -4653,7 +4670,11 @@ pub struct PendingBatchZoneMoveRequest {
     pub exile_duration: Option<Duration>,
     #[serde(default)]
     pub exile_tracking: ZoneDeliveryExileTracking,
-    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashSet::is_empty",
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub replacement_applied: HashSet<AppliedReplacementKey>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub face_down_in_exile: bool,
@@ -9126,20 +9147,34 @@ pub enum WaitingFor {
         /// key means "no legal targets" (no fallback). New prompts always emit
         /// `Some` — computed by the same engine constraints model that enforces
         /// legality in `validate_attack_declaration`.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            serialize_with = "crate::types::deterministic_serde::option_hash_map",
+            deserialize_with = "crate::types::deterministic_serde::deserialize_option_numeric_hash_map"
+        )]
         valid_attack_targets_by_attacker:
             Option<HashMap<ObjectId, Vec<crate::game::combat::AttackTarget>>>,
         /// CR 508.1c / CR 508.1d: per-creature combat requirement/restriction
         /// (must-attack / can't-attack) for display badges and Confirm gating.
         /// Display-only — computed by `combat::attacker_constraints_for_active_player`,
         /// the same predicates that enforce legality in `validate_attackers`.
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        #[serde(
+            default,
+            skip_serializing_if = "HashMap::is_empty",
+            serialize_with = "crate::types::deterministic_serde::hash_map",
+            deserialize_with = "crate::types::deterministic_serde::deserialize_numeric_hash_map"
+        )]
         attacker_constraints: HashMap<ObjectId, crate::game::combat::CombatRequirement>,
     },
     DeclareBlockers {
         player: PlayerId,
         valid_blocker_ids: Vec<ObjectId>,
-        #[serde(default)]
+        #[serde(
+            default,
+            serialize_with = "crate::types::deterministic_serde::hash_map",
+            deserialize_with = "crate::types::deterministic_serde::deserialize_numeric_hash_map"
+        )]
         valid_block_targets: HashMap<ObjectId, Vec<ObjectId>>,
         /// CR 702.111b (Menace) + CR 509.1b: per-attacker minimum-blocker count
         /// (`count`) plus the `sources` carriers imposing it, for attackers
@@ -9148,13 +9183,23 @@ pub enum WaitingFor {
         /// attackers with the trivial requirement of 1 are omitted. Computed by
         /// `combat::block_requirements_for_player` — the same authority that
         /// enforces the requirement in `validate_blocks`.
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        #[serde(
+            default,
+            skip_serializing_if = "HashMap::is_empty",
+            serialize_with = "crate::types::deterministic_serde::hash_map",
+            deserialize_with = "crate::types::deterministic_serde::deserialize_numeric_hash_map"
+        )]
         block_requirements: HashMap<ObjectId, crate::game::combat::BlockRequirement>,
         /// CR 509.1b / CR 509.1c: per-creature combat requirement/restriction
         /// (must-block / can't-block) for display badges and Confirm gating.
         /// Display-only — computed by `combat::blocker_constraints_for_player`,
         /// the same predicate that enforces legality in `validate_blockers_for_player`.
-        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        #[serde(
+            default,
+            skip_serializing_if = "HashMap::is_empty",
+            serialize_with = "crate::types::deterministic_serde::hash_map",
+            deserialize_with = "crate::types::deterministic_serde::deserialize_numeric_hash_map"
+        )]
         blocker_constraints: HashMap<ObjectId, crate::game::combat::CombatRequirement>,
     },
     /// CR 502.3: During the untap step, the active player may choose not to
@@ -9523,7 +9568,11 @@ pub enum WaitingFor {
         context: super::ability::SpellContext,
         /// CR 614.5 + CR 616.1f: replacement effects already applied to the
         /// event that produced this choice.
-        #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+        #[serde(
+            default,
+            skip_serializing_if = "HashSet::is_empty",
+            serialize_with = "crate::types::deterministic_serde::hash_set"
+        )]
         replacement_applied: HashSet<AppliedReplacementKey>,
         /// Players still to face the same choice in APNAP order (CR 701.55d).
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -12819,7 +12868,11 @@ pub struct LiminalEntry {
     pub kind: LiminalEntryKind,
     /// CR 614.5: applied replacement identities from the projected entry. Meld
     /// redirects seed both physical component moves with this shared set.
-    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashSet::is_empty",
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub replacement_applied: HashSet<AppliedReplacementKey>,
 }
 
@@ -13024,7 +13077,10 @@ declare_game_state! {
     // the default SipHash RandomState: ObjectId is a thin integer key and this
     // map is looked up millions of times per large-board resolution — profiling
     // showed SipHash hashing + HAMT lookup was ~35% of resolution CPU.
-    #[serde(deserialize_with = "deserialize_objects_with_trigger_provenance")]
+    #[serde(
+        deserialize_with = "deserialize_objects_with_trigger_provenance",
+        serialize_with = "crate::types::deterministic_serde::im_hash_map"
+    )]
     pub objects: im::HashMap<ObjectId, GameObject, rustc_hash::FxBuildHasher>,
     pub next_object_id: u64,
     /// CR 603.7: persisted monotonic delayed-trigger installation allocator.
@@ -13073,6 +13129,7 @@ declare_game_state! {
     pub battlefield: im::Vector<ObjectId>,
     pub stack: im::Vector<StackEntry>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub stack_paid_facts: HashMap<ObjectId, StackPaidSnapshot>,
     pub exile: im::Vector<ObjectId>,
 
@@ -13136,6 +13193,7 @@ declare_game_state! {
     // Replacement effects
     pub pending_replacement: Option<PendingReplacement>,
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub liminal_entries: HashMap<ObjectId, LiminalEntry>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_liminal_entry_resume: Option<PendingLiminalEntryResume>,
@@ -13168,7 +13226,11 @@ declare_game_state! {
     /// via `resolve_ability_chain`, so clearing earlier wipes the seed before
     /// those later token proposals and re-prompts the originating token-choice
     /// replacement (issue #4886).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::types::deterministic_serde::option_hash_set"
+    )]
     pub post_replacement_token_choice_applied:
         Option<std::collections::HashSet<crate::types::proposed_event::AppliedReplacementKey>>,
 
@@ -13326,6 +13388,7 @@ declare_game_state! {
     /// Memorial" without inferring source by name-diffing. Display metadata
     /// only — never read by game logic. Empty objects skip serialization.
     #[serde(default, skip_serializing_if = "im::HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::im_hash_map")]
     pub attribution: im::HashMap<ObjectId, ObjectAttribution>,
 
     /// CR 613.1d: Remote recipients whose live card types were derived by a
@@ -13441,6 +13504,7 @@ declare_game_state! {
 
     /// CR 603.7: Object sets tracked for delayed triggers ("those cards", "that creature").
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub tracked_object_sets: HashMap<TrackedSetId, Vec<ObjectId>>,
 
     #[serde(default)]
@@ -13477,22 +13541,26 @@ declare_game_state! {
     /// action provenance (selection sets via `publish_fresh_tracked_set`) are
     /// absent here and are read only by `caused_by: None` references.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map_of_hash_map")]
     pub tracked_set_member_causes: HashMap<TrackedSetId, HashMap<ObjectId, ThisWayCause>>,
 
     // Commander support
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub commander_cast_count: HashMap<ObjectId, u32>,
 
     /// Owner stamped when a commander cast from the command zone is recorded.
     /// CR 903.8: `commander_casts_from_command_zone` must count committed casts
     /// even when the recorded `ObjectId` no longer has `is_commander` set.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub commander_cast_owners: HashMap<ObjectId, PlayerId>,
 
     /// CR 903.9a: Commanders whose owner declined the zone-return choice this
     /// SBA cycle. Cleared when the commander changes zones again (giving the
     /// owner a fresh choice opportunity).
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub commander_declined_zone_return: HashSet<ObjectId>,
 
     /// CR 120.3 + CR 120.6 + CR 702.11b: Battlefield objects that have actually
@@ -13503,6 +13571,7 @@ declare_game_state! {
     /// would-deal amount of CR 120.1a); cleared when the object leaves the
     /// battlefield so a flickered object starts with a clean slate.
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub objects_that_dealt_damage: HashSet<ObjectId>,
 
     /// CR 500.7: Extra turns granted by effects, stored as a LIFO stack.
@@ -13524,6 +13593,7 @@ declare_game_state! {
     /// CR 614.10a: Per-player counts of step occurrences to skip. A pending skip
     /// is consumed only when the named step would otherwise happen.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::vec_hash_map")]
     pub steps_to_skip: Vec<HashMap<Phase, u32>>,
 
     /// CR 614.10 + CR 614.10a: Per-player turn-scoped combat-phase skip state.
@@ -13599,6 +13669,7 @@ declare_game_state! {
     pub priority_passes: BTreeSet<PlayerId>,
     /// Per-player auto-pass flags. When set, the engine auto-passes for this player.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub auto_pass: HashMap<PlayerId, AutoPassMode>,
 
     /// Per-player phase-stop preferences. While a player's `UntilTurnBoundary`
@@ -13610,17 +13681,20 @@ declare_game_state! {
     /// carries a `PhaseStopScope` (all turns / own turn / opponents' turns),
     /// resolved against `active_player` (CR 102.1) by `phase_stop_hit`.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub phase_stops: HashMap<PlayerId, Vec<PhaseStop>>,
 
     /// Sparse per-player priority-passing preference. Missing entries are
     /// [`PriorityPassingMode::Standard`], preserving legacy saved-game behavior.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub priority_passing_modes: HashMap<PlayerId, PriorityPassingMode>,
 
     /// CR 605.3: Lands manually tapped for mana via TapLandForMana this priority window.
     /// Per-player map enables multiplayer correctness (e.g., UnlessPayment opponent tapping).
     /// Cleared on priority pass, cast, non-mana action, or phase transition.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub lands_tapped_for_mana: HashMap<PlayerId, Vec<ObjectId>>,
 
     /// CR 103.5 + 103.5b: Per-player ledger of bottom cards already put on the
@@ -13638,6 +13712,7 @@ declare_game_state! {
     ///
     /// Cleared when the mulligan flow finishes (all players out of `pending`).
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub prepaid_mulligan_bottoms: HashMap<PlayerId, u8>,
 
     /// When true, `GameAction::Debug(...)` actions are accepted.
@@ -13873,6 +13948,7 @@ declare_game_state! {
 
     // Trigger constraint tracking keyed by exact source incarnation + occurrence.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub triggers_fired_this_turn: HashSet<TriggerDefinitionRef>,
     /// CR 603.4: Per-trigger fire counts for MaxTimesPerTurn constraint.
     /// Tracks how many times each exact occurrence has fired this turn.
@@ -13885,8 +13961,10 @@ declare_game_state! {
     /// CR 603.2: Tracks per-opponent-per-turn firing for
     /// OncePerOpponentPerTurn. Keyed by exact occurrence and opponent.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub triggers_fired_this_turn_per_opponent: HashSet<(TriggerDefinitionRef, PlayerId)>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub triggers_fired_this_game: HashSet<TriggerDefinitionRef>,
     #[serde(
         default,
@@ -13906,6 +13984,7 @@ declare_game_state! {
     /// `abilities[]` entry, so it cannot use `activated_abilities_this_turn`
     /// (keyed by `(source_id, ability_index)`). Cleared at turn start.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub crew_activated_this_turn: HashSet<ObjectIncarnationRef>,
     /// CR 606.1 + CR 606.3 + CR 603.4: Per-player count of loyalty-ability
     /// activations this turn. Incremented in
@@ -13917,6 +13996,7 @@ declare_game_state! {
     /// conditions like The Chain Veil's "if you activated a loyalty ability of
     /// a planeswalker this turn". Cleared at turn start.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub loyalty_abilities_activated_this_turn: HashMap<PlayerId, u32>,
     /// CR 606.3: Per-player extra loyalty-activation grants for this turn —
     /// each entry raises the per-permanent CR 606.3 cap for every planeswalker
@@ -13925,6 +14005,7 @@ declare_game_state! {
     /// activated ability). Consumed by
     /// `planeswalker::can_activate_loyalty_ability`. Cleared at turn start.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub extra_loyalty_activations_this_turn: HashMap<PlayerId, u32>,
     /// CR 701.43d: Permanents exerted this turn via the "you may exert it as it
     /// attacks" optional attack cost (Combat Celebrant, Glory-Bound Initiate,
@@ -13934,6 +14015,7 @@ declare_game_state! {
     /// start. Distinct from the exert *cost* path (a `CantUntap` transient), this
     /// set is the authoritative "was exerted this turn" record.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub exerted_this_turn: std::collections::HashSet<ObjectId>,
     /// CR 701.26 + CR 603.4: Count of times each object became tapped this turn,
     /// keyed by object id. Populated at the central `GameEvent::PermanentTapped`
@@ -13942,6 +14024,7 @@ declare_game_state! {
     /// turn" — the count model (not a HashSet) keeps the CR 603.4 resolution-time
     /// re-check of `FirstTimeObjectTappedThisTurn` correct.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub object_tap_count_this_turn: std::collections::HashMap<ObjectId, u32>,
     /// CR 122.1 + CR 603.4: Count of distinct counter-placement *occurrences*
     /// (put-events, not records) on each object this turn, keyed by object id.
@@ -13955,6 +14038,7 @@ declare_game_state! {
     /// `impl PartialEq` (mirrors `object_tap_count_this_turn`): a per-turn
     /// observational counter must not perturb board-equality.
     #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub object_counter_placement_count_this_turn: std::collections::HashMap<ObjectId, u32>,
     /// CR 508.1g + CR 508.2: Declaration events (e.g. `AttackersDeclared`) held
     /// while the active player resolves the optional "exert as it attacks"
@@ -13984,6 +14068,7 @@ declare_game_state! {
     /// used this turn. Keyed by the granting permanent's ObjectId.
     /// CR 400.7: Zone change creates new ObjectId, naturally resetting.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub graveyard_cast_permissions_used: HashSet<ObjectId>,
     /// CR 110.4 + CR 601.2a: Tracks which permanent-type slots a
     /// `OncePerTurnPerPermanentType` graveyard-cast permission source has
@@ -13996,6 +14081,7 @@ declare_game_state! {
     /// CR 400.7: Zone change creates a new source `ObjectId`, naturally
     /// resetting all slots.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub graveyard_cast_permissions_used_per_type: HashSet<(ObjectId, super::card_type::CoreType)>,
     /// CR 110.4: Transient slot stashed by the ChoosePermanentTypeSlot dispatch
     /// for the land-play path. Consumed by `record_graveyard_play_permission` on
@@ -14007,6 +14093,7 @@ declare_game_state! {
     /// permanent's ObjectId. Unlimited sources (Omniscience) never populate this.
     /// CR 400.7: Zone change creates new ObjectId, naturally resetting.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub hand_cast_free_permissions_used: HashSet<ObjectId>,
     /// CR 118.9 + CR 601.2b: Tracks which once-per-turn `CastWithAlternativeCost`
     /// grant sources (As Foretold) have already had their alternative cost applied
@@ -14015,10 +14102,12 @@ declare_game_state! {
     /// CR 400.7: Zone change creates a new ObjectId, so the permission naturally
     /// resets when the source leaves and returns.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub alt_cost_grant_permissions_used: HashSet<ObjectId>,
     /// CR 601.2a: Tracks once-per-turn `PlayFromExile` permission sources
     /// consumed this turn. Keyed by the granting source's ObjectId.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub exile_play_permissions_used: HashSet<ObjectId>,
     /// CR 601.2a + CR 603.7 + CR 611.2a: Tracks `single_use` `PlayFromExile`
     /// grants whose one allowed cast has already been spent. Keyed by the
@@ -14030,6 +14119,7 @@ declare_game_state! {
     /// per turn — it is pruned only when the grant itself expires
     /// (`layers::prune_*_casting_permissions` clears stale tracked-set entries).
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub exile_play_single_use_consumed: HashSet<TrackedSetId>,
     /// CR 601.2a + CR 113.6b: Tracks `OncePerTurn` `StaticMode::ExileCastPermission`
     /// sources that have already had a spell cast through them this turn
@@ -14040,6 +14130,7 @@ declare_game_state! {
     /// CR 400.7: Zone change creates a new source `ObjectId`, naturally
     /// resetting the slot when the source leaves and re-enters play.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub exile_cast_permissions_used: HashSet<ObjectId>,
     /// CR 601.2a + CR 401.5: Tracks `OncePerTurn`
     /// `StaticMode::TopOfLibraryCastPermission` sources that have already had a
@@ -14052,6 +14143,7 @@ declare_game_state! {
     /// CR 400.7: Zone change creates a new source `ObjectId`, naturally
     /// resetting the slot when the source leaves and re-enters play.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub top_of_library_cast_permissions_used: HashSet<ObjectId>,
     /// CR 113.6b + CR 601.2a: Per-turn rolling list of cards that have been
     /// exiled "with" each linked-exile source during the current turn. Keyed
@@ -14068,6 +14160,7 @@ declare_game_state! {
     /// only by `StaticMode::ExileCastPermission` and similar per-turn
     /// permissions.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub cards_exiled_with_source_this_turn: HashMap<ObjectId, Vec<ObjectId>>,
     /// CR 702.94a + CR 603.11: Per-player first-card-drawn-this-turn tracking for
     /// miracle's linked triggered ability. Populated by the draw pipeline on the
@@ -14077,11 +14170,13 @@ declare_game_state! {
     /// "first card drawn" condition without re-counting. Absent key means the
     /// player has not drawn yet this turn.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub first_card_drawn_this_turn: HashMap<PlayerId, ObjectId>,
     /// Object IDs of cards actually drawn this turn, per player. Cards remain
     /// in this list even if they later leave hand; consumers filter by current
     /// zone when presenting choices.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub cards_drawn_this_turn: HashMap<PlayerId, Vec<ObjectId>>,
     /// CR 702.94a + CR 603.11: FIFO queue of miracle reveal offers accumulated
     /// during the current action's resolution. Populated by the draw pipeline
@@ -14100,6 +14195,7 @@ declare_game_state! {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending_paradigm_remaining_offers: Option<PendingParadigmRemainingOffers>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub spells_cast_this_game: HashMap<PlayerId, u32>,
     /// Per-player spell cast history this game.
     /// CR 117.1: Mirrors `spells_cast_this_turn_by_player` but is not cleared
@@ -14107,18 +14203,22 @@ declare_game_state! {
     /// Second Sun's "another spell named {LITERAL} this game") can scan the
     /// full game-scope history.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub spells_cast_this_game_by_player: HashMap<PlayerId, im::Vector<SpellCastRecord>>,
     /// Per-player spell cast history this turn.
     /// Each entry records the spell's relevant characteristics at cast time,
     /// enabling data-driven filtered counting at resolution.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub spells_cast_this_turn_by_player: HashMap<PlayerId, im::Vector<SpellCastRecord>>,
     /// Per-player land play origin history this turn.
     /// Mirrors `Player::lands_played_this_turn` when origin-sensitive
     /// conditions need to distinguish hand plays from exile/graveyard plays.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub lands_played_this_turn_by_player: HashMap<PlayerId, im::Vector<LandPlayRecord>>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub players_who_searched_library_this_turn: HashSet<PlayerId>,
     /// CR 603.4: Typed player-action events performed this turn. This is the
     /// turn-scoped counterpart to `player_actions_this_way`, preserving repeated
@@ -14126,10 +14226,13 @@ declare_game_state! {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub player_actions_this_turn: Vec<(PlayerId, PlayerActionKind)>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub players_attacked_this_step: HashSet<PlayerId>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub players_attacked_this_turn: HashSet<PlayerId>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub attacking_creatures_this_turn: HashMap<PlayerId, u32>,
     /// CR 508.6 + CR 508.1b: For each attacking player, the set of defending
     /// players they attacked this turn, accumulated across every combat's
@@ -14138,12 +14241,14 @@ declare_game_state! {
     /// `PlayerFilter::OpponentAttacked { You, ThisTurn }` for "opponents you
     /// attacked this turn" (Militant Angel).
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map_of_hash_set")]
     pub attacked_defenders_this_turn: HashMap<PlayerId, HashSet<PlayerId>>,
     /// CR 508.6 + CR 508.1b: For each creature declared as an attacker this
     /// turn, the defending players it attacked. This is the source-specific
     /// counterpart to `attacked_defenders_this_turn` for text like "each player
     /// this creature attacked this turn" (Angel of Destiny).
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map_of_hash_set")]
     pub creature_attacked_defenders_this_turn: HashMap<ObjectId, HashSet<PlayerId>>,
     /// CR 500.8 + CR 506.1: Number of combat phases that have begun this turn.
     /// Used by intervening-if triggers that only fire during the first combat phase.
@@ -14158,6 +14263,7 @@ declare_game_state! {
     /// CR 508.1a: Object IDs of creatures declared as attackers this turn.
     /// Persists after combat ends for post-combat filtering.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub creatures_attacked_this_turn: HashSet<ObjectId>,
     /// CR 508.1a + CR 608.2c: Declaration-time attacker snapshots for filtered
     /// post-combat queries ("attacked with a token/commander/Dinosaur this
@@ -14168,8 +14274,10 @@ declare_game_state! {
     /// CR 509.1a: Object IDs of creatures declared as blockers this turn.
     /// Persists after combat ends for post-combat filtering.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub creatures_blocked_this_turn: HashSet<ObjectId>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub players_who_created_token_this_turn: HashSet<PlayerId>,
     /// CR 111.2: Token creation snapshots this turn, preserving creation-time
     /// characteristics for filtered "tokens you created this turn" quantities.
@@ -14178,10 +14286,13 @@ declare_game_state! {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub counter_added_this_turn: Vec<CounterAddedRecord>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub players_who_discarded_card_this_turn: HashSet<PlayerId>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub cards_discarded_this_turn_by_player: HashMap<PlayerId, u32>,
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub players_who_sacrificed_artifact_this_turn: HashSet<PlayerId>,
     /// CR 701.21a: Sacrificed permanent snapshots this turn, preserving
     /// event-time characteristics for filtered "you sacrificed [quality] this
@@ -14197,6 +14308,7 @@ declare_game_state! {
     /// stacking duplicate batched triggers (issue #3866) without suppressing a
     /// later distinct leave by the same object in the same turn.
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub batched_zone_change_trigger_fired: HashSet<(TriggerDefinitionRef, usize)>,
     /// CR 403.3: Battlefield entry snapshots this turn, enabling data-driven ETB queries.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -14215,6 +14327,7 @@ declare_game_state! {
     /// `turns::start_next_turn` per CR 514. Read by `casting_variant_candidates`
     /// to gate the Freerunning cast permission on the spell's controller.
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub assassin_or_commander_dealt_combat_damage_this_turn: HashSet<PlayerId>,
     /// CR 702.76a + CR 608.2i: Set of `(controller, creature type)` entries for
     /// sources that dealt combat damage to a player this turn (snapshot at
@@ -14225,9 +14338,11 @@ declare_game_state! {
     /// `turns::start_next_turn` per CR 514. Read by `casting_variant_candidates`
     /// to gate the Prowl cast permission ("had any of this spell's creature types").
     #[serde(default, skip_serializing_if = "im::HashSet::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::im_hash_set")]
     pub creature_types_dealt_combat_damage_this_turn: im::HashSet<(PlayerId, String)>,
     /// CR 700.14: Cumulative mana spent on spells this turn per player (for Expend triggers).
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub mana_spent_on_spells_this_turn: HashMap<PlayerId, u32>,
     /// CR 601.2f: One-shot cost reductions for the next spell cast.
     /// Consumed when the player casts their next qualifying spell.
@@ -14247,20 +14362,24 @@ declare_game_state! {
     /// CR 700.2: "choose one that hasn't been chosen this turn"
     /// Note: ObjectId-keyed — zone changes create new ObjectId per CR 400.7, naturally resetting tracking.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub modal_modes_chosen_this_turn: HashSet<(ObjectId, usize)>,
     /// Modal modes chosen this game per source: (ObjectId, mode_index).
     /// CR 700.2: "choose one that hasn't been chosen" (game-scoped)
     /// Note: ObjectId-keyed — zone changes create new ObjectId per CR 400.7, naturally resetting tracking.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub modal_modes_chosen_this_game: HashSet<(ObjectId, usize)>,
 
     /// Cards currently revealed to all players (e.g. during a RevealHand effect).
     /// `filter_state_for_player` skips hiding these cards.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub revealed_cards: HashSet<ObjectId>,
     /// Cards that have been publicly revealed at least once. Unlike
     /// `revealed_cards`, this is not cleared at the next action boundary.
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub public_revealed_cards: HashSet<ObjectId>,
 
     /// Typed suspended-resolution authority. Families move here one at a
@@ -14507,6 +14626,7 @@ declare_game_state! {
     /// library this way" counts the opponents who accepted that offer, even
     /// across player-scope iterations and interactive continuations.
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub player_actions_this_way: HashSet<(PlayerId, PlayerActionKind)>,
 
     /// CR 608.2c: Numeric result from the preceding effect in a sub_ability chain.
@@ -14552,6 +14672,7 @@ declare_game_state! {
     /// carried-subject continuations like "Each player discards ..., then draws
     /// that many ..." after all players have completed the discard pass.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub last_effect_counts_by_player: HashMap<PlayerId, i32>,
 
     /// CR 608.2e: Clause-local equalization snapshot. Each `player_scope` link
@@ -14581,6 +14702,7 @@ declare_game_state! {
     /// CR 702.131a: Players who have the city's blessing (from Ascend).
     /// Once gained, the city's blessing is permanent for the rest of the game.
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub city_blessing: HashSet<PlayerId>,
 
     /// CR 702.50a-b: Active Epic effects — one per resolved Epic spell. Each
@@ -14812,6 +14934,7 @@ declare_game_state! {
     /// Full event batches for triggered abilities currently on the stack,
     /// keyed by stack entry id. Single-event triggers omit an entry here.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub stack_trigger_event_batches: HashMap<ObjectId, Vec<GameEvent>>,
     /// Private CR 603.7 receipt for delayed-trigger abilities currently on the
     /// stack. This side table follows the entry through serialization without
@@ -14819,18 +14942,21 @@ declare_game_state! {
     /// without a row (or its legacy delayed-provenance predecessor) is
     /// ambiguous and rejected at restore rather than guessed as ordinary.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub(crate) stack_trigger_firings: HashMap<ObjectId, TriggerFiring>,
 
     /// CR 400.7: Last Known Information cache.
     /// Populated before zone changes for objects leaving the battlefield.
     /// Cleared on phase/step transitions via `advance_phase()`.
     #[serde(default, skip_serializing_if = "im::HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::im_hash_map")]
     pub lki_cache: im::HashMap<ObjectId, LKISnapshot>,
     /// CR 608.2h + CR 707.2: Full copiable-values LKI for objects that leave a
     /// public zone. Ordinary `LKISnapshot` is intentionally filter-shaped and
     /// does not carry ability definitions; copy effects need the complete
     /// copiable surface when the copy source later ceases to exist.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub lki_copiable_values: HashMap<ObjectId, CopiableValues>,
 
     /// CR 400.7 + CR 608.2h: LKI keyed by exact object incarnation. The legacy
@@ -14839,6 +14965,7 @@ declare_game_state! {
     /// departure of a re-entered object cannot overwrite the earlier object's LKI.
     /// Cleared with `lki_cache` on phase/step transitions.
     #[serde(default, skip_serializing_if = "im::HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::im_hash_map_of_im_hash_map")]
     pub lki_by_incarnation: im::HashMap<ObjectId, im::HashMap<u64, LKISnapshot>>,
 
     /// CR 607.2b + CR 603.10e: Last-known "cards exiled with [source]" linkage,
@@ -14851,6 +14978,7 @@ declare_game_state! {
     /// stale entries (cards that later left exile) contribute nothing.
     /// Cleared on phase/step transitions via `advance_phase()`.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub linked_exile_lki: HashMap<ObjectId, Vec<LinkedExileSnapshot>>,
 
     /// Transient: set by PayCost resolver when payment fails.
@@ -14903,13 +15031,16 @@ declare_game_state! {
 
     /// CR 701.54: Per-player ring level (0-3, 4 levels total).
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub ring_level: HashMap<PlayerId, u8>,
     /// CR 701.54: Per-player ring-bearer (the creature the Ring is on).
     #[serde(default)]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub ring_bearer: HashMap<PlayerId, Option<ObjectId>>,
 
     /// CR 309 / CR 701.49: Per-player dungeon venture progress.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub dungeon_progress: HashMap<PlayerId, crate::game::dungeon::DungeonProgress>,
     /// CR 901.15: The planar deck (single-deck Planechase option). Front = top;
     /// the active face-up plane/phenomenon lives in the command zone, NOT here.
@@ -14924,6 +15055,7 @@ declare_game_state! {
     /// has taken this turn. Effect-caused planar die rolls do not increment
     /// this counter.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_map")]
     pub planar_die_actions_this_turn: HashMap<PlayerId, u32>,
     /// CR 904.3 / CR 904.4: The archenemy's scheme deck (single-deck Archenemy
     /// option). Front = top; face-down in the command zone (CR 314.2). Schemes
@@ -15191,6 +15323,7 @@ impl ConniveSubject {
 pub struct PendingConniveReentry {
     pub conniver: ConniveSubject,
     pub count: u32,
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub applied: HashSet<AppliedReplacementKey>,
 }
 
@@ -15277,6 +15410,7 @@ pub struct PostReplacementDrain {
     /// time. It is co-owned, not merely co-located. (The reading that it has an
     /// independent lifecycle comes from looking at the *instant* of the
     /// `combat_damage` clear rather than its *purpose*; that reading is wrong.)
+    #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
     pub applied: HashSet<AppliedReplacementKey>,
 
     /// CR 615.5 + CR 609.7: source of the *prevented event itself* (the damage
@@ -15606,7 +15740,10 @@ pub struct DrawSequenceFrame {
     /// that produced this frame. Every individual draw, including one resumed
     /// after a replacement choice, starts with this set so an originating
     /// replacement cannot apply to its own substitute draw.
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub applied: HashSet<AppliedReplacementKey>,
     /// The instruction's completion behavior. Old saves default to [`DrawSequenceOrigin::Plain`].
     #[serde(default)]
@@ -21343,12 +21480,92 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityDefinition, AbilityKind, Effect, PostReplacementContinuation, QuantityExpr,
-        ResolvedAbility, TargetFilter,
+        ResolvedAbility, TargetFilter, TriggerBaseSetInstanceRef, TriggerDefinitionOccurrenceRef,
     };
+    use crate::types::deterministic_serde::test_support::ReverseBuildHasher;
     use crate::types::identifiers::{
         DelayedTriggerInstanceId, DelayedTriggerOrigin, DelayedTriggerToken,
     };
     use crate::types::resolved_commands::ResolvedDelayedTriggerCommand;
+
+    #[derive(Serialize)]
+    struct TupleKeyFixture<'a> {
+        #[serde(serialize_with = "tuple_key_map::serialize")]
+        values: &'a HashMap<(ObjectId, usize), u32, ReverseBuildHasher>,
+    }
+
+    #[derive(Serialize)]
+    struct TriggerRefFixture<'a> {
+        #[serde(serialize_with = "trigger_definition_ref_map::serialize")]
+        values: &'a HashMap<TriggerDefinitionRef, u32, ReverseBuildHasher>,
+    }
+
+    fn printed_trigger_ref(printed_index: usize) -> TriggerDefinitionRef {
+        TriggerDefinitionRef {
+            source: ObjectIncarnationRef::of(ObjectId(7), 3),
+            occurrence: TriggerDefinitionOccurrenceRef::Printed {
+                base_set: TriggerBaseSetInstanceRef::INITIAL,
+                printed_index,
+            },
+        }
+    }
+
+    #[test]
+    fn special_map_serializers_sort_typed_keys_without_changing_wire_shapes() {
+        let mut tuple_values = HashMap::with_hasher(ReverseBuildHasher);
+        tuple_values.insert((ObjectId(7), 0), 10);
+        tuple_values.insert((ObjectId(7), 1), 11);
+        tuple_values.insert((ObjectId(7), 2), 12);
+        assert_eq!(
+            tuple_values.keys().copied().collect::<Vec<_>>(),
+            vec![(ObjectId(7), 2), (ObjectId(7), 1), (ObjectId(7), 0)],
+            "hostile tuple map must expose descending native iteration"
+        );
+        assert_eq!(
+            serde_json::to_string(&TupleKeyFixture {
+                values: &tuple_values,
+            })
+            .expect("tuple-key fixture should serialize"),
+            r#"{"values":{"7_0":10,"7_1":11,"7_2":12}}"#
+        );
+        let tuple_round_trip: HashMap<(ObjectId, usize), u32> = tuple_key_map::deserialize(
+            &mut serde_json::Deserializer::from_str(r#"{"7_2":12,"7_0":10,"7_1":11}"#),
+        )
+        .expect("tuple-key object should deserialize");
+        assert_eq!(tuple_round_trip.len(), 3);
+        assert_eq!(tuple_round_trip.get(&(ObjectId(7), 1)), Some(&11));
+
+        let mut trigger_values = HashMap::with_hasher(ReverseBuildHasher);
+        trigger_values.insert(printed_trigger_ref(0), 10);
+        trigger_values.insert(printed_trigger_ref(1), 11);
+        trigger_values.insert(printed_trigger_ref(2), 12);
+        assert_eq!(
+            trigger_values
+                .keys()
+                .map(|key| match key.occurrence {
+                    TriggerDefinitionOccurrenceRef::Printed { printed_index, .. } => printed_index,
+                    _ => unreachable!("fixture uses printed trigger refs"),
+                })
+                .collect::<Vec<_>>(),
+            vec![2, 1, 0],
+            "hostile trigger map must expose descending native iteration"
+        );
+        assert_eq!(
+            serde_json::to_string(&TriggerRefFixture {
+                values: &trigger_values,
+            })
+            .expect("trigger-ref fixture should serialize"),
+            r#"{"values":[[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":0}}},10],[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":1}}},11],[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":2}}},12]]}"#
+        );
+        let trigger_round_trip = trigger_definition_ref_map::deserialize(
+            &mut serde_json::Deserializer::from_str(
+                r#"[[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":2}}},12],[{"source":{"object_id":7,"incarnation":3},"occurrence":{"type":"Printed","data":{"base_set":1,"printed_index":0}}},10]]"#,
+            ),
+        )
+        .expect("trigger-ref pair array should deserialize");
+        assert_eq!(trigger_round_trip.len(), 2);
+        assert_eq!(trigger_round_trip.get(&printed_trigger_ref(2)), Some(&12));
+    }
 
     #[test]
     fn migration_preserves_missing_install_roots_as_legacy() {
@@ -23746,6 +23963,29 @@ mod tests {
         assert!(
             !loop_states_equal(&ordinary, &delayed),
             "ordinary and delayed stack-trigger firings must not share a loop identity"
+        );
+    }
+
+    #[test]
+    fn stack_trigger_firings_numeric_map_round_trips_populated() {
+        let mut state = normal_trigger_firing_fixture();
+        let mut second_entry = state.stack.back().expect("fixture stack entry").clone();
+        second_entry.id = ObjectId(9_004);
+        state.stack.push_back(second_entry);
+        state
+            .stack_trigger_firings
+            .insert(ObjectId(9_004), TriggerFiring::LegacyDelayed);
+        assert_eq!(state.stack_trigger_firings.len(), 2);
+
+        let serialized = serde_json::to_string(&state).expect("state should serialize");
+        assert!(serialized.contains(
+            "\"stack_trigger_firings\":{\"9003\":\"Ordinary\",\"9004\":\"LegacyDelayed\"}"
+        ));
+        let restored: GameState = serde_json::from_str(&serialized).expect("state should restore");
+        assert_eq!(restored.stack_trigger_firings, state.stack_trigger_firings);
+        assert_eq!(
+            serde_json::to_string(&restored).expect("restored state should serialize"),
+            serialized
         );
     }
 

--- a/crates/engine/src/types/identifiers.rs
+++ b/crates/engine/src/types/identifiers.rs
@@ -37,7 +37,7 @@ pub struct LogicalZoneChangeGroupId(pub u64);
 
 /// Unique identifier for a set of objects tracked across delayed trigger boundaries.
 /// CR 603.7: Delayed triggers reference the specific objects from the originating effect.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TrackedSetId(pub u64);
 

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -6,6 +6,7 @@ pub mod card;
 pub mod card_type;
 pub mod counter;
 pub mod definitions;
+pub(crate) mod deterministic_serde;
 pub mod events;
 pub mod format;
 pub mod game_state;

--- a/crates/engine/src/types/player.rs
+++ b/crates/engine/src/types/player.rs
@@ -163,12 +163,19 @@ pub struct Player {
     pub is_eliminated: bool,
 
     /// Avatar crossover: which bending types this player has performed this turn.
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "crate::types::deterministic_serde::hash_set"
+    )]
     pub bending_types_this_turn: HashSet<BendingType>,
 
     /// CR 122.1: Player counters (experience, rad, ticket, etc.).
     /// Poison counters route to the dedicated `poison_counters` field via method accessors.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "HashMap::is_empty",
+        serialize_with = "crate::types::deterministic_serde::hash_map"
+    )]
     pub player_counters: HashMap<PlayerCounterKind, u32>,
 
     /// Phasing status. Default `Active`. While `PhasedOut`, the player is

--- a/crates/engine/src/types/proposed_event.rs
+++ b/crates/engine/src/types/proposed_event.rs
@@ -78,7 +78,7 @@ pub struct BoundSearchFoundCandidate {
     pub is_optional: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 #[serde(tag = "type")]
 pub enum AppliedReplacementKey {
     Object { source: ObjectId, index: usize },
@@ -418,6 +418,7 @@ pub enum ProposedEvent {
         /// delivered.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         enter_as_copy: Option<Box<CopyTokenSpec>>,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     Damage {
@@ -425,11 +426,13 @@ pub enum ProposedEvent {
         target: TargetRef,
         amount: u32,
         is_combat: bool,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     Draw {
         player_id: PlayerId,
         count: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 701.23a + CR 614.1: One card found during a search, before the
@@ -442,6 +445,7 @@ pub enum ProposedEvent {
         library_owner: Option<PlayerId>,
         object_id: ObjectId,
         disposition: SearchFoundDisposition,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 701.22a + CR 614.1a: A player is about to scry cards. Replacement
@@ -449,6 +453,7 @@ pub enum ProposedEvent {
     Scry {
         player_id: PlayerId,
         count: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 701.17a + CR 614.1a: A player is about to mill cards. Count-level
@@ -458,6 +463,7 @@ pub enum ProposedEvent {
         player_id: PlayerId,
         count: u32,
         destination: Zone,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 705.1 + CR 614.1a: A player is about to flip a single coin. Carried
@@ -467,12 +473,14 @@ pub enum ProposedEvent {
     CoinFlip {
         player_id: PlayerId,
         count: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 701.37a + CR 614.1a: A creature is about to explore. Replacement
     /// effects can modify the explore action (e.g., add a scry prelude).
     Explore {
         object_id: ObjectId,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 701.50a + CR 614.1a: A creature is about to connive (draw N, discard N,
@@ -489,6 +497,7 @@ pub enum ProposedEvent {
         /// a legacy raw-id-only parked event cannot reconstruct this authority.
         subject: Box<EventObjectSnapshot>,
         count: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 701.34a + CR 614.1a: A player is about to proliferate. Replacement
@@ -497,16 +506,19 @@ pub enum ProposedEvent {
     Proliferate {
         player_id: PlayerId,
         count: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     LifeGain {
         player_id: PlayerId,
         amount: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     LifeLoss {
         player_id: PlayerId,
         amount: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     AddCounter {
@@ -516,12 +528,14 @@ pub enum ProposedEvent {
         #[serde(flatten)]
         placement: CounterPlacement,
         count: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     RemoveCounter {
         object_id: ObjectId,
         counter_type: CounterType,
         count: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 122.5: Moving a counter is atomic: remove it from one object and put
@@ -536,6 +550,7 @@ pub enum ProposedEvent {
         remove_count: u32,
         add_count: u32,
         stage: CounterMoveStage,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 111.1 + CR 614.1a: Token creation event carrying the full
@@ -564,6 +579,7 @@ pub enum ProposedEvent {
         enter_tapped: EtbTapState,
         /// CR 614.1a: Number of tokens to create. May be modified by replacement effects.
         count: u32,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     TokenEntry {
@@ -572,6 +588,7 @@ pub enum ProposedEvent {
         enter_tapped: EtbTapState,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         enter_with_counters: Vec<(CounterType, u32)>,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     Discard {
@@ -584,20 +601,24 @@ pub enum ProposedEvent {
         /// actions (cleanup hand-size discard).
         #[serde(default)]
         caused_by_effect: bool,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     Tap {
         object_id: ObjectId,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     Untap {
         object_id: ObjectId,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 614.1e + CR 708.11: a permanent is being turned face up. "As ~ is turned
     /// face up" replacement effects apply here (megamorph/disguise).
     TurnFaceUp {
         object_id: ObjectId,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     Destroy {
@@ -605,11 +626,13 @@ pub enum ProposedEvent {
         source: Option<ObjectId>,
         /// CR 701.19c: When true, regeneration shields cannot prevent this destruction.
         cant_regenerate: bool,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     Sacrifice {
         object_id: ObjectId,
         player_id: PlayerId,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 500.1 + CR 614.1b + CR 614.10: A turn is about to begin. Carried
@@ -621,6 +644,7 @@ pub enum ProposedEvent {
     BeginTurn {
         player_id: PlayerId,
         is_extra_turn: bool,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 500.1 + CR 614.1b: A phase/step is about to begin. Carried through
@@ -631,6 +655,7 @@ pub enum ProposedEvent {
     BeginPhase {
         player_id: PlayerId,
         phase: Phase,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 106.3 + CR 614.1a: Mana is about to be produced by a source and added
@@ -648,6 +673,7 @@ pub enum ProposedEvent {
         /// ability with the tap symbol in its cost.
         #[serde(default)]
         tapped_for_mana: bool,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 703.4q + CR 614.1a + CR 616.1: A player's step-end "empty unspent
@@ -670,7 +696,11 @@ pub enum ProposedEvent {
     EmptyManaPool {
         player_id: PlayerId,
         units: Vec<UnitDecision>,
-        #[serde(default, deserialize_with = "deserialize_applied_keys_step_end_mana")]
+        #[serde(
+            default,
+            deserialize_with = "deserialize_applied_keys_step_end_mana",
+            serialize_with = "crate::types::deterministic_serde::hash_set"
+        )]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 701.31 + CR 614.1a: A player is about to planeswalk. All CR 701.31c
@@ -685,6 +715,7 @@ pub enum ProposedEvent {
         /// only the cause their Oracle text names.
         #[serde(default)]
         cause: PlaneswalkCause,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
     /// CR 701.3a + CR 614.1a: An Aura, Equipment, or Fortification is about to
@@ -699,6 +730,7 @@ pub enum ProposedEvent {
     Attach {
         attachment_id: ObjectId,
         target_id: ObjectId,
+        #[serde(serialize_with = "crate::types::deterministic_serde::hash_set")]
         applied: HashSet<AppliedReplacementKey>,
     },
 }

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -137,7 +137,11 @@ pub struct PendingMutateMerge {
 pub struct ChangeZoneFrame {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pending: Option<PendingChangeZoneIteration>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "crate::types::deterministic_serde::option_hash_set"
+    )]
     pub devour_eligible_snapshot: Option<HashSet<ObjectId>>,
 }
 

--- a/crates/engine/tests/integration/deterministic_game_state_serde.rs
+++ b/crates/engine/tests/integration/deterministic_game_state_serde.rs
@@ -1909,6 +1909,25 @@ fn declare_attackers_numeric_maps_round_trip_through_value_bare_raw_and_trusted(
     malformed["data"]["attacker_constraints"] = serde_json::json!({"01": {"kind": "CantAttack"}});
     assert!(serde_json::from_value::<WaitingFor>(malformed).is_err());
 
+    let valid_attack_targets = value["data"]["valid_attack_targets"].clone();
+
+    let mut malformed_optional = value.clone();
+    malformed_optional["data"]["valid_attack_targets_by_attacker"] =
+        serde_json::json!({"01": valid_attack_targets.clone()});
+    let error = serde_json::from_value::<WaitingFor>(malformed_optional).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        r#"invalid value: string "01", expected a canonical unsigned decimal map key"#,
+        "the optional numeric-map deserializer must reject at the noncanonical key path"
+    );
+
+    let mut canonical_optional = value.clone();
+    canonical_optional["data"]["valid_attack_targets_by_attacker"] =
+        serde_json::json!({"1": valid_attack_targets});
+    let restored = serde_json::from_value::<WaitingFor>(canonical_optional.clone())
+        .expect("the same valid payload must deserialize with a canonical numeric key");
+    assert_eq!(waiting_value(&restored), canonical_optional);
+
     let mut state = GameState::new(FormatConfig::standard(), 2, 42);
     state.waiting_for = waiting;
     assert_waiting_round_trip_across_persistence_forms(state);

--- a/crates/engine/tests/integration/deterministic_game_state_serde.rs
+++ b/crates/engine/tests/integration/deterministic_game_state_serde.rs
@@ -1,0 +1,2128 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use engine::game::combat::{
+    AttackTarget, BlockRequirement, CombatRequirement, CombatState, DamageAssignment, DamageTarget,
+};
+use engine::game::dungeon::DungeonProgress;
+use engine::game::game_object::{BackFaceData, GameObject, ProtectionStartSnapshot};
+use engine::game::printed_cards::intrinsic_copiable_values;
+use engine::types::ability::ThisWayCause;
+use engine::types::attribution::ObjectAttribution;
+use engine::types::card_type::CardType;
+use engine::types::definitions::Definitions;
+use engine::types::events::{GameEvent, PlayerActionKind};
+use engine::types::game_state::{
+    AutoPassMode, LandPlayRecord, LiminalEntry, LinkedExileSnapshot, PendingConniveReentry,
+    PersistedGameState, PriorityPassingMode, SpellCastRecord, StackPaidSnapshot, WaitingFor,
+};
+use engine::types::identifiers::{CardId, ObjectId, TrackedSetId};
+use engine::types::keywords::ProtectionTarget;
+use engine::types::mana::{ManaColor, ManaCost};
+use engine::types::phase::{PhaseStop, PhaseStopScope};
+use engine::types::proposed_event::AppliedReplacementKey;
+use engine::types::zones::EtbTapState;
+use engine::types::{FormatConfig, GameState, Phase, PlayerId, Zone};
+use syn::{Fields, GenericArgument, Item, PathArguments, Type};
+
+const HASH_SET: &str = "serialize_with=\"crate::types::deterministic_serde::hash_set\"";
+const OPTION_HASH_SET: &str =
+    "serialize_with=\"crate::types::deterministic_serde::option_hash_set\"";
+const HASH_MAP: &str = "serialize_with=\"crate::types::deterministic_serde::hash_map\"";
+const OPTION_HASH_MAP: &str =
+    "serialize_with=\"crate::types::deterministic_serde::option_hash_map\"";
+const VEC_HASH_MAP: &str = "serialize_with=\"crate::types::deterministic_serde::vec_hash_map\"";
+const HASH_MAP_OF_HASH_SET: &str =
+    "serialize_with=\"crate::types::deterministic_serde::hash_map_of_hash_set\"";
+const HASH_MAP_OF_HASH_MAP: &str =
+    "serialize_with=\"crate::types::deterministic_serde::hash_map_of_hash_map\"";
+const IM_HASH_SET: &str = "serialize_with=\"crate::types::deterministic_serde::im_hash_set\"";
+const IM_HASH_MAP: &str = "serialize_with=\"crate::types::deterministic_serde::im_hash_map\"";
+const IM_HASH_MAP_OF_IM_HASH_MAP: &str =
+    "serialize_with=\"crate::types::deterministic_serde::im_hash_map_of_im_hash_map\"";
+const NUMERIC_HASH_MAP_DESERIALIZER: &str =
+    "deserialize_with=\"crate::types::deterministic_serde::deserialize_numeric_hash_map\"";
+const OPTION_NUMERIC_HASH_MAP_DESERIALIZER: &str =
+    "deserialize_with=\"crate::types::deterministic_serde::deserialize_option_numeric_hash_map\"";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Classification {
+    Canonical(&'static str),
+    SerdeSkip,
+    DeserializeOnlyOrRuntime,
+    NonStringJsonMapKey,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct OwnerSpec {
+    shape: &'static str,
+    classification: Classification,
+    map_key_types: &'static [&'static str],
+    numeric_deserializer: Option<&'static str>,
+}
+
+#[derive(Debug)]
+struct DiscoveredOwner {
+    shape: String,
+    serde: String,
+    map_key_types: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoundTripGroup {
+    DirectGameState,
+    CombatState,
+    DeclareAttackers,
+    DeclareBlockers,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct NumericRoundTripOwner {
+    id: &'static str,
+    map_key_types: &'static [&'static str],
+    group: RoundTripGroup,
+    numeric_deserializer: Option<&'static str>,
+}
+
+const NUMERIC_MAP_ROUND_TRIP_OWNERS: &[NumericRoundTripOwner] = &[
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::objects", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::stack_paid_facts", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::liminal_entries", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::attribution", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::tracked_object_sets", map_key_types: &["TrackedSetId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::tracked_set_member_causes", map_key_types: &["TrackedSetId", "ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::commander_cast_count", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::commander_cast_owners", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::auto_pass", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::phase_stops", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::priority_passing_modes", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::lands_tapped_for_mana", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::prepaid_mulligan_bottoms", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::loyalty_abilities_activated_this_turn", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::extra_loyalty_activations_this_turn", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::object_tap_count_this_turn", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::object_counter_placement_count_this_turn", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::cards_exiled_with_source_this_turn", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::first_card_drawn_this_turn", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::cards_drawn_this_turn", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::spells_cast_this_game", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::spells_cast_this_game_by_player", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::spells_cast_this_turn_by_player", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::lands_played_this_turn_by_player", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::attacking_creatures_this_turn", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::attacked_defenders_this_turn", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::creature_attacked_defenders_this_turn", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::cards_discarded_this_turn_by_player", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::mana_spent_on_spells_this_turn", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::last_effect_counts_by_player", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::stack_trigger_event_batches", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::stack_trigger_firings", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::lki_cache", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::lki_copiable_values", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::lki_by_incarnation", map_key_types: &["ObjectId", "u64"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::linked_exile_lki", map_key_types: &["ObjectId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::ring_level", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::ring_bearer", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::dungeon_progress", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::GameState::planar_die_actions_this_turn", map_key_types: &["PlayerId"], group: RoundTripGroup::DirectGameState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/game/combat.rs::CombatState::blocker_assignments", map_key_types: &["ObjectId"], group: RoundTripGroup::CombatState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/game/combat.rs::CombatState::blocker_to_attacker", map_key_types: &["ObjectId"], group: RoundTripGroup::CombatState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/game/combat.rs::CombatState::attacked_defenders_this_combat", map_key_types: &["PlayerId"], group: RoundTripGroup::CombatState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/game/combat.rs::CombatState::creature_attacked_defenders_this_combat", map_key_types: &["ObjectId"], group: RoundTripGroup::CombatState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/game/combat.rs::CombatState::damage_assignments", map_key_types: &["ObjectId"], group: RoundTripGroup::CombatState, numeric_deserializer: None },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::WaitingFor::DeclareAttackers::valid_attack_targets_by_attacker", map_key_types: &["ObjectId"], group: RoundTripGroup::DeclareAttackers, numeric_deserializer: Some(OPTION_NUMERIC_HASH_MAP_DESERIALIZER) },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::WaitingFor::DeclareAttackers::attacker_constraints", map_key_types: &["ObjectId"], group: RoundTripGroup::DeclareAttackers, numeric_deserializer: Some(NUMERIC_HASH_MAP_DESERIALIZER) },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::WaitingFor::DeclareBlockers::valid_block_targets", map_key_types: &["ObjectId"], group: RoundTripGroup::DeclareBlockers, numeric_deserializer: Some(NUMERIC_HASH_MAP_DESERIALIZER) },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::WaitingFor::DeclareBlockers::block_requirements", map_key_types: &["ObjectId"], group: RoundTripGroup::DeclareBlockers, numeric_deserializer: Some(NUMERIC_HASH_MAP_DESERIALIZER) },
+    NumericRoundTripOwner { id: "src/types/game_state.rs::WaitingFor::DeclareBlockers::blocker_constraints", map_key_types: &["ObjectId"], group: RoundTripGroup::DeclareBlockers, numeric_deserializer: Some(NUMERIC_HASH_MAP_DESERIALIZER) },
+];
+
+fn owner_id(file: &str, owner: &str, variant: Option<&str>, field: &str) -> String {
+    match variant {
+        Some(variant) => format!("{file}::{owner}::{variant}::{field}"),
+        None => format!("{file}::{owner}::{field}"),
+    }
+}
+
+fn add_spec(
+    specs: &mut BTreeMap<String, OwnerSpec>,
+    file: &str,
+    owner: &str,
+    variant: Option<&str>,
+    field: &'static str,
+    shape: &'static str,
+    classification: Classification,
+) {
+    let id = owner_id(file, owner, variant, field);
+    assert!(
+        specs
+            .insert(
+                id.clone(),
+                OwnerSpec {
+                    shape,
+                    classification,
+                    map_key_types: &[],
+                    numeric_deserializer: None,
+                },
+            )
+            .is_none(),
+        "duplicate owner spec: {id}"
+    );
+}
+
+fn expected_manifest() -> BTreeMap<String, OwnerSpec> {
+    let mut specs = BTreeMap::new();
+    let game_state = "src/types/game_state.rs";
+
+    for field in [
+        "commander_declined_zone_return",
+        "objects_that_dealt_damage",
+        "triggers_fired_this_turn",
+        "triggers_fired_this_turn_per_opponent",
+        "triggers_fired_this_game",
+        "crew_activated_this_turn",
+        "exerted_this_turn",
+        "graveyard_cast_permissions_used",
+        "graveyard_cast_permissions_used_per_type",
+        "hand_cast_free_permissions_used",
+        "alt_cost_grant_permissions_used",
+        "exile_play_permissions_used",
+        "exile_play_single_use_consumed",
+        "exile_cast_permissions_used",
+        "top_of_library_cast_permissions_used",
+        "players_who_searched_library_this_turn",
+        "players_attacked_this_step",
+        "players_attacked_this_turn",
+        "creatures_attacked_this_turn",
+        "creatures_blocked_this_turn",
+        "players_who_created_token_this_turn",
+        "players_who_discarded_card_this_turn",
+        "players_who_sacrificed_artifact_this_turn",
+        "batched_zone_change_trigger_fired",
+        "assassin_or_commander_dealt_combat_damage_this_turn",
+        "modal_modes_chosen_this_turn",
+        "modal_modes_chosen_this_game",
+        "revealed_cards",
+        "public_revealed_cards",
+        "player_actions_this_way",
+        "city_blessing",
+    ] {
+        add_spec(
+            &mut specs,
+            game_state,
+            "GameState",
+            None,
+            field,
+            "HashSet",
+            Classification::Canonical(HASH_SET),
+        );
+    }
+    add_spec(
+        &mut specs,
+        game_state,
+        "GameState",
+        None,
+        "post_replacement_token_choice_applied",
+        "Option<HashSet>",
+        Classification::Canonical(OPTION_HASH_SET),
+    );
+    add_spec(
+        &mut specs,
+        game_state,
+        "GameState",
+        None,
+        "creature_types_dealt_combat_damage_this_turn",
+        "im::HashSet",
+        Classification::Canonical(IM_HASH_SET),
+    );
+
+    for field in [
+        "stack_paid_facts",
+        "liminal_entries",
+        "tracked_object_sets",
+        "commander_cast_count",
+        "commander_cast_owners",
+        "auto_pass",
+        "phase_stops",
+        "priority_passing_modes",
+        "lands_tapped_for_mana",
+        "prepaid_mulligan_bottoms",
+        "loyalty_abilities_activated_this_turn",
+        "extra_loyalty_activations_this_turn",
+        "object_tap_count_this_turn",
+        "object_counter_placement_count_this_turn",
+        "cards_exiled_with_source_this_turn",
+        "first_card_drawn_this_turn",
+        "cards_drawn_this_turn",
+        "spells_cast_this_game",
+        "spells_cast_this_game_by_player",
+        "spells_cast_this_turn_by_player",
+        "lands_played_this_turn_by_player",
+        "attacking_creatures_this_turn",
+        "cards_discarded_this_turn_by_player",
+        "mana_spent_on_spells_this_turn",
+        "last_effect_counts_by_player",
+        "stack_trigger_event_batches",
+        "stack_trigger_firings",
+        "lki_copiable_values",
+        "linked_exile_lki",
+        "ring_level",
+        "ring_bearer",
+        "dungeon_progress",
+        "planar_die_actions_this_turn",
+    ] {
+        add_spec(
+            &mut specs,
+            game_state,
+            "GameState",
+            None,
+            field,
+            "HashMap",
+            Classification::Canonical(HASH_MAP),
+        );
+    }
+    add_spec(
+        &mut specs,
+        game_state,
+        "GameState",
+        None,
+        "tracked_set_member_causes",
+        "HashMap<HashMap>",
+        Classification::Canonical(HASH_MAP_OF_HASH_MAP),
+    );
+    add_spec(
+        &mut specs,
+        game_state,
+        "GameState",
+        None,
+        "steps_to_skip",
+        "Vec<HashMap>",
+        Classification::Canonical(VEC_HASH_MAP),
+    );
+    for field in [
+        "attacked_defenders_this_turn",
+        "creature_attacked_defenders_this_turn",
+    ] {
+        add_spec(
+            &mut specs,
+            game_state,
+            "GameState",
+            None,
+            field,
+            "HashMap<HashSet>",
+            Classification::Canonical(HASH_MAP_OF_HASH_SET),
+        );
+    }
+    for field in ["objects", "attribution", "lki_cache"] {
+        add_spec(
+            &mut specs,
+            game_state,
+            "GameState",
+            None,
+            field,
+            "im::HashMap",
+            Classification::Canonical(IM_HASH_MAP),
+        );
+    }
+    add_spec(
+        &mut specs,
+        game_state,
+        "GameState",
+        None,
+        "lki_by_incarnation",
+        "im::HashMap<im::HashMap>",
+        Classification::Canonical(IM_HASH_MAP_OF_IM_HASH_MAP),
+    );
+    for (field, adapter) in [
+        (
+            "trigger_fire_counts_this_turn",
+            "with=\"trigger_definition_ref_map\"",
+        ),
+        ("activated_abilities_this_turn", "with=\"tuple_key_map\""),
+        ("activated_abilities_this_game", "with=\"tuple_key_map\""),
+        ("ability_resolutions_this_turn", "with=\"tuple_key_map\""),
+    ] {
+        add_spec(
+            &mut specs,
+            game_state,
+            "GameState",
+            None,
+            field,
+            "HashMap",
+            Classification::Canonical(adapter),
+        );
+    }
+
+    for field in [
+        "static_gate_truth",
+        "remote_type_layer_recipients",
+        "card_face_registry",
+        "meld_pair_registry",
+        "momir_pool_faces",
+        "pending_taps_for_mana_overrides",
+        "combat_prevention_tally",
+    ] {
+        let shape = match field {
+            "remote_type_layer_recipients" => "im::HashSet",
+            "card_face_registry" | "meld_pair_registry" | "momir_pool_faces" => "Arc<HashMap>",
+            "combat_prevention_tally" => "Option<HashMap>",
+            "static_gate_truth" => "im::HashMap",
+            _ => "HashMap",
+        };
+        add_spec(
+            &mut specs,
+            game_state,
+            "GameState",
+            None,
+            field,
+            shape,
+            Classification::SerdeSkip,
+        );
+    }
+
+    for (owner, field, shape) in [
+        ("PublicStateDirty", "dirty_objects", "HashSet"),
+        ("PublicStateDirty", "dirty_players", "HashSet"),
+        ("TriggerIndex", "by_key", "im::HashMap"),
+        ("ReplacementIndex", "by_event", "im::HashMap"),
+    ] {
+        add_spec(
+            &mut specs,
+            game_state,
+            owner,
+            None,
+            field,
+            shape,
+            Classification::DeserializeOnlyOrRuntime,
+        );
+    }
+    for owner in ["LKISnapshot", "CounterAddedRecord"] {
+        add_spec(
+            &mut specs,
+            game_state,
+            owner,
+            None,
+            "counters",
+            "HashMap",
+            Classification::Canonical("with=\"counter_map_serde\""),
+        );
+    }
+
+    for (owner, variant, field, shape, adapter) in [
+        (
+            "WaitingFor",
+            Some("DeclareAttackers"),
+            "valid_attack_targets_by_attacker",
+            "Option<HashMap>",
+            OPTION_HASH_MAP,
+        ),
+        (
+            "WaitingFor",
+            Some("DeclareAttackers"),
+            "attacker_constraints",
+            "HashMap",
+            HASH_MAP,
+        ),
+        (
+            "WaitingFor",
+            Some("DeclareBlockers"),
+            "valid_block_targets",
+            "HashMap",
+            HASH_MAP,
+        ),
+        (
+            "WaitingFor",
+            Some("DeclareBlockers"),
+            "block_requirements",
+            "HashMap",
+            HASH_MAP,
+        ),
+        (
+            "WaitingFor",
+            Some("DeclareBlockers"),
+            "blocker_constraints",
+            "HashMap",
+            HASH_MAP,
+        ),
+        (
+            "WaitingFor",
+            Some("ChooseOneOfBranch"),
+            "replacement_applied",
+            "HashSet",
+            HASH_SET,
+        ),
+        (
+            "PendingChooseOneOf",
+            None,
+            "replacement_applied",
+            "HashSet",
+            HASH_SET,
+        ),
+        (
+            "PendingBatchDeliveries",
+            None,
+            "replacement_applied",
+            "HashSet",
+            HASH_SET,
+        ),
+        (
+            "PendingBatchZoneChangeCause",
+            Some("Draw"),
+            "seed_applied",
+            "HashSet",
+            HASH_SET,
+        ),
+        (
+            "PendingBatchZoneMoveRequest",
+            None,
+            "replacement_applied",
+            "HashSet",
+            HASH_SET,
+        ),
+        (
+            "LiminalEntry",
+            None,
+            "replacement_applied",
+            "HashSet",
+            HASH_SET,
+        ),
+        (
+            "PendingConniveReentry",
+            None,
+            "applied",
+            "HashSet",
+            HASH_SET,
+        ),
+        ("PostReplacementDrain", None, "applied", "HashSet", HASH_SET),
+        ("DrawSequenceFrame", None, "applied", "HashSet", HASH_SET),
+    ] {
+        add_spec(
+            &mut specs,
+            game_state,
+            owner,
+            variant,
+            field,
+            shape,
+            Classification::Canonical(adapter),
+        );
+    }
+
+    for (file, owner, variant, field, shape, classification) in [
+        (
+            "src/types/player.rs",
+            "Player",
+            None,
+            "bending_types_this_turn",
+            "HashSet",
+            Classification::Canonical(HASH_SET),
+        ),
+        (
+            "src/types/player.rs",
+            "Player",
+            None,
+            "player_counters",
+            "HashMap",
+            Classification::Canonical(HASH_MAP),
+        ),
+        (
+            "src/types/events.rs",
+            "EventObjectSnapshot",
+            None,
+            "counters",
+            "HashMap",
+            Classification::Canonical("with=\"crate::types::counter::counter_map_serde\""),
+        ),
+        (
+            "src/types/ability.rs",
+            "ResolvedAbility",
+            None,
+            "replacement_applied",
+            "HashSet",
+            Classification::Canonical(HASH_SET),
+        ),
+        (
+            "src/types/resolution.rs",
+            "ChangeZoneFrame",
+            None,
+            "devour_eligible_snapshot",
+            "Option<HashSet>",
+            Classification::Canonical(OPTION_HASH_SET),
+        ),
+        (
+            "src/types/resolution.rs",
+            "LegacyChangeZoneWire",
+            None,
+            "devour_eligible_snapshot",
+            "Option<HashSet>",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+        (
+            "src/types/resolution.rs",
+            "LegacyReplacementTailsWire",
+            None,
+            "post_replacement_applied",
+            "HashSet",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+        (
+            "src/game/game_object.rs",
+            "GameObject",
+            None,
+            "protection_start_exempt_attachments",
+            "HashMap",
+            Classification::NonStringJsonMapKey,
+        ),
+        (
+            "src/game/game_object.rs",
+            "GameObject",
+            None,
+            "counters",
+            "HashMap",
+            Classification::Canonical("with=\"counter_map_serde\""),
+        ),
+        (
+            "src/game/game_object.rs",
+            "GameObject",
+            None,
+            "specialize_faces",
+            "Option<HashMap>",
+            Classification::Canonical(OPTION_HASH_MAP),
+        ),
+        (
+            "src/game/game_object.rs",
+            "GameObject",
+            None,
+            "goaded_by",
+            "HashSet",
+            Classification::Canonical(HASH_SET),
+        ),
+        (
+            "src/game/game_object.rs",
+            "GameObject",
+            None,
+            "detained_by",
+            "HashSet",
+            Classification::Canonical(HASH_SET),
+        ),
+        (
+            "src/game/combat.rs",
+            "CombatState",
+            None,
+            "blocker_assignments",
+            "HashMap",
+            Classification::Canonical(HASH_MAP),
+        ),
+        (
+            "src/game/combat.rs",
+            "CombatState",
+            None,
+            "blocker_to_attacker",
+            "HashMap",
+            Classification::Canonical(HASH_MAP),
+        ),
+        (
+            "src/game/combat.rs",
+            "CombatState",
+            None,
+            "attacked_defenders_this_combat",
+            "HashMap<HashSet>",
+            Classification::Canonical(HASH_MAP_OF_HASH_SET),
+        ),
+        (
+            "src/game/combat.rs",
+            "CombatState",
+            None,
+            "creature_attacked_defenders_this_combat",
+            "HashMap<HashSet>",
+            Classification::Canonical(HASH_MAP_OF_HASH_SET),
+        ),
+        (
+            "src/game/combat.rs",
+            "CombatState",
+            None,
+            "attacking_incarnations_this_combat",
+            "HashSet",
+            Classification::Canonical(HASH_SET),
+        ),
+        (
+            "src/game/combat.rs",
+            "CombatState",
+            None,
+            "damage_assignments",
+            "HashMap",
+            Classification::Canonical(HASH_MAP),
+        ),
+        (
+            "src/game/combat.rs",
+            "CombatState",
+            None,
+            "first_strike_participants",
+            "Option<HashSet>",
+            Classification::Canonical(OPTION_HASH_SET),
+        ),
+        (
+            "src/game/combat.rs",
+            "AttackDeclarationConstraints",
+            None,
+            "legal_targets",
+            "HashMap",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+        (
+            "src/game/combat.rs",
+            "AttackDeclarationConstraints",
+            None,
+            "needs_companion",
+            "HashSet",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+        (
+            "src/game/combat.rs",
+            "AttackDeclarationConstraints",
+            None,
+            "must_be_sole",
+            "HashSet",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+        (
+            "src/game/zone_pipeline.rs",
+            "ZoneChangeCause",
+            Some("Draw"),
+            "seed_applied",
+            "HashSet",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+        (
+            "src/game/zone_pipeline.rs",
+            "ZoneMoveRequest",
+            None,
+            "replacement_applied",
+            "HashSet",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+        (
+            "src/game/effects/choose_one_of.rs",
+            "PromptRequest",
+            None,
+            "replacement_applied",
+            "HashSet",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+        (
+            "src/game/effects/choose_one_of.rs",
+            "BranchSelection",
+            None,
+            "replacement_applied",
+            "HashSet",
+            Classification::DeserializeOnlyOrRuntime,
+        ),
+    ] {
+        add_spec(
+            &mut specs,
+            file,
+            owner,
+            variant,
+            field,
+            shape,
+            classification,
+        );
+    }
+
+    for variant in [
+        "ZoneChange",
+        "Damage",
+        "Draw",
+        "SearchFound",
+        "Scry",
+        "Mill",
+        "CoinFlip",
+        "Explore",
+        "Connive",
+        "Proliferate",
+        "LifeGain",
+        "LifeLoss",
+        "AddCounter",
+        "RemoveCounter",
+        "MoveCounter",
+        "CreateToken",
+        "TokenEntry",
+        "Discard",
+        "Tap",
+        "Untap",
+        "TurnFaceUp",
+        "Destroy",
+        "Sacrifice",
+        "BeginTurn",
+        "BeginPhase",
+        "ProduceMana",
+        "EmptyManaPool",
+        "Planeswalk",
+        "Attach",
+    ] {
+        add_spec(
+            &mut specs,
+            "src/types/proposed_event.rs",
+            "ProposedEvent",
+            Some(variant),
+            "applied",
+            "HashSet",
+            Classification::Canonical(HASH_SET),
+        );
+    }
+
+    for owner in NUMERIC_MAP_ROUND_TRIP_OWNERS {
+        let spec = specs.get_mut(owner.id).unwrap_or_else(|| {
+            panic!(
+                "numeric round-trip owner missing from manifest: {}",
+                owner.id
+            )
+        });
+        spec.map_key_types = owner.map_key_types;
+        spec.numeric_deserializer = owner.numeric_deserializer;
+    }
+
+    specs
+}
+
+fn first_type_argument(segment: &syn::PathSegment) -> Option<&Type> {
+    let PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return None;
+    };
+    arguments.args.iter().find_map(|argument| match argument {
+        GenericArgument::Type(ty) => Some(ty),
+        _ => None,
+    })
+}
+
+fn nth_type_argument(segment: &syn::PathSegment, index: usize) -> Option<&Type> {
+    let PathArguments::AngleBracketed(arguments) = &segment.arguments else {
+        return None;
+    };
+    arguments
+        .args
+        .iter()
+        .filter_map(|argument| match argument {
+            GenericArgument::Type(ty) => Some(ty),
+            _ => None,
+        })
+        .nth(index)
+}
+
+fn type_label(ty: &Type) -> String {
+    match ty {
+        Type::Path(path) => path.path.segments.last().map_or_else(
+            || "<empty-path>".to_string(),
+            |segment| segment.ident.to_string(),
+        ),
+        Type::Tuple(tuple) => format!(
+            "({})",
+            tuple
+                .elems
+                .iter()
+                .map(type_label)
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        _ => "<complex-type>".to_string(),
+    }
+}
+
+fn unordered_map_key_types(ty: &Type) -> Vec<String> {
+    let Type::Path(path) = ty else {
+        return Vec::new();
+    };
+    let Some(segment) = path.path.segments.last() else {
+        return Vec::new();
+    };
+    match segment.ident.to_string().as_str() {
+        "Option" | "Vec" | "Arc" => first_type_argument(segment)
+            .map(unordered_map_key_types)
+            .unwrap_or_default(),
+        "HashMap" => {
+            let mut keys = nth_type_argument(segment, 0)
+                .map(type_label)
+                .into_iter()
+                .collect::<Vec<_>>();
+            if let Some(value) = nth_type_argument(segment, 1) {
+                keys.extend(unordered_map_key_types(value));
+            }
+            keys
+        }
+        "SpecializeFaceMap" => vec!["ManaColor".to_string()],
+        _ => Vec::new(),
+    }
+}
+
+fn hash_shape(ty: &Type) -> Option<String> {
+    let Type::Path(path) = ty else {
+        return None;
+    };
+    let segment = path.path.segments.last()?;
+    let name = segment.ident.to_string();
+    match name.as_str() {
+        "Option" | "Vec" | "Arc" => {
+            hash_shape(first_type_argument(segment)?).map(|inner| format!("{name}<{inner}>"))
+        }
+        "HashSet" => Some(
+            if path.path.segments.iter().any(|part| part.ident == "im") {
+                "im::HashSet".to_string()
+            } else {
+                "HashSet".to_string()
+            },
+        ),
+        "HashMap" => {
+            let prefix = if path.path.segments.iter().any(|part| part.ident == "im") {
+                "im::HashMap"
+            } else {
+                "HashMap"
+            };
+            Some(match nth_type_argument(segment, 1).and_then(hash_shape) {
+                Some(inner) => format!("{prefix}<{inner}>"),
+                None => prefix.to_string(),
+            })
+        }
+        "SpecializeFaceMap" => Some("HashMap".to_string()),
+        _ => None,
+    }
+}
+
+fn serde_metadata(attributes: &[syn::Attribute]) -> String {
+    attributes
+        .iter()
+        .filter(|attribute| attribute.path().is_ident("serde"))
+        .filter_map(|attribute| match &attribute.meta {
+            syn::Meta::List(list) => Some(list.tokens.to_string().replace(' ', "")),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(";")
+}
+
+fn discover_fields(
+    discovered: &mut BTreeMap<String, DiscoveredOwner>,
+    file: &str,
+    owner: &str,
+    variant: Option<&str>,
+    fields: &Fields,
+) {
+    let Fields::Named(fields) = fields else {
+        return;
+    };
+    for field in &fields.named {
+        let Some(shape) = hash_shape(&field.ty) else {
+            continue;
+        };
+        let field_name = field.ident.as_ref().expect("named field").to_string();
+        let id = owner_id(file, owner, variant, &field_name);
+        let serde = serde_metadata(&field.attrs);
+        let map_key_types = unordered_map_key_types(&field.ty);
+        assert!(
+            discovered
+                .insert(
+                    id.clone(),
+                    DiscoveredOwner {
+                        shape,
+                        serde,
+                        map_key_types,
+                    },
+                )
+                .is_none(),
+            "duplicate discovered owner: {id}"
+        );
+    }
+}
+
+fn discover_file(discovered: &mut BTreeMap<String, DiscoveredOwner>, file: &str, source: &str) {
+    let syntax = syn::parse_file(source).unwrap_or_else(|error| panic!("parse {file}: {error}"));
+    for item in syntax.items {
+        match item {
+            Item::Struct(item) => discover_fields(
+                discovered,
+                file,
+                &item.ident.to_string(),
+                None,
+                &item.fields,
+            ),
+            Item::Enum(item) => {
+                let owner = item.ident.to_string();
+                for variant in item.variants {
+                    discover_fields(
+                        discovered,
+                        file,
+                        &owner,
+                        Some(&variant.ident.to_string()),
+                        &variant.fields,
+                    );
+                }
+            }
+            Item::Macro(item)
+                if item
+                    .mac
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|segment| segment.ident == "declare_game_state") =>
+            {
+                let synthetic = format!("struct GameState {{ {} }}", item.mac.tokens);
+                let game_state: syn::ItemStruct = syn::parse_str(&synthetic)
+                    .unwrap_or_else(|error| panic!("parse declare_game_state fields: {error}"));
+                discover_fields(discovered, file, "GameState", None, &game_state.fields);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn discovered_manifest() -> BTreeMap<String, DiscoveredOwner> {
+    let mut discovered = BTreeMap::new();
+    for (file, source) in [
+        (
+            "src/types/game_state.rs",
+            include_str!("../../src/types/game_state.rs"),
+        ),
+        (
+            "src/types/player.rs",
+            include_str!("../../src/types/player.rs"),
+        ),
+        (
+            "src/types/events.rs",
+            include_str!("../../src/types/events.rs"),
+        ),
+        (
+            "src/types/ability.rs",
+            include_str!("../../src/types/ability.rs"),
+        ),
+        (
+            "src/types/proposed_event.rs",
+            include_str!("../../src/types/proposed_event.rs"),
+        ),
+        (
+            "src/types/resolution.rs",
+            include_str!("../../src/types/resolution.rs"),
+        ),
+        (
+            "src/game/game_object.rs",
+            include_str!("../../src/game/game_object.rs"),
+        ),
+        (
+            "src/game/combat.rs",
+            include_str!("../../src/game/combat.rs"),
+        ),
+        (
+            "src/game/zone_pipeline.rs",
+            include_str!("../../src/game/zone_pipeline.rs"),
+        ),
+        (
+            "src/game/effects/choose_one_of.rs",
+            include_str!("../../src/game/effects/choose_one_of.rs"),
+        ),
+    ] {
+        discover_file(&mut discovered, file, source);
+    }
+    discovered
+}
+
+#[test]
+fn serde_hash_owner_census_is_exhaustive_and_every_canonical_owner_names_its_adapter() {
+    let expected = expected_manifest();
+    let discovered = discovered_manifest();
+    let expected_ids: BTreeSet<_> = expected.keys().cloned().collect();
+    let discovered_ids: BTreeSet<_> = discovered.keys().cloned().collect();
+
+    let missing = expected_ids.difference(&discovered_ids).collect::<Vec<_>>();
+    let unexpected = discovered_ids
+        .difference(&expected_ids)
+        .map(|id| {
+            let owner = &discovered[id];
+            format!("{id} shape={} serde={}", owner.shape, owner.serde)
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        missing.is_empty() && unexpected.is_empty(),
+        "serde hash owner census mismatch\nmissing expected owners: {missing:#?}\nunclassified discovered owners: {unexpected:#?}"
+    );
+
+    let numeric_key_types = ["ObjectId", "PlayerId", "TrackedSetId", "u64"];
+    let discovered_numeric_ids: BTreeSet<_> = discovered
+        .iter()
+        .filter(|(_, owner)| {
+            !owner.map_key_types.is_empty()
+                && owner
+                    .map_key_types
+                    .iter()
+                    .all(|key| numeric_key_types.contains(&key.as_str()))
+        })
+        .filter(|(id, _)| {
+            matches!(
+                expected[id.as_str()].classification,
+                Classification::Canonical(_)
+            )
+        })
+        .map(|(id, _)| id.clone())
+        .collect();
+    let expected_numeric_ids: BTreeSet<_> = NUMERIC_MAP_ROUND_TRIP_OWNERS
+        .iter()
+        .map(|owner| owner.id.to_string())
+        .collect();
+    assert_eq!(
+        discovered_numeric_ids, expected_numeric_ids,
+        "numeric map owners and explicit populated round-trip assignments diverged"
+    );
+
+    for (id, spec) in expected {
+        let actual = &discovered[&id];
+        assert_eq!(
+            actual.shape, spec.shape,
+            "{id}: discovered hash shape changed; classification={:?}, serde={}",
+            spec.classification, actual.serde
+        );
+        if !spec.map_key_types.is_empty() {
+            assert_eq!(
+                actual.map_key_types, spec.map_key_types,
+                "{id}: numeric map key type path changed"
+            );
+            match spec.numeric_deserializer {
+                Some(adapter) => assert!(
+                    actual.serde.contains(adapter),
+                    "{id}: missing numeric map-key deserializer {adapter}; actual serde={}",
+                    actual.serde
+                ),
+                None => assert!(
+                    !actual.serde.contains(NUMERIC_HASH_MAP_DESERIALIZER)
+                        && !actual.serde.contains(OPTION_NUMERIC_HASH_MAP_DESERIALIZER),
+                    "{id}: field-local numeric deserializer is not justified here; actual serde={}",
+                    actual.serde
+                ),
+            }
+        }
+        match spec.classification {
+            Classification::Canonical(adapter) => assert!(
+                actual.serde.contains(adapter),
+                "{id}: shape={} classification={:?}; missing serde adapter {adapter}; actual serde={}",
+                actual.shape,
+                spec.classification,
+                actual.serde
+            ),
+            Classification::SerdeSkip => assert!(
+                actual.serde.split(';').any(|attribute| {
+                    attribute == "skip"
+                        || attribute.split(',').any(|part| part == "skip")
+                }),
+                "{id}: shape={} classification={:?}; expected serde(skip); actual serde={}",
+                actual.shape,
+                spec.classification,
+                actual.serde
+            ),
+            Classification::DeserializeOnlyOrRuntime => {}
+            Classification::NonStringJsonMapKey => assert!(
+                !actual.serde.contains("deterministic_serde"),
+                "{id}: the non-string JSON key owner must not invent a generic wire adapter; actual serde={}",
+                actual.serde
+            ),
+        }
+    }
+
+    assert_eq!(
+        NUMERIC_MAP_ROUND_TRIP_OWNERS.len(),
+        50,
+        "the reviewed numeric-map owner matrix must remain exact"
+    );
+    for group in [
+        RoundTripGroup::DirectGameState,
+        RoundTripGroup::CombatState,
+        RoundTripGroup::DeclareAttackers,
+        RoundTripGroup::DeclareBlockers,
+    ] {
+        assert!(
+            NUMERIC_MAP_ROUND_TRIP_OWNERS
+                .iter()
+                .any(|owner| owner.group == group),
+            "numeric round-trip group {group:?} has no assigned owner"
+        );
+    }
+}
+
+fn back_face(name: &str) -> BackFaceData {
+    BackFaceData {
+        name: name.to_string(),
+        power: None,
+        toughness: None,
+        loyalty: None,
+        printed_loyalty: None,
+        defense: None,
+        card_types: CardType::default(),
+        mana_cost: ManaCost::default(),
+        keywords: Vec::new(),
+        abilities: Vec::new(),
+        trigger_definitions: Definitions::default(),
+        replacement_definitions: Definitions::default(),
+        static_definitions: Definitions::default(),
+        color: Vec::new(),
+        printed_ref: None,
+        modal: None,
+        additional_cost: None,
+        strive_cost: None,
+        casting_restrictions: Vec::new(),
+        casting_options: Vec::new(),
+        layout_kind: None,
+    }
+}
+
+fn field_fragment<'a>(serialized: &'a str, field: &str, next_field: &str) -> &'a str {
+    let start_marker = format!("\"{field}\":");
+    let next_marker = format!(",\"{next_field}\":");
+    let start = serialized
+        .find(&start_marker)
+        .unwrap_or_else(|| panic!("serialized state lacks {field}"));
+    let remainder = &serialized[start..];
+    let end = remainder
+        .find(&next_marker)
+        .unwrap_or_else(|| panic!("serialized state lacks field after {field}: {next_field}"));
+    &remainder[..end]
+}
+
+fn build_populated_state(reverse: bool) -> GameState {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let player_order = if reverse {
+        [PlayerId(1), PlayerId(0)]
+    } else {
+        [PlayerId(0), PlayerId(1)]
+    };
+    let mut token_creator_order = (0_u8..32).map(PlayerId).collect::<Vec<_>>();
+    if reverse {
+        token_creator_order.reverse();
+    }
+    state.players_who_created_token_this_turn = token_creator_order.into_iter().collect();
+    state.ring_level = player_order
+        .into_iter()
+        .map(|player| (player, player.0 + 1))
+        .collect();
+
+    let inner_order = if reverse {
+        [PlayerId(1), PlayerId(0)]
+    } else {
+        [PlayerId(0), PlayerId(1)]
+    };
+    let outer_order = if reverse {
+        [PlayerId(1), PlayerId(0)]
+    } else {
+        [PlayerId(0), PlayerId(1)]
+    };
+    state.attacked_defenders_this_turn = outer_order
+        .into_iter()
+        .map(|player| (player, inner_order.into_iter().collect()))
+        .collect();
+    state.steps_to_skip = vec![
+        [
+            (engine::types::Phase::PostCombatMain, 2),
+            (engine::types::Phase::PreCombatMain, 1),
+        ]
+        .into_iter()
+        .collect(),
+        [(engine::types::Phase::End, 3)].into_iter().collect(),
+    ];
+    state.player_actions_this_turn = vec![
+        (PlayerId(1), PlayerActionKind::Scry),
+        (PlayerId(0), PlayerActionKind::SearchedLibrary),
+    ];
+
+    let mut first = GameObject::new(
+        ObjectId(1),
+        CardId(1),
+        PlayerId(0),
+        "First Deterministic Object".to_string(),
+        Zone::Battlefield,
+    );
+    first.goaded_by = inner_order.into_iter().collect();
+    let mut specialize_faces = HashMap::new();
+    if reverse {
+        specialize_faces.insert(ManaColor::Blue, back_face("Blue Face"));
+        specialize_faces.insert(ManaColor::White, back_face("White Face"));
+    } else {
+        specialize_faces.insert(ManaColor::White, back_face("White Face"));
+        specialize_faces.insert(ManaColor::Blue, back_face("Blue Face"));
+    }
+    first.specialize_faces = Some(specialize_faces);
+    let second = GameObject::new(
+        ObjectId(2),
+        CardId(2),
+        PlayerId(1),
+        "Second Deterministic Object".to_string(),
+        Zone::Battlefield,
+    );
+    if reverse {
+        state.objects.insert(ObjectId(2), second);
+        state.objects.insert(ObjectId(1), first);
+    } else {
+        state.objects.insert(ObjectId(1), first);
+        state.objects.insert(ObjectId(2), second);
+    }
+
+    let mut combat = CombatState::default();
+    let assignments = [
+        (
+            ObjectId(1),
+            vec![DamageAssignment {
+                target: DamageTarget::Player(PlayerId(1)),
+                amount: 1,
+            }],
+        ),
+        (
+            ObjectId(2),
+            vec![DamageAssignment {
+                target: DamageTarget::Player(PlayerId(0)),
+                amount: 2,
+            }],
+        ),
+    ];
+    for (key, value) in if reverse {
+        assignments.into_iter().rev().collect::<Vec<_>>()
+    } else {
+        assignments.into_iter().collect()
+    } {
+        combat.damage_assignments.insert(key, value);
+    }
+    state.combat = Some(combat);
+
+    let constraints = [
+        (
+            ObjectId(1),
+            CombatRequirement::CantAttack {
+                sources: Vec::new(),
+            },
+        ),
+        (
+            ObjectId(2),
+            CombatRequirement::CantAttack {
+                sources: Vec::new(),
+            },
+        ),
+    ];
+    state.waiting_for = WaitingFor::DeclareAttackers {
+        player: PlayerId(0),
+        valid_attacker_ids: vec![ObjectId(2), ObjectId(1)],
+        valid_attack_targets: Vec::new(),
+        valid_attack_targets_by_attacker: None,
+        attacker_constraints: if reverse {
+            constraints.into_iter().rev().collect()
+        } else {
+            constraints.into_iter().collect()
+        },
+    };
+
+    let conniver = state
+        .capture_connive_subject(ObjectId(1))
+        .expect("fixture object should produce a connive snapshot");
+    let applied_order = if reverse { [2, 1] } else { [1, 2] };
+    state.push_connive_reentry(PendingConniveReentry {
+        conniver,
+        count: 2,
+        applied: applied_order
+            .into_iter()
+            .map(AppliedReplacementKey::floating)
+            .collect(),
+    });
+
+    state
+}
+
+fn assert_representative_membership(state: &GameState) {
+    assert_eq!(state.players_who_created_token_this_turn.len(), 32);
+    for player in (0_u8..32).map(PlayerId) {
+        assert!(state.players_who_created_token_this_turn.contains(&player));
+    }
+    assert_eq!(state.ring_level.len(), 2);
+    assert_eq!(state.attacked_defenders_this_turn.len(), 2);
+    assert_eq!(state.steps_to_skip.len(), 2);
+    assert_eq!(state.objects.len(), 2);
+    assert_eq!(
+        state
+            .objects
+            .get(&ObjectId(1))
+            .and_then(|object| object.specialize_faces.as_ref())
+            .map(HashMap::len),
+        Some(2)
+    );
+    assert_eq!(
+        state
+            .combat
+            .as_ref()
+            .map(|combat| combat.damage_assignments.len()),
+        Some(2)
+    );
+    assert_eq!(
+        state
+            .active_connive_reentry()
+            .map(|pending| pending.applied.len()),
+        Some(2)
+    );
+}
+
+fn build_all_direct_numeric_maps_state() -> GameState {
+    let mut state = build_populated_state(false);
+    let first = state.objects[&ObjectId(1)].clone();
+    let second = state.objects[&ObjectId(2)].clone();
+
+    state.stack_paid_facts = HashMap::from([
+        (
+            ObjectId(1),
+            StackPaidSnapshot {
+                actual_mana_spent: 1,
+                ..Default::default()
+            },
+        ),
+        (
+            ObjectId(2),
+            StackPaidSnapshot {
+                actual_mana_spent: 2,
+                ..Default::default()
+            },
+        ),
+    ]);
+    state.liminal_entries = HashMap::from([
+        (
+            ObjectId(1),
+            LiminalEntry {
+                object: first.clone(),
+                name: "First liminal".to_string(),
+                source_id: ObjectId(11),
+                controller: PlayerId(0),
+                enters_attacking: false,
+                attach_to: None,
+                sacrifice_at: None,
+                remaining_count: 1,
+                created_ids: vec![ObjectId(101)],
+                copy_resume: None,
+                spec_resume: None,
+                enter_tapped: EtbTapState::Unspecified,
+                enter_with_counters: Vec::new(),
+                kind: Default::default(),
+                replacement_applied: Default::default(),
+            },
+        ),
+        (
+            ObjectId(2),
+            LiminalEntry {
+                object: second.clone(),
+                name: "Second liminal".to_string(),
+                source_id: ObjectId(22),
+                controller: PlayerId(1),
+                enters_attacking: false,
+                attach_to: None,
+                sacrifice_at: None,
+                remaining_count: 2,
+                created_ids: vec![ObjectId(202)],
+                copy_resume: None,
+                spec_resume: None,
+                enter_tapped: EtbTapState::Tapped,
+                enter_with_counters: Vec::new(),
+                kind: Default::default(),
+                replacement_applied: Default::default(),
+            },
+        ),
+    ]);
+    state.attribution = im::HashMap::from_iter([
+        (ObjectId(1), ObjectAttribution::default()),
+        (ObjectId(2), ObjectAttribution::default()),
+    ]);
+    state.tracked_object_sets = HashMap::from([
+        (TrackedSetId(1), vec![ObjectId(11)]),
+        (TrackedSetId(2), vec![ObjectId(22), ObjectId(23)]),
+    ]);
+    state.tracked_set_member_causes = HashMap::from([
+        (
+            TrackedSetId(1),
+            HashMap::from([
+                (ObjectId(11), ThisWayCause::Exiled),
+                (ObjectId(12), ThisWayCause::Sacrificed),
+            ]),
+        ),
+        (
+            TrackedSetId(2),
+            HashMap::from([
+                (ObjectId(21), ThisWayCause::Destroyed),
+                (ObjectId(22), ThisWayCause::Milled),
+            ]),
+        ),
+    ]);
+    state.commander_cast_count = HashMap::from([(ObjectId(1), 1), (ObjectId(2), 2)]);
+    state.commander_cast_owners =
+        HashMap::from([(ObjectId(1), PlayerId(0)), (ObjectId(2), PlayerId(1))]);
+    state.auto_pass = HashMap::from([
+        (
+            PlayerId(0),
+            AutoPassMode::UntilStackEmpty {
+                initial_stack_len: 1,
+            },
+        ),
+        (
+            PlayerId(1),
+            AutoPassMode::UntilStackEmpty {
+                initial_stack_len: 2,
+            },
+        ),
+    ]);
+    state.phase_stops = HashMap::from([
+        (
+            PlayerId(0),
+            vec![PhaseStop {
+                phase: Phase::Upkeep,
+                scope: PhaseStopScope::OwnTurn,
+            }],
+        ),
+        (
+            PlayerId(1),
+            vec![PhaseStop {
+                phase: Phase::End,
+                scope: PhaseStopScope::OpponentsTurns,
+            }],
+        ),
+    ]);
+    state.priority_passing_modes = HashMap::from([
+        (PlayerId(0), PriorityPassingMode::Standard),
+        (PlayerId(1), PriorityPassingMode::SkipLowUseWindows),
+    ]);
+    state.lands_tapped_for_mana = HashMap::from([
+        (PlayerId(0), vec![ObjectId(11)]),
+        (PlayerId(1), vec![ObjectId(21), ObjectId(22)]),
+    ]);
+    state.prepaid_mulligan_bottoms = HashMap::from([(PlayerId(0), 1), (PlayerId(1), 2)]);
+    state.loyalty_abilities_activated_this_turn =
+        HashMap::from([(PlayerId(0), 1), (PlayerId(1), 2)]);
+    state.extra_loyalty_activations_this_turn = HashMap::from([(PlayerId(0), 2), (PlayerId(1), 3)]);
+    state.object_tap_count_this_turn = HashMap::from([(ObjectId(1), 1), (ObjectId(2), 2)]);
+    state.object_counter_placement_count_this_turn =
+        HashMap::from([(ObjectId(1), 3), (ObjectId(2), 4)]);
+    state.cards_exiled_with_source_this_turn = HashMap::from([
+        (ObjectId(1), vec![ObjectId(11)]),
+        (ObjectId(2), vec![ObjectId(21), ObjectId(22)]),
+    ]);
+    state.first_card_drawn_this_turn =
+        HashMap::from([(PlayerId(0), ObjectId(11)), (PlayerId(1), ObjectId(22))]);
+    state.cards_drawn_this_turn = HashMap::from([
+        (PlayerId(0), vec![ObjectId(11)]),
+        (PlayerId(1), vec![ObjectId(21), ObjectId(22)]),
+    ]);
+    state.spells_cast_this_game = HashMap::from([(PlayerId(0), 1), (PlayerId(1), 2)]);
+    let first_spell = SpellCastRecord {
+        name: "First spell".to_string(),
+        mana_value: 1,
+        ..Default::default()
+    };
+    let second_spell = SpellCastRecord {
+        name: "Second spell".to_string(),
+        mana_value: 2,
+        ..Default::default()
+    };
+    state.spells_cast_this_game_by_player = HashMap::from([
+        (PlayerId(0), im::Vector::from(vec![first_spell.clone()])),
+        (
+            PlayerId(1),
+            im::Vector::from(vec![first_spell.clone(), second_spell.clone()]),
+        ),
+    ]);
+    state.spells_cast_this_turn_by_player = HashMap::from([
+        (PlayerId(0), im::Vector::from(vec![first_spell])),
+        (PlayerId(1), im::Vector::from(vec![second_spell])),
+    ]);
+    state.lands_played_this_turn_by_player = HashMap::from([
+        (
+            PlayerId(0),
+            im::Vector::from(vec![LandPlayRecord {
+                from_zone: Zone::Hand,
+            }]),
+        ),
+        (
+            PlayerId(1),
+            im::Vector::from(vec![LandPlayRecord {
+                from_zone: Zone::Exile,
+            }]),
+        ),
+    ]);
+    state.attacking_creatures_this_turn = HashMap::from([(PlayerId(0), 1), (PlayerId(1), 2)]);
+    state.attacked_defenders_this_turn = HashMap::from([
+        (
+            PlayerId(0),
+            [PlayerId(1), PlayerId(0)].into_iter().collect(),
+        ),
+        (
+            PlayerId(1),
+            [PlayerId(0), PlayerId(1)].into_iter().collect(),
+        ),
+    ]);
+    state.creature_attacked_defenders_this_turn = HashMap::from([
+        (
+            ObjectId(1),
+            [PlayerId(1), PlayerId(0)].into_iter().collect(),
+        ),
+        (
+            ObjectId(2),
+            [PlayerId(0), PlayerId(1)].into_iter().collect(),
+        ),
+    ]);
+    state.cards_discarded_this_turn_by_player = HashMap::from([(PlayerId(0), 1), (PlayerId(1), 2)]);
+    state.mana_spent_on_spells_this_turn = HashMap::from([(PlayerId(0), 3), (PlayerId(1), 4)]);
+    state.last_effect_counts_by_player = HashMap::from([(PlayerId(0), -1), (PlayerId(1), 2)]);
+    state.stack_trigger_event_batches = HashMap::from([
+        (
+            ObjectId(1),
+            vec![GameEvent::PriorityPassed {
+                player_id: PlayerId(0),
+            }],
+        ),
+        (
+            ObjectId(2),
+            vec![
+                GameEvent::PriorityPassed {
+                    player_id: PlayerId(1),
+                },
+                GameEvent::PriorityPassed {
+                    player_id: PlayerId(0),
+                },
+            ],
+        ),
+    ]);
+    let first_lki = first.snapshot_public_characteristics();
+    let second_lki = second.snapshot_public_characteristics();
+    state.lki_cache = im::HashMap::from_iter([
+        (ObjectId(1), first_lki.clone()),
+        (ObjectId(2), second_lki.clone()),
+    ]);
+    state.lki_copiable_values = HashMap::from([
+        (ObjectId(1), intrinsic_copiable_values(&first)),
+        (ObjectId(2), intrinsic_copiable_values(&second)),
+    ]);
+    state.lki_by_incarnation = im::HashMap::from_iter([
+        (
+            ObjectId(1),
+            im::HashMap::from_iter([(1, first_lki.clone()), (2, second_lki.clone())]),
+        ),
+        (
+            ObjectId(2),
+            im::HashMap::from_iter([(1, second_lki.clone()), (2, first_lki.clone())]),
+        ),
+    ]);
+    state.linked_exile_lki = HashMap::from([
+        (
+            ObjectId(1),
+            vec![LinkedExileSnapshot {
+                exiled_id: ObjectId(11),
+                owner: PlayerId(0),
+                mana_value: 1,
+            }],
+        ),
+        (
+            ObjectId(2),
+            vec![LinkedExileSnapshot {
+                exiled_id: ObjectId(22),
+                owner: PlayerId(1),
+                mana_value: 2,
+            }],
+        ),
+    ]);
+    state.ring_level = HashMap::from([(PlayerId(0), 1), (PlayerId(1), 2)]);
+    state.ring_bearer = HashMap::from([
+        (PlayerId(0), Some(ObjectId(1))),
+        (PlayerId(1), Some(ObjectId(2))),
+    ]);
+    state.dungeon_progress = HashMap::from([
+        (
+            PlayerId(0),
+            DungeonProgress {
+                current_room: 1,
+                ..Default::default()
+            },
+        ),
+        (
+            PlayerId(1),
+            DungeonProgress {
+                current_room: 2,
+                ..Default::default()
+            },
+        ),
+    ]);
+    state.planar_die_actions_this_turn = HashMap::from([(PlayerId(0), 1), (PlayerId(1), 2)]);
+
+    state
+}
+
+#[test]
+fn every_direct_numeric_key_game_state_map_round_trips_populated() {
+    let state = build_all_direct_numeric_maps_state();
+    let serialized = serde_json::to_string(&state).expect("populated state should serialize");
+    let before: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+    let restored: GameState =
+        serde_json::from_str(&serialized).expect("every direct numeric map should restore");
+    let reserialized = serde_json::to_string(&restored).expect("restored state should serialize");
+    let after: serde_json::Value = serde_json::from_str(&reserialized).unwrap();
+
+    let direct_fields = [
+        "objects",
+        "stack_paid_facts",
+        "liminal_entries",
+        "attribution",
+        "tracked_object_sets",
+        "tracked_set_member_causes",
+        "commander_cast_count",
+        "commander_cast_owners",
+        "auto_pass",
+        "phase_stops",
+        "priority_passing_modes",
+        "lands_tapped_for_mana",
+        "prepaid_mulligan_bottoms",
+        "loyalty_abilities_activated_this_turn",
+        "extra_loyalty_activations_this_turn",
+        "object_tap_count_this_turn",
+        "object_counter_placement_count_this_turn",
+        "cards_exiled_with_source_this_turn",
+        "first_card_drawn_this_turn",
+        "cards_drawn_this_turn",
+        "spells_cast_this_game",
+        "spells_cast_this_game_by_player",
+        "spells_cast_this_turn_by_player",
+        "lands_played_this_turn_by_player",
+        "attacking_creatures_this_turn",
+        "attacked_defenders_this_turn",
+        "creature_attacked_defenders_this_turn",
+        "cards_discarded_this_turn_by_player",
+        "mana_spent_on_spells_this_turn",
+        "last_effect_counts_by_player",
+        "stack_trigger_event_batches",
+        "lki_cache",
+        "lki_copiable_values",
+        "lki_by_incarnation",
+        "linked_exile_lki",
+        "ring_level",
+        "ring_bearer",
+        "dungeon_progress",
+        "planar_die_actions_this_turn",
+    ];
+    assert_eq!(
+        direct_fields.len(),
+        39,
+        "private stack_trigger_firings is covered by its unit test"
+    );
+    for field in direct_fields {
+        let value = &before[field];
+        assert_eq!(
+            value.as_object().map(serde_json::Map::len),
+            Some(2),
+            "{field}: pre-serialization reach guard must contain two keys"
+        );
+        assert_eq!(
+            after[field], *value,
+            "{field}: exact key/value membership changed"
+        );
+    }
+    for field in ["tracked_set_member_causes", "lki_by_incarnation"] {
+        for (outer_key, inner) in before[field].as_object().unwrap() {
+            assert_eq!(
+                inner.as_object().map(serde_json::Map::len),
+                Some(2),
+                "{field}[{outer_key}]: nested reach guard must contain two keys"
+            );
+        }
+    }
+    assert_eq!(
+        reserialized, serialized,
+        "canonical bytes must survive restore"
+    );
+    assert_eq!(
+        before["player_actions_this_turn"],
+        serde_json::json!([[1, "Scry"], [0, "SearchedLibrary"]])
+    );
+}
+
+#[test]
+fn every_numeric_key_combat_map_round_trips_populated() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let combat = CombatState {
+        blocker_assignments: HashMap::from([
+            (ObjectId(1), vec![ObjectId(11)]),
+            (ObjectId(2), vec![ObjectId(21), ObjectId(22)]),
+        ]),
+        blocker_to_attacker: HashMap::from([
+            (ObjectId(11), vec![ObjectId(1)]),
+            (ObjectId(22), vec![ObjectId(2), ObjectId(3)]),
+        ]),
+        attacked_defenders_this_combat: HashMap::from([
+            (
+                PlayerId(0),
+                [PlayerId(0), PlayerId(1)].into_iter().collect(),
+            ),
+            (
+                PlayerId(1),
+                [PlayerId(1), PlayerId(0)].into_iter().collect(),
+            ),
+        ]),
+        creature_attacked_defenders_this_combat: HashMap::from([
+            (
+                ObjectId(1),
+                [PlayerId(0), PlayerId(1)].into_iter().collect(),
+            ),
+            (
+                ObjectId(2),
+                [PlayerId(1), PlayerId(0)].into_iter().collect(),
+            ),
+        ]),
+        damage_assignments: HashMap::from([
+            (
+                ObjectId(1),
+                vec![DamageAssignment {
+                    target: DamageTarget::Player(PlayerId(1)),
+                    amount: 1,
+                }],
+            ),
+            (
+                ObjectId(2),
+                vec![DamageAssignment {
+                    target: DamageTarget::Player(PlayerId(0)),
+                    amount: 2,
+                }],
+            ),
+        ]),
+        ..Default::default()
+    };
+    state.combat = Some(combat);
+
+    let serialized = serde_json::to_string(&state).unwrap();
+    let before: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+    let restored: GameState = serde_json::from_str(&serialized).unwrap();
+    let reserialized = serde_json::to_string(&restored).unwrap();
+    let after: serde_json::Value = serde_json::from_str(&reserialized).unwrap();
+    for field in [
+        "blocker_assignments",
+        "blocker_to_attacker",
+        "attacked_defenders_this_combat",
+        "creature_attacked_defenders_this_combat",
+        "damage_assignments",
+    ] {
+        assert_eq!(
+            before["combat"][field]
+                .as_object()
+                .map(serde_json::Map::len),
+            Some(2),
+            "CombatState.{field}: pre-serialization reach guard"
+        );
+        assert_eq!(
+            after["combat"][field], before["combat"][field],
+            "CombatState.{field}: exact membership changed"
+        );
+    }
+    assert_eq!(reserialized, serialized);
+}
+
+fn waiting_value(waiting_for: &WaitingFor) -> serde_json::Value {
+    serde_json::to_value(waiting_for).expect("waiting payload should serialize")
+}
+
+fn assert_waiting_round_trip_across_persistence_forms(state: GameState) {
+    let expected = waiting_value(&state.waiting_for);
+    let serialized = serde_json::to_string(&state).expect("state should serialize");
+    let bare: GameState = serde_json::from_str(&serialized).expect("bare state should restore");
+    assert_eq!(waiting_value(&bare.waiting_for), expected);
+
+    for persisted in [
+        PersistedGameState::Raw(Box::new(state.clone())),
+        PersistedGameState::capture(state.clone()),
+    ] {
+        let serialized = serde_json::to_string(&persisted).expect("persistence should serialize");
+        let restored: PersistedGameState =
+            serde_json::from_str(&serialized).expect("persistence should restore");
+        assert_eq!(
+            waiting_value(&restored.into_game_state().waiting_for),
+            expected
+        );
+    }
+}
+
+#[test]
+fn declare_attackers_numeric_maps_round_trip_through_value_bare_raw_and_trusted() {
+    let waiting = WaitingFor::DeclareAttackers {
+        player: PlayerId(0),
+        valid_attacker_ids: vec![ObjectId(3), ObjectId(2), ObjectId(1)],
+        valid_attack_targets: vec![
+            AttackTarget::Player(PlayerId(1)),
+            AttackTarget::Planeswalker(ObjectId(9)),
+        ],
+        valid_attack_targets_by_attacker: Some(HashMap::from([
+            (ObjectId(1), vec![AttackTarget::Player(PlayerId(1))]),
+            (
+                ObjectId(2),
+                vec![
+                    AttackTarget::Player(PlayerId(1)),
+                    AttackTarget::Planeswalker(ObjectId(9)),
+                ],
+            ),
+        ])),
+        attacker_constraints: HashMap::from([
+            (
+                ObjectId(1),
+                CombatRequirement::CantAttack {
+                    sources: vec![ObjectId(11)],
+                },
+            ),
+            (
+                ObjectId(2),
+                CombatRequirement::MustAttack {
+                    players: vec![PlayerId(1)],
+                    sources: vec![ObjectId(22)],
+                },
+            ),
+        ]),
+    };
+    let value = waiting_value(&waiting);
+    assert_eq!(
+        value["data"]["valid_attack_targets_by_attacker"]
+            .as_object()
+            .map(serde_json::Map::len),
+        Some(2)
+    );
+    assert_eq!(
+        value["data"]["attacker_constraints"]
+            .as_object()
+            .map(serde_json::Map::len),
+        Some(2)
+    );
+    assert_eq!(
+        value["data"]["valid_attacker_ids"],
+        serde_json::json!([3, 2, 1])
+    );
+    let restored: WaitingFor = serde_json::from_value(value.clone()).unwrap();
+    assert_eq!(waiting_value(&restored), value);
+
+    for optional in [Some(HashMap::new()), None] {
+        let boundary = WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            valid_attacker_ids: vec![ObjectId(2), ObjectId(1)],
+            valid_attack_targets: Vec::new(),
+            valid_attack_targets_by_attacker: optional,
+            attacker_constraints: HashMap::new(),
+        };
+        let boundary_value = waiting_value(&boundary);
+        assert_eq!(
+            waiting_value(&serde_json::from_value::<WaitingFor>(boundary_value.clone()).unwrap()),
+            boundary_value
+        );
+    }
+
+    let mut malformed = value.clone();
+    malformed["data"]["attacker_constraints"] = serde_json::json!({"01": {"kind": "CantAttack"}});
+    assert!(serde_json::from_value::<WaitingFor>(malformed).is_err());
+
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.waiting_for = waiting;
+    assert_waiting_round_trip_across_persistence_forms(state);
+}
+
+#[test]
+fn declare_blockers_numeric_maps_round_trip_through_value_bare_raw_and_trusted() {
+    let waiting = WaitingFor::DeclareBlockers {
+        player: PlayerId(1),
+        valid_blocker_ids: vec![ObjectId(4), ObjectId(3)],
+        valid_block_targets: HashMap::from([
+            (ObjectId(3), vec![ObjectId(1)]),
+            (ObjectId(4), vec![ObjectId(1), ObjectId(2)]),
+        ]),
+        block_requirements: HashMap::from([
+            (
+                ObjectId(1),
+                BlockRequirement {
+                    count: 2,
+                    sources: vec![ObjectId(11)],
+                },
+            ),
+            (
+                ObjectId(2),
+                BlockRequirement {
+                    count: 3,
+                    sources: vec![ObjectId(22)],
+                },
+            ),
+        ]),
+        blocker_constraints: HashMap::from([
+            (
+                ObjectId(3),
+                CombatRequirement::CantBlock {
+                    sources: vec![ObjectId(33)],
+                },
+            ),
+            (
+                ObjectId(4),
+                CombatRequirement::MustBlock {
+                    sources: vec![ObjectId(44)],
+                    attackers: vec![ObjectId(2)],
+                },
+            ),
+        ]),
+    };
+    let value = waiting_value(&waiting);
+    for field in [
+        "valid_block_targets",
+        "block_requirements",
+        "blocker_constraints",
+    ] {
+        assert_eq!(
+            value["data"][field].as_object().map(serde_json::Map::len),
+            Some(2),
+            "DeclareBlockers.{field}: pre-serialization reach guard"
+        );
+    }
+    assert_eq!(
+        value["data"]["valid_blocker_ids"],
+        serde_json::json!([4, 3])
+    );
+    let restored: WaitingFor = serde_json::from_value(value.clone()).unwrap();
+    assert_eq!(waiting_value(&restored), value);
+
+    let empty = WaitingFor::DeclareBlockers {
+        player: PlayerId(1),
+        valid_blocker_ids: vec![ObjectId(4), ObjectId(3)],
+        valid_block_targets: HashMap::new(),
+        block_requirements: HashMap::new(),
+        blocker_constraints: HashMap::new(),
+    };
+    let empty_value = waiting_value(&empty);
+    assert_eq!(
+        waiting_value(&serde_json::from_value::<WaitingFor>(empty_value.clone()).unwrap()),
+        empty_value
+    );
+
+    let mut malformed = value.clone();
+    malformed["data"]["blocker_constraints"] = serde_json::json!({"-1": {"kind": "CantBlock"}});
+    assert!(serde_json::from_value::<WaitingFor>(malformed).is_err());
+
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    state.waiting_for = waiting;
+    assert_waiting_round_trip_across_persistence_forms(state);
+}
+
+#[test]
+fn real_game_state_hash_owners_are_canonical_and_round_trip_across_all_persistence_forms() {
+    let forward = build_populated_state(false);
+    let reverse = build_populated_state(true);
+    assert_representative_membership(&forward);
+    assert_representative_membership(&reverse);
+
+    let canonical_token_creators = (0_u8..32).map(PlayerId).collect::<Vec<_>>();
+    let native_token_creator_order = forward
+        .players_who_created_token_this_turn
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
+    assert_ne!(
+        native_token_creator_order, canonical_token_creators,
+        "fixture must expose a noncanonical native HashSet iteration order"
+    );
+
+    let forward_json = serde_json::to_string(&forward).expect("forward state should serialize");
+    let reverse_json = serde_json::to_string(&reverse).expect("reverse state should serialize");
+    assert_eq!(
+        forward_json, reverse_json,
+        "logical insertion history must not affect bytes"
+    );
+    let forward_value: serde_json::Value =
+        serde_json::from_str(&forward_json).expect("serialized state should be valid JSON");
+    assert_eq!(
+        forward_value["players_who_created_token_this_turn"],
+        serde_json::to_value(&canonical_token_creators)
+            .expect("canonical token-creator IDs should serialize")
+    );
+    assert!(forward_json.contains("\"ring_level\":{\"0\":1,\"1\":2}"));
+    assert!(forward_json.contains("\"attacked_defenders_this_turn\":{\"0\":[0,1],\"1\":[0,1]}"));
+    assert!(forward_json
+        .contains("\"steps_to_skip\":[{\"PreCombatMain\":1,\"PostCombatMain\":2},{\"End\":3}]"));
+    assert!(forward_json.contains("\"objects\":{\"1\":"));
+    let first_name = forward_json
+        .find("First Deterministic Object")
+        .expect("first object payload should serialize");
+    let second_name = forward_json
+        .find("Second Deterministic Object")
+        .expect("second object payload should serialize");
+    assert!(
+        first_name < second_name,
+        "objects must emit by typed numeric key order"
+    );
+    let specialize = field_fragment(&forward_json, "specialize_faces", "foretold");
+    assert!(
+        specialize.find("\"White\"").expect("white face")
+            < specialize.find("\"Blue\"").expect("blue face"),
+        "specialize faces must follow ManaColor::Ord"
+    );
+    assert!(forward_json.contains("\"goaded_by\":[0,1]"));
+    assert!(forward_json.contains(
+        "\"damage_assignments\":{\"1\":[{\"target\":{\"Player\":1},\"amount\":1}],\"2\":[{\"target\":{\"Player\":0},\"amount\":2}]}"
+    ));
+    assert!(forward_json.contains(
+        "\"attacker_constraints\":{\"1\":{\"kind\":\"CantAttack\"},\"2\":{\"kind\":\"CantAttack\"}}"
+    ));
+    assert!(forward_json.contains(
+        "\"applied\":[{\"type\":\"Floating\",\"index\":1},{\"type\":\"Floating\",\"index\":2}]"
+    ));
+    assert!(forward_json.contains("\"valid_attacker_ids\":[2,1]",));
+    assert!(forward_json
+        .contains("\"player_actions_this_turn\":[[1,\"Scry\"],[0,\"SearchedLibrary\"]]"));
+
+    let empty = GameState::new(FormatConfig::standard(), 2, 42);
+    let empty_json = serde_json::to_value(&empty).expect("empty state should serialize");
+    assert_eq!(
+        empty_json["players_who_created_token_this_turn"],
+        serde_json::json!([])
+    );
+    let mut singleton = empty;
+    singleton
+        .players_who_created_token_this_turn
+        .insert(PlayerId(0));
+    let singleton_json = serde_json::to_value(&singleton).expect("singleton should serialize");
+    assert_eq!(
+        singleton_json["players_who_created_token_this_turn"],
+        serde_json::json!([0])
+    );
+
+    let bare: GameState = serde_json::from_str(&forward_json).expect("bare state should restore");
+    assert_representative_membership(&bare);
+    assert_eq!(
+        serde_json::to_string(&bare).expect("bare state should reserialize"),
+        forward_json
+    );
+
+    for persisted in [
+        PersistedGameState::Raw(Box::new(forward.clone())),
+        PersistedGameState::capture(forward.clone()),
+    ] {
+        let serialized =
+            serde_json::to_string(&persisted).expect("persisted state should serialize");
+        let restored: PersistedGameState =
+            serde_json::from_str(&serialized).expect("persisted state should restore");
+        let restored = restored.into_game_state();
+        assert_representative_membership(&restored);
+        assert_eq!(
+            serde_json::to_string(&restored).expect("restored state should reserialize"),
+            forward_json
+        );
+    }
+}
+
+#[test]
+fn populated_protection_tuple_map_keeps_its_existing_non_string_json_key_failure() {
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let mut object = GameObject::new(
+        ObjectId(1),
+        CardId(1),
+        PlayerId(0),
+        "Protection Fixture".to_string(),
+        Zone::Battlefield,
+    );
+    object.protection_start_exempt_attachments.insert(
+        (0, 0, ObjectId(2)),
+        ProtectionStartSnapshot {
+            resolved_quality: ProtectionTarget::Color(ManaColor::White),
+            attachment_ids: vec![ObjectId(3)],
+        },
+    );
+    assert_eq!(object.protection_start_exempt_attachments.len(), 1);
+    state.objects.insert(ObjectId(1), object);
+
+    let error = serde_json::to_value(&state)
+        .expect_err("the existing tuple-key map has no nonempty JSON representation");
+    assert_eq!(error.to_string(), "key must be a string");
+}

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -5172,58 +5172,11 @@ fn migrated_dump_decodes_through_both_decoders_and_unmigrated_through_neither() 
     // That is a real change to how six fixtures restore, and the two arms above cannot
     // witness it — they assert only that a decode succeeds or fails.
     //
-    // `GameState` has NO `PartialEq`, so this compares the SERIALIZED forms — key by key,
-    // recursively. Several fields are `HashSet`-backed and therefore have NO canonical array
-    // order (two sets built in one process do not even share a hasher seed), so a difference
-    // that is order-only under one of THOSE keys is accepted as a set difference and every
-    // other difference FAILS, naming its own key path. A blanket "sort every array" would
-    // have hidden a real reordering of the stack, a library or a seat order; a hand-picked
-    // single-field normalization would have flaked the first time a different set field
-    // happened to serialize in a different order — which is exactly what it did.
-    //
-    // The allowlist is DERIVED, not remembered:
-    //   grep -rhoE 'pub [a-z_0-9]+: (std::collections::)?HashSet<' \
-    //     crates/engine/src/types/*.rs crates/engine/src/analysis/*.rs | sort -u
-    // An unlisted key that differs only by order still FAILS and names itself, so drift is
-    // loud rather than silent.
-    const SET_BACKED_FIELDS: &[&str] = &[
-        "alt_cost_grant_permissions_used",
-        "applied",
-        "assassin_or_commander_dealt_combat_damage_this_turn",
-        "batched_zone_change_trigger_fired",
-        "bending_types_this_turn",
-        "city_blessing",
-        "commander_declined_zone_return",
-        "creatures_attacked_this_turn",
-        "creatures_blocked_this_turn",
-        "crew_activated_this_turn",
-        "dirty_objects",
-        "dirty_players",
-        "exerted_this_turn",
-        "exile_cast_permissions_used",
-        "exile_play_permissions_used",
-        "exile_play_single_use_consumed",
-        "graveyard_cast_permissions_used",
-        "graveyard_cast_permissions_used_per_type",
-        "hand_cast_free_permissions_used",
-        "modal_modes_chosen_this_game",
-        "modal_modes_chosen_this_turn",
-        "objects_that_dealt_damage",
-        "player_actions_this_way",
-        "players_attacked_this_step",
-        "players_attacked_this_turn",
-        "players_who_created_token_this_turn",
-        "players_who_discarded_card_this_turn",
-        "players_who_sacrificed_artifact_this_turn",
-        "players_who_searched_library_this_turn",
-        "public_revealed_cards",
-        "replacement_applied",
-        "revealed_cards",
-        "top_of_library_cast_permissions_used",
-        "triggers_fired_this_game",
-        "triggers_fired_this_turn",
-        "triggers_fired_this_turn_per_opponent",
-    ];
+    // `GameState` has no `PartialEq`, so compare its serialized forms recursively.
+    // Hash-backed owners now serialize canonically at their field boundaries; arrays are
+    // therefore always order-sensitive here, including libraries, stacks, and trigger order.
+    // Sorting below is diagnostic only: it distinguishes reordering from changed membership
+    // without ever accepting either difference.
 
     /// Collect every path at which `a` and `b` differ in a way that set-ordering cannot
     /// explain. Returns an empty vec iff the two states are equal modulo set order.
@@ -5248,18 +5201,12 @@ fn migrated_dump_decodes_through_both_decoders_and_unmigrated_through_neither() 
             }
             (Value::Array(x), Value::Array(y)) if x == y => {}
             (Value::Array(x), Value::Array(y)) => {
-                let leaf = path.rsplit('.').next().unwrap_or(path);
                 let (mut xs, mut ys) = (x.clone(), y.clone());
                 let key = |v: &Value| v.to_string();
                 xs.sort_by_key(key);
                 ys.sort_by_key(key);
-                if xs == ys && SET_BACKED_FIELDS.contains(&leaf) {
-                    // Order-only difference under a `HashSet`-backed field: not a state
-                    // difference at all, because that field HAS no canonical order.
-                } else if xs == ys {
-                    out.push(format!(
-                        "{path} (REORDERED, and it is not a set-backed field)"
-                    ));
+                if xs == ys {
+                    out.push(format!("{path} (REORDERED)"));
                 } else {
                     out.push(format!("{path} (different elements)"));
                 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -147,6 +147,7 @@ mod demon_of_fates_design;
 mod descendants_fury_sacrificed_referent_4795;
 mod destroy_redirect_to_battlefield_delivery_tail;
 mod deterministic_blocker_prompt_order;
+mod deterministic_game_state_serde;
 mod devour_co_entry_regression;
 mod devour_intellect_treasure_rider;
 mod dig_impossible_keep_count;


### PR DESCRIPTION
## Summary
Makes serialized `GameState` deterministic: hash-backed collections (`HashSet`/`HashMap` and `im` equivalents) reachable from the serialized state graph now emit a canonical sorted order at their owning field/type boundary, so identical states serialize byte-identically across processes. Found by an external deterministic-replay harness: replaying an identical seeded action sequence in a fresh process diverged at one transition with `players_who_created_token_this_turn` serializing `[0,1]` in one process and `[1,0]` in the other. Ordering-semantic collections (libraries, the stack, trigger order) are untouched; numeric-keyed maps keep their exact default wire representation and gain narrow field-owned deserializers because Serde's internal `Content` buffering otherwise breaks their numeric-key round-trip.

## Files changed
- crates/engine/src/types/deterministic_serde.rs (new)
- crates/engine/src/types/game_state.rs
- crates/engine/src/types/{ability,counter,events,identifiers,mod,player,proposed_event,resolution}.rs
- crates/engine/src/game/{combat,game_object}.rs
- crates/engine/tests/integration/deterministic_game_state_serde.rs (new)
- crates/engine/tests/integration/{loop_shortcut,main}.rs
- crates/engine/Cargo.toml, Cargo.lock (dev-dependency `syn` for the exhaustive census guard test)

## CR references
None — serialization determinism only; no rules behavior changes.

## Implementation method (required)
Method: /engine-implementer

## Track
Developer

## LLM
Model: gpt-5.6-sol
Thinking: high
Tier: Frontier

## Review history
Supersedes #6989, which was closed for a `Tier:` declaration predating the 2026-07-24 policy revision (corrected here; the implementing model gpt-5.6-sol is Frontier-tier per AI-CONTRIBUTOR §0.1.1). Both findings from the #6989 review are already addressed on this head (`7a01cbba`): the untrusted `MapAccess::size_hint` preallocation is capped with an adversarial regression, and a `HashMap<PlayerId, _>` strict-key fixture covers the `u8` boundary (rejects key "256", with a positive reach-guard in the same test).

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `tilt get uiresource clippy` — Tilt unavailable in this worktree; used the documented direct fallback.
- `cargo fmt --all` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — passed on head `df220c4ebae49b87aaf7b003b76fe0f2862b14f8`.
- `cargo test -p phase-engine` — passed on head `df220c4ebae49b87aaf7b003b76fe0f2862b14f8` (full unit + integration suites).
- Plan verification matrix (16 targeted test invocations incl. populated `WaitingFor::DeclareAttackers.attacker_constraints` round-trip and adverse-order byte-identity through the real `GameState` fields) — all passed on head `df220c4ebae49b87aaf7b003b76fe0f2862b14f8`.
- Revert probe — with the owning-field serializer reverted, `deterministic_game_state_serde` production-boundary regression failed 5/5 fresh runs; restored, passed.
- `./scripts/gen-card-data.sh` — passed on head `df220c4ebae49b87aaf7b003b76fe0f2862b14f8`: generated card data for ~35627 cards.
- `cargo coverage` — passed on head `df220c4ebae49b87aaf7b003b76fe0f2862b14f8`: timeless legal 15123/16179 fully supported (93.5%); vintage legal 29840/32267 fully supported (92.5%).
- `cargo semantic-audit` — passed on head `df220c4ebae49b87aaf7b003b76fe0f2862b14f8`: 32699 cards audited, 295 existing findings.

## Gate A
Gate A PASS head=7a01cbba992249e4c87803232d28190c0f3fb067 base=6d7821dced9623609edea342b47dd9c704ff0b36

## Anchored on
- crates/engine/src/game/combat.rs:5218 — existing `ordered_valid_blocker_ids` establishes the deterministic-ordering-at-the-producing-seam precedent (PR #5771 heritage) that this change extends to serialized state.
- crates/engine/src/types/counter.rs:212 — existing `counter_map_serde` module owns a specialized field-boundary wire representation; the new `deterministic_serde` adapters follow the same field-owned serde-module pattern.

## Final review-impl
Final review-impl PASS head=7a01cbba992249e4c87803232d28190c0f3fb067 (initial pipeline review plus fresh-context review of the review-fix delta)

## Claimed parse impact
None.

## Validation Failures
Resolved local environment issue: `cargo coverage` initially failed to compile due to `No space left on device`; cleared a generated target cache and reran all affected checks cleanly. Plan-review ran 4 rounds to clean (6 → 1 → 1 → 0 findings, including one executor hard-stop for a numeric-key round-trip contradiction that round 4 resolved); implementation review ran 2 rounds to clean (2 → 0 findings). Contributor-environment note per the engine-implementer skill: pipeline steps ran as isolated fresh contexts (Codex CLI sessions) with artifact-only handoffs rather than spawned Claude subagents.

## CI Failures
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Game-state serialization is now deterministic, producing stable output for maps and sets.
  * Serialization and deserialization provide more consistent ordering and validation for numeric keys.
  * Existing empty-value handling and wire-format compatibility are preserved.

* **Tests**
  * Added comprehensive coverage for deterministic ordering, round trips, malformed keys, nested collections, and allocation safety.
  * Improved state comparison diagnostics to reliably detect array reordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
