### PR TITLE
fix(client): keep the hover preview open over castable graveyard/exile cards

### DIFF
--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -33,6 +33,7 @@ import {
   computeReorderedHand,
   flankingHandIndices,
   isHandPermutation,
+  HAND_REORDER_SELECTOR,
 } from "./handInsertionSlot.ts";
 import { useCastableZoneObjects } from "../../hooks/useCastableZoneObjects.ts";
 import { ZONE_THEME, type ZoneTheme } from "../../viewmodel/zoneAffordance.ts";
@@ -136,15 +137,19 @@ export function PlayerHand() {
 
   // Castable graveyard/exile cards, rendered as colored "wings" continuing the
   // hand fan (engine authority — see useCastableZoneObjects). These are NOT
-  // hand cards: they carry no `data-card-hover`, so the reorder DOM sweep never
+  // hand cards: they carry no `data-hand-card`, so the reorder DOM sweep never
   // sees them and they can never be dragged into the middle of the hand. Their
-  // only drag gesture is flick-up-to-cast.
+  // only drag gesture is flick-up-to-cast. They DO carry `data-card-hover` —
+  // that attribute means "inspectable", not "reorderable" (see ZoneFanCard).
   const exileCards = useCastableZoneObjects("exile", playerId);
   const graveyardCards = useCastableZoneObjects("graveyard", playerId);
 
   // The perspective player's companion trails the fan as its far-right card
-  // (see CompanionFanCard). Like the wings it carries no `data-card-hover`, so
-  // it stays out of the reorder DOM sweep. Shown only until used: on
+  // (see CompanionFanCard). Like the wings it carries no `data-hand-card`, so it
+  // stays out of the reorder DOM sweep. Unlike the wings it also carries no
+  // `data-card-hover` — correctly so: it opens no preview to keep alive, being a
+  // name-only `CompanionInfo` with no `ObjectId` to inspect. Shown only until
+  // used: on
   // `CompanionToHand` the engine flips `used` AND creates the real hand
   // GameObject, so a still-shown ghost would duplicate the real card.
   const companion = player?.companion;
@@ -276,7 +281,7 @@ export function PlayerHand() {
 
       // One DOM sweep, reused for both the slot and the arrow position.
       const rects = Array.from(
-        container.querySelectorAll<HTMLElement>("[data-card-hover]"),
+        container.querySelectorAll<HTMLElement>(HAND_REORDER_SELECTOR),
       ).map((el) => {
         const r = el.getBoundingClientRect();
         return {
@@ -488,7 +493,10 @@ export function PlayerHand() {
       // returns transform-free layout values, so the fan's rotation/scale don't
       // pollute the width or the resting overlap (the negative margin-left).
       const container = handContainerRef.current;
-      const cards = container?.querySelectorAll<HTMLElement>("[data-card-hover]");
+      // Same selector as the handleDrag sweep: the measurement assumes cards[0]
+      // carries margin-left 0 and cards[1] the fan overlap, which only holds for
+      // the hand's own cards, not the wings.
+      const cards = container?.querySelectorAll<HTMLElement>(HAND_REORDER_SELECTOR);
       if (cards && cards.length >= 2) {
         const cs0 = getComputedStyle(cards[0]);
         const cardWidthPx = parseFloat(cs0.width);
@@ -1047,7 +1055,7 @@ interface ZoneFanCardProps {
 
 // A castable graveyard/exile card sitting in the hand fan's wing. It mirrors
 // HandCard's resting animation (arc + tilt + hover lift) for visual continuity
-// but is deliberately NOT part of the reorder system: no `data-card-hover`, no
+// but is deliberately NOT part of the reorder system: no `data-hand-card`, no
 // insertion-slot wiring, no displacement spring. Its sole drag gesture is
 // flick-up-to-cast (CR-agnostic UI gating, same generic DRAG_PLAY_THRESHOLD as
 // the commander zone). Per-source drag policy lives here — a zone card can
@@ -1090,6 +1098,14 @@ const ZoneFanCard = memo(function ZoneFanCard({
 
   return (
     <motion.div
+      // Marks the card as inspectable, which is what usePreviewDismiss's 300ms
+      // `[data-card-hover]:hover` poll (and uiStore's 50ms deferred clear) test
+      // for. Without it the poll saw nothing hovered and tore the preview down
+      // ~600ms after it appeared, so a flashback/escape/encore card could only
+      // be read for an instant — the preview now lasts as long as the hover,
+      // exactly like a hand card. It does NOT make the card reorderable: the
+      // reorder sweeps select `[data-hand-card]`.
+      data-card-hover
       layout
       initial={{ opacity: 0, y: restingY + 10 }}
       animate={{ opacity: 1, y: restingY + arcOffset, rotate: rotation }}

--- a/client/src/components/hand/__tests__/ZoneFanCardHover.test.tsx
+++ b/client/src/components/hand/__tests__/ZoneFanCardHover.test.tsx
@@ -1,0 +1,151 @@
+import { act, cleanup, fireEvent, render, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { GameAction } from "../../../adapter/types.ts";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { gameObjectFactory } from "../../../test/factories/gameObjectFactory.ts";
+import { gameStateFactory } from "../../../test/factories/gameStateFactory.ts";
+import { GameCardPreview } from "../../card/GameCardPreview.tsx";
+import { HAND_REORDER_SELECTOR } from "../handInsertionSlot.ts";
+import { PlayerHand } from "../PlayerHand.tsx";
+
+vi.mock("../../../hooks/useCardImage.ts", () => ({
+  useCardImage: () => ({
+    src: "card.png",
+    isLoading: false,
+    isRotated: false,
+    isFlip: false,
+  }),
+}));
+
+vi.mock("../../../hooks/useEngineCardData.ts", () => ({
+  useEngineCardData: () => null,
+  useCardParseDetails: () => null,
+  useCardRulings: () => [],
+}));
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  cleanup();
+  useGameStore.setState({ gameState: null, spellCosts: {}, legalActionsByObject: {} });
+  useUiStore.setState({
+    inspectedObjectId: null,
+    inspectedFaceIndex: 0,
+    previewSticky: false,
+    altHeld: false,
+  });
+});
+
+function castSpell(objectId: number): GameAction {
+  return { type: "CastSpell", data: { object_id: objectId, card_id: 1, targets: [] } };
+}
+
+function graveyardWingState() {
+  const gyCard = gameObjectFactory.withId(301).inGraveyard().named("Encore Card").build();
+  const handCard = gameObjectFactory.withId(302).inHand().named("Hand Card").build();
+  const gameState = gameStateFactory
+    .withPlayers({ id: 0, hand: [handCard.id], graveyard: [gyCard.id] }, 1)
+    .withObjects(gyCard, handCard)
+    .build();
+  useGameStore.setState({
+    gameState,
+    spellCosts: {},
+    legalActionsByObject: { [String(gyCard.id)]: [castSpell(gyCard.id)] },
+  });
+  return { gyCard, handCard };
+}
+
+/**
+ * Stand in for the browser's `:hover` hit-test, which jsdom does not implement.
+ *
+ * Deliberately consults the real attribute on the element under the cursor
+ * rather than returning it unconditionally: that is what makes the dismissal
+ * test discriminating. Revert the production change and `hovered` no longer
+ * matches `[data-card-hover]`, so this returns null exactly as a real browser
+ * would over an untagged element, and the poll dismisses the preview.
+ */
+function simulatePointerOver(hovered: Element) {
+  const realQuerySelector = document.querySelector.bind(document);
+  vi.spyOn(document, "querySelector").mockImplementation((selector: string) => {
+    if (selector === "[data-card-hover]:hover") {
+      return hovered.matches("[data-card-hover]") ? hovered : null;
+    }
+    return realQuerySelector(selector);
+  });
+}
+
+/**
+ * Regression guard for the graveyard/exile wing preview.
+ *
+ * `data-card-hover` means "inspectable card" — usePreviewDismiss polls
+ * `[data-card-hover]:hover` every 300ms and tears the preview down when nothing
+ * matches. The wings once omitted the attribute (to stay out of the reorder DOM
+ * sweep), so hovering a flashback / escape / encore card showed its image for
+ * roughly 600ms and then dropped it, with the cursor still on the card.
+ *
+ * The two concerns are now carried by two attributes: `data-card-hover` for
+ * inspectability (wings included) and `data-hand-card` for reorderability
+ * (wings excluded). Both halves are asserted here — dropping either one
+ * reintroduces a bug.
+ */
+describe("castable graveyard/exile wing hover", () => {
+  it("keeps the preview open while the pointer rests on a wing card", () => {
+    vi.useFakeTimers();
+    graveyardWingState();
+
+    const { container } = render(
+      <>
+        <PlayerHand />
+        <GameCardPreview />
+      </>,
+    );
+
+    // Locate the wing by its card art and climb to ZoneFanCard's root (the
+    // element that owns the hover handlers). Deliberately NOT located by
+    // `[data-card-hover]`: finding it through the very attribute under test
+    // would make a revert fail at this lookup rather than at the dismissal
+    // assertion below, which is the behaviour this test exists to pin.
+    const art = within(container).getByAltText("Encore Card");
+    const wing = art.closest<HTMLElement>(".cursor-pointer");
+    expect(wing).not.toBeNull();
+    simulatePointerOver(wing!);
+
+    act(() => {
+      fireEvent.mouseEnter(wing!);
+      vi.advanceTimersByTime(0);
+    });
+
+    const preview = () => container.querySelector<HTMLElement>("[data-card-preview]");
+    expect(preview()).not.toBeNull();
+    expect(within(preview()!).getByAltText("Encore Card")).toBeInTheDocument();
+
+    // usePreviewDismiss polls every 300ms and skips its first tick, so the old
+    // behaviour dropped the preview by ~600ms. Run well past that with the
+    // pointer never leaving the card.
+    act(() => vi.advanceTimersByTime(1500));
+
+    expect(useUiStore.getState().inspectedObjectId).not.toBeNull();
+    expect(preview()).not.toBeNull();
+    expect(within(preview()!).getByAltText("Encore Card")).toBeInTheDocument();
+  });
+
+  it("marks wing cards inspectable but not reorderable", () => {
+    const { handCard } = graveyardWingState();
+
+    const { container } = render(<PlayerHand />);
+
+    // The wing rendered at all (engine surfaced a cast action for it).
+    const inspectable = container.querySelectorAll("[data-card-hover]");
+    expect(inspectable.length).toBe(2);
+
+    // ...but only the hand card is part of the reorder index space. Queried
+    // through the exported selector, so pointing it back at `[data-card-hover]`
+    // — the naive one-line version of this fix — turns this assertion red
+    // instead of silently admitting the wings into the reorder rects.
+    const reorderable = container.querySelectorAll(HAND_REORDER_SELECTOR);
+    expect(reorderable.length).toBe(1);
+    expect((reorderable[0] as HTMLElement).dataset.objectId).toBe(String(handCard.id));
+  });
+});

--- a/client/src/components/hand/handInsertionSlot.ts
+++ b/client/src/components/hand/handInsertionSlot.ts
@@ -9,6 +9,23 @@ export interface HandSlotRect {
 }
 
 /**
+ * The DOM selector that defines the reorder index space: every element it
+ * matches inside the hand container becomes one `HandSlotRect`, so a card it
+ * matches is a card the player can drop another card next to.
+ *
+ * It is deliberately NOT `[data-card-hover]`. That attribute means
+ * "inspectable" — it is what `usePreviewDismiss`'s `:hover` poll and `uiStore`'s
+ * deferred clear test for — and the castable exile/graveyard wings carry it so
+ * their preview survives a hover. Reusing it here would silently admit the wings
+ * into the reorder index space, shifting every slot and arrow position by the
+ * wing count while `computeReorderedHand` still indexes `player.hand`.
+ *
+ * Named here, beside the functions that consume the rects, so the two concerns
+ * cannot be re-merged by editing a string literal at a call site.
+ */
+export const HAND_REORDER_SELECTOR = "[data-hand-card]";
+
+/**
  * Fraction of a card's width that the *visible* slot between the two flanking
  * cards should open to once they slide apart. The drop target reads as a real
  * gap you could drop a card into, not a hairline.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Hovering a castable graveyard/exile card showed its preview for roughly 600ms and then dropped it, with the cursor still on the card. `usePreviewDismiss` polls `[data-card-hover]:hover` every 300ms and dismisses when nothing matches; `ZoneFanCard` never carried the attribute, so the poll found nothing hovered and tore down a preview the player was still reading. Every cast-from-elsewhere mechanic is affected — flashback, escape, encore, disturb, foretell-from-exile — since all of them render through `ZoneFanCard`.

The attribute was omitted for a real reason: the hand's two reorder DOM sweeps also selected `[data-card-hover]`, so tagging the wings would have admitted them into the reorder index space, shifting every insertion slot and arrow position by the wing count while `computeReorderedHand` still indexes `player.hand`. One attribute was carrying two unrelated meanings.

This splits them. `data-card-hover` now means "inspectable" and the wings carry it; the reorder sweeps select `HAND_REORDER_SELECTOR` (`[data-hand-card]`, hand cards only). Naming the selector next to the functions that consume its rects keeps the two concerns from being re-merged by editing a string literal at a call site.

## Files changed

- `client/src/components/hand/PlayerHand.tsx` — `ZoneFanCard` gains `data-card-hover`; both reorder sweeps (`handleDrag`, `handleDragStart`) select `HAND_REORDER_SELECTOR`; the wing and companion comments corrected, the latter having become false
- `client/src/components/hand/handInsertionSlot.ts` — `HAND_REORDER_SELECTOR`, defined beside the functions consuming the rects it produces
- `client/src/components/hand/__tests__/ZoneFanCardHover.test.tsx` (new) — a runtime dismissal test through `PlayerHand` + `GameCardPreview`, and an attribute-split test

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — frontend-only change; no `crates/engine/` path is touched (3 files, all under `client/src/components/hand/`).

## CR references

None. No rules behavior changes; this is a UI hover-lifetime fix.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head. — **See "Validation Failures": the review ran, but in-session rather than as an independent fresh-context agent. Not claiming the box.**
- [x] Both anchors cite existing analogous code at the same seam.

All results from the pushed head `ef6fb16f7`:

- `npx tsc -b --force --pretty false` — **EXIT=0**, 0 error lines.
- `npx eslint .` — **EXIT=0**, `✖ 27 problems (0 errors, 27 warnings)`. `eslint .` cannot gate on the count alone, so the gate is the warning **set**, compared against the merge base by reverting the three files and re-running: `onlyInPOST=0 onlyInBASE=0`, 27 on both arms.
- `npx vitest run` (full configured suite) — **EXIT=0**, `Test Files 281 passed | 3 skipped (284)`, `Tests 2467 passed | 12 todo (2479)`. Merge base `cdb99baba`, re-measured on the same runner by restoring all three files to their base content: `Test Files 280 passed | 3 skipped (283)`, `Tests 2465 passed | 12 todo (2477)`. **Delta: +1 file, +2 tests, −0 removed.** (An earlier draft of this body quoted `2466` as the base; that figure was measured with this PR's own test file already present and was wrong.)
- **Browser verification was NOT performed.** The dismissal is pinned by the runtime test below, not by a manual pass in a real browser.

**Two-sided controls**, each flipping its own named assertion:

- **Revert control** (drop `data-card-hover` from `ZoneFanCard`, i.e. the pre-fix code): the runtime test fails at `ZoneFanCardHover.test.tsx:129` — `expect(useUiStore.getState().inspectedObjectId).not.toBeNull()` → `expected null not to be null`. It fails **after** the preview has opened and been asserted present, so the failure is the dismissal itself, not a lookup. The wing is located by card art (`getByAltText` → `closest(".cursor-pointer")`), deliberately not by `[data-card-hover]`; locating it through the attribute under test made an earlier revision fail at the lookup instead — a vacuous control, replaced.
- **Naive-fix control** (`HAND_REORDER_SELECTOR` pointed back at `[data-card-hover]`, i.e. adding the attribute without splitting the selector): the attribute-split test fails — `expected 2 to be 1` on the reorder rect count, showing the wing had entered the reorder index space. Before the constant existed, the full suite passed under this mutant; the constant is what makes it detectable.
- The `:hover` stand-in in the test consults the real attribute on the element under the cursor rather than returning it unconditionally, which is what makes the revert control discriminating rather than tautological.

## Gate A

Gate A PASS head=ef6fb16f7ab9ee0d3e1798b5950693ed9a29f4b9 base=cdb99baba1e32ca937af2e86f81a55f86dcbd4fe

## Anchored on

- `client/src/components/hand/PlayerHand.tsx:931` — `HandCard`'s root, the sibling in the same module, already carries `data-card-hover` and `data-hand-card` as two separate manual tags. `ZoneFanCard` now mirrors that shape exactly, minus the reorder tag it must not have.
- `client/src/components/hand/useHandScrubPreview.ts:17` — existing precedent in the same module for addressing hand-only cards as `[data-hand-card][data-object-id]` rather than through `[data-card-hover]`. The reorder sweeps now follow the selector convention this established.

## Final review-impl

**Not claimed as PASS.** A `$review-impl` pass ran against the committed head and its findings were addressed with code, but it was a self-review in the implementing session, not an independent fresh-context agent. Recording it as `Final review-impl PASS` would misrepresent what ran. What it produced:

1. **Test pinned the marker, not the behavior** — the original test asserted only attribute counts. Replaced with the runtime dismissal test through `PlayerHand` + `GameCardPreview` (real `usePreviewDismiss` wiring) described above.
2. **Vacuous revert control** — the runtime test located the wing via `[data-card-hover]`, so a revert failed at the lookup rather than the dismissal. Re-anchored on the card art.
3. **A comment made false by the change** — `PlayerHand.tsx`'s companion note read "Like the wings it carries no `data-card-hover`, so it stays out of the reorder DOM sweep", which after this change is wrong on both clauses. Corrected, including why the companion correctly still carries neither tag.

## Claimed parse impact

None.

## Scope Expansion

None.

## Named follow-ups (deliberately not fixed here)

1. **Same mechanism, different surface: the game log's card links.** `client/src/components/log/LogEntry.tsx:29` opens the preview with `onClick={() => onInspectObject(...)}` on a `<button>` that carries neither `data-card-hover` nor `previewSticky`, so `usePreviewDismiss`'s poll should dismiss it within ~600ms exactly as it did here. Not fixed in this PR because the right remedy is a product decision rather than a mechanical one: a click is an explicit-intent gesture, so `setPreviewSticky(true)` (matching the long-press path in `useCardHover`) is likely more correct than the hover-scoped tag, and that choice belongs to the maintainers. Reported from code reading; **not reproduced in a browser.**
2. **`ZoneFanCard` and `HandCard` both hand-roll what `useCardHover` exists to provide** — `useLongPress` + `inspectObject` + `setPreviewSticky` + the manual `data-card-hover` tag, which `useCardHover.ts:63` says should come from the hook precisely so call sites cannot forget it. Adopting the hook in `ZoneFanCard` alone would make it diverge from its sibling in the same file and would change touch behavior, so this PR mirrors the sibling instead (per Gate B) and leaves the unification of both call sites as separate work.

## Validation Failures

The final `$review-impl` was a self-review rather than an independent fresh-context agent, so the mandatory-review gate in `CONTRIBUTING.md` is **not** satisfied on its own terms. Its three findings are all fixed at this head (above), and the mechanical gates plus the two-sided controls are the evidence offered in its place. Flagging rather than papering over it.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved card reordering so only cards in the player’s hand are included.
  * Prevented graveyard and exile preview cards from interfering with drag-and-drop positioning.
  * Enabled hover previews for cards displayed in graveyard and exile wings.

* **Tests**
  * Added coverage for hover previews and hand reordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->