### PR TITLE
fix(ai): make the duel-suite comparator see the regressions it was blind to

### DIFF
--- a/.github/workflows/ai-gate.yml
+++ b/.github/workflows/ai-gate.yml
@@ -47,17 +47,22 @@ jobs:
           cargo run --profile tool --features cli --bin oracle-gen -- data/ --stats --names-out data/card-names.json > data/card-data.json
 
       - name: Run quick AI gate
-        run: cargo ai-gate --games 10
+        run: cargo ai-gate --games 10 --seed 10573729 --difficulty medium
 
   ai-gate-nightly:
     name: Nightly AI gate drift monitor
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
-    # `--full-suite --games 100` consistently exceeded the prior 90m ceiling
-    # (never completed since at least 2026-06-13). Raised to 300m — generous
-    # headroom under GitHub's 360m hosted-runner cap — to get a first completion
-    # and a real-duration baseline to right-size from. The ceiling only bills the
-    # failure case; a job that finishes in 2h stops at 2h.
+    # The gate's workload flags MUST equal the corresponding fields in
+    # crates/phase-ai/baselines/suite-baseline.json. The comparator refuses a pair
+    # whose workloads disagree, so a divergent value here makes this job incapable
+    # of any verdict; crates/phase-ai/tests/gate_cli.rs reds if an invocation
+    # written down in this directory drifts from the baseline.
+    #
+    # What the leg buys at that workload: liveness across the whole matchup
+    # registry, plus mirror classification at a low-power band — not a drift gate
+    # at the band a larger per-matchup sample would give. The ceiling only bills
+    # the failure case; a job that finishes early stops early.
     timeout-minutes: 300
     steps:
       - uses: actions/checkout@v4
@@ -84,7 +89,7 @@ jobs:
           # skipped, and nothing else has invoked cargo yet — the redirect then
           # dies with "No such file or directory" and the gate never executes.
           mkdir -p target
-          cargo ai-gate --full-suite --games 100 > target/ai-gate-report.md
+          cargo ai-gate --full-suite --games 10 --seed 10573729 --difficulty medium > target/ai-gate-report.md
 
       - name: Open or update drift issue
         if: steps.gate.outcome == 'failure'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,11 +176,13 @@ jobs:
 
       - name: Build binaries launched by integration tests
         # `CARGO_BIN_EXE_*` embeds target/debug paths. Nextest's archive does
-        # not preserve those launcher paths, so share the two binaries the
-        # integration tests execute directly with every shard.
+        # not preserve those launcher paths, so share the binaries the
+        # integration tests execute directly with every shard. This list and the
+        # two below must cover every such binary;
+        # `crates/phase-ai/tests/gate_cli.rs` reds when they fall behind.
         run: |
           cargo build -p probe-pin
-          cargo build -p phase-ai --bin ai-commander
+          cargo build -p phase-ai --bin ai-commander --bin ai-duel
 
       - name: Upload test archive
         uses: actions/upload-artifact@v4
@@ -197,6 +199,7 @@ jobs:
           path: |
             target/debug/probe-pin
             target/debug/ai-commander
+            target/debug/ai-duel
           compression-level: 0
           if-no-files-found: error
           retention-days: 1
@@ -241,7 +244,7 @@ jobs:
 
       - name: Restore test runtime binary permissions
         # Actions artifacts preserve file contents but not executable bits.
-        run: chmod +x target/debug/probe-pin target/debug/ai-commander
+        run: chmod +x target/debug/probe-pin target/debug/ai-commander target/debug/ai-duel
 
       - name: Run tests
         # The archive retains build options. Each shard only extracts it and

--- a/crates/phase-ai/src/bin/ai_duel.rs
+++ b/crates/phase-ai/src/bin/ai_duel.rs
@@ -20,7 +20,8 @@ use engine::types::player::PlayerId;
 use phase_ai::auto_play::run_ai_actions;
 use phase_ai::config::{create_config_for_players, AiDifficulty, Platform};
 use phase_ai::duel_suite::compare::{
-    compare as compare_reports, emit_gate_verdict, load_report, CompareOptions,
+    compare as compare_reports, emit_gate_verdict, load_report, render_error_markdown,
+    CompareOptions,
 };
 use phase_ai::duel_suite::run::{resolve_matchup, run_suite, AttributionMode, SuiteOptions};
 use phase_ai::duel_suite::{all_matchups, find_matchup};
@@ -728,10 +729,21 @@ fn run_compare(args: &[String]) -> i32 {
         }
     }
 
+    // A report that cannot be READ is refused on the same terms as one that cannot be COMPARED.
+    // Review found these two arms spoke only to stderr while every other refusal on this path
+    // publishes a stdout body, so a caller redirecting stdout — which is the only way this
+    // command is used in CI — got an empty file and no statement of what failed. That is the
+    // same defect this PR fixed twice already, at `compare`'s error arm and in `ai-perf-gate`;
+    // these were the last two instances of it on the gate's report contract.
+    //
+    // The path stays on stderr because `CompareError` carries the cause but not the file, and a
+    // refusal that says "I/O error" without naming which of two inputs it was reading is not
+    // actionable.
     let baseline = match load_report(&baseline_path) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Failed to load baseline {}: {e}", baseline_path.display());
+            print!("{}", render_error_markdown(&e));
             return 2;
         }
     };
@@ -739,6 +751,7 @@ fn run_compare(args: &[String]) -> i32 {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Failed to load current {}: {e}", current_path.display());
+            print!("{}", render_error_markdown(&e));
             return 2;
         }
     };

--- a/crates/phase-ai/src/bin/ai_duel.rs
+++ b/crates/phase-ai/src/bin/ai_duel.rs
@@ -730,11 +730,9 @@ fn run_compare(args: &[String]) -> i32 {
     }
 
     // A report that cannot be READ is refused on the same terms as one that cannot be COMPARED.
-    // Review found these two arms spoke only to stderr while every other refusal on this path
-    // publishes a stdout body, so a caller redirecting stdout — which is the only way this
-    // command is used in CI — got an empty file and no statement of what failed. That is the
-    // same defect this PR fixed twice already, at `compare`'s error arm and in `ai-perf-gate`;
-    // these were the last two instances of it on the gate's report contract.
+    // Every other refusal on this path publishes a stdout body; an arm that spoke only to stderr
+    // would hand a caller redirecting stdout — the only way this command is used in CI — an empty
+    // file and no statement of what failed.
     //
     // The path stays on stderr because `CompareError` carries the cause but not the file, and a
     // refusal that says "I/O error" without naming which of two inputs it was reading is not

--- a/crates/phase-ai/src/bin/ai_duel.rs
+++ b/crates/phase-ai/src/bin/ai_duel.rs
@@ -20,8 +20,7 @@ use engine::types::player::PlayerId;
 use phase_ai::auto_play::run_ai_actions;
 use phase_ai::config::{create_config_for_players, AiDifficulty, Platform};
 use phase_ai::duel_suite::compare::{
-    compare as compare_reports, load_report, print_markdown as print_compare_markdown,
-    CompareOptions,
+    compare as compare_reports, emit_gate_verdict, load_report, CompareOptions,
 };
 use phase_ai::duel_suite::run::{resolve_matchup, run_suite, AttributionMode, SuiteOptions};
 use phase_ai::duel_suite::{all_matchups, find_matchup};
@@ -707,7 +706,8 @@ fn print_usage() {
     eprintln!("Compare mode (CI regression gate):");
     eprintln!("  compare BASELINE CURRENT   Diff two suite reports");
     eprintln!("  reports paired-seed flips and a binomial sign-test p-value");
-    eprintln!("  Exit code 0 if no regressions; 1 if any matchup FAILs.");
+    eprintln!("  Exit code 0 if no regressions; 1 if any matchup FAILs; 2 if the two");
+    eprintln!("  reports cannot be compared at all (the refusal is printed to stdout).");
 }
 
 /// Parse `compare` subcommand arguments and run the comparison. Returns the
@@ -743,19 +743,17 @@ fn run_compare(args: &[String]) -> i32 {
         }
     };
 
-    let report = match compare_reports(&baseline, &current, &CompareOptions) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("Compare failed: {e}");
-            return 2;
-        }
-    };
-    print_compare_markdown(&report);
-    if report.any_fail() {
-        1
-    } else {
-        0
+    // Third caller of the same two statements, and it had the same defect: a refusal spoke
+    // only to stderr, so anything redirecting this command's stdout got an empty file and no
+    // statement of what failed. Routed through the shared emitter rather than repaired in
+    // place — `tests/gate_cli.rs` drives THIS binary, because it is the only one of the three
+    // that needs no card database, so the contract is bound at a real process boundary for
+    // milliseconds instead of a full suite run.
+    let comparison = compare_reports(&baseline, &current, &CompareOptions);
+    if let Err(e) = &comparison {
+        eprintln!("Compare failed: {e}");
     }
+    emit_gate_verdict(&comparison)
 }
 
 fn list_matchups() {

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -11,7 +11,9 @@ use std::process::Command;
 
 use engine::database::CardDatabase;
 use phase_ai::config::AiDifficulty;
-use phase_ai::duel_suite::compare::{compare, load_report, print_markdown, CompareOptions};
+use phase_ai::duel_suite::compare::{
+    compare, gate_verdict, load_report, print_markdown, CompareOptions,
+};
 use phase_ai::duel_suite::run::{run_suite, SuiteOptions, SuiteReport};
 
 const DEFAULT_BASELINE: &str = "crates/phase-ai/baselines/suite-baseline.json";
@@ -99,16 +101,17 @@ fn main() {
         }
     };
 
-    let report = match compare(&baseline, &current, &CompareOptions) {
-        Ok(report) => report,
-        Err(err) => {
-            eprintln!("compare failed: {err}");
-            std::process::exit(2);
-        }
-    };
-    print_markdown(&report);
-    if report.any_fail() {
-        std::process::exit(1);
+    // stdout carries the report body — the nightly redirects it into the file it posts as a
+    // drift issue — so a refusal has to be printed there too, not only to stderr. `gate_verdict`
+    // owns both halves so the pair is testable; `main` prints and exits.
+    let comparison = compare(&baseline, &current, &CompareOptions);
+    if let Err(err) = &comparison {
+        eprintln!("compare failed: {err}");
+    }
+    let (body, code) = gate_verdict(&comparison);
+    print!("{body}");
+    if code != 0 {
+        std::process::exit(code);
     }
 }
 

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 use engine::database::CardDatabase;
 use phase_ai::config::AiDifficulty;
 use phase_ai::duel_suite::compare::{
-    compare, gate_verdict, load_report, print_markdown, CompareOptions,
+    compare, gate_verdict, load_report, print_markdown, render_error_markdown, CompareOptions,
 };
 use phase_ai::duel_suite::run::{run_suite, SuiteOptions, SuiteReport};
 
@@ -96,7 +96,13 @@ fn main() {
     let baseline = match load_report(&args.baseline) {
         Ok(report) => report,
         Err(err) => {
+            // Same reasoning as the compare refusal below: the nightly posts stdout, so a
+            // read failure that spoke only to stderr produced a red job whose issue body was
+            // the suite table and no statement of what went wrong. This is also the only
+            // caller that can reach `render_error_markdown`'s I/O arm — `compare` does no
+            // I/O, so before this the arm existed and was unreachable.
             eprintln!("failed to load baseline {}: {err}", args.baseline.display());
+            print!("{}", render_error_markdown(&err));
             std::process::exit(2);
         }
     };

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 use engine::database::CardDatabase;
 use phase_ai::config::AiDifficulty;
 use phase_ai::duel_suite::compare::{
-    compare, gate_verdict, load_report, print_markdown, render_error_markdown, CompareOptions,
+    compare, emit_gate_verdict, load_report, print_markdown, render_error_markdown, CompareOptions,
 };
 use phase_ai::duel_suite::run::{run_suite, SuiteOptions, SuiteReport};
 
@@ -114,8 +114,7 @@ fn main() {
     if let Err(err) = &comparison {
         eprintln!("compare failed: {err}");
     }
-    let (body, code) = gate_verdict(&comparison);
-    print!("{body}");
+    let code = emit_gate_verdict(&comparison);
     if code != 0 {
         std::process::exit(code);
     }

--- a/crates/phase-ai/src/bin/ai_perf_gate.rs
+++ b/crates/phase-ai/src/bin/ai_perf_gate.rs
@@ -34,8 +34,8 @@ use std::process::{Command, Stdio};
 use engine::database::CardDatabase;
 use phase_ai::duel_suite::perf::{
     compare, default_scenarios, load_report, median_report, print_markdown, print_repro_margin,
-    repro_margin_report, run_perf_suite, PerfReport, PERF_ACTION_CAP, PERF_BASE_SEED,
-    PERF_SAMPLE_COUNT,
+    render_error_markdown, repro_margin_report, run_perf_suite, PerfReport, PERF_ACTION_CAP,
+    PERF_BASE_SEED, PERF_SAMPLE_COUNT,
 };
 use phase_ai::duel_suite::{find_matchup, resolve_deck_ref};
 
@@ -256,10 +256,16 @@ fn run_parent_gate(args: &Args) {
         return;
     }
 
+    // Both bail-outs print the refusal to STDOUT as well as stderr. The workflow redirects
+    // stdout into `target/ai-perf-gate-report.md` and posts it as a drift issue, and nothing
+    // on the path above this point writes to stdout — so a stderr-only refusal left that file
+    // at zero bytes and the workflow answered it with "failed without a drift report" and no
+    // issue. The exit code and a non-empty body are needed TOGETHER; either alone posts nothing.
     let baseline = match load_report(&args.baseline) {
         Ok(report) => report,
         Err(err) => {
             eprintln!("failed to load baseline {}: {err}", args.baseline.display());
+            print!("{}", render_error_markdown(&err));
             cleanup_temps(&temp_paths);
             std::process::exit(2);
         }
@@ -269,6 +275,7 @@ fn run_parent_gate(args: &Args) {
         Ok(report) => report,
         Err(err) => {
             eprintln!("compare failed: {err}");
+            print!("{}", render_error_markdown(&err));
             cleanup_temps(&temp_paths);
             std::process::exit(2);
         }

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -688,8 +688,8 @@ fn render_markdown(report: &CompareReport) -> String {
             (None, None) => "—".to_string(),
         };
         let cells = [
-            row.matchup_id.clone(),
-            exercises.join(", "),
+            md_cell(&row.matchup_id),
+            md_cell(&exercises.join(", ")),
             baseline_cell,
             current_cell,
             row.flipped_w_to_l.to_string(),
@@ -711,13 +711,29 @@ fn render_markdown(report: &CompareReport) -> String {
                 // Reason spans one labelled cell plus blanks for the rest, so the row stays
                 // rectangular no matter how many columns the table has.
                 out.push_str(&format!(
-                    "|  ↳ _{reason}_ |{}\n",
+                    "|  ↳ _{}_ |{}\n",
+                    md_cell(reason),
                     " |".repeat(COLUMNS.len() - 1)
                 ));
             }
         }
     }
     out
+}
+
+/// Encode a report-provided string for one markdown table cell.
+///
+/// Every cell below that originates in a report rather than in this file goes through here.
+/// Report fields are free-form and arrive from JSON — `fail_reason` is whatever the suite
+/// wrote, and `ai_duel compare` will read whatever file it is handed — so a `|` silently adds
+/// a column to that row and a newline ends the row early. Either way the table stops being
+/// rectangular exactly when a matchup is already failing, which is the moment the diagnostics
+/// are actually read.
+///
+/// Applied uniformly rather than only to the fields that look risky today: deciding per field
+/// means re-deciding every time a field is added, and one of those decisions will be wrong.
+fn md_cell(text: &str) -> String {
+    text.replace('|', "\\|").replace(['\n', '\r'], " ")
 }
 
 /// Render the comparison table to stdout + emit a summary line.
@@ -1825,6 +1841,52 @@ mod tests {
     /// same cell count, or the table renders broken in the nightly drift issue that
     /// `.github/workflows/ai-gate.yml` posts. Exercises all four row shapes at once: a paired row
     /// that warns (so its reason continuation is emitted), a New row, and a Removed row.
+    /// Reachability arm for `md_cell`. `markdown_rows_are_rectangular` asserted the property
+    /// this test is named for, but every one of its fixtures was pipe-free — so it passed for
+    /// a reason unrelated to the hazard and gave false confidence about exactly the invariant
+    /// it claimed. A `fail_reason` is free-form text from a report, and `ai_duel compare`
+    /// reads whatever file it is handed, so a pipe is reachable input, not a hypothetical.
+    #[test]
+    fn report_supplied_pipes_cannot_add_columns() {
+        let mut baseline = mk_report(vec![mk_result("m|id", 5, 10, SuiteStatus::Pass)]);
+        let mut current = mk_report(vec![mk_result("m|id", 5, 10, SuiteStatus::Fail)]);
+        baseline.results[0].matchup_id = "m|id".into();
+        current.results[0].matchup_id = "m|id".into();
+        current.results[0].fail_reason =
+            Some("imbalance: p0=0.10 | CI [0.02, 0.40] | excludes 0.50".into());
+
+        let report = compare(&baseline, &current, &CompareOptions).unwrap();
+        let rendered = render_markdown(&report);
+
+        // PREMISE: the row really did render a reason carrying pipes, so this is not vacuous.
+        assert!(
+            rendered.contains("excludes 0.50"),
+            "reason must be rendered:\n{rendered}"
+        );
+        assert_eq!(report.rows[0].status, CompareStatus::Fail);
+
+        // Every row — header, separator, data, and the reason continuation — must have the
+        // same cell count. An unescaped pipe shows up here as a longer row.
+        // Count SEPARATORS the way a markdown parser does — a `|` preceded by a backslash is
+        // cell content, not a boundary. Splitting on the raw character cannot tell the escape
+        // from the hazard, so it would report this test green against a broken encoder.
+        let separators = |line: &str| {
+            line.char_indices()
+                .filter(|(i, c)| *c == '|' && (*i == 0 || !line[..*i].ends_with('\\')))
+                .count()
+        };
+        let widths: Vec<usize> = rendered
+            .lines()
+            .filter(|l| l.starts_with('|'))
+            .map(separators)
+            .collect();
+        assert!(widths.len() >= 4, "expected a reason row too: {widths:?}");
+        assert!(
+            widths.iter().all(|w| *w == widths[0]),
+            "pipes changed the column count: {widths:?}\n{rendered}"
+        );
+    }
+
     #[test]
     fn markdown_rows_are_rectangular() {
         let paired_before: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -163,12 +163,26 @@ pub fn compare(
     // reports derive their seeds the same way and play them under the same AI, so the two
     // inputs that define what a seed means are checked before any row is classified.
     //
-    // `games_per_matchup` is deliberately NOT here. It changes how MANY seeds exist, not
-    // what a seed means, so the samples that do pair are still comparable — and the nightly
-    // job runs `--games 100` against a `games_per_matchup: 10` baseline today, so erroring
-    // would break a live workflow instead of informing it. That difference is surfaced as
-    // the unpaired counters below, which is the honest treatment: it was previously
-    // discarded in silence.
+    // `games_per_matchup` IS here, and the reasoning that kept it out is recorded because it
+    // was wrong in an instructive way. It changes how MANY seeds exist rather than what a seed
+    // means, so the samples that do pair really are comparable — from which an earlier draft
+    // concluded that counting the unpaired remainder (the `unpaired_*` columns below) was the
+    // honest treatment, and that erroring would break a live nightly that runs `--games 100`
+    // against a `games_per_matchup: 10` baseline.
+    //
+    // The error in that is one layer downstream of the comparator. A `Warn` leaves `any_fail`
+    // false, so the gate exits 0, so the nightly step SUCCEEDS, and the step that publishes the
+    // report is guarded by `if: steps.gate.outcome == 'failure'`. The counters were therefore
+    // written to a file nobody reads: a green run that compared a tenth of its sample and said
+    // so only where nothing was listening. Producing a diagnostic is not surfacing it. A gate
+    // whose verdict covers 10% of the evidence must not be able to return Pass, so this is an
+    // incompatibility, and the diagnostics survive it — `render_error_markdown` puts the two
+    // values on stdout, which is what the workflow captures as the report body, so the failure
+    // opens a drift issue that says exactly which knob to turn.
+    //
+    // The columns stay. A mismatch of this field is now refused, but two reports built at the
+    // same `games_per_matchup` can still fail to pair — a crashed matchup, a filter change —
+    // and that remainder is still counted rather than skipped.
     //
     // `card_data_hash` is also not here: the committed baseline's hash matches no card-data
     // present on any current checkout, so gating it would fail every run immediately. The
@@ -186,6 +200,13 @@ pub fn compare(
             field: "difficulty",
             baseline: baseline.difficulty.clone(),
             current: current.difficulty.clone(),
+        });
+    }
+    if baseline.games_per_matchup != current.games_per_matchup {
+        return Err(CompareError::WorkloadMismatch {
+            field: "games_per_matchup",
+            baseline: baseline.games_per_matchup.to_string(),
+            current: current.games_per_matchup.to_string(),
         });
     }
 
@@ -738,14 +759,19 @@ fn render_markdown(report: &CompareReport) -> String {
 /// Applied uniformly rather than only to the fields that look risky today: deciding per field
 /// means re-deciding every time a field is added, and one of those decisions will be wrong.
 fn md_cell(text: &str) -> String {
-    text.replace('|', "\\|").replace(['\n', '\r'], " ")
+    // ORDER IS LOAD-BEARING: backslashes first, then pipes. The reverse — which this function
+    // did until review caught it — turns the input `\|` into `\\|`, and a markdown parser
+    // reads that as an escaped backslash followed by a LIVE separator, so the very input that
+    // looks pre-escaped is the one that breaks the row. Escaping backslashes first makes every
+    // backslash run even before any `\|` is introduced, so no emitted `|` can ever be preceded
+    // by an odd run.
+    text.replace('\\', "\\\\")
+        .replace('|', "\\|")
+        .replace(['\n', '\r'], " ")
 }
 
-/// Render the comparison table to stdout + emit a summary line.
-pub fn print_markdown(report: &CompareReport) {
-    println!();
-    print!("{}", render_markdown(report));
-
+/// Everything a successful comparison writes to stdout: the table, plus the counts line.
+fn render_stdout(report: &CompareReport) -> String {
     let mut pass = 0usize;
     let mut warn = 0usize;
     let mut fail = 0usize;
@@ -760,7 +786,56 @@ pub fn print_markdown(report: &CompareReport) {
             CompareStatus::Removed => removed += 1,
         }
     }
-    println!("\ncompare: {fail} FAIL, {warn} WARN, {pass} PASS, {new} NEW, {removed} REMOVED");
+    format!(
+        "\n{}\ncompare: {fail} FAIL, {warn} WARN, {pass} PASS, {new} NEW, {removed} REMOVED\n",
+        render_markdown(report)
+    )
+}
+
+/// Render the comparison table to stdout + emit a summary line.
+pub fn print_markdown(report: &CompareReport) {
+    print!("{}", render_stdout(report));
+}
+
+/// The report body for a comparison that could not be made at all.
+///
+/// A refused comparison is the case most likely to be read by someone who did not run it: the
+/// nightly captures stdout into `target/ai-gate-report.md` and posts it as a drift issue, and it
+/// posts nothing when that file is empty. Writing the refusal only to stderr would therefore turn
+/// a hard, correct refusal into "AI gate failed without a drift report" — a red job with no
+/// statement of what is wrong. The remedy is named per field, because the reader of the issue is
+/// the person who has to choose between re-recording the baseline and changing the workload.
+pub fn render_error_markdown(err: &CompareError) -> String {
+    let remedy = match err {
+        CompareError::WorkloadMismatch { field, .. } => format!(
+            "The two reports were produced under different `{field}`, so their seeds do not \
+             denote the same games and no verdict can be built by pairing them. Either re-record \
+             the baseline under the current workload (`cargo ai-gate --refresh-baseline` with the \
+             same flags this run used) or run the gate under the baseline's workload. This is not \
+             drift: nothing was measured."
+        ),
+        CompareError::SchemaMismatch { .. } => "The baseline predates the current report format. \
+             Re-record it with `cargo ai-gate --refresh-baseline`."
+            .to_string(),
+        CompareError::Io(_) | CompareError::Parse(_) => {
+            "The baseline could not be read. Check the path and the file's contents.".to_string()
+        }
+    };
+    format!("## AI gate: comparison refused\n\n**{err}**\n\n{remedy}\n")
+}
+
+/// What the gate prints on stdout and what it exits with, decided together.
+///
+/// These two are one decision, not two: the nightly opens its drift issue only when the exit is
+/// non-zero, and aborts with "failed without a drift report" when stdout was empty, so a change
+/// that satisfies either alone silently disables the other. Returning both from one function is
+/// what lets a test bind the pair — `main` only prints and exits.
+pub fn gate_verdict(comparison: &Result<CompareReport, CompareError>) -> (String, i32) {
+    match comparison {
+        Ok(report) if report.any_fail() => (render_stdout(report), 1),
+        Ok(report) => (render_stdout(report), 0),
+        Err(err) => (render_error_markdown(err), 2),
+    }
 }
 
 #[cfg(test)]
@@ -1555,18 +1630,13 @@ mod tests {
         line.split('|').nth(index + 1).unwrap().trim()
     }
 
-    /// **Every column carries the value it claims to.** Round 3 of review measured that the table
-    /// was pinned by header *label* only: freezing the `Δ avg turns` cell to a constant, and
-    /// swapping the `dec→draw` / `draw→dec` cells so the recorded incident would print its counters
-    /// backwards, both survived the entire suite. A column that renders the wrong number defeats
-    /// the invariant exactly as thoroughly as a missing one, since columns are the only surface
-    /// that survives first-match-wins reason suppression.
+    /// Only `unpaired_baseline` moves: every seed that pairs is UNCHANGED, so every other axis
+    /// reads zero. Before this arm existed such a row scored zero on everything and returned
+    /// Pass while half its samples went unexamined.
     ///
-    /// The fixture gives every numeric axis a DISTINCT value (2, 3, 4, 1, and two different
-    /// p-values), so no pair of cells can be transposed without changing the rendered text.
-    /// Condition: only `unpaired_baseline` moves. Every paired seed is UNCHANGED, so every
-    /// other axis reads zero — before this arm existed the row scored zero on everything and
-    /// returned Pass while half its samples went unexamined.
+    /// (The two paragraphs that stood here were copied from
+    /// `markdown_cells_carry_their_own_column_values` and described that test's distinct-value
+    /// fixture, which this one does not have — every counter here is deliberately zero.)
     #[test]
     fn an_unmatched_baseline_sample_warns_instead_of_passing() {
         let before: &[(u64, Option<u8>, u32)] = &[
@@ -1727,11 +1797,17 @@ mod tests {
         assert_eq!(report.rows.len(), 1);
     }
 
-    /// `games_per_matchup` differing must NOT error: the nightly runs `--games 100` against a
-    /// 10-game baseline, so erroring would break a live workflow. The samples that pair are
-    /// still comparable, and the ones that do not are surfaced as unpaired counts instead.
+    /// A differing `games_per_matchup` is refused, and this test is the inversion of one that
+    /// asserted the opposite. The samples that pair really are comparable, which is why the
+    /// earlier version counted the remainder and Warned — but a Warn keeps `any_fail` false, the
+    /// gate exits 0, and the nightly publishes its report only on a non-zero exit. The counters
+    /// existed and were never read. A verdict drawn from a tenth of the sample must not be able
+    /// to come back Pass.
+    ///
+    /// The two assertions below are the pair that makes this a fix rather than a trade: the row
+    /// count pins that no verdict is produced, and the body pins that the diagnostics survive.
     #[test]
-    fn a_different_games_per_matchup_is_reported_not_refused() {
+    fn a_different_games_per_matchup_is_refused_with_its_diagnostics_intact() {
         let before: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10)];
         let after: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(0), 10)];
         let mut baseline = mk_report(vec![mk_result_from_games("n", before)]);
@@ -1739,10 +1815,69 @@ mod tests {
         baseline.games_per_matchup = 1;
         current.games_per_matchup = 2;
 
-        let report = compare(&baseline, &current, &CompareOptions).expect("must not refuse");
-        assert_eq!(report.rows[0].unpaired_current, 1);
-        assert_eq!(report.rows[0].status, CompareStatus::Warn);
-        assert!(!report.any_fail());
+        // PREMISE: the two fields that already gated are equal, so the refusal below can only
+        // come from the new one.
+        assert_eq!(baseline.base_seed, current.base_seed);
+        assert_eq!(baseline.difficulty, current.difficulty);
+
+        let err = compare(&baseline, &current, &CompareOptions).expect_err("must refuse");
+        assert!(
+            matches!(&err, CompareError::WorkloadMismatch { field, .. } if *field == "games_per_matchup"),
+            "unexpected error: {err:?}"
+        );
+
+        // Both values reach the reader, so the drift issue says which knob to turn.
+        let body = render_error_markdown(&err);
+        assert!(body.contains("games_per_matchup"), "{body}");
+        assert!(body.contains("baseline=1"), "{body}");
+        assert!(body.contains("current=2"), "{body}");
+        assert!(body.contains("--refresh-baseline"), "{body}");
+    }
+
+    /// The workflow's two conditions for posting a drift issue, asserted together on the refusal
+    /// path: a non-zero exit (`if: steps.gate.outcome == 'failure'`) AND a non-empty stdout body
+    /// (`if [ ! -s target/ai-gate-report.md ]; then ... exit 1`). Pinning one alone cannot see
+    /// the failure this change exists to prevent — the pre-change behaviour satisfied neither on
+    /// a mismatched workload, and printing the refusal to stderr alone would satisfy only the
+    /// first, producing a red job whose issue body is empty.
+    #[test]
+    fn a_refused_comparison_exits_nonzero_and_still_writes_a_report_body() {
+        let mut baseline = mk_report(vec![mk_result("n", 5, 10, SuiteStatus::Pass)]);
+        let current = mk_report(vec![mk_result("n", 5, 10, SuiteStatus::Pass)]);
+        baseline.games_per_matchup = 99;
+
+        let (body, code) = gate_verdict(&compare(&baseline, &current, &CompareOptions));
+        assert_eq!(code, 2, "a refusal must fail the gate step");
+        assert!(!body.trim().is_empty(), "the report body must not be empty");
+        assert!(body.contains("games_per_matchup"), "{body}");
+    }
+
+    /// Control arm for the test above: `gate_verdict` must not be a constant. An implementation
+    /// returning `(something, 2)` for everything would satisfy the refusal assertions completely
+    /// while breaking every green run, so the three outcomes are pinned to three distinct codes
+    /// — and each carries a body, because the nightly aborts on an empty report file whatever
+    /// the exit code was.
+    #[test]
+    fn gate_verdict_maps_each_outcome_to_its_own_exit_code() {
+        let clean = mk_report(vec![mk_result("n", 5, 10, SuiteStatus::Pass)]);
+        let (pass_body, pass_code) = gate_verdict(&compare(&clean, &clean, &CompareOptions));
+        assert_eq!(pass_code, 0);
+        assert!(pass_body.contains("compare: 0 FAIL"), "{pass_body}");
+
+        // A matchup that regressed into Fail: a comparison that succeeded and found drift.
+        let regressed = mk_report(vec![mk_result("n", 5, 10, SuiteStatus::Fail)]);
+        let comparison = compare(&clean, &regressed, &CompareOptions);
+        // PREMISE: this really is the drift path, not another refusal.
+        assert!(comparison.as_ref().expect("must compare").any_fail());
+        let (fail_body, fail_code) = gate_verdict(&comparison);
+        assert_eq!(fail_code, 1);
+        assert!(fail_body.contains("| n |"), "{fail_body}");
+
+        let mut incomparable = clean.clone();
+        incomparable.schema_version += 1;
+        let (err_body, err_code) = gate_verdict(&compare(&incomparable, &clean, &CompareOptions));
+        assert_eq!(err_code, 2);
+        assert!(err_body.contains("schema_version"), "{err_body}");
     }
 
     #[test]
@@ -1849,6 +1984,69 @@ mod tests {
     /// same cell count, or the table renders broken in the nightly drift issue that
     /// `.github/workflows/ai-gate.yml` posts. Exercises all four row shapes at once: a paired row
     /// that warns (so its reason continuation is emitted), a New row, and a Removed row.
+    /// Count the `|` characters a markdown parser would treat as cell boundaries.
+    ///
+    /// A pipe is a separator iff the run of backslashes immediately before it has EVEN length:
+    /// each pair is one literal backslash, and an odd leftover escapes the pipe. The obvious
+    /// "is the previous character a backslash" test is what this replaces — it is right for `\|`
+    /// and wrong for `\\|`, which is a literal backslash followed by a LIVE separator, and being
+    /// wrong in exactly that direction it would call a broken encoder green.
+    fn md_separator_count(line: &str) -> usize {
+        line.char_indices()
+            .filter(|(i, c)| {
+                *c == '|' && line[..*i].chars().rev().take_while(|p| *p == '\\').count() % 2 == 0
+            })
+            .count()
+    }
+
+    /// The escape order inside `md_cell`, pinned from the outside. Escaping pipes before
+    /// backslashes turns the input `\|` into `\\|` — an escaped backslash followed by a live
+    /// separator — so the one input that already looks escaped is the one that breaks the row.
+    /// `fail_reason` is free-form text from a JSON report, so a backslash is reachable input.
+    ///
+    /// Both parities are exercised, because an encoder can be wrong in either direction: `\|`
+    /// (odd run, must stay content) and `\\|` (even run, a real separator that must be escaped
+    /// into the cell). A fixture carrying only one of them cannot distinguish the two.
+    #[test]
+    fn a_backslash_before_a_pipe_cannot_smuggle_a_separator() {
+        let reason = r"odd \| even \\| tail";
+        let baseline = mk_report(vec![mk_result("m", 5, 10, SuiteStatus::Pass)]);
+        let mut current = mk_report(vec![mk_result("m", 5, 10, SuiteStatus::Fail)]);
+        current.results[0].fail_reason = Some(reason.to_string());
+
+        let report = compare(&baseline, &current, &CompareOptions).unwrap();
+        let rendered = render_markdown(&report);
+
+        // PREMISE: the reason really was rendered, so the row below exists.
+        assert!(rendered.contains("tail"), "reason must render:\n{rendered}");
+
+        let widths: Vec<usize> = rendered
+            .lines()
+            .filter(|l| l.starts_with('|'))
+            .map(md_separator_count)
+            .collect();
+        assert!(widths.len() >= 3, "expected a reason row: {widths:?}");
+        assert!(
+            widths.iter().all(|w| *w == widths[0]),
+            "a backslash run changed the column count: {widths:?}\n{rendered}"
+        );
+
+        // CONTROL: the previous implementation, inlined, on this same input. Without this the
+        // assertion above could be passing for a reason unrelated to the escape order.
+        let pipes_first = |t: &str| t.replace('|', r"\|").replace(['\n', '\r'], " ");
+        let old_row = format!("|  ↳ _{}_ |", pipes_first(reason));
+        let new_row = format!("|  ↳ _{}_ |", md_cell(reason));
+        assert_eq!(
+            md_separator_count(&new_row),
+            2,
+            "the fixed encoder must emit exactly the two boundaries this row owns: {new_row}"
+        );
+        assert!(
+            md_separator_count(&old_row) > 2,
+            "fixture is not discriminating — the old encoder must leak a separator: {old_row}"
+        );
+    }
+
     /// Reachability arm for `md_cell`. `markdown_rows_are_rectangular` asserted the property
     /// this test is named for, but every one of its fixtures was pipe-free — so it passed for
     /// a reason unrelated to the hazard and gave false confidence about exactly the invariant
@@ -1875,18 +2073,10 @@ mod tests {
 
         // Every row — header, separator, data, and the reason continuation — must have the
         // same cell count. An unescaped pipe shows up here as a longer row.
-        // Count SEPARATORS the way a markdown parser does — a `|` preceded by a backslash is
-        // cell content, not a boundary. Splitting on the raw character cannot tell the escape
-        // from the hazard, so it would report this test green against a broken encoder.
-        let separators = |line: &str| {
-            line.char_indices()
-                .filter(|(i, c)| *c == '|' && (*i == 0 || !line[..*i].ends_with('\\')))
-                .count()
-        };
         let widths: Vec<usize> = rendered
             .lines()
             .filter(|l| l.starts_with('|'))
-            .map(separators)
+            .map(md_separator_count)
             .collect();
         assert!(widths.len() >= 4, "expected a reason row too: {widths:?}");
         assert!(

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 
 use super::run::{GameResult, MatchupResult, SuiteReport, SuiteStatus};
-use super::{Expected, FeatureKind};
+use super::{refusal_markdown, Expected, FeatureKind};
 
 const MIRROR_AVG_TURN_WARN_DELTA: f64 = 3.0;
 
@@ -800,28 +800,49 @@ pub fn print_markdown(report: &CompareReport) {
 /// The report body for a comparison that could not be made at all.
 ///
 /// A refused comparison is the case most likely to be read by someone who did not run it: the
-/// nightly captures stdout into `target/ai-gate-report.md` and posts it as a drift issue, and it
-/// posts nothing when that file is empty. Writing the refusal only to stderr would therefore turn
-/// a hard, correct refusal into "AI gate failed without a drift report" — a red job with no
-/// statement of what is wrong. The remedy is named per field, because the reader of the issue is
-/// the person who has to choose between re-recording the baseline and changing the workload.
+/// nightly captures stdout into `target/ai-gate-report.md` and posts it as a drift issue.
+///
+/// The reason is NOT that stderr-only would leave that file empty. Review measured the opposite:
+/// `run_suite` prints the suite's own table to stdout before the baseline is ever loaded
+/// (`run.rs`, `print_markdown_table`), so on this path the file always has content and the
+/// workflow's empty-file abort is unreachable. What a stderr-only refusal actually produces is
+/// worse to read than an empty file: a red job whose issue body is a table of PASSing matchups
+/// and no statement of what failed. (An earlier draft of this comment asserted the empty-file
+/// story, which was false here — though it is true of `ai-perf-gate`, whose refusal path this
+/// commit fixes for exactly that reason.)
 pub fn render_error_markdown(err: &CompareError) -> String {
     let remedy = match err {
-        CompareError::WorkloadMismatch { field, .. } => format!(
+        CompareError::WorkloadMismatch {
+            field,
+            baseline,
+            current,
+        } => format!(
             "The two reports were produced under different `{field}`, so their seeds do not \
-             denote the same games and no verdict can be built by pairing them. Either re-record \
-             the baseline under the current workload (`cargo ai-gate --refresh-baseline` with the \
-             same flags this run used) or run the gate under the baseline's workload. This is not \
-             drift: nothing was measured."
+             denote the same games and no verdict can be built by pairing them. This is not \
+             drift: nothing was measured.\n\n\
+             Two remedies. Pick the workload this gate should measure at, then make EVERY \
+             invocation that reads this baseline use it — the baseline file is shared, so \
+             re-recording it to suit one job starts failing this same check in every other job \
+             that compares against it at a different workload.\n\n\
+             1. **Move the baseline to `{current}`** — re-record it under the workload this run \
+             used (`cargo ai-gate --refresh-baseline` with this run's flags), AND align every \
+             other invocation that compares against it.\n\
+             2. **Move this run to `{baseline}`** — invoke the gate under the workload the \
+             baseline was recorded at (for `games_per_matchup`, the `--games` flag). Touches \
+             nothing else.\n\n\
+             Until one of them is done this gate fails every run, by design: a verdict built \
+             from a fraction of the sample is not a verdict."
         ),
         CompareError::SchemaMismatch { .. } => "The baseline predates the current report format. \
              Re-record it with `cargo ai-gate --refresh-baseline`."
             .to_string(),
         CompareError::Io(_) | CompareError::Parse(_) => {
-            "The baseline could not be read. Check the path and the file's contents.".to_string()
+            "The baseline could not be read. Check the path, and that the file is the JSON a \
+             previous `--refresh-baseline` wrote."
+                .to_string()
         }
     };
-    format!("## AI gate: comparison refused\n\n**{err}**\n\n{remedy}\n")
+    refusal_markdown(err, &remedy)
 }
 
 /// What the gate prints on stdout and what it exits with, decided together.
@@ -1831,7 +1852,68 @@ mod tests {
         assert!(body.contains("games_per_matchup"), "{body}");
         assert!(body.contains("baseline=1"), "{body}");
         assert!(body.contains("current=2"), "{body}");
-        assert!(body.contains("--refresh-baseline"), "{body}");
+
+        // BOTH remedies, named with their concrete target values. One-remedy text reads as
+        // "you must re-record", which is the more expensive of the two and not always the
+        // one the reader wants — and a reader who believes it is the only option will take
+        // it. Each direction is asserted through the value it moves TO, so a text that names
+        // both remedies but transposes their targets fails here.
+        assert!(
+            body.contains("--refresh-baseline"),
+            "refresh remedy missing: {body}"
+        );
+        assert!(body.contains("--games"), "re-run remedy missing: {body}");
+        assert!(
+            body.contains("Move the baseline to `2`"),
+            "remedy 1 must target the CURRENT workload: {body}"
+        );
+        assert!(
+            body.contains("Move this run to `1`"),
+            "remedy 2 must target the BASELINE workload: {body}"
+        );
+    }
+
+    /// Every refusal variant renders a body, including the two `compare` itself cannot produce.
+    ///
+    /// `Io` and `Parse` are reachable only through `load_report`, which `bin/ai_gate.rs` calls
+    /// before `compare` — review found that arm was written and unreachable, because the caller
+    /// that could hit it was still failing to stderr alone. That caller is now wired to this
+    /// function, and this test covers the arm regardless of which caller reaches it.
+    ///
+    /// The `assert_ne!` against the bare `Display` is the discriminating half: an implementation
+    /// that forwarded the error string would satisfy every other assertion here while losing the
+    /// remedy, and losing the remedy is the whole failure mode.
+    #[test]
+    fn every_refusal_renders_a_body_that_says_more_than_the_error_line() {
+        let io = CompareError::Io(std::io::Error::other("disk"));
+        let parse = CompareError::Parse(serde_json::from_str::<SuiteReport>("{").unwrap_err());
+        let schema = CompareError::SchemaMismatch {
+            baseline: 1,
+            current: 2,
+        };
+        let workload = CompareError::WorkloadMismatch {
+            field: "games_per_matchup",
+            baseline: "10".to_string(),
+            current: "100".to_string(),
+        };
+
+        for err in [&io, &parse, &schema, &workload] {
+            let body = render_error_markdown(err);
+            assert!(!body.trim().is_empty(), "empty body for {err:?}");
+            assert!(
+                body.contains("## Gate: comparison refused"),
+                "missing heading for {err:?}: {body}"
+            );
+            assert!(
+                body.contains(&err.to_string()),
+                "body must carry the error itself for {err:?}: {body}"
+            );
+            assert_ne!(
+                body.trim(),
+                err.to_string().trim(),
+                "body must add a remedy, not echo the error, for {err:?}"
+            );
+        }
     }
 
     /// The workflow's two conditions for posting a drift issue, asserted together on the refusal
@@ -1862,7 +1944,14 @@ mod tests {
         let clean = mk_report(vec![mk_result("n", 5, 10, SuiteStatus::Pass)]);
         let (pass_body, pass_code) = gate_verdict(&compare(&clean, &clean, &CompareOptions));
         assert_eq!(pass_code, 0);
-        assert!(pass_body.contains("compare: 0 FAIL"), "{pass_body}");
+        // The WHOLE line, not `contains("compare: 0 FAIL")`. Four of five counters are zero on
+        // this fixture, so the substring form is invariant under transposing pass/warn, under
+        // zeroing every counter, and under deleting the tally loop outright — measured, all
+        // three still contain it. A count that is only ever asserted at zero is not asserted.
+        assert!(
+            pass_body.contains("compare: 0 FAIL, 0 WARN, 1 PASS, 0 NEW, 0 REMOVED"),
+            "{pass_body}"
+        );
 
         // A matchup that regressed into Fail: a comparison that succeeded and found drift.
         let regressed = mk_report(vec![mk_result("n", 5, 10, SuiteStatus::Fail)]);
@@ -1873,11 +1962,35 @@ mod tests {
         assert_eq!(fail_code, 1);
         assert!(fail_body.contains("| n |"), "{fail_body}");
 
+        // A tally with two DISTINCT non-zero counters, so no pair of counters can be
+        // transposed without changing the rendered line. `1 PASS` and `2 NEW` are different
+        // numbers in different slots; the single-row fixture above cannot see that.
+        let mut widened = clean.clone();
+        widened
+            .results
+            .push(mk_result("fresh-a", 5, 10, SuiteStatus::Pass));
+        widened
+            .results
+            .push(mk_result("fresh-b", 5, 10, SuiteStatus::Pass));
+        let (mixed_body, mixed_code) = gate_verdict(&compare(&clean, &widened, &CompareOptions));
+        assert_eq!(mixed_code, 0);
+        assert!(
+            mixed_body.contains("compare: 0 FAIL, 0 WARN, 1 PASS, 2 NEW, 0 REMOVED"),
+            "{mixed_body}"
+        );
+
         let mut incomparable = clean.clone();
         incomparable.schema_version += 1;
         let (err_body, err_code) = gate_verdict(&compare(&incomparable, &clean, &CompareOptions));
         assert_eq!(err_code, 2);
+        // `schema_version` comes from the Display impl, so it does NOT pin the remedy text or
+        // the heading. Both are asserted separately or they can be emptied in silence.
         assert!(err_body.contains("schema_version"), "{err_body}");
+        assert!(
+            err_body.contains("## Gate: comparison refused"),
+            "{err_body}"
+        );
+        assert!(err_body.contains("--refresh-baseline"), "{err_body}");
     }
 
     #[test]
@@ -1980,10 +2093,6 @@ mod tests {
         assert_eq!(cell(&rendered, "shifted", "status"), "FAIL");
     }
 
-    /// Every emitted row — header, separator, data, and the reason continuation — must have the
-    /// same cell count, or the table renders broken in the nightly drift issue that
-    /// `.github/workflows/ai-gate.yml` posts. Exercises all four row shapes at once: a paired row
-    /// that warns (so its reason continuation is emitted), a New row, and a Removed row.
     /// Count the `|` characters a markdown parser would treat as cell boundaries.
     ///
     /// A pipe is a separator iff the run of backslashes immediately before it has EVEN length:
@@ -2045,6 +2154,36 @@ mod tests {
             md_separator_count(&old_row) > 2,
             "fixture is not discriminating — the old encoder must leak a separator: {old_row}"
         );
+
+        // Trailing backslashes, asserted on the ENCODER rather than on row width, and the
+        // distinction is the point. Cells are joined with `" | "`, so a trailing backslash is
+        // separated from the boundary by a space and the row stays rectangular under BOTH
+        // encoders — a width assertion here would pass for a reason unrelated to the bug.
+        // The property that does separate them is that an emitted cell never ends in an ODD
+        // backslash run, since the very next character the renderer writes is a separator's
+        // neighbourhood. Runs 0..=4 cover both parities and the boundary case of none.
+        for run in 0..=4usize {
+            let input = format!("tail{}", "\\".repeat(run));
+            let encoded = md_cell(&input);
+            let trailing = encoded.chars().rev().take_while(|c| *c == '\\').count();
+            assert_eq!(
+                trailing % 2,
+                0,
+                "run of {run} must encode to an even trailing run, got {trailing}: {encoded:?}"
+            );
+            // CONTROL: the previous encoder leaves odd runs odd, so this loop is discriminating
+            // for every odd `run` rather than trivially true.
+            let old_trailing = pipes_first(&input)
+                .chars()
+                .rev()
+                .take_while(|c| *c == '\\')
+                .count();
+            assert_eq!(
+                old_trailing % 2,
+                run % 2,
+                "control drifted — the old encoder must preserve run parity: {input:?}"
+            );
+        }
     }
 
     /// Reachability arm for `md_cell`. `markdown_rows_are_rectangular` asserted the property
@@ -2085,6 +2224,10 @@ mod tests {
         );
     }
 
+    /// Every emitted row — header, separator, data, and the reason continuation — must have the
+    /// same cell count, or the table renders broken in the nightly drift issue that
+    /// `.github/workflows/ai-gate.yml` posts. Exercises all four row shapes at once: a paired row
+    /// that warns (so its reason continuation is emitted), a New row, and a Removed row.
     #[test]
     fn markdown_rows_are_rectangular() {
         let paired_before: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -836,9 +836,12 @@ pub fn render_error_markdown(err: &CompareError) -> String {
         CompareError::SchemaMismatch { .. } => "The baseline predates the current report format. \
              Re-record it with `cargo ai-gate --refresh-baseline`."
             .to_string(),
+        // "report", not "baseline": `ai-duel compare` now renders this arm for a failure on
+        // EITHER input, so naming the baseline would send the reader to the wrong file half the
+        // time. The side and the exact path are on stderr, where they are known.
         CompareError::Io(_) | CompareError::Parse(_) => {
-            "The baseline could not be read. Check the path, and that the file is the JSON a \
-             previous `--refresh-baseline` wrote."
+            "The report could not be read. Check the path named on stderr, and that the file is \
+             the JSON a previous `--refresh-baseline` wrote."
                 .to_string()
         }
     };

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -38,10 +38,24 @@ pub struct CompareRow {
     pub baseline: Option<MatchupResult>,
     pub current: Option<MatchupResult>,
     pub delta_p0_pp: Option<f32>,
+    /// `current.avg_turns - baseline.avg_turns`. Carried on the row, not only inside a reason
+    /// string: the verdict chain is first-match-wins, so whichever arm fires suppresses every
+    /// other arm's message. Every axis the chain can decide on therefore gets a column of its
+    /// own, and this was the last one without.
+    pub avg_turn_delta: Option<f64>,
+    /// `Some((baseline, current))` when the matchup's own suite verdict changed, `None` when it
+    /// held. The third axis this chain decides on, and like the other two it needs a surface of
+    /// its own — a row that fails on paired outcomes prints only that reason.
+    pub suite_status_shift: Option<(SuiteStatus, SuiteStatus)>,
     pub flipped_w_to_l: usize,
     pub flipped_l_to_w: usize,
+    /// `Some(_) → None` — games that stopped resolving. See `PairedSeedShift`.
+    pub decisive_to_draw: usize,
+    /// `None → Some(_)` — games that started resolving.
+    pub draw_to_decisive: usize,
     pub unchanged: usize,
     pub sign_test_p: Option<f64>,
+    pub draw_sign_test_p: Option<f64>,
     pub status: CompareStatus,
     pub reason: Option<String>,
 }
@@ -159,10 +173,15 @@ fn classify_row(
             baseline: Some(b.clone()),
             current: None,
             delta_p0_pp: None,
+            avg_turn_delta: None,
+            suite_status_shift: None,
             flipped_w_to_l: 0,
             flipped_l_to_w: 0,
+            decisive_to_draw: 0,
+            draw_to_decisive: 0,
             unchanged: 0,
             sign_test_p: None,
+            draw_sign_test_p: None,
             status: CompareStatus::Removed,
             reason: Some("matchup removed from current report".to_string()),
         },
@@ -183,10 +202,15 @@ fn classify_row(
                 baseline: None,
                 current: Some(c.clone()),
                 delta_p0_pp: None,
+                avg_turn_delta: None,
+                suite_status_shift: None,
                 flipped_w_to_l: 0,
                 flipped_l_to_w: 0,
+                decisive_to_draw: 0,
+                draw_to_decisive: 0,
                 unchanged: 0,
                 sign_test_p: None,
+                draw_sign_test_p: None,
                 status,
                 reason,
             }
@@ -198,6 +222,34 @@ fn classify_row(
             let paired = paired_seed_shift(b, c);
             let avg_turn_delta = c.avg_turns - b.avg_turns;
 
+            // TIER ORDER IS LOAD-BEARING. Two earlier drafts of this comment overclaimed what it
+            // buys — the first said "no input that reaches Fail or Warn today can change verdict"
+            // (false: Warn escalates), the second said "nothing with a flat draw axis changes
+            // verdict" (false once the status axis landed in the same commit). Both were caught by
+            // review running the claim through the compiled base. So, by construction and stated
+            // to its exact edge:
+            //
+            //   1. Nothing that reaches Fail today changes verdict. The W/L Fail arm is still
+            //      first and its counters are byte-identical to before, so it wins every input it
+            //      used to win.
+            //   2. A row whose draw counters are EQUAL and where NEITHER report's status is
+            //      `Fail` takes precisely the pre-change path. That is the full precondition, not
+            //      a draw-axis-only one: every new guard below needs either unequal draw counters
+            //      or a `Fail` on one side, so with both absent none can fire. This is what keeps
+            //      identity comparisons and every unaffected regression bit-for-bit unchanged.
+            //   3. A W/L *Warn* DOES escalate to Fail — via the draw Fail arm when the draw axis
+            //      is significantly negative, and via the status Fail arm when the matchup newly
+            //      fails its own suite check. Both escalations are intended: those are the
+            //      failures this gate exists to catch, and suppressing either because the win/loss
+            //      axis also wobbled insignificantly would reintroduce the same blindness one case
+            //      narrower. Pinned by `draw_regression_escalates_an_insignificant_win_loss_warn`
+            //      and `status_regression_escalates_an_insignificant_win_loss_warn` — one per
+            //      escalating arm, because a claim about an arm that no test exercises is how the
+            //      first two drafts of this comment stayed wrong.
+            //
+            // Do not reorder to group same-axis arms together: moving either Fail arm below the
+            // W/L Warn arm silently demotes its clause-3 escalation back to Warn. Both reorders
+            // are covered by the two tests named above.
             let (status, reason) = if paired.flipped_w_to_l > paired.flipped_l_to_w
                 && paired.sign_test_p.is_some_and(|p| p < 0.05)
             {
@@ -210,6 +262,41 @@ fn classify_row(
                         paired.sign_test_p.unwrap_or(1.0),
                     )),
                 )
+            } else if paired.decisive_to_draw > paired.draw_to_decisive
+                && paired.draw_sign_test_p.is_some_and(|p| p < 0.05)
+            {
+                // Games that used to resolve stopped resolving: the signature of a stalled or
+                // looping AI. Asymmetric BY CONSTRUCTION — this arm requires decisive→draw to
+                // dominate, so the improvement direction can never reach Fail through it.
+                (
+                    CompareStatus::Fail,
+                    Some(format!(
+                        "paired draw regression: decisive→draw={} draw→decisive={} sign-test p={:.4}",
+                        paired.decisive_to_draw,
+                        paired.draw_to_decisive,
+                        paired.draw_sign_test_p.unwrap_or(1.0),
+                    )),
+                )
+            } else if b.status != SuiteStatus::Fail && c.status == SuiteStatus::Fail {
+                // The matchup newly fails its OWN suite check (mirror imbalance, expectation
+                // violation). Without this arm the comparison read the paired game outcomes and
+                // nothing else, so a run could carry `status: "Fail"` on an existing matchup and
+                // still exit 0 — measured on `.ab/noC-1.json`, whose enchantress-mirror row is
+                // `status: "Fail"` while its compare section reported `0 FAIL, 0 WARN, 3 PASS`.
+                //
+                // Keyed on `Fail` specifically, not on any status change, because `Fail` is the
+                // only status this file already acts on: the new-matchup arm above matches
+                // `SuiteStatus::Fail` and treats `Pass`/`Open` alike. Same authority, same
+                // vocabulary, extended from new matchups to existing ones.
+                (
+                    CompareStatus::Fail,
+                    Some(format!(
+                        "matchup status regressed {:?} → {:?}: {}",
+                        b.status,
+                        c.status,
+                        c.fail_reason.as_deref().unwrap_or("no reason"),
+                    )),
+                )
             } else if paired.flipped_w_to_l != paired.flipped_l_to_w {
                 (
                     CompareStatus::Warn,
@@ -220,6 +307,49 @@ fn classify_row(
                         paired.sign_test_p.unwrap_or(1.0),
                     )),
                 )
+            } else if paired.decisive_to_draw != paired.draw_to_decisive {
+                // Any imbalance on the draw axis is reported, in either direction. The improvement
+                // direction (draw→decisive dominating) lands HERE and never above: a comparator
+                // that stayed silent about games that started resolving would be hiding a
+                // behavior change, which is the same reason the win/loss tier warns on L→W too.
+                (
+                    CompareStatus::Warn,
+                    Some(format!(
+                        "paired draw shift: decisive→draw={} draw→decisive={} sign-test p={:.4}",
+                        paired.decisive_to_draw,
+                        paired.draw_to_decisive,
+                        paired.draw_sign_test_p.unwrap_or(1.0),
+                    )),
+                )
+            } else if b.status == SuiteStatus::Fail {
+                // The baseline already recorded this matchup as failing. One arm, two messages,
+                // rather than two sibling arms: the axis is `b.status == Fail` and `c.status` is
+                // the parameter.
+                //
+                // Neither case can reach Fail — the arm above requires the regression direction —
+                // but neither may be silent either:
+                //   * Recovery is a behavior change, and a comparator that hid it would be as
+                //     wrong as one that hid a regression (the same reason the W/L tier warns on
+                //     L→W and the draw tier warns on draw→decisive).
+                //   * STILL failing is reported every run rather than passing quietly. Review
+                //     showed this is reachable, not theoretical: `--refresh-baseline` writes the
+                //     current report verbatim with no `any_fail` check, so one refresh from a
+                //     failing run would otherwise make that matchup exit 0 forever.
+                //
+                // It is a Warn and not a Fail deliberately: the exit code answers "did this change
+                // make things worse", and the baseline — however it got that way — already
+                // sanctions this state. Making a baseline-sanctioned failure red is a policy call
+                // about whether a baseline may bless a failure at all, which belongs with the
+                // `--refresh-baseline` guard in `bin/ai_gate.rs`, not here.
+                let reason = if c.status == SuiteStatus::Fail {
+                    format!(
+                        "matchup still failing (baseline also Fail): {}",
+                        c.fail_reason.as_deref().unwrap_or("no reason")
+                    )
+                } else {
+                    format!("matchup status recovered {:?} → {:?}", b.status, c.status)
+                };
+                (CompareStatus::Warn, Some(reason))
             } else if matches!(c.expected, Expected::Mirror { .. })
                 && avg_turn_delta.abs() > MIRROR_AVG_TURN_WARN_DELTA
             {
@@ -237,10 +367,15 @@ fn classify_row(
                 baseline: Some(b.clone()),
                 current: Some(c.clone()),
                 delta_p0_pp: Some(delta_pp),
+                avg_turn_delta: Some(avg_turn_delta),
+                suite_status_shift: (b.status != c.status).then_some((b.status, c.status)),
                 flipped_w_to_l: paired.flipped_w_to_l,
                 flipped_l_to_w: paired.flipped_l_to_w,
+                decisive_to_draw: paired.decisive_to_draw,
+                draw_to_decisive: paired.draw_to_decisive,
                 unchanged: paired.unchanged,
                 sign_test_p: paired.sign_test_p,
+                draw_sign_test_p: paired.draw_sign_test_p,
                 status,
                 reason,
             }
@@ -251,8 +386,15 @@ fn classify_row(
 struct PairedSeedShift {
     flipped_w_to_l: usize,
     flipped_l_to_w: usize,
+    /// `Some(_) → None`: a game that used to resolve no longer does. The regression signal —
+    /// the signature of a stalled or looping AI.
+    decisive_to_draw: usize,
+    /// `None → Some(_)`: a game that used to stall now resolves. The improvement signal.
+    draw_to_decisive: usize,
     unchanged: usize,
     sign_test_p: Option<f64>,
+    /// Sign test on the draw axis, computed exactly like `sign_test_p` is on the win/loss axis.
+    draw_sign_test_p: Option<f64>,
 }
 
 fn paired_seed_shift(baseline: &MatchupResult, current: &MatchupResult) -> PairedSeedShift {
@@ -260,16 +402,28 @@ fn paired_seed_shift(baseline: &MatchupResult, current: &MatchupResult) -> Paire
         current.games.iter().map(|game| (game.seed, game)).collect();
     let mut flipped_w_to_l = 0;
     let mut flipped_l_to_w = 0;
+    let mut decisive_to_draw = 0;
+    let mut draw_to_decisive = 0;
     let mut unchanged = 0;
 
     for baseline_game in &baseline.games {
         let Some(current_game) = current_by_seed.get(&baseline_game.seed) else {
             continue;
         };
+        // EXHAUSTIVE, no `_` fallback. The wildcard this replaces is how the decisive→draw class
+        // became invisible: it swept `Some(_) → None` into `unchanged`, so a matchup could lose
+        // most of its winners and the comparison would report no movement at all. Listing every
+        // shape means a future `winner` representation breaks the build instead of silently
+        // rejoining `unchanged`.
         match (baseline_game.winner, current_game.winner) {
             (Some(0), Some(1)) => flipped_w_to_l += 1,
             (Some(1), Some(0)) => flipped_l_to_w += 1,
-            _ => unchanged += 1,
+            (Some(_), None) => decisive_to_draw += 1,
+            (None, Some(_)) => draw_to_decisive += 1,
+            // Same winner, or drawn on both sides. Non-0/1 seat pairs land here as they always
+            // have — the duel suite is two-player, and changing that classification is out of
+            // this change's scope.
+            (Some(_), Some(_)) | (None, None) => unchanged += 1,
         }
     }
 
@@ -277,11 +431,18 @@ fn paired_seed_shift(baseline: &MatchupResult, current: &MatchupResult) -> Paire
     let sign_test_p =
         (flips > 0).then(|| sign_test_mid_p_upper_tail(flips, flipped_w_to_l.max(flipped_l_to_w)));
 
+    let draw_flips = decisive_to_draw + draw_to_decisive;
+    let draw_sign_test_p = (draw_flips > 0)
+        .then(|| sign_test_mid_p_upper_tail(draw_flips, decisive_to_draw.max(draw_to_decisive)));
+
     PairedSeedShift {
         flipped_w_to_l,
         flipped_l_to_w,
+        decisive_to_draw,
+        draw_to_decisive,
         unchanged,
         sign_test_p,
+        draw_sign_test_p,
     }
 }
 
@@ -320,11 +481,48 @@ fn status_str(s: CompareStatus) -> &'static str {
     }
 }
 
-/// Render a markdown table of the comparison to stdout + emit a summary line.
-pub fn print_markdown(report: &CompareReport) {
-    println!();
-    println!("| matchup | exercises | baseline p0% | current p0% | flips W→L | flips L→W | sign p | status |");
-    println!("|---------|-----------|--------------|-------------|-----------|-----------|--------|--------|");
+/// The column headers, in order. Named once so tests can assert that every axis the verdict chain
+/// decides on has a surface here — see `COLUMNS` usage in `render_markdown` and the invariant below.
+const COLUMNS: &[&str] = &[
+    "matchup",
+    "exercises",
+    "baseline p0%",
+    "current p0%",
+    "flips W→L",
+    "flips L→W",
+    "sign p",
+    "dec→draw",
+    "draw→dec",
+    "draw sign p",
+    "Δ avg turns",
+    "suite status",
+    "status",
+];
+
+/// Build the markdown table as a string.
+///
+/// INVARIANT: every axis the verdict chain can decide on has a column here. The chain is
+/// first-match-wins, so whichever arm fires suppresses every other arm's reason string — a row that
+/// warns on the win/loss axis printed only the W/L reason and hid its draw movement, and a row that
+/// warns on the draw axis hid its mirror avg-turn drift the same way. Columns are the only surface
+/// that survives that suppression, so each axis owns one: W/L flips + sign p, draw counters + draw
+/// sign p, avg-turn delta, and suite status. **Adding a verdict arm means adding a column.**
+///
+/// Separated from `print_markdown` so that invariant is enforced by tests rather than asserted in a
+/// comment: `markdown_has_a_column_for_every_verdict_axis` and `markdown_rows_are_rectangular` read
+/// this string. When it was inlined in a `println!`, both new columns could be deleted with the
+/// whole suite still green.
+fn render_markdown(report: &CompareReport) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("| {} |\n", COLUMNS.join(" | ")));
+    out.push_str(&format!(
+        "|{}|\n",
+        COLUMNS
+            .iter()
+            .map(|c| "-".repeat(c.chars().count() + 2))
+            .collect::<Vec<_>>()
+            .join("|")
+    ));
     for row in &report.rows {
         let exercises: Vec<String> = row.exercises.iter().map(|f| format!("{f:?}")).collect();
         let baseline_cell = match &row.baseline {
@@ -339,23 +537,58 @@ pub fn print_markdown(report: &CompareReport) {
             Some(p) => format!("{p:.4}"),
             None => "—".to_string(),
         };
-        println!(
-            "| {} | {} | {} | {} | {} | {} | {} | {} |",
-            row.matchup_id,
+        let draw_sign_p_cell = match row.draw_sign_test_p {
+            Some(p) => format!("{p:.4}"),
+            None => "—".to_string(),
+        };
+        let avg_turn_cell = match row.avg_turn_delta {
+            Some(d) => format!("{d:+.1}"),
+            None => "—".to_string(),
+        };
+        // Falls back to the CURRENT status when nothing shifted, so the column is populated on
+        // every row that has a current report — including new matchups, whose verdict is decided
+        // from `c.status` but which have no shift to show. A blank cell under a status-decided
+        // verdict would break the invariant above.
+        let suite_status_cell = match (row.suite_status_shift, row.current.as_ref()) {
+            (Some((before, after)), _) => format!("{before:?}→{after:?}"),
+            (None, Some(c)) => format!("{:?}", c.status),
+            (None, None) => "—".to_string(),
+        };
+        let cells = [
+            row.matchup_id.clone(),
             exercises.join(", "),
             baseline_cell,
             current_cell,
-            row.flipped_w_to_l,
-            row.flipped_l_to_w,
+            row.flipped_w_to_l.to_string(),
+            row.flipped_l_to_w.to_string(),
             sign_p_cell,
-            status_str(row.status),
-        );
+            row.decisive_to_draw.to_string(),
+            row.draw_to_decisive.to_string(),
+            draw_sign_p_cell,
+            avg_turn_cell,
+            suite_status_cell,
+            status_str(row.status).to_string(),
+        ];
+        debug_assert_eq!(cells.len(), COLUMNS.len());
+        out.push_str(&format!("| {} |\n", cells.join(" | ")));
         if let Some(reason) = &row.reason {
             if !matches!(row.status, CompareStatus::Pass) {
-                println!("|  ↳ _{reason}_ | | | | | | | |");
+                // Reason spans one labelled cell plus blanks for the rest, so the row stays
+                // rectangular no matter how many columns the table has.
+                out.push_str(&format!(
+                    "|  ↳ _{reason}_ |{}\n",
+                    " |".repeat(COLUMNS.len() - 1)
+                ));
             }
         }
     }
+    out
+}
+
+/// Render the comparison table to stdout + emit a summary line.
+pub fn print_markdown(report: &CompareReport) {
+    println!();
+    print!("{}", render_markdown(report));
 
     let mut pass = 0usize;
     let mut warn = 0usize;
@@ -427,6 +660,982 @@ mod tests {
         }
     }
 
+    /// Build a matchup from explicit `(seed, winner, turns)` rows, so a fixture can carry a
+    /// REAL recorded run instead of the synthetic win/loss ladder `mk_result` generates.
+    fn mk_result_from_games(id: &str, rows: &[(u64, Option<u8>, u32)]) -> MatchupResult {
+        let games: Vec<GameResult> = rows
+            .iter()
+            .map(|(seed, winner, turns)| GameResult {
+                seed: *seed,
+                winner: *winner,
+                turns: *turns,
+            })
+            .collect();
+        let p0_wins = games.iter().filter(|g| g.winner == Some(0)).count();
+        let p1_wins = games.iter().filter(|g| g.winner == Some(1)).count();
+        let draws = games.iter().filter(|g| g.winner.is_none()).count();
+        MatchupResult {
+            matchup_id: id.into(),
+            exercises: vec![FeatureKind::AggroPressure],
+            p0_label: "A".into(),
+            p1_label: "B".into(),
+            expected: Expected::Mirror { tolerance: 0.15 },
+            p0_wins,
+            p1_wins,
+            draws,
+            games,
+            total_turns: 0,
+            total_duration_ms: 0,
+            avg_turns: 10.0,
+            avg_duration_ms: 1000.0,
+            status: SuiteStatus::Pass,
+            fail_reason: None,
+            attribution: None,
+        }
+    }
+
+    /// **P2 — the paired-seed shift is blind to decisive→draw.**
+    ///
+    /// HISTORICAL, not synthetic. These ten rows are the committed `suite-baseline.json`'s
+    /// `enchantress-mirror` games paired by seed against a real recorded gate run
+    /// (`.ab/noC-1.json`, the A+B+D leg of #6969). Eight of the ten stopped having a winner —
+    /// baseline 4 p0 / 6 p1 / 0 draws became 1 / 1 / **8**.
+    ///
+    /// `paired_seed_shift` only recognizes `Some(0)→Some(1)` and `Some(1)→Some(0)`; every
+    /// `Some(_)→None` falls into the `_` arm and is tallied as UNCHANGED. So `flips == 0`,
+    /// `sign_test_p == None`, and the comparison PASSES a matchup in which 80% of the games
+    /// stopped resolving. That is the exact signature of a stalled or looping AI, and a branch
+    /// that drew every game would pass this gate.
+    #[test]
+    fn paired_seed_shift_counts_decisive_to_draw_as_a_shift() {
+        let baseline = mk_result_from_games(
+            "enchantress-mirror",
+            &[
+                (10593729, Some(1), 10),
+                (10593730, Some(0), 18),
+                (10593731, Some(1), 12),
+                (10593732, Some(1), 14),
+                (10593733, Some(1), 11),
+                (10593734, Some(0), 15),
+                (10593735, Some(0), 15),
+                (10593736, Some(0), 14),
+                (10593737, Some(1), 18),
+                (10593738, Some(1), 19),
+            ],
+        );
+        let current = mk_result_from_games(
+            "enchantress-mirror",
+            &[
+                (10593729, None, 8),
+                (10593730, None, 12),
+                (10593731, Some(1), 12),
+                (10593732, None, 11),
+                (10593733, None, 9),
+                (10593734, None, 12),
+                (10593735, Some(0), 15),
+                (10593736, None, 13),
+                (10593737, None, 17),
+                (10593738, None, 9),
+            ],
+        );
+
+        // PREMISE: the fixture really carries the shift it claims (8 lost winners, 2 kept).
+        assert_eq!(
+            baseline.draws, 0,
+            "premise: the baseline matchup had no draws"
+        );
+        assert_eq!(current.draws, 8, "premise: the recorded run drew 8 of 10");
+
+        let shift = paired_seed_shift(&baseline, &current);
+
+        // Before this change these eight landed in a `_ => unchanged` arm and `unchanged` read 10.
+        assert_eq!(
+            shift.unchanged, 2,
+            "eight games stopped having a winner; they are a SHIFT, not 'unchanged'"
+        );
+        assert_eq!(
+            (shift.decisive_to_draw, shift.draw_to_decisive),
+            (8, 0),
+            "the shift is eight decisive→draw, none back"
+        );
+        // The W/L axis is genuinely silent here, and that is CORRECT — no game changed which
+        // player won. Pinned so the fix is read as adding a second axis, not as repairing the
+        // first: a fix that started reporting W→L flips for these rows would be wrong.
+        assert_eq!(
+            (shift.flipped_w_to_l, shift.flipped_l_to_w),
+            (0, 0),
+            "PIN: no directional win/loss flip occurred; the shift is entirely decisive→draw"
+        );
+    }
+
+    /// The end-to-end consequence: the matchup must NOT pass.
+    ///
+    /// This is the claim that matters to a reviewer — not that a private counter is wrong, but
+    /// that `cargo ai-gate`'s comparison reported no problem for a run in which 8 of 10 games
+    /// stopped resolving. Both matchups are marked `Pass` in their own right (the suite-status
+    /// half is a separate check), so this row isolates the COMPARISON's verdict.
+    ///
+    /// Measured before the fix: `CompareStatus::Pass`.
+    #[test]
+    fn compare_fails_a_matchup_that_lost_eight_of_ten_winners() {
+        let rows_before: &[(u64, Option<u8>, u32)] = &[
+            (10593729, Some(1), 10),
+            (10593730, Some(0), 18),
+            (10593731, Some(1), 12),
+            (10593732, Some(1), 14),
+            (10593733, Some(1), 11),
+            (10593734, Some(0), 15),
+            (10593735, Some(0), 15),
+            (10593736, Some(0), 14),
+            (10593737, Some(1), 18),
+            (10593738, Some(1), 19),
+        ];
+        let rows_after: &[(u64, Option<u8>, u32)] = &[
+            (10593729, None, 8),
+            (10593730, None, 12),
+            (10593731, Some(1), 12),
+            (10593732, None, 11),
+            (10593733, None, 9),
+            (10593734, None, 12),
+            (10593735, Some(0), 15),
+            (10593736, None, 13),
+            (10593737, None, 17),
+            (10593738, None, 9),
+        ];
+        let baseline = mk_report(vec![mk_result_from_games(
+            "enchantress-mirror",
+            rows_before,
+        )]);
+        let current = mk_report(vec![mk_result_from_games("enchantress-mirror", rows_after)]);
+
+        let result = compare(&baseline, &current, &CompareOptions).unwrap();
+        assert_eq!(result.rows.len(), 1, "premise: exactly one paired matchup");
+
+        // n=8, k=8 ⇒ mid-p = 1/512 ≈ 0.00195 < 0.05, so this reaches Fail, not merely Warn.
+        assert_eq!(
+            result.rows[0].status,
+            CompareStatus::Fail,
+            "8 of 10 games stopped having a winner — the comparison must not report Pass; reason={:?}",
+            result.rows[0].reason
+        );
+        // The counters and their ORDER are pinned, not just the word "draw": transposing them in
+        // the reason string would report the recorded incident as an improvement.
+        assert!(
+            result.rows[0]
+                .reason
+                .as_deref()
+                .is_some_and(|r| r.contains("decisive→draw=8 draw→decisive=0")),
+            "reason={:?}",
+            result.rows[0].reason
+        );
+        assert!(result.any_fail(), "the compare exit code must reflect it");
+    }
+
+    /// TRIVIALIZE control. A fix that failed on ANY draw-axis movement, ignoring direction and
+    /// significance, would pass every other test in this module — including both demonstration
+    /// rows — and would be wrong. Games that STARTED resolving are an improvement.
+    ///
+    /// Same magnitude as the regression row (8 of 10), opposite direction. Must be Warn: reported
+    /// because any imbalance is worth surfacing, never Fail.
+    #[test]
+    fn draw_to_decisive_improvement_warns_but_never_fails() {
+        let stalled: &[(u64, Option<u8>, u32)] = &[
+            (1, None, 8),
+            (2, None, 12),
+            (3, Some(1), 12),
+            (4, None, 11),
+            (5, None, 9),
+            (6, None, 12),
+            (7, Some(0), 15),
+            (8, None, 13),
+            (9, None, 17),
+            (10, None, 9),
+        ];
+        let resolving: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(1), 10),
+            (2, Some(0), 18),
+            (3, Some(1), 12),
+            (4, Some(1), 14),
+            (5, Some(1), 11),
+            (6, Some(0), 15),
+            (7, Some(0), 15),
+            (8, Some(0), 14),
+            (9, Some(1), 18),
+            (10, Some(1), 19),
+        ];
+        let baseline = mk_report(vec![mk_result_from_games("enchantress-mirror", stalled)]);
+        let current = mk_report(vec![mk_result_from_games("enchantress-mirror", resolving)]);
+
+        let result = compare(&baseline, &current, &CompareOptions).unwrap();
+        assert_eq!(
+            result.rows[0].draw_to_decisive, 8,
+            "premise: this fixture really is the improvement direction"
+        );
+        assert_eq!(
+            result.rows[0].decisive_to_draw, 0,
+            "premise: nothing regressed on the draw axis"
+        );
+        // The statistic is computed on `max(decisive_to_draw, draw_to_decisive)`, so it must read
+        // the DOMINANT direction whichever one that is. Replacing the `max` with `decisive_to_draw`
+        // leaves the verdict correct (the Fail arm's dominance guard protects it) but prints
+        // 0.9980 instead of 0.0020 in the reason string and the `draw sign p` column.
+        assert!(
+            result.rows[0].draw_sign_test_p.is_some_and(|p| p < 0.05),
+            "the reported statistic must describe the 8-0 shift, not its complement; got {:?}",
+            result.rows[0].draw_sign_test_p
+        );
+        assert_eq!(
+            result.rows[0].status,
+            CompareStatus::Warn,
+            "improvement is reported, never failed; reason={:?}",
+            result.rows[0].reason
+        );
+        assert!(!result.any_fail(), "an improvement must not fail the gate");
+    }
+
+    /// **The escalation the tier order actually produces.** An independent review measured this
+    /// input against both the pre-change and post-change comparator and found the earlier
+    /// "no input that reaches Fail or Warn today can change verdict" claim FALSE: the draw Fail
+    /// arm sits above the W/L Warn arm, so a Warn escalates to Fail.
+    ///
+    /// The escalation is intended — 8 of 11 games ceasing to resolve is the failure this gate
+    /// exists to catch, and suppressing it because the win/loss axis also wobbled insignificantly
+    /// would reintroduce the same blindness one case narrower. It is pinned here because the
+    /// claim that it *couldn't* happen was the reason it went untested.
+    ///
+    /// The two premise asserts below are what make this a proof of escalation without compiling
+    /// the old code: `sign_test_p > 0.05` means the W/L Fail arm cannot fire, and
+    /// `flipped_w_to_l != flipped_l_to_w` means the old chain fell to the W/L Warn arm. Warn
+    /// before, Fail now.
+    #[test]
+    fn draw_regression_escalates_an_insignificant_win_loss_warn() {
+        let before: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(0), 10),
+            (3, Some(0), 10),
+            (4, Some(1), 10),
+            (5, Some(1), 10),
+            (6, Some(1), 10),
+            (7, Some(1), 10),
+            (8, Some(1), 10),
+            (9, Some(1), 10),
+            (10, Some(1), 10),
+            (11, Some(1), 10),
+        ];
+        let after: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(1), 10),
+            (2, Some(1), 10),
+            (3, Some(1), 10),
+            (4, None, 10),
+            (5, None, 10),
+            (6, None, 10),
+            (7, None, 10),
+            (8, None, 10),
+            (9, None, 10),
+            (10, None, 10),
+            (11, None, 10),
+        ];
+        let baseline = mk_report(vec![mk_result_from_games("m", before)]);
+        let current = mk_report(vec![mk_result_from_games("m", after)]);
+        let row = &compare(&baseline, &current, &CompareOptions).unwrap().rows[0];
+
+        // PREMISE 1: the W/L Fail arm cannot be what fired — 3 flips one way is p=0.0625.
+        assert_eq!((row.flipped_w_to_l, row.flipped_l_to_w), (3, 0));
+        assert!(
+            row.sign_test_p.is_some_and(|p| p > 0.05),
+            "premise: the win/loss axis is INSIGNIFICANT, so the W/L Fail arm is out; got {:?}",
+            row.sign_test_p
+        );
+        // PREMISE 2: the old chain therefore reached the W/L Warn arm (`w2l != l2w`).
+        assert_ne!(
+            row.flipped_w_to_l, row.flipped_l_to_w,
+            "premise: this input used to land on the win/loss Warn arm"
+        );
+
+        assert_eq!(
+            row.status,
+            CompareStatus::Fail,
+            "a significant draw regression escalates a W/L Warn to Fail; reason={:?}",
+            row.reason
+        );
+        assert!(
+            row.reason.as_deref().is_some_and(|r| r.contains("draw")),
+            "the draw arm won, not the W/L Warn arm below it; reason={:?}",
+            row.reason
+        );
+    }
+
+    /// First-match-wins means a firing arm suppresses every other arm's reason string. Here the
+    /// draw Warn arm shadows the mirror avg-turn Warn arm: same status, different message, and
+    /// the drift magnitude would vanish entirely if the row did not carry it.
+    ///
+    /// That is why `avg_turn_delta` is a field and a column rather than only a reason string —
+    /// the same argument that put the draw counters in the table.
+    #[test]
+    fn mirror_drift_magnitude_survives_a_shadowing_reason() {
+        let before: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(1), 10),
+            (3, Some(0), 10),
+            (4, Some(1), 10),
+        ];
+        let after: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(1), 10),
+            (3, Some(0), 10),
+            (4, None, 22),
+        ];
+        let baseline = mk_report(vec![mk_result_from_games("mirror", before)]);
+        let mut current_result = mk_result_from_games("mirror", after);
+        current_result.avg_turns = 16.0; // baseline is 10.0 → +6.0, past MIRROR_AVG_TURN_WARN_DELTA
+        let current = mk_report(vec![current_result]);
+        let row = &compare(&baseline, &current, &CompareOptions).unwrap().rows[0];
+
+        // PREMISE: the mirror avg-turn arm WOULD have fired — it is genuinely shadowed, not absent.
+        assert!(matches!(
+            row.current.as_ref().unwrap().expected,
+            Expected::Mirror { .. }
+        ));
+        assert_eq!(row.avg_turn_delta, Some(6.0));
+        assert!(
+            row.avg_turn_delta.unwrap().abs() > MIRROR_AVG_TURN_WARN_DELTA,
+            "premise: the drift is past the warn threshold"
+        );
+        // PREMISE: one game stopped resolving, but not significantly (n=1 ⇒ p=0.25).
+        assert_eq!((row.decisive_to_draw, row.draw_to_decisive), (1, 0));
+        assert!(row.draw_sign_test_p.is_some_and(|p| p > 0.05));
+
+        assert_eq!(row.status, CompareStatus::Warn);
+        assert!(
+            row.reason
+                .as_deref()
+                .is_some_and(|r| r.contains("decisive→draw=1 draw→decisive=0")),
+            "the draw arm shadows the avg-turn arm's message, with its counters in order; reason={:?}",
+            row.reason
+        );
+        assert!(
+            !row.reason.as_deref().unwrap().contains("avg-turn"),
+            "premise of this test: the avg-turn message really is suppressed"
+        );
+    }
+
+    /// The no-draw-shift control: with the draw counters equal, both draw guards (`>` and `!=`)
+    /// are false and the chain falls through as it did before this change.
+    ///
+    /// Scope, stated precisely because an earlier version of this doc overclaimed: the fixture is
+    /// an identity comparison, so ALL axes are flat, and it therefore pins only the draw guards'
+    /// inertness — not the full precondition of invariant 2, and not the tier order, which
+    /// `draw_regression_escalates_an_insignificant_win_loss_warn` pins.
+    #[test]
+    fn compare_without_draw_shift_is_unaffected() {
+        let rows: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(0), 11),
+            (3, Some(1), 12),
+            (4, Some(1), 13),
+        ];
+        let report = mk_report(vec![mk_result_from_games("red-mirror", rows)]);
+        let result = compare(&report, &report, &CompareOptions).unwrap();
+
+        assert_eq!(
+            (
+                result.rows[0].decisive_to_draw,
+                result.rows[0].draw_to_decisive
+            ),
+            (0, 0),
+            "premise: the draw axis is flat, so the new tiers must be inert"
+        );
+        assert_eq!(result.rows[0].draw_sign_test_p, None);
+        assert_eq!(result.rows[0].status, CompareStatus::Pass);
+        assert!(!result.any_fail());
+    }
+
+    /// **The status axis, isolated.** An existing matchup that newly fails its OWN suite check
+    /// must fail the comparison. Before this arm existed, `classify_row`'s paired branch read the
+    /// game outcomes and nothing else, so a run could carry `status: "Fail"` on an existing
+    /// matchup and still exit 0.
+    ///
+    /// Every outcome axis is held FLAT here (premise-asserted below), so the status axis is the
+    /// only thing that can produce a verdict — which is what makes this the drop-mutant's target.
+    #[test]
+    fn status_regression_to_fail_flags_a_matchup_with_unchanged_outcomes() {
+        let games: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(1), 10),
+            (3, Some(0), 10),
+            (4, Some(1), 10),
+        ];
+        let baseline = mk_report(vec![mk_result_from_games("enchantress-mirror", games)]);
+        let mut failing = mk_result_from_games("enchantress-mirror", games);
+        failing.status = SuiteStatus::Fail;
+        // Verbatim from `.ab/noC-1.json`'s enchantress-mirror row.
+        failing.fail_reason =
+            Some("mirror imbalance: p0=0.10, Wilson 95% CI [0.02, 0.40] excludes 0.50".into());
+        let current = mk_report(vec![failing]);
+        let row = &compare(&baseline, &current, &CompareOptions).unwrap().rows[0];
+
+        // PREMISE: every outcome axis is flat, so nothing above the status arm can fire.
+        assert_eq!((row.flipped_w_to_l, row.flipped_l_to_w), (0, 0));
+        assert_eq!((row.decisive_to_draw, row.draw_to_decisive), (0, 0));
+        assert_eq!(row.avg_turn_delta, Some(0.0));
+        assert_eq!(
+            row.suite_status_shift,
+            Some((SuiteStatus::Pass, SuiteStatus::Fail))
+        );
+
+        assert_eq!(
+            row.status,
+            CompareStatus::Fail,
+            "a matchup that started failing its own suite check must fail the comparison; reason={:?}",
+            row.reason
+        );
+        assert!(
+            row.reason
+                .as_deref()
+                .is_some_and(|r| r.contains("Pass → Fail") && r.contains("mirror imbalance")),
+            "the reason names the shift AND carries the matchup's own fail_reason; got {:?}",
+            row.reason
+        );
+    }
+
+    /// **The recorded incident, whole — and it had TWO independent holes.**
+    ///
+    /// This is `.ab/noC-1.json`'s `enchantress-mirror` row as recorded: the eight games that
+    /// stopped resolving AND `status: "Fail"` with its Wilson-CI reason. The run's compare section
+    /// nonetheless printed `0 FAIL, 0 WARN, 3 PASS`, because neither the draw axis nor the suite
+    /// status axis existed in the comparison. Both are asserted present so a future edit that
+    /// closes one and reopens the other cannot pass this row.
+    ///
+    /// The reason string is the draw one: the draw Fail arm sits above the status Fail arm, so the
+    /// more specific outcome diagnosis wins. The status hole is still visible on the row via
+    /// `suite_status_shift` — which is exactly why every axis carries a field and a column instead
+    /// of relying on the first-match-wins reason.
+    #[test]
+    fn noc1_enchantress_row_carries_both_holes() {
+        let before: &[(u64, Option<u8>, u32)] = &[
+            (10593729, Some(1), 10),
+            (10593730, Some(0), 18),
+            (10593731, Some(1), 12),
+            (10593732, Some(1), 14),
+            (10593733, Some(1), 11),
+            (10593734, Some(0), 15),
+            (10593735, Some(0), 15),
+            (10593736, Some(0), 14),
+            (10593737, Some(1), 18),
+            (10593738, Some(1), 19),
+        ];
+        let after: &[(u64, Option<u8>, u32)] = &[
+            (10593729, None, 8),
+            (10593730, None, 12),
+            (10593731, Some(1), 12),
+            (10593732, None, 11),
+            (10593733, None, 9),
+            (10593734, None, 12),
+            (10593735, Some(0), 15),
+            (10593736, None, 13),
+            (10593737, None, 17),
+            (10593738, None, 9),
+        ];
+        let baseline = mk_report(vec![mk_result_from_games("enchantress-mirror", before)]);
+        let mut recorded = mk_result_from_games("enchantress-mirror", after);
+        recorded.status = SuiteStatus::Fail;
+        recorded.fail_reason =
+            Some("mirror imbalance: p0=0.10, Wilson 95% CI [0.02, 0.40] excludes 0.50".into());
+        let current = mk_report(vec![recorded]);
+        let report = compare(&baseline, &current, &CompareOptions).unwrap();
+        let row = &report.rows[0];
+
+        // HOLE 1: eight games stopped resolving.
+        assert_eq!((row.decisive_to_draw, row.draw_to_decisive), (8, 0));
+        // HOLE 2: the matchup failed its own suite check.
+        assert_eq!(
+            row.suite_status_shift,
+            Some((SuiteStatus::Pass, SuiteStatus::Fail))
+        );
+
+        assert_eq!(row.status, CompareStatus::Fail);
+        assert!(report.any_fail(), "the recorded run must not exit 0");
+        assert!(
+            row.reason.as_deref().is_some_and(|r| r.contains("draw")),
+            "the outcome diagnosis is the more specific one and wins; reason={:?}",
+            row.reason
+        );
+    }
+
+    /// Status-axis asymmetry, same shape as the draw axis: a matchup that STOPPED failing is an
+    /// improvement. It is reported, because a comparator silent about it would hide a behavior
+    /// change — but it can never Fail, since the Fail arm requires the regression direction.
+    #[test]
+    fn status_recovery_warns_but_never_fails() {
+        let games: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(1), 10),
+            (3, Some(0), 10),
+            (4, Some(1), 10),
+        ];
+        let mut was_failing = mk_result_from_games("enchantress-mirror", games);
+        was_failing.status = SuiteStatus::Fail;
+        was_failing.fail_reason = Some("mirror imbalance".into());
+        let baseline = mk_report(vec![was_failing]);
+        let current = mk_report(vec![mk_result_from_games("enchantress-mirror", games)]);
+        let report = compare(&baseline, &current, &CompareOptions).unwrap();
+        let row = &report.rows[0];
+
+        assert_eq!(
+            row.suite_status_shift,
+            Some((SuiteStatus::Fail, SuiteStatus::Pass)),
+            "premise: this fixture really is the recovery direction"
+        );
+        assert_eq!(
+            row.status,
+            CompareStatus::Warn,
+            "recovery is reported, never failed; reason={:?}",
+            row.reason
+        );
+        // The merged arm's two branches share a status, so only the message distinguishes them.
+        // Without this the recovery branch had no output assertion at all and could be emptied.
+        assert!(
+            row.reason
+                .as_deref()
+                .is_some_and(|r| r.contains("recovered") && r.contains("Fail → Pass")),
+            "reason={:?}",
+            row.reason
+        );
+        assert!(!report.any_fail(), "an improvement must not fail the gate");
+
+        // Second branch case: `Fail → Open` is also recovery. Keying the still-failing branch on
+        // `c.status != Pass` instead of `== Fail` would mislabel this row as still failing, and
+        // the `Fail → Pass` case above cannot tell the two keyings apart.
+        let mut was_failing = mk_result_from_games("enchantress-mirror", games);
+        was_failing.status = SuiteStatus::Fail;
+        let mut now_open = mk_result_from_games("enchantress-mirror", games);
+        now_open.status = SuiteStatus::Open;
+        let report = compare(
+            &mk_report(vec![was_failing]),
+            &mk_report(vec![now_open]),
+            &CompareOptions,
+        )
+        .unwrap();
+        assert!(
+            report.rows[0]
+                .reason
+                .as_deref()
+                .is_some_and(|r| r.contains("recovered") && r.contains("Fail → Open")),
+            "reason={:?}",
+            report.rows[0].reason
+        );
+    }
+
+    /// The status analogue of `draw_regression_escalates_an_insignificant_win_loss_warn`, and it
+    /// exists because round 2 of review showed the status Fail arm's placement was UNPINNED:
+    /// moving it below the W/L Warn arm left the whole suite green. The concrete consequence —
+    /// measured — was `any_fail() == false` on a matchup that newly fails its own suite check.
+    ///
+    /// Same premise structure: the W/L axis is insignificant (p=0.0625) so the W/L Fail arm cannot
+    /// fire, and `w2l != l2w` so the pre-change chain landed on the W/L Warn arm. Warn before,
+    /// Fail now.
+    #[test]
+    fn status_regression_escalates_an_insignificant_win_loss_warn() {
+        let before: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(0), 10),
+            (3, Some(0), 10),
+            (4, Some(1), 10),
+            (5, Some(1), 10),
+            (6, Some(1), 10),
+            (7, Some(1), 10),
+            (8, Some(1), 10),
+            (9, Some(1), 10),
+            (10, Some(1), 10),
+            (11, Some(1), 10),
+        ];
+        let after: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(1), 10),
+            (2, Some(1), 10),
+            (3, Some(1), 10),
+            (4, Some(1), 10),
+            (5, Some(1), 10),
+            (6, Some(1), 10),
+            (7, Some(1), 10),
+            (8, Some(1), 10),
+            (9, Some(1), 10),
+            (10, Some(1), 10),
+            (11, Some(1), 10),
+        ];
+        let baseline = mk_report(vec![mk_result_from_games("m", before)]);
+        let mut failing = mk_result_from_games("m", after);
+        failing.status = SuiteStatus::Fail;
+        failing.fail_reason = Some("mirror imbalance".into());
+        let report = compare(&baseline, &mk_report(vec![failing]), &CompareOptions).unwrap();
+        let row = &report.rows[0];
+
+        // PREMISE: the W/L axis is insignificant, so the W/L Fail arm is out...
+        assert_eq!((row.flipped_w_to_l, row.flipped_l_to_w), (3, 0));
+        assert!(row.sign_test_p.is_some_and(|p| p > 0.05));
+        // ...and the draw axis is flat, so neither draw arm can fire either.
+        assert_eq!((row.decisive_to_draw, row.draw_to_decisive), (0, 0));
+
+        assert_eq!(
+            row.status,
+            CompareStatus::Fail,
+            "a matchup that newly fails its own check escalates a W/L Warn to Fail; reason={:?}",
+            row.reason
+        );
+        assert!(report.any_fail(), "and the gate must exit non-zero");
+        assert!(
+            row.reason
+                .as_deref()
+                .is_some_and(|r| r.contains("status regressed")),
+            "the status arm won, not the W/L Warn arm below it; reason={:?}",
+            row.reason
+        );
+    }
+
+    /// A matchup that was ALREADY failing in the baseline and is still failing is reported every
+    /// run, not passed over in silence.
+    ///
+    /// Reachable, not theoretical: `--refresh-baseline` writes the current report verbatim with no
+    /// `any_fail` check, so a single refresh from a failing run would otherwise make that matchup
+    /// exit 0 forever. Warn rather than Fail is deliberate — see the arm's comment.
+    #[test]
+    fn a_matchup_still_failing_is_reported_every_run() {
+        let games: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];
+        let mut was_failing = mk_result_from_games("m", games);
+        was_failing.status = SuiteStatus::Fail;
+        was_failing.fail_reason = Some("mirror imbalance".into());
+        let mut still_failing = mk_result_from_games("m", games);
+        still_failing.status = SuiteStatus::Fail;
+        still_failing.fail_reason = Some("mirror imbalance".into());
+        let report = compare(
+            &mk_report(vec![was_failing]),
+            &mk_report(vec![still_failing]),
+            &CompareOptions,
+        )
+        .unwrap();
+        let row = &report.rows[0];
+
+        // PREMISE: the status did not shift, and every outcome axis is flat — so a chain that
+        // only looked at transitions and outcomes would have nothing at all to say here.
+        assert_eq!(row.suite_status_shift, None);
+        assert_eq!((row.flipped_w_to_l, row.flipped_l_to_w), (0, 0));
+        assert_eq!((row.decisive_to_draw, row.draw_to_decisive), (0, 0));
+
+        assert_eq!(row.status, CompareStatus::Warn);
+        assert!(
+            row.reason
+                .as_deref()
+                .is_some_and(|r| r.contains("still failing")),
+            "reason={:?}",
+            row.reason
+        );
+        assert!(
+            !report.any_fail(),
+            "reported, but not red: the baseline already sanctions this state"
+        );
+    }
+
+    /// The column invariant, enforced instead of asserted in a comment. Round 2 of review measured
+    /// that both new columns could be deleted with the entire suite still green, because the table
+    /// was built inline in `println!` and nothing read it.
+    ///
+    /// One column per axis the verdict chain can decide on: win/loss, draw, avg-turn, suite status.
+    #[test]
+    fn markdown_has_a_column_for_every_verdict_axis() {
+        for axis in [
+            "flips W→L",
+            "flips L→W",
+            "sign p",
+            "dec→draw",
+            "draw→dec",
+            "draw sign p",
+            "Δ avg turns",
+            "suite status",
+        ] {
+            assert!(
+                COLUMNS.contains(&axis),
+                "the chain can decide a verdict on {axis} but the table has no column for it"
+            );
+        }
+        let report = mk_report(vec![mk_result("red-mirror", 5, 10, SuiteStatus::Pass)]);
+        let rendered = render_markdown(&compare(&report, &report, &CompareOptions).unwrap());
+        let header = rendered.lines().next().unwrap();
+        // Exact cell equality, not `contains`. The mutation this catches is on the RENDERED header
+        // line: drop its last cell and a containment loop still passes, because the surviving
+        // "suite status" cell CONTAINS the string "status". Measured — that variant went from
+        // killing 1 test to killing 2.
+        //
+        // Scope, stated because the two mutations are easy to conflate: against a mutation of
+        // `COLUMNS` itself this assertion is tautological, since the header is generated from
+        // `COLUMNS`. That variant is caught anyway, by the `debug_assert_eq!` on cell count in
+        // `render_markdown` and by the rectangularity test.
+        let header_cells: Vec<&str> = header
+            .split('|')
+            .map(str::trim)
+            .filter(|c| !c.is_empty())
+            .collect();
+        assert_eq!(header_cells, COLUMNS, "header cells drifted from COLUMNS");
+
+        // `status_str`'s `Pass` arm is the last rendered arm of that 5-variant cluster with no
+        // assertion binding it — WARN, FAIL, NEW and REMOVED are each pinned by a cell assertion
+        // elsewhere, and mutating `Pass => "PASS"` survived the whole suite. This fixture is an
+        // identity comparison, so it is the only one that renders a Pass row.
+        assert_eq!(cell(&rendered, "red-mirror", "status"), "PASS");
+    }
+
+    /// Read the cell under a named column, so an assertion binds a column to the field it renders
+    /// rather than to a position. Splitting `| a | b |` yields a leading empty segment, hence +1.
+    fn cell<'a>(rendered: &'a str, matchup_id: &str, column: &str) -> &'a str {
+        let index = COLUMNS
+            .iter()
+            .position(|c| *c == column)
+            .unwrap_or_else(|| panic!("no column named {column}"));
+        let line = rendered
+            .lines()
+            .find(|l| l.starts_with(&format!("| {matchup_id} |")))
+            .unwrap_or_else(|| panic!("no row for {matchup_id} in:\n{rendered}"));
+        line.split('|').nth(index + 1).unwrap().trim()
+    }
+
+    /// **Every column carries the value it claims to.** Round 3 of review measured that the table
+    /// was pinned by header *label* only: freezing the `Δ avg turns` cell to a constant, and
+    /// swapping the `dec→draw` / `draw→dec` cells so the recorded incident would print its counters
+    /// backwards, both survived the entire suite. A column that renders the wrong number defeats
+    /// the invariant exactly as thoroughly as a missing one, since columns are the only surface
+    /// that survives first-match-wins reason suppression.
+    ///
+    /// The fixture gives every numeric axis a DISTINCT value (2, 3, 4, 1, and two different
+    /// p-values), so no pair of cells can be transposed without changing the rendered text.
+    #[test]
+    fn markdown_cells_carry_their_own_column_values() {
+        let before: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(0), 10),
+            (3, Some(1), 10),
+            (4, Some(1), 10),
+            (5, Some(1), 10),
+            (6, Some(0), 10),
+            (7, Some(0), 10),
+            (8, Some(1), 10),
+            (9, Some(1), 10),
+            (10, None, 10),
+            (11, Some(0), 10),
+        ];
+        let after: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(1), 10),
+            (2, Some(1), 10),
+            (3, Some(0), 10),
+            (4, Some(0), 10),
+            (5, Some(0), 10),
+            (6, None, 10),
+            (7, None, 10),
+            (8, None, 10),
+            (9, None, 10),
+            (10, Some(0), 10),
+            (11, Some(0), 10),
+            // Present only in the current report. `paired_seed_shift` walks the BASELINE games and
+            // skips unmatched seeds, so this moves the win rate without touching a flip counter —
+            // which is what makes the two p0% cells differ while the four counters stay distinct.
+            (12, Some(0), 10),
+        ];
+        let baseline = mk_report(vec![mk_result_from_games("distinct", before)]);
+        let mut current_result = mk_result_from_games("distinct", after);
+        current_result.avg_turns = 16.0; // baseline 10.0 → +6.0
+        let report = compare(&baseline, &mk_report(vec![current_result]), &CompareOptions).unwrap();
+        let row = &report.rows[0];
+
+        // PREMISE: the four counters really are pairwise distinct, so a transposition must show.
+        assert_eq!(
+            (
+                row.flipped_w_to_l,
+                row.flipped_l_to_w,
+                row.decisive_to_draw,
+                row.draw_to_decisive
+            ),
+            (2, 3, 4, 1)
+        );
+        // PREMISE: the two win-rate cells DIFFER. They rendered identical `45%` in the first
+        // version of this test, so swapping them survived — the premise has to be asserted, not
+        // assumed, or "no pair of cells can be transposed" is false for the pair nobody checked.
+        assert_ne!(
+            winrate(row.baseline.as_ref().unwrap()),
+            winrate(row.current.as_ref().unwrap())
+        );
+
+        let rendered = render_markdown(&report);
+        assert_eq!(cell(&rendered, "distinct", "exercises"), "AggroPressure");
+        assert_eq!(cell(&rendered, "distinct", "baseline p0%"), "45%");
+        assert_eq!(cell(&rendered, "distinct", "current p0%"), "50%");
+        assert_eq!(cell(&rendered, "distinct", "flips W→L"), "2");
+        assert_eq!(cell(&rendered, "distinct", "flips L→W"), "3");
+        assert_eq!(cell(&rendered, "distinct", "dec→draw"), "4");
+        assert_eq!(cell(&rendered, "distinct", "draw→dec"), "1");
+        assert_eq!(cell(&rendered, "distinct", "sign p"), "0.3438");
+        assert_eq!(cell(&rendered, "distinct", "draw sign p"), "0.1094");
+        assert_eq!(cell(&rendered, "distinct", "Δ avg turns"), "+6.0");
+        assert_eq!(cell(&rendered, "distinct", "suite status"), "Pass");
+        assert_eq!(cell(&rendered, "distinct", "status"), "WARN");
+    }
+
+    /// The `suite status` column's SHIFT branch — the one the status axis exists to surface — was
+    /// rendered by no test: replacing it with a constant survived the whole suite, because every
+    /// other rendered fixture has `suite_status_shift == None`. Round 3's finding, one column over.
+    #[test]
+    fn markdown_renders_a_suite_status_shift() {
+        let games: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];
+        let baseline = mk_report(vec![mk_result_from_games("shifted", games)]);
+        let mut failing = mk_result_from_games("shifted", games);
+        failing.status = SuiteStatus::Fail;
+        failing.fail_reason = Some("mirror imbalance".into());
+        let report = compare(&baseline, &mk_report(vec![failing]), &CompareOptions).unwrap();
+
+        // PREMISE: this row really carries a shift, so the fallback branch is not what renders it.
+        assert_eq!(
+            report.rows[0].suite_status_shift,
+            Some((SuiteStatus::Pass, SuiteStatus::Fail))
+        );
+        let rendered = render_markdown(&report);
+        assert_eq!(cell(&rendered, "shifted", "suite status"), "Pass→Fail");
+        assert_eq!(cell(&rendered, "shifted", "status"), "FAIL");
+    }
+
+    /// Every emitted row — header, separator, data, and the reason continuation — must have the
+    /// same cell count, or the table renders broken in the nightly drift issue that
+    /// `.github/workflows/ai-gate.yml` posts. Exercises all four row shapes at once: a paired row
+    /// that warns (so its reason continuation is emitted), a New row, and a Removed row.
+    #[test]
+    fn markdown_rows_are_rectangular() {
+        let paired_before: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];
+        let paired_after: &[(u64, Option<u8>, u32)] = &[(1, Some(1), 10), (2, Some(1), 10)];
+        let baseline = mk_report(vec![
+            mk_result_from_games("paired", paired_before),
+            mk_result_from_games("removed", paired_before),
+        ]);
+        let current = mk_report(vec![
+            mk_result_from_games("paired", paired_after),
+            mk_result_from_games("brand-new", paired_after),
+        ]);
+        let report = compare(&baseline, &current, &CompareOptions).unwrap();
+        let rendered = render_markdown(&report);
+
+        // PREMISE: all four row shapes really are present, otherwise this measures less than it
+        // claims to.
+        assert!(
+            rendered.contains("|  ↳ _"),
+            "no reason continuation emitted"
+        );
+        assert!(rendered.contains("| NEW |"), "no New row emitted");
+        assert!(rendered.contains("| REMOVED |"), "no Removed row emitted");
+
+        // A New row's verdict is decided FROM its suite status, so that column must carry a value
+        // even though there is no shift to show. It read `—` until review measured it.
+        let new_row = rendered.lines().find(|l| l.contains("| NEW |")).unwrap();
+        assert!(
+            new_row.contains("| Pass | NEW |"),
+            "a status-decided verdict must not print a blank status cell: {new_row}"
+        );
+
+        // The `—` fallbacks are what New and Removed rows print in the paired-only columns, and
+        // every one of them survived a fully green suite until review measured it. A New row has no
+        // baseline to compare against; a Removed row has no current report at all.
+        //
+        // All six sites are listed deliberately. The first pass at this pinned five and missed
+        // `draw sign p` — which is the fallback the real gate renders on every row today, since a
+        // matchup with a flat draw axis has no statistic to report. Sweeping a defect by recipe
+        // means sweeping ALL of its sites; a partial sweep reads as complete.
+        assert_eq!(cell(&rendered, "brand-new", "baseline p0%"), "—");
+        assert_eq!(cell(&rendered, "brand-new", "sign p"), "—");
+        assert_eq!(cell(&rendered, "brand-new", "draw sign p"), "—");
+        assert_eq!(cell(&rendered, "brand-new", "Δ avg turns"), "—");
+        assert_eq!(cell(&rendered, "removed", "current p0%"), "—");
+        assert_eq!(cell(&rendered, "removed", "suite status"), "—");
+        assert_eq!(
+            cell(&rendered, "removed", "status"),
+            "REMOVED",
+            "and the Removed row still reaches its own verdict"
+        );
+
+        // The separator is GENERATED from the header widths, so its validity is not free: an empty
+        // fill still has the right pipe count but renders the whole table as one paragraph in the
+        // issue body. Measured: `"-".repeat(0)` survives a pipe-count-only check.
+        //
+        // Indexed rather than filtered on purpose. The obvious spelling —
+        // `.split('|').filter(|s| !s.is_empty())` — is VACUOUS against exactly the mutation this
+        // is here to catch: with empty fills every segment is empty, the filter drops all of them,
+        // and the loop body never runs. Measured that too, while fixing this.
+        let separator = rendered.lines().nth(1).unwrap();
+        let segments: Vec<&str> = separator.split('|').collect();
+        assert_eq!(
+            segments.len(),
+            COLUMNS.len() + 2,
+            "separator is not bounded by pipes with one segment per column: {separator}"
+        );
+        for segment in &segments[1..=COLUMNS.len()] {
+            assert!(
+                segment.len() >= 3 && segment.chars().all(|c| c == '-'),
+                "separator segment {segment:?} is not a valid markdown rule: {separator}"
+            );
+        }
+
+        let expected = COLUMNS.len() + 1; // n cells ⇒ n+1 pipes
+        for line in rendered.lines() {
+            assert_eq!(
+                line.matches('|').count(),
+                expected,
+                "row has the wrong cell count: {line}"
+            );
+        }
+    }
+
+    /// The mirror avg-turn arm is guarded on `Expected::Mirror`, and every other fixture in this
+    /// module is a mirror — so deleting that guard survived the whole suite. A `Triangle` matchup
+    /// has no symmetry expectation, and a turn-count drift is not a finding for it.
+    ///
+    /// Pre-existing arm, pinned here because this change reorders around it: the new draw and
+    /// status Warn arms sit directly above it.
+    #[test]
+    fn avg_turn_drift_is_only_a_finding_for_mirrors() {
+        let games: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];
+        let mut base = mk_result_from_games("triangle", games);
+        base.expected = Expected::Triangle {
+            p0_winrate_min: 0.4,
+            p0_winrate_max: 0.6,
+        };
+        let mut drifted = mk_result_from_games("triangle", games);
+        drifted.expected = Expected::Triangle {
+            p0_winrate_min: 0.4,
+            p0_winrate_max: 0.6,
+        };
+        drifted.avg_turns = 20.0; // +10.0, far past MIRROR_AVG_TURN_WARN_DELTA
+
+        let report = compare(
+            &mk_report(vec![base]),
+            &mk_report(vec![drifted]),
+            &CompareOptions,
+        )
+        .unwrap();
+
+        // PREMISE: the drift really is past the threshold, so only the Mirror guard suppresses it.
+        assert_eq!(report.rows[0].avg_turn_delta, Some(10.0));
+        assert!(report.rows[0].avg_turn_delta.unwrap() > MIRROR_AVG_TURN_WARN_DELTA);
+        // PREMISE: nothing else could produce a verdict here.
+        assert_eq!(
+            (
+                report.rows[0].flipped_w_to_l,
+                report.rows[0].flipped_l_to_w,
+                report.rows[0].decisive_to_draw,
+                report.rows[0].draw_to_decisive
+            ),
+            (0, 0, 0, 0)
+        );
+
+        assert_eq!(
+            report.rows[0].status,
+            CompareStatus::Pass,
+            "a non-mirror matchup has no symmetry expectation to drift from; reason={:?}",
+            report.rows[0].reason
+        );
+    }
+
     #[test]
     fn compare_identity_is_pass() {
         let report = mk_report(vec![mk_result("red-mirror", 5, 10, SuiteStatus::Pass)]);
@@ -443,11 +1652,17 @@ mod tests {
         let result = compare(&baseline, &current, &CompareOptions).unwrap();
         assert!(result.any_fail());
         assert_eq!(result.rows[0].status, CompareStatus::Fail);
-        assert!(result.rows[0]
-            .reason
-            .as_ref()
-            .unwrap()
-            .contains("paired regression"));
+        // The counters and their ORDER, not just the phrase: transposing the two format args here
+        // printed `W→L=0 L→W=10` for this very fixture — a regression reported as an improvement —
+        // and survived the whole suite until review measured it.
+        assert!(
+            result.rows[0]
+                .reason
+                .as_deref()
+                .is_some_and(|r| r.contains("paired regression: W→L=10 L→W=0")),
+            "reason={:?}",
+            result.rows[0].reason
+        );
     }
 
     #[test]
@@ -466,6 +1681,15 @@ mod tests {
         let result = compare(&baseline, &current, &CompareOptions).unwrap();
         assert!(!result.any_fail());
         assert_eq!(result.rows[0].status, CompareStatus::Warn);
+        // Same in-order pin on the win/loss Warn reason as on its Fail sibling above.
+        assert!(
+            result.rows[0]
+                .reason
+                .as_deref()
+                .is_some_and(|r| r.contains("paired shift: W→L=0 L→W=2")),
+            "reason={:?}",
+            result.rows[0].reason
+        );
     }
 
     #[test]

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -808,12 +808,11 @@ fn render_markdown(report: &CompareReport) -> String {
 /// Applied uniformly rather than only to the fields that look risky today: deciding per field
 /// means re-deciding every time a field is added, and one of those decisions will be wrong.
 fn md_cell(text: &str) -> String {
-    // ORDER IS LOAD-BEARING: backslashes first, then pipes. The reverse — which this function
-    // did until review caught it — turns the input `\|` into `\\|`, and a markdown parser
-    // reads that as an escaped backslash followed by a LIVE separator, so the very input that
-    // looks pre-escaped is the one that breaks the row. Escaping backslashes first makes every
-    // backslash run even before any `\|` is introduced, so no emitted `|` can ever be preceded
-    // by an odd run.
+    // ORDER IS LOAD-BEARING: backslashes first, then pipes. The reverse turns the input `\|`
+    // into `\\|`, and a markdown parser reads that as an escaped backslash followed by a LIVE
+    // separator, so the very input that looks pre-escaped is the one that breaks the row.
+    // Escaping backslashes first makes every backslash run even before any `\|` is introduced,
+    // so no emitted `|` can ever be preceded by an odd run.
     text.replace('\\', "\\\\")
         .replace('|', "\\|")
         .replace(['\n', '\r'], " ")
@@ -851,12 +850,11 @@ pub fn print_markdown(report: &CompareReport) {
 /// A refused comparison is the case most likely to be read by someone who did not run it: the
 /// nightly captures stdout into `target/ai-gate-report.md` and posts it as a drift issue.
 ///
-/// The reason is NOT that stderr-only would leave that file empty. Review measured the opposite:
-/// `run_suite` prints the suite's own table to stdout before the baseline is ever loaded
-/// (`run.rs`, `print_markdown_table`), so on this path the file always has content and the
-/// workflow's empty-file abort is unreachable. What a stderr-only refusal actually produces is
-/// worse to read than an empty file: a red job whose issue body is a table of PASSing matchups
-/// and no statement of what failed.
+/// The workflow's empty-file abort is unreachable on this path: `run_suite` prints the suite's
+/// own table to stdout (`run.rs`, `print_markdown_table`) before the baseline is ever loaded, so
+/// the file always has content. What a stderr-only refusal produces is worse to read than an
+/// empty file — a red job whose issue body is a table of PASSing matchups and no statement of
+/// what failed.
 pub fn render_error_markdown(err: &CompareError) -> String {
     let remedy = match err {
         CompareError::WorkloadMismatch {
@@ -1221,20 +1219,17 @@ mod tests {
         assert!(!result.any_fail(), "an improvement must not fail the gate");
     }
 
-    /// **The escalation the tier order actually produces.** An independent review measured this
-    /// input against both the pre-change and post-change comparator and found the earlier
-    /// "no input that reaches Fail or Warn today can change verdict" claim FALSE: the draw Fail
-    /// arm sits above the W/L Warn arm, so a Warn escalates to Fail.
+    /// **The escalation the tier order produces.** The draw Fail arm sits above the win/loss
+    /// Warn arm, so a draw regression escalates a verdict the win/loss axis alone would only
+    /// have warned on.
     ///
     /// The escalation is intended — 8 of 11 games ceasing to resolve is the failure this gate
     /// exists to catch, and suppressing it because the win/loss axis also wobbled insignificantly
-    /// would reintroduce the same blindness one case narrower. It is pinned here because the
-    /// claim that it *couldn't* happen was the reason it went untested.
+    /// would reintroduce the same blindness one case narrower.
     ///
-    /// The two premise asserts below are what make this a proof of escalation without compiling
-    /// the old code: `sign_test_p > 0.05` means the W/L Fail arm cannot fire, and
-    /// `flipped_w_to_l != flipped_l_to_w` means the old chain fell to the W/L Warn arm. Warn
-    /// before, Fail now.
+    /// The two premise asserts below are what attribute the Fail to the draw axis:
+    /// `sign_test_p > 0.05` means the W/L Fail arm cannot fire, and
+    /// `flipped_w_to_l != flipped_l_to_w` means the W/L axis reaches its Warn arm.
     #[test]
     fn draw_regression_escalates_an_insignificant_win_loss_warn() {
         let before: &[(u64, Option<u8>, u32)] = &[
@@ -1553,14 +1548,12 @@ mod tests {
         );
     }
 
-    /// The status analogue of `draw_regression_escalates_an_insignificant_win_loss_warn`, and it
-    /// exists because round 2 of review showed the status Fail arm's placement was UNPINNED:
-    /// moving it below the W/L Warn arm left the whole suite green. The concrete consequence —
-    /// measured — was `any_fail() == false` on a matchup that newly fails its own suite check.
+    /// The status analogue of `draw_regression_escalates_an_insignificant_win_loss_warn`: this is
+    /// what pins the status Fail arm ABOVE the win/loss Warn arm. Moved below it, this fixture
+    /// reports `any_fail() == false` on a matchup that newly fails its own suite check.
     ///
     /// Same premise structure: the W/L axis is insignificant (p=0.0625) so the W/L Fail arm cannot
-    /// fire, and `w2l != l2w` so the pre-change chain landed on the W/L Warn arm. Warn before,
-    /// Fail now.
+    /// fire, and `w2l != l2w` so the W/L axis reaches its Warn arm.
     #[test]
     fn status_regression_escalates_an_insignificant_win_loss_warn() {
         let before: &[(u64, Option<u8>, u32)] = &[
@@ -1664,11 +1657,9 @@ mod tests {
         );
     }
 
-    /// The column invariant, enforced instead of asserted in a comment. Round 2 of review measured
-    /// that both new columns could be deleted with the entire suite still green, because the table
-    /// was built inline in `println!` and nothing read it.
-    ///
-    /// One column per axis the verdict chain can decide on: win/loss, draw, avg-turn, suite status.
+    /// One column per axis the verdict chain can decide on: win/loss, draw, avg-turn, suite
+    /// status. Enforced here rather than asserted in a comment, so a column dropped from the
+    /// renderer cannot leave the suite green.
     #[test]
     fn markdown_has_a_column_for_every_verdict_axis() {
         for axis in [
@@ -2028,10 +2019,9 @@ mod tests {
 
     /// Every refusal variant renders a body, including the two `compare` itself cannot produce.
     ///
-    /// `Io` and `Parse` are reachable only through `load_report`, which `bin/ai_gate.rs` calls
-    /// before `compare` — review found that arm was written and unreachable, because the caller
-    /// that could hit it was still failing to stderr alone. That caller is now wired to this
-    /// function, and this test covers the arm regardless of which caller reaches it.
+    /// `Io` and `Parse` reach this renderer only from `load_report`'s callers, never from
+    /// `compare`, so covering them here holds the arms live regardless of which caller gets
+    /// there.
     ///
     /// The `assert_ne!` against the bare `Display` is the discriminating half: an implementation
     /// that forwarded the error string would satisfy every other assertion here while losing the
@@ -2409,16 +2399,15 @@ mod tests {
         assert!(rendered.contains("| REMOVED |"), "no Removed row emitted");
 
         // A New row's verdict is decided FROM its suite status, so that column must carry a value
-        // even though there is no shift to show. It read `—` until review measured it.
+        // even though there is no shift to show.
         let new_row = rendered.lines().find(|l| l.contains("| NEW |")).unwrap();
         assert!(
             new_row.contains("| Pass | NEW |"),
             "a status-decided verdict must not print a blank status cell: {new_row}"
         );
 
-        // The `—` fallbacks are what New and Removed rows print in the paired-only columns, and
-        // every one of them survived a fully green suite until review measured it. A New row has no
-        // baseline to compare against; a Removed row has no current report at all.
+        // The `—` fallbacks are what New and Removed rows print in the paired-only columns: a New
+        // row has no baseline to compare against, a Removed row no current report at all.
         //
         // Every `—` fallback site is asserted; a partial sweep reads as complete.
         assert_eq!(cell(&rendered, "brand-new", "baseline p0%"), "—");
@@ -2532,8 +2521,7 @@ mod tests {
         assert!(result.any_fail());
         assert_eq!(result.rows[0].status, CompareStatus::Fail);
         // The counters and their ORDER, not just the phrase: transposing the two format args here
-        // printed `W→L=0 L→W=10` for this very fixture — a regression reported as an improvement —
-        // and survived the whole suite until review measured it.
+        // printed `W→L=0 L→W=10` for this very fixture: a regression reported as an improvement.
         assert!(
             result.rows[0]
                 .reason

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -859,6 +859,20 @@ pub fn gate_verdict(comparison: &Result<CompareReport, CompareError>) -> (String
     }
 }
 
+/// Write the gate's stdout body and return the process exit code.
+///
+/// Every binary that compares two suite reports ends in these same two statements, and review
+/// pointed out that a unit test on `gate_verdict` cannot see them: a `main` that printed to
+/// stderr, or exited 0 on a refusal, would revert the whole fix with the suite green. Both
+/// halves live here so that surface is one shared function instead of one copy per binary —
+/// and `tests/gate_cli.rs` drives it through a real process, so the pairing is bound at the
+/// boundary CI actually redirects, not just at the library call below it.
+pub fn emit_gate_verdict(comparison: &Result<CompareReport, CompareError>) -> i32 {
+    let (body, code) = gate_verdict(comparison);
+    print!("{body}");
+    code
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -410,9 +410,14 @@ fn classify_row(
                 //     wrong as one that hid a regression (the same reason the W/L tier warns on
                 //     L→W and the draw tier warns on draw→decisive).
                 //   * STILL failing is reported every run rather than passing quietly. Review
-                //     showed this is reachable, not theoretical: `--refresh-baseline` writes the
-                //     current report verbatim with no `any_fail` check, so one refresh from a
-                //     failing run would otherwise make that matchup exit 0 forever.
+                //     showed this is reachable, not theoretical: nothing revalidates a committed
+                //     baseline when it is loaded, so a baseline that already sanctions a failure
+                //     keeps sanctioning it, and that matchup exits 0 forever. (The wording is
+                //     deliberately about the baseline rather than about `--refresh-baseline`
+                //     writing without a verdict check: that WAS the mechanism, and #7029 adds the
+                //     missing check, so naming it here would make this comment false the day that
+                //     lands. Reachability does not depend on it — a baseline blessed before the
+                //     guard, or hand-edited, is unaffected by any guard on the write path.)
                 //
                 // It is a Warn and not a Fail deliberately: the exit code answers "did this change
                 // make things worse", and the baseline — however it got that way — already
@@ -1445,9 +1450,12 @@ mod tests {
     /// A matchup that was ALREADY failing in the baseline and is still failing is reported every
     /// run, not passed over in silence.
     ///
-    /// Reachable, not theoretical: `--refresh-baseline` writes the current report verbatim with no
-    /// `any_fail` check, so a single refresh from a failing run would otherwise make that matchup
-    /// exit 0 forever. Warn rather than Fail is deliberate — see the arm's comment.
+    /// Reachable, not theoretical, and durably so: nothing revalidates a committed baseline on
+    /// load, so a baseline that already sanctions a failure keeps sanctioning it regardless of
+    /// what guards the write path. (#7029 adds the missing verdict check to `--refresh-baseline`;
+    /// this row stays reachable through baselines blessed before it, or hand-edited.)
+    ///
+    /// Warn rather than Fail is deliberate — see the arm's comment.
     #[test]
     fn a_matchup_still_failing_is_reported_every_run() {
         let games: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -481,15 +481,12 @@ fn classify_row(
                 //   * Recovery is a behavior change, and a comparator that hid it would be as
                 //     wrong as one that hid a regression (the same reason the W/L tier warns on
                 //     L→W and the draw tier warns on draw→decisive).
-                //   * STILL failing is reported every run rather than passing quietly. Review
-                //     showed this is reachable, not theoretical: nothing revalidates a committed
-                //     baseline when it is loaded, so a baseline that already sanctions a failure
-                //     keeps sanctioning it, and that matchup exits 0 forever. (The wording is
-                //     deliberately about the baseline rather than about `--refresh-baseline`
-                //     writing without a verdict check: that WAS the mechanism, and #7029 adds the
-                //     missing check, so naming it here would make this comment false the day that
-                //     lands. Reachability does not depend on it — a baseline blessed before the
-                //     guard, or hand-edited, is unaffected by any guard on the write path.)
+                //   * STILL failing is reported every run rather than passing quietly. Nothing
+                //     revalidates a committed baseline when it is loaded, so a baseline that
+                //     already sanctions a failure keeps sanctioning it and that matchup exits 0
+                //     forever — a baseline blessed before, or hand-edited around, any guard on the
+                //     `--refresh-baseline` write path stays reachable however that path is
+                //     guarded.
                 //
                 // It is a Warn and not a Fail deliberately: the exit code answers "did this change
                 // make things worse", and the baseline — however it got that way — already
@@ -921,12 +918,12 @@ pub fn gate_verdict(comparison: &Result<CompareReport, CompareError>) -> (String
 
 /// Write the gate's stdout body and return the process exit code.
 ///
-/// Every binary that compares two suite reports ends in these same two statements, and review
-/// pointed out that a unit test on `gate_verdict` cannot see them: a `main` that printed to
-/// stderr, or exited 0 on a refusal, would revert the whole fix with the suite green. Both
-/// halves live here so that surface is one shared function instead of one copy per binary —
-/// and `tests/gate_cli.rs` drives it through a real process, so the pairing is bound at the
-/// boundary CI actually redirects, not just at the library call below it.
+/// Every binary that compares two suite reports ends in these same two statements, which a unit
+/// test on `gate_verdict` cannot see: a `main` that printed to stderr, or exited 0 on a refusal,
+/// would revert the whole fix with the suite green. Both halves live here so that surface is one
+/// shared function instead of one copy per binary — and `tests/gate_cli.rs` drives it through a
+/// real process, so the pairing is bound at the boundary CI actually redirects, not just at the
+/// library call below it.
 pub fn emit_gate_verdict(comparison: &Result<CompareReport, CompareError>) -> i32 {
     let (body, code) = gate_verdict(comparison);
     print!("{body}");
@@ -1227,9 +1224,10 @@ mod tests {
     /// exists to catch, and suppressing it because the win/loss axis also wobbled insignificantly
     /// would reintroduce the same blindness one case narrower.
     ///
-    /// The two premise asserts below are what attribute the Fail to the draw axis:
-    /// `sign_test_p > 0.05` means the W/L Fail arm cannot fire, and
-    /// `flipped_w_to_l != flipped_l_to_w` means the W/L axis reaches its Warn arm.
+    /// The asserts below are what attribute the Fail to the draw axis: `sign_test_p > 0.05` means
+    /// the W/L Fail arm cannot fire, `flipped_w_to_l != flipped_l_to_w` means the W/L axis reaches
+    /// its Warn arm, and the status Fail arm is out because both fixtures report
+    /// `SuiteStatus::Pass` — which the `reason` assert then confirms by name.
     #[test]
     fn draw_regression_escalates_an_insignificant_win_loss_warn() {
         let before: &[(u64, Option<u8>, u32)] = &[
@@ -1790,9 +1788,8 @@ mod tests {
             ),
             (0, 0, 0, 0)
         );
-        // Mirrored against the test above: this one must be (0, 2), not (2, 0). A single
-        // fixture covering "some unpaired sample exists" would pass with the two counters
-        // swapped, which is the transposition defect this PR already had to fix once.
+        // Mirrored against the test above: this one must be (0, 2), not (2, 0). A single fixture
+        // covering "some unpaired sample exists" would pass with the two counters transposed.
         assert_eq!((row.unpaired_baseline, row.unpaired_current), (0, 2));
         assert_eq!(row.status, CompareStatus::Warn);
         assert!(!report.any_fail());

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -81,6 +81,22 @@ impl CompareReport {
     }
 }
 
+/// Which of the two reports a refusal is about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReportSide {
+    Baseline,
+    Current,
+}
+
+impl std::fmt::Display for ReportSide {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ReportSide::Baseline => "baseline",
+            ReportSide::Current => "current",
+        })
+    }
+}
+
 #[derive(Debug)]
 pub enum CompareError {
     Io(std::io::Error),
@@ -88,6 +104,13 @@ pub enum CompareError {
     SchemaMismatch {
         baseline: u32,
         current: u32,
+    },
+    /// One report is internally malformed: pairing keys on the seed number, so a repeated seed
+    /// has no single partner. Some games would be counted twice and others never visited.
+    DuplicateSeed {
+        side: ReportSide,
+        matchup_id: String,
+        seed: u64,
     },
     /// A configuration that defines what a seed *means* differs between the reports, so
     /// pairing by seed number would compare two unrelated games and call the difference
@@ -119,6 +142,15 @@ impl std::fmt::Display for CompareError {
                 "{field} mismatch: baseline={baseline} current={current} — \
                  the reports describe different workloads and cannot be paired by seed"
             ),
+            CompareError::DuplicateSeed {
+                side,
+                matchup_id,
+                seed,
+            } => write!(
+                f,
+                "{side} report repeats seed {seed} in matchup {matchup_id} — the pairing is \
+                 ambiguous and some games would go uncompared"
+            ),
         }
     }
 }
@@ -145,6 +177,21 @@ pub fn load_report(path: &Path) -> Result<SuiteReport, CompareError> {
     Ok(report)
 }
 
+/// The first matchup in `report` that lists a seed twice, with that seed.
+///
+/// `run_suite` derives seeds as `base_seed + matchup_idx * 1000 + game_idx`, so a real report
+/// cannot hit this; it fires on a hand-edited or corrupted one.
+fn first_duplicate_seed(report: &SuiteReport) -> Option<(&str, u64)> {
+    report.results.iter().find_map(|matchup| {
+        let mut seen = HashSet::new();
+        matchup
+            .games
+            .iter()
+            .find(|game| !seen.insert(game.seed))
+            .map(|game| (matchup.matchup_id.as_str(), game.seed))
+    })
+}
+
 /// Core comparison entry point. Takes two reports and an options block;
 /// returns a `CompareReport` whose `any_fail()` drives the exit code.
 pub fn compare(
@@ -163,22 +210,16 @@ pub fn compare(
     // reports derive their seeds the same way and play them under the same AI, so the two
     // inputs that define what a seed means are checked before any row is classified.
     //
-    // `games_per_matchup` IS here, and the reasoning that kept it out is recorded because it
-    // was wrong in an instructive way. It changes how MANY seeds exist rather than what a seed
-    // means, so the samples that do pair really are comparable — from which an earlier draft
-    // concluded that counting the unpaired remainder (the `unpaired_*` columns below) was the
-    // honest treatment, and that erroring would break a live nightly that runs `--games 100`
-    // against a `games_per_matchup: 10` baseline.
-    //
-    // The error in that is one layer downstream of the comparator. A `Warn` leaves `any_fail`
-    // false, so the gate exits 0, so the nightly step SUCCEEDS, and the step that publishes the
-    // report is guarded by `if: steps.gate.outcome == 'failure'`. The counters were therefore
-    // written to a file nobody reads: a green run that compared a tenth of its sample and said
-    // so only where nothing was listening. Producing a diagnostic is not surfacing it. A gate
-    // whose verdict covers 10% of the evidence must not be able to return Pass, so this is an
-    // incompatibility, and the diagnostics survive it — `render_error_markdown` puts the two
-    // values on stdout, which is what the workflow captures as the report body, so the failure
-    // opens a drift issue that says exactly which knob to turn.
+    // `games_per_matchup` IS here, even though it changes how MANY seeds exist rather than
+    // what a seed means, so the samples that do pair really are comparable. Counting the
+    // unpaired remainder and Warning is not enough: a `Warn` leaves `any_fail` false, so the
+    // gate exits 0, so the nightly step SUCCEEDS, and the step that publishes the report is
+    // guarded by `if: steps.gate.outcome == 'failure'`. The counters would be written to a file
+    // nobody reads — a diagnostic written where nothing is listening is not a surfaced
+    // diagnostic. A verdict covering a tenth of the evidence must not be able to Pass, so this
+    // is an incompatibility, and the diagnostics survive it: `render_error_markdown` puts the
+    // two values on stdout, which is what the workflow captures as the report body, so the
+    // failure opens a drift issue that says exactly which knob to turn.
     //
     // The columns stay. A mismatch of this field is now refused, but two reports built at the
     // same `games_per_matchup` can still fail to pair — a crashed matchup, a filter change —
@@ -208,6 +249,22 @@ pub fn compare(
             baseline: baseline.games_per_matchup.to_string(),
             current: current.games_per_matchup.to_string(),
         });
+    }
+
+    // After the workload guards: incomparability is the more fundamental refusal, and a report
+    // that repeats a seed is malformed rather than incomparable. Both sides are checked from one
+    // array so neither can be forgotten.
+    for (side, report) in [
+        (ReportSide::Baseline, baseline),
+        (ReportSide::Current, current),
+    ] {
+        if let Some((matchup_id, seed)) = first_duplicate_seed(report) {
+            return Err(CompareError::DuplicateSeed {
+                side,
+                matchup_id: matchup_id.to_string(),
+                seed,
+            });
+        }
     }
 
     // BTreeMap for deterministic iteration order.
@@ -305,22 +362,16 @@ fn classify_row(
             let paired = paired_seed_shift(b, c);
             let avg_turn_delta = c.avg_turns - b.avg_turns;
 
-            // TIER ORDER IS LOAD-BEARING. THREE earlier drafts of this comment overclaimed what
-            // it buys — "no input that reaches Fail or Warn today can change verdict" (false:
-            // Warn escalates), "nothing with a flat draw axis changes verdict" (false once the
-            // status axis landed in the same commit), and clause 2 as previously written (false
-            // once the unpaired axis landed, because its precondition named only the axes that
-            // existed when it was written). Every one was caught by review running the claim
-            // through the compiled base. The failure mode is always identical: a precondition
-            // enumerated over today's axes, silently falsified by tomorrow's. So — stated to its
-            // exact edge, and explicitly scoped to the axes that exist NOW:
+            // TIER ORDER IS LOAD-BEARING. A precondition enumerated over today's axes is
+            // silently falsified by tomorrow's, so each clause below is stated to its exact edge
+            // and explicitly scoped to the axes that exist NOW:
             //
-            //   0. Every claim below presupposes two COMPARABLE reports. `compare` rejects a
-            //      mismatched `base_seed` or `difficulty` with `WorkloadMismatch` before any row
-            //      is classified, so such a pair now yields no verdict at all — INCLUDING pairs
-            //      that would previously have produced a Fail. That is intended, not a
-            //      regression: a verdict built by pairing seed numbers across two different
-            //      workloads was never meaningful, it merely looked like one.
+            //   0. Every claim below presupposes two COMPARABLE reports. `compare` rejects any
+            //      pair whose workload fields disagree, and any report that repeats a seed,
+            //      before a row is classified — so such a pair yields no verdict at all,
+            //      INCLUDING pairs that would otherwise have produced a Fail. That is intended:
+            //      a verdict built by pairing seed numbers across two different workloads was
+            //      never meaningful, it merely looked like one.
             //   1. Given comparable reports, nothing that reaches Fail today changes verdict. The
             //      W/L Fail arm is still first and its counters are byte-identical to before, so
             //      it wins every input it used to win.
@@ -337,8 +388,8 @@ fn classify_row(
             //      axis also wobbled insignificantly would reintroduce the same blindness one case
             //      narrower. Pinned by `draw_regression_escalates_an_insignificant_win_loss_warn`
             //      and `status_regression_escalates_an_insignificant_win_loss_warn` — one per
-            //      escalating arm, because a claim about an arm that no test exercises is how the
-            //      first two drafts of this comment stayed wrong.
+            //      escalating arm, because a claim about an arm that no test exercises is an
+            //      unpinned claim.
             //   4. A row that previously Passed with unmatched seeds now Warns. This is the
             //      false-green the unpaired arm exists to close: two reports sharing no seeds at
             //      all scored zero on every counter and passed. Pinned per direction —
@@ -545,9 +596,7 @@ fn paired_seed_shift(baseline: &MatchupResult, current: &MatchupResult) -> Paire
     let mut unpaired_baseline = 0;
 
     // Seeds present on both sides. Counting the intersection lets the current-side leftover
-    // be derived by subtraction instead of walked a second time, and it stays correct if a
-    // report ever repeats a seed (`current_by_seed` keeps one entry per seed, so deriving
-    // from `games.len()` alone would undercount).
+    // be derived by subtraction instead of walked a second time.
     let mut paired = 0usize;
 
     for baseline_game in &baseline.games {
@@ -585,9 +634,9 @@ fn paired_seed_shift(baseline: &MatchupResult, current: &MatchupResult) -> Paire
         .then(|| sign_test_mid_p_upper_tail(draw_flips, decisive_to_draw.max(draw_to_decisive)));
 
     // Current games never visited by the loop above, because pairing walks the baseline.
-    // `current_by_seed` is deduplicated by seed, so this is the count of distinct current
-    // seeds the baseline does not contain — saturating because a repeated baseline seed can
-    // push `paired` above the map's length without meaning anything went uncompared.
+    // `compare` refuses a report that repeats a seed, so `paired` cannot exceed the map's
+    // length and this subtraction is exact; `saturating_sub` keeps the function total for the
+    // unit tests that drive it on unvalidated input.
     let unpaired_current = current_by_seed.len().saturating_sub(paired);
 
     PairedSeedShift {
@@ -807,9 +856,7 @@ pub fn print_markdown(report: &CompareReport) {
 /// (`run.rs`, `print_markdown_table`), so on this path the file always has content and the
 /// workflow's empty-file abort is unreachable. What a stderr-only refusal actually produces is
 /// worse to read than an empty file: a red job whose issue body is a table of PASSing matchups
-/// and no statement of what failed. (An earlier draft of this comment asserted the empty-file
-/// story, which was false here — though it is true of `ai-perf-gate`, whose refusal path this
-/// commit fixes for exactly that reason.)
+/// and no statement of what failed.
 pub fn render_error_markdown(err: &CompareError) -> String {
     let remedy = match err {
         CompareError::WorkloadMismatch {
@@ -832,6 +879,18 @@ pub fn render_error_markdown(err: &CompareError) -> String {
              nothing else.\n\n\
              Until one of them is done this gate fails every run, by design: a verdict built \
              from a fraction of the sample is not a verdict."
+        ),
+        CompareError::DuplicateSeed {
+            side,
+            matchup_id,
+            seed,
+        } => format!(
+            "The {side} report lists seed `{seed}` more than once in matchup `{matchup_id}`. \
+             Pairing keys on the seed number, so a repeated seed has no single partner: one \
+             game would be compared twice and another never visited at all. Nothing was \
+             measured — this is not drift.\n\n\
+             Regenerate the report rather than editing it: `cargo ai-gate --refresh-baseline` \
+             for a baseline, a fresh gate run for a current report."
         ),
         CompareError::SchemaMismatch { .. } => "The baseline predates the current report format. \
              Re-record it with `cargo ai-gate --refresh-baseline`."
@@ -1291,10 +1350,9 @@ mod tests {
     /// The no-draw-shift control: with the draw counters equal, both draw guards (`>` and `!=`)
     /// are false and the chain falls through as it did before this change.
     ///
-    /// Scope, stated precisely because an earlier version of this doc overclaimed: the fixture is
-    /// an identity comparison, so ALL axes are flat, and it therefore pins only the draw guards'
-    /// inertness — not the full precondition of invariant 2, and not the tier order, which
-    /// `draw_regression_escalates_an_insignificant_win_loss_warn` pins.
+    /// Scope: the fixture is an identity comparison, so ALL axes are flat, and it therefore pins
+    /// only the draw guards' inertness — not the full precondition of invariant 2, and not the
+    /// tier order, which `draw_regression_escalates_an_insignificant_win_loss_warn` pins.
     #[test]
     fn compare_without_draw_shift_is_unaffected() {
         let rows: &[(u64, Option<u8>, u32)] = &[
@@ -1671,10 +1729,6 @@ mod tests {
     /// Only `unpaired_baseline` moves: every seed that pairs is UNCHANGED, so every other axis
     /// reads zero. Before this arm existed such a row scored zero on everything and returned
     /// Pass while half its samples went unexamined.
-    ///
-    /// (The two paragraphs that stood here were copied from
-    /// `markdown_cells_carry_their_own_column_values` and described that test's distinct-value
-    /// fixture, which this one does not have — every counter here is deliberately zero.)
     #[test]
     fn an_unmatched_baseline_sample_warns_instead_of_passing() {
         let before: &[(u64, Option<u8>, u32)] = &[
@@ -1835,12 +1889,10 @@ mod tests {
         assert_eq!(report.rows.len(), 1);
     }
 
-    /// A differing `games_per_matchup` is refused, and this test is the inversion of one that
-    /// asserted the opposite. The samples that pair really are comparable, which is why the
-    /// earlier version counted the remainder and Warned — but a Warn keeps `any_fail` false, the
-    /// gate exits 0, and the nightly publishes its report only on a non-zero exit. The counters
-    /// existed and were never read. A verdict drawn from a tenth of the sample must not be able
-    /// to come back Pass.
+    /// A differing `games_per_matchup` is refused. The samples that pair are comparable, but a
+    /// `Warn` keeps `any_fail` false, the gate exits 0, and the nightly publishes only on a
+    /// non-zero exit — so a verdict drawn from a tenth of the sample must not be able to come
+    /// back Pass.
     ///
     /// The two assertions below are the pair that makes this a fix rather than a trade: the row
     /// count pins that no verdict is produced, and the body pins that the diagnostics survive.
@@ -1890,6 +1942,90 @@ mod tests {
         );
     }
 
+    /// A repeated seed has no single partner. Pairing walks the baseline and looks each seed up
+    /// in a map keyed by seed, so the duplicate's second game re-pairs against the same current
+    /// game while a real current game is never visited — and `unpaired_current`, the counter that
+    /// would have said so, reads zero.
+    #[test]
+    fn a_repeated_seed_is_refused_rather_than_silently_dropping_current_games() {
+        let baseline = mk_report(vec![mk_result_from_games(
+            "dup",
+            &[(1, Some(0), 10), (1, Some(0), 10)],
+        )]);
+        let current = mk_report(vec![mk_result_from_games(
+            "dup",
+            &[(1, Some(0), 10), (2, Some(1), 10)],
+        )]);
+
+        // PREMISE: every workload field agrees, so the refusal can only come from the seed.
+        assert_eq!(baseline.base_seed, current.base_seed);
+        assert_eq!(baseline.difficulty, current.difficulty);
+        assert_eq!(baseline.games_per_matchup, current.games_per_matchup);
+
+        let err = compare(&baseline, &current, &CompareOptions).expect_err("must refuse");
+        assert!(
+            matches!(
+                &err,
+                CompareError::DuplicateSeed {
+                    side: ReportSide::Baseline,
+                    matchup_id,
+                    seed,
+                } if matchup_id == "dup" && *seed == 1
+            ),
+            "unexpected error: {err:?}"
+        );
+
+        // The refusal reaches the reader with the coordinates it needs to find the bad report.
+        let body = render_error_markdown(&err);
+        assert!(body.contains("baseline"), "{body}");
+        assert!(body.contains("dup"), "{body}");
+        assert!(body.contains("--refresh-baseline"), "{body}");
+    }
+
+    /// The other end of the class: the same malformedness on the current side.
+    #[test]
+    fn a_repeated_seed_in_the_current_report_is_refused_too() {
+        let baseline = mk_report(vec![mk_result_from_games(
+            "dup",
+            &[(1, Some(0), 10), (2, Some(1), 10)],
+        )]);
+        let current = mk_report(vec![mk_result_from_games(
+            "dup",
+            &[(1, Some(0), 10), (1, Some(0), 10)],
+        )]);
+
+        let err = compare(&baseline, &current, &CompareOptions).expect_err("must refuse");
+        assert!(
+            matches!(
+                &err,
+                CompareError::DuplicateSeed {
+                    side: ReportSide::Current,
+                    ..
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    /// The adversarial admitted member. A longer current run with DISTINCT seeds is the
+    /// legitimate unpaired-remainder case, and the guard must not turn it into a refusal — the
+    /// counter it pins is the one a duplicate corrupts.
+    #[test]
+    fn a_longer_current_run_with_distinct_seeds_still_compares() {
+        let baseline = mk_report(vec![mk_result_from_games(
+            "n",
+            &[(1, Some(0), 10), (2, Some(1), 10)],
+        )]);
+        let current = mk_report(vec![mk_result_from_games(
+            "n",
+            &[(1, Some(0), 10), (2, Some(1), 10), (3, Some(0), 10)],
+        )]);
+
+        let report = compare(&baseline, &current, &CompareOptions).expect("distinct seeds pair");
+        assert_eq!(report.rows[0].unpaired_current, 1);
+        assert_eq!(report.rows[0].unpaired_baseline, 0);
+    }
+
     /// Every refusal variant renders a body, including the two `compare` itself cannot produce.
     ///
     /// `Io` and `Parse` are reachable only through `load_report`, which `bin/ai_gate.rs` calls
@@ -1914,7 +2050,13 @@ mod tests {
             current: "100".to_string(),
         };
 
-        for err in [&io, &parse, &schema, &workload] {
+        let duplicate = CompareError::DuplicateSeed {
+            side: ReportSide::Baseline,
+            matchup_id: "red-mirror".to_string(),
+            seed: 7,
+        };
+
+        for err in [&io, &parse, &schema, &workload, &duplicate] {
             let body = render_error_markdown(err);
             assert!(!body.trim().is_empty(), "empty body for {err:?}");
             assert!(
@@ -2021,10 +2163,8 @@ mod tests {
             (6, Some(0), 10),
             (7, Some(0), 10),
             // p0 win, and still `Some(_) → None` in `after`, so this separates the two win-rate
-            // cells WITHOUT touching any of the four counters. Earlier this test made the rates
-            // differ by giving `after` an extra seed absent from `before` and leaning on
-            // `paired_seed_shift` skipping it in silence. That skip is now counted and warned on,
-            // so the fixture is re-derived to stand on matched seed sets instead of on a hole.
+            // cells WITHOUT touching any of the four counters. Both sides carry the same seed
+            // set, so the separation cannot come from an unpaired-seed skip.
             (8, Some(0), 10),
             (9, Some(1), 10),
             (10, None, 10),
@@ -2059,9 +2199,8 @@ mod tests {
             ),
             (2, 3, 4, 1)
         );
-        // PREMISE: the two win-rate cells DIFFER. They rendered identical `45%` in the first
-        // version of this test, so swapping them survived — the premise has to be asserted, not
-        // assumed, or "no pair of cells can be transposed" is false for the pair nobody checked.
+        // PREMISE: the two win-rate cells DIFFER. Identical cells would let a transposition
+        // survive, so the premise is asserted rather than assumed.
         assert_ne!(
             winrate(row.baseline.as_ref().unwrap()),
             winrate(row.current.as_ref().unwrap())
@@ -2281,10 +2420,7 @@ mod tests {
         // every one of them survived a fully green suite until review measured it. A New row has no
         // baseline to compare against; a Removed row has no current report at all.
         //
-        // All six sites are listed deliberately. The first pass at this pinned five and missed
-        // `draw sign p` — which is the fallback the real gate renders on every row today, since a
-        // matchup with a flat draw axis has no statistic to report. Sweeping a defect by recipe
-        // means sweeping ALL of its sites; a partial sweep reads as complete.
+        // Every `—` fallback site is asserted; a partial sweep reads as complete.
         assert_eq!(cell(&rendered, "brand-new", "baseline p0%"), "—");
         assert_eq!(cell(&rendered, "brand-new", "sign p"), "—");
         assert_eq!(cell(&rendered, "brand-new", "draw sign p"), "—");

--- a/crates/phase-ai/src/duel_suite/compare.rs
+++ b/crates/phase-ai/src/duel_suite/compare.rs
@@ -54,6 +54,12 @@ pub struct CompareRow {
     /// `None → Some(_)` — games that started resolving.
     pub draw_to_decisive: usize,
     pub unchanged: usize,
+    /// Baseline samples the comparison could not examine, and current samples it never
+    /// visited. Carried on the row for the same reason every other axis is: the verdict
+    /// chain is first-match-wins, so whichever arm fires suppresses every other arm's
+    /// message, and a column is the only surface that survives that suppression.
+    pub unpaired_baseline: usize,
+    pub unpaired_current: usize,
     pub sign_test_p: Option<f64>,
     pub draw_sign_test_p: Option<f64>,
     pub status: CompareStatus,
@@ -79,7 +85,20 @@ impl CompareReport {
 pub enum CompareError {
     Io(std::io::Error),
     Parse(serde_json::Error),
-    SchemaMismatch { baseline: u32, current: u32 },
+    SchemaMismatch {
+        baseline: u32,
+        current: u32,
+    },
+    /// A configuration that defines what a seed *means* differs between the reports, so
+    /// pairing by seed number would compare two unrelated games and call the difference
+    /// drift. One parameterized variant rather than a sibling per field, mirroring
+    /// `PerfCompareError::WorkloadMismatch`, which already solves this for the perf
+    /// comparator.
+    WorkloadMismatch {
+        field: &'static str,
+        baseline: String,
+        current: String,
+    },
 }
 
 impl std::fmt::Display for CompareError {
@@ -90,6 +109,15 @@ impl std::fmt::Display for CompareError {
             CompareError::SchemaMismatch { baseline, current } => write!(
                 f,
                 "schema_version mismatch: baseline={baseline} current={current}"
+            ),
+            CompareError::WorkloadMismatch {
+                field,
+                baseline,
+                current,
+            } => write!(
+                f,
+                "{field} mismatch: baseline={baseline} current={current} — \
+                 the reports describe different workloads and cannot be paired by seed"
             ),
         }
     }
@@ -128,6 +156,36 @@ pub fn compare(
         return Err(CompareError::SchemaMismatch {
             baseline: baseline.schema_version,
             current: current.schema_version,
+        });
+    }
+
+    // Everything below pairs games by seed NUMBER. That is only meaningful while both
+    // reports derive their seeds the same way and play them under the same AI, so the two
+    // inputs that define what a seed means are checked before any row is classified.
+    //
+    // `games_per_matchup` is deliberately NOT here. It changes how MANY seeds exist, not
+    // what a seed means, so the samples that do pair are still comparable — and the nightly
+    // job runs `--games 100` against a `games_per_matchup: 10` baseline today, so erroring
+    // would break a live workflow instead of informing it. That difference is surfaced as
+    // the unpaired counters below, which is the honest treatment: it was previously
+    // discarded in silence.
+    //
+    // `card_data_hash` is also not here: the committed baseline's hash matches no card-data
+    // present on any current checkout, so gating it would fail every run immediately. The
+    // perf comparator reaches the same conclusion — it carries card-data hashes as
+    // informational report fields rather than as a guard.
+    if baseline.base_seed != current.base_seed {
+        return Err(CompareError::WorkloadMismatch {
+            field: "base_seed",
+            baseline: baseline.base_seed.to_string(),
+            current: current.base_seed.to_string(),
+        });
+    }
+    if baseline.difficulty != current.difficulty {
+        return Err(CompareError::WorkloadMismatch {
+            field: "difficulty",
+            baseline: baseline.difficulty.clone(),
+            current: current.difficulty.clone(),
         });
     }
 
@@ -180,6 +238,8 @@ fn classify_row(
             decisive_to_draw: 0,
             draw_to_decisive: 0,
             unchanged: 0,
+            unpaired_baseline: 0,
+            unpaired_current: 0,
             sign_test_p: None,
             draw_sign_test_p: None,
             status: CompareStatus::Removed,
@@ -209,6 +269,8 @@ fn classify_row(
                 decisive_to_draw: 0,
                 draw_to_decisive: 0,
                 unchanged: 0,
+                unpaired_baseline: 0,
+                unpaired_current: 0,
                 sign_test_p: None,
                 draw_sign_test_p: None,
                 status,
@@ -222,21 +284,31 @@ fn classify_row(
             let paired = paired_seed_shift(b, c);
             let avg_turn_delta = c.avg_turns - b.avg_turns;
 
-            // TIER ORDER IS LOAD-BEARING. Two earlier drafts of this comment overclaimed what it
-            // buys — the first said "no input that reaches Fail or Warn today can change verdict"
-            // (false: Warn escalates), the second said "nothing with a flat draw axis changes
-            // verdict" (false once the status axis landed in the same commit). Both were caught by
-            // review running the claim through the compiled base. So, by construction and stated
-            // to its exact edge:
+            // TIER ORDER IS LOAD-BEARING. THREE earlier drafts of this comment overclaimed what
+            // it buys — "no input that reaches Fail or Warn today can change verdict" (false:
+            // Warn escalates), "nothing with a flat draw axis changes verdict" (false once the
+            // status axis landed in the same commit), and clause 2 as previously written (false
+            // once the unpaired axis landed, because its precondition named only the axes that
+            // existed when it was written). Every one was caught by review running the claim
+            // through the compiled base. The failure mode is always identical: a precondition
+            // enumerated over today's axes, silently falsified by tomorrow's. So — stated to its
+            // exact edge, and explicitly scoped to the axes that exist NOW:
             //
-            //   1. Nothing that reaches Fail today changes verdict. The W/L Fail arm is still
-            //      first and its counters are byte-identical to before, so it wins every input it
-            //      used to win.
-            //   2. A row whose draw counters are EQUAL and where NEITHER report's status is
-            //      `Fail` takes precisely the pre-change path. That is the full precondition, not
-            //      a draw-axis-only one: every new guard below needs either unequal draw counters
-            //      or a `Fail` on one side, so with both absent none can fire. This is what keeps
-            //      identity comparisons and every unaffected regression bit-for-bit unchanged.
+            //   0. Every claim below presupposes two COMPARABLE reports. `compare` rejects a
+            //      mismatched `base_seed` or `difficulty` with `WorkloadMismatch` before any row
+            //      is classified, so such a pair now yields no verdict at all — INCLUDING pairs
+            //      that would previously have produced a Fail. That is intended, not a
+            //      regression: a verdict built by pairing seed numbers across two different
+            //      workloads was never meaningful, it merely looked like one.
+            //   1. Given comparable reports, nothing that reaches Fail today changes verdict. The
+            //      W/L Fail arm is still first and its counters are byte-identical to before, so
+            //      it wins every input it used to win.
+            //   2. A row whose draw counters are EQUAL, whose seed sets match EXACTLY, and where
+            //      NEITHER report's status is `Fail` takes precisely the pre-change path. All
+            //      three conjuncts are required, one per guard added since: every new arm below
+            //      needs unequal draw counters, or a `Fail` on one side, or an unmatched seed, so
+            //      with all three absent none can fire. This is what keeps identity comparisons
+            //      and every unaffected regression bit-for-bit unchanged.
             //   3. A W/L *Warn* DOES escalate to Fail — via the draw Fail arm when the draw axis
             //      is significantly negative, and via the status Fail arm when the matchup newly
             //      fails its own suite check. Both escalations are intended: those are the
@@ -246,6 +318,12 @@ fn classify_row(
             //      and `status_regression_escalates_an_insignificant_win_loss_warn` — one per
             //      escalating arm, because a claim about an arm that no test exercises is how the
             //      first two drafts of this comment stayed wrong.
+            //   4. A row that previously Passed with unmatched seeds now Warns. This is the
+            //      false-green the unpaired arm exists to close: two reports sharing no seeds at
+            //      all scored zero on every counter and passed. Pinned per direction —
+            //      `an_unmatched_baseline_sample_warns_instead_of_passing` and
+            //      `an_extra_current_sample_warns_instead_of_passing` — because one fixture
+            //      covering both directions would let either direction rot unnoticed.
             //
             // Do not reorder to group same-axis arms together: moving either Fail arm below the
             // W/L Warn arm silently demotes its clause-3 escalation back to Warn. Both reorders
@@ -357,6 +435,28 @@ fn classify_row(
                     CompareStatus::Warn,
                     Some(format!("mirror avg-turn drift {avg_turn_delta:+.1} turns")),
                 )
+            } else if paired.unpaired_baseline > 0 || paired.unpaired_current > 0 {
+                // LAST of the Warn arms, and the position is deliberate in both directions.
+                //
+                // Not higher: every arm above reports measured drift, which is what the gate
+                // exists to find. This one reports reduced COVERAGE — it says the other
+                // numbers rest on fewer samples than the reports contain, not that anything
+                // regressed. The nightly runs `--games 100` against a 10-game baseline, so
+                // this condition is true on every row every night; ranking it above the drift
+                // arms would replace every real headline with a coverage notice.
+                //
+                // Not absent: without it, two reports sharing no seeds at all produce zero on
+                // every counter and return Pass, which is the false-green this arm exists to
+                // close. Both counters share one arm because the remedy is identical — align
+                // the workloads — and splitting them would be two siblings differing only in
+                // a direction label, with the direction already carried by its own column.
+                (
+                    CompareStatus::Warn,
+                    Some(format!(
+                        "incomplete pairing: {} baseline sample(s) unmatched, {} current sample(s) never compared",
+                        paired.unpaired_baseline, paired.unpaired_current,
+                    )),
+                )
             } else {
                 (CompareStatus::Pass, None)
             };
@@ -374,6 +474,8 @@ fn classify_row(
                 decisive_to_draw: paired.decisive_to_draw,
                 draw_to_decisive: paired.draw_to_decisive,
                 unchanged: paired.unchanged,
+                unpaired_baseline: paired.unpaired_baseline,
+                unpaired_current: paired.unpaired_current,
                 sign_test_p: paired.sign_test_p,
                 draw_sign_test_p: paired.draw_sign_test_p,
                 status,
@@ -392,6 +494,15 @@ struct PairedSeedShift {
     /// `None → Some(_)`: a game that used to stall now resolves. The improvement signal.
     draw_to_decisive: usize,
     unchanged: usize,
+    /// Baseline games whose seed is absent from the current report — samples the comparison
+    /// could not examine. Previously a bare `continue`: the sample vanished and every
+    /// counter below stayed silent about it, so a pair of reports sharing no seeds at all
+    /// scored zero on every axis and returned Pass.
+    unpaired_baseline: usize,
+    /// Current games whose seed is absent from the baseline. Pairing walks the baseline, so
+    /// these were never visited at all — a strictly larger current run could add any number
+    /// of losses and no counter would move.
+    unpaired_current: usize,
     sign_test_p: Option<f64>,
     /// Sign test on the draw axis, computed exactly like `sign_test_p` is on the win/loss axis.
     draw_sign_test_p: Option<f64>,
@@ -405,11 +516,23 @@ fn paired_seed_shift(baseline: &MatchupResult, current: &MatchupResult) -> Paire
     let mut decisive_to_draw = 0;
     let mut draw_to_decisive = 0;
     let mut unchanged = 0;
+    let mut unpaired_baseline = 0;
+
+    // Seeds present on both sides. Counting the intersection lets the current-side leftover
+    // be derived by subtraction instead of walked a second time, and it stays correct if a
+    // report ever repeats a seed (`current_by_seed` keeps one entry per seed, so deriving
+    // from `games.len()` alone would undercount).
+    let mut paired = 0usize;
 
     for baseline_game in &baseline.games {
         let Some(current_game) = current_by_seed.get(&baseline_game.seed) else {
+            // NOT a bare `continue` any more. A skipped sample is a sample the comparison
+            // could not examine, and staying silent about it is how a partial comparison
+            // reported Pass with every counter at zero.
+            unpaired_baseline += 1;
             continue;
         };
+        paired += 1;
         // EXHAUSTIVE, no `_` fallback. The wildcard this replaces is how the decisive→draw class
         // became invisible: it swept `Some(_) → None` into `unchanged`, so a matchup could lose
         // most of its winners and the comparison would report no movement at all. Listing every
@@ -435,12 +558,20 @@ fn paired_seed_shift(baseline: &MatchupResult, current: &MatchupResult) -> Paire
     let draw_sign_test_p = (draw_flips > 0)
         .then(|| sign_test_mid_p_upper_tail(draw_flips, decisive_to_draw.max(draw_to_decisive)));
 
+    // Current games never visited by the loop above, because pairing walks the baseline.
+    // `current_by_seed` is deduplicated by seed, so this is the count of distinct current
+    // seeds the baseline does not contain — saturating because a repeated baseline seed can
+    // push `paired` above the map's length without meaning anything went uncompared.
+    let unpaired_current = current_by_seed.len().saturating_sub(paired);
+
     PairedSeedShift {
         flipped_w_to_l,
         flipped_l_to_w,
         decisive_to_draw,
         draw_to_decisive,
         unchanged,
+        unpaired_baseline,
+        unpaired_current,
         sign_test_p,
         draw_sign_test_p,
     }
@@ -494,6 +625,8 @@ const COLUMNS: &[&str] = &[
     "dec→draw",
     "draw→dec",
     "draw sign p",
+    "unpaired base",
+    "unpaired cur",
     "Δ avg turns",
     "suite status",
     "status",
@@ -565,6 +698,8 @@ fn render_markdown(report: &CompareReport) -> String {
             row.decisive_to_draw.to_string(),
             row.draw_to_decisive.to_string(),
             draw_sign_p_cell,
+            row.unpaired_baseline.to_string(),
+            row.unpaired_current.to_string(),
             avg_turn_cell,
             suite_status_cell,
             status_str(row.status).to_string(),
@@ -1405,6 +1540,187 @@ mod tests {
     ///
     /// The fixture gives every numeric axis a DISTINCT value (2, 3, 4, 1, and two different
     /// p-values), so no pair of cells can be transposed without changing the rendered text.
+    /// Condition: only `unpaired_baseline` moves. Every paired seed is UNCHANGED, so every
+    /// other axis reads zero — before this arm existed the row scored zero on everything and
+    /// returned Pass while half its samples went unexamined.
+    #[test]
+    fn an_unmatched_baseline_sample_warns_instead_of_passing() {
+        let before: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(1), 10),
+            (3, Some(0), 10),
+            (4, Some(1), 10),
+        ];
+        // Seeds 3 and 4 never ran in current. The two that DID pair are identical.
+        let after: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];
+
+        let report = compare(
+            &mk_report(vec![mk_result_from_games("partial", before)]),
+            &mk_report(vec![mk_result_from_games("partial", after)]),
+            &CompareOptions,
+        )
+        .unwrap();
+        let row = &report.rows[0];
+
+        // PREMISE: every other axis really is flat, so the verdict below can only come from
+        // the unpaired arm. Without this the test would pass even if some other arm fired.
+        assert_eq!(
+            (
+                row.flipped_w_to_l,
+                row.flipped_l_to_w,
+                row.decisive_to_draw,
+                row.draw_to_decisive
+            ),
+            (0, 0, 0, 0)
+        );
+        assert_eq!((row.unpaired_baseline, row.unpaired_current), (2, 0));
+        assert_eq!(row.status, CompareStatus::Warn);
+        assert!(!report.any_fail());
+
+        let rendered = render_markdown(&report);
+        assert_eq!(cell(&rendered, "partial", "unpaired base"), "2");
+        assert_eq!(cell(&rendered, "partial", "unpaired cur"), "0");
+        assert_eq!(cell(&rendered, "partial", "status"), "WARN");
+    }
+
+    /// The other direction, and the one no counter could ever have seen: pairing walks the
+    /// BASELINE, so extra current samples were not skipped — they were never visited. A
+    /// current run could add any number of losses here and every counter would stay zero.
+    #[test]
+    fn an_extra_current_sample_warns_instead_of_passing() {
+        let before: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(1), 10)];
+        let after: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(1), 10),
+            (3, Some(1), 10),
+            (4, Some(1), 10),
+        ];
+
+        let report = compare(
+            &mk_report(vec![mk_result_from_games("extra", before)]),
+            &mk_report(vec![mk_result_from_games("extra", after)]),
+            &CompareOptions,
+        )
+        .unwrap();
+        let row = &report.rows[0];
+
+        assert_eq!(
+            (
+                row.flipped_w_to_l,
+                row.flipped_l_to_w,
+                row.decisive_to_draw,
+                row.draw_to_decisive
+            ),
+            (0, 0, 0, 0)
+        );
+        // Mirrored against the test above: this one must be (0, 2), not (2, 0). A single
+        // fixture covering "some unpaired sample exists" would pass with the two counters
+        // swapped, which is the transposition defect this PR already had to fix once.
+        assert_eq!((row.unpaired_baseline, row.unpaired_current), (0, 2));
+        assert_eq!(row.status, CompareStatus::Warn);
+        assert!(!report.any_fail());
+
+        let rendered = render_markdown(&report);
+        assert_eq!(cell(&rendered, "extra", "unpaired base"), "0");
+        assert_eq!(cell(&rendered, "extra", "unpaired cur"), "2");
+    }
+
+    /// The arm is LAST, so a row with real drift keeps the drift headline and reports the
+    /// coverage gap through its columns. This pins the tier position: promoting the unpaired
+    /// arm above the W/L arm would replace this reason string and flip this test.
+    #[test]
+    fn an_unpaired_sample_does_not_shadow_a_real_drift_reason() {
+        let before: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(0), 10),
+            (2, Some(0), 10),
+            (3, Some(0), 10),
+            (4, Some(0), 10),
+        ];
+        let after: &[(u64, Option<u8>, u32)] = &[
+            (1, Some(1), 10),
+            (2, Some(1), 10),
+            (3, Some(1), 10),
+            (5, Some(1), 10),
+        ];
+
+        let report = compare(
+            &mk_report(vec![mk_result_from_games("both", before)]),
+            &mk_report(vec![mk_result_from_games("both", after)]),
+            &CompareOptions,
+        )
+        .unwrap();
+        let row = &report.rows[0];
+
+        assert_eq!((row.unpaired_baseline, row.unpaired_current), (1, 1));
+        assert!(
+            row.reason.as_deref().unwrap().starts_with("paired"),
+            "drift reason must survive; got {:?}",
+            row.reason
+        );
+        // ...and the coverage gap is still visible, because columns outlive suppression.
+        let rendered = render_markdown(&report);
+        assert_eq!(cell(&rendered, "both", "unpaired base"), "1");
+        assert_eq!(cell(&rendered, "both", "unpaired cur"), "1");
+    }
+
+    #[test]
+    fn a_different_base_seed_is_refused_rather_than_compared() {
+        let mut baseline = mk_report(vec![mk_result("m", 5, 10, SuiteStatus::Pass)]);
+        let mut current = mk_report(vec![mk_result("m", 5, 10, SuiteStatus::Pass)]);
+        baseline.base_seed = 1;
+        current.base_seed = 2;
+
+        let err = compare(&baseline, &current, &CompareOptions).unwrap_err();
+        assert!(
+            matches!(&err, CompareError::WorkloadMismatch { field, .. } if *field == "base_seed"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_different_difficulty_is_refused_rather_than_compared() {
+        let baseline = mk_report(vec![mk_result("m", 5, 10, SuiteStatus::Pass)]);
+        let mut current = mk_report(vec![mk_result("m", 5, 10, SuiteStatus::Pass)]);
+        current.difficulty = "cEDH".into();
+
+        let err = compare(&baseline, &current, &CompareOptions).unwrap_err();
+        assert!(
+            matches!(&err, CompareError::WorkloadMismatch { field, .. } if *field == "difficulty"),
+            "got {err:?}"
+        );
+    }
+
+    /// The control arm for both guards above. Without it, a mutant that made `compare` reject
+    /// EVERY pair would satisfy the two mismatch tests and nothing would notice.
+    #[test]
+    fn matching_workloads_are_compared_normally() {
+        let baseline = mk_report(vec![mk_result("m", 5, 10, SuiteStatus::Pass)]);
+        let current = mk_report(vec![mk_result("m", 5, 10, SuiteStatus::Pass)]);
+
+        assert_eq!(baseline.base_seed, current.base_seed);
+        assert_eq!(baseline.difficulty, current.difficulty);
+        let report = compare(&baseline, &current, &CompareOptions).expect("must compare");
+        assert_eq!(report.rows.len(), 1);
+    }
+
+    /// `games_per_matchup` differing must NOT error: the nightly runs `--games 100` against a
+    /// 10-game baseline, so erroring would break a live workflow. The samples that pair are
+    /// still comparable, and the ones that do not are surfaced as unpaired counts instead.
+    #[test]
+    fn a_different_games_per_matchup_is_reported_not_refused() {
+        let before: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10)];
+        let after: &[(u64, Option<u8>, u32)] = &[(1, Some(0), 10), (2, Some(0), 10)];
+        let mut baseline = mk_report(vec![mk_result_from_games("n", before)]);
+        let mut current = mk_report(vec![mk_result_from_games("n", after)]);
+        baseline.games_per_matchup = 1;
+        current.games_per_matchup = 2;
+
+        let report = compare(&baseline, &current, &CompareOptions).expect("must not refuse");
+        assert_eq!(report.rows[0].unpaired_current, 1);
+        assert_eq!(report.rows[0].status, CompareStatus::Warn);
+        assert!(!report.any_fail());
+    }
+
     #[test]
     fn markdown_cells_carry_their_own_column_values() {
         let before: &[(u64, Option<u8>, u32)] = &[
@@ -1415,7 +1731,12 @@ mod tests {
             (5, Some(1), 10),
             (6, Some(0), 10),
             (7, Some(0), 10),
-            (8, Some(1), 10),
+            // p0 win, and still `Some(_) → None` in `after`, so this separates the two win-rate
+            // cells WITHOUT touching any of the four counters. Earlier this test made the rates
+            // differ by giving `after` an extra seed absent from `before` and leaning on
+            // `paired_seed_shift` skipping it in silence. That skip is now counted and warned on,
+            // so the fixture is re-derived to stand on matched seed sets instead of on a hole.
+            (8, Some(0), 10),
             (9, Some(1), 10),
             (10, None, 10),
             (11, Some(0), 10),
@@ -1432,10 +1753,6 @@ mod tests {
             (9, None, 10),
             (10, Some(0), 10),
             (11, Some(0), 10),
-            // Present only in the current report. `paired_seed_shift` walks the BASELINE games and
-            // skips unmatched seeds, so this moves the win rate without touching a flip counter —
-            // which is what makes the two p0% cells differ while the four counters stay distinct.
-            (12, Some(0), 10),
         ];
         let baseline = mk_report(vec![mk_result_from_games("distinct", before)]);
         let mut current_result = mk_result_from_games("distinct", after);
@@ -1460,11 +1777,17 @@ mod tests {
             winrate(row.baseline.as_ref().unwrap()),
             winrate(row.current.as_ref().unwrap())
         );
+        // PREMISE: and it achieves that on MATCHED seed sets, so this test measures the
+        // transposition property alone. If a future edit reintroduces an unmatched seed here, the
+        // row would also start carrying the unpaired axis and this fixture would quietly become
+        // two tests wearing one name.
+        assert_eq!((row.unpaired_baseline, row.unpaired_current), (0, 0));
 
         let rendered = render_markdown(&report);
         assert_eq!(cell(&rendered, "distinct", "exercises"), "AggroPressure");
-        assert_eq!(cell(&rendered, "distinct", "baseline p0%"), "45%");
-        assert_eq!(cell(&rendered, "distinct", "current p0%"), "50%");
+        // 6/11 vs 5/11 — separated by the seed-8 outcome, not by an uncompared sample.
+        assert_eq!(cell(&rendered, "distinct", "baseline p0%"), "55%");
+        assert_eq!(cell(&rendered, "distinct", "current p0%"), "45%");
         assert_eq!(cell(&rendered, "distinct", "flips W→L"), "2");
         assert_eq!(cell(&rendered, "distinct", "flips L→W"), "3");
         assert_eq!(cell(&rendered, "distinct", "dec→draw"), "4");

--- a/crates/phase-ai/src/duel_suite/mod.rs
+++ b/crates/phase-ai/src/duel_suite/mod.rs
@@ -20,6 +20,18 @@ mod tests;
 
 use serde::{Deserialize, Serialize};
 
+/// Wrap a refused comparison in the markdown envelope both gates publish.
+///
+/// Both `ai-gate` and `ai-perf-gate` redirect stdout into a file that
+/// `.github/workflows/ai-gate.yml` posts as a drift issue, and both abort when that file
+/// is empty. A refusal that reaches only stderr is therefore invisible exactly where it
+/// matters most — the reader of a red job sees no statement of what failed. One envelope
+/// rather than two so the two gates cannot drift into describing the same situation
+/// differently; the remedy text stays per-error-type, because the knobs differ.
+pub(crate) fn refusal_markdown(err: &dyn std::fmt::Display, remedy: &str) -> String {
+    format!("## Gate: comparison refused\n\n**{err}**\n\n{remedy}\n")
+}
+
 pub use run::{run_suite, MatchupResult, SuiteReport, SuiteStatus};
 pub use snapshots::{load_snapshot, resolve_deck_ref, SnapshotError};
 pub use spec::{all_matchups, find_matchup, MATCHUPS};

--- a/crates/phase-ai/src/duel_suite/perf.rs
+++ b/crates/phase-ai/src/duel_suite/perf.rs
@@ -451,9 +451,9 @@ pub fn run_perf_suite(
 /// real trajectory — this gate compares aggregate COST LEVELS, not a replayed game.
 ///
 /// Panics (internal invariant, not a runtime input path) if `samples` is empty or
-/// the samples disagree on schema_version / base_seed / action_cap — every sample
-/// is produced by the same binary at the same const workload, so disagreement is a
-/// bug. Provenance (git_sha, card_data_hash) is left None for the caller to stamp.
+/// the samples disagree on any workload field — every sample is produced by the
+/// same binary at the same const workload, so disagreement is a bug. Provenance
+/// (git_sha, card_data_hash) is left None for the caller to stamp.
 pub fn median_report(samples: &[PerfReport]) -> PerfReport {
     assert!(
         !samples.is_empty(),
@@ -467,6 +467,9 @@ pub fn median_report(samples: &[PerfReport]) -> PerfReport {
         );
         assert_eq!(s.base_seed, first.base_seed, "sample seed mismatch");
         assert_eq!(s.action_cap, first.action_cap, "sample action_cap mismatch");
+        // Order-sensitive: samples come from the same const `default_scenarios()`, so this is
+        // an internal invariant rather than a runtime input path.
+        assert_eq!(s.scenarios, first.scenarios, "sample scenario mismatch");
     }
     // All samples share an identical key set (from_snapshot is a total destructure).
     let mut counters = BTreeMap::new();
@@ -554,8 +557,8 @@ impl PerfCompareReport {
 }
 
 /// Comparison error. Parallels the win-rate gate's `compare::CompareError` but
-/// is defined locally (that type lives in the out-of-bounds `compare.rs` and
-/// lacks the workload-mismatch variant this gate needs).
+/// is defined locally: the two gates carry different payloads and render their
+/// refusals separately.
 #[derive(Debug)]
 pub enum PerfCompareError {
     Io(std::io::Error),
@@ -565,8 +568,8 @@ pub enum PerfCompareError {
         baseline: u32,
         current: u32,
     },
-    /// The workload (seed or action_cap) differs — the counter payloads describe
-    /// different runs, so any comparison would be a false PASS/FAIL (exit 2).
+    /// A workload field differs — the counter payloads describe different runs, so
+    /// any comparison would be a false PASS/FAIL (exit 2).
     WorkloadMismatch {
         field: &'static str,
         baseline: String,
@@ -617,6 +620,13 @@ pub fn load_report(path: &Path) -> Result<PerfReport, PerfCompareError> {
     Ok(report)
 }
 
+/// The scenario list as a sorted multiset, for comparison.
+fn sorted_scenarios(scenarios: &[String]) -> Vec<&str> {
+    let mut sorted: Vec<&str> = scenarios.iter().map(String::as_str).collect();
+    sorted.sort_unstable();
+    sorted
+}
+
 /// FAIL threshold for a counter: `baseline * ratio + floor`, rounded via f64
 /// (the counters are far below f64's 2^53 exact-integer ceiling).
 fn fail_threshold(baseline: u64) -> u64 {
@@ -629,8 +639,8 @@ fn counter_fails(baseline: u64, current: u64) -> bool {
     (current as f64) > (baseline as f64) * PERF_TOLERANCE_RATIO + PERF_ABSOLUTE_FLOOR as f64
 }
 
-/// Compare a current report against a baseline. Guards run in order: (1) schema
-/// version, (2) workload (seed/action_cap). Only then are counters classified
+/// Compare a current report against a baseline. Guards run in order: schema
+/// version first, then every workload field. Only then are counters classified
 /// per key across the union of baseline and current keys.
 pub fn compare(
     baseline: &PerfReport,
@@ -663,6 +673,20 @@ pub fn compare(
             field: "sample_count",
             baseline: baseline.sample_count.to_string(),
             current: current.sample_count.to_string(),
+        });
+    }
+
+    // Counters are summed field-wise across scenarios, so the aggregate does not say which
+    // scenarios produced it. The sum is order-invariant, which makes a reorder the same
+    // workload — but a repeat is not, because that scenario's cost is counted twice. Hence a
+    // sorted multiset, and the message renders the same sorted form that was compared.
+    let baseline_scenarios = sorted_scenarios(&baseline.scenarios);
+    let current_scenarios = sorted_scenarios(&current.scenarios);
+    if baseline_scenarios != current_scenarios {
+        return Err(PerfCompareError::WorkloadMismatch {
+            field: "scenarios",
+            baseline: baseline_scenarios.join(", "),
+            current: current_scenarios.join(", "),
         });
     }
 
@@ -1404,6 +1428,71 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // Matrix 15: the counter aggregate does not say which scenarios produced it, so a
+    // differing scenario list is a differing workload. Three arms, three wrong
+    // implementations: `Vec` equality fails the reorder arm, `HashSet` fails the repeat arm,
+    // no guard at all fails the length arm.
+    #[test]
+    fn a_different_scenario_list_is_refused_rather_than_compared() {
+        let mut baseline = mk_report(&[("c", 1)]);
+        baseline.scenarios = vec!["a".to_string(), "b".to_string()];
+        let mut current = mk_report(&[("c", 1)]);
+        current.scenarios = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+
+        let err = compare(&baseline, &current).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PerfCompareError::WorkloadMismatch {
+                    field: "scenarios",
+                    ..
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_reordered_scenario_list_still_compares() {
+        let mut baseline = mk_report(&[("c", 1)]);
+        baseline.scenarios = vec!["a".to_string(), "b".to_string()];
+        let mut current = mk_report(&[("c", 1)]);
+        current.scenarios = vec!["b".to_string(), "a".to_string()];
+
+        compare(&baseline, &current).expect("a field-wise sum is order-invariant");
+    }
+
+    #[test]
+    fn a_repeated_scenario_is_refused() {
+        let mut baseline = mk_report(&[("c", 1)]);
+        baseline.scenarios = vec!["a".to_string(), "a".to_string(), "b".to_string()];
+        let mut current = mk_report(&[("c", 1)]);
+        current.scenarios = vec!["a".to_string(), "b".to_string()];
+
+        let err = compare(&baseline, &current).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PerfCompareError::WorkloadMismatch {
+                    field: "scenarios",
+                    ..
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    // Matrix 13 (hostile): `scenarios` is the member the sample-agreement loop omitted, so a
+    // median over mixed scenario lists was stamped with the first sample's and read as clean.
+    #[test]
+    #[should_panic(expected = "sample scenario mismatch")]
+    fn median_report_rejects_samples_that_disagree_on_scenarios() {
+        let mut odd = mk_report(&[("c", 1)]);
+        odd.scenarios = vec!["a-scenario-the-other-sample-did-not-run".to_string()];
+        let samples = [mk_report(&[("c", 1)]), odd];
+        let _ = median_report(&samples);
     }
 
     // Matrix M-even: median totality for even K — deterministic upper-middle at

--- a/crates/phase-ai/src/duel_suite/perf.rs
+++ b/crates/phase-ai/src/duel_suite/perf.rs
@@ -74,6 +74,7 @@ use engine::game::perf_counters::{self, PerfCounterSnapshot};
 use serde::{Deserialize, Serialize};
 
 use crate::config::AiDifficulty;
+use crate::duel_suite::refusal_markdown;
 
 use super::find_matchup;
 use super::run::{drive_game, resolve_matchup};
@@ -711,6 +712,40 @@ fn verdict_str(v: CounterVerdict) -> &'static str {
     }
 }
 
+/// The report body for a perf comparison that could not be made at all.
+///
+/// This gate has the failure the duel-suite gate only looked like it had. Nothing in
+/// `bin/ai_perf_gate.rs` writes to stdout before `compare` — every diagnostic on the way
+/// there is `eprintln!` — so a refusal that reached only stderr left
+/// `target/ai-perf-gate-report.md` at zero bytes, and `.github/workflows/ai-gate.yml`
+/// answers an empty report by aborting with "Decision-cost perf gate failed without a
+/// drift report" and posting no issue at all. The refusal was produced and then thrown
+/// away. Sharing `refusal_markdown` with the duel-suite gate so the two cannot drift.
+pub fn render_error_markdown(err: &PerfCompareError) -> String {
+    let remedy = match err {
+        PerfCompareError::WorkloadMismatch {
+            field,
+            baseline,
+            current,
+        } => format!(
+            "The samples were taken under different `{field}` (`{baseline}` vs `{current}`), so \
+             their counters describe different runs and any comparison would be a false verdict. \
+             Either re-record the baseline under the current workload \
+             (`cargo ai-perf-gate --refresh-baseline`) — checking first that every other \
+             invocation reading this baseline uses that workload too — or run the gate under the \
+             baseline's workload. Nothing was measured, so this is not a perf regression."
+        ),
+        PerfCompareError::SchemaMismatch { .. } => "The baseline predates the current report \
+             format. Bump `schema_version` and re-record it with \
+             `cargo ai-perf-gate --refresh-baseline`."
+            .to_string(),
+        PerfCompareError::Io(_) | PerfCompareError::Parse(_) => "The baseline could not be read. \
+             Check the path, and that the file is the JSON a previous `--refresh-baseline` wrote."
+            .to_string(),
+    };
+    refusal_markdown(err, &remedy)
+}
+
 /// Render the comparison as a markdown table to stdout; diagnostics (hash-delta
 /// annotation, removed-field warning) go to stderr so a redirected stdout report
 /// stays a clean table.
@@ -1042,6 +1077,59 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    /// Every refusal this gate can produce must carry a non-empty report body naming what
+    /// happened, because the workflow posts stdout and aborts on an empty file — so a refusal
+    /// that reaches only stderr posts nothing at all. Asserted over EVERY variant by
+    /// construction rather than over the one that is easiest to build: a variant added later
+    /// with no remedy would otherwise ship silently.
+    ///
+    /// The `assert_ne!` against the bare `Display` is the discriminating half. Without it a
+    /// `render_error_markdown` that just forwarded the error string would pass every other
+    /// assertion here, and that implementation is precisely the one that loses the remedy.
+    #[test]
+    fn every_refusal_renders_a_body_that_says_more_than_the_error_line() {
+        let io = PerfCompareError::Io(std::io::Error::other("disk"));
+        let parse = PerfCompareError::Parse(serde_json::from_str::<PerfReport>("{").unwrap_err());
+        let schema = PerfCompareError::SchemaMismatch {
+            baseline: 1,
+            current: 2,
+        };
+        let workload = PerfCompareError::WorkloadMismatch {
+            field: "action_cap",
+            baseline: "10".to_string(),
+            current: "20".to_string(),
+        };
+
+        for err in [&io, &parse, &schema, &workload] {
+            let body = render_error_markdown(err);
+            assert!(!body.trim().is_empty(), "empty body for {err:?}");
+            assert!(
+                body.contains("## Gate: comparison refused"),
+                "missing heading for {err:?}: {body}"
+            );
+            assert!(
+                body.contains(&err.to_string()),
+                "body must carry the error itself for {err:?}: {body}"
+            );
+            assert_ne!(
+                body.trim(),
+                err.to_string().trim(),
+                "body must add a remedy, not echo the error, for {err:?}"
+            );
+        }
+
+        // The workload arm is the reachable one in CI, so its two values and both directions
+        // of remedy are pinned rather than left to the loop's generic assertions.
+        let body = render_error_markdown(&workload);
+        assert!(body.contains("action_cap"), "{body}");
+        assert!(body.contains("`10`") && body.contains("`20`"), "{body}");
+        assert!(body.contains("--refresh-baseline"), "{body}");
+        assert!(
+            body.contains("run the gate under the baseline's workload"),
+            "{body}"
+        );
     }
 
     // Matrix 7: adapter totality — a distinct non-zero value per field yields one

--- a/crates/phase-ai/tests/gate_cli.rs
+++ b/crates/phase-ai/tests/gate_cli.rs
@@ -274,6 +274,8 @@ fn is_comment(line: &str) -> bool {
     line.trim_start().starts_with('#')
 }
 
+const DEBUG_DIR: &str = "target/debug/";
+
 /// `target/debug/<name>` occurrences on the non-comment `ci.yml` lines `keep` selects.
 ///
 /// Shipping a binary to a shard is a CONJUNCTION over two independently editable sites: the
@@ -281,14 +283,13 @@ fn is_comment(line: &str) -> bool {
 /// Actions artifacts drop. Neither implies the other, so the two are scanned separately and
 /// never unioned. `match_indices`, not `find`: the `chmod` line names several binaries.
 fn debug_binaries(ci_yml: &str, keep: impl Fn(&str) -> bool) -> BTreeSet<String> {
-    const PREFIX: &str = "target/debug/";
     let mut names = BTreeSet::new();
     for line in ci_yml
         .lines()
         .filter(|line| !is_comment(line) && keep(line))
     {
-        for (idx, _) in line.match_indices(PREFIX) {
-            let name = binary_name(&line[idx + PREFIX.len()..]);
+        for (idx, _) in line.match_indices(DEBUG_DIR) {
+            let name = binary_name(&line[idx + DEBUG_DIR.len()..]);
             if !name.is_empty() {
                 names.insert(name);
             }
@@ -297,8 +298,20 @@ fn debug_binaries(ci_yml: &str, keep: impl Fn(&str) -> bool) -> BTreeSet<String>
     names
 }
 
+/// Lines that ARE an upload `path:` entry: the whole trimmed content is one `target/debug/<name>`,
+/// as a block-scalar item or as the single-entry inline form. Keyed on any mention instead, a
+/// `run: ls -l target/debug/<name>` elsewhere in the file would enroll a binary the upload step
+/// never carries, and the set-equality assertion would then confirm agreement about a binary that
+/// never reaches the shard. Every command form (`chmod +x …`, `ls -l …`) leaves a prefix, so none
+/// of them can pass this.
 fn uploaded_binaries(ci_yml: &str) -> BTreeSet<String> {
-    debug_binaries(ci_yml, |line| !line.contains("chmod"))
+    debug_binaries(ci_yml, |line| {
+        let entry = line.trim();
+        let entry = entry.strip_prefix("path:").map_or(entry, str::trim_start);
+        entry
+            .strip_prefix(DEBUG_DIR)
+            .is_some_and(|name| name == binary_name(name))
+    })
 }
 
 fn chmod_binaries(ci_yml: &str) -> BTreeSet<String> {
@@ -392,6 +405,39 @@ fn the_upload_and_chmod_scanners_partition_the_file() {
         chmod_binaries(FIXTURE),
         BTreeSet::from(["beta".to_string()])
     );
+}
+
+/// A `target/debug/<name>` that is merely MENTIONED — an `ls`, a `cp`, a diagnostic — is not an
+/// upload `path:` entry. Keyed on any mention, `spare` below joins BOTH sets: every subset
+/// assertion holds and the two sets compare equal, so the suite stays green while `spare` is
+/// never uploaded and its consumer dies at spawn in the shard.
+#[test]
+fn a_mentioned_binary_is_not_an_uploaded_one() {
+    // The three real shapes: a block-scalar `path:` entry, a diagnostic that merely names a
+    // binary, and the chmod line that names both.
+    const FIXTURE: &str = "          path: |
+            target/debug/shipped
+        run: ls -l target/debug/spare
+        run: chmod +x target/debug/shipped target/debug/spare
+";
+
+    assert_eq!(
+        uploaded_binaries(FIXTURE),
+        BTreeSet::from(["shipped".to_string()])
+    );
+    assert_eq!(
+        chmod_binaries(FIXTURE),
+        BTreeSet::from(["shipped".to_string(), "spare".to_string()])
+    );
+    assert_ne!(uploaded_binaries(FIXTURE), chmod_binaries(FIXTURE));
+
+    // The consumer of the un-uploaded binary is named by the upload leg, and only by it.
+    let consumers = BTreeSet::from(["spare".to_string()]);
+    assert_eq!(
+        unshipped(&consumers, &uploaded_binaries(FIXTURE)),
+        vec!["spare".to_string()]
+    );
+    assert!(unshipped(&consumers, &chmod_binaries(FIXTURE)).is_empty());
 }
 
 /// Every `cargo ai-gate` invocation written down in `.github/workflows/`, as `(file, tokens)`.

--- a/crates/phase-ai/tests/gate_cli.rs
+++ b/crates/phase-ai/tests/gate_cli.rs
@@ -1,9 +1,8 @@
 //! The gate's process-level contract: exit status and stdout body, together.
 //!
-//! Review found that every test for this pairing stopped at the library call, while the two
-//! statements that actually matter — print the body, exit with the code — lived in a binary no
-//! test executed. A `main` that printed the refusal to stderr, or exited 0 on it, would revert
-//! the fix with the whole unit suite green.
+//! The two statements that actually matter — print the body, exit with the code — live in a
+//! binary, not in the library, so a `main` that printed the refusal to stderr or exited 0 on it
+//! is invisible to the unit suite. These tests spawn the binary and read both.
 //!
 //! `.github/workflows/ai-gate.yml` redirects the gate's **stdout** into a file, posts that file
 //! as a drift issue only when the step **failed**, and aborts when the file is empty. Those two
@@ -132,10 +131,10 @@ fn a_refused_comparison_exits_nonzero_and_writes_its_reason_to_stdout() {
 
 /// A report that cannot be READ must refuse on the same terms as one that cannot be COMPARED.
 ///
-/// Review found these two arms returned 2 after an `eprintln!` alone, so the workflow's redirected
-/// stdout stayed empty and its "failed without a drift report" abort fired instead of the refusal
-/// being posted. Both inputs are covered because they are separate arms in the source — a fix
-/// applied to one and not the other is exactly the shape of defect this file exists to catch.
+/// A refusal that reaches only stderr leaves the workflow's redirected stdout empty, and its
+/// "failed without a drift report" abort fires instead of the refusal being posted. Both inputs
+/// are covered because they are separate arms in the source — a fix applied to one and not the
+/// other is exactly the shape of defect this file exists to catch.
 ///
 /// Missing and malformed are both exercised because they take different `CompareError` variants
 /// (`Io` vs `Parse`) to the same renderer, and a remedy keyed on only one of them would leave the
@@ -269,6 +268,12 @@ fn binary_name(rest: &str) -> String {
         .collect()
 }
 
+/// A commented-out YAML line. Both workflow scanners below skip these — an illustrative or
+/// disabled command inside a comment is not a live site.
+fn is_comment(line: &str) -> bool {
+    line.trim_start().starts_with('#')
+}
+
 /// `target/debug/<name>` occurrences on the non-comment `ci.yml` lines `keep` selects.
 ///
 /// Shipping a binary to a shard is a CONJUNCTION over two independently editable sites: the
@@ -280,7 +285,7 @@ fn debug_binaries(ci_yml: &str, keep: impl Fn(&str) -> bool) -> BTreeSet<String>
     let mut names = BTreeSet::new();
     for line in ci_yml
         .lines()
-        .filter(|line| !line.trim_start().starts_with('#') && keep(line))
+        .filter(|line| !is_comment(line) && keep(line))
     {
         for (idx, _) in line.match_indices(PREFIX) {
             let name = binary_name(&line[idx + PREFIX.len()..]);
@@ -344,6 +349,16 @@ fn every_binary_an_integration_test_spawns_is_shipped_to_the_test_shards() {
         unshipped(&consumers, &chmodded)
     );
 
+    // The two ci.yml sites name the SAME binaries, in both directions. A chmod on a name the
+    // upload omitted fails the step loudly; an uploaded-but-unchmodded name reaches the shard and
+    // dies at spawn. Set against set, never against a literal, so a fourth consumer passes once
+    // it is added to both sites and fails while it is missing from one.
+    assert_eq!(
+        uploaded, chmodded,
+        "ci.yml's `Upload test runtime binaries` path: list and its `chmod +x` line must name the \
+         same binaries"
+    );
+
     // Refused end, withheld from ONE site: a name absent from either list alone must be named
     // by that leg and by no other. An implementation that unioned the two sites passes the
     // assertions above while shipping a PermissionDenied.
@@ -401,7 +416,7 @@ fn gate_invocations(root: &Path) -> Vec<(String, Vec<String>)> {
             .to_string_lossy()
             .into_owned();
         let text = fs::read_to_string(&path).expect("read workflow");
-        for line in text.lines() {
+        for line in text.lines().filter(|line| !is_comment(line)) {
             let invokes_gate = line
                 .match_indices(NEEDLE)
                 .any(|(idx, _)| !line[idx + NEEDLE.len()..].starts_with('-'));
@@ -520,4 +535,28 @@ fn every_workflow_gate_invocation_spells_the_baseline_workload() {
         "control must name exactly the divergent invocation; findings:\n{}",
         control.join("\n")
     );
+}
+
+/// A commented-out invocation is not an invocation. Without the skip, an illustrative
+/// `# cargo ai-gate ...` line anywhere under `.github/workflows/` becomes a finding, and the
+/// scanner starts dictating what the comments beside it are allowed to say.
+#[test]
+fn a_commented_out_gate_invocation_is_not_scanned() {
+    let root = tempdir("commented-invocation");
+    let workflows = root.join(".github/workflows");
+    fs::create_dir_all(&workflows).expect("create workflow fixture dir");
+    write(
+        &workflows,
+        "fixture.yml",
+        "  # cargo ai-gate --games 100 --seed 7 --difficulty medium\n\
+         run: cargo ai-gate --games 40 --seed 7 --difficulty medium\n",
+    );
+
+    let found = gate_invocations(&root);
+
+    // PREMISE: the live line IS picked up, or the count below is satisfied by a dead scanner.
+    assert_eq!(found.len(), 1, "{found:?}");
+    assert_eq!(flag(&found[0].1, "--games"), Some("40"), "{found:?}");
+
+    fs::remove_dir_all(&root).ok();
 }

--- a/crates/phase-ai/tests/gate_cli.rs
+++ b/crates/phase-ai/tests/gate_cli.rs
@@ -14,7 +14,14 @@
 //! `emit_gate_verdict` that needs no card database and plays no games — it reads two report
 //! files and prints a verdict. That makes this a millisecond test instead of a full suite run,
 //! and it exercises the same shared emitter `ai-gate` and `ai-perf-gate` end in.
+//!
+//! The same subject widens to the CI contracts this crate's tests depend on: the hand-maintained
+//! lists in `.github/workflows/` that must agree with what the code does, which nothing else
+//! checks.
 
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use phase_ai::duel_suite::run::{GameResult, MatchupResult, SuiteReport, SuiteStatus};
@@ -22,11 +29,10 @@ use phase_ai::duel_suite::Expected;
 
 /// Build the fixture from the real types rather than hand-written JSON.
 ///
-/// The first draft of this test hand-wrote the report and got `Expected`'s encoding wrong — it
-/// is an internally tagged enum — so both arms failed on a parse error instead of on the
-/// contract under test. Serialising the actual structs cannot drift from the schema: a field
-/// added to `SuiteReport` breaks compilation here rather than silently producing a fixture the
-/// binary rejects, and the parse is exercised by the binary, not asserted by the test.
+/// Serialising the actual structs cannot drift from the schema (`Expected` is internally tagged,
+/// which a hand-written fixture gets wrong silently): a field added to `SuiteReport` breaks
+/// compilation here rather than producing a fixture the binary rejects on a parse error instead
+/// of on the contract under test, and the parse is exercised by the binary, not asserted here.
 ///
 /// `games_per_matchup` is the workload knob; everything else is held equal so the refusal in
 /// the first test can only come from that field.
@@ -199,4 +205,319 @@ fn a_comparable_pair_exits_zero_and_writes_a_table() {
     );
 
     std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Repository root, from the crate this test compiles in.
+///
+/// `CARGO_MANIFEST_DIR` points at source the shard's checkout provides, unlike `CARGO_BIN_EXE_*`,
+/// which points at a build artifact the archive does not ship.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+/// Every `.rs` file under `dir`, recursively. Callers pass directories they have confirmed exist.
+fn rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("read a directory that is_dir() reported") {
+        let path = entry.expect("read directory entry").path();
+        if path.is_dir() {
+            if path.file_name().is_some_and(|name| name == "target") {
+                continue;
+            }
+            rs_files(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Binaries named by a literal `CARGO_BIN_EXE_<name>` under `crates/*/tests` and `crates/*/benches`.
+///
+/// Cargo sets that variable only when building an integration test or a benchmark, so an
+/// occurrence elsewhere would not compile. This is a LOWER BOUND on "every binary a test spawns":
+/// a name assembled through `concat!` or supplied by a build script evades a textual scan.
+fn bin_exe_consumers(root: &Path) -> BTreeSet<String> {
+    const PREFIX: &str = "CARGO_BIN_EXE_";
+    let mut files = Vec::new();
+    // The one directory whose absence means the scanner is aimed wrong; a missing per-crate
+    // `tests`/`benches` is the normal case (most crates have neither).
+    for entry in fs::read_dir(root.join("crates")).expect("read crates/") {
+        let crate_dir = entry.expect("read crates/ entry").path();
+        for sub in ["tests", "benches"] {
+            let dir = crate_dir.join(sub);
+            if dir.is_dir() {
+                rs_files(&dir, &mut files);
+            }
+        }
+    }
+    let mut names = BTreeSet::new();
+    for path in files {
+        let text = fs::read_to_string(&path).expect("read integration-test source");
+        for (idx, _) in text.match_indices(PREFIX) {
+            let name = binary_name(&text[idx + PREFIX.len()..]);
+            if !name.is_empty() {
+                names.insert(name);
+            }
+        }
+    }
+    names
+}
+
+/// The leading crate-name-shaped token of `rest`.
+fn binary_name(rest: &str) -> String {
+    rest.chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect()
+}
+
+/// `target/debug/<name>` occurrences on the non-comment `ci.yml` lines `keep` selects.
+///
+/// Shipping a binary to a shard is a CONJUNCTION over two independently editable sites: the
+/// upload `path:` list carries the file, and the `chmod +x` line restores the executable bit
+/// Actions artifacts drop. Neither implies the other, so the two are scanned separately and
+/// never unioned. `match_indices`, not `find`: the `chmod` line names several binaries.
+fn debug_binaries(ci_yml: &str, keep: impl Fn(&str) -> bool) -> BTreeSet<String> {
+    const PREFIX: &str = "target/debug/";
+    let mut names = BTreeSet::new();
+    for line in ci_yml
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#') && keep(line))
+    {
+        for (idx, _) in line.match_indices(PREFIX) {
+            let name = binary_name(&line[idx + PREFIX.len()..]);
+            if !name.is_empty() {
+                names.insert(name);
+            }
+        }
+    }
+    names
+}
+
+fn uploaded_binaries(ci_yml: &str) -> BTreeSet<String> {
+    debug_binaries(ci_yml, |line| !line.contains("chmod"))
+}
+
+fn chmod_binaries(ci_yml: &str) -> BTreeSet<String> {
+    debug_binaries(ci_yml, |line| line.contains("chmod"))
+}
+
+fn unshipped(consumers: &BTreeSet<String>, shipped: &BTreeSet<String>) -> Vec<String> {
+    consumers.difference(shipped).cloned().collect()
+}
+
+/// The sharded CI jobs replay a nextest archive and never invoke Cargo, so every binary an
+/// integration test spawns has to be hand-shipped to them by `ci.yml`. A name that reaches
+/// neither list dies at `Command::spawn`, in the shard, with the rest of the suite green.
+#[test]
+fn every_binary_an_integration_test_spawns_is_shipped_to_the_test_shards() {
+    let root = repo_root();
+    let consumers = bin_exe_consumers(&root);
+    assert!(
+        !consumers.is_empty(),
+        "no CARGO_BIN_EXE_ consumer found under crates/*/tests — the scanner or the tree moved"
+    );
+
+    let ci = fs::read_to_string(root.join(".github/workflows/ci.yml")).expect("read ci.yml");
+    let uploaded = uploaded_binaries(&ci);
+    let chmodded = chmod_binaries(&ci);
+    assert!(
+        !uploaded.is_empty(),
+        "no uploaded binary found in ci.yml — the scanner or the upload step moved"
+    );
+    assert!(
+        !chmodded.is_empty(),
+        "no chmod'd binary found in ci.yml — the scanner or the chmod step moved"
+    );
+
+    assert!(
+        unshipped(&consumers, &uploaded).is_empty(),
+        "{:?} are spawned by an integration test but are not in ci.yml's `Upload test runtime \
+         binaries` path: list. The shards replay an archive and never invoke cargo, so a \
+         CARGO_BIN_EXE_ path that was not uploaded resolves to a file that does not exist.",
+        unshipped(&consumers, &uploaded)
+    );
+    assert!(
+        unshipped(&consumers, &chmodded).is_empty(),
+        "{:?} are spawned by an integration test but are not on ci.yml's `chmod +x` line. \
+         Actions artifacts preserve file contents but not executable bits, so an \
+         uploaded-but-not-chmod'd binary reaches the shard and fails at spawn with \
+         PermissionDenied.",
+        unshipped(&consumers, &chmodded)
+    );
+
+    // Refused end, withheld from ONE site: a name absent from either list alone must be named
+    // by that leg and by no other. An implementation that unioned the two sites passes the
+    // assertions above while shipping a PermissionDenied.
+    let victim = consumers.iter().next().expect("non-empty above").clone();
+    let mut degraded = chmodded.clone();
+    degraded.remove(&victim);
+    assert_eq!(unshipped(&consumers, &degraded), vec![victim.clone()]);
+    assert!(unshipped(&consumers, &uploaded).is_empty());
+
+    // Admitted end: containment, not equality — a shipped binary nothing spawns stays admitted.
+    let spare = "a-binary-no-integration-test-spawns".to_string();
+    let mut wider_uploaded = uploaded.clone();
+    wider_uploaded.insert(spare.clone());
+    let mut wider_chmod = chmodded.clone();
+    wider_chmod.insert(spare);
+    assert!(unshipped(&consumers, &wider_uploaded).is_empty());
+    assert!(unshipped(&consumers, &wider_chmod).is_empty());
+}
+
+/// The two scanners must read DIFFERENT lines. The real lists are equal, so every set-level
+/// assertion above survives a pair that aliased — this fixture is what does not.
+#[test]
+fn the_upload_and_chmod_scanners_partition_the_file() {
+    const FIXTURE: &str = "  path: target/debug/alpha\n  run: chmod +x target/debug/beta\n";
+
+    assert_eq!(
+        uploaded_binaries(FIXTURE),
+        BTreeSet::from(["alpha".to_string()])
+    );
+    assert_eq!(
+        chmod_binaries(FIXTURE),
+        BTreeSet::from(["beta".to_string()])
+    );
+}
+
+/// Every `cargo ai-gate` invocation written down in `.github/workflows/`, as `(file, tokens)`.
+///
+/// `cargo ai-perf-gate` is a different binary with its own baseline, so the match requires a
+/// non-`-` boundary after the name.
+fn gate_invocations(root: &Path) -> Vec<(String, Vec<String>)> {
+    const NEEDLE: &str = "cargo ai-gate";
+    let mut out = Vec::new();
+    // A missing directory means the scanner is aimed wrong; it must not yield an empty pass.
+    for entry in fs::read_dir(root.join(".github/workflows")).expect("read .github/workflows") {
+        let path = entry.expect("read workflow entry").path();
+        if !matches!(
+            path.extension().and_then(|e| e.to_str()),
+            Some("yml" | "yaml")
+        ) {
+            continue;
+        }
+        let file = path
+            .file_name()
+            .expect("a file with an extension has a name")
+            .to_string_lossy()
+            .into_owned();
+        let text = fs::read_to_string(&path).expect("read workflow");
+        for line in text.lines() {
+            let invokes_gate = line
+                .match_indices(NEEDLE)
+                .any(|(idx, _)| !line[idx + NEEDLE.len()..].starts_with('-'));
+            if invokes_gate {
+                out.push((
+                    file.clone(),
+                    line.split_whitespace().map(str::to_string).collect(),
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// The token after `name`, when `name` is present.
+fn flag<'a>(tokens: &'a [String], name: &str) -> Option<&'a str> {
+    let idx = tokens.iter().position(|token| token == name)?;
+    tokens.get(idx + 1).map(String::as_str)
+}
+
+/// Each invocation's disagreements with the baseline, one string per (invocation, field).
+///
+/// A field is compared case-insensitively because `AiDifficulty::from_label` folds case — and a
+/// MISSING field is a finding too: an unspelled value comes from a `bin/ai_gate.rs` default, so
+/// a change there would break the job at runtime with every test still green.
+fn findings(invocations: &[(String, Vec<String>)], baseline: &SuiteReport) -> Vec<String> {
+    let expected = [
+        ("--games", baseline.games_per_matchup.to_string()),
+        ("--seed", baseline.base_seed.to_string()),
+        ("--difficulty", baseline.difficulty.clone()),
+    ];
+    let mut out = Vec::new();
+    for (file, tokens) in invocations {
+        for (name, want) in &expected {
+            match flag(tokens, name) {
+                None => out.push(format!(
+                    "{file}: `{name}` is not spelled out; its value comes from a binary default \
+                     nothing checks. Add `{name} {want}`."
+                )),
+                Some(got) if !got.eq_ignore_ascii_case(want) => out.push(format!(
+                    "{file}: `{name} {got}`, but the baseline was recorded at `{want}`. The \
+                     comparator refuses a pair whose workloads disagree, so this invocation can \
+                     reach no verdict. Set `{name} {want}`."
+                )),
+                Some(_) => {}
+            }
+        }
+    }
+    out
+}
+
+/// The gate's workload must be written down where it is invoked, at the value the baseline was
+/// recorded at. Anything else makes the job incapable of a verdict — the comparator refuses the
+/// pair — and an unspelled field hides the dependency on a binary constant instead.
+#[test]
+fn every_workflow_gate_invocation_spells_the_baseline_workload() {
+    let root = repo_root();
+    let invocations = gate_invocations(&root);
+    assert!(
+        !invocations.is_empty(),
+        "no `cargo ai-gate` invocation found under .github/workflows — the scanner or the \
+         workflows moved"
+    );
+
+    for (file, tokens) in &invocations {
+        assert!(
+            flag(tokens, "--baseline").is_none(),
+            "{file} names its own baseline; extend this check to resolve a baseline per \
+             invocation before comparing any of them against the default one"
+        );
+    }
+
+    let baseline = phase_ai::duel_suite::compare::load_report(
+        &root.join("crates/phase-ai/baselines/suite-baseline.json"),
+    )
+    .expect("load the committed baseline through the production loader");
+
+    let live = findings(&invocations, &baseline);
+    assert!(
+        live.is_empty(),
+        "workflow gate invocations disagree with the baseline:\n{}",
+        live.join("\n")
+    );
+
+    // Two invocations, one matching and one divergent, driven through the same call: the
+    // findings must name the divergent one and only it. A file-level verdict fails here, and an
+    // instrument that cannot produce a finding at all fails here too.
+    let spell = |games: usize| {
+        format!(
+            "cargo ai-gate --games {games} --seed {} --difficulty {}",
+            baseline.base_seed,
+            baseline.difficulty.to_lowercase()
+        )
+    };
+    let tokens = |line: String| line.split_whitespace().map(str::to_string).collect();
+    let control = findings(
+        &[
+            (
+                "matching.yml".to_string(),
+                tokens(spell(baseline.games_per_matchup)),
+            ),
+            (
+                "divergent.yml".to_string(),
+                tokens(spell(baseline.games_per_matchup + 90)),
+            ),
+        ],
+        &baseline,
+    );
+    let named: BTreeSet<&str> = control
+        .iter()
+        .map(|finding| finding.split(':').next().expect("a finding names its file"))
+        .collect();
+    assert_eq!(
+        named,
+        BTreeSet::from(["divergent.yml"]),
+        "control must name exactly the divergent invocation; findings:\n{}",
+        control.join("\n")
+    );
 }

--- a/crates/phase-ai/tests/gate_cli.rs
+++ b/crates/phase-ai/tests/gate_cli.rs
@@ -124,6 +124,59 @@ fn a_refused_comparison_exits_nonzero_and_writes_its_reason_to_stdout() {
     std::fs::remove_dir_all(&dir).ok();
 }
 
+/// A report that cannot be READ must refuse on the same terms as one that cannot be COMPARED.
+///
+/// Review found these two arms returned 2 after an `eprintln!` alone, so the workflow's redirected
+/// stdout stayed empty and its "failed without a drift report" abort fired instead of the refusal
+/// being posted. Both inputs are covered because they are separate arms in the source — a fix
+/// applied to one and not the other is exactly the shape of defect this file exists to catch.
+///
+/// Missing and malformed are both exercised because they take different `CompareError` variants
+/// (`Io` vs `Parse`) to the same renderer, and a remedy keyed on only one of them would leave the
+/// other with an empty body.
+#[test]
+fn an_unreadable_report_still_publishes_a_refusal_body() {
+    for (case, make_bad) in [("missing", false), ("malformed", true)] {
+        for bad_side in ["baseline", "current"] {
+            let dir = tempdir(&format!("unreadable-{case}-{bad_side}"));
+            let good = write(&dir, "good.json", &report_json(10));
+            let bad = dir.join(format!("{bad_side}-bad.json"));
+            if make_bad {
+                std::fs::write(&bad, "{ this is not a suite report").expect("write malformed");
+            }
+            // PREMISE: the "missing" case really is missing, or it would be testing nothing.
+            assert_eq!(bad.exists(), make_bad, "fixture for {case}/{bad_side}");
+
+            let (baseline, current) = if bad_side == "baseline" {
+                (bad.clone(), good.clone())
+            } else {
+                (good.clone(), bad.clone())
+            };
+            let (code, stdout, stderr) = run(&baseline, &current);
+
+            assert_eq!(code, 2, "{case}/{bad_side} must exit 2; stderr:\n{stderr}");
+            assert!(
+                stdout.contains("Gate: comparison refused"),
+                "{case}/{bad_side} must publish a refusal body on STDOUT, not stderr; \
+                 stdout was {} bytes:\n{stdout}",
+                stdout.len()
+            );
+            // The body must say more than the header — an envelope with no remedy is the same
+            // empty-file problem wearing a title.
+            assert!(
+                stdout.contains("could not be read"),
+                "{case}/{bad_side} body must carry the remedy; stdout:\n{stdout}"
+            );
+            // The side is what makes it actionable, and it lives on stderr by design.
+            assert!(
+                stderr.contains(bad_side),
+                "{case}/{bad_side} stderr must name which report failed; stderr:\n{stderr}"
+            );
+            std::fs::remove_dir_all(&dir).ok();
+        }
+    }
+}
+
 /// Control arm. Without it every assertion above is satisfied by a binary that refuses
 /// everything, which would be a worse regression than the one being fixed.
 #[test]

--- a/crates/phase-ai/tests/gate_cli.rs
+++ b/crates/phase-ai/tests/gate_cli.rs
@@ -1,0 +1,149 @@
+//! The gate's process-level contract: exit status and stdout body, together.
+//!
+//! Review found that every test for this pairing stopped at the library call, while the two
+//! statements that actually matter — print the body, exit with the code — lived in a binary no
+//! test executed. A `main` that printed the refusal to stderr, or exited 0 on it, would revert
+//! the fix with the whole unit suite green.
+//!
+//! `.github/workflows/ai-gate.yml` redirects the gate's **stdout** into a file, posts that file
+//! as a drift issue only when the step **failed**, and aborts when the file is empty. Those two
+//! conditions are one contract: satisfying either alone posts nothing. So these tests assert
+//! both on the same invocation rather than in separate cases.
+//!
+//! `ai-duel compare` is the binary under test because it is the only one of the three sharing
+//! `emit_gate_verdict` that needs no card database and plays no games — it reads two report
+//! files and prints a verdict. That makes this a millisecond test instead of a full suite run,
+//! and it exercises the same shared emitter `ai-gate` and `ai-perf-gate` end in.
+
+use std::process::Command;
+
+use phase_ai::duel_suite::run::{GameResult, MatchupResult, SuiteReport, SuiteStatus};
+use phase_ai::duel_suite::Expected;
+
+/// Build the fixture from the real types rather than hand-written JSON.
+///
+/// The first draft of this test hand-wrote the report and got `Expected`'s encoding wrong — it
+/// is an internally tagged enum — so both arms failed on a parse error instead of on the
+/// contract under test. Serialising the actual structs cannot drift from the schema: a field
+/// added to `SuiteReport` breaks compilation here rather than silently producing a fixture the
+/// binary rejects, and the parse is exercised by the binary, not asserted by the test.
+///
+/// `games_per_matchup` is the workload knob; everything else is held equal so the refusal in
+/// the first test can only come from that field.
+fn report_json(games_per_matchup: usize) -> String {
+    let report = SuiteReport {
+        schema_version: 2,
+        git_sha: None,
+        card_data_hash: None,
+        unix_timestamp_secs: 0,
+        difficulty: "Medium".to_string(),
+        games_per_matchup,
+        base_seed: 7,
+        results: vec![MatchupResult {
+            matchup_id: "red-mirror".to_string(),
+            exercises: Vec::new(),
+            p0_label: "a".to_string(),
+            p1_label: "b".to_string(),
+            expected: Expected::Mirror { tolerance: 0.4 },
+            p0_wins: 1,
+            p1_wins: 0,
+            draws: 0,
+            games: vec![GameResult {
+                seed: 1,
+                winner: Some(0),
+                turns: 10,
+            }],
+            total_turns: 10,
+            total_duration_ms: 1,
+            avg_turns: 10.0,
+            avg_duration_ms: 1.0,
+            status: SuiteStatus::Pass,
+            fail_reason: None,
+            attribution: None,
+        }],
+    };
+    serde_json::to_string_pretty(&report).expect("serialize fixture")
+}
+
+fn write(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, body).expect("write fixture");
+    path
+}
+
+fn run(baseline: &std::path::Path, current: &std::path::Path) -> (i32, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_ai-duel"))
+        .args([
+            "compare",
+            &baseline.display().to_string(),
+            &current.display().to_string(),
+        ])
+        .output()
+        .expect("spawn ai-duel");
+    (
+        out.status.code().expect("exit code"),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn tempdir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("phase-gate-cli-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create tempdir");
+    dir
+}
+
+/// The refusal route, asserted as the PAIR the workflow needs. A non-zero exit with an empty
+/// stdout aborts the publishing step ("failed without a drift report"); a populated stdout with
+/// a zero exit never reaches it. Both, or the drift issue does not exist.
+#[test]
+fn a_refused_comparison_exits_nonzero_and_writes_its_reason_to_stdout() {
+    let dir = tempdir("refuse");
+    let baseline = write(&dir, "baseline.json", &report_json(10));
+    let current = write(&dir, "current.json", &report_json(100));
+
+    let (code, stdout, stderr) = run(&baseline, &current);
+
+    assert_ne!(
+        code, 0,
+        "a refusal must fail the step; stdout was:\n{stdout}"
+    );
+    assert!(
+        !stdout.trim().is_empty(),
+        "an empty report body aborts the publishing step; stderr was:\n{stderr}"
+    );
+    // The body must be the refusal, not merely non-empty — a table of PASSing rows with no
+    // statement of what failed is the outcome this whole change exists to prevent.
+    assert!(stdout.contains("comparison refused"), "stdout:\n{stdout}");
+    assert!(stdout.contains("games_per_matchup"), "stdout:\n{stdout}");
+    assert!(
+        stdout.contains("10") && stdout.contains("100"),
+        "stdout:\n{stdout}"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Control arm. Without it every assertion above is satisfied by a binary that refuses
+/// everything, which would be a worse regression than the one being fixed.
+#[test]
+fn a_comparable_pair_exits_zero_and_writes_a_table() {
+    let dir = tempdir("accept");
+    let baseline = write(&dir, "baseline.json", &report_json(10));
+    let current = write(&dir, "current.json", &report_json(10));
+
+    let (code, stdout, stderr) = run(&baseline, &current);
+
+    assert_eq!(
+        code, 0,
+        "identical reports must compare clean; stderr:\n{stderr}"
+    );
+    assert!(stdout.contains("| red-mirror |"), "stdout:\n{stdout}");
+    assert!(stdout.contains("compare: 0 FAIL"), "stdout:\n{stdout}");
+    assert!(
+        !stdout.contains("comparison refused"),
+        "control arm must not refuse; stdout:\n{stdout}"
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

**The duel-suite comparison gate returned `PASS` on a recorded run that had two independent regressions in it.** In that run (`.ab/noC-1.json`, the A+B+D leg of #6969), `enchantress-mirror` had 8 of 10 games stop having a winner **and** carried `status: "Fail"` with `fail_reason: "mirror imbalance: p0=0.10, Wilson 95% CI [0.02, 0.40] excludes 0.50"`. The compare section printed `0 FAIL, 0 WARN, 3 PASS` and the gate exited 0.

Two causes, both in `classify_row`'s paired branch:

1. `paired_seed_shift` classified only `Some(0)→Some(1)` and `Some(1)→Some(0)`; every `Some(_) → None` fell into a `_ => unchanged` wildcard. A branch that made the AI stall or loop every game — the exact failure this gate exists to catch — produced `flips=0`, `sign_test_p=None`, and a green comparison.
2. The paired branch read game outcomes and nothing else. It never looked at `SuiteStatus`, so an *existing* matchup that newly failed its own suite check did not fail the comparison. Only the new-matchup arm ever read that field.

This makes the draw axis and the suite-status axis first-class, severity-ordered peers of the win/loss axis, and removes the wildcard that hid the first one.

## Files changed

- `crates/phase-ai/src/duel_suite/compare.rs` — the substance of the change, of which roughly 85% is tests and comments. `decisive_to_draw` / `draw_to_decisive` / `draw_sign_test_p` on `PairedSeedShift` and `CompareRow`; exhaustive classification match; four new verdict arms (draw Fail/Warn, status Fail/Warn); `avg_turn_delta` and `suite_status_shift` carried on the row; `render_markdown` extracted from `print_markdown` over a `COLUMNS` constant, with seven new columns; twenty-seven new tests (10 → 37).
- `crates/phase-ai/src/bin/ai_gate.rs` — `main` routed through `gate_verdict`, so the stdout body and the exit code are decided in one place the tests can reach (round-2 review).

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — the change is confined to `crates/phase-ai/src/duel_suite/compare.rs`, the duel-suite report comparator (CI gate tooling). No `crates/engine/` game logic, parser, effect, resolver, or targeting code is touched, and no AI decision-making behavior changes: this alters how two recorded reports are *compared*, not how any game is played.

Flow used: measured-defect probe → written plan → implementation → mutant discharge → real-data acceptance → **five rounds of independent `review-impl`**. Rounds 1-4 each returned FAIL, as did round 5's first pass; round 5's re-review returned PASS with one LOW, which this head closes rather than discloses. The findings and their fixes are described inline below rather than summarised away, because two of them were false claims in this PR's own documentation and three were defects in fixes for earlier findings.

## CR references

None. This is CI comparison tooling, not game rules.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Measured at the current head `edc1c1ea3`, after rebase onto `562e7b5d2`:

- `cargo test -p phase-ai --lib duel_suite::compare` — **37 passed, 0 failed** (10 before this change)
- `cargo test -p phase-ai --lib` — **2049 passed, 0 failed, 8 ignored**
- `cargo test -p phase-ai --test gate_cli` — **2 passed, 0 failed** (real process, no card data, 0.02s)
- `cargo clippy -p phase-ai --all-targets -- -D warnings` — rc=0
- `cargo fmt --all --check` — rc=0
- `ai-gate --games 10` (CI's exact gate invocation, `server-release`, against the committed baseline) — **`compare: 0 FAIL, 0 WARN, 3 PASS, 0 NEW, 0 REMOVED`, rc=0**, zero refusals

### The live gate stays green, structurally

| matchup | W→L | L→W | sign p | dec→draw | draw→dec | draw sign p | unpaired base | unpaired cur | Δ avg turns | suite status | status |
|---|---|---|---|---|---|---|---|---|---|---|---|
| affinity-mirror | 0 | 0 | — | **0** | **0** | — | **0** | **0** | +0.8 | **Pass** | PASS |
| enchantress-mirror | 2 | 2 | 0.5000 | **0** | **0** | — | **0** | **0** | -1.5 | **Pass** | PASS |
| red-mirror | 0 | 0 | — | **0** | **0** | — | **0** | **0** | +0.0 | **Pass** | PASS |

Every row has equal draw counters and no `Fail` on either side — which is exactly the precondition of the invariant stated at the site, so every new guard is false and the chain takes the pre-change path. The live run is an *instance* of the invariant, not merely consistent with it.

All three new columns carry real values through the actual binary rather than only in tests, and the table is well-formed after the `render_markdown` extraction, so the refactor did not disturb the real output path.

Per-seed cross-check of the only draws in the whole run: affinity seeds `10592735` and `10592736` drew in the current run and are `null` in the committed baseline, so both classify `(None, None) => unchanged` — which is what `dec→draw=0 / draw→dec=0` reports. The instrument agrees with the hand count.

Disclosure: this is **not** an identity comparison. The committed baseline records `card_data_hash=56b033662b27ea926a2db73a8b83007b6352ff35`, and no `card-data.json` reachable from this checkout hashes to it — the input the baseline was recorded against no longer exists, so an identity re-run is not achievable. This ran against current card data, which makes the result stronger for the question that matters: the new axes stay silent across genuine data drift.

### The failure this fixes, measured on real recorded data

The acceptance run is the **real comparator over two recorded reports** — committed `crates/phase-ai/baselines/suite-baseline.json` versus `.ab/noC-1.json`, a real gate run (the A+B+D leg of #6969). Not synthetic:

| arm | enchantress-mirror | red-mirror | affinity-mirror | `any_fail()` |
|---|---|---|---|---|
| **BASE** (this PR's two verdict tiers removed) | **PASS** — despite `decisive→draw=8` | PASS `0/0` | PASS `0/0` | **false** |
| **POST** (this PR) | **FAIL** — `paired draw regression: decisive→draw=8 draw→decisive=0 sign-test p=0.0020` | PASS `0/0` | PASS `0/0` | **true** |

`red-mirror` and `affinity-mirror` are the built-in negative controls on real data: both measure `0` on the draw axis and neither moves. The BASE and POST artifacts were diffed and differ, so this is not a stale-binary false pass. `draw_sign_test_p = 0.001953125` is exactly the hand-derived `1/512`, produced by the already-existing `sign_test_mid_p_upper_tail` — reused, not reimplemented.

### Mutant evidence — 30 mutants over the module's 26 tests

The verdict chain, each mutant flipping a distinct set: dropping either draw tier, dropping the status arm, **reordering either Fail arm below the W/L Warn arm** (1 test each — precisely the edit the "Do not reorder" comment warns against), restoring the literal pre-fix classification, firing on any movement regardless of direction or significance, making `Fail→Fail` silent again, and reading the draw statistic in one fixed direction.

Review then measured, twice, that the **reporting** layer was pinned far more weakly than the chain. Sixteen mutations survived a whole green suite across rounds 3 and 4; all now fail a test. The most consequential:

| mutant | what it corrupted |
|---|---|
| AVG-FROZEN | `Δ avg turns` cell frozen to a constant |
| DEC-SWAP | `dec→draw` / `draw→dec` cells transposed — the recorded incident would print its counters backwards |
| SEP-EMPTY | separator fill emptied — right pipe count, renders the whole table as one paragraph |
| REC-EMPTY | recovery message emptied |
| DRAW-FAIL-SWAP / DRAW-WARN-SWAP | counters transposed inside either draw reason string |
| STATUS-NO-SHIFT | status reason drops the `Pass → Fail` it names |
| MERGED-KEY | merged arm re-keyed `!= Pass` instead of `== Fail`, mislabelling `Fail → Open` |
| WL-FAIL-SWAP / WL-WARN-SWAP | counters transposed inside either **win/loss** reason — a 10-0 regression printed as `W→L=0 L→W=10` |
| SHIFT-CELL | the `suite status` column's shift branch — the one the status axis exists to surface — replaced by a constant |
| NONE-DASH | the `—` fallbacks that New and Removed rows print |
| MIRROR-GUARD | the avg-turn arm's `Expected::Mirror` guard deleted (pre-existing arm; every fixture was a mirror) |

Cells are now asserted by column **name** against a fixture whose four counters are pairwise distinct (2, 3, 4, 1), so no transposition can hide; the separator is checked to be a valid markdown rule; every reason string is pinned to its counters in order.

**Two of these fixes were themselves defective, and are disclosed rather than quietly corrected.** The natural spelling of the separator check — `.split('|').filter(|s| !s.is_empty())` — drops every segment exactly when the fill is empty, so SEP-EMPTY survived a second time. And the first cell-transposition fixture rendered `45%` in *both* win-rate columns, so swapping them changed nothing; the fixture now differs them via a current-only seed, which moves the rate without touching a flip counter. A guard is not a guard until its mutant dies.

The working tree was restored and verified byte-identical after every mutant run.

### What the tier order actually guarantees — swept, not argued

Two earlier drafts of this invariant were false, both caught by review compiling the base and running candidate inputs through both versions. The claim is now stated to its exact edge and **verified over 1,327,104 paired inputs** against the compiled base, comparing `(status, reason)` on each. The domain covers the counters, both statuses ∈ {Pass, Fail, Open}², every `Expected` variant, seeds present in only one report, duplicate seeds within a matchup, empty game vectors, zero-matchup reports, and NaN/infinite turn deltas:

- **Clause 1 — nothing that reaches Fail today changes verdict.** The W/L Fail arm is still first with byte-identical counters. Measured: **0 violations**; every base-`Fail` input keeps verdict *and* reason byte-identical.
- **Clause 2 — a row whose draw counters are EQUAL and where NEITHER report's status is `Fail` takes precisely the pre-change path.** That is the full precondition: every new guard needs either unequal draw counters or a `Fail` on one side. Measured: **0 violations**.
- **Clause 3 — a W/L *Warn* DOES escalate to Fail**, via the draw Fail arm on a significant draw regression and via the status Fail arm when the matchup newly fails its own check. Intended: those are the failures this gate exists to catch, and suppressing either because the win/loss axis also wobbled insignificantly would reintroduce the same blindness one case narrower.

**Zero violations of either clause, zero `Fail→X`, zero `X→Pass`.** Head severity is monotone ≥ base on every input, and all 287,712 escalations to Fail are attributable to a significant draw regression or a `non-Fail→Fail` status shift — nothing this PR does can make a comparison quieter than it was.

Each clause names the test that pins it, because all three false claims in this PR's history had the same shape: a claim about an arm that no test exercises.

The two directions on each axis are deliberately asymmetric. `decisive→draw` dominating is the regression signal and can reach **Fail**; `draw→decisive` dominating is an improvement and can never Fail through that arm — it requires `decisive_to_draw > draw_to_decisive` — but still **Warns**, because a comparator silent about games that started resolving would be hiding a behavior change. Same shape on the status axis.

### Reason strings are first-match-wins, so every axis gets a column

Review also measured that the new draw WARN arm *shadows* the mirror avg-turn WARN arm: same input, pre-change → `Warn "mirror avg-turn drift +6.0 turns"`, this PR → `Warn "paired draw shift: …"`. Status unchanged, but the drift magnitude then surfaced nowhere, because the table had no avg-turns column and the reason string was its only surface — the same argument used to justify the draw columns, turned against this change.

Fixed by carrying `avg_turn_delta` on `CompareRow` and adding a `Δ avg turns` column, which generalizes to the invariant now written at `print_markdown`: **every axis the verdict chain can decide on owns a column, because the chain is first-match-wins and columns are the only surface that survives suppression.** Adding a verdict arm means adding a column. Pinned by `mirror_drift_magnitude_survives_a_shadowing_reason`.

**No baseline refresh.** `baselines/suite-baseline.json` is untouched.

## Review response (maintainer CHANGES_REQUESTED, 2026-08-05)

Two further commits. Both findings reproduced independently at the reviewed head before being fixed.

**HIGH — partial comparison could report PASS.** Confirmed: `compare` validated only `schema_version`, and `paired_seed_shift` `continue`d past baseline seeds missing from current while never traversing extra current games at all. Two reports sharing no seeds scored zero on every counter and passed.

The remedy splits, because two defects hid behind one symptom. A different `base_seed` or `difficulty` makes a seed *number* denote a different game, so `compare` now returns `CompareError::WorkloadMismatch { field, baseline, current }` — one parameterized variant mirroring the `PerfCompareError::WorkloadMismatch` you pointed at, rather than a sibling per field. A different `games_per_matchup` is not that: it changes how many seeds exist, not what one means, so the samples that do pair remain comparable. It is counted rather than gated — see the disclosure below. `card_data_hash` is likewise not gated: the committed baseline's hash matches no card-data present on a current checkout, and `perf.rs` carries card-data hashes as informational fields for the same reason.

`PairedSeedShift`/`CompareRow` gain `unpaired_baseline` and `unpaired_current`, each with a column, and a Warn arm fires when either is non-zero. The arm sits last among the Warns so a row with real drift keeps its drift headline and reports the coverage gap through its columns instead; promoting it flips exactly one test.

**LOW — unescaped cells.** Confirmed, and it indicted an existing test of mine: `markdown_rows_are_rectangular` asserted precisely this property and passed, because every one of its fixtures was pipe-free. `md_cell` now encodes every report-supplied cell, with a pipe-bearing reachability fixture.

**Disclosure — the nightly.** ~~This change makes the discarded samples visible as `unpaired cur` and Warn-level.~~ **That was false, and round 2 below replaces it.** A Warn exits 0, so the nightly step succeeded, so the step that publishes the report never ran — the counters went to a file nobody read. The correction is in the round-2 section.

**Verification at the new head.** 2044 lib tests pass; `clippy -D warnings` and `cargo check --workspace --all-targets` both clean; the live gate is green against the committed baseline (`0 FAIL, 0 WARN, 3 PASS`, rc=0) with both new columns reading `0`. Twelve mutants across the two commits, tree restored byte-identical after each — including a control arm so a reject-everything mutant cannot pass as a working guard, and a mutant pinning the deliberate `games_per_matchup` non-gate against a later reader "fixing" it.

## Review response (maintainer round 2, 2026-08-05 11:07Z)

**HIGH — the workload mismatch was a green, unpublished partial comparison. Confirmed, and it falsified a claim in the section above.**

Reproduced at the reviewed head before changing anything, because the disclosure I wrote in round 1 said this change "makes it visible as `unpaired cur` and Warn-level" and that the nightly "starts saying out loud that it discards 90 of every 100 samples". Both are false where it matters:

- `ai-gate.yml:87` — `cargo ai-gate --full-suite --games 100 > target/ai-gate-report.md`. stdout, and only stdout, becomes the issue body.
- `ai-gate.yml:90` — `Open or update drift issue` is guarded by `if: steps.gate.outcome == 'failure'`.
- `CompareReport::any_fail` counts only `Fail`, so a Warn exits 0, the step succeeds, and that guard is false.

The columns were therefore written to a file nobody reads. Producing a diagnostic is not surfacing it. I had verified the counters reached the report and stopped one layer short of the consumer.

**Remedy: hard incompatibility with preserved diagnostics** — the first of the two you offered. The second (align the nightly baseline or workload) needs either a baseline refresh or a workflow edit, and I do not take either unilaterally.

`compare` now returns `WorkloadMismatch` for `games_per_matchup`, and `render_error_markdown` writes the field, both values and the remedy **to stdout**, which is what the workflow captures. Printing the refusal only to stderr would have traded a green false-pass for a red job with an empty issue body (`:95` aborts with "AI gate failed without a drift report") — a different failure, not a fix. `gate_verdict` returns the stdout body and the exit code together because the issue posts only when the exit is non-zero **and** the file is non-empty; a test pinning either alone cannot see this mode. `main` now only prints and exits.

The stdout byte stream for a successful run is unchanged by that refactor, which matters because the nightly posts it verbatim: `println!()` + `print!(table)` + `println!("\ncompare: …")` and `format!("\n{table}\ncompare: …\n")` emit the same bytes, and the live run's file confirms it — leading `\n`, table, then `| PASS |\n\ncompare: 0 FAIL, 0 WARN, 3 PASS, 0 NEW, 0 REMOVED\n`.

The unpaired columns stay. A same-workload pair can still fail to pair — a crashed matchup, a filter change — and that remainder is still counted rather than skipped.

**Consequence, stated up front: the nightly will fail every night until baseline or workflow is aligned.** It runs `--games 100` against a `games_per_matchup: 10` baseline. The required PR gate runs `--games 10` (`ai-gate.yml:50`), matches the baseline header exactly, and is unaffected — the live run below is that invocation. I will do whichever alignment you prefer as a follow-up; it is one line either way, but one line in a file I do not edit unasked.

**MED — `md_cell` escape order. Confirmed, and the test that was supposed to catch it had the same bug in mirror image.** Escaping `|` before `\` turns a report-supplied `\|` into `\\|` — an escaped backslash followed by a live separator — so the input that looks already-safe is the one that breaks the row. Backslashes are escaped first now. The in-test separator counter used "the previous character is a backslash", which is right for `\|` and wrong for `\\|`; it is now `md_separator_count`, keyed on run-length parity, shared by both pipe tests. The new fixture carries both parities and inlines the previous encoder as a control, asserting it leaks a separator where the fixed one does not — without that arm the assertion could pass for an unrelated reason.

**LOW — copied doc paragraph.** Confirmed; the two paragraphs describing a distinct-value fixture belonged to `markdown_cells_carry_their_own_column_values`. Removed, with a one-line note saying where they went so the next reader does not re-copy them.

**Mutants for this round — 8, all killed, tree sha256-restored after each.**

| mutant | killed by |
|---|---|
| drop the `games_per_matchup` guard | 2 |
| `render_error_markdown` → empty string | 3 |
| `gate_verdict` always exits 0 | 2 |
| `gate_verdict` always exits 2 | **1** — only the three-outcome control |
| refusal body drops both values | 2 (the exit-code assertion **survives**) |
| `md_cell` → pipes-first | 1 |
| `md_cell` → identity | 2 |
| separator counter → previous-character rule | 1 |

The last four rows are the point. A reject-everything `gate_verdict` satisfies every refusal assertion and is caught only by the control arm. Emptying the body kills the body assertions while the exit-code assertion survives, and forcing exit 0 does the reverse — so the two halves you asked to see asserted end-to-end are pinned separately rather than by one test that could be passing for either reason. And reverting the counter kills the same test as reverting the encoder, which is the measurement that would otherwise have hidden the encoder bug.

**Answers to the three CodeRabbit nitpicks** are in a separate comment, with the measurements behind each.

## Review response (round 3, 2026-08-05 12:06Z) — one blocker is not mine to close

**HIGH — the nightly workload is permanently incompatible with the committed baseline. Confirmed, and it invalidates the remedy I offered in round 2.**

Measured independently before accepting it, and my own reviewer had reached it first:

- `ai-gate.yml:50` — PR gate, `cargo ai-gate --games 10`, quick filter (3 matchups), **no `continue-on-error`**.
- `ai-gate.yml:87` — nightly, `cargo ai-gate --full-suite --games 100` (32 matchups).
- Both compare against the **same default baseline**. Neither passes `--baseline`. It records `games_per_matchup: 10` and **3** results.

With a symmetric guard no single value satisfies both: at `10` the nightly refuses, at `100` the **required PR gate** refuses on every pull request. So the remedy I offered last round — regenerate the baseline at 100 — would have traded a red nightly for a red required check. That advice was also in the shipped error text; it is rewritten, and the text now carries the constraint that makes the choice non-local: a baseline is shared, so whichever workload is chosen, every invocation comparing against it must use that one.

Worth adding to the picture: the mismatch is not only `games`. The nightly runs 32 matchups against a 3-matchup baseline, so 29 report `NEW` every night. That baseline was never the nightly's baseline; this PR made a long-standing mismatch fatal instead of quiet.

**Both of your suggested fixes need something I don't do unasked, so I am offering rather than choosing.** Committing a workload-specific 100-game baseline means editing `.github/workflows/ai-gate.yml` to select it *and* recording 32 × 100 games — measured at ~15–39 s/game on this box, so hundreds of CPU-hours, not something to produce unreviewed. Using one workload consistently is a one-line workflow edit. I don't edit workflow files without being asked to; say which and I will, including the recording run with the paired-seed report attached so the refresh is auditable. My weak preference and its downside are in a separate comment.

Until then this PR leaves the nightly failing loudly with an accurate explanation, which is the outcome your previous review asked for, rather than green while comparing a tenth of its sample.

**MED — coverage stopped at `gate_verdict`, not the process boundary. Fixed, not disclosed.**

You were right that a regression in `main` could re-split exit from output with every unit test green. `emit_gate_verdict` now owns both statements and all three comparing binaries end in it — `ai-gate`, `ai-duel compare`, and `ai-perf-gate` through its own renderer. `ai-duel compare` turned out to have the identical defect and is fixed by routing rather than patched in place.

`crates/phase-ai/tests/gate_cli.rs` drives the contract through a **real process**. It runs `ai-duel compare` because that is the only one of the three needing no card database and playing no games, so it costs 0.02 s and adds no card-data load for `scripts/check-test-card-data-load.sh` to object to. Both halves are asserted on the same invocation — the issue posts only when the step failed **and** the file is non-empty — with a control arm so a refuse-everything binary cannot pass.

Its fixture is built from the real structs and serialised. The first draft hand-wrote the JSON, got `Expected`'s internally-tagged encoding wrong, and both arms failed on a parse error rather than on the contract; running it is what caught that.

**Also fixed this round, from an independent review pass that returned FAIL on the round-2 head:**

- The round-2 claim that a stderr-only refusal would leave the report file empty was **false**: `run_suite` prints the suite table to stdout before the baseline is loaded, so `[ ! -s ]` is unreachable on that path — my own end-to-end log showed the refusal *below* a rendered table and I read past it. The real consequence is a red job whose issue body is a table of PASSing rows and no statement of what failed. Both doc comments corrected.
- **The empty-report failure was real in the other binary.** `ai-perf-gate` writes nothing to stdout before `compare`, so a `PerfCompareError` produced a zero-byte report and "Decision-cost perf gate failed without a drift report" — exactly what round 2 claimed it had refused to ship, in the gate I cited as prior art without checking its caller. Fixed on both its bail-outs.
- `render_error_markdown`'s I/O arm was unreachable (`compare` does no I/O) while the real baseline-read failure was still stderr-only. That call site is wired, which fixes the gap and makes the arm live.
- `contains("compare: 0 FAIL")` was degenerate — four of five counters are zero in that fixture, so it survived transposing counters, zeroing them, and deleting the tally loop. Now pins the whole line, plus a fixture with two distinct non-zero counts.

**Mutants this round: 10, all killed, files sha256-restored after each.** Seven on the library fixes (dropping the shared remedy fails 3 tests; reducing it to the bare error line fails 4; emptying the perf renderer fails its own; deleting remedy 2 fails the refusal test; zeroing the tally and transposing pass/new each fail the verdict test the old substring could not see; reverting `md_cell` now also fails on trailing-run parity) and three at the process boundary (stderr instead of stdout fails **both** CLI tests; always-return-0 fails only the exit assertion; reverting `ai-duel` to stderr-only fails only the refusal test — so each half is independently load-bearing where CI actually reads them).


## Gate A


Gate A PASS head=8eaee5fe919a97c4a9ffd024bebf505158ac2f41 base=c44a4512e6f91684068c259a028eb44b4d801340

Re-recorded at the current head after rebasing onto `upstream/main`. Base passed explicitly rather
than left to the script's default, which resolves against `origin/main` — a fork ref that lags.
Range non-empty (8 commits, 7 files) but contains **zero parser paths**, so the parser-specific
verdict is vacuous by construction and is labelled rather than presented as a pass. Gate G also PASS.

## Anchored on


- crates/phase-ai/src/duel_suite/compare.rs:352 — the existing paired win/loss FAIL arm (dominance test plus `sign_test_p < 0.05`). The new draw FAIL tier is the same shape at the same seam: same predicate form, same reason-string format, same `if/else if` chain in `classify_row`.
- crates/phase-ai/src/duel_suite/compare.rs:606 — `sign_test_mid_p_upper_tail`, the existing significance statistic. The draw axis reuses it verbatim with `n = decisive_to_draw + draw_to_decisive` and `k = max(...)`, exactly as the win/loss axis calls it. No new statistic was written.

Both line numbers were re-derived at this head with `grep -n` after the rebase, not carried over: the
previously recorded `:259` and `:449` had drifted and now point at unrelated lines.

## Final review-impl


Final review-impl PENDING head=8eaee5fe919a97c4a9ffd024bebf505158ac2f41

Deliberately not a PASS line, because a PASS here would be false. The most recent certification is
`cert-r7 FAIL head=3c9646266`, and no independent pass has run against this head. The maintainer's
latest review (2026-08-05T16:13:23Z) also carries an open HIGH blocker — the repository invokes the
same default 10-game baseline from two incompatible workloads (`ai-gate.yml:49-50` at `--games 10`,
`:78-87` at `--full-suite --games 100`, against a `suite-baseline.json` recording
`games_per_matchup: 10`) — which is unaddressed at this head: no commit on this branch postdates that
review. The rebase above changes only the base (diff byte-identical across it, md5 `a12bb582741c`);
it does not answer the blocker.

This section is expected to keep the artifact gate red on the review-impl axis, and that is the
correct signal rather than something to paper over.

## Claimed parse impact

None.

## Scope Expansion

**Two items, both deliberate and both reviewed.**

**1. The suite-status axis.** Review found that an *existing* matchup whose own `SuiteStatus` goes to `Fail` did not fail the comparison — proven from this PR's own evidence artifact, which carries `status: "Fail"` on enchantress-mirror while its compare section read `0 FAIL, 0 WARN, 3 PASS`. The incident this PR is built on had two independent holes; shipping a fix for one and leaving a known-latent sibling in a **required** gate would make more work later, so it is closed here. New: a Fail arm (`b.status != Fail && c.status == Fail`, carrying the matchup's own `fail_reason`), and one Warn arm parameterized by `c.status` rather than two siblings: recovery (`Fail → non-Fail`) and still-failing (`Fail → Fail`) are both reported, never failed — the same asymmetry as the draw axis. Plus `suite_status_shift` on the row, a `suite status` column, and tests including `noc1_enchantress_row_carries_both_holes`, which pins the recorded incident whole by asserting **both** holes so a future edit that closes one and reopens the other cannot pass it.

The still-failing case exists because review showed it is *reachable*, not theoretical: nothing revalidates a committed baseline when it is loaded, so a baseline that already sanctions a failure keeps sanctioning it and that matchup exits 0 forever. It Warns rather than Fails deliberately — the exit code answers "did this change make things worse", and the baseline, however it got that way, already sanctions that state. **Whether a baseline may bless a failure at all is a policy question, and its other half is a guard on `--refresh-baseline` in `bin/ai_gate.rs`; that is now #7029 rather than smuggled in here.**

(Phrased about the baseline rather than about `--refresh-baseline` writing without a verdict check. That *was* the mechanism, and #7029 adds the missing check — so naming it as the reason would make this paragraph, and the two source comments quoting it, false the day #7029 lands. Reachability does not depend on it: a baseline blessed before that guard, or hand-edited, is unaffected by any guard on the write path.)

Keyed on `Fail` specifically rather than any status change, and not by preference: `Fail` is the only status this file already acts on — the new-matchup arm matches `SuiteStatus::Fail` and treats `Pass`/`Open` alike. Same authority, same vocabulary, extended from new matchups to existing ones. Inert on current data (all three live matchups hold their own verdict, so the `suite status` column reads `Pass` on every row of the live run).

**2. Table columns.** `print_markdown` gained `dec→draw`, `draw→dec`, `draw sign p`, `Δ avg turns`, and `suite status`; `CompareRow` carries `avg_turn_delta` and `suite_status_shift`. The verdict chain is first-match-wins, so a row that fires on one axis prints only that axis's reason and hides every other axis's magnitude — review measured exactly that regression in an earlier revision of this PR, where the new draw Warn arm shadowed the mirror avg-turn reason and the drift magnitude then surfaced nowhere. `bin/ai_gate.rs` and `bin/ai_duel.rs` are the only callers of `print_markdown`, neither reads the columns, and no CI step parses the table — `.github/workflows/ai-gate.yml` `cat`s the whole file into an issue body. Verified through the real binary, not only tests: the 13-column table renders correctly and every new column carries real values. `render_markdown` was split out of `print_markdown` so this invariant is enforced by tests rather than asserted in a comment — while the table was inlined in `println!`, the new columns could be deleted with the whole suite green.

Disclosed non-change: `(Some(a), Some(b))` pairs with seats other than 0/1 still count as `unchanged`, exactly as before. The duel suite is two-player; reclassifying them is out of scope.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer comparison reports with detailed verdicts, mismatch handling, and summary metrics.
  * Comparison errors now produce readable markdown guidance for CI troubleshooting.
  * Gate commands consistently report results and select appropriate exit codes.
* **Bug Fixes**
  * Incomplete pairing and workload mismatches are now detected and clearly reported.
  * Output formatting is consistent and safely escapes special characters.
* **Tests**
  * Expanded coverage for comparison outcomes, refusal cases, CLI behavior, and markdown formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
